### PR TITLE
feat: attribute beta links to the Boardsesh user (and tick) that attached them

### DIFF
--- a/design/render-velvet-send-tokens.mjs
+++ b/design/render-velvet-send-tokens.mjs
@@ -17,20 +17,48 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 
 // ---------- token data (source: docs/ai-design-guidelines.md) ----------
 const brand = {
-  light: { tint: '#6D28D9', fill: '#6D28D9', onPrimary: '#FFFFFF', accent: '#FF8A3D', success: '#047857', warning: '#B45309', error: '#C81E1E' },
-  dark: { tint: '#A78BFA', fill: '#7C3AED', onPrimary: '#FFFFFF', accent: '#FF8A3D', success: '#34D399', warning: '#FBBF24', error: '#F87171' },
+  light: {
+    tint: '#6D28D9',
+    fill: '#6D28D9',
+    onPrimary: '#FFFFFF',
+    accent: '#FF8A3D',
+    success: '#047857',
+    warning: '#B45309',
+    error: '#C81E1E',
+  },
+  dark: {
+    tint: '#A78BFA',
+    fill: '#7C3AED',
+    onPrimary: '#FFFFFF',
+    accent: '#FF8A3D',
+    success: '#34D399',
+    warning: '#FBBF24',
+    error: '#F87171',
+  },
 };
 
 const surfaces = {
   light: {
-    background: '#F4F1FB', secondaryBackground: '#FFFFFF', elevatedSurface: '#FFFFFF',
-    label: '#16111F', secondaryLabel: '#5B5563', tertiaryLabel: '#8E8898',
-    separator: 'rgba(60,55,75,0.18)', fill: 'rgba(109,40,217,0.10)', accent: '#6D28D9',
+    background: '#F4F1FB',
+    secondaryBackground: '#FFFFFF',
+    elevatedSurface: '#FFFFFF',
+    label: '#16111F',
+    secondaryLabel: '#5B5563',
+    tertiaryLabel: '#8E8898',
+    separator: 'rgba(60,55,75,0.18)',
+    fill: 'rgba(109,40,217,0.10)',
+    accent: '#6D28D9',
   },
   dark: {
-    background: '#0F0B16', secondaryBackground: '#181225', elevatedSurface: '#221A32',
-    label: '#F5F2FB', secondaryLabel: '#A9A2B6', tertiaryLabel: '#6E687C',
-    separator: 'rgba(180,168,205,0.20)', fill: 'rgba(199,184,232,0.12)', accent: '#A78BFA',
+    background: '#0F0B16',
+    secondaryBackground: '#181225',
+    elevatedSurface: '#221A32',
+    label: '#F5F2FB',
+    secondaryLabel: '#A9A2B6',
+    tertiaryLabel: '#6E687C',
+    separator: 'rgba(180,168,205,0.20)',
+    fill: 'rgba(199,184,232,0.12)',
+    accent: '#A78BFA',
   },
 };
 
@@ -79,22 +107,65 @@ const typeScale = [
   ['caption2', 11, 400, 13, 11, 500, 16],
 ];
 
-const spacingScale = [['0', 0], ['1', 4], ['2', 8], ['3', 12], ['4', 16], ['5', 20], ['6', 24], ['8', 32], ['10', 40], ['12', 48], ['16', 64]];
-const radiiScale = [['none', 0], ['sm', 4], ['md', 8], ['lg', 12], ['xl', 16], ['full', 28]]; // 'full' drawn as a pill
-const shadowScale = [['xs', 1, 0.05, 1], ['sm', 1, 0.1, 2], ['md', 4, 0.1, 4], ['lg', 10, 0.1, 8], ['xl', 20, 0.1, 12]];
+const spacingScale = [
+  ['0', 0],
+  ['1', 4],
+  ['2', 8],
+  ['3', 12],
+  ['4', 16],
+  ['5', 20],
+  ['6', 24],
+  ['8', 32],
+  ['10', 40],
+  ['12', 48],
+  ['16', 64],
+];
+const radiiScale = [
+  ['none', 0],
+  ['sm', 4],
+  ['md', 8],
+  ['lg', 12],
+  ['xl', 16],
+  ['full', 28],
+]; // 'full' drawn as a pill
+const shadowScale = [
+  ['xs', 1, 0.05, 1],
+  ['sm', 1, 0.1, 2],
+  ['md', 4, 0.1, 4],
+  ['lg', 10, 0.1, 8],
+  ['xl', 20, 0.1, 12],
+];
 
 const changelog = [
   ['CANON', 'Velvet Send', 'brand', 'Now the canonical design language — sourced from packages/mobile/src/theme.'],
-  ['ADD', 'brand.tint / primary', '#6D28D9 · #A78BFA', 'Violet brand foreground (text, icons, links). Lifts to #A78BFA in dark.'],
-  ['ADD', 'brand.primaryFill', '#6D28D9 · #7C3AED', 'Filled-surface brand. Brighter #7C3AED in dark so white text clears AA.'],
+  [
+    'ADD',
+    'brand.tint / primary',
+    '#6D28D9 · #A78BFA',
+    'Violet brand foreground (text, icons, links). Lifts to #A78BFA in dark.',
+  ],
+  [
+    'ADD',
+    'brand.primaryFill',
+    '#6D28D9 · #7C3AED',
+    'Filled-surface brand. Brighter #7C3AED in dark so white text clears AA.',
+  ],
   ['ADD', 'brand.accent', '#FF8A3D', 'Warm amber spark — fill-only, always pair with dark text.'],
-  ['VARIANT', 'Liquid Glass / Material 3', '—', 'One palette, two render variants. Resolved per device; users can override.'],
+  [
+    'VARIANT',
+    'Liquid Glass / Material 3',
+    '—',
+    'One palette, two render variants. Resolved per device; users can override.',
+  ],
   ['LEGACY', 'web rose/sage', '#8C4A52', 'packages/web still on the old palette — pending migration, not a peer.'],
   ['SHARED', 'grade colours', '—', 'Only @boardsesh/board-constants grade colours are shared web↔mobile.'],
 ];
 
 // ---------- sheet theme (rendered in the dark Velvet Send surface tokens) ----------
-const W = 1680, S = 2, P = 72, CW = W - 2 * P;
+const W = 1680,
+  S = 2,
+  P = 72,
+  CW = W - 2 * P;
 const C = {
   bg: surfaces.dark.background,
   panel: '#181225',
@@ -124,7 +195,9 @@ function text(x, baseline, str, { f = F.body, size = 15, weight = 400, fill = C.
   );
 }
 function rect(x, ry, w, h, r, { fill = 'none', stroke = 'none', sw = 1 } = {}) {
-  push(`<rect x="${x}" y="${ry}" width="${w}" height="${h}" rx="${r}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`);
+  push(
+    `<rect x="${x}" y="${ry}" width="${w}" height="${h}" rx="${r}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`,
+  );
 }
 
 // Naive word-wrap; returns array of lines that fit within maxW at the given size.
@@ -171,12 +244,19 @@ function swatch(x, yTop, w, hex, { name, sub, onSwatch, cardH = 116 } = {}) {
   rect(x, yTop, w, cardH, 12, { fill: hex, stroke: C.swatchBd, sw: 1 });
   if (onSwatch) {
     text(x + 14, yTop + cardH - 14, onSwatch.toUpperCase(), {
-      f: F.mono, size: 11, ls: 1.4, fill: isLight ? 'rgba(0,0,0,0.62)' : 'rgba(255,255,255,0.85)',
+      f: F.mono,
+      size: 11,
+      ls: 1.4,
+      fill: isLight ? 'rgba(0,0,0,0.62)' : 'rgba(255,255,255,0.85)',
     });
   }
   let cy = yTop + cardH + 22;
-  if (name) { text(x, cy, name, { f: F.mono, size: 13, fill: C.ink }); cy += 19; }
-  text(x, cy, hex.toUpperCase(), { f: F.mono, size: 12, fill: C.muted }); cy += 18;
+  if (name) {
+    text(x, cy, name, { f: F.mono, size: 13, fill: C.ink });
+    cy += 19;
+  }
+  text(x, cy, hex.toUpperCase(), { f: F.mono, size: 12, fill: C.muted });
+  cy += 18;
   let h = cardH + 22 + (name ? 19 : 0) + 18;
   if (sub) {
     const sh = paragraph(x, cy, sub, { size: 12, fill: C.faint, lh: 16, maxW: w });
@@ -194,11 +274,25 @@ function pairSwatch(x, yTop, w, lightHex, darkHex, { name, sub, cardH = 116 } = 
   push(`<rect x="${x + w / 2}" y="${yTop}" width="${w / 2}" height="${cardH}" fill="${darkHex}" />`);
   push('</g>');
   rect(x, yTop, w, cardH, 12, { fill: 'none', stroke: C.swatchBd, sw: 1 });
-  text(x + 12, yTop + cardH - 12, 'LIGHT', { f: F.mono, size: 10, ls: 1.2, fill: luminance(lightHex) > 0.6 ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.8)' });
-  text(x + w / 2 + 12, yTop + cardH - 12, 'DARK', { f: F.mono, size: 10, ls: 1.2, fill: luminance(darkHex) > 0.6 ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.8)' });
+  text(x + 12, yTop + cardH - 12, 'LIGHT', {
+    f: F.mono,
+    size: 10,
+    ls: 1.2,
+    fill: luminance(lightHex) > 0.6 ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.8)',
+  });
+  text(x + w / 2 + 12, yTop + cardH - 12, 'DARK', {
+    f: F.mono,
+    size: 10,
+    ls: 1.2,
+    fill: luminance(darkHex) > 0.6 ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.8)',
+  });
   let cy = yTop + cardH + 22;
-  if (name) { text(x, cy, name, { f: F.mono, size: 13, fill: C.ink }); cy += 19; }
-  text(x, cy, `${lightHex.toUpperCase()}  ·  ${darkHex.toUpperCase()}`, { f: F.mono, size: 12, fill: C.muted }); cy += 18;
+  if (name) {
+    text(x, cy, name, { f: F.mono, size: 13, fill: C.ink });
+    cy += 19;
+  }
+  text(x, cy, `${lightHex.toUpperCase()}  ·  ${darkHex.toUpperCase()}`, { f: F.mono, size: 12, fill: C.muted });
+  cy += 18;
   let h = cardH + 22 + (name ? 19 : 0) + 18;
   if (sub) h += paragraph(x, cy, sub, { size: 12, fill: C.faint, lh: 16, maxW: w });
   return h;
@@ -207,7 +301,9 @@ function pairSwatch(x, yTop, w, lightHex, darkHex, { name, sub, cardH = 116 } = 
 function luminance(hex) {
   if (typeof hex !== 'string' || hex[0] !== '#' || hex.length < 7) return 0.5; // rgba()/unknown → assume mid
   const n = parseInt(hex.slice(1, 7), 16);
-  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  const r = (n >> 16) & 255,
+    g = (n >> 8) & 255,
+    b = n & 255;
   return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
 }
 
@@ -220,7 +316,10 @@ function grid(items, render, { cols = 3, gap = 22, cardH = 116 }) {
   let rowH = 0;
   items.forEach((item, i) => {
     const col = i % cols;
-    if (col === 0 && i > 0) { y += rowH + 26; rowH = 0; }
+    if (col === 0 && i > 0) {
+      y += rowH + 26;
+      rowH = 0;
+    }
     const x = P + col * (cw + gap);
     const h = render(item, x, y, cw, cardH);
     rowH = Math.max(rowH, h);
@@ -233,11 +332,19 @@ function tile(x, yTop, size) {
   const id = `tile${clipId++}`;
   const gap = size * 0.022;
   const inner = (size - gap) / 2;
-  push(`<clipPath id="${id}"><rect x="${x}" y="${yTop}" width="${size}" height="${size}" rx="${size * 0.225}" /></clipPath>`);
+  push(
+    `<clipPath id="${id}"><rect x="${x}" y="${yTop}" width="${size}" height="${size}" rx="${size * 0.225}" /></clipPath>`,
+  );
   push(`<g clip-path="url(#${id})">`);
   push(`<rect x="${x}" y="${yTop}" width="${size}" height="${size}" fill="#000" />`);
-  const cells = [[0, 0, '#9C27B0'], [inner + gap, 0, '#7B1FA2'], [0, inner + gap, '#6A1B9A'], [inner + gap, inner + gap, '#4A148C']];
-  for (const [cx, cy, hex] of cells) push(`<rect x="${x + cx}" y="${yTop + cy}" width="${inner}" height="${inner}" fill="${hex}" />`);
+  const cells = [
+    [0, 0, '#9C27B0'],
+    [inner + gap, 0, '#7B1FA2'],
+    [0, inner + gap, '#6A1B9A'],
+    [inner + gap, inner + gap, '#4A148C'],
+  ];
+  for (const [cx, cy, hex] of cells)
+    push(`<rect x="${x + cx}" y="${yTop + cy}" width="${inner}" height="${inner}" fill="${hex}" />`);
   push('</g>');
 }
 
@@ -245,43 +352,74 @@ function tile(x, yTop, size) {
 // Header
 text(P, y + 14, 'VELVET SEND · DESIGN TOKENS · v1', { f: F.mono, size: 12, fill: C.faint, ls: 2.8 });
 text(P, y + 78, 'Color & token reference', { f: F.disp, size: 58, weight: 800, fill: C.ink, ls: -1.4 });
-paragraph(P, y + 124, 'The single visual reference for Velvet Send — the violet design language in packages/mobile, anchored on the logo’s V11–V16 grade purples. One palette renders through two platform variants: Liquid Glass on iOS 26, Material 3 everywhere else. Values mirror docs/ai-design-guidelines.md.', { size: 15.5, fill: C.muted, lh: 24, maxW: 1060 });
+paragraph(
+  P,
+  y + 124,
+  'The single visual reference for Velvet Send — the violet design language in packages/mobile, anchored on the logo’s V11–V16 grade purples. One palette renders through two platform variants: Liquid Glass on iOS 26, Material 3 everywhere else. Values mirror docs/ai-design-guidelines.md.',
+  { size: 15.5, fill: C.muted, lh: 24, maxW: 1060 },
+);
 tile(W - P - 200, y, 200);
 y += 234;
 push(`<rect x="${P}" y="${y}" width="${CW}" height="1" fill="rgba(180,168,205,0.22)" />`);
 y += 56;
 
 // 01 Brand colours
-sectionHead('01 — Brand colours', 'Violet identity, light + dark', 'Read brand colours from useTheme().brandColors — the provider resolves the right set per scheme. Foreground (tint/primary) and filled-surface (primaryFill) are different values in dark mode: the tint lifts to #A78BFA for legibility on near-black, while filled buttons use a brighter #7C3AED so white text still clears WCAG AA (5.70:1).');
+sectionHead(
+  '01 — Brand colours',
+  'Violet identity, light + dark',
+  'Read brand colours from useTheme().brandColors — the provider resolves the right set per scheme. Foreground (tint/primary) and filled-surface (primaryFill) are different values in dark mode: the tint lifts to #A78BFA for legibility on near-black, while filled buttons use a brighter #7C3AED so white text still clears WCAG AA (5.70:1).',
+);
 grid(
   [
-    { l: brand.light.tint, d: brand.dark.tint, name: 'tint / primary', sub: 'Brand foreground: text, icons, links, borders' },
+    {
+      l: brand.light.tint,
+      d: brand.dark.tint,
+      name: 'tint / primary',
+      sub: 'Brand foreground: text, icons, links, borders',
+    },
     { l: brand.light.fill, d: brand.dark.fill, name: 'primaryFill', sub: 'Filled surface / button background' },
     { single: '#FFFFFF', name: 'onPrimary', sub: 'Text + icon sitting on primaryFill' },
     { single: brand.light.accent, name: 'accent', sub: 'Amber spark — fill-only, pair with dark text', on: 'amber' },
   ],
-  (it, x, yy, w) => (it.single ? swatch(x, yy, w, it.single, { name: it.name, sub: it.sub, onSwatch: it.on }) : pairSwatch(x, yy, w, it.l, it.d, { name: it.name, sub: it.sub })),
+  (it, x, yy, w) =>
+    it.single
+      ? swatch(x, yy, w, it.single, { name: it.name, sub: it.sub, onSwatch: it.on })
+      : pairSwatch(x, yy, w, it.l, it.d, { name: it.name, sub: it.sub }),
   { cols: 4 },
 );
 rule();
 
 // 02 The mark
-sectionHead('02 — The mark', 'Four V-grade purples from the logo', 'The brand violet is drawn from the logo’s upper-grade purple cluster (V11–V16) — the project-zone grades a climber works toward. The product tint #6D28D9 sits in this family. The four-quadrant mark stays readable down to favicon scale.', { descMax: 900 });
+sectionHead(
+  '02 — The mark',
+  'Four V-grade purples from the logo',
+  'The brand violet is drawn from the logo’s upper-grade purple cluster (V11–V16) — the project-zone grades a climber works toward. The product tint #6D28D9 sits in this family. The four-quadrant mark stays readable down to favicon scale.',
+  { descMax: 900 },
+);
 tile(P, y, 240);
 {
   const gx = P + 240 + 44;
   const gw = CW - 240 - 44;
   const cw = (gw - 22) / 2;
   mark.forEach((m, i) => {
-    const col = i % 2, row = Math.floor(i / 2);
-    swatch(gx + col * (cw + 22), y + row * 150, cw, m.hex, { name: `grades.${m.v.toLowerCase()}`, sub: m.role, cardH: 96 });
+    const col = i % 2,
+      row = Math.floor(i / 2);
+    swatch(gx + col * (cw + 22), y + row * 150, cw, m.hex, {
+      name: `grades.${m.v.toLowerCase()}`,
+      sub: m.role,
+      cardH: 96,
+    });
   });
   y += 240;
 }
 rule();
 
 // 03 V-grade scale
-sectionHead('03 — V-grade scale', 'The shared climbing-grade ramp', 'Grade colours live in @boardsesh/board-constants (V_GRADE_COLORS) and are the only palette shared between web and mobile. A yellow→red→purple arc that ends on the logo’s V11–V16 purples (★) — the violet brand grows out of this top end.');
+sectionHead(
+  '03 — V-grade scale',
+  'The shared climbing-grade ramp',
+  'Grade colours live in @boardsesh/board-constants (V_GRADE_COLORS) and are the only palette shared between web and mobile. A yellow→red→purple arc that ends on the logo’s V11–V16 purples (★) — the violet brand grows out of this top end.',
+);
 {
   const n = grades.length;
   const gap = 6;
@@ -289,14 +427,22 @@ sectionHead('03 — V-grade scale', 'The shared climbing-grade ramp', 'Grade col
   grades.forEach(([v, hex], i) => {
     const x = P + i * (bw + gap);
     rect(x, y, bw, 96, 5, { fill: hex });
-    text(x + bw / 2, y + 96 - 11, v, { f: F.mono, size: 11, fill: luminance(hex) > 0.55 ? 'rgba(0,0,0,0.7)' : 'rgba(255,255,255,0.85)', anchor: 'middle' });
+    text(x + bw / 2, y + 96 - 11, v, {
+      f: F.mono,
+      size: 11,
+      fill: luminance(hex) > 0.55 ? 'rgba(0,0,0,0.7)' : 'rgba(255,255,255,0.85)',
+      anchor: 'middle',
+    });
   });
   y += 96 + 28;
-  const cols = 6, lgap = 18;
+  const cols = 6,
+    lgap = 18;
   const cw = (CW - (cols - 1) * lgap) / cols;
   grades.forEach(([v, hex, note], i) => {
-    const col = i % cols, row = Math.floor(i / cols);
-    const x = P + col * (cw + lgap), yy = y + row * 30;
+    const col = i % cols,
+      row = Math.floor(i / cols);
+    const x = P + col * (cw + lgap),
+      yy = y + row * 30;
     rect(x, yy - 11, 14, 14, 3, { fill: hex, stroke: C.swatchBd, sw: 1 });
     text(x + 24, yy, v, { f: F.mono, size: 12, fill: C.ink });
     text(x + 64, yy, hex.toUpperCase(), { f: F.mono, size: 11, fill: C.muted });
@@ -307,7 +453,11 @@ sectionHead('03 — V-grade scale', 'The shared climbing-grade ramp', 'Grade col
 rule();
 
 // 04 Semantic
-sectionHead('04 — Semantic colours', 'Status tones, light + dark', 'Success, warning and error brighten in dark mode so they stay legible on the near-black surface ladder. Same role keys across both schemes.');
+sectionHead(
+  '04 — Semantic colours',
+  'Status tones, light + dark',
+  'Success, warning and error brighten in dark mode so they stay legible on the near-black surface ladder. Same role keys across both schemes.',
+);
 grid(
   [
     { l: brand.light.success, d: brand.dark.success, name: 'success', sub: 'Logged climb, confirmation' },
@@ -320,23 +470,41 @@ grid(
 rule();
 
 // 04 System surfaces
-sectionHead('05 — System surfaces & labels', 'Backgrounds, text and chrome', 'Resolved by platform and variant via useTheme().systemColors. iOS Liquid Glass uses Apple PlatformColor (adapts natively); Android and Material use these explicit, violet-tinted hexes. Same keys in every case.');
+sectionHead(
+  '05 — System surfaces & labels',
+  'Backgrounds, text and chrome',
+  'Resolved by platform and variant via useTheme().systemColors. iOS Liquid Glass uses Apple PlatformColor (adapts natively); Android and Material use these explicit, violet-tinted hexes. Same keys in every case.',
+);
 const surfKeys = [
-  ['background', 'Screen base'], ['secondaryBackground', 'Cards, sheets'], ['elevatedSurface', 'Raised tile'],
-  ['label', 'Primary text'], ['secondaryLabel', 'Secondary text'], ['tertiaryLabel', 'Tertiary text'],
-  ['separator', 'Hairlines'], ['fill', 'Faint violet track'], ['accent', 'Links, active tab'],
+  ['background', 'Screen base'],
+  ['secondaryBackground', 'Cards, sheets'],
+  ['elevatedSurface', 'Raised tile'],
+  ['label', 'Primary text'],
+  ['secondaryLabel', 'Secondary text'],
+  ['tertiaryLabel', 'Tertiary text'],
+  ['separator', 'Hairlines'],
+  ['fill', 'Faint violet track'],
+  ['accent', 'Links, active tab'],
 ];
 text(P, y, 'LIGHT', { f: F.mono, size: 11, fill: C.faint, ls: 2 });
 y += 22;
-grid(surfKeys, ([k, sub], x, yy, w) => swatch(x, yy, w, hexish(surfaces.light[k]), { name: k, sub, cardH: 78 }), { cols: 3 });
+grid(surfKeys, ([k, sub], x, yy, w) => swatch(x, yy, w, hexish(surfaces.light[k]), { name: k, sub, cardH: 78 }), {
+  cols: 3,
+});
 y += 34;
 text(P, y, 'DARK', { f: F.mono, size: 11, fill: C.faint, ls: 2 });
 y += 22;
-grid(surfKeys, ([k, sub], x, yy, w) => swatch(x, yy, w, hexish(surfaces.dark[k]), { name: k, sub, cardH: 78 }), { cols: 3 });
+grid(surfKeys, ([k, sub], x, yy, w) => swatch(x, yy, w, hexish(surfaces.dark[k]), { name: k, sub, cardH: 78 }), {
+  cols: 3,
+});
 rule();
 
 // 05 Typography
-sectionHead('06 — Typography', 'Apple HIG (Liquid Glass) vs Material 3', 'Two scales, same keys, resolved per variant via theme.textStyles. System font only (San Francisco / Roboto). HIG keeps bold display weights for brand identity; M3 drops them to regular. Spec format: size / weight / line-height.');
+sectionHead(
+  '06 — Typography',
+  'Apple HIG (Liquid Glass) vs Material 3',
+  'Two scales, same keys, resolved per variant via theme.textStyles. System font only (San Francisco / Roboto). HIG keeps bold display weights for brand identity; M3 drops them to regular. Spec format: size / weight / line-height.',
+);
 {
   const colW = CW / 2 - 20;
   text(P, y, 'LIQUID GLASS · HIG', { f: F.mono, size: 11, fill: C.faint, ls: 1.8 });
@@ -356,7 +524,11 @@ sectionHead('06 — Typography', 'Apple HIG (Liquid Glass) vs Material 3', 'Two 
 rule();
 
 // 06 Spacing, radii, shadows
-sectionHead('07 — Spacing · radii · shadows', 'Geometry tokens', 'A 4pt spacing grid, six base radii (the button corner is the one value that differs by variant — 10dp Liquid Glass, 20dp Material), and a five-step shadow ladder carrying both iOS shadow and Android elevation.');
+sectionHead(
+  '07 — Spacing · radii · shadows',
+  'Geometry tokens',
+  'A 4pt spacing grid, six base radii (the button corner is the one value that differs by variant — 10dp Liquid Glass, 20dp Material), and a five-step shadow ladder carrying both iOS shadow and Android elevation.',
+);
 {
   // spacing bars
   text(P, y, 'SPACING', { f: F.mono, size: 11, fill: C.faint, ls: 2 });
@@ -372,8 +544,10 @@ sectionHead('07 — Spacing · radii · shadows', 'Geometry tokens', 'A 4pt spac
   const rx0 = P + CW / 2 + 20;
   text(rx0, y - 28, 'RADII', { f: F.mono, size: 11, fill: C.faint, ls: 2 });
   radiiScale.forEach(([k, r], i) => {
-    const col = i % 3, row = Math.floor(i / 3);
-    const bx = rx0 + col * 150, by = y + row * 140;
+    const col = i % 3,
+      row = Math.floor(i / 3);
+    const bx = rx0 + col * 150,
+      by = y + row * 140;
     const isPill = k === 'full';
     rect(bx, by, isPill ? 120 : 96, 96, isPill ? 48 : r, { fill: 'none', stroke: brand.dark.tint, sw: 2 });
     text(bx, by + 96 + 22, k === 'full' ? 'full (pill)' : `${k} · ${r}`, { f: F.mono, size: 12, fill: C.muted });
@@ -393,13 +567,39 @@ sectionHead('07 — Spacing · radii · shadows', 'Geometry tokens', 'A 4pt spac
 rule();
 
 // 07 Variants
-sectionHead('08 — The two variants', 'Liquid Glass and Material 3', 'Same palette and component APIs; the chrome follows the platform. A control is the same product in both, drawn the way that platform draws controls. Users on iOS 26 get Liquid Glass by default; everyone else gets Material 3, and either can be chosen explicitly.');
+sectionHead(
+  '08 — The two variants',
+  'Liquid Glass and Material 3',
+  'Same palette and component APIs; the chrome follows the platform. A control is the same product in both, drawn the way that platform draws controls. Users on iOS 26 get Liquid Glass by default; everyone else gets Material 3, and either can be chosen explicitly.',
+);
 {
   const pw = (CW - 28) / 2;
   const ph = 230;
   const panels = [
-    { title: 'Liquid Glass', sub: 'iOS 26 — Apple HIG', btnR: 10, lines: ['Button corner — 10dp', 'Sheet corners — soft (glass)', 'Tab bar — 49pt', 'Type — Apple HIG scale', 'Motion — reanimated springs'] },
-    { title: 'Material 3', sub: 'Android / older iOS / fallback', btnR: 20, lines: ['Button corner — 20dp', 'Sheet corners — 28dp', 'Nav bar — 80dp + indicator pill', 'Type — Material 3 scale', 'Feedback — ripple'] },
+    {
+      title: 'Liquid Glass',
+      sub: 'iOS 26 — Apple HIG',
+      btnR: 10,
+      lines: [
+        'Button corner — 10dp',
+        'Sheet corners — soft (glass)',
+        'Tab bar — 49pt',
+        'Type — Apple HIG scale',
+        'Motion — reanimated springs',
+      ],
+    },
+    {
+      title: 'Material 3',
+      sub: 'Android / older iOS / fallback',
+      btnR: 20,
+      lines: [
+        'Button corner — 20dp',
+        'Sheet corners — 28dp',
+        'Nav bar — 80dp + indicator pill',
+        'Type — Material 3 scale',
+        'Feedback — ripple',
+      ],
+    },
   ];
   panels.forEach((p, i) => {
     const x = P + i * (pw + 28);
@@ -416,7 +616,11 @@ sectionHead('08 — The two variants', 'Liquid Glass and Material 3', 'Same pale
 rule();
 
 // 08 Changelog / migration
-sectionHead('09 — What this establishes', 'Velvet Send vs the legacy web palette', 'Velvet Send replaces the old rose/sage web palette as the design language. Web hasn’t migrated yet — that palette is legacy, not a peer.');
+sectionHead(
+  '09 — What this establishes',
+  'Velvet Send vs the legacy web palette',
+  'Velvet Send replaces the old rose/sage web palette as the design language. Web hasn’t migrated yet — that palette is legacy, not a peer.',
+);
 {
   const kindColor = { CANON: '#A78BFA', ADD: '#34D399', VARIANT: '#60A5FA', LEGACY: '#FBBF24', SHARED: '#A9A2B6' };
   const cols = [P + 0, P + 130, P + 430, P + 720];
@@ -443,7 +647,12 @@ y += 30;
 push(`<rect x="${P}" y="${y}" width="${CW}" height="1" fill="rgba(180,168,205,0.1)" />`);
 y += 30;
 text(P, y, 'Boardsesh · Velvet Send · design tokens · v1', { f: F.mono, size: 11, fill: C.faint });
-text(W - P, y, 'Source: docs/ai-design-guidelines.md · packages/mobile/src/theme', { f: F.mono, size: 11, fill: C.faint, anchor: 'end' });
+text(W - P, y, 'Source: docs/ai-design-guidelines.md · packages/mobile/src/theme', {
+  f: F.mono,
+  size: 11,
+  fill: C.faint,
+  anchor: 'end',
+});
 y += 56;
 
 // ---------- assemble + rasterise ----------

--- a/design/velvet-send-design-tokens.jsx
+++ b/design/velvet-send-design-tokens.jsx
@@ -17,97 +17,197 @@
   const TOK = {
     // Brand — light + dark. tint/primary = foreground; primaryFill = filled surface.
     brand: {
-      tint:        { l: "#6D28D9", d: "#A78BFA", name: "brand.tint / primary", use: "Foreground: text, icons, links, borders" },
-      primaryFill: { l: "#6D28D9", d: "#7C3AED", name: "brand.primaryFill",    use: "Filled surface / button background" },
-      onPrimary:   { hex: "#FFFFFF",             name: "brand.onPrimary",      use: "Text + icon on primaryFill" },
-      accent:      { hex: "#FF8A3D",             name: "brand.accent",         use: "Amber spark — fill-only, pair with dark text" },
+      tint: {
+        l: '#6D28D9',
+        d: '#A78BFA',
+        name: 'brand.tint / primary',
+        use: 'Foreground: text, icons, links, borders',
+      },
+      primaryFill: { l: '#6D28D9', d: '#7C3AED', name: 'brand.primaryFill', use: 'Filled surface / button background' },
+      onPrimary: { hex: '#FFFFFF', name: 'brand.onPrimary', use: 'Text + icon on primaryFill' },
+      accent: { hex: '#FF8A3D', name: 'brand.accent', use: 'Amber spark — fill-only, pair with dark text' },
     },
     // Semantic — light + dark.
     semantic: {
-      success: { l: "#047857", d: "#34D399", name: "success", use: "Logged climb, confirmation" },
-      warning: { l: "#B45309", d: "#FBBF24", name: "warning", use: "Caution, non-blocking warnings" },
-      error:   { l: "#C81E1E", d: "#F87171", name: "error",   use: "Destructive, validation errors" },
+      success: { l: '#047857', d: '#34D399', name: 'success', use: 'Logged climb, confirmation' },
+      warning: { l: '#B45309', d: '#FBBF24', name: 'warning', use: 'Caution, non-blocking warnings' },
+      error: { l: '#C81E1E', d: '#F87171', name: 'error', use: 'Destructive, validation errors' },
     },
     // System surfaces & labels — Android-fallback / Material-tonal hexes (iOS uses
     // PlatformColor for the same roles). Read via useTheme().systemColors.
     surfaces: {
       light: {
-        background: "#F4F1FB", secondaryBackground: "#FFFFFF", elevatedSurface: "#FFFFFF",
-        label: "#16111F", secondaryLabel: "#5B5563", tertiaryLabel: "#8E8898",
-        separator: "rgba(60,55,75,0.18)", fill: "rgba(109,40,217,0.10)", accent: "#6D28D9",
+        background: '#F4F1FB',
+        secondaryBackground: '#FFFFFF',
+        elevatedSurface: '#FFFFFF',
+        label: '#16111F',
+        secondaryLabel: '#5B5563',
+        tertiaryLabel: '#8E8898',
+        separator: 'rgba(60,55,75,0.18)',
+        fill: 'rgba(109,40,217,0.10)',
+        accent: '#6D28D9',
       },
       dark: {
-        background: "#0F0B16", secondaryBackground: "#181225", elevatedSurface: "#221A32",
-        label: "#F5F2FB", secondaryLabel: "#A9A2B6", tertiaryLabel: "#6E687C",
-        separator: "rgba(180,168,205,0.20)", fill: "rgba(199,184,232,0.12)", accent: "#A78BFA",
+        background: '#0F0B16',
+        secondaryBackground: '#181225',
+        elevatedSurface: '#221A32',
+        label: '#F5F2FB',
+        secondaryLabel: '#A9A2B6',
+        tertiaryLabel: '#6E687C',
+        separator: 'rgba(180,168,205,0.20)',
+        fill: 'rgba(199,184,232,0.12)',
+        accent: '#A78BFA',
       },
     },
     surfaceMeta: {
-      background: "Screen base", secondaryBackground: "Cards, sheets", elevatedSurface: "Raised tile",
-      label: "Primary text", secondaryLabel: "Secondary text", tertiaryLabel: "Tertiary text",
-      separator: "Hairlines", fill: "Faint violet track", accent: "Links, active tab",
+      background: 'Screen base',
+      secondaryBackground: 'Cards, sheets',
+      elevatedSurface: 'Raised tile',
+      label: 'Primary text',
+      secondaryLabel: 'Secondary text',
+      tertiaryLabel: 'Tertiary text',
+      separator: 'Hairlines',
+      fill: 'Faint violet track',
+      accent: 'Links, active tab',
     },
     // Logo mark — four V-grade purples (V11–V16 family).
     mark: [
-      { hex: "#9C27B0", name: "grades.v11", role: "top-left — brightest" },
-      { hex: "#7B1FA2", name: "grades.v12", role: "top-right" },
-      { hex: "#6A1B9A", name: "grades.v13", role: "bottom-left" },
-      { hex: "#4A148C", name: "grades.v15", role: "bottom-right — deepest" },
+      { hex: '#9C27B0', name: 'grades.v11', role: 'top-left — brightest' },
+      { hex: '#7B1FA2', name: 'grades.v12', role: 'top-right' },
+      { hex: '#6A1B9A', name: 'grades.v13', role: 'bottom-left' },
+      { hex: '#4A148C', name: 'grades.v15', role: 'bottom-right — deepest' },
     ],
     // Canonical V-grade ramp — packages/board-constants/src/grade-colors.ts. ★ = logo range.
     grades: [
-      ["V0", "#FFD400", "golden yellow"], ["V1", "#FFB300", "amber"], ["V2", "#FF9100", "orange"],
-      ["V3", "#FF6D2E", "deep orange"], ["V4", "#FF5026", "red-orange"], ["V5", "#F03E3E", "red"],
-      ["V6", "#E22A2A", "red"], ["V7", "#CF1F3C", "crimson"], ["V8", "#B81A5A", "raspberry"],
-      ["V9", "#9E1A78", "magenta"], ["V10", "#7E1C8E", "grape · bridge"], ["V11", "#9C27B0", "★ logo"],
-      ["V12", "#7B1FA2", "★ logo"], ["V13", "#6A1B9A", "★ logo"], ["V14", "#5C1A87", "logo"],
-      ["V15", "#4A148C", "★ logo"], ["V16", "#38006B", "logo"], ["V17", "#2A0054", "darkest"],
+      ['V0', '#FFD400', 'golden yellow'],
+      ['V1', '#FFB300', 'amber'],
+      ['V2', '#FF9100', 'orange'],
+      ['V3', '#FF6D2E', 'deep orange'],
+      ['V4', '#FF5026', 'red-orange'],
+      ['V5', '#F03E3E', 'red'],
+      ['V6', '#E22A2A', 'red'],
+      ['V7', '#CF1F3C', 'crimson'],
+      ['V8', '#B81A5A', 'raspberry'],
+      ['V9', '#9E1A78', 'magenta'],
+      ['V10', '#7E1C8E', 'grape · bridge'],
+      ['V11', '#9C27B0', '★ logo'],
+      ['V12', '#7B1FA2', '★ logo'],
+      ['V13', '#6A1B9A', '★ logo'],
+      ['V14', '#5C1A87', 'logo'],
+      ['V15', '#4A148C', '★ logo'],
+      ['V16', '#38006B', 'logo'],
+      ['V17', '#2A0054', 'darkest'],
     ],
     // Typography — [key, HIG size/wt/lh, M3 size/wt/lh].
     type: [
-      ["largeTitle", 34, 700, 41, 28, 400, 36], ["title1", 28, 700, 34, 24, 400, 32],
-      ["title2", 22, 700, 28, 22, 400, 28], ["title3", 20, 600, 25, 22, 500, 28],
-      ["headline", 17, 600, 22, 16, 500, 24], ["body", 17, 400, 22, 16, 400, 24],
-      ["callout", 16, 400, 21, 16, 400, 24], ["subheadline", 15, 400, 20, 14, 400, 20],
-      ["footnote", 13, 400, 18, 12, 400, 16], ["caption1", 12, 400, 16, 11, 500, 16],
-      ["caption2", 11, 400, 13, 11, 500, 16],
+      ['largeTitle', 34, 700, 41, 28, 400, 36],
+      ['title1', 28, 700, 34, 24, 400, 32],
+      ['title2', 22, 700, 28, 22, 400, 28],
+      ['title3', 20, 600, 25, 22, 500, 28],
+      ['headline', 17, 600, 22, 16, 500, 24],
+      ['body', 17, 400, 22, 16, 400, 24],
+      ['callout', 16, 400, 21, 16, 400, 24],
+      ['subheadline', 15, 400, 20, 14, 400, 20],
+      ['footnote', 13, 400, 18, 12, 400, 16],
+      ['caption1', 12, 400, 16, 11, 500, 16],
+      ['caption2', 11, 400, 13, 11, 500, 16],
     ],
-    spacing: [["0", 0], ["1", 4], ["2", 8], ["3", 12], ["4", 16], ["5", 20], ["6", 24], ["8", 32], ["10", 40], ["12", 48], ["16", 64]],
-    radii: [["none", 0], ["sm", 4], ["md", 8], ["lg", 12], ["xl", 16], ["full", 9999]],
-    shadows: [["xs", "iOS y1 · opacity 0.05", "elevation 1"], ["sm", "iOS y1 · opacity 0.1", "elevation 2"], ["md", "iOS y4 · opacity 0.1", "elevation 4"], ["lg", "iOS y10 · opacity 0.1", "elevation 8"], ["xl", "iOS y20 · opacity 0.1", "elevation 12"]],
+    spacing: [
+      ['0', 0],
+      ['1', 4],
+      ['2', 8],
+      ['3', 12],
+      ['4', 16],
+      ['5', 20],
+      ['6', 24],
+      ['8', 32],
+      ['10', 40],
+      ['12', 48],
+      ['16', 64],
+    ],
+    radii: [
+      ['none', 0],
+      ['sm', 4],
+      ['md', 8],
+      ['lg', 12],
+      ['xl', 16],
+      ['full', 9999],
+    ],
+    shadows: [
+      ['xs', 'iOS y1 · opacity 0.05', 'elevation 1'],
+      ['sm', 'iOS y1 · opacity 0.1', 'elevation 2'],
+      ['md', 'iOS y4 · opacity 0.1', 'elevation 4'],
+      ['lg', 'iOS y10 · opacity 0.1', 'elevation 8'],
+      ['xl', 'iOS y20 · opacity 0.1', 'elevation 12'],
+    ],
   };
 
   // Sheet theme — drawn in the dark Velvet Send surface tokens.
-  const SHEET = { bg: "#0F0B16", ink: "#F5F2FB", muted: "#A9A2B6", faint: "#6E687C", panel: "rgba(255,255,255,0.015)", border: "rgba(180,168,205,0.14)", swatchBd: "rgba(180,168,205,0.16)", rule: "rgba(180,168,205,0.16)" };
+  const SHEET = {
+    bg: '#0F0B16',
+    ink: '#F5F2FB',
+    muted: '#A9A2B6',
+    faint: '#6E687C',
+    panel: 'rgba(255,255,255,0.015)',
+    border: 'rgba(180,168,205,0.14)',
+    swatchBd: 'rgba(180,168,205,0.16)',
+    rule: 'rgba(180,168,205,0.16)',
+  };
   const FONT_DISPLAY = "-apple-system, 'Helvetica Neue', Helvetica, Arial, sans-serif";
   const FONT_MONO = "Menlo, 'SF Mono', 'JetBrains Mono', monospace";
 
   const lum = (hex) => {
-    if (typeof hex !== "string" || hex[0] !== "#" || hex.length < 7) return 0.5;
+    if (typeof hex !== 'string' || hex[0] !== '#' || hex.length < 7) return 0.5;
     const n = parseInt(hex.slice(1, 7), 16);
     return (0.2126 * ((n >> 16) & 255) + 0.7152 * ((n >> 8) & 255) + 0.0722 * (n & 255)) / 255;
   };
-  const onColor = (hex) => (lum(hex) > 0.6 ? "rgba(0,0,0,0.62)" : "rgba(255,255,255,0.85)");
+  const onColor = (hex) => (lum(hex) > 0.6 ? 'rgba(0,0,0,0.62)' : 'rgba(255,255,255,0.85)');
 
   // ---------- atoms ----------
   const Mono = ({ children, c = SHEET.muted, s = 12, ls = 0.2 }) => (
     <span style={{ fontFamily: FONT_MONO, fontSize: s, color: c, letterSpacing: ls }}>{children}</span>
   );
   const Caps = ({ children, c = SHEET.faint, s = 12, mb = 0 }) => (
-    <div style={{ fontFamily: FONT_MONO, fontSize: s, color: c, letterSpacing: 2.6, textTransform: "uppercase", marginBottom: mb }}>{children}</div>
+    <div
+      style={{
+        fontFamily: FONT_MONO,
+        fontSize: s,
+        color: c,
+        letterSpacing: 2.6,
+        textTransform: 'uppercase',
+        marginBottom: mb,
+      }}
+    >
+      {children}
+    </div>
   );
   const H = ({ children, s = 30, mb = 8 }) => (
-    <div style={{ fontFamily: FONT_DISPLAY, fontWeight: 800, fontSize: s, color: SHEET.ink, letterSpacing: -0.5, marginBottom: mb }}>{children}</div>
+    <div
+      style={{
+        fontFamily: FONT_DISPLAY,
+        fontWeight: 800,
+        fontSize: s,
+        color: SHEET.ink,
+        letterSpacing: -0.5,
+        marginBottom: mb,
+      }}
+    >
+      {children}
+    </div>
   );
   const P = ({ children, c = SHEET.muted, s = 14.5, mb = 0, max }) => (
-    <div style={{ fontFamily: FONT_DISPLAY, fontSize: s, color: c, lineHeight: 1.55, marginBottom: mb, maxWidth: max }}>{children}</div>
+    <div style={{ fontFamily: FONT_DISPLAY, fontSize: s, color: c, lineHeight: 1.55, marginBottom: mb, maxWidth: max }}>
+      {children}
+    </div>
   );
   const Rule = ({ my = 40 }) => <div style={{ height: 1, background: SHEET.rule, margin: `${my}px 0` }} />;
   const Section = ({ eyebrow, title, desc, descMax = 980, children }) => (
     <div>
       <Caps mb={14}>{eyebrow}</Caps>
       <H>{title}</H>
-      <P max={descMax} mb={28}>{desc}</P>
+      <P max={descMax} mb={28}>
+        {desc}
+      </P>
       {children}
     </div>
   );
@@ -115,18 +215,50 @@
   // ---------- swatch primitives ----------
   function Caption({ name, hex, sub }) {
     return (
-      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 3 }}>
-        {name && <Mono c={SHEET.ink} s={13}>{name}</Mono>}
-        <Mono c={SHEET.muted} s={12}>{hex}</Mono>
-        {sub && <P c={SHEET.faint} s={12}>{sub}</P>}
+      <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {name && (
+          <Mono c={SHEET.ink} s={13}>
+            {name}
+          </Mono>
+        )}
+        <Mono c={SHEET.muted} s={12}>
+          {hex}
+        </Mono>
+        {sub && (
+          <P c={SHEET.faint} s={12}>
+            {sub}
+          </P>
+        )}
       </div>
     );
   }
   function Swatch({ hex, name, sub, onSwatch, h = 116 }) {
     return (
       <div>
-        <div style={{ background: hex, height: h, borderRadius: 12, border: `1px solid ${SHEET.swatchBd}`, display: "flex", alignItems: "flex-end", padding: 14 }}>
-          {onSwatch && <span style={{ fontFamily: FONT_MONO, fontSize: 11, letterSpacing: 1.4, textTransform: "uppercase", color: onColor(hex) }}>{onSwatch}</span>}
+        <div
+          style={{
+            background: hex,
+            height: h,
+            borderRadius: 12,
+            border: `1px solid ${SHEET.swatchBd}`,
+            display: 'flex',
+            alignItems: 'flex-end',
+            padding: 14,
+          }}
+        >
+          {onSwatch && (
+            <span
+              style={{
+                fontFamily: FONT_MONO,
+                fontSize: 11,
+                letterSpacing: 1.4,
+                textTransform: 'uppercase',
+                color: onColor(hex),
+              }}
+            >
+              {onSwatch}
+            </span>
+          )}
         </div>
         <Caption name={name} hex={hex.toUpperCase()} sub={sub} />
       </div>
@@ -135,10 +267,23 @@
   function PairSwatch({ l, d, name, sub, h = 116 }) {
     return (
       <div>
-        <div style={{ height: h, borderRadius: 12, border: `1px solid ${SHEET.swatchBd}`, overflow: "hidden", display: "flex" }}>
-          {[["LIGHT", l], ["DARK", d]].map(([tag, hex]) => (
-            <div key={tag} style={{ flex: 1, background: hex, display: "flex", alignItems: "flex-end", padding: 12 }}>
-              <span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: 1.2, color: onColor(hex) }}>{tag}</span>
+        <div
+          style={{
+            height: h,
+            borderRadius: 12,
+            border: `1px solid ${SHEET.swatchBd}`,
+            overflow: 'hidden',
+            display: 'flex',
+          }}
+        >
+          {[
+            ['LIGHT', l],
+            ['DARK', d],
+          ].map(([tag, hex]) => (
+            <div key={tag} style={{ flex: 1, background: hex, display: 'flex', alignItems: 'flex-end', padding: 12 }}>
+              <span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: 1.2, color: onColor(hex) }}>
+                {tag}
+              </span>
             </div>
           ))}
         </div>
@@ -150,11 +295,36 @@
   // The four-phone mark.
   function TileMini({ size = 240, gap = 0.022 }) {
     const inner = (1 - gap) / 2;
-    const cells = [[0, 0, "#9C27B0"], [inner + gap, 0, "#7B1FA2"], [0, inner + gap, "#6A1B9A"], [inner + gap, inner + gap, "#4A148C"]];
+    const cells = [
+      [0, 0, '#9C27B0'],
+      [inner + gap, 0, '#7B1FA2'],
+      [0, inner + gap, '#6A1B9A'],
+      [inner + gap, inner + gap, '#4A148C'],
+    ];
     return (
-      <div style={{ width: size, height: size, position: "relative", borderRadius: size * 0.225, overflow: "hidden", background: "#000", boxShadow: "0 8px 30px rgba(0,0,0,0.5)" }}>
+      <div
+        style={{
+          width: size,
+          height: size,
+          position: 'relative',
+          borderRadius: size * 0.225,
+          overflow: 'hidden',
+          background: '#000',
+          boxShadow: '0 8px 30px rgba(0,0,0,0.5)',
+        }}
+      >
         {cells.map(([x, y, c], i) => (
-          <div key={i} style={{ position: "absolute", left: `${x * 100}%`, top: `${y * 100}%`, width: `${inner * 100}%`, height: `${inner * 100}%`, background: c }} />
+          <div
+            key={i}
+            style={{
+              position: 'absolute',
+              left: `${x * 100}%`,
+              top: `${y * 100}%`,
+              width: `${inner * 100}%`,
+              height: `${inner * 100}%`,
+              background: c,
+            }}
+          />
         ))}
       </div>
     );
@@ -162,21 +332,63 @@
 
   // ---------- sections ----------
   const HeaderBlock = () => (
-    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 40, paddingBottom: 36, borderBottom: "1px solid rgba(180,168,205,0.22)" }}>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        gap: 40,
+        paddingBottom: 36,
+        borderBottom: '1px solid rgba(180,168,205,0.22)',
+      }}
+    >
       <div>
         <Caps mb={16}>Velvet Send · design tokens · v1</Caps>
-        <div style={{ fontFamily: FONT_DISPLAY, fontWeight: 800, fontSize: 58, color: SHEET.ink, letterSpacing: -1.4, lineHeight: 1, marginBottom: 18 }}>Color &amp; token reference</div>
-        <P max={1060} s={15.5}>The single visual reference for Velvet Send — the violet design language in <Mono c={SHEET.ink}>packages/mobile</Mono>, anchored on the logo's V11–V16 grade purples. One palette renders through two platform variants: Liquid Glass on iOS 26, Material 3 everywhere else. Values mirror <Mono c={SHEET.ink}>docs/ai-design-guidelines.md</Mono>.</P>
+        <div
+          style={{
+            fontFamily: FONT_DISPLAY,
+            fontWeight: 800,
+            fontSize: 58,
+            color: SHEET.ink,
+            letterSpacing: -1.4,
+            lineHeight: 1,
+            marginBottom: 18,
+          }}
+        >
+          Color &amp; token reference
+        </div>
+        <P max={1060} s={15.5}>
+          The single visual reference for Velvet Send — the violet design language in{' '}
+          <Mono c={SHEET.ink}>packages/mobile</Mono>, anchored on the logo's V11–V16 grade purples. One palette renders
+          through two platform variants: Liquid Glass on iOS 26, Material 3 everywhere else. Values mirror{' '}
+          <Mono c={SHEET.ink}>docs/ai-design-guidelines.md</Mono>.
+        </P>
       </div>
       <TileMini size={200} />
     </div>
   );
 
   const BrandSection = () => (
-    <Section eyebrow="01 — Brand colours" title="Violet identity, light + dark" desc={<>Read brand colours from <Mono c={SHEET.ink}>useTheme().brandColors</Mono> — the provider resolves the right set per scheme. Foreground (tint/primary) and filled-surface (primaryFill) differ in dark mode: the tint lifts to #A78BFA for legibility on near-black, while filled buttons use a brighter #7C3AED so white text still clears WCAG AA (5.70:1).</>}>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 22 }}>
+    <Section
+      eyebrow="01 — Brand colours"
+      title="Violet identity, light + dark"
+      desc={
+        <>
+          Read brand colours from <Mono c={SHEET.ink}>useTheme().brandColors</Mono> — the provider resolves the right
+          set per scheme. Foreground (tint/primary) and filled-surface (primaryFill) differ in dark mode: the tint lifts
+          to #A78BFA for legibility on near-black, while filled buttons use a brighter #7C3AED so white text still
+          clears WCAG AA (5.70:1).
+        </>
+      }
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 22 }}>
         <PairSwatch l={TOK.brand.tint.l} d={TOK.brand.tint.d} name={TOK.brand.tint.name} sub={TOK.brand.tint.use} />
-        <PairSwatch l={TOK.brand.primaryFill.l} d={TOK.brand.primaryFill.d} name={TOK.brand.primaryFill.name} sub={TOK.brand.primaryFill.use} />
+        <PairSwatch
+          l={TOK.brand.primaryFill.l}
+          d={TOK.brand.primaryFill.d}
+          name={TOK.brand.primaryFill.name}
+          sub={TOK.brand.primaryFill.use}
+        />
         <Swatch hex={TOK.brand.onPrimary.hex} name={TOK.brand.onPrimary.name} sub={TOK.brand.onPrimary.use} />
         <Swatch hex={TOK.brand.accent.hex} name={TOK.brand.accent.name} sub={TOK.brand.accent.use} onSwatch="amber" />
       </div>
@@ -184,32 +396,68 @@
   );
 
   const MarkSection = () => (
-    <Section eyebrow="02 — The mark" title="Four V-grade purples from the logo" descMax={900} desc="The brand violet is drawn from the logo's upper-grade purple cluster (V11–V16) — the project-zone grades a climber works toward. The product tint #6D28D9 sits in this family. The four-quadrant mark stays readable down to favicon scale.">
-      <div style={{ display: "flex", gap: 44, alignItems: "flex-start" }}>
+    <Section
+      eyebrow="02 — The mark"
+      title="Four V-grade purples from the logo"
+      descMax={900}
+      desc="The brand violet is drawn from the logo's upper-grade purple cluster (V11–V16) — the project-zone grades a climber works toward. The product tint #6D28D9 sits in this family. The four-quadrant mark stays readable down to favicon scale."
+    >
+      <div style={{ display: 'flex', gap: 44, alignItems: 'flex-start' }}>
         <TileMini size={240} />
-        <div style={{ flex: 1, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 22 }}>
-          {TOK.mark.map((m, i) => <Swatch key={i} hex={m.hex} name={m.name} sub={m.role} h={96} />)}
+        <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 22 }}>
+          {TOK.mark.map((m, i) => (
+            <Swatch key={i} hex={m.hex} name={m.name} sub={m.role} h={96} />
+          ))}
         </div>
       </div>
     </Section>
   );
 
   const GradeSection = () => (
-    <Section eyebrow="03 — V-grade scale" title="The shared climbing-grade ramp" desc={<>Grade colours live in <Mono c={SHEET.ink}>@boardsesh/board-constants</Mono> (V_GRADE_COLORS) and are the only palette shared between web and mobile. A yellow→red→purple arc that ends on the logo's V11–V16 purples (★) — the violet brand grows out of this top end.</>}>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(18, 1fr)", gap: 6, marginBottom: 24 }}>
+    <Section
+      eyebrow="03 — V-grade scale"
+      title="The shared climbing-grade ramp"
+      desc={
+        <>
+          Grade colours live in <Mono c={SHEET.ink}>@boardsesh/board-constants</Mono> (V_GRADE_COLORS) and are the only
+          palette shared between web and mobile. A yellow→red→purple arc that ends on the logo's V11–V16 purples (★) —
+          the violet brand grows out of this top end.
+        </>
+      }
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(18, 1fr)', gap: 6, marginBottom: 24 }}>
         {TOK.grades.map(([v, hex], i) => (
-          <div key={i} style={{ background: hex, height: 96, borderRadius: 5, display: "flex", alignItems: "flex-end", justifyContent: "center", paddingBottom: 6 }}>
+          <div
+            key={i}
+            style={{
+              background: hex,
+              height: 96,
+              borderRadius: 5,
+              display: 'flex',
+              alignItems: 'flex-end',
+              justifyContent: 'center',
+              paddingBottom: 6,
+            }}
+          >
             <span style={{ fontFamily: FONT_MONO, fontSize: 11, color: onColor(hex) }}>{v}</span>
           </div>
         ))}
       </div>
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 18 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 18 }}>
         {TOK.grades.map(([v, hex, note], i) => (
-          <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <div style={{ width: 14, height: 14, background: hex, borderRadius: 3, border: `1px solid ${SHEET.swatchBd}` }} />
-            <Mono c={SHEET.ink} s={12}>{v}</Mono>
-            <Mono c={SHEET.muted} s={11}>{hex.toUpperCase()}</Mono>
-            <Mono c={SHEET.faint} s={10}>{note}</Mono>
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div
+              style={{ width: 14, height: 14, background: hex, borderRadius: 3, border: `1px solid ${SHEET.swatchBd}` }}
+            />
+            <Mono c={SHEET.ink} s={12}>
+              {v}
+            </Mono>
+            <Mono c={SHEET.muted} s={11}>
+              {hex.toUpperCase()}
+            </Mono>
+            <Mono c={SHEET.faint} s={10}>
+              {note}
+            </Mono>
           </div>
         ))}
       </div>
@@ -217,20 +465,38 @@
   );
 
   const SemanticSection = () => (
-    <Section eyebrow="04 — Semantic colours" title="Status tones, light + dark" desc="Success, warning and error brighten in dark mode so they stay legible on the near-black surface ladder. Same role keys across both schemes.">
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 22 }}>
-        {Object.values(TOK.semantic).map((t, i) => <PairSwatch key={i} l={t.l} d={t.d} name={t.name} sub={t.use} />)}
+    <Section
+      eyebrow="04 — Semantic colours"
+      title="Status tones, light + dark"
+      desc="Success, warning and error brighten in dark mode so they stay legible on the near-black surface ladder. Same role keys across both schemes."
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 22 }}>
+        {Object.values(TOK.semantic).map((t, i) => (
+          <PairSwatch key={i} l={t.l} d={t.d} name={t.name} sub={t.use} />
+        ))}
       </div>
     </Section>
   );
 
   const SurfaceGrid = ({ scheme }) => (
-    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 22 }}>
-      {Object.entries(TOK.surfaces[scheme]).map(([k, hex]) => <Swatch key={k} hex={hex} name={k} sub={TOK.surfaceMeta[k]} h={78} />)}
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 22 }}>
+      {Object.entries(TOK.surfaces[scheme]).map(([k, hex]) => (
+        <Swatch key={k} hex={hex} name={k} sub={TOK.surfaceMeta[k]} h={78} />
+      ))}
     </div>
   );
   const SurfacesSection = () => (
-    <Section eyebrow="05 — System surfaces & labels" title="Backgrounds, text and chrome" desc={<>Resolved by platform and variant via <Mono c={SHEET.ink}>useTheme().systemColors</Mono>. iOS Liquid Glass uses Apple PlatformColor (adapts natively); Android and Material use these explicit, violet-tinted hexes. Same keys in every case.</>}>
+    <Section
+      eyebrow="05 — System surfaces & labels"
+      title="Backgrounds, text and chrome"
+      desc={
+        <>
+          Resolved by platform and variant via <Mono c={SHEET.ink}>useTheme().systemColors</Mono>. iOS Liquid Glass uses
+          Apple PlatformColor (adapts natively); Android and Material use these explicit, violet-tinted hexes. Same keys
+          in every case.
+        </>
+      }
+    >
       <Caps mb={18}>Light</Caps>
       <SurfaceGrid scheme="light" />
       <div style={{ height: 34 }} />
@@ -240,14 +506,46 @@
   );
 
   const TypeSection = () => (
-    <Section eyebrow="06 — Typography" title="Apple HIG (Liquid Glass) vs Material 3" desc={<>Two scales, same keys, resolved per variant via <Mono c={SHEET.ink}>theme.textStyles</Mono>. System font only (San Francisco / Roboto). HIG keeps bold display weights for brand identity; M3 drops them to regular. Spec: size / weight / line-height.</>}>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 40 }}>
-        {[["Liquid Glass · HIG", 1, 2, 3], ["Material 3", 4, 5, 6]].map(([label, si, wi, li]) => (
+    <Section
+      eyebrow="06 — Typography"
+      title="Apple HIG (Liquid Glass) vs Material 3"
+      desc={
+        <>
+          Two scales, same keys, resolved per variant via <Mono c={SHEET.ink}>theme.textStyles</Mono>. System font only
+          (San Francisco / Roboto). HIG keeps bold display weights for brand identity; M3 drops them to regular. Spec:
+          size / weight / line-height.
+        </>
+      }
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40 }}>
+        {[
+          ['Liquid Glass · HIG', 1, 2, 3],
+          ['Material 3', 4, 5, 6],
+        ].map(([label, si, wi, li]) => (
           <div key={label}>
             <Caps mb={18}>{label}</Caps>
             {TOK.type.map((row) => (
-              <div key={row[0]} style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", padding: "8px 0", borderBottom: "1px solid rgba(180,168,205,0.07)" }}>
-                <span style={{ fontFamily: FONT_DISPLAY, fontWeight: row[wi], fontSize: Math.min(row[si], 30), color: SHEET.ink, letterSpacing: -0.3 }}>{row[0]}</span>
+              <div
+                key={row[0]}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  justifyContent: 'space-between',
+                  padding: '8px 0',
+                  borderBottom: '1px solid rgba(180,168,205,0.07)',
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: FONT_DISPLAY,
+                    fontWeight: row[wi],
+                    fontSize: Math.min(row[si], 30),
+                    color: SHEET.ink,
+                    letterSpacing: -0.3,
+                  }}
+                >
+                  {row[0]}
+                </span>
                 <Mono c={SHEET.faint} s={12}>{`${row[si]}/${row[wi]}/${row[li]}`}</Mono>
               </div>
             ))}
@@ -258,12 +556,16 @@
   );
 
   const GeometrySection = () => (
-    <Section eyebrow="07 — Spacing · radii · shadows" title="Geometry tokens" desc="A 4pt spacing grid, six base radii (the button corner is the one value that differs by variant — 10dp Liquid Glass, 20dp Material), and a five-step shadow ladder carrying both iOS shadow and Android elevation.">
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 40 }}>
+    <Section
+      eyebrow="07 — Spacing · radii · shadows"
+      title="Geometry tokens"
+      desc="A 4pt spacing grid, six base radii (the button corner is the one value that differs by variant — 10dp Liquid Glass, 20dp Material), and a five-step shadow ladder carrying both iOS shadow and Android elevation."
+    >
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40 }}>
         <div>
           <Caps mb={18}>Spacing</Caps>
           {TOK.spacing.map(([k, v]) => (
-            <div key={k} style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 12 }}>
+            <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 12 }}>
               <div style={{ width: Math.max(v, 2), height: 14, background: TOK.brand.tint.d, borderRadius: 2 }} />
               <Mono c={SHEET.ink} s={12}>{`spacing.${k}`}</Mono>
               <Mono c={SHEET.muted} s={12}>{`${v}px`}</Mono>
@@ -272,19 +574,30 @@
         </div>
         <div>
           <Caps mb={18}>Radii</Caps>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 18, marginBottom: 30 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 18, marginBottom: 30 }}>
             {TOK.radii.map(([k, r]) => (
               <div key={k}>
-                <div style={{ width: k === "full" ? 120 : 96, height: 96, border: `2px solid ${TOK.brand.tint.d}`, borderRadius: k === "full" ? 48 : r }} />
-                <Mono c={SHEET.muted} s={12}>{k === "full" ? "full (pill)" : `${k} · ${r}`}</Mono>
+                <div
+                  style={{
+                    width: k === 'full' ? 120 : 96,
+                    height: 96,
+                    border: `2px solid ${TOK.brand.tint.d}`,
+                    borderRadius: k === 'full' ? 48 : r,
+                  }}
+                />
+                <Mono c={SHEET.muted} s={12}>
+                  {k === 'full' ? 'full (pill)' : `${k} · ${r}`}
+                </Mono>
               </div>
             ))}
           </div>
           <Caps mb={14}>Shadows</Caps>
           {TOK.shadows.map(([k, ios, el]) => (
-            <div key={k} style={{ display: "flex", gap: 24, marginBottom: 6 }}>
-              <Mono c={SHEET.ink} s={12} >{`shadow.${k}`}</Mono>
-              <Mono c={SHEET.muted} s={12}>{ios}</Mono>
+            <div key={k} style={{ display: 'flex', gap: 24, marginBottom: 6 }}>
+              <Mono c={SHEET.ink} s={12}>{`shadow.${k}`}</Mono>
+              <Mono c={SHEET.muted} s={12}>
+                {ios}
+              </Mono>
               <Mono c={SHEET.faint} s={12}>{`Android ${el}`}</Mono>
             </div>
           ))}
@@ -295,20 +608,69 @@
 
   const VariantsSection = () => {
     const panels = [
-      { title: "Liquid Glass", sub: "iOS 26 — Apple HIG", btnR: 10, lines: ["Button corner — 10dp", "Sheet corners — soft (glass)", "Tab bar — 49pt", "Type — Apple HIG scale", "Motion — reanimated springs"] },
-      { title: "Material 3", sub: "Android / older iOS / fallback", btnR: 20, lines: ["Button corner — 20dp", "Sheet corners — 28dp", "Nav bar — 80dp + indicator pill", "Type — Material 3 scale", "Feedback — ripple"] },
+      {
+        title: 'Liquid Glass',
+        sub: 'iOS 26 — Apple HIG',
+        btnR: 10,
+        lines: [
+          'Button corner — 10dp',
+          'Sheet corners — soft (glass)',
+          'Tab bar — 49pt',
+          'Type — Apple HIG scale',
+          'Motion — reanimated springs',
+        ],
+      },
+      {
+        title: 'Material 3',
+        sub: 'Android / older iOS / fallback',
+        btnR: 20,
+        lines: [
+          'Button corner — 20dp',
+          'Sheet corners — 28dp',
+          'Nav bar — 80dp + indicator pill',
+          'Type — Material 3 scale',
+          'Feedback — ripple',
+        ],
+      },
     ];
     return (
-      <Section eyebrow="08 — The two variants" title="Liquid Glass and Material 3" desc="Same palette and component APIs; the chrome follows the platform. A control is the same product in both, drawn the way that platform draws controls. Users on iOS 26 get Liquid Glass by default; everyone else gets Material 3, and either can be chosen explicitly.">
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 28 }}>
+      <Section
+        eyebrow="08 — The two variants"
+        title="Liquid Glass and Material 3"
+        desc="Same palette and component APIs; the chrome follows the platform. A control is the same product in both, drawn the way that platform draws controls. Users on iOS 26 get Liquid Glass by default; everyone else gets Material 3, and either can be chosen explicitly."
+      >
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 28 }}>
           {panels.map((p) => (
-            <div key={p.title} style={{ border: `1px solid ${SHEET.border}`, borderRadius: 14, padding: 24, background: SHEET.panel }}>
-              <H s={22} mb={4}>{p.title}</H>
+            <div
+              key={p.title}
+              style={{ border: `1px solid ${SHEET.border}`, borderRadius: 14, padding: 24, background: SHEET.panel }}
+            >
+              <H s={22} mb={4}>
+                {p.title}
+              </H>
               <Caps mb={20}>{p.sub}</Caps>
-              <div style={{ display: "flex", alignItems: "center", gap: 24 }}>
-                <button style={{ background: TOK.brand.primaryFill.d, color: "#FFFFFF", fontFamily: FONT_DISPLAY, fontWeight: 700, fontSize: 15, padding: "13px 26px", borderRadius: p.btnR, border: "none", cursor: "default" }}>Log ascent</button>
-                <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
-                  {p.lines.map((ln, j) => <Mono key={j} c={SHEET.muted} s={12.5}>{ln}</Mono>)}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+                <button
+                  style={{
+                    background: TOK.brand.primaryFill.d,
+                    color: '#FFFFFF',
+                    fontFamily: FONT_DISPLAY,
+                    fontWeight: 700,
+                    fontSize: 15,
+                    padding: '13px 26px',
+                    borderRadius: p.btnR,
+                    border: 'none',
+                    cursor: 'default',
+                  }}
+                >
+                  Log ascent
+                </button>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+                  {p.lines.map((ln, j) => (
+                    <Mono key={j} c={SHEET.muted} s={12.5}>
+                      {ln}
+                    </Mono>
+                  ))}
                 </div>
               </div>
             </div>
@@ -320,27 +682,83 @@
 
   const ChangelogSection = () => {
     const rows = [
-      ["CANON", "Velvet Send", "brand", "Now the canonical design language — sourced from packages/mobile/src/theme."],
-      ["ADD", "brand.tint / primary", "#6D28D9 · #A78BFA", "Violet brand foreground. Lifts to #A78BFA in dark."],
-      ["ADD", "brand.primaryFill", "#6D28D9 · #7C3AED", "Filled-surface brand. Brighter #7C3AED in dark so white text clears AA."],
-      ["ADD", "brand.accent", "#FF8A3D", "Warm amber spark — fill-only, always pair with dark text."],
-      ["VARIANT", "Liquid Glass / Material 3", "—", "One palette, two render variants; resolved per device, user-overridable."],
-      ["LEGACY", "web rose/sage", "#8C4A52", "packages/web still on the old palette — pending migration, not a peer."],
-      ["SHARED", "grade colours", "—", "Only @boardsesh/board-constants grade colours are shared web↔mobile."],
+      ['CANON', 'Velvet Send', 'brand', 'Now the canonical design language — sourced from packages/mobile/src/theme.'],
+      ['ADD', 'brand.tint / primary', '#6D28D9 · #A78BFA', 'Violet brand foreground. Lifts to #A78BFA in dark.'],
+      [
+        'ADD',
+        'brand.primaryFill',
+        '#6D28D9 · #7C3AED',
+        'Filled-surface brand. Brighter #7C3AED in dark so white text clears AA.',
+      ],
+      ['ADD', 'brand.accent', '#FF8A3D', 'Warm amber spark — fill-only, always pair with dark text.'],
+      [
+        'VARIANT',
+        'Liquid Glass / Material 3',
+        '—',
+        'One palette, two render variants; resolved per device, user-overridable.',
+      ],
+      ['LEGACY', 'web rose/sage', '#8C4A52', 'packages/web still on the old palette — pending migration, not a peer.'],
+      ['SHARED', 'grade colours', '—', 'Only @boardsesh/board-constants grade colours are shared web↔mobile.'],
     ];
-    const kindColor = { CANON: "#A78BFA", ADD: "#34D399", VARIANT: "#60A5FA", LEGACY: "#FBBF24", SHARED: "#A9A2B6" };
+    const kindColor = { CANON: '#A78BFA', ADD: '#34D399', VARIANT: '#60A5FA', LEGACY: '#FBBF24', SHARED: '#A9A2B6' };
     return (
-      <Section eyebrow="09 — What this establishes" title="Velvet Send vs the legacy web palette" desc="Velvet Send replaces the old rose/sage web palette as the design language. Web hasn't migrated yet — that palette is legacy, not a peer.">
-        <div style={{ border: `1px solid ${SHEET.border}`, borderRadius: 10, overflow: "hidden", marginTop: 8 }}>
-          <div style={{ display: "grid", gridTemplateColumns: "110px 1.3fr 0.9fr 2.4fr", padding: "12px 18px", background: "rgba(255,255,255,0.025)", borderBottom: `1px solid ${SHEET.rule}` }}>
-            {["KIND", "TOKEN", "VALUE", "NOTE"].map((h) => <Mono key={h} c={SHEET.faint} s={11}>{h}</Mono>)}
+      <Section
+        eyebrow="09 — What this establishes"
+        title="Velvet Send vs the legacy web palette"
+        desc="Velvet Send replaces the old rose/sage web palette as the design language. Web hasn't migrated yet — that palette is legacy, not a peer."
+      >
+        <div style={{ border: `1px solid ${SHEET.border}`, borderRadius: 10, overflow: 'hidden', marginTop: 8 }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '110px 1.3fr 0.9fr 2.4fr',
+              padding: '12px 18px',
+              background: 'rgba(255,255,255,0.025)',
+              borderBottom: `1px solid ${SHEET.rule}`,
+            }}
+          >
+            {['KIND', 'TOKEN', 'VALUE', 'NOTE'].map((h) => (
+              <Mono key={h} c={SHEET.faint} s={11}>
+                {h}
+              </Mono>
+            ))}
           </div>
           {rows.map((r, i) => (
-            <div key={i} style={{ display: "grid", gridTemplateColumns: "110px 1.3fr 0.9fr 2.4fr", padding: "14px 18px", borderBottom: i < rows.length - 1 ? "1px solid rgba(180,168,205,0.06)" : "none", alignItems: "center" }}>
-              <div><span style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: 1, color: kindColor[r[0]], padding: "3px 9px", border: `1px solid ${kindColor[r[0]]}66`, borderRadius: 999, background: `${kindColor[r[0]]}1A` }}>{r[0]}</span></div>
-              <Mono c={SHEET.ink} s={13}>{r[1]}</Mono>
-              <Mono c={SHEET.muted} s={12}>{r[2]}</Mono>
-              <P c={SHEET.muted} s={12.5} mb={0}>{r[3]}</P>
+            <div
+              key={i}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '110px 1.3fr 0.9fr 2.4fr',
+                padding: '14px 18px',
+                borderBottom: i < rows.length - 1 ? '1px solid rgba(180,168,205,0.06)' : 'none',
+                alignItems: 'center',
+              }}
+            >
+              <div>
+                <span
+                  style={{
+                    fontFamily: FONT_MONO,
+                    fontSize: 10,
+                    letterSpacing: 1,
+                    color: kindColor[r[0]],
+                    padding: '3px 9px',
+                    border: `1px solid ${kindColor[r[0]]}66`,
+                    borderRadius: 999,
+                    background: `${kindColor[r[0]]}1A`,
+                  }}
+                >
+                  {r[0]}
+                </span>
+              </div>
+              <Mono c={SHEET.ink} s={13}>
+                {r[1]}
+              </Mono>
+              <Mono c={SHEET.muted} s={12}>
+                {r[2]}
+              </Mono>
+              <P c={SHEET.muted} s={12.5} mb={0}>
+                {r[3]}
+              </P>
             </div>
           ))}
         </div>
@@ -356,33 +774,89 @@
       if (!ref.current || !window.htmlToImage) return;
       setDownloading(true);
       try {
-        const dataUrl = await window.htmlToImage.toPng(ref.current, { pixelRatio: 2, backgroundColor: SHEET.bg, cacheBust: true });
-        const link = document.createElement("a");
-        link.download = "velvet-send-design-tokens-v1.png";
+        const dataUrl = await window.htmlToImage.toPng(ref.current, {
+          pixelRatio: 2,
+          backgroundColor: SHEET.bg,
+          cacheBust: true,
+        });
+        const link = document.createElement('a');
+        link.download = 'velvet-send-design-tokens-v1.png';
         link.href = dataUrl;
         link.click();
-      } catch (e) { console.error(e); }
+      } catch (e) {
+        console.error(e);
+      }
       setDownloading(false);
     };
     return (
-      <div ref={ref} style={{ width: "100%", minHeight: "100%", background: SHEET.bg, padding: "56px 72px", boxSizing: "border-box", color: SHEET.ink, position: "relative" }}>
-        <button onClick={downloadPng} disabled={downloading} style={{ position: "absolute", top: 24, right: 24, zIndex: 10, fontFamily: FONT_MONO, fontSize: 11, letterSpacing: 1.6, textTransform: "uppercase", color: SHEET.ink, background: "rgba(244,241,234,0.08)", border: "1px solid rgba(244,241,234,0.18)", borderRadius: 6, padding: "10px 16px", cursor: downloading ? "wait" : "pointer" }}>
-          {downloading ? "Rendering…" : "↓ Download PNG"}
+      <div
+        ref={ref}
+        style={{
+          width: '100%',
+          minHeight: '100%',
+          background: SHEET.bg,
+          padding: '56px 72px',
+          boxSizing: 'border-box',
+          color: SHEET.ink,
+          position: 'relative',
+        }}
+      >
+        <button
+          onClick={downloadPng}
+          disabled={downloading}
+          style={{
+            position: 'absolute',
+            top: 24,
+            right: 24,
+            zIndex: 10,
+            fontFamily: FONT_MONO,
+            fontSize: 11,
+            letterSpacing: 1.6,
+            textTransform: 'uppercase',
+            color: SHEET.ink,
+            background: 'rgba(244,241,234,0.08)',
+            border: '1px solid rgba(244,241,234,0.18)',
+            borderRadius: 6,
+            padding: '10px 16px',
+            cursor: downloading ? 'wait' : 'pointer',
+          }}
+        >
+          {downloading ? 'Rendering…' : '↓ Download PNG'}
         </button>
         <HeaderBlock />
         <div style={{ height: 56 }} />
-        <BrandSection /><Rule />
-        <MarkSection /><Rule />
-        <GradeSection /><Rule />
-        <SemanticSection /><Rule />
-        <SurfacesSection /><Rule />
-        <TypeSection /><Rule />
-        <GeometrySection /><Rule />
-        <VariantsSection /><Rule />
+        <BrandSection />
+        <Rule />
+        <MarkSection />
+        <Rule />
+        <GradeSection />
+        <Rule />
+        <SemanticSection />
+        <Rule />
+        <SurfacesSection />
+        <Rule />
+        <TypeSection />
+        <Rule />
+        <GeometrySection />
+        <Rule />
+        <VariantsSection />
+        <Rule />
         <ChangelogSection />
-        <div style={{ marginTop: 48, paddingTop: 24, borderTop: "1px solid rgba(180,168,205,0.1)", display: "flex", justifyContent: "space-between" }}>
-          <Mono c={SHEET.faint} s={11}>Boardsesh · Velvet Send · design tokens · v1</Mono>
-          <Mono c={SHEET.faint} s={11}>Source: docs/ai-design-guidelines.md · packages/mobile/src/theme</Mono>
+        <div
+          style={{
+            marginTop: 48,
+            paddingTop: 24,
+            borderTop: '1px solid rgba(180,168,205,0.1)',
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Mono c={SHEET.faint} s={11}>
+            Boardsesh · Velvet Send · design tokens · v1
+          </Mono>
+          <Mono c={SHEET.faint} s={11}>
+            Source: docs/ai-design-guidelines.md · packages/mobile/src/theme
+          </Mono>
         </div>
       </div>
     );

--- a/docs/KILTER_HTTP_API_SPEC.md
+++ b/docs/KILTER_HTTP_API_SPEC.md
@@ -39,12 +39,12 @@
 
 Networking splits into four planes:
 
-| Plane | Host | Transport | Purpose |
-| --- | --- | --- | --- |
-| **Identity** | `idp.kiltergrips.com` | HTTPS (Keycloak OIDC) | Login, registration, refresh, logout |
-| **REST API** | `portal.kiltergrips.com` | HTTPS / JSON | Mutations (create climb, log ascent, follow user, etc.) and on-demand reads |
-| **Realtime sync** | `sync1.kiltergrips.com` | HTTPS streaming + WebSocket (PowerSync) | Bidirectional sync of the Postgres-backed catalog into a local SQLite mirror |
-| **Maps** | `places.googleapis.com` | HTTPS / JSON | Gym/wall location autocomplete |
+| Plane             | Host                     | Transport                               | Purpose                                                                      |
+| ----------------- | ------------------------ | --------------------------------------- | ---------------------------------------------------------------------------- |
+| **Identity**      | `idp.kiltergrips.com`    | HTTPS (Keycloak OIDC)                   | Login, registration, refresh, logout                                         |
+| **REST API**      | `portal.kiltergrips.com` | HTTPS / JSON                            | Mutations (create climb, log ascent, follow user, etc.) and on-demand reads  |
+| **Realtime sync** | `sync1.kiltergrips.com`  | HTTPS streaming + WebSocket (PowerSync) | Bidirectional sync of the Postgres-backed catalog into a local SQLite mirror |
+| **Maps**          | `places.googleapis.com`  | HTTPS / JSON                            | Gym/wall location autocomplete                                               |
 
 Most reads go to a **local SQLite mirror**, but that mirror is filled by **two different mechanisms**, and the split matters for interop:
 
@@ -82,12 +82,12 @@ A `/v2/users/` path also exists alongside the `/api/users/` routes. Its purpose 
 
 Authentication is delegated to Keycloak, with Authorization Code + PKCE.
 
-| Endpoint | URL |
-| --- | --- |
-| Issuer / discovery | `https://idp.kiltergrips.com/realms/kilter` |
-| Authorization | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/auth` |
-| Token | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token` |
-| Logout | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/logout` |
+| Endpoint           | URL                                                                        |
+| ------------------ | -------------------------------------------------------------------------- |
+| Issuer / discovery | `https://idp.kiltergrips.com/realms/kilter`                                |
+| Authorization      | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/auth`   |
+| Token              | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token`  |
+| Logout             | `https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/logout` |
 
 **Redirect URI scheme**: `com.kiltergrips:/oauthredirect`.
 
@@ -121,12 +121,12 @@ Authentication is delegated to Keycloak, with Authorization Code + PKCE.
 
 ## 4. HTTP conventions
 
-| Header | Value |
-| --- | --- |
-| `Authorization` | `Bearer <access_token>` (Keycloak access JWT) |
-| `Content-Type` | `application/json` for POST/PUT/PATCH bodies; `multipart/form-data` for image upload |
-| `Accept` | `application/json` |
-| `User-Agent` | Stock HTTP-client default; no custom UA |
+| Header          | Value                                                                                |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `Authorization` | `Bearer <access_token>` (Keycloak access JWT)                                        |
+| `Content-Type`  | `application/json` for POST/PUT/PATCH bodies; `multipart/form-data` for image upload |
+| `Accept`        | `application/json`                                                                   |
+| `User-Agent`    | Stock HTTP-client default; no custom UA                                              |
 
 Path conventions:
 
@@ -145,35 +145,35 @@ For each endpoint, **path** is well-established. **Method** is inferred from sem
 
 ### 5.1 Users
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/users/` | Get current authenticated user |
-| `GET` | `/api/users/find` | Search users (by email / username / display name) |
-| `POST` | `/api/users/register?redirectUrl=<frontend_url>` | Server-side user creation; redirects browser to the frontend on success |
-| `POST` | `/api/users/email/verification` | Trigger an email-verification message for the current user |
-| `GET` | `/api/users/email/verify/{token}` | Email-confirmation landing endpoint (called via deeplink) |
-| `POST` | `/api/users/resend/id/{userId}` | Resend verification or reset email for a user |
-| `GET` | `/api/users/user-settings` | Read the current user's settings |
-| `PUT` | `/api/users/user-settings` | Update the current user's settings |
-| `GET` | `/api/users/user-analytics` | Aggregated user stats (totals, distributions, last-session date) |
-| `POST` | `/api/users/block-climb` | Hide a climb from the current user's feed |
-| `DELETE` | `/api/users/unblock-climb/{climbUuid}?angle=<deg>` | Un-hide a previously blocked climb |
-| `GET` | `/v2/users/` | Unknown v2 namespace — possibly paginated user listing or admin variant |
+| Method   | Path                                               | Purpose                                                                 |
+| -------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| `GET`    | `/api/users/`                                      | Get current authenticated user                                          |
+| `GET`    | `/api/users/find`                                  | Search users (by email / username / display name)                       |
+| `POST`   | `/api/users/register?redirectUrl=<frontend_url>`   | Server-side user creation; redirects browser to the frontend on success |
+| `POST`   | `/api/users/email/verification`                    | Trigger an email-verification message for the current user              |
+| `GET`    | `/api/users/email/verify/{token}`                  | Email-confirmation landing endpoint (called via deeplink)               |
+| `POST`   | `/api/users/resend/id/{userId}`                    | Resend verification or reset email for a user                           |
+| `GET`    | `/api/users/user-settings`                         | Read the current user's settings                                        |
+| `PUT`    | `/api/users/user-settings`                         | Update the current user's settings                                      |
+| `GET`    | `/api/users/user-analytics`                        | Aggregated user stats (totals, distributions, last-session date)        |
+| `POST`   | `/api/users/block-climb`                           | Hide a climb from the current user's feed                               |
+| `DELETE` | `/api/users/unblock-climb/{climbUuid}?angle=<deg>` | Un-hide a previously blocked climb                                      |
+| `GET`    | `/v2/users/`                                       | Unknown v2 namespace — possibly paginated user listing or admin variant |
 
 **User DTO** (camelCase, inferred):
 
 ```jsonc
 {
   "userUuid": "uuid",
-  "username": "string",        // unique handle
+  "username": "string", // unique handle
   "email": "string",
   "firstName": "string",
   "lastName": "string",
-  "displayName": "string",     // optional, derived
+  "displayName": "string", // optional, derived
   "profilePictureUrl": "string",
   "bio": "string",
   "createdAt": "ISO-8601",
-  "updatedAt": "ISO-8601"
+  "updatedAt": "ISO-8601",
 }
 ```
 
@@ -183,7 +183,7 @@ For each endpoint, **path** is well-established. **Method** is inferred from sem
 {
   "errorCode": "EMAIL_TAKEN | USERNAME_TAKEN | INVALID_EMAIL | …",
   "message": "human-readable",
-  "field": "email | username | …"
+  "field": "email | username | …",
 }
 ```
 
@@ -191,44 +191,44 @@ For each endpoint, **path** is well-established. **Method** is inferred from sem
 
 ### 5.2 Climbs
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/climbs/` | Paginated climb list (filtered by query params) |
-| `GET` | `/api/climbs/all/` | Full climb listing (used by initial sync / catalog warm-up) |
-| `GET` | `/api/climbs/single/{climbUuid}` | Fetch one climb |
-| `GET` | `/api/climbs/curated` | Curated/featured climbs |
-| `GET` | `/api/climbs/logged` | Climbs the current user has logged |
-| `GET` | `/api/climbs/delteduuids` | UUIDs of deleted climbs (sync cleanup; note the typo) |
-| `GET` | `/api/climbs/climbdetails/` | Climb details (joined with rating/log info) |
-| `GET` | `/api/climbs/climbdetails/user` | Current user's climbs with stats |
-| `GET` | `/api/climbs/climbdetails/{productName}/edges?edgeLeft=&edgeRight=&edgeBottom=&edgeTop=&limit=&offset=` | Paginated climbs for a wall, filtered by frame region |
-| `GET` | `/api/climbs/climbdetails/{productName}/edges/count` | Count for the above (for pagination UI) |
-| `POST` | `/api/climbs/create-climb/transaction` | Atomic create — writes the climb + mounting holes + stats rows in one transaction |
-| `POST` | `/api/climbs/update-climb/transaction` | Atomic update of climb + mounting holes |
+| Method | Path                                                                                                    | Purpose                                                                           |
+| ------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `GET`  | `/api/climbs/`                                                                                          | Paginated climb list (filtered by query params)                                   |
+| `GET`  | `/api/climbs/all/`                                                                                      | Full climb listing (used by initial sync / catalog warm-up)                       |
+| `GET`  | `/api/climbs/single/{climbUuid}`                                                                        | Fetch one climb                                                                   |
+| `GET`  | `/api/climbs/curated`                                                                                   | Curated/featured climbs                                                           |
+| `GET`  | `/api/climbs/logged`                                                                                    | Climbs the current user has logged                                                |
+| `GET`  | `/api/climbs/delteduuids`                                                                               | UUIDs of deleted climbs (sync cleanup; note the typo)                             |
+| `GET`  | `/api/climbs/climbdetails/`                                                                             | Climb details (joined with rating/log info)                                       |
+| `GET`  | `/api/climbs/climbdetails/user`                                                                         | Current user's climbs with stats                                                  |
+| `GET`  | `/api/climbs/climbdetails/{productName}/edges?edgeLeft=&edgeRight=&edgeBottom=&edgeTop=&limit=&offset=` | Paginated climbs for a wall, filtered by frame region                             |
+| `GET`  | `/api/climbs/climbdetails/{productName}/edges/count`                                                    | Count for the above (for pagination UI)                                           |
+| `POST` | `/api/climbs/create-climb/transaction`                                                                  | Atomic create — writes the climb + mounting holes + stats rows in one transaction |
+| `POST` | `/api/climbs/update-climb/transaction`                                                                  | Atomic update of climb + mounting holes                                           |
 
 **Climb DTO** — JSON key on the wire (camelCase, inferred) mapped to the snake_case Postgres column that PowerSync mirrors:
 
-| JSON key | Postgres column | Type | Notes |
-| --- | --- | --- | --- |
-| `climbUuid` | `climb_uuid` | string | PK |
-| `name` | `name` | string | display name |
-| `description` | `description` | string? | |
-| `userUuid` | `user_uuid` | string | setter |
-| `username` | `username` | string | setter username (denormalized) |
-| `productName` | `product_name` | string | e.g. `Kilter Board Original`, `Kilter Board Homewall` |
-| `productLayoutUuid` | `product_layout_uuid` | string | specific board+set combo |
-| `edgeLeft`,`edgeRight`,`edgeBottom`,`edgeTop` | `edge_*` | integer | bounding box on the board |
-| `frameCount` | `frame_count` | integer | for multi-frame climbs |
-| `framesPace` | `frames_pace` | integer | ms per frame |
-| `angle` | `angle` | integer? | preferred angle, optional |
-| `allowMatch` | `allow_match` | bool | matching hands on a hold permitted |
-| `isDraft` | `is_draft` | bool | |
-| `isListed` | `is_listed` | bool | public vs unlisted |
-| `accumulatedHoldSetValue` | `accumulated_hold_set_value` | integer | sum of "value" across hold sets used |
-| `curated` | `curated` | bool? | featured |
-| `isDeleted` | `is_deleted` | bool | soft-delete; cleared via `/delteduuids` |
-| `createdAt`,`updatedAt` | `created_at`,`updated_at` | ISO-8601 | |
-| `climbConcat` | `climb_concat` | string | canonical placement-encoded string (same encoding used by the LED protocol — see [`AURORA_BLUETOOTH_PROTOCOL_SPEC.md`](AURORA_BLUETOOTH_PROTOCOL_SPEC.md)) |
+| JSON key                                      | Postgres column              | Type     | Notes                                                                                                                                                      |
+| --------------------------------------------- | ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `climbUuid`                                   | `climb_uuid`                 | string   | PK                                                                                                                                                         |
+| `name`                                        | `name`                       | string   | display name                                                                                                                                               |
+| `description`                                 | `description`                | string?  |                                                                                                                                                            |
+| `userUuid`                                    | `user_uuid`                  | string   | setter                                                                                                                                                     |
+| `username`                                    | `username`                   | string   | setter username (denormalized)                                                                                                                             |
+| `productName`                                 | `product_name`               | string   | e.g. `Kilter Board Original`, `Kilter Board Homewall`                                                                                                      |
+| `productLayoutUuid`                           | `product_layout_uuid`        | string   | specific board+set combo                                                                                                                                   |
+| `edgeLeft`,`edgeRight`,`edgeBottom`,`edgeTop` | `edge_*`                     | integer  | bounding box on the board                                                                                                                                  |
+| `frameCount`                                  | `frame_count`                | integer  | for multi-frame climbs                                                                                                                                     |
+| `framesPace`                                  | `frames_pace`                | integer  | ms per frame                                                                                                                                               |
+| `angle`                                       | `angle`                      | integer? | preferred angle, optional                                                                                                                                  |
+| `allowMatch`                                  | `allow_match`                | bool     | matching hands on a hold permitted                                                                                                                         |
+| `isDraft`                                     | `is_draft`                   | bool     |                                                                                                                                                            |
+| `isListed`                                    | `is_listed`                  | bool     | public vs unlisted                                                                                                                                         |
+| `accumulatedHoldSetValue`                     | `accumulated_hold_set_value` | integer  | sum of "value" across hold sets used                                                                                                                       |
+| `curated`                                     | `curated`                    | bool?    | featured                                                                                                                                                   |
+| `isDeleted`                                   | `is_deleted`                 | bool     | soft-delete; cleared via `/delteduuids`                                                                                                                    |
+| `createdAt`,`updatedAt`                       | `created_at`,`updated_at`    | ISO-8601 |                                                                                                                                                            |
+| `climbConcat`                                 | `climb_concat`               | string   | canonical placement-encoded string (same encoding used by the LED protocol — see [`AURORA_BLUETOOTH_PROTOCOL_SPEC.md`](AURORA_BLUETOOTH_PROTOCOL_SPEC.md)) |
 
 The `create-climb/transaction` and `update-climb/transaction` request bodies are presumed to include the parent climb fields plus an array of `mountingHoles` (see [§5.5](#55-climb-mounting-holes)).
 
@@ -236,25 +236,25 @@ The `create-climb/transaction` and `update-climb/transaction` request bodies are
 
 ### 5.3 Climb statistics
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/climb-stat/` | Per-climb stats for a single climb+angle |
-| `GET` | `/api/climb-stat/all/` | Bulk stats listing |
+| Method | Path                   | Purpose                                  |
+| ------ | ---------------------- | ---------------------------------------- |
+| `GET`  | `/api/climb-stat/`     | Per-climb stats for a single climb+angle |
+| `GET`  | `/api/climb-stat/all/` | Bulk stats listing                       |
 
 **ClimbStat DTO**:
 
-| JSON key | Postgres column | Type |
-| --- | --- | --- |
-| `climbUuid` | `climb_uuid` | string |
-| `angle` | `angle` | integer |
-| `ascentCount` | `ascent_count` | integer |
-| `currentDifficultyId` | `current_difficulty_id` | integer (FK into difficulty_grades) |
-| `officialKilterDifficulty` | `official_kilter_difficulty` | integer? |
-| `difficultyAverage` | `difficulty_average` | float |
-| `qualityAverage` | `quality_average` | float |
-| `faUsername` | `fa_username` | string? — first-ascent username |
-| `faAt` | `fa_at` | ISO-8601? |
-| `curated` | `curated` | bool? |
+| JSON key                   | Postgres column              | Type                                |
+| -------------------------- | ---------------------------- | ----------------------------------- |
+| `climbUuid`                | `climb_uuid`                 | string                              |
+| `angle`                    | `angle`                      | integer                             |
+| `ascentCount`              | `ascent_count`               | integer                             |
+| `currentDifficultyId`      | `current_difficulty_id`      | integer (FK into difficulty_grades) |
+| `officialKilterDifficulty` | `official_kilter_difficulty` | integer?                            |
+| `difficultyAverage`        | `difficulty_average`         | float                               |
+| `qualityAverage`           | `quality_average`            | float                               |
+| `faUsername`               | `fa_username`                | string? — first-ascent username     |
+| `faAt`                     | `fa_at`                      | ISO-8601?                           |
+| `curated`                  | `curated`                    | bool?                               |
 
 Primary key is `(climb_uuid, angle)`.
 
@@ -262,13 +262,13 @@ Primary key is `(climb_uuid, angle)`.
 
 ### 5.4 Climb ratings
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/climb-rating/` | List the current user's ratings (likely filterable by `climbUuid` / `angle`) |
-| `GET` | `/api/climb-rating/{climbRatingUuid}` | Fetch a single rating |
-| `POST` | `/api/climb-rating/` | Create a rating |
-| `PUT` | `/api/climb-rating/{climbRatingUuid}` | Update a rating |
-| `DELETE` | `/api/climb-rating/{climbRatingUuid}` | Delete a rating |
+| Method   | Path                                  | Purpose                                                                      |
+| -------- | ------------------------------------- | ---------------------------------------------------------------------------- |
+| `GET`    | `/api/climb-rating/`                  | List the current user's ratings (likely filterable by `climbUuid` / `angle`) |
+| `GET`    | `/api/climb-rating/{climbRatingUuid}` | Fetch a single rating                                                        |
+| `POST`   | `/api/climb-rating/`                  | Create a rating                                                              |
+| `PUT`    | `/api/climb-rating/{climbRatingUuid}` | Update a rating                                                              |
+| `DELETE` | `/api/climb-rating/{climbRatingUuid}` | Delete a rating                                                              |
 
 **ClimbRating DTO** (inferred):
 
@@ -278,12 +278,12 @@ Primary key is `(climb_uuid, angle)`.
   "userUuid": "uuid",
   "climbUuid": "uuid",
   "angle": 40,
-  "rating": 4,                  // 1–5 stars
-  "difficultyGradeId": 16,      // user's perceived difficulty
+  "rating": 4, // 1–5 stars
+  "difficultyGradeId": 16, // user's perceived difficulty
   "comment": "Great moves on the crux",
-  "weight": 1.0,                // optional, confidence/ascent-count weight
+  "weight": 1.0, // optional, confidence/ascent-count weight
   "createdAt": "ISO-8601",
-  "updatedAt": "ISO-8601"
+  "updatedAt": "ISO-8601",
 }
 ```
 
@@ -291,9 +291,9 @@ Primary key is `(climb_uuid, angle)`.
 
 ### 5.5 Climb mounting holes
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/climb-mounting-holes/{climbUuid}?angle=&productLayoutUuid=` | Hold placements for one climb on a specific layout |
+| Method | Path                                                              | Purpose                                            |
+| ------ | ----------------------------------------------------------------- | -------------------------------------------------- |
+| `GET`  | `/api/climb-mounting-holes/{climbUuid}?angle=&productLayoutUuid=` | Hold placements for one climb on a specific layout |
 
 **ClimbMountingHole DTO**:
 
@@ -302,10 +302,10 @@ Primary key is `(climb_uuid, angle)`.
   "climbMountingHoleUuid": "uuid",
   "climbUuid": "uuid",
   "productLayoutUuid": "uuid",
-  "mountingHoleId": 123,        // FK into the static hole catalog
-  "placementTypeId": 12,        // start / hand / foot / finish — same enum used by the LED protocol
-  "x": 0.42,                    // sometimes inlined; otherwise resolved from mounting_hole_id
-  "y": 0.71
+  "mountingHoleId": 123, // FK into the static hole catalog
+  "placementTypeId": 12, // start / hand / foot / finish — same enum used by the LED protocol
+  "x": 0.42, // sometimes inlined; otherwise resolved from mounting_hole_id
+  "y": 0.71,
 }
 ```
 
@@ -315,14 +315,14 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
 
 ### 5.6 Logs (ascents and attempts)
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/logs/` | List the current user's logs |
-| `GET` | `/api/logs/{logUuid}` | Fetch a single log |
-| `POST` | `/api/logs/` | Create one log |
-| `POST` | `/api/logs/bulk` | Bulk-upload logs (offline-first sync of pending entries) |
-| `PUT` | `/api/logs/{logUuid}` | Update a log |
-| `DELETE` | `/api/logs/{logUuid}` | Delete a log |
+| Method   | Path                  | Purpose                                                  |
+| -------- | --------------------- | -------------------------------------------------------- |
+| `GET`    | `/api/logs/`          | List the current user's logs                             |
+| `GET`    | `/api/logs/{logUuid}` | Fetch a single log                                       |
+| `POST`   | `/api/logs/`          | Create one log                                           |
+| `POST`   | `/api/logs/bulk`      | Bulk-upload logs (offline-first sync of pending entries) |
+| `PUT`    | `/api/logs/{logUuid}` | Update a log                                             |
+| `DELETE` | `/api/logs/{logUuid}` | Delete a log                                             |
 
 **Log DTO**:
 
@@ -333,13 +333,13 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
   "climbUuid": "uuid",
   "productLayoutUuid": "uuid",
   "angle": 40,
-  "topped": true,                // sent the route
-  "flashed": false,              // sent on first session/with beta
-  "sentimentValue": 4,           // emoji rating, 1–5
-  "rating": 4,                   // overlaps with ClimbRating; bulk endpoint may write both
+  "topped": true, // sent the route
+  "flashed": false, // sent on first session/with beta
+  "sentimentValue": 4, // emoji rating, 1–5
+  "rating": 4, // overlaps with ClimbRating; bulk endpoint may write both
   "difficultyGradeId": 18,
   "comment": "string",
-  "createdAt": "ISO-8601"
+  "createdAt": "ISO-8601",
 }
 ```
 
@@ -347,18 +347,18 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
 
 ### 5.7 Circuits and circuit climbs
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/circuits` | List circuits (optionally filtered by `userUuid`, `isPublic`) |
-| `GET` | `/api/circuits/{circuitUuid}` | One circuit with its climbs |
-| `GET` | `/api/circuits/get-circuit/{circuitUuid}` | Alternative single-fetch endpoint (legacy or alias) |
-| `POST` | `/api/circuits` | Create circuit |
-| `PUT` | `/api/circuits/{circuitUuid}` | Update circuit metadata |
-| `DELETE` | `/api/circuits/{circuitUuid}` | Delete circuit |
-| `GET` | `/api/circuit-climbs?circuitUuid=` | List climbs in a circuit |
-| `POST` | `/api/circuit-climbs` | Add a climb to a circuit |
-| `PUT` | `/api/circuit-climbs/{circuitClimbUuid}` | Reorder a climb within a circuit |
-| `DELETE` | `/api/circuit-climbs/{circuitClimbUuid}` | Remove a climb from a circuit |
+| Method   | Path                                      | Purpose                                                       |
+| -------- | ----------------------------------------- | ------------------------------------------------------------- |
+| `GET`    | `/api/circuits`                           | List circuits (optionally filtered by `userUuid`, `isPublic`) |
+| `GET`    | `/api/circuits/{circuitUuid}`             | One circuit with its climbs                                   |
+| `GET`    | `/api/circuits/get-circuit/{circuitUuid}` | Alternative single-fetch endpoint (legacy or alias)           |
+| `POST`   | `/api/circuits`                           | Create circuit                                                |
+| `PUT`    | `/api/circuits/{circuitUuid}`             | Update circuit metadata                                       |
+| `DELETE` | `/api/circuits/{circuitUuid}`             | Delete circuit                                                |
+| `GET`    | `/api/circuit-climbs?circuitUuid=`        | List climbs in a circuit                                      |
+| `POST`   | `/api/circuit-climbs`                     | Add a climb to a circuit                                      |
+| `PUT`    | `/api/circuit-climbs/{circuitClimbUuid}`  | Reorder a climb within a circuit                              |
+| `DELETE` | `/api/circuit-climbs/{circuitClimbUuid}`  | Remove a climb from a circuit                                 |
 
 **Circuit DTO**:
 
@@ -370,11 +370,11 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
   "color": "#FF5733",
   "isPublic": false,
   "userUuid": "uuid",
-  "creatorName": "string",       // denormalized
+  "creatorName": "string", // denormalized
   "creatorProfilePicture": "url",
-  "count": 12,                   // climbs in circuit (joined)
+  "count": 12, // climbs in circuit (joined)
   "createdAt": "ISO-8601",
-  "updatedAt": "ISO-8601"
+  "updatedAt": "ISO-8601",
 }
 ```
 
@@ -386,7 +386,7 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
   "circuitUuid": "uuid",
   "climbUuid": "uuid",
   "order": 3,
-  "addedAt": "ISO-8601"
+  "addedAt": "ISO-8601",
 }
 ```
 
@@ -394,13 +394,13 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
 
 ### 5.8 Walls (boards)
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/walls` | List walls (filtered by `gymUuid` and/or `productName`) |
-| `GET` | `/api/walls/climbcount` | Climb counts per wall |
-| `POST` | `/api/walls/custom-wall` | Register a user-owned custom wall (homewall) |
-| `PUT` | `/api/walls/custom-wall/{wallUuid}` | Update a custom wall |
-| `DELETE` | `/api/walls/custom-wall/{wallUuid}` | Delete a custom wall |
+| Method   | Path                                | Purpose                                                 |
+| -------- | ----------------------------------- | ------------------------------------------------------- |
+| `GET`    | `/api/walls`                        | List walls (filtered by `gymUuid` and/or `productName`) |
+| `GET`    | `/api/walls/climbcount`             | Climb counts per wall                                   |
+| `POST`   | `/api/walls/custom-wall`            | Register a user-owned custom wall (homewall)            |
+| `PUT`    | `/api/walls/custom-wall/{wallUuid}` | Update a custom wall                                    |
+| `DELETE` | `/api/walls/custom-wall/{wallUuid}` | Delete a custom wall                                    |
 
 **Wall DTO**:
 
@@ -408,17 +408,17 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
 {
   "wallUuid": "uuid",
   "name": "Main Wall",
-  "gymUuid": "uuid",             // null for homewalls
+  "gymUuid": "uuid", // null for homewalls
   "productName": "Kilter Board Original",
   "productLayoutUuid": "uuid",
-  "serialNumber": "string",      // hardware Bluetooth serial
+  "serialNumber": "string", // hardware Bluetooth serial
   "isAdjustable": true,
   "minAngle": 0,
   "maxAngle": 70,
   "angleIncrements": 5,
-  "angle": 40,                   // currently set angle
+  "angle": 40, // currently set angle
   "isListed": true,
-  "boardDisplayName": "string"   // branded label
+  "boardDisplayName": "string", // branded label
 }
 ```
 
@@ -426,14 +426,14 @@ The placement-type enum is the same one used over Bluetooth (see [`AURORA_BLUETO
 
 ### 5.9 Gyms and followers
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/followers/` | Followers of the current user |
-| `GET` | `/api/followers/user` | Users the current user follows |
-| `GET` | `/api/followers/user/following` | Following list (variant — likely `?userUuid=` parameterized) |
-| `GET` | `/api/followers/gym/?gymUuid=` | Followers of a gym |
-| `POST` | `/api/followers/` | Follow a user or gym |
-| `DELETE` | `/api/followers/` | Unfollow |
+| Method   | Path                            | Purpose                                                      |
+| -------- | ------------------------------- | ------------------------------------------------------------ |
+| `GET`    | `/api/followers/`               | Followers of the current user                                |
+| `GET`    | `/api/followers/user`           | Users the current user follows                               |
+| `GET`    | `/api/followers/user/following` | Following list (variant — likely `?userUuid=` parameterized) |
+| `GET`    | `/api/followers/gym/?gymUuid=`  | Followers of a gym                                           |
+| `POST`   | `/api/followers/`               | Follow a user or gym                                         |
+| `DELETE` | `/api/followers/`               | Unfollow                                                     |
 
 Gym endpoints don't surface as `/api/gyms` paths — gym data appears to be **read exclusively from the PowerSync SQLite mirror** (see [§7](#7-local-sqlite-schema-client-side-mirror)). Discovery / "find gym near me" is handled client-side by querying the local DB after Google Places autocomplete narrows the geographic region (see [§8](#8-third-party-integrations)).
 
@@ -441,24 +441,24 @@ Gym endpoints don't surface as `/api/gyms` paths — gym data appears to be **re
 
 ### 5.10 Notifications
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `GET` | `/api/notifications/` | List notifications |
-| `PUT` | `/api/notifications/{notificationUuid}` | Mark read |
-| `DELETE` | `/api/notifications/{notificationUuid}` | Dismiss |
+| Method   | Path                                    | Purpose            |
+| -------- | --------------------------------------- | ------------------ |
+| `GET`    | `/api/notifications/`                   | List notifications |
+| `PUT`    | `/api/notifications/{notificationUuid}` | Mark read          |
+| `DELETE` | `/api/notifications/{notificationUuid}` | Dismiss            |
 
 **Notification DTO** (inferred):
 
 ```jsonc
 {
   "notificationUuid": "uuid",
-  "userUuid": "uuid",            // recipient
+  "userUuid": "uuid", // recipient
   "type": "climb_rated | comment_added | followed | wall_added | …",
   "relatedUserUuid": "uuid",
   "relatedClimbUuid": "uuid",
   "message": "string",
   "isRead": false,
-  "createdAt": "ISO-8601"
+  "createdAt": "ISO-8601",
 }
 ```
 
@@ -466,8 +466,8 @@ Gym endpoints don't surface as `/api/gyms` paths — gym data appears to be **re
 
 ### 5.11 Reporting and moderation
 
-| Method | Path | Purpose |
-| --- | --- | --- |
+| Method | Path                | Purpose                                                     |
+| ------ | ------------------- | ----------------------------------------------------------- |
 | `POST` | `/api/report-climb` | Flag a climb (inappropriate content, broken hardware, etc.) |
 
 **Report DTO**:
@@ -477,7 +477,7 @@ Gym endpoints don't surface as `/api/gyms` paths — gym data appears to be **re
   "climbUuid": "uuid",
   "angle": 40,
   "reason": "inappropriate | broken_holds | offensive_name | other",
-  "comment": "string"
+  "comment": "string",
 }
 ```
 
@@ -485,10 +485,10 @@ Gym endpoints don't surface as `/api/gyms` paths — gym data appears to be **re
 
 ### 5.12 Image upload
 
-| Method | Path | Purpose |
-| --- | --- | --- |
-| `POST` | `/api/image` | Upload an image (multipart/form-data) |
-| `GET` | `/api/image/user` | List the current user's uploaded images |
+| Method | Path              | Purpose                                 |
+| ------ | ----------------- | --------------------------------------- |
+| `POST` | `/api/image`      | Upload an image (multipart/form-data)   |
+| `GET`  | `/api/image/user` | List the current user's uploaded images |
 
 > Confidence: HIGH for paths; MEDIUM for multipart shape.
 

--- a/docs/KILTER_POWERSYNC_SPEC.md
+++ b/docs/KILTER_POWERSYNC_SPEC.md
@@ -8,7 +8,7 @@
 >
 > Where confidence is lower than HIGH, sections are explicitly marked.
 
-> **Correction (2026-06-01).** Earlier drafts of this doc assumed the *entire* catalog — including the world-readable climb catalog — is mirrored through PowerSync, served from inferred `public_climbs` / `global_catalog` buckets. The decompiled app shows that is **wrong**. PowerSync carries only (a) the small global **reference catalog** (holds, hold sets, grades, products, layouts, mounting holes, placement types) and (b) **per-user data** (the signed-in user's logs, attempts, ratings, circuits, walls, settings, social graph). The **public climb catalog (`climbs` + `climb_stats`) is fetched over REST**, paginated by board region, and cached into local SQLite — see [§6](#6-what-syncs-where) and [KILTER_HTTP_API_SPEC.md §5.2](KILTER_HTTP_API_SPEC.md#52-climbs). There is no PowerSync bucket that streams every public climb to every client. If you are trying to "sync the `public_climbs` bucket", stop — it does not exist; pull the catalog via REST instead.
+> **Correction (2026-06-01).** Earlier drafts of this doc assumed the _entire_ catalog — including the world-readable climb catalog — is mirrored through PowerSync, served from inferred `public_climbs` / `global_catalog` buckets. The decompiled app shows that is **wrong**. PowerSync carries only (a) the small global **reference catalog** (holds, hold sets, grades, products, layouts, mounting holes, placement types) and (b) **per-user data** (the signed-in user's logs, attempts, ratings, circuits, walls, settings, social graph). The **public climb catalog (`climbs` + `climb_stats`) is fetched over REST**, paginated by board region, and cached into local SQLite — see [§6](#6-what-syncs-where) and [KILTER_HTTP_API_SPEC.md §5.2](KILTER_HTTP_API_SPEC.md#52-climbs). There is no PowerSync bucket that streams every public climb to every client. If you are trying to "sync the `public_climbs` bucket", stop — it does not exist; pull the catalog via REST instead.
 
 ---
 
@@ -50,7 +50,7 @@ PowerSync sits between a Postgres database and SQLite clients. The shape:
 
 Key concepts:
 
-- **Sync rules** (server-side YAML) declare *buckets*. Each bucket is a parameterised query over Postgres that selects which rows belong in it. Buckets are the unit of sync — a client subscribes to buckets, the server streams oplog rows.
+- **Sync rules** (server-side YAML) declare _buckets_. Each bucket is a parameterised query over Postgres that selects which rows belong in it. Buckets are the unit of sync — a client subscribes to buckets, the server streams oplog rows.
 - **Parameters** come from the auth JWT (e.g. `request.user_id()`) or from client-supplied parameters in the connection request. Typical patterns: a `global` bucket of public catalog rows; one `by_user[uid]` bucket per authenticated user; potentially `by_wall[wall_uuid]`, `by_circuit[circuit_uuid]`, etc.
 - **Client schema**: clients register a SQLite schema declaring which tables/columns/indexes they want. The PowerSync SQLite extension creates the tables and maintains them as oplog rows arrive.
 - **CRUD upstream**: clients enqueue local mutations into a `ps_crud` table. PowerSync's `uploadData` callback hands those rows to app code, which calls the developer's REST API. After the REST call succeeds, the client calls `write-checkpoint2.json` so PowerSync knows the write has been persisted server-side.
@@ -62,18 +62,18 @@ PowerSync's client and protocol are open-source: see [`powersync-ja/powersync-se
 
 ## 2. Kilter's PowerSync deployment
 
-| Property | Value |
-| --- | --- |
-| Service host | `https://sync1.kiltergrips.com` |
-| Sync core | **Rust core `0.4.10`** (`powersync_rs_version` string in `libpowersync.so`), wrapped by the PowerSync Dart SDK |
-| Local schema mode | **Raw tables** — the app declares real `CREATE TABLE`s and PowerSync applies oplog rows through configured INSERT/UPDATE/DELETE statements, instead of the default auto-generated `ps_data_*` views (`RawTable` / `raw_tables` / `PendingStatement` in `libpowersync.so`) |
-| Sync model | PowerSync **Sync Streams** (`ps_stream_subscriptions`, `StreamSubscriptionRequest`, `subscribe`/`unsubscribe`, per-subscription `ttl`) — the newer stream-subscription protocol, not classic JWT-only bucket derivation |
-| Storage | Local SQLite + the PowerSync SQLite extension |
-| Backend connector | Custom — Kilter implements their own connector backed by the REST API |
-| Auth mode | **Keycloak access token used directly** as PowerSync JWT (see [§3](#3-authentication-for-the-sync-stream)) |
-| Streaming endpoint | `POST https://sync1.kiltergrips.com/sync/stream` |
-| Write-checkpoint endpoint | `https://sync1.kiltergrips.com/write-checkpoint2.json?client_id=<powersync_client_id>` |
-| Content-Type negotiation | `Accept: application/vnd.powersync.bson-stream;q=0.9,application/x-ndjson;q=0.8` |
+| Property                  | Value                                                                                                                                                                                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Service host              | `https://sync1.kiltergrips.com`                                                                                                                                                                                                                                           |
+| Sync core                 | **Rust core `0.4.10`** (`powersync_rs_version` string in `libpowersync.so`), wrapped by the PowerSync Dart SDK                                                                                                                                                            |
+| Local schema mode         | **Raw tables** — the app declares real `CREATE TABLE`s and PowerSync applies oplog rows through configured INSERT/UPDATE/DELETE statements, instead of the default auto-generated `ps_data_*` views (`RawTable` / `raw_tables` / `PendingStatement` in `libpowersync.so`) |
+| Sync model                | PowerSync **Sync Streams** (`ps_stream_subscriptions`, `StreamSubscriptionRequest`, `subscribe`/`unsubscribe`, per-subscription `ttl`) — the newer stream-subscription protocol, not classic JWT-only bucket derivation                                                   |
+| Storage                   | Local SQLite + the PowerSync SQLite extension                                                                                                                                                                                                                             |
+| Backend connector         | Custom — Kilter implements their own connector backed by the REST API                                                                                                                                                                                                     |
+| Auth mode                 | **Keycloak access token used directly** as PowerSync JWT (see [§3](#3-authentication-for-the-sync-stream))                                                                                                                                                                |
+| Streaming endpoint        | `POST https://sync1.kiltergrips.com/sync/stream`                                                                                                                                                                                                                          |
+| Write-checkpoint endpoint | `https://sync1.kiltergrips.com/write-checkpoint2.json?client_id=<powersync_client_id>`                                                                                                                                                                                    |
+| Content-Type negotiation  | `Accept: application/vnd.powersync.bson-stream;q=0.9,application/x-ndjson;q=0.8`                                                                                                                                                                                          |
 
 The client identifies itself with a stable UUID returned by `SELECT powersync_client_id()` — the PowerSync extension generates and persists this per install. It's appended to write-checkpoint calls so the server can correlate uploaded writes with the streaming session.
 
@@ -90,26 +90,36 @@ Kilter does **not** mint a separate PowerSync JWT. The standard Keycloak `access
 This is **confirmed working** by a standalone `@powersync/node` scraper that syncs `gyms` + `walls`:
 
 ```ts
-const KILTER_AUTH_URL  = "https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token";
-const KILTER_SYNC_ENDPOINT = "https://sync1.kiltergrips.com";
-const KILTER_CLIENT_ID  = "kilter";              // the realm's public client
-const KILTER_SCOPE      = "openid offline_access";
+const KILTER_AUTH_URL = 'https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token';
+const KILTER_SYNC_ENDPOINT = 'https://sync1.kiltergrips.com';
+const KILTER_CLIENT_ID = 'kilter'; // the realm's public client
+const KILTER_SCOPE = 'openid offline_access';
 
 // Resource-Owner-Password grant → access_token, used verbatim as the PowerSync token.
 const body = new URLSearchParams({
-  grant_type: "password", client_id: KILTER_CLIENT_ID, username, password, scope: KILTER_SCOPE,
+  grant_type: 'password',
+  client_id: KILTER_CLIENT_ID,
+  username,
+  password,
+  scope: KILTER_SCOPE,
 });
-const { access_token, expires_in } = await (await fetch(KILTER_AUTH_URL, {
-  method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body,
-})).json();
+const { access_token, expires_in } = await (
+  await fetch(KILTER_AUTH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+).json();
 
 const connector: PowerSyncBackendConnector = {
   fetchCredentials: async () => ({
     endpoint: KILTER_SYNC_ENDPOINT,
-    token: access_token,                          // Keycloak JWT, no exchange
+    token: access_token, // Keycloak JWT, no exchange
     expiresAt: new Date(Date.now() + (expires_in - 60) * 1000),
   }),
-  uploadData: async () => { /* read-only scraper */ },
+  uploadData: async () => {
+    /* read-only scraper */
+  },
 };
 ```
 
@@ -117,8 +127,8 @@ The minted access token carries `aud: ["kilter", "account"]` (the `account` audi
 
 **Two token theories that are NOT the answer** — both come up when the public climb catalog fails to sync, and both are dead ends:
 
-1. *"A different scope (`kilter-catalog`, `portal`, …) would mint `aud: ["kilter-portal", …]` and unlock more buckets."* The app binary contains exactly one OAuth scope (`offline_access`, plus implicit `openid`) and one realm/client. There is no second audience or catalog scope anywhere in `libapp.so`. PowerSync checks `aud` **once per connection**, not per bucket — if the token authenticates the stream at all (it does; gyms/walls sync), audience is not gating any particular table.
-2. *"The portal/web uses a different `client_id` that gets broader buckets."* The only Keycloak client is `kilter`. The other client-id strings in the binary (`androidClientId`, `iosClientId`, `kilter-app-analytics`, `…firebasestorage.app`) are **Firebase / Google** identifiers for Google Sign-In, Places, and analytics — unrelated to PowerSync auth.
+1. _"A different scope (`kilter-catalog`, `portal`, …) would mint `aud: ["kilter-portal", …]` and unlock more buckets."_ The app binary contains exactly one OAuth scope (`offline_access`, plus implicit `openid`) and one realm/client. There is no second audience or catalog scope anywhere in `libapp.so`. PowerSync checks `aud` **once per connection**, not per bucket — if the token authenticates the stream at all (it does; gyms/walls sync), audience is not gating any particular table.
+2. _"The portal/web uses a different `client_id` that gets broader buckets."_ The only Keycloak client is `kilter`. The other client-id strings in the binary (`androidClientId`, `iosClientId`, `kilter-app-analytics`, `…firebasestorage.app`) are **Firebase / Google** identifiers for Google Sign-In, Places, and analytics — unrelated to PowerSync auth.
 
 The real reason the catalog doesn't sync is structural, not credential: the public climb catalog is not served by PowerSync at all (see [§6](#6-what-syncs-where)). No token change unlocks it.
 
@@ -159,13 +169,13 @@ The body shape is fixed by the PowerSync protocol — clients don't choose bucke
 
 The server responds with `Transfer-Encoding: chunked`, emitting newline-delimited JSON (or length-prefixed BSON if the client negotiated BSON). Message types:
 
-| Message | Purpose |
-| --- | --- |
-| `StreamingSyncCheckpoint` | Marks a consistent checkpoint that includes a `last_op_id`, list of buckets, and per-bucket checksums |
-| `StreamingSyncCheckpointDiff` | Incremental change to the active bucket set |
-| `StreamingSyncCheckpointComplete` | Server has finished sending all data up to the checkpoint |
-| `StreamingSyncData` | A batch of oplog rows for one bucket (`{ bucket, data: [{ op_id, op, object_type, object_id, checksum, data }] }`) |
-| `StreamingSyncKeepalive` | Periodic heartbeat with `token_expires_in` seconds — client should refresh auth before this hits zero |
+| Message                           | Purpose                                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `StreamingSyncCheckpoint`         | Marks a consistent checkpoint that includes a `last_op_id`, list of buckets, and per-bucket checksums              |
+| `StreamingSyncCheckpointDiff`     | Incremental change to the active bucket set                                                                        |
+| `StreamingSyncCheckpointComplete` | Server has finished sending all data up to the checkpoint                                                          |
+| `StreamingSyncData`               | A batch of oplog rows for one bucket (`{ bucket, data: [{ op_id, op, object_type, object_id, checksum, data }] }`) |
+| `StreamingSyncKeepalive`          | Periodic heartbeat with `token_expires_in` seconds — client should refresh auth before this hits zero              |
 
 ### 4.3 CRUD upload
 
@@ -192,37 +202,37 @@ These rows stream from `sync1.kiltergrips.com` and are confirmed (`gyms`, `walls
 
 **Global reference catalog** (small, identical for every user — the "static" board data):
 
-| Table | Indexed columns (and inferred PK) | Notes |
-| --- | --- | --- |
-| `products` | `product_name` (pk) | Board models (Kilter Original / Homewall / Mini / Grasshopper / etc.) |
-| `product_layouts` | `product_layout_uuid` (pk), `product_name` | Specific layout variants per product |
-| `mounting_holes` | `mounting_hole_uuid` (pk), `product_name` | Hardware catalog — every hole on every board |
-| `holds` | `hold_id` (pk) | Hold catalog |
-| `hold_sets` | `hold_set_name` (pk) | Hold-set groupings (Kilter HS, KS, etc.) |
-| `placement_types` | `placement_type` (pk), `short_ref` | start/hand/foot/finish enum |
-| `difficulty_grades` | `difficulty_grade_id` (pk) | Grade catalog (V-scale, font-scale) |
-| `gyms` | `gym_uuid` (pk) | Gym directory — schema confirmed (see [§5.3](#53-gyms-table-confirmed-schema)) |
-| `walls` | `wall_uuid` (pk), `product_layout_uuid`, `product_name`, `gym_uuid` | Physical boards |
+| Table               | Indexed columns (and inferred PK)                                   | Notes                                                                          |
+| ------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `products`          | `product_name` (pk)                                                 | Board models (Kilter Original / Homewall / Mini / Grasshopper / etc.)          |
+| `product_layouts`   | `product_layout_uuid` (pk), `product_name`                          | Specific layout variants per product                                           |
+| `mounting_holes`    | `mounting_hole_uuid` (pk), `product_name`                           | Hardware catalog — every hole on every board                                   |
+| `holds`             | `hold_id` (pk)                                                      | Hold catalog                                                                   |
+| `hold_sets`         | `hold_set_name` (pk)                                                | Hold-set groupings (Kilter HS, KS, etc.)                                       |
+| `placement_types`   | `placement_type` (pk), `short_ref`                                  | start/hand/foot/finish enum                                                    |
+| `difficulty_grades` | `difficulty_grade_id` (pk)                                          | Grade catalog (V-scale, font-scale)                                            |
+| `gyms`              | `gym_uuid` (pk)                                                     | Gym directory — schema confirmed (see [§5.3](#53-gyms-table-confirmed-schema)) |
+| `walls`             | `wall_uuid` (pk), `product_layout_uuid`, `product_name`, `gym_uuid` | Physical boards                                                                |
 
 **Per-user data** (scoped to the authenticated `sub` by server-side stream rules):
 
-| Table | Indexed columns (and inferred PK) | Notes |
-| --- | --- | --- |
-| `users` | `user_uuid` (pk), `email` | Profiles |
-| `user_settings` | `user_uuid` (pk) | Per-user preferences |
-| `user_analytics` | `user_uuid` (pk) | Aggregated stats |
-| `user_followers` | `user_uuid` | Follower edges |
-| `user_blocked_climbs` | `user_uuid`, `climb_uuid` | Composite |
-| `user_notifications` | `user_uuid`, `receiver_uuid` | Notification feed |
-| `gym_followers` | `user_uuid` | Gym follow edges |
-| `gym_notifications` | `gym_uuid`, `receiver_uuid` | Notifications scoped to a gym |
-| `logs` | `user_uuid`, `climb_uuid`, `product_layout_uuid`, `created_at` | Confirmed ascents |
-| `attempts` | `user_uuid`, `product_layout_uuid`, `angle` | **Separate** from `logs` — attempts/bids vs sends |
-| `climb_ratings` | `climb_rating_uuid` (pk), `user_uuid`, `climb_uuid`, `wall_uuid`, `gym_uuid`, `product_layout_uuid`, `difficulty_grade_id` | Heavily indexed |
-| `circuits` | `circuit_uuid` (pk) | Curated route lists |
-| `circuit_climbs` | `circuit_uuid`, `climb_uuid` | Many-to-many |
-| `climb_mounting_holes` | `climb_uuid`, `product_layout_uuid`, `mounting_hole_uuid`, `hold_placement_id`, `placement_type`, `default_placement_type`, `hold_id` | Hold placements per climb |
-| `climb_beta_links` | `climb_uuid`, `angle`, `link` | External beta video/post links |
+| Table                  | Indexed columns (and inferred PK)                                                                                                     | Notes                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `users`                | `user_uuid` (pk), `email`                                                                                                             | Profiles                                          |
+| `user_settings`        | `user_uuid` (pk)                                                                                                                      | Per-user preferences                              |
+| `user_analytics`       | `user_uuid` (pk)                                                                                                                      | Aggregated stats                                  |
+| `user_followers`       | `user_uuid`                                                                                                                           | Follower edges                                    |
+| `user_blocked_climbs`  | `user_uuid`, `climb_uuid`                                                                                                             | Composite                                         |
+| `user_notifications`   | `user_uuid`, `receiver_uuid`                                                                                                          | Notification feed                                 |
+| `gym_followers`        | `user_uuid`                                                                                                                           | Gym follow edges                                  |
+| `gym_notifications`    | `gym_uuid`, `receiver_uuid`                                                                                                           | Notifications scoped to a gym                     |
+| `logs`                 | `user_uuid`, `climb_uuid`, `product_layout_uuid`, `created_at`                                                                        | Confirmed ascents                                 |
+| `attempts`             | `user_uuid`, `product_layout_uuid`, `angle`                                                                                           | **Separate** from `logs` — attempts/bids vs sends |
+| `climb_ratings`        | `climb_rating_uuid` (pk), `user_uuid`, `climb_uuid`, `wall_uuid`, `gym_uuid`, `product_layout_uuid`, `difficulty_grade_id`            | Heavily indexed                                   |
+| `circuits`             | `circuit_uuid` (pk)                                                                                                                   | Curated route lists                               |
+| `circuit_climbs`       | `circuit_uuid`, `climb_uuid`                                                                                                          | Many-to-many                                      |
+| `climb_mounting_holes` | `climb_uuid`, `product_layout_uuid`, `mounting_hole_uuid`, `hold_placement_id`, `placement_type`, `default_placement_type`, `hold_id` | Hold placements per climb                         |
+| `climb_beta_links`     | `climb_uuid`, `angle`, `link`                                                                                                         | External beta video/post links                    |
 
 > The app writes `logs`, `attempts`, `climb_ratings`, `circuits`, `circuit_climbs`, `walls`, `user_settings`, `user_blocked_climbs` locally (direct `INSERT … RETURNING *`) for optimistic UI, then uploads via REST; PowerSync mirrors the server's version back. For a read-only Boardsesh consumer, treat them as read-only sync targets.
 
@@ -230,13 +240,13 @@ These rows stream from `sync1.kiltergrips.com` and are confirmed (`gyms`, `walls
 
 These are plain local SQLite tables the app fills itself. **They are not PowerSync buckets.** This is the correction at the heart of this revision.
 
-| Table | Populated by | Notes |
-| --- | --- | --- |
-| `climbs` | REST: `GET /api/climbs/climbdetails/{productName}/edges?…limit=&offset=` (paginated by board region), `/api/climbs/curated`, `/api/climbs/all/` | Direct `INSERT INTO climbs (id, climb_uuid, …)` in app code. The full public climb catalog. |
-| `climb_stats` | REST: `/api/climb-stat/all/` (and inline with climb detail) | Direct `INSERT INTO climb_stats (…)`. Per-climb-angle aggregates. |
-| `climbs_for_product_fetch_info` | App bookkeeping | Tracks paginated-fetch progress per `(product_name, edge_*)`; drives the "Downloading data…" preparing screen on first login. Proof that the catalog is pulled, not streamed. |
-| `product_layout_updates` | App bookkeeping | Per-layout cache-invalidation marker (`updated_at`). |
-| `recently_tried_climbs` | App-local | Device-only history; never leaves the device. |
+| Table                           | Populated by                                                                                                                                    | Notes                                                                                                                                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `climbs`                        | REST: `GET /api/climbs/climbdetails/{productName}/edges?…limit=&offset=` (paginated by board region), `/api/climbs/curated`, `/api/climbs/all/` | Direct `INSERT INTO climbs (id, climb_uuid, …)` in app code. The full public climb catalog.                                                                                   |
+| `climb_stats`                   | REST: `/api/climb-stat/all/` (and inline with climb detail)                                                                                     | Direct `INSERT INTO climb_stats (…)`. Per-climb-angle aggregates.                                                                                                             |
+| `climbs_for_product_fetch_info` | App bookkeeping                                                                                                                                 | Tracks paginated-fetch progress per `(product_name, edge_*)`; drives the "Downloading data…" preparing screen on first login. Proof that the catalog is pulled, not streamed. |
+| `product_layout_updates`        | App bookkeeping                                                                                                                                 | Per-layout cache-invalidation marker (`updated_at`).                                                                                                                          |
+| `recently_tried_climbs`         | App-local                                                                                                                                       | Device-only history; never leaves the device.                                                                                                                                 |
 
 See [§6](#6-what-syncs-where) for the full data-flow picture and [KILTER_HTTP_API_SPEC.md §5.2](KILTER_HTTP_API_SPEC.md#52-climbs) for the catalog endpoints and `climbs` schema.
 
@@ -292,7 +302,7 @@ Kilter splits catalog data across **two transports**, and that split is the answ
 Five independent signals in the app, all pointing the same way:
 
 1. **Direct inserts.** The app issues `INSERT INTO climbs (id, climb_uuid, climb_concat, name, …)` and `INSERT INTO climb_stats (…)` itself — you don't hand-write inserts into a PowerSync-managed view.
-2. **A progress table.** `climbs_for_product_fetch_info(product_name, count, progress, edge_left, edge_right, edge_bottom, edge_top, last_updated_at)` exists only to track *paginated fetching* of climbs by board region. PowerSync tracks its own sync state; a per-region progress counter is a REST-pagination artifact.
+2. **A progress table.** `climbs_for_product_fetch_info(product_name, count, progress, edge_left, edge_right, edge_bottom, edge_top, last_updated_at)` exists only to track _paginated fetching_ of climbs by board region. PowerSync tracks its own sync state; a per-region progress counter is a REST-pagination artifact.
 3. **A count endpoint.** `/edges/count` returns a total so the client can drive a progress bar — a REST/pagination idiom, meaningless for a streamed bucket.
 4. **A "preparing" screen.** `preparing_screen.dart` shows "Downloading data…" on first login while it pages the catalog in. PowerSync's first sync needs no app-driven download loop.
 5. **It's confirmed empty over PowerSync.** A working `@powersync/node` scraper syncs `gyms`/`walls` fine but gets no public catalog when it adds `climbs` to the schema — because nothing streams there.
@@ -302,7 +312,7 @@ Five independent signals in the app, all pointing the same way:
 - **Catalog (Flow A):** pull `climbs` + `climb_stats` over REST, paging `/api/climbs/climbdetails/{productName}/edges` per product per board region (or try `/api/climbs/all/` + `/api/climb-stat/all/` for a bulk pull), using the same Keycloak token. Do **not** model it as a PowerSync bucket. See [kilter-sync.md → Catalog sync (Flow A)](kilter-sync.md#catalog-sync-flow-a).
 - **Per-user (Flow B):** a normal `@powersync/node` connection with the user's token streams their `logs` / `attempts` / `climb_ratings` / `circuits`, plus the reference catalog and `gyms`/`walls`. This is the part PowerSync is genuinely for.
 
-> Confidence: HIGH that the public catalog is REST-fed (five signals + the working scraper). HIGH that reference + per-user data is PowerSync. The exact server-side stream/bucket *names* remain server-side and unverifiable from the client, but they no longer matter for the integration — the client never names a bucket, it declares tables and the server fills them.
+> Confidence: HIGH that the public catalog is REST-fed (five signals + the working scraper). HIGH that reference + per-user data is PowerSync. The exact server-side stream/bucket _names_ remain server-side and unverifiable from the client, but they no longer matter for the integration — the client never names a bucket, it declares tables and the server fills them.
 
 ---
 

--- a/packages/backend/src/graphql/resolvers/beta-videos/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/mutations.ts
@@ -1,0 +1,49 @@
+import { GraphQLError } from 'graphql';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../../../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { requireAuthenticated } from '../shared/helpers';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { invalidateRecentBetaLinksCache } from './queries';
+
+export const betaLinkMutations = {
+  deleteBetaLink: async (
+    _: unknown,
+    { boardType, climbUuid, link }: { boardType: string; climbUuid: string; link: string },
+    ctx: ConnectionContext,
+  ): Promise<boolean> => {
+    requireAuthenticated(ctx);
+    const userId = ctx.userId!;
+
+    const [row] = await db
+      .select({ createdByUserId: dbSchema.boardBetaLinks.createdByUserId })
+      .from(dbSchema.boardBetaLinks)
+      .where(
+        and(
+          eq(dbSchema.boardBetaLinks.boardType, boardType),
+          eq(dbSchema.boardBetaLinks.climbUuid, climbUuid),
+          eq(dbSchema.boardBetaLinks.link, link),
+        ),
+      )
+      .limit(1);
+
+    if (!row || row.createdByUserId !== userId) {
+      throw new GraphQLError('You can only delete beta links you attached.', {
+        extensions: { code: 'BETA_LINK_NOT_OWNER' },
+      });
+    }
+
+    await db
+      .delete(dbSchema.boardBetaLinks)
+      .where(
+        and(
+          eq(dbSchema.boardBetaLinks.boardType, boardType),
+          eq(dbSchema.boardBetaLinks.climbUuid, climbUuid),
+          eq(dbSchema.boardBetaLinks.link, link),
+        ),
+      );
+
+    invalidateRecentBetaLinksCache().catch(() => {});
+    return true;
+  },
+};

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -17,6 +17,12 @@ import { logger } from '../../../utils/logger';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { applyRateLimit, requireAuthenticated } from '../shared/helpers';
 
+type BetaLinkAttacher = {
+  id: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
 type BetaLinkResult = {
   climbUuid: string;
   link: string;
@@ -25,6 +31,7 @@ type BetaLinkResult = {
   thumbnail: string | null;
   isListed: boolean | null;
   createdAt: string | null;
+  attachedByUser: BetaLinkAttacher | null;
 };
 
 type RecentBetaLinkResult = {
@@ -121,7 +128,7 @@ const TIKTOK_ENRICH: EnrichConfig = {
 
 const ENRICH_CONCURRENCY = 5;
 
-function passthroughResult(row: Row): BetaLinkResult {
+function passthroughResult(row: Row, attachedByUser: BetaLinkAttacher | null = null): BetaLinkResult {
   return {
     climbUuid: row.climbUuid,
     link: row.link,
@@ -130,6 +137,7 @@ function passthroughResult(row: Row): BetaLinkResult {
     thumbnail: isOurS3Url(row.thumbnail) ? row.thumbnail : null,
     isListed: row.isListed,
     createdAt: row.createdAt,
+    attachedByUser,
   };
 }
 
@@ -168,7 +176,11 @@ async function persistEnriched(row: Row, persistedThumbnail: string | null, newU
  * `gone` heuristic miss — those signals can flap when IG rate-limits us or
  * serves a login wall.
  */
-async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | null> {
+async function enrichRow(
+  row: Row,
+  cfg: EnrichConfig,
+  attachedByUser: BetaLinkAttacher | null,
+): Promise<BetaLinkResult | null> {
   const haveCachedThumbnail = isOurS3Url(row.thumbnail);
 
   // Short-circuit: once we've cached the thumbnail we have everything we
@@ -187,6 +199,7 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
       thumbnail: row.thumbnail,
       isListed: row.isListed,
       createdAt: row.createdAt,
+      attachedByUser,
     };
   }
 
@@ -200,7 +213,7 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
   if (meta.status === 'transient_error') {
     // No cached thumbnail; passthroughResult will return thumbnail: null but
     // keeps the row visible in the slider with whatever metadata we have.
-    return passthroughResult(row);
+    return passthroughResult(row, attachedByUser);
   }
 
   // haveCachedThumbnail is necessarily false past the short-circuit above —
@@ -227,6 +240,7 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
     thumbnail,
     isListed: row.isListed,
     createdAt: row.createdAt,
+    attachedByUser,
   };
 }
 
@@ -263,13 +277,13 @@ function makeLimiter(concurrency: number): <T>(task: () => Promise<T>) => Promis
   };
 }
 
-async function enrichRowSafe(row: Row): Promise<BetaLinkResult | null> {
+async function enrichRowSafe(row: Row, attachedByUser: BetaLinkAttacher | null): Promise<BetaLinkResult | null> {
   if (isKayaClimbUrl(row.link)) return null;
-  if (isInstagramUrl(row.link)) return enrichRow(row, INSTAGRAM_ENRICH);
-  if (isTikTokUrl(row.link)) return enrichRow(row, TIKTOK_ENRICH);
+  if (isInstagramUrl(row.link)) return enrichRow(row, INSTAGRAM_ENRICH, attachedByUser);
+  if (isTikTokUrl(row.link)) return enrichRow(row, TIKTOK_ENRICH, attachedByUser);
   // Unknown platform: serve only an already-cached thumbnail (don't hot-link
   // an arbitrary URL).
-  return passthroughResult(row);
+  return passthroughResult(row, attachedByUser);
 }
 
 // snake_case shape returned by the raw SQL CTE; we cache the row set in this
@@ -421,12 +435,24 @@ export const betaLinkQueries = {
     { boardType, climbUuid }: { boardType: string; climbUuid: string },
   ): Promise<BetaLinkResult[]> => {
     const rows = await db
-      .select()
+      .select({
+        betaLink: dbSchema.boardBetaLinks,
+        displayName: dbSchema.userProfiles.displayName,
+        avatarUrl: dbSchema.userProfiles.avatarUrl,
+      })
       .from(dbSchema.boardBetaLinks)
+      .leftJoin(dbSchema.userProfiles, eq(dbSchema.boardBetaLinks.createdByUserId, dbSchema.userProfiles.userId))
       .where(and(eq(dbSchema.boardBetaLinks.boardType, boardType), eq(dbSchema.boardBetaLinks.climbUuid, climbUuid)));
 
     const limit = makeLimiter(ENRICH_CONCURRENCY);
-    const enriched = await Promise.all(rows.map((row) => limit(() => enrichRowSafe(row))));
+    const enriched = await Promise.all(
+      rows.map(({ betaLink, displayName, avatarUrl }) => {
+        const attachedByUser = betaLink.createdByUserId
+          ? { id: betaLink.createdByUserId, displayName: displayName ?? null, avatarUrl: avatarUrl ?? null }
+          : null;
+        return limit(() => enrichRowSafe(betaLink, attachedByUser));
+      }),
+    );
 
     return enriched.filter((r): r is BetaLinkResult => r !== null);
   },
@@ -515,6 +541,7 @@ export const betaLinkQueries = {
           thumbnail: r.thumbnail,
           isListed: r.is_listed,
           createdAt: r.created_at,
+          attachedByUser: null,
         },
         climbName: r.climb_name,
         boardType: r.board_type,

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -52,6 +52,7 @@ import { feedbackMutations } from './feedback/mutations';
 import { integrationQueries } from './integrations/queries';
 import { integrationMutations } from './integrations/mutations';
 import { betaLinkQueries } from './beta-videos/queries';
+import { betaLinkMutations } from './beta-videos/mutations';
 import { isNoMatchClimb } from './shared/helpers';
 
 export const resolvers = {
@@ -112,6 +113,7 @@ export const resolvers = {
     ...sessionEditMutations,
     ...feedbackMutations,
     ...integrationMutations,
+    ...betaLinkMutations,
   },
 
   Subscription: {

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, inArray, isNull } from 'drizzle-orm';
+import { eq, and, inArray, isNull, sql } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext, TickStatus } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
@@ -468,8 +468,21 @@ export const tickMutations = {
             foreignUsername: betaPlan.foreignUsername,
             createdAt: now,
             createdByUserId: userId,
+            attachedByTickId: uuid,
           })
-          .onConflictDoNothing();
+          .onConflictDoUpdate({
+            target: [
+              dbSchema.boardBetaLinks.boardType,
+              dbSchema.boardBetaLinks.climbUuid,
+              dbSchema.boardBetaLinks.link,
+            ],
+            set: {
+              // Only fill in attribution when the existing row has no attribution yet —
+              // preserve any attribution already set by a different user or path.
+              createdByUserId: sql`CASE WHEN ${dbSchema.boardBetaLinks.createdByUserId} IS NULL THEN EXCLUDED.created_by_user_id ELSE ${dbSchema.boardBetaLinks.createdByUserId} END`,
+              attachedByTickId: sql`CASE WHEN ${dbSchema.boardBetaLinks.attachedByTickId} IS NULL THEN EXCLUDED.attached_by_tick_id ELSE ${dbSchema.boardBetaLinks.attachedByTickId} END`,
+            },
+          });
       }
 
       return [createdTick];

--- a/packages/db/drizzle/0124_clean_mephisto.sql
+++ b/packages/db/drizzle/0124_clean_mephisto.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "board_beta_links" ADD COLUMN "attached_by_tick_id" text;--> statement-breakpoint
+CREATE INDEX "board_beta_links_attached_by_tick_idx" ON "board_beta_links" USING btree ("attached_by_tick_id") WHERE "board_beta_links"."attached_by_tick_id" IS NOT NULL;--> statement-breakpoint
+-- FK is added manually because the Drizzle schema doesn't declare a references() on
+-- this column (the boards/ schema avoids cross-package references to app/ascents).
+-- ON DELETE SET NULL keeps the community video record when a tick is deleted.
+--
+-- Postgres has no `ADD CONSTRAINT IF NOT EXISTS`; use a DO block guarded
+-- by pg_constraint lookup so the statement is safe to re-run.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'board_beta_links_attached_by_tick_id_fkey'
+      AND conrelid = '"board_beta_links"'::regclass
+  ) THEN
+    ALTER TABLE "board_beta_links"
+      ADD CONSTRAINT "board_beta_links_attached_by_tick_id_fkey"
+      FOREIGN KEY ("attached_by_tick_id") REFERENCES "boardsesh_ticks"("uuid") ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/packages/db/drizzle/meta/0114_snapshot.json
+++ b/packages/db/drizzle/meta/0114_snapshot.json
@@ -38,10 +38,7 @@
       "compositePrimaryKeys": {
         "board_attempts_board_type_id_pk": {
           "name": "board_attempts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -164,11 +161,7 @@
       "compositePrimaryKeys": {
         "board_beta_links_board_type_climb_uuid_link_pk": {
           "name": "board_beta_links_board_type_climb_uuid_link_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "link"
-          ]
+          "columns": ["board_type", "climb_uuid", "link"]
         }
       },
       "uniqueConstraints": {},
@@ -241,14 +234,8 @@
           "name": "board_circuits_user_fk",
           "tableFrom": "board_circuits",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -256,10 +243,7 @@
       "compositePrimaryKeys": {
         "board_circuits_board_type_uuid_pk": {
           "name": "board_circuits_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -302,14 +286,8 @@
           "name": "board_circuits_climbs_circuit_fk",
           "tableFrom": "board_circuits_climbs",
           "tableTo": "board_circuits",
-          "columnsFrom": [
-            "board_type",
-            "circuit_uuid"
-          ],
-          "columnsTo": [
-            "board_type",
-            "uuid"
-          ],
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "columnsTo": ["board_type", "uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -317,12 +295,8 @@
           "name": "board_circuits_climbs_climb_fk",
           "tableFrom": "board_circuits_climbs",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -330,11 +304,7 @@
       "compositePrimaryKeys": {
         "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
           "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "circuit_uuid",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -413,12 +383,8 @@
           "name": "board_climb_aliases_canonical_fk",
           "tableFrom": "board_climb_aliases",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "canonical_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["canonical_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -426,10 +392,7 @@
       "compositePrimaryKeys": {
         "board_climb_aliases_board_type_alias_uuid_pk": {
           "name": "board_climb_aliases_board_type_alias_uuid_pk",
-          "columns": [
-            "board_type",
-            "alias_uuid"
-          ]
+          "columns": ["board_type", "alias_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -518,12 +481,8 @@
           "name": "board_climb_holds_climb_fk",
           "tableFrom": "board_climb_holds",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -531,11 +490,7 @@
       "compositePrimaryKeys": {
         "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
           "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "hold_id"
-          ]
+          "columns": ["board_type", "climb_uuid", "hold_id"]
         }
       },
       "uniqueConstraints": {},
@@ -723,12 +678,8 @@
           "name": "board_climb_ratings_user_id_users_id_fk",
           "tableFrom": "board_climb_ratings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -832,11 +783,7 @@
       "compositePrimaryKeys": {
         "board_climb_stats_board_type_climb_uuid_angle_pk": {
           "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "angle"
-          ]
+          "columns": ["board_type", "climb_uuid", "angle"]
         }
       },
       "uniqueConstraints": {},
@@ -1294,12 +1241,8 @@
           "name": "board_climbs_user_id_users_id_fk",
           "tableFrom": "board_climbs",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1350,10 +1293,7 @@
       "compositePrimaryKeys": {
         "board_difficulty_grades_board_type_difficulty_pk": {
           "name": "board_difficulty_grades_board_type_difficulty_pk",
-          "columns": [
-            "board_type",
-            "difficulty"
-          ]
+          "columns": ["board_type", "difficulty"]
         }
       },
       "uniqueConstraints": {},
@@ -1421,14 +1361,8 @@
           "name": "board_holes_product_fk",
           "tableFrom": "board_holes",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1436,10 +1370,7 @@
       "compositePrimaryKeys": {
         "board_holes_board_type_id_pk": {
           "name": "board_holes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1499,10 +1430,7 @@
       "compositePrimaryKeys": {
         "board_kits_board_type_serial_number_pk": {
           "name": "board_kits_board_type_serial_number_pk",
-          "columns": [
-            "board_type",
-            "serial_number"
-          ]
+          "columns": ["board_type", "serial_number"]
         }
       },
       "uniqueConstraints": {},
@@ -1581,14 +1509,8 @@
           "name": "board_layout_aliases_layout_fk",
           "tableFrom": "board_layout_aliases",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1596,10 +1518,7 @@
       "compositePrimaryKeys": {
         "board_layout_aliases_board_type_layout_uuid_pk": {
           "name": "board_layout_aliases_board_type_layout_uuid_pk",
-          "columns": [
-            "board_type",
-            "layout_uuid"
-          ]
+          "columns": ["board_type", "layout_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -1677,14 +1596,8 @@
           "name": "board_layouts_product_fk",
           "tableFrom": "board_layouts",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1692,10 +1605,7 @@
       "compositePrimaryKeys": {
         "board_layouts_board_type_id_pk": {
           "name": "board_layouts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1744,14 +1654,8 @@
           "name": "board_leds_product_size_fk",
           "tableFrom": "board_leds",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1759,14 +1663,8 @@
           "name": "board_leds_hole_fk",
           "tableFrom": "board_leds",
           "tableTo": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1774,10 +1672,7 @@
       "compositePrimaryKeys": {
         "board_leds_board_type_id_pk": {
           "name": "board_leds_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1844,14 +1739,8 @@
           "name": "board_placement_roles_product_fk",
           "tableFrom": "board_placement_roles",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1859,10 +1748,7 @@
       "compositePrimaryKeys": {
         "board_placement_roles_board_type_id_pk": {
           "name": "board_placement_roles_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1957,14 +1843,8 @@
           "name": "board_placements_layout_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1972,14 +1852,8 @@
           "name": "board_placements_hole_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1987,14 +1861,8 @@
           "name": "board_placements_set_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2002,14 +1870,8 @@
           "name": "board_placements_role_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_placement_roles",
-          "columnsFrom": [
-            "board_type",
-            "default_placement_role_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         }
@@ -2017,10 +1879,7 @@
       "compositePrimaryKeys": {
         "board_placements_board_type_id_pk": {
           "name": "board_placements_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2111,14 +1970,8 @@
           "name": "board_product_sizes_product_fk",
           "tableFrom": "board_product_sizes",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2126,10 +1979,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_board_type_id_pk": {
           "name": "board_product_sizes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2190,14 +2040,8 @@
           "name": "board_psls_product_size_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2205,14 +2049,8 @@
           "name": "board_psls_layout_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2220,14 +2058,8 @@
           "name": "board_psls_set_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2235,10 +2067,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_layouts_sets_board_type_id_pk": {
           "name": "board_product_sizes_layouts_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2298,10 +2127,7 @@
       "compositePrimaryKeys": {
         "board_products_board_type_id_pk": {
           "name": "board_products_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2343,10 +2169,7 @@
       "compositePrimaryKeys": {
         "board_sets_board_type_id_pk": {
           "name": "board_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2382,10 +2205,7 @@
       "compositePrimaryKeys": {
         "board_shared_syncs_board_type_table_name_pk": {
           "name": "board_shared_syncs_board_type_table_name_pk",
-          "columns": [
-            "board_type",
-            "table_name"
-          ]
+          "columns": ["board_type", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2433,12 +2253,7 @@
       "compositePrimaryKeys": {
         "board_tags_board_type_entity_uuid_user_id_name_pk": {
           "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
-          "columns": [
-            "board_type",
-            "entity_uuid",
-            "user_id",
-            "name"
-          ]
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
         }
       },
       "uniqueConstraints": {},
@@ -2481,14 +2296,8 @@
           "name": "board_user_syncs_user_fk",
           "tableFrom": "board_user_syncs",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2496,11 +2305,7 @@
       "compositePrimaryKeys": {
         "board_user_syncs_board_type_user_id_table_name_pk": {
           "name": "board_user_syncs_board_type_user_id_table_name_pk",
-          "columns": [
-            "board_type",
-            "user_id",
-            "table_name"
-          ]
+          "columns": ["board_type", "user_id", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2542,10 +2347,7 @@
       "compositePrimaryKeys": {
         "board_users_board_type_id_pk": {
           "name": "board_users_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2636,14 +2438,8 @@
           "name": "board_walls_user_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2651,14 +2447,8 @@
           "name": "board_walls_product_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         },
@@ -2666,14 +2456,8 @@
           "name": "board_walls_layout_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         },
@@ -2681,14 +2465,8 @@
           "name": "board_walls_product_size_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         }
@@ -2696,10 +2474,7 @@
       "compositePrimaryKeys": {
         "board_walls_board_type_uuid_pk": {
           "name": "board_walls_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -2784,12 +2559,8 @@
           "name": "accounts_userId_users_id_fk",
           "tableFrom": "accounts",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2797,10 +2568,7 @@
       "compositePrimaryKeys": {
         "accounts_provider_providerAccountId_pk": {
           "name": "accounts_provider_providerAccountId_pk",
-          "columns": [
-            "provider",
-            "providerAccountId"
-          ]
+          "columns": ["provider", "providerAccountId"]
         }
       },
       "uniqueConstraints": {},
@@ -2837,12 +2605,8 @@
           "name": "sessions_userId_users_id_fk",
           "tableFrom": "sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2938,10 +2702,7 @@
       "compositePrimaryKeys": {
         "verificationTokens_identifier_token_pk": {
           "name": "verificationTokens_identifier_token_pk",
-          "columns": [
-            "identifier",
-            "token"
-          ]
+          "columns": ["identifier", "token"]
         }
       },
       "uniqueConstraints": {},
@@ -2986,12 +2747,8 @@
           "name": "user_credentials_user_id_users_id_fk",
           "tableFrom": "user_credentials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3051,12 +2808,8 @@
           "name": "user_profiles_user_id_users_id_fk",
           "tableFrom": "user_profiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3224,12 +2977,8 @@
           "name": "aurora_credentials_user_id_users_id_fk",
           "tableFrom": "aurora_credentials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3358,12 +3107,8 @@
           "name": "user_board_mappings_user_id_users_id_fk",
           "tableFrom": "user_board_mappings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3484,12 +3229,8 @@
           "name": "mobile_refresh_tokens_user_id_users_id_fk",
           "tableFrom": "mobile_refresh_tokens",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3558,12 +3299,8 @@
           "name": "gym_follows_gym_id_gyms_id_fk",
           "tableFrom": "gym_follows",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3571,12 +3308,8 @@
           "name": "gym_follows_user_id_users_id_fk",
           "tableFrom": "gym_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3652,12 +3385,8 @@
           "name": "gym_members_gym_id_gyms_id_fk",
           "tableFrom": "gym_members",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3665,12 +3394,8 @@
           "name": "gym_members_user_id_users_id_fk",
           "tableFrom": "gym_members",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3855,12 +3580,8 @@
           "name": "gyms_owner_id_users_id_fk",
           "tableFrom": "gyms",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3870,9 +3591,7 @@
         "gyms_uuid_unique": {
           "name": "gyms_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -3967,12 +3686,8 @@
           "name": "board_follows_user_id_users_id_fk",
           "tableFrom": "board_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3980,12 +3695,8 @@
           "name": "board_follows_board_uuid_user_boards_uuid_fk",
           "tableFrom": "board_follows",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4296,12 +4007,8 @@
           "name": "user_boards_owner_id_users_id_fk",
           "tableFrom": "user_boards",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4309,12 +4016,8 @@
           "name": "user_boards_gym_id_gyms_id_fk",
           "tableFrom": "user_boards",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4324,9 +4027,7 @@
         "user_boards_uuid_unique": {
           "name": "user_boards_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -4458,12 +4159,8 @@
           "name": "user_board_serials_user_id_users_id_fk",
           "tableFrom": "user_board_serials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4471,12 +4168,8 @@
           "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
           "tableFrom": "user_board_serials",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4530,12 +4223,8 @@
           "name": "board_session_clients_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_clients",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4598,12 +4287,8 @@
           "name": "board_session_queues_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_queues",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4848,12 +4533,8 @@
           "name": "board_sessions_created_by_user_id_users_id_fk",
           "tableFrom": "board_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "created_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -4861,12 +4542,8 @@
           "name": "board_sessions_board_id_user_boards_id_fk",
           "tableFrom": "board_sessions",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4965,12 +4642,8 @@
           "name": "session_boards_session_id_board_sessions_id_fk",
           "tableFrom": "session_boards",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4978,12 +4651,8 @@
           "name": "session_boards_board_id_user_boards_id_fk",
           "tableFrom": "session_boards",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5118,12 +4787,8 @@
           "name": "user_favorites_user_id_users_id_fk",
           "tableFrom": "user_favorites",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5280,12 +4945,8 @@
           "name": "inferred_sessions_user_id_users_id_fk",
           "tableFrom": "inferred_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5369,12 +5030,8 @@
           "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5382,12 +5039,8 @@
           "name": "session_member_overrides_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5395,12 +5048,8 @@
           "name": "session_member_overrides_added_by_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "users",
-          "columnsFrom": [
-            "added_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["added_by_user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5410,10 +5059,7 @@
         "session_member_overrides_session_user_unique": {
           "name": "session_member_overrides_session_user_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "policies": {},
@@ -5864,12 +5510,8 @@
           "name": "boardsesh_ticks_user_id_users_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5877,12 +5519,8 @@
           "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5890,12 +5528,8 @@
           "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "inferred_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["inferred_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5903,12 +5537,8 @@
           "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "previous_inferred_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["previous_inferred_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5916,12 +5546,8 @@
           "name": "boardsesh_ticks_board_id_user_boards_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -5931,9 +5557,7 @@
         "boardsesh_ticks_uuid_unique": {
           "name": "boardsesh_ticks_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6047,12 +5671,8 @@
           "name": "playlist_climbs_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_climbs",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6143,12 +5763,8 @@
           "name": "playlist_ownership_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_ownership",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6156,12 +5772,8 @@
           "name": "playlist_ownership_user_id_users_id_fk",
           "tableFrom": "playlist_ownership",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6392,9 +6004,7 @@
         "playlists_uuid_unique": {
           "name": "playlists_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6489,12 +6099,8 @@
           "name": "user_playlist_pins_user_id_users_id_fk",
           "tableFrom": "user_playlist_pins",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6502,12 +6108,8 @@
           "name": "user_playlist_pins_playlist_id_playlists_id_fk",
           "tableFrom": "user_playlist_pins",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6698,12 +6300,8 @@
           "name": "user_hold_classifications_user_id_users_id_fk",
           "tableFrom": "user_hold_classifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6839,12 +6437,8 @@
           "name": "esp32_controllers_user_id_users_id_fk",
           "tableFrom": "esp32_controllers",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6854,9 +6448,7 @@
         "esp32_controllers_api_key_unique": {
           "name": "esp32_controllers_api_key_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "api_key"
-          ]
+          "columns": ["api_key"]
         }
       },
       "policies": {},
@@ -6951,12 +6543,8 @@
           "name": "playlist_follows_follower_id_users_id_fk",
           "tableFrom": "playlist_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6964,12 +6552,8 @@
           "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
           "tableFrom": "playlist_follows",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["playlist_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7068,12 +6652,8 @@
           "name": "setter_follows_follower_id_users_id_fk",
           "tableFrom": "setter_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7172,12 +6752,8 @@
           "name": "user_follows_follower_id_users_id_fk",
           "tableFrom": "user_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7185,12 +6761,8 @@
           "name": "user_follows_following_id_users_id_fk",
           "tableFrom": "user_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "following_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7344,12 +6916,8 @@
           "name": "comments_user_id_users_id_fk",
           "tableFrom": "comments",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7359,9 +6927,7 @@
         "comments_uuid_unique": {
           "name": "comments_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7481,12 +7047,8 @@
           "name": "votes_user_id_users_id_fk",
           "tableFrom": "votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7673,12 +7235,8 @@
           "name": "notifications_recipient_id_users_id_fk",
           "tableFrom": "notifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "recipient_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7686,12 +7244,8 @@
           "name": "notifications_actor_id_users_id_fk",
           "tableFrom": "notifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7699,12 +7253,8 @@
           "name": "notifications_comment_id_comments_id_fk",
           "tableFrom": "notifications",
           "tableTo": "comments",
-          "columnsFrom": [
-            "comment_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -7714,9 +7264,7 @@
         "notifications_uuid_unique": {
           "name": "notifications_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7909,12 +7457,8 @@
           "name": "feed_items_recipient_id_users_id_fk",
           "tableFrom": "feed_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "recipient_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7922,12 +7466,8 @@
           "name": "feed_items_actor_id_users_id_fk",
           "tableFrom": "feed_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8009,12 +7549,8 @@
           "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_classic_status",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8114,12 +7650,8 @@
           "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_community_status",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8317,12 +7849,8 @@
           "name": "climb_proposals_proposer_id_users_id_fk",
           "tableFrom": "climb_proposals",
           "tableTo": "users",
-          "columnsFrom": [
-            "proposer_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["proposer_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8330,12 +7858,8 @@
           "name": "climb_proposals_resolved_by_users_id_fk",
           "tableFrom": "climb_proposals",
           "tableTo": "users",
-          "columnsFrom": [
-            "resolved_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8345,9 +7869,7 @@
         "climb_proposals_uuid_unique": {
           "name": "climb_proposals_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -8419,12 +7941,8 @@
           "name": "community_roles_user_id_users_id_fk",
           "tableFrom": "community_roles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8432,12 +7950,8 @@
           "name": "community_roles_granted_by_users_id_fk",
           "tableFrom": "community_roles",
           "tableTo": "users",
-          "columnsFrom": [
-            "granted_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8447,11 +7961,7 @@
         "community_roles_user_role_board_idx": {
           "name": "community_roles_user_role_board_idx",
           "nullsNotDistinct": true,
-          "columns": [
-            "user_id",
-            "role",
-            "board_type"
-          ]
+          "columns": ["user_id", "role", "board_type"]
         }
       },
       "policies": {},
@@ -8547,12 +8057,8 @@
           "name": "community_settings_set_by_users_id_fk",
           "tableFrom": "community_settings",
           "tableTo": "users",
-          "columnsFrom": [
-            "set_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["set_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8649,12 +8155,8 @@
           "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
           "tableFrom": "proposal_votes",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8662,12 +8164,8 @@
           "name": "proposal_votes_user_id_users_id_fk",
           "tableFrom": "proposal_votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8789,12 +8287,8 @@
           "name": "new_climb_subscriptions_user_id_users_id_fk",
           "tableFrom": "new_climb_subscriptions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8905,10 +8399,7 @@
       "compositePrimaryKeys": {
         "vote_counts_entity_type_entity_id_pk": {
           "name": "vote_counts_entity_type_entity_id_pk",
-          "columns": [
-            "entity_type",
-            "entity_id"
-          ]
+          "columns": ["entity_type", "entity_id"]
         }
       },
       "uniqueConstraints": {},
@@ -8977,12 +8468,8 @@
           "name": "board_session_participants_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_participants",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8990,12 +8477,8 @@
           "name": "board_session_participants_user_id_users_id_fk",
           "tableFrom": "board_session_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9003,10 +8486,7 @@
       "compositePrimaryKeys": {
         "board_session_participants_session_id_user_id_pk": {
           "name": "board_session_participants_session_id_user_id_pk",
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "uniqueConstraints": {},
@@ -9156,12 +8636,8 @@
           "name": "app_feedback_user_id_users_id_fk",
           "tableFrom": "app_feedback",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9217,12 +8693,8 @@
           "name": "user_climb_percentiles_user_id_users_id_fk",
           "tableFrom": "user_climb_percentiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9322,12 +8794,8 @@
           "name": "activity_push_tokens_session_id_board_sessions_id_fk",
           "tableFrom": "activity_push_tokens",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9335,12 +8803,8 @@
           "name": "activity_push_tokens_user_id_users_id_fk",
           "tableFrom": "activity_push_tokens",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9356,60 +8820,32 @@
     "public.gym_member_role": {
       "name": "gym_member_role",
       "schema": "public",
-      "values": [
-        "admin",
-        "member"
-      ]
+      "values": ["admin", "member"]
     },
     "public.aurora_table_type": {
       "name": "aurora_table_type",
       "schema": "public",
-      "values": [
-        "ascents",
-        "bids"
-      ]
+      "values": ["ascents", "bids"]
     },
     "public.kilter_table_type": {
       "name": "kilter_table_type",
       "schema": "public",
-      "values": [
-        "logs",
-        "attempts"
-      ]
+      "values": ["logs", "attempts"]
     },
     "public.tick_status": {
       "name": "tick_status",
       "schema": "public",
-      "values": [
-        "flash",
-        "send",
-        "attempt"
-      ]
+      "values": ["flash", "send", "attempt"]
     },
     "public.hold_type": {
       "name": "hold_type",
       "schema": "public",
-      "values": [
-        "jug",
-        "sloper",
-        "pinch",
-        "crimp",
-        "pocket"
-      ]
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
     },
     "public.social_entity_type": {
       "name": "social_entity_type",
       "schema": "public",
-      "values": [
-        "playlist_climb",
-        "climb",
-        "tick",
-        "comment",
-        "proposal",
-        "board",
-        "gym",
-        "session"
-      ]
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
     },
     "public.notification_type": {
       "name": "notification_type",
@@ -9433,40 +8869,22 @@
     "public.feed_item_type": {
       "name": "feed_item_type",
       "schema": "public",
-      "values": [
-        "ascent",
-        "new_climb",
-        "comment",
-        "proposal_approved",
-        "session_summary"
-      ]
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
     },
     "public.community_role_type": {
       "name": "community_role_type",
       "schema": "public",
-      "values": [
-        "admin",
-        "community_leader"
-      ]
+      "values": ["admin", "community_leader"]
     },
     "public.proposal_status": {
       "name": "proposal_status",
       "schema": "public",
-      "values": [
-        "open",
-        "approved",
-        "rejected",
-        "superseded"
-      ]
+      "values": ["open", "approved", "rejected", "superseded"]
     },
     "public.proposal_type": {
       "name": "proposal_type",
       "schema": "public",
-      "values": [
-        "grade",
-        "classic",
-        "benchmark"
-      ]
+      "values": ["grade", "classic", "benchmark"]
     }
   },
   "schemas": {},

--- a/packages/db/drizzle/meta/0117_snapshot.json
+++ b/packages/db/drizzle/meta/0117_snapshot.json
@@ -38,10 +38,7 @@
       "compositePrimaryKeys": {
         "board_attempts_board_type_id_pk": {
           "name": "board_attempts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -164,11 +161,7 @@
       "compositePrimaryKeys": {
         "board_beta_links_board_type_climb_uuid_link_pk": {
           "name": "board_beta_links_board_type_climb_uuid_link_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "link"
-          ]
+          "columns": ["board_type", "climb_uuid", "link"]
         }
       },
       "uniqueConstraints": {},
@@ -241,14 +234,8 @@
           "name": "board_circuits_user_fk",
           "tableFrom": "board_circuits",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -256,10 +243,7 @@
       "compositePrimaryKeys": {
         "board_circuits_board_type_uuid_pk": {
           "name": "board_circuits_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -302,14 +286,8 @@
           "name": "board_circuits_climbs_circuit_fk",
           "tableFrom": "board_circuits_climbs",
           "tableTo": "board_circuits",
-          "columnsFrom": [
-            "board_type",
-            "circuit_uuid"
-          ],
-          "columnsTo": [
-            "board_type",
-            "uuid"
-          ],
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "columnsTo": ["board_type", "uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -317,12 +295,8 @@
           "name": "board_circuits_climbs_climb_fk",
           "tableFrom": "board_circuits_climbs",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -330,11 +304,7 @@
       "compositePrimaryKeys": {
         "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
           "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "circuit_uuid",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -413,12 +383,8 @@
           "name": "board_climb_aliases_canonical_fk",
           "tableFrom": "board_climb_aliases",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "canonical_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["canonical_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -426,10 +392,7 @@
       "compositePrimaryKeys": {
         "board_climb_aliases_board_type_alias_uuid_pk": {
           "name": "board_climb_aliases_board_type_alias_uuid_pk",
-          "columns": [
-            "board_type",
-            "alias_uuid"
-          ]
+          "columns": ["board_type", "alias_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -518,12 +481,8 @@
           "name": "board_climb_holds_climb_fk",
           "tableFrom": "board_climb_holds",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -531,11 +490,7 @@
       "compositePrimaryKeys": {
         "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
           "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "hold_id"
-          ]
+          "columns": ["board_type", "climb_uuid", "hold_id"]
         }
       },
       "uniqueConstraints": {},
@@ -723,12 +678,8 @@
           "name": "board_climb_ratings_user_id_users_id_fk",
           "tableFrom": "board_climb_ratings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -839,11 +790,7 @@
       "compositePrimaryKeys": {
         "board_climb_stats_board_type_climb_uuid_angle_pk": {
           "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "angle"
-          ]
+          "columns": ["board_type", "climb_uuid", "angle"]
         }
       },
       "uniqueConstraints": {},
@@ -1301,12 +1248,8 @@
           "name": "board_climbs_user_id_users_id_fk",
           "tableFrom": "board_climbs",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1357,10 +1300,7 @@
       "compositePrimaryKeys": {
         "board_difficulty_grades_board_type_difficulty_pk": {
           "name": "board_difficulty_grades_board_type_difficulty_pk",
-          "columns": [
-            "board_type",
-            "difficulty"
-          ]
+          "columns": ["board_type", "difficulty"]
         }
       },
       "uniqueConstraints": {},
@@ -1428,14 +1368,8 @@
           "name": "board_holes_product_fk",
           "tableFrom": "board_holes",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1443,10 +1377,7 @@
       "compositePrimaryKeys": {
         "board_holes_board_type_id_pk": {
           "name": "board_holes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1506,10 +1437,7 @@
       "compositePrimaryKeys": {
         "board_kits_board_type_serial_number_pk": {
           "name": "board_kits_board_type_serial_number_pk",
-          "columns": [
-            "board_type",
-            "serial_number"
-          ]
+          "columns": ["board_type", "serial_number"]
         }
       },
       "uniqueConstraints": {},
@@ -1588,14 +1516,8 @@
           "name": "board_layout_aliases_layout_fk",
           "tableFrom": "board_layout_aliases",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1603,10 +1525,7 @@
       "compositePrimaryKeys": {
         "board_layout_aliases_board_type_layout_uuid_pk": {
           "name": "board_layout_aliases_board_type_layout_uuid_pk",
-          "columns": [
-            "board_type",
-            "layout_uuid"
-          ]
+          "columns": ["board_type", "layout_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -1684,14 +1603,8 @@
           "name": "board_layouts_product_fk",
           "tableFrom": "board_layouts",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1699,10 +1612,7 @@
       "compositePrimaryKeys": {
         "board_layouts_board_type_id_pk": {
           "name": "board_layouts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1751,14 +1661,8 @@
           "name": "board_leds_product_size_fk",
           "tableFrom": "board_leds",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1766,14 +1670,8 @@
           "name": "board_leds_hole_fk",
           "tableFrom": "board_leds",
           "tableTo": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1781,10 +1679,7 @@
       "compositePrimaryKeys": {
         "board_leds_board_type_id_pk": {
           "name": "board_leds_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1851,14 +1746,8 @@
           "name": "board_placement_roles_product_fk",
           "tableFrom": "board_placement_roles",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1866,10 +1755,7 @@
       "compositePrimaryKeys": {
         "board_placement_roles_board_type_id_pk": {
           "name": "board_placement_roles_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1964,14 +1850,8 @@
           "name": "board_placements_layout_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1979,14 +1859,8 @@
           "name": "board_placements_hole_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1994,14 +1868,8 @@
           "name": "board_placements_set_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2009,14 +1877,8 @@
           "name": "board_placements_role_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_placement_roles",
-          "columnsFrom": [
-            "board_type",
-            "default_placement_role_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         }
@@ -2024,10 +1886,7 @@
       "compositePrimaryKeys": {
         "board_placements_board_type_id_pk": {
           "name": "board_placements_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2118,14 +1977,8 @@
           "name": "board_product_sizes_product_fk",
           "tableFrom": "board_product_sizes",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2133,10 +1986,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_board_type_id_pk": {
           "name": "board_product_sizes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2197,14 +2047,8 @@
           "name": "board_psls_product_size_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2212,14 +2056,8 @@
           "name": "board_psls_layout_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2227,14 +2065,8 @@
           "name": "board_psls_set_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2242,10 +2074,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_layouts_sets_board_type_id_pk": {
           "name": "board_product_sizes_layouts_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2305,10 +2134,7 @@
       "compositePrimaryKeys": {
         "board_products_board_type_id_pk": {
           "name": "board_products_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2350,10 +2176,7 @@
       "compositePrimaryKeys": {
         "board_sets_board_type_id_pk": {
           "name": "board_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2389,10 +2212,7 @@
       "compositePrimaryKeys": {
         "board_shared_syncs_board_type_table_name_pk": {
           "name": "board_shared_syncs_board_type_table_name_pk",
-          "columns": [
-            "board_type",
-            "table_name"
-          ]
+          "columns": ["board_type", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2440,12 +2260,7 @@
       "compositePrimaryKeys": {
         "board_tags_board_type_entity_uuid_user_id_name_pk": {
           "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
-          "columns": [
-            "board_type",
-            "entity_uuid",
-            "user_id",
-            "name"
-          ]
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
         }
       },
       "uniqueConstraints": {},
@@ -2488,14 +2303,8 @@
           "name": "board_user_syncs_user_fk",
           "tableFrom": "board_user_syncs",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2503,11 +2312,7 @@
       "compositePrimaryKeys": {
         "board_user_syncs_board_type_user_id_table_name_pk": {
           "name": "board_user_syncs_board_type_user_id_table_name_pk",
-          "columns": [
-            "board_type",
-            "user_id",
-            "table_name"
-          ]
+          "columns": ["board_type", "user_id", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2549,10 +2354,7 @@
       "compositePrimaryKeys": {
         "board_users_board_type_id_pk": {
           "name": "board_users_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2643,14 +2445,8 @@
           "name": "board_walls_user_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2658,14 +2454,8 @@
           "name": "board_walls_product_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         },
@@ -2673,14 +2463,8 @@
           "name": "board_walls_layout_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         },
@@ -2688,14 +2472,8 @@
           "name": "board_walls_product_size_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         }
@@ -2703,10 +2481,7 @@
       "compositePrimaryKeys": {
         "board_walls_board_type_uuid_pk": {
           "name": "board_walls_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -2791,12 +2566,8 @@
           "name": "accounts_userId_users_id_fk",
           "tableFrom": "accounts",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2804,10 +2575,7 @@
       "compositePrimaryKeys": {
         "accounts_provider_providerAccountId_pk": {
           "name": "accounts_provider_providerAccountId_pk",
-          "columns": [
-            "provider",
-            "providerAccountId"
-          ]
+          "columns": ["provider", "providerAccountId"]
         }
       },
       "uniqueConstraints": {},
@@ -2844,12 +2612,8 @@
           "name": "sessions_userId_users_id_fk",
           "tableFrom": "sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2945,10 +2709,7 @@
       "compositePrimaryKeys": {
         "verificationTokens_identifier_token_pk": {
           "name": "verificationTokens_identifier_token_pk",
-          "columns": [
-            "identifier",
-            "token"
-          ]
+          "columns": ["identifier", "token"]
         }
       },
       "uniqueConstraints": {},
@@ -2993,12 +2754,8 @@
           "name": "user_credentials_user_id_users_id_fk",
           "tableFrom": "user_credentials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3058,12 +2815,8 @@
           "name": "user_profiles_user_id_users_id_fk",
           "tableFrom": "user_profiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3231,12 +2984,8 @@
           "name": "aurora_credentials_user_id_users_id_fk",
           "tableFrom": "aurora_credentials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3365,12 +3114,8 @@
           "name": "user_board_mappings_user_id_users_id_fk",
           "tableFrom": "user_board_mappings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3491,12 +3236,8 @@
           "name": "mobile_refresh_tokens_user_id_users_id_fk",
           "tableFrom": "mobile_refresh_tokens",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3565,12 +3306,8 @@
           "name": "gym_follows_gym_id_gyms_id_fk",
           "tableFrom": "gym_follows",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3578,12 +3315,8 @@
           "name": "gym_follows_user_id_users_id_fk",
           "tableFrom": "gym_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3659,12 +3392,8 @@
           "name": "gym_members_gym_id_gyms_id_fk",
           "tableFrom": "gym_members",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3672,12 +3401,8 @@
           "name": "gym_members_user_id_users_id_fk",
           "tableFrom": "gym_members",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3862,12 +3587,8 @@
           "name": "gyms_owner_id_users_id_fk",
           "tableFrom": "gyms",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3877,9 +3598,7 @@
         "gyms_uuid_unique": {
           "name": "gyms_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -3974,12 +3693,8 @@
           "name": "board_follows_user_id_users_id_fk",
           "tableFrom": "board_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3987,12 +3702,8 @@
           "name": "board_follows_board_uuid_user_boards_uuid_fk",
           "tableFrom": "board_follows",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4303,12 +4014,8 @@
           "name": "user_boards_owner_id_users_id_fk",
           "tableFrom": "user_boards",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4316,12 +4023,8 @@
           "name": "user_boards_gym_id_gyms_id_fk",
           "tableFrom": "user_boards",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4331,9 +4034,7 @@
         "user_boards_uuid_unique": {
           "name": "user_boards_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -4465,12 +4166,8 @@
           "name": "user_board_serials_user_id_users_id_fk",
           "tableFrom": "user_board_serials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4478,12 +4175,8 @@
           "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
           "tableFrom": "user_board_serials",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4537,12 +4230,8 @@
           "name": "board_session_clients_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_clients",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4605,12 +4294,8 @@
           "name": "board_session_queues_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_queues",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4855,12 +4540,8 @@
           "name": "board_sessions_created_by_user_id_users_id_fk",
           "tableFrom": "board_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "created_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -4868,12 +4549,8 @@
           "name": "board_sessions_board_id_user_boards_id_fk",
           "tableFrom": "board_sessions",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4972,12 +4649,8 @@
           "name": "session_boards_session_id_board_sessions_id_fk",
           "tableFrom": "session_boards",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4985,12 +4658,8 @@
           "name": "session_boards_board_id_user_boards_id_fk",
           "tableFrom": "session_boards",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5125,12 +4794,8 @@
           "name": "user_favorites_user_id_users_id_fk",
           "tableFrom": "user_favorites",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5287,12 +4952,8 @@
           "name": "inferred_sessions_user_id_users_id_fk",
           "tableFrom": "inferred_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5376,12 +5037,8 @@
           "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5389,12 +5046,8 @@
           "name": "session_member_overrides_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5402,12 +5055,8 @@
           "name": "session_member_overrides_added_by_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "users",
-          "columnsFrom": [
-            "added_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["added_by_user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5417,10 +5066,7 @@
         "session_member_overrides_session_user_unique": {
           "name": "session_member_overrides_session_user_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "policies": {},
@@ -5871,12 +5517,8 @@
           "name": "boardsesh_ticks_user_id_users_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5884,12 +5526,8 @@
           "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5897,12 +5535,8 @@
           "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "inferred_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["inferred_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5910,12 +5544,8 @@
           "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "previous_inferred_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["previous_inferred_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5923,12 +5553,8 @@
           "name": "boardsesh_ticks_board_id_user_boards_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -5938,9 +5564,7 @@
         "boardsesh_ticks_uuid_unique": {
           "name": "boardsesh_ticks_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6054,12 +5678,8 @@
           "name": "playlist_climbs_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_climbs",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6150,12 +5770,8 @@
           "name": "playlist_ownership_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_ownership",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6163,12 +5779,8 @@
           "name": "playlist_ownership_user_id_users_id_fk",
           "tableFrom": "playlist_ownership",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6399,9 +6011,7 @@
         "playlists_uuid_unique": {
           "name": "playlists_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6496,12 +6106,8 @@
           "name": "user_playlist_pins_user_id_users_id_fk",
           "tableFrom": "user_playlist_pins",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6509,12 +6115,8 @@
           "name": "user_playlist_pins_playlist_id_playlists_id_fk",
           "tableFrom": "user_playlist_pins",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6705,12 +6307,8 @@
           "name": "user_hold_classifications_user_id_users_id_fk",
           "tableFrom": "user_hold_classifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6846,12 +6444,8 @@
           "name": "esp32_controllers_user_id_users_id_fk",
           "tableFrom": "esp32_controllers",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6861,9 +6455,7 @@
         "esp32_controllers_api_key_unique": {
           "name": "esp32_controllers_api_key_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "api_key"
-          ]
+          "columns": ["api_key"]
         }
       },
       "policies": {},
@@ -6958,12 +6550,8 @@
           "name": "playlist_follows_follower_id_users_id_fk",
           "tableFrom": "playlist_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6971,12 +6559,8 @@
           "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
           "tableFrom": "playlist_follows",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["playlist_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7075,12 +6659,8 @@
           "name": "setter_follows_follower_id_users_id_fk",
           "tableFrom": "setter_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7179,12 +6759,8 @@
           "name": "user_follows_follower_id_users_id_fk",
           "tableFrom": "user_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7192,12 +6768,8 @@
           "name": "user_follows_following_id_users_id_fk",
           "tableFrom": "user_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "following_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7351,12 +6923,8 @@
           "name": "comments_user_id_users_id_fk",
           "tableFrom": "comments",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7366,9 +6934,7 @@
         "comments_uuid_unique": {
           "name": "comments_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7488,12 +7054,8 @@
           "name": "votes_user_id_users_id_fk",
           "tableFrom": "votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7680,12 +7242,8 @@
           "name": "notifications_recipient_id_users_id_fk",
           "tableFrom": "notifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "recipient_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7693,12 +7251,8 @@
           "name": "notifications_actor_id_users_id_fk",
           "tableFrom": "notifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7706,12 +7260,8 @@
           "name": "notifications_comment_id_comments_id_fk",
           "tableFrom": "notifications",
           "tableTo": "comments",
-          "columnsFrom": [
-            "comment_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -7721,9 +7271,7 @@
         "notifications_uuid_unique": {
           "name": "notifications_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7916,12 +7464,8 @@
           "name": "feed_items_recipient_id_users_id_fk",
           "tableFrom": "feed_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "recipient_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7929,12 +7473,8 @@
           "name": "feed_items_actor_id_users_id_fk",
           "tableFrom": "feed_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8016,12 +7556,8 @@
           "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_classic_status",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8121,12 +7657,8 @@
           "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_community_status",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8324,12 +7856,8 @@
           "name": "climb_proposals_proposer_id_users_id_fk",
           "tableFrom": "climb_proposals",
           "tableTo": "users",
-          "columnsFrom": [
-            "proposer_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["proposer_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8337,12 +7865,8 @@
           "name": "climb_proposals_resolved_by_users_id_fk",
           "tableFrom": "climb_proposals",
           "tableTo": "users",
-          "columnsFrom": [
-            "resolved_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8352,9 +7876,7 @@
         "climb_proposals_uuid_unique": {
           "name": "climb_proposals_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -8426,12 +7948,8 @@
           "name": "community_roles_user_id_users_id_fk",
           "tableFrom": "community_roles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8439,12 +7957,8 @@
           "name": "community_roles_granted_by_users_id_fk",
           "tableFrom": "community_roles",
           "tableTo": "users",
-          "columnsFrom": [
-            "granted_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8454,11 +7968,7 @@
         "community_roles_user_role_board_idx": {
           "name": "community_roles_user_role_board_idx",
           "nullsNotDistinct": true,
-          "columns": [
-            "user_id",
-            "role",
-            "board_type"
-          ]
+          "columns": ["user_id", "role", "board_type"]
         }
       },
       "policies": {},
@@ -8554,12 +8064,8 @@
           "name": "community_settings_set_by_users_id_fk",
           "tableFrom": "community_settings",
           "tableTo": "users",
-          "columnsFrom": [
-            "set_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["set_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8656,12 +8162,8 @@
           "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
           "tableFrom": "proposal_votes",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8669,12 +8171,8 @@
           "name": "proposal_votes_user_id_users_id_fk",
           "tableFrom": "proposal_votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8796,12 +8294,8 @@
           "name": "new_climb_subscriptions_user_id_users_id_fk",
           "tableFrom": "new_climb_subscriptions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8912,10 +8406,7 @@
       "compositePrimaryKeys": {
         "vote_counts_entity_type_entity_id_pk": {
           "name": "vote_counts_entity_type_entity_id_pk",
-          "columns": [
-            "entity_type",
-            "entity_id"
-          ]
+          "columns": ["entity_type", "entity_id"]
         }
       },
       "uniqueConstraints": {},
@@ -8984,12 +8475,8 @@
           "name": "board_session_participants_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_participants",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8997,12 +8484,8 @@
           "name": "board_session_participants_user_id_users_id_fk",
           "tableFrom": "board_session_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9010,10 +8493,7 @@
       "compositePrimaryKeys": {
         "board_session_participants_session_id_user_id_pk": {
           "name": "board_session_participants_session_id_user_id_pk",
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "uniqueConstraints": {},
@@ -9163,12 +8643,8 @@
           "name": "app_feedback_user_id_users_id_fk",
           "tableFrom": "app_feedback",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9224,12 +8700,8 @@
           "name": "user_climb_percentiles_user_id_users_id_fk",
           "tableFrom": "user_climb_percentiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9329,12 +8801,8 @@
           "name": "activity_push_tokens_session_id_board_sessions_id_fk",
           "tableFrom": "activity_push_tokens",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9342,12 +8810,8 @@
           "name": "activity_push_tokens_user_id_users_id_fk",
           "tableFrom": "activity_push_tokens",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9436,10 +8900,7 @@
       "compositePrimaryKeys": {
         "board_climb_send_stats_board_type_climb_uuid_pk": {
           "name": "board_climb_send_stats_board_type_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -9532,10 +8993,7 @@
       "compositePrimaryKeys": {
         "board_setter_stats_board_type_setter_username_pk": {
           "name": "board_setter_stats_board_type_setter_username_pk",
-          "columns": [
-            "board_type",
-            "setter_username"
-          ]
+          "columns": ["board_type", "setter_username"]
         }
       },
       "uniqueConstraints": {},
@@ -9548,60 +9006,32 @@
     "public.gym_member_role": {
       "name": "gym_member_role",
       "schema": "public",
-      "values": [
-        "admin",
-        "member"
-      ]
+      "values": ["admin", "member"]
     },
     "public.aurora_table_type": {
       "name": "aurora_table_type",
       "schema": "public",
-      "values": [
-        "ascents",
-        "bids"
-      ]
+      "values": ["ascents", "bids"]
     },
     "public.kilter_table_type": {
       "name": "kilter_table_type",
       "schema": "public",
-      "values": [
-        "logs",
-        "attempts"
-      ]
+      "values": ["logs", "attempts"]
     },
     "public.tick_status": {
       "name": "tick_status",
       "schema": "public",
-      "values": [
-        "flash",
-        "send",
-        "attempt"
-      ]
+      "values": ["flash", "send", "attempt"]
     },
     "public.hold_type": {
       "name": "hold_type",
       "schema": "public",
-      "values": [
-        "jug",
-        "sloper",
-        "pinch",
-        "crimp",
-        "pocket"
-      ]
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
     },
     "public.social_entity_type": {
       "name": "social_entity_type",
       "schema": "public",
-      "values": [
-        "playlist_climb",
-        "climb",
-        "tick",
-        "comment",
-        "proposal",
-        "board",
-        "gym",
-        "session"
-      ]
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
     },
     "public.notification_type": {
       "name": "notification_type",
@@ -9625,40 +9055,22 @@
     "public.feed_item_type": {
       "name": "feed_item_type",
       "schema": "public",
-      "values": [
-        "ascent",
-        "new_climb",
-        "comment",
-        "proposal_approved",
-        "session_summary"
-      ]
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
     },
     "public.community_role_type": {
       "name": "community_role_type",
       "schema": "public",
-      "values": [
-        "admin",
-        "community_leader"
-      ]
+      "values": ["admin", "community_leader"]
     },
     "public.proposal_status": {
       "name": "proposal_status",
       "schema": "public",
-      "values": [
-        "open",
-        "approved",
-        "rejected",
-        "superseded"
-      ]
+      "values": ["open", "approved", "rejected", "superseded"]
     },
     "public.proposal_type": {
       "name": "proposal_type",
       "schema": "public",
-      "values": [
-        "grade",
-        "classic",
-        "benchmark"
-      ]
+      "values": ["grade", "classic", "benchmark"]
     }
   },
   "schemas": {},

--- a/packages/db/drizzle/meta/0118_snapshot.json
+++ b/packages/db/drizzle/meta/0118_snapshot.json
@@ -38,10 +38,7 @@
       "compositePrimaryKeys": {
         "board_attempts_board_type_id_pk": {
           "name": "board_attempts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -164,11 +161,7 @@
       "compositePrimaryKeys": {
         "board_beta_links_board_type_climb_uuid_link_pk": {
           "name": "board_beta_links_board_type_climb_uuid_link_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "link"
-          ]
+          "columns": ["board_type", "climb_uuid", "link"]
         }
       },
       "uniqueConstraints": {},
@@ -241,14 +234,8 @@
           "name": "board_circuits_user_fk",
           "tableFrom": "board_circuits",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -256,10 +243,7 @@
       "compositePrimaryKeys": {
         "board_circuits_board_type_uuid_pk": {
           "name": "board_circuits_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -302,14 +286,8 @@
           "name": "board_circuits_climbs_circuit_fk",
           "tableFrom": "board_circuits_climbs",
           "tableTo": "board_circuits",
-          "columnsFrom": [
-            "board_type",
-            "circuit_uuid"
-          ],
-          "columnsTo": [
-            "board_type",
-            "uuid"
-          ],
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "columnsTo": ["board_type", "uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -317,12 +295,8 @@
           "name": "board_circuits_climbs_climb_fk",
           "tableFrom": "board_circuits_climbs",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -330,11 +304,7 @@
       "compositePrimaryKeys": {
         "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
           "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "circuit_uuid",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -413,12 +383,8 @@
           "name": "board_climb_aliases_canonical_fk",
           "tableFrom": "board_climb_aliases",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "canonical_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["canonical_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -426,10 +392,7 @@
       "compositePrimaryKeys": {
         "board_climb_aliases_board_type_alias_uuid_pk": {
           "name": "board_climb_aliases_board_type_alias_uuid_pk",
-          "columns": [
-            "board_type",
-            "alias_uuid"
-          ]
+          "columns": ["board_type", "alias_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -518,12 +481,8 @@
           "name": "board_climb_holds_climb_fk",
           "tableFrom": "board_climb_holds",
           "tableTo": "board_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -531,11 +490,7 @@
       "compositePrimaryKeys": {
         "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
           "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "hold_id"
-          ]
+          "columns": ["board_type", "climb_uuid", "hold_id"]
         }
       },
       "uniqueConstraints": {},
@@ -723,12 +678,8 @@
           "name": "board_climb_ratings_user_id_users_id_fk",
           "tableFrom": "board_climb_ratings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -839,11 +790,7 @@
       "compositePrimaryKeys": {
         "board_climb_stats_board_type_climb_uuid_angle_pk": {
           "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "angle"
-          ]
+          "columns": ["board_type", "climb_uuid", "angle"]
         }
       },
       "uniqueConstraints": {},
@@ -1301,12 +1248,8 @@
           "name": "board_climbs_user_id_users_id_fk",
           "tableFrom": "board_climbs",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1357,10 +1300,7 @@
       "compositePrimaryKeys": {
         "board_difficulty_grades_board_type_difficulty_pk": {
           "name": "board_difficulty_grades_board_type_difficulty_pk",
-          "columns": [
-            "board_type",
-            "difficulty"
-          ]
+          "columns": ["board_type", "difficulty"]
         }
       },
       "uniqueConstraints": {},
@@ -1428,14 +1368,8 @@
           "name": "board_holes_product_fk",
           "tableFrom": "board_holes",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1443,10 +1377,7 @@
       "compositePrimaryKeys": {
         "board_holes_board_type_id_pk": {
           "name": "board_holes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1506,10 +1437,7 @@
       "compositePrimaryKeys": {
         "board_kits_board_type_serial_number_pk": {
           "name": "board_kits_board_type_serial_number_pk",
-          "columns": [
-            "board_type",
-            "serial_number"
-          ]
+          "columns": ["board_type", "serial_number"]
         }
       },
       "uniqueConstraints": {},
@@ -1588,14 +1516,8 @@
           "name": "board_layout_aliases_layout_fk",
           "tableFrom": "board_layout_aliases",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1603,10 +1525,7 @@
       "compositePrimaryKeys": {
         "board_layout_aliases_board_type_layout_uuid_pk": {
           "name": "board_layout_aliases_board_type_layout_uuid_pk",
-          "columns": [
-            "board_type",
-            "layout_uuid"
-          ]
+          "columns": ["board_type", "layout_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -1684,14 +1603,8 @@
           "name": "board_layouts_product_fk",
           "tableFrom": "board_layouts",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1699,10 +1612,7 @@
       "compositePrimaryKeys": {
         "board_layouts_board_type_id_pk": {
           "name": "board_layouts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1751,14 +1661,8 @@
           "name": "board_leds_product_size_fk",
           "tableFrom": "board_leds",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1766,14 +1670,8 @@
           "name": "board_leds_hole_fk",
           "tableFrom": "board_leds",
           "tableTo": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1781,10 +1679,7 @@
       "compositePrimaryKeys": {
         "board_leds_board_type_id_pk": {
           "name": "board_leds_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1851,14 +1746,8 @@
           "name": "board_placement_roles_product_fk",
           "tableFrom": "board_placement_roles",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -1866,10 +1755,7 @@
       "compositePrimaryKeys": {
         "board_placement_roles_board_type_id_pk": {
           "name": "board_placement_roles_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1964,14 +1850,8 @@
           "name": "board_placements_layout_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1979,14 +1859,8 @@
           "name": "board_placements_hole_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -1994,14 +1868,8 @@
           "name": "board_placements_set_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2009,14 +1877,8 @@
           "name": "board_placements_role_fk",
           "tableFrom": "board_placements",
           "tableTo": "board_placement_roles",
-          "columnsFrom": [
-            "board_type",
-            "default_placement_role_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         }
@@ -2024,10 +1886,7 @@
       "compositePrimaryKeys": {
         "board_placements_board_type_id_pk": {
           "name": "board_placements_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2118,14 +1977,8 @@
           "name": "board_product_sizes_product_fk",
           "tableFrom": "board_product_sizes",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2133,10 +1986,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_board_type_id_pk": {
           "name": "board_product_sizes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2197,14 +2047,8 @@
           "name": "board_psls_product_size_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2212,14 +2056,8 @@
           "name": "board_psls_layout_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2227,14 +2065,8 @@
           "name": "board_psls_set_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
           "tableTo": "board_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2242,10 +2074,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_layouts_sets_board_type_id_pk": {
           "name": "board_product_sizes_layouts_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2305,10 +2134,7 @@
       "compositePrimaryKeys": {
         "board_products_board_type_id_pk": {
           "name": "board_products_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2350,10 +2176,7 @@
       "compositePrimaryKeys": {
         "board_sets_board_type_id_pk": {
           "name": "board_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2389,10 +2212,7 @@
       "compositePrimaryKeys": {
         "board_shared_syncs_board_type_table_name_pk": {
           "name": "board_shared_syncs_board_type_table_name_pk",
-          "columns": [
-            "board_type",
-            "table_name"
-          ]
+          "columns": ["board_type", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2440,12 +2260,7 @@
       "compositePrimaryKeys": {
         "board_tags_board_type_entity_uuid_user_id_name_pk": {
           "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
-          "columns": [
-            "board_type",
-            "entity_uuid",
-            "user_id",
-            "name"
-          ]
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
         }
       },
       "uniqueConstraints": {},
@@ -2488,14 +2303,8 @@
           "name": "board_user_syncs_user_fk",
           "tableFrom": "board_user_syncs",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2503,11 +2312,7 @@
       "compositePrimaryKeys": {
         "board_user_syncs_board_type_user_id_table_name_pk": {
           "name": "board_user_syncs_board_type_user_id_table_name_pk",
-          "columns": [
-            "board_type",
-            "user_id",
-            "table_name"
-          ]
+          "columns": ["board_type", "user_id", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2549,10 +2354,7 @@
       "compositePrimaryKeys": {
         "board_users_board_type_id_pk": {
           "name": "board_users_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2643,14 +2445,8 @@
           "name": "board_walls_user_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_users",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         },
@@ -2658,14 +2454,8 @@
           "name": "board_walls_product_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_products",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         },
@@ -2673,14 +2463,8 @@
           "name": "board_walls_layout_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         },
@@ -2688,14 +2472,8 @@
           "name": "board_walls_product_size_fk",
           "tableFrom": "board_walls",
           "tableTo": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
           "onDelete": "restrict",
           "onUpdate": "cascade"
         }
@@ -2703,10 +2481,7 @@
       "compositePrimaryKeys": {
         "board_walls_board_type_uuid_pk": {
           "name": "board_walls_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -2791,12 +2566,8 @@
           "name": "accounts_userId_users_id_fk",
           "tableFrom": "accounts",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2804,10 +2575,7 @@
       "compositePrimaryKeys": {
         "accounts_provider_providerAccountId_pk": {
           "name": "accounts_provider_providerAccountId_pk",
-          "columns": [
-            "provider",
-            "providerAccountId"
-          ]
+          "columns": ["provider", "providerAccountId"]
         }
       },
       "uniqueConstraints": {},
@@ -2844,12 +2612,8 @@
           "name": "sessions_userId_users_id_fk",
           "tableFrom": "sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2945,10 +2709,7 @@
       "compositePrimaryKeys": {
         "verificationTokens_identifier_token_pk": {
           "name": "verificationTokens_identifier_token_pk",
-          "columns": [
-            "identifier",
-            "token"
-          ]
+          "columns": ["identifier", "token"]
         }
       },
       "uniqueConstraints": {},
@@ -2993,12 +2754,8 @@
           "name": "user_credentials_user_id_users_id_fk",
           "tableFrom": "user_credentials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3058,12 +2815,8 @@
           "name": "user_profiles_user_id_users_id_fk",
           "tableFrom": "user_profiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3231,12 +2984,8 @@
           "name": "aurora_credentials_user_id_users_id_fk",
           "tableFrom": "aurora_credentials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3365,12 +3114,8 @@
           "name": "user_board_mappings_user_id_users_id_fk",
           "tableFrom": "user_board_mappings",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3491,12 +3236,8 @@
           "name": "mobile_refresh_tokens_user_id_users_id_fk",
           "tableFrom": "mobile_refresh_tokens",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3565,12 +3306,8 @@
           "name": "gym_follows_gym_id_gyms_id_fk",
           "tableFrom": "gym_follows",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3578,12 +3315,8 @@
           "name": "gym_follows_user_id_users_id_fk",
           "tableFrom": "gym_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3659,12 +3392,8 @@
           "name": "gym_members_gym_id_gyms_id_fk",
           "tableFrom": "gym_members",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3672,12 +3401,8 @@
           "name": "gym_members_user_id_users_id_fk",
           "tableFrom": "gym_members",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3862,12 +3587,8 @@
           "name": "gyms_owner_id_users_id_fk",
           "tableFrom": "gyms",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3877,9 +3598,7 @@
         "gyms_uuid_unique": {
           "name": "gyms_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -3974,12 +3693,8 @@
           "name": "board_follows_user_id_users_id_fk",
           "tableFrom": "board_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3987,12 +3702,8 @@
           "name": "board_follows_board_uuid_user_boards_uuid_fk",
           "tableFrom": "board_follows",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4303,12 +4014,8 @@
           "name": "user_boards_owner_id_users_id_fk",
           "tableFrom": "user_boards",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4316,12 +4023,8 @@
           "name": "user_boards_gym_id_gyms_id_fk",
           "tableFrom": "user_boards",
           "tableTo": "gyms",
-          "columnsFrom": [
-            "gym_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4331,9 +4034,7 @@
         "user_boards_uuid_unique": {
           "name": "user_boards_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -4465,12 +4166,8 @@
           "name": "user_board_serials_user_id_users_id_fk",
           "tableFrom": "user_board_serials",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4478,12 +4175,8 @@
           "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
           "tableFrom": "user_board_serials",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4537,12 +4230,8 @@
           "name": "board_session_clients_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_clients",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4605,12 +4294,8 @@
           "name": "board_session_queues_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_queues",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -4855,12 +4540,8 @@
           "name": "board_sessions_created_by_user_id_users_id_fk",
           "tableFrom": "board_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "created_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -4868,12 +4549,8 @@
           "name": "board_sessions_board_id_user_boards_id_fk",
           "tableFrom": "board_sessions",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -4972,12 +4649,8 @@
           "name": "session_boards_session_id_board_sessions_id_fk",
           "tableFrom": "session_boards",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -4985,12 +4658,8 @@
           "name": "session_boards_board_id_user_boards_id_fk",
           "tableFrom": "session_boards",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5125,12 +4794,8 @@
           "name": "user_favorites_user_id_users_id_fk",
           "tableFrom": "user_favorites",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5287,12 +4952,8 @@
           "name": "inferred_sessions_user_id_users_id_fk",
           "tableFrom": "inferred_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5376,12 +5037,8 @@
           "name": "session_member_overrides_session_id_inferred_sessions_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5389,12 +5046,8 @@
           "name": "session_member_overrides_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5402,12 +5055,8 @@
           "name": "session_member_overrides_added_by_user_id_users_id_fk",
           "tableFrom": "session_member_overrides",
           "tableTo": "users",
-          "columnsFrom": [
-            "added_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["added_by_user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -5417,10 +5066,7 @@
         "session_member_overrides_session_user_unique": {
           "name": "session_member_overrides_session_user_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "policies": {},
@@ -5871,12 +5517,8 @@
           "name": "boardsesh_ticks_user_id_users_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -5884,12 +5526,8 @@
           "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5897,12 +5535,8 @@
           "name": "boardsesh_ticks_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "inferred_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["inferred_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5910,12 +5544,8 @@
           "name": "boardsesh_ticks_previous_inferred_session_id_inferred_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "inferred_sessions",
-          "columnsFrom": [
-            "previous_inferred_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["previous_inferred_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -5923,12 +5553,8 @@
           "name": "boardsesh_ticks_board_id_user_boards_id_fk",
           "tableFrom": "boardsesh_ticks",
           "tableTo": "user_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -5938,9 +5564,7 @@
         "boardsesh_ticks_uuid_unique": {
           "name": "boardsesh_ticks_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6054,12 +5678,8 @@
           "name": "playlist_climbs_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_climbs",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6150,12 +5770,8 @@
           "name": "playlist_ownership_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_ownership",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6163,12 +5779,8 @@
           "name": "playlist_ownership_user_id_users_id_fk",
           "tableFrom": "playlist_ownership",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6420,9 +6032,7 @@
         "playlists_uuid_unique": {
           "name": "playlists_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -6517,12 +6127,8 @@
           "name": "user_playlist_pins_user_id_users_id_fk",
           "tableFrom": "user_playlist_pins",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6530,12 +6136,8 @@
           "name": "user_playlist_pins_playlist_id_playlists_id_fk",
           "tableFrom": "user_playlist_pins",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6726,12 +6328,8 @@
           "name": "user_hold_classifications_user_id_users_id_fk",
           "tableFrom": "user_hold_classifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6867,12 +6465,8 @@
           "name": "esp32_controllers_user_id_users_id_fk",
           "tableFrom": "esp32_controllers",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -6882,9 +6476,7 @@
         "esp32_controllers_api_key_unique": {
           "name": "esp32_controllers_api_key_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "api_key"
-          ]
+          "columns": ["api_key"]
         }
       },
       "policies": {},
@@ -6979,12 +6571,8 @@
           "name": "playlist_follows_follower_id_users_id_fk",
           "tableFrom": "playlist_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -6992,12 +6580,8 @@
           "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
           "tableFrom": "playlist_follows",
           "tableTo": "playlists",
-          "columnsFrom": [
-            "playlist_uuid"
-          ],
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsFrom": ["playlist_uuid"],
+          "columnsTo": ["uuid"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7096,12 +6680,8 @@
           "name": "setter_follows_follower_id_users_id_fk",
           "tableFrom": "setter_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7200,12 +6780,8 @@
           "name": "user_follows_follower_id_users_id_fk",
           "tableFrom": "user_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "follower_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7213,12 +6789,8 @@
           "name": "user_follows_following_id_users_id_fk",
           "tableFrom": "user_follows",
           "tableTo": "users",
-          "columnsFrom": [
-            "following_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7372,12 +6944,8 @@
           "name": "comments_user_id_users_id_fk",
           "tableFrom": "comments",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7387,9 +6955,7 @@
         "comments_uuid_unique": {
           "name": "comments_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7509,12 +7075,8 @@
           "name": "votes_user_id_users_id_fk",
           "tableFrom": "votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -7701,12 +7263,8 @@
           "name": "notifications_recipient_id_users_id_fk",
           "tableFrom": "notifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "recipient_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7714,12 +7272,8 @@
           "name": "notifications_actor_id_users_id_fk",
           "tableFrom": "notifications",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -7727,12 +7281,8 @@
           "name": "notifications_comment_id_comments_id_fk",
           "tableFrom": "notifications",
           "tableTo": "comments",
-          "columnsFrom": [
-            "comment_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -7742,9 +7292,7 @@
         "notifications_uuid_unique": {
           "name": "notifications_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -7937,12 +7485,8 @@
           "name": "feed_items_recipient_id_users_id_fk",
           "tableFrom": "feed_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "recipient_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -7950,12 +7494,8 @@
           "name": "feed_items_actor_id_users_id_fk",
           "tableFrom": "feed_items",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8037,12 +7577,8 @@
           "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_classic_status",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8142,12 +7678,8 @@
           "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_community_status",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8345,12 +7877,8 @@
           "name": "climb_proposals_proposer_id_users_id_fk",
           "tableFrom": "climb_proposals",
           "tableTo": "users",
-          "columnsFrom": [
-            "proposer_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["proposer_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8358,12 +7886,8 @@
           "name": "climb_proposals_resolved_by_users_id_fk",
           "tableFrom": "climb_proposals",
           "tableTo": "users",
-          "columnsFrom": [
-            "resolved_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8373,9 +7897,7 @@
         "climb_proposals_uuid_unique": {
           "name": "climb_proposals_uuid_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "uuid"
-          ]
+          "columns": ["uuid"]
         }
       },
       "policies": {},
@@ -8447,12 +7969,8 @@
           "name": "community_roles_user_id_users_id_fk",
           "tableFrom": "community_roles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8460,12 +7978,8 @@
           "name": "community_roles_granted_by_users_id_fk",
           "tableFrom": "community_roles",
           "tableTo": "users",
-          "columnsFrom": [
-            "granted_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8475,11 +7989,7 @@
         "community_roles_user_role_board_idx": {
           "name": "community_roles_user_role_board_idx",
           "nullsNotDistinct": true,
-          "columns": [
-            "user_id",
-            "role",
-            "board_type"
-          ]
+          "columns": ["user_id", "role", "board_type"]
         }
       },
       "policies": {},
@@ -8575,12 +8085,8 @@
           "name": "community_settings_set_by_users_id_fk",
           "tableFrom": "community_settings",
           "tableTo": "users",
-          "columnsFrom": [
-            "set_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["set_by"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -8677,12 +8183,8 @@
           "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
           "tableFrom": "proposal_votes",
           "tableTo": "climb_proposals",
-          "columnsFrom": [
-            "proposal_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -8690,12 +8192,8 @@
           "name": "proposal_votes_user_id_users_id_fk",
           "tableFrom": "proposal_votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8817,12 +8315,8 @@
           "name": "new_climb_subscriptions_user_id_users_id_fk",
           "tableFrom": "new_climb_subscriptions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -8933,10 +8427,7 @@
       "compositePrimaryKeys": {
         "vote_counts_entity_type_entity_id_pk": {
           "name": "vote_counts_entity_type_entity_id_pk",
-          "columns": [
-            "entity_type",
-            "entity_id"
-          ]
+          "columns": ["entity_type", "entity_id"]
         }
       },
       "uniqueConstraints": {},
@@ -9005,12 +8496,8 @@
           "name": "board_session_participants_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_participants",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9018,12 +8505,8 @@
           "name": "board_session_participants_user_id_users_id_fk",
           "tableFrom": "board_session_participants",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9031,10 +8514,7 @@
       "compositePrimaryKeys": {
         "board_session_participants_session_id_user_id_pk": {
           "name": "board_session_participants_session_id_user_id_pk",
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "uniqueConstraints": {},
@@ -9184,12 +8664,8 @@
           "name": "app_feedback_user_id_users_id_fk",
           "tableFrom": "app_feedback",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9245,12 +8721,8 @@
           "name": "user_climb_percentiles_user_id_users_id_fk",
           "tableFrom": "user_climb_percentiles",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -9350,12 +8822,8 @@
           "name": "activity_push_tokens_session_id_board_sessions_id_fk",
           "tableFrom": "activity_push_tokens",
           "tableTo": "board_sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -9363,12 +8831,8 @@
           "name": "activity_push_tokens_user_id_users_id_fk",
           "tableFrom": "activity_push_tokens",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -9457,10 +8921,7 @@
       "compositePrimaryKeys": {
         "board_climb_send_stats_board_type_climb_uuid_pk": {
           "name": "board_climb_send_stats_board_type_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -9553,10 +9014,7 @@
       "compositePrimaryKeys": {
         "board_setter_stats_board_type_setter_username_pk": {
           "name": "board_setter_stats_board_type_setter_username_pk",
-          "columns": [
-            "board_type",
-            "setter_username"
-          ]
+          "columns": ["board_type", "setter_username"]
         }
       },
       "uniqueConstraints": {},
@@ -9569,60 +9027,32 @@
     "public.gym_member_role": {
       "name": "gym_member_role",
       "schema": "public",
-      "values": [
-        "admin",
-        "member"
-      ]
+      "values": ["admin", "member"]
     },
     "public.aurora_table_type": {
       "name": "aurora_table_type",
       "schema": "public",
-      "values": [
-        "ascents",
-        "bids"
-      ]
+      "values": ["ascents", "bids"]
     },
     "public.kilter_table_type": {
       "name": "kilter_table_type",
       "schema": "public",
-      "values": [
-        "logs",
-        "attempts"
-      ]
+      "values": ["logs", "attempts"]
     },
     "public.tick_status": {
       "name": "tick_status",
       "schema": "public",
-      "values": [
-        "flash",
-        "send",
-        "attempt"
-      ]
+      "values": ["flash", "send", "attempt"]
     },
     "public.hold_type": {
       "name": "hold_type",
       "schema": "public",
-      "values": [
-        "jug",
-        "sloper",
-        "pinch",
-        "crimp",
-        "pocket"
-      ]
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
     },
     "public.social_entity_type": {
       "name": "social_entity_type",
       "schema": "public",
-      "values": [
-        "playlist_climb",
-        "climb",
-        "tick",
-        "comment",
-        "proposal",
-        "board",
-        "gym",
-        "session"
-      ]
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
     },
     "public.notification_type": {
       "name": "notification_type",
@@ -9646,40 +9076,22 @@
     "public.feed_item_type": {
       "name": "feed_item_type",
       "schema": "public",
-      "values": [
-        "ascent",
-        "new_climb",
-        "comment",
-        "proposal_approved",
-        "session_summary"
-      ]
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
     },
     "public.community_role_type": {
       "name": "community_role_type",
       "schema": "public",
-      "values": [
-        "admin",
-        "community_leader"
-      ]
+      "values": ["admin", "community_leader"]
     },
     "public.proposal_status": {
       "name": "proposal_status",
       "schema": "public",
-      "values": [
-        "open",
-        "approved",
-        "rejected",
-        "superseded"
-      ]
+      "values": ["open", "approved", "rejected", "superseded"]
     },
     "public.proposal_type": {
       "name": "proposal_type",
       "schema": "public",
-      "values": [
-        "grade",
-        "classic",
-        "benchmark"
-      ]
+      "values": ["grade", "classic", "benchmark"]
     }
   },
   "schemas": {},

--- a/packages/db/drizzle/meta/0122_snapshot.json
+++ b/packages/db/drizzle/meta/0122_snapshot.json
@@ -38,10 +38,7 @@
       "compositePrimaryKeys": {
         "board_attempts_board_type_id_pk": {
           "name": "board_attempts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -164,11 +161,7 @@
       "compositePrimaryKeys": {
         "board_beta_links_board_type_climb_uuid_link_pk": {
           "name": "board_beta_links_board_type_climb_uuid_link_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "link"
-          ]
+          "columns": ["board_type", "climb_uuid", "link"]
         }
       },
       "uniqueConstraints": {},
@@ -240,15 +233,9 @@
         "board_circuits_user_fk": {
           "name": "board_circuits_user_fk",
           "tableFrom": "board_circuits",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
           "tableTo": "board_users",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -256,10 +243,7 @@
       "compositePrimaryKeys": {
         "board_circuits_board_type_uuid_pk": {
           "name": "board_circuits_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -301,28 +285,18 @@
         "board_circuits_climbs_circuit_fk": {
           "name": "board_circuits_climbs_circuit_fk",
           "tableFrom": "board_circuits_climbs",
-          "columnsFrom": [
-            "board_type",
-            "circuit_uuid"
-          ],
+          "columnsFrom": ["board_type", "circuit_uuid"],
           "tableTo": "board_circuits",
-          "columnsTo": [
-            "board_type",
-            "uuid"
-          ],
+          "columnsTo": ["board_type", "uuid"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_circuits_climbs_climb_fk": {
           "name": "board_circuits_climbs_climb_fk",
           "tableFrom": "board_circuits_climbs",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
           "tableTo": "board_climbs",
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsTo": ["uuid"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -330,11 +304,7 @@
       "compositePrimaryKeys": {
         "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
           "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "circuit_uuid",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -412,13 +382,9 @@
         "board_climb_aliases_canonical_fk": {
           "name": "board_climb_aliases_canonical_fk",
           "tableFrom": "board_climb_aliases",
-          "columnsFrom": [
-            "canonical_uuid"
-          ],
+          "columnsFrom": ["canonical_uuid"],
           "tableTo": "board_climbs",
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsTo": ["uuid"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -426,10 +392,7 @@
       "compositePrimaryKeys": {
         "board_climb_aliases_board_type_alias_uuid_pk": {
           "name": "board_climb_aliases_board_type_alias_uuid_pk",
-          "columns": [
-            "board_type",
-            "alias_uuid"
-          ]
+          "columns": ["board_type", "alias_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -517,13 +480,9 @@
         "board_climb_holds_climb_fk": {
           "name": "board_climb_holds_climb_fk",
           "tableFrom": "board_climb_holds",
-          "columnsFrom": [
-            "climb_uuid"
-          ],
+          "columnsFrom": ["climb_uuid"],
           "tableTo": "board_climbs",
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsTo": ["uuid"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -531,11 +490,7 @@
       "compositePrimaryKeys": {
         "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
           "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "hold_id"
-          ]
+          "columns": ["board_type", "climb_uuid", "hold_id"]
         }
       },
       "uniqueConstraints": {},
@@ -722,13 +677,9 @@
         "board_climb_ratings_user_id_users_id_fk": {
           "name": "board_climb_ratings_user_id_users_id_fk",
           "tableFrom": "board_climb_ratings",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -839,11 +790,7 @@
       "compositePrimaryKeys": {
         "board_climb_stats_board_type_climb_uuid_angle_pk": {
           "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid",
-            "angle"
-          ]
+          "columns": ["board_type", "climb_uuid", "angle"]
         }
       },
       "uniqueConstraints": {},
@@ -1300,13 +1247,9 @@
         "board_climbs_user_id_users_id_fk": {
           "name": "board_climbs_user_id_users_id_fk",
           "tableFrom": "board_climbs",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -1357,10 +1300,7 @@
       "compositePrimaryKeys": {
         "board_difficulty_grades_board_type_difficulty_pk": {
           "name": "board_difficulty_grades_board_type_difficulty_pk",
-          "columns": [
-            "board_type",
-            "difficulty"
-          ]
+          "columns": ["board_type", "difficulty"]
         }
       },
       "uniqueConstraints": {},
@@ -1427,15 +1367,9 @@
         "board_holes_product_fk": {
           "name": "board_holes_product_fk",
           "tableFrom": "board_holes",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -1443,10 +1377,7 @@
       "compositePrimaryKeys": {
         "board_holes_board_type_id_pk": {
           "name": "board_holes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1506,10 +1437,7 @@
       "compositePrimaryKeys": {
         "board_kits_board_type_serial_number_pk": {
           "name": "board_kits_board_type_serial_number_pk",
-          "columns": [
-            "board_type",
-            "serial_number"
-          ]
+          "columns": ["board_type", "serial_number"]
         }
       },
       "uniqueConstraints": {},
@@ -1587,15 +1515,9 @@
         "board_layout_aliases_layout_fk": {
           "name": "board_layout_aliases_layout_fk",
           "tableFrom": "board_layout_aliases",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -1603,10 +1525,7 @@
       "compositePrimaryKeys": {
         "board_layout_aliases_board_type_layout_uuid_pk": {
           "name": "board_layout_aliases_board_type_layout_uuid_pk",
-          "columns": [
-            "board_type",
-            "layout_uuid"
-          ]
+          "columns": ["board_type", "layout_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -1683,15 +1602,9 @@
         "board_layouts_product_fk": {
           "name": "board_layouts_product_fk",
           "tableFrom": "board_layouts",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -1699,10 +1612,7 @@
       "compositePrimaryKeys": {
         "board_layouts_board_type_id_pk": {
           "name": "board_layouts_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1750,30 +1660,18 @@
         "board_leds_product_size_fk": {
           "name": "board_leds_product_size_fk",
           "tableFrom": "board_leds",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
           "tableTo": "board_product_sizes",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_leds_hole_fk": {
           "name": "board_leds_hole_fk",
           "tableFrom": "board_leds",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
           "tableTo": "board_holes",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -1781,10 +1679,7 @@
       "compositePrimaryKeys": {
         "board_leds_board_type_id_pk": {
           "name": "board_leds_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1850,15 +1745,9 @@
         "board_placement_roles_product_fk": {
           "name": "board_placement_roles_product_fk",
           "tableFrom": "board_placement_roles",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -1866,10 +1755,7 @@
       "compositePrimaryKeys": {
         "board_placement_roles_board_type_id_pk": {
           "name": "board_placement_roles_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -1963,60 +1849,36 @@
         "board_placements_layout_fk": {
           "name": "board_placements_layout_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_placements_hole_fk": {
           "name": "board_placements_hole_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": [
-            "board_type",
-            "hole_id"
-          ],
+          "columnsFrom": ["board_type", "hole_id"],
           "tableTo": "board_holes",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_placements_set_fk": {
           "name": "board_placements_set_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
           "tableTo": "board_sets",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_placements_role_fk": {
           "name": "board_placements_role_fk",
           "tableFrom": "board_placements",
-          "columnsFrom": [
-            "board_type",
-            "default_placement_role_id"
-          ],
+          "columnsFrom": ["board_type", "default_placement_role_id"],
           "tableTo": "board_placement_roles",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "restrict"
         }
@@ -2024,10 +1886,7 @@
       "compositePrimaryKeys": {
         "board_placements_board_type_id_pk": {
           "name": "board_placements_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2117,15 +1976,9 @@
         "board_product_sizes_product_fk": {
           "name": "board_product_sizes_product_fk",
           "tableFrom": "board_product_sizes",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -2133,10 +1986,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_board_type_id_pk": {
           "name": "board_product_sizes_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2196,45 +2046,27 @@
         "board_psls_product_size_fk": {
           "name": "board_psls_product_size_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
           "tableTo": "board_product_sizes",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_psls_layout_fk": {
           "name": "board_psls_layout_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_psls_set_fk": {
           "name": "board_psls_set_fk",
           "tableFrom": "board_product_sizes_layouts_sets",
-          "columnsFrom": [
-            "board_type",
-            "set_id"
-          ],
+          "columnsFrom": ["board_type", "set_id"],
           "tableTo": "board_sets",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -2242,10 +2074,7 @@
       "compositePrimaryKeys": {
         "board_product_sizes_layouts_sets_board_type_id_pk": {
           "name": "board_product_sizes_layouts_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2305,10 +2134,7 @@
       "compositePrimaryKeys": {
         "board_products_board_type_id_pk": {
           "name": "board_products_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2350,10 +2176,7 @@
       "compositePrimaryKeys": {
         "board_sets_board_type_id_pk": {
           "name": "board_sets_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2389,10 +2212,7 @@
       "compositePrimaryKeys": {
         "board_shared_syncs_board_type_table_name_pk": {
           "name": "board_shared_syncs_board_type_table_name_pk",
-          "columns": [
-            "board_type",
-            "table_name"
-          ]
+          "columns": ["board_type", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2440,12 +2260,7 @@
       "compositePrimaryKeys": {
         "board_tags_board_type_entity_uuid_user_id_name_pk": {
           "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
-          "columns": [
-            "board_type",
-            "entity_uuid",
-            "user_id",
-            "name"
-          ]
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
         }
       },
       "uniqueConstraints": {},
@@ -2487,15 +2302,9 @@
         "board_user_syncs_user_fk": {
           "name": "board_user_syncs_user_fk",
           "tableFrom": "board_user_syncs",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
           "tableTo": "board_users",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         }
@@ -2503,11 +2312,7 @@
       "compositePrimaryKeys": {
         "board_user_syncs_board_type_user_id_table_name_pk": {
           "name": "board_user_syncs_board_type_user_id_table_name_pk",
-          "columns": [
-            "board_type",
-            "user_id",
-            "table_name"
-          ]
+          "columns": ["board_type", "user_id", "table_name"]
         }
       },
       "uniqueConstraints": {},
@@ -2549,10 +2354,7 @@
       "compositePrimaryKeys": {
         "board_users_board_type_id_pk": {
           "name": "board_users_board_type_id_pk",
-          "columns": [
-            "board_type",
-            "id"
-          ]
+          "columns": ["board_type", "id"]
         }
       },
       "uniqueConstraints": {},
@@ -2642,60 +2444,36 @@
         "board_walls_user_fk": {
           "name": "board_walls_user_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": [
-            "board_type",
-            "user_id"
-          ],
+          "columnsFrom": ["board_type", "user_id"],
           "tableTo": "board_users",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "cascade"
         },
         "board_walls_product_fk": {
           "name": "board_walls_product_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": [
-            "board_type",
-            "product_id"
-          ],
+          "columnsFrom": ["board_type", "product_id"],
           "tableTo": "board_products",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "restrict"
         },
         "board_walls_layout_fk": {
           "name": "board_walls_layout_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": [
-            "board_type",
-            "layout_id"
-          ],
+          "columnsFrom": ["board_type", "layout_id"],
           "tableTo": "board_layouts",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "restrict"
         },
         "board_walls_product_size_fk": {
           "name": "board_walls_product_size_fk",
           "tableFrom": "board_walls",
-          "columnsFrom": [
-            "board_type",
-            "product_size_id"
-          ],
+          "columnsFrom": ["board_type", "product_size_id"],
           "tableTo": "board_product_sizes",
-          "columnsTo": [
-            "board_type",
-            "id"
-          ],
+          "columnsTo": ["board_type", "id"],
           "onUpdate": "cascade",
           "onDelete": "restrict"
         }
@@ -2703,10 +2481,7 @@
       "compositePrimaryKeys": {
         "board_walls_board_type_uuid_pk": {
           "name": "board_walls_board_type_uuid_pk",
-          "columns": [
-            "board_type",
-            "uuid"
-          ]
+          "columns": ["board_type", "uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -2790,13 +2565,9 @@
         "accounts_userId_users_id_fk": {
           "name": "accounts_userId_users_id_fk",
           "tableFrom": "accounts",
-          "columnsFrom": [
-            "userId"
-          ],
+          "columnsFrom": ["userId"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -2804,10 +2575,7 @@
       "compositePrimaryKeys": {
         "accounts_provider_providerAccountId_pk": {
           "name": "accounts_provider_providerAccountId_pk",
-          "columns": [
-            "provider",
-            "providerAccountId"
-          ]
+          "columns": ["provider", "providerAccountId"]
         }
       },
       "uniqueConstraints": {},
@@ -2843,13 +2611,9 @@
         "sessions_userId_users_id_fk": {
           "name": "sessions_userId_users_id_fk",
           "tableFrom": "sessions",
-          "columnsFrom": [
-            "userId"
-          ],
+          "columnsFrom": ["userId"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -2945,10 +2709,7 @@
       "compositePrimaryKeys": {
         "verificationTokens_identifier_token_pk": {
           "name": "verificationTokens_identifier_token_pk",
-          "columns": [
-            "identifier",
-            "token"
-          ]
+          "columns": ["identifier", "token"]
         }
       },
       "uniqueConstraints": {},
@@ -2992,13 +2753,9 @@
         "user_credentials_user_id_users_id_fk": {
           "name": "user_credentials_user_id_users_id_fk",
           "tableFrom": "user_credentials",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3057,13 +2814,9 @@
         "user_profiles_user_id_users_id_fk": {
           "name": "user_profiles_user_id_users_id_fk",
           "tableFrom": "user_profiles",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3230,13 +2983,9 @@
         "aurora_credentials_user_id_users_id_fk": {
           "name": "aurora_credentials_user_id_users_id_fk",
           "tableFrom": "aurora_credentials",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3364,13 +3113,9 @@
         "user_board_mappings_user_id_users_id_fk": {
           "name": "user_board_mappings_user_id_users_id_fk",
           "tableFrom": "user_board_mappings",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3490,13 +3235,9 @@
         "mobile_refresh_tokens_user_id_users_id_fk": {
           "name": "mobile_refresh_tokens_user_id_users_id_fk",
           "tableFrom": "mobile_refresh_tokens",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3564,26 +3305,18 @@
         "gym_follows_gym_id_gyms_id_fk": {
           "name": "gym_follows_gym_id_gyms_id_fk",
           "tableFrom": "gym_follows",
-          "columnsFrom": [
-            "gym_id"
-          ],
+          "columnsFrom": ["gym_id"],
           "tableTo": "gyms",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "gym_follows_user_id_users_id_fk": {
           "name": "gym_follows_user_id_users_id_fk",
           "tableFrom": "gym_follows",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3658,26 +3391,18 @@
         "gym_members_gym_id_gyms_id_fk": {
           "name": "gym_members_gym_id_gyms_id_fk",
           "tableFrom": "gym_members",
-          "columnsFrom": [
-            "gym_id"
-          ],
+          "columnsFrom": ["gym_id"],
           "tableTo": "gyms",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "gym_members_user_id_users_id_fk": {
           "name": "gym_members_user_id_users_id_fk",
           "tableFrom": "gym_members",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3861,13 +3586,9 @@
         "gyms_owner_id_users_id_fk": {
           "name": "gyms_owner_id_users_id_fk",
           "tableFrom": "gyms",
-          "columnsFrom": [
-            "owner_id"
-          ],
+          "columnsFrom": ["owner_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -3876,9 +3597,7 @@
       "uniqueConstraints": {
         "gyms_uuid_unique": {
           "name": "gyms_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -3973,26 +3692,18 @@
         "board_follows_user_id_users_id_fk": {
           "name": "board_follows_user_id_users_id_fk",
           "tableFrom": "board_follows",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "board_follows_board_uuid_user_boards_uuid_fk": {
           "name": "board_follows_board_uuid_user_boards_uuid_fk",
           "tableFrom": "board_follows",
-          "columnsFrom": [
-            "board_uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
           "tableTo": "user_boards",
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsTo": ["uuid"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -4302,26 +4013,18 @@
         "user_boards_owner_id_users_id_fk": {
           "name": "user_boards_owner_id_users_id_fk",
           "tableFrom": "user_boards",
-          "columnsFrom": [
-            "owner_id"
-          ],
+          "columnsFrom": ["owner_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "user_boards_gym_id_gyms_id_fk": {
           "name": "user_boards_gym_id_gyms_id_fk",
           "tableFrom": "user_boards",
-          "columnsFrom": [
-            "gym_id"
-          ],
+          "columnsFrom": ["gym_id"],
           "tableTo": "gyms",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -4330,9 +4033,7 @@
       "uniqueConstraints": {
         "user_boards_uuid_unique": {
           "name": "user_boards_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -4470,26 +4171,18 @@
         "user_board_serials_user_id_users_id_fk": {
           "name": "user_board_serials_user_id_users_id_fk",
           "tableFrom": "user_board_serials",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "user_board_serials_board_uuid_user_boards_uuid_fk": {
           "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
           "tableFrom": "user_board_serials",
-          "columnsFrom": [
-            "board_uuid"
-          ],
+          "columnsFrom": ["board_uuid"],
           "tableTo": "user_boards",
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsTo": ["uuid"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -4542,13 +4235,9 @@
         "board_session_clients_session_id_board_sessions_id_fk": {
           "name": "board_session_clients_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_clients",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -4610,13 +4299,9 @@
         "board_session_queues_session_id_board_sessions_id_fk": {
           "name": "board_session_queues_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_queues",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -4854,26 +4539,18 @@
         "board_sessions_created_by_user_id_users_id_fk": {
           "name": "board_sessions_created_by_user_id_users_id_fk",
           "tableFrom": "board_sessions",
-          "columnsFrom": [
-            "created_by_user_id"
-          ],
+          "columnsFrom": ["created_by_user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         },
         "board_sessions_board_id_user_boards_id_fk": {
           "name": "board_sessions_board_id_user_boards_id_fk",
           "tableFrom": "board_sessions",
-          "columnsFrom": [
-            "board_id"
-          ],
+          "columnsFrom": ["board_id"],
           "tableTo": "user_boards",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -4971,26 +4648,18 @@
         "session_boards_session_id_board_sessions_id_fk": {
           "name": "session_boards_session_id_board_sessions_id_fk",
           "tableFrom": "session_boards",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "session_boards_board_id_user_boards_id_fk": {
           "name": "session_boards_board_id_user_boards_id_fk",
           "tableFrom": "session_boards",
-          "columnsFrom": [
-            "board_id"
-          ],
+          "columnsFrom": ["board_id"],
           "tableTo": "user_boards",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -5074,26 +4743,18 @@
         "session_health_kit_workouts_session_id_board_sessions_id_fk": {
           "name": "session_health_kit_workouts_session_id_board_sessions_id_fk",
           "tableFrom": "session_health_kit_workouts",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "session_health_kit_workouts_user_id_users_id_fk": {
           "name": "session_health_kit_workouts_user_id_users_id_fk",
           "tableFrom": "session_health_kit_workouts",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -5101,10 +4762,7 @@
       "compositePrimaryKeys": {
         "session_health_kit_workouts_session_id_user_id_pk": {
           "name": "session_health_kit_workouts_session_id_user_id_pk",
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "uniqueConstraints": {},
@@ -5235,13 +4893,9 @@
         "user_favorites_user_id_users_id_fk": {
           "name": "user_favorites_user_id_users_id_fk",
           "tableFrom": "user_favorites",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -5668,39 +5322,27 @@
         "boardsesh_ticks_user_id_users_id_fk": {
           "name": "boardsesh_ticks_user_id_users_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "boardsesh_ticks_session_id_board_sessions_id_fk": {
           "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         },
         "boardsesh_ticks_board_id_user_boards_id_fk": {
           "name": "boardsesh_ticks_board_id_user_boards_id_fk",
           "tableFrom": "boardsesh_ticks",
-          "columnsFrom": [
-            "board_id"
-          ],
+          "columnsFrom": ["board_id"],
           "tableTo": "user_boards",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -5709,9 +5351,7 @@
       "uniqueConstraints": {
         "boardsesh_ticks_uuid_unique": {
           "name": "boardsesh_ticks_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -5825,13 +5465,9 @@
         "playlist_climbs_playlist_id_playlists_id_fk": {
           "name": "playlist_climbs_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_climbs",
-          "columnsFrom": [
-            "playlist_id"
-          ],
+          "columnsFrom": ["playlist_id"],
           "tableTo": "playlists",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -5921,26 +5557,18 @@
         "playlist_ownership_playlist_id_playlists_id_fk": {
           "name": "playlist_ownership_playlist_id_playlists_id_fk",
           "tableFrom": "playlist_ownership",
-          "columnsFrom": [
-            "playlist_id"
-          ],
+          "columnsFrom": ["playlist_id"],
           "tableTo": "playlists",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "playlist_ownership_user_id_users_id_fk": {
           "name": "playlist_ownership_user_id_users_id_fk",
           "tableFrom": "playlist_ownership",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -6191,9 +5819,7 @@
       "uniqueConstraints": {
         "playlists_uuid_unique": {
           "name": "playlists_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -6288,26 +5914,18 @@
         "user_playlist_pins_user_id_users_id_fk": {
           "name": "user_playlist_pins_user_id_users_id_fk",
           "tableFrom": "user_playlist_pins",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "user_playlist_pins_playlist_id_playlists_id_fk": {
           "name": "user_playlist_pins_playlist_id_playlists_id_fk",
           "tableFrom": "user_playlist_pins",
-          "columnsFrom": [
-            "playlist_id"
-          ],
+          "columnsFrom": ["playlist_id"],
           "tableTo": "playlists",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -6497,13 +6115,9 @@
         "user_hold_classifications_user_id_users_id_fk": {
           "name": "user_hold_classifications_user_id_users_id_fk",
           "tableFrom": "user_hold_classifications",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -6638,13 +6252,9 @@
         "esp32_controllers_user_id_users_id_fk": {
           "name": "esp32_controllers_user_id_users_id_fk",
           "tableFrom": "esp32_controllers",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -6653,9 +6263,7 @@
       "uniqueConstraints": {
         "esp32_controllers_api_key_unique": {
           "name": "esp32_controllers_api_key_unique",
-          "columns": [
-            "api_key"
-          ],
+          "columns": ["api_key"],
           "nullsNotDistinct": false
         }
       },
@@ -6750,26 +6358,18 @@
         "playlist_follows_follower_id_users_id_fk": {
           "name": "playlist_follows_follower_id_users_id_fk",
           "tableFrom": "playlist_follows",
-          "columnsFrom": [
-            "follower_id"
-          ],
+          "columnsFrom": ["follower_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "playlist_follows_playlist_uuid_playlists_uuid_fk": {
           "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
           "tableFrom": "playlist_follows",
-          "columnsFrom": [
-            "playlist_uuid"
-          ],
+          "columnsFrom": ["playlist_uuid"],
           "tableTo": "playlists",
-          "columnsTo": [
-            "uuid"
-          ],
+          "columnsTo": ["uuid"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -6867,13 +6467,9 @@
         "setter_follows_follower_id_users_id_fk": {
           "name": "setter_follows_follower_id_users_id_fk",
           "tableFrom": "setter_follows",
-          "columnsFrom": [
-            "follower_id"
-          ],
+          "columnsFrom": ["follower_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -6971,26 +6567,18 @@
         "user_follows_follower_id_users_id_fk": {
           "name": "user_follows_follower_id_users_id_fk",
           "tableFrom": "user_follows",
-          "columnsFrom": [
-            "follower_id"
-          ],
+          "columnsFrom": ["follower_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "user_follows_following_id_users_id_fk": {
           "name": "user_follows_following_id_users_id_fk",
           "tableFrom": "user_follows",
-          "columnsFrom": [
-            "following_id"
-          ],
+          "columnsFrom": ["following_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -7143,13 +6731,9 @@
         "comments_user_id_users_id_fk": {
           "name": "comments_user_id_users_id_fk",
           "tableFrom": "comments",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -7158,9 +6742,7 @@
       "uniqueConstraints": {
         "comments_uuid_unique": {
           "name": "comments_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -7280,13 +6862,9 @@
         "votes_user_id_users_id_fk": {
           "name": "votes_user_id_users_id_fk",
           "tableFrom": "votes",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -7472,39 +7050,27 @@
         "notifications_recipient_id_users_id_fk": {
           "name": "notifications_recipient_id_users_id_fk",
           "tableFrom": "notifications",
-          "columnsFrom": [
-            "recipient_id"
-          ],
+          "columnsFrom": ["recipient_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "notifications_actor_id_users_id_fk": {
           "name": "notifications_actor_id_users_id_fk",
           "tableFrom": "notifications",
-          "columnsFrom": [
-            "actor_id"
-          ],
+          "columnsFrom": ["actor_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         },
         "notifications_comment_id_comments_id_fk": {
           "name": "notifications_comment_id_comments_id_fk",
           "tableFrom": "notifications",
-          "columnsFrom": [
-            "comment_id"
-          ],
+          "columnsFrom": ["comment_id"],
           "tableTo": "comments",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -7513,9 +7079,7 @@
       "uniqueConstraints": {
         "notifications_uuid_unique": {
           "name": "notifications_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -7708,26 +7272,18 @@
         "feed_items_recipient_id_users_id_fk": {
           "name": "feed_items_recipient_id_users_id_fk",
           "tableFrom": "feed_items",
-          "columnsFrom": [
-            "recipient_id"
-          ],
+          "columnsFrom": ["recipient_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "feed_items_actor_id_users_id_fk": {
           "name": "feed_items_actor_id_users_id_fk",
           "tableFrom": "feed_items",
-          "columnsFrom": [
-            "actor_id"
-          ],
+          "columnsFrom": ["actor_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -7808,13 +7364,9 @@
         "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
           "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_classic_status",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
           "tableTo": "climb_proposals",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -7913,13 +7465,9 @@
         "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
           "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
           "tableFrom": "climb_community_status",
-          "columnsFrom": [
-            "last_proposal_id"
-          ],
+          "columnsFrom": ["last_proposal_id"],
           "tableTo": "climb_proposals",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -8116,26 +7664,18 @@
         "climb_proposals_proposer_id_users_id_fk": {
           "name": "climb_proposals_proposer_id_users_id_fk",
           "tableFrom": "climb_proposals",
-          "columnsFrom": [
-            "proposer_id"
-          ],
+          "columnsFrom": ["proposer_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "climb_proposals_resolved_by_users_id_fk": {
           "name": "climb_proposals_resolved_by_users_id_fk",
           "tableFrom": "climb_proposals",
-          "columnsFrom": [
-            "resolved_by"
-          ],
+          "columnsFrom": ["resolved_by"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -8144,9 +7684,7 @@
       "uniqueConstraints": {
         "climb_proposals_uuid_unique": {
           "name": "climb_proposals_uuid_unique",
-          "columns": [
-            "uuid"
-          ],
+          "columns": ["uuid"],
           "nullsNotDistinct": false
         }
       },
@@ -8218,26 +7756,18 @@
         "community_roles_user_id_users_id_fk": {
           "name": "community_roles_user_id_users_id_fk",
           "tableFrom": "community_roles",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "community_roles_granted_by_users_id_fk": {
           "name": "community_roles_granted_by_users_id_fk",
           "tableFrom": "community_roles",
-          "columnsFrom": [
-            "granted_by"
-          ],
+          "columnsFrom": ["granted_by"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -8246,11 +7776,7 @@
       "uniqueConstraints": {
         "community_roles_user_role_board_idx": {
           "name": "community_roles_user_role_board_idx",
-          "columns": [
-            "user_id",
-            "role",
-            "board_type"
-          ],
+          "columns": ["user_id", "role", "board_type"],
           "nullsNotDistinct": true
         }
       },
@@ -8346,13 +7872,9 @@
         "community_settings_set_by_users_id_fk": {
           "name": "community_settings_set_by_users_id_fk",
           "tableFrom": "community_settings",
-          "columnsFrom": [
-            "set_by"
-          ],
+          "columnsFrom": ["set_by"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -8448,26 +7970,18 @@
         "proposal_votes_proposal_id_climb_proposals_id_fk": {
           "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
           "tableFrom": "proposal_votes",
-          "columnsFrom": [
-            "proposal_id"
-          ],
+          "columnsFrom": ["proposal_id"],
           "tableTo": "climb_proposals",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "proposal_votes_user_id_users_id_fk": {
           "name": "proposal_votes_user_id_users_id_fk",
           "tableFrom": "proposal_votes",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -8588,13 +8102,9 @@
         "new_climb_subscriptions_user_id_users_id_fk": {
           "name": "new_climb_subscriptions_user_id_users_id_fk",
           "tableFrom": "new_climb_subscriptions",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -8705,10 +8215,7 @@
       "compositePrimaryKeys": {
         "vote_counts_entity_type_entity_id_pk": {
           "name": "vote_counts_entity_type_entity_id_pk",
-          "columns": [
-            "entity_type",
-            "entity_id"
-          ]
+          "columns": ["entity_type", "entity_id"]
         }
       },
       "uniqueConstraints": {},
@@ -8776,26 +8283,18 @@
         "board_session_participants_session_id_board_sessions_id_fk": {
           "name": "board_session_participants_session_id_board_sessions_id_fk",
           "tableFrom": "board_session_participants",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "board_session_participants_user_id_users_id_fk": {
           "name": "board_session_participants_user_id_users_id_fk",
           "tableFrom": "board_session_participants",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -8803,10 +8302,7 @@
       "compositePrimaryKeys": {
         "board_session_participants_session_id_user_id_pk": {
           "name": "board_session_participants_session_id_user_id_pk",
-          "columns": [
-            "session_id",
-            "user_id"
-          ]
+          "columns": ["session_id", "user_id"]
         }
       },
       "uniqueConstraints": {},
@@ -8955,13 +8451,9 @@
         "app_feedback_user_id_users_id_fk": {
           "name": "app_feedback_user_id_users_id_fk",
           "tableFrom": "app_feedback",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -9016,13 +8508,9 @@
         "user_climb_percentiles_user_id_users_id_fk": {
           "name": "user_climb_percentiles_user_id_users_id_fk",
           "tableFrom": "user_climb_percentiles",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         }
@@ -9121,26 +8609,18 @@
         "activity_push_tokens_session_id_board_sessions_id_fk": {
           "name": "activity_push_tokens_session_id_board_sessions_id_fk",
           "tableFrom": "activity_push_tokens",
-          "columnsFrom": [
-            "session_id"
-          ],
+          "columnsFrom": ["session_id"],
           "tableTo": "board_sessions",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "cascade"
         },
         "activity_push_tokens_user_id_users_id_fk": {
           "name": "activity_push_tokens_user_id_users_id_fk",
           "tableFrom": "activity_push_tokens",
-          "columnsFrom": [
-            "user_id"
-          ],
+          "columnsFrom": ["user_id"],
           "tableTo": "users",
-          "columnsTo": [
-            "id"
-          ],
+          "columnsTo": ["id"],
           "onUpdate": "no action",
           "onDelete": "set null"
         }
@@ -9229,10 +8709,7 @@
       "compositePrimaryKeys": {
         "board_climb_send_stats_board_type_climb_uuid_pk": {
           "name": "board_climb_send_stats_board_type_climb_uuid_pk",
-          "columns": [
-            "board_type",
-            "climb_uuid"
-          ]
+          "columns": ["board_type", "climb_uuid"]
         }
       },
       "uniqueConstraints": {},
@@ -9325,10 +8802,7 @@
       "compositePrimaryKeys": {
         "board_setter_stats_board_type_setter_username_pk": {
           "name": "board_setter_stats_board_type_setter_username_pk",
-          "columns": [
-            "board_type",
-            "setter_username"
-          ]
+          "columns": ["board_type", "setter_username"]
         }
       },
       "uniqueConstraints": {},
@@ -9341,60 +8815,32 @@
     "public.gym_member_role": {
       "name": "gym_member_role",
       "schema": "public",
-      "values": [
-        "admin",
-        "member"
-      ]
+      "values": ["admin", "member"]
     },
     "public.aurora_table_type": {
       "name": "aurora_table_type",
       "schema": "public",
-      "values": [
-        "ascents",
-        "bids"
-      ]
+      "values": ["ascents", "bids"]
     },
     "public.kilter_table_type": {
       "name": "kilter_table_type",
       "schema": "public",
-      "values": [
-        "logs",
-        "attempts"
-      ]
+      "values": ["logs", "attempts"]
     },
     "public.tick_status": {
       "name": "tick_status",
       "schema": "public",
-      "values": [
-        "flash",
-        "send",
-        "attempt"
-      ]
+      "values": ["flash", "send", "attempt"]
     },
     "public.hold_type": {
       "name": "hold_type",
       "schema": "public",
-      "values": [
-        "jug",
-        "sloper",
-        "pinch",
-        "crimp",
-        "pocket"
-      ]
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
     },
     "public.social_entity_type": {
       "name": "social_entity_type",
       "schema": "public",
-      "values": [
-        "playlist_climb",
-        "climb",
-        "tick",
-        "comment",
-        "proposal",
-        "board",
-        "gym",
-        "session"
-      ]
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
     },
     "public.notification_type": {
       "name": "notification_type",
@@ -9418,40 +8864,22 @@
     "public.feed_item_type": {
       "name": "feed_item_type",
       "schema": "public",
-      "values": [
-        "ascent",
-        "new_climb",
-        "comment",
-        "proposal_approved",
-        "session_summary"
-      ]
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
     },
     "public.community_role_type": {
       "name": "community_role_type",
       "schema": "public",
-      "values": [
-        "admin",
-        "community_leader"
-      ]
+      "values": ["admin", "community_leader"]
     },
     "public.proposal_status": {
       "name": "proposal_status",
       "schema": "public",
-      "values": [
-        "open",
-        "approved",
-        "rejected",
-        "superseded"
-      ]
+      "values": ["open", "approved", "rejected", "superseded"]
     },
     "public.proposal_type": {
       "name": "proposal_type",
       "schema": "public",
-      "values": [
-        "grade",
-        "classic",
-        "benchmark"
-      ]
+      "values": ["grade", "classic", "benchmark"]
     }
   },
   "schemas": {},

--- a/packages/db/drizzle/meta/0124_snapshot.json
+++ b/packages/db/drizzle/meta/0124_snapshot.json
@@ -1,0 +1,9210 @@
+{
+  "id": "91e5ed27-9dd2-4ec7-850a-dd5cddc071a5",
+  "prevId": "f02c731a-06c4-4bf9-a631-229f481d3f63",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aurora_credentials_sync_priority_idx": {
+          "name": "aurora_credentials_sync_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_by_tick_id": {
+          "name": "attached_by_tick_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_beta_links_attached_by_tick_idx": {
+          "name": "board_beta_links_attached_by_tick_idx",
+          "columns": [
+            {
+              "expression": "attached_by_tick_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_beta_links\".\"attached_by_tick_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": ["board_type", "climb_uuid", "link"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_circuits",
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "columnsTo": ["board_type", "uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_aliases": {
+      "name": "board_climb_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_uuid": {
+          "name": "alias_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_uuid": {
+          "name": "canonical_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_aliases_canonical_idx": {
+          "name": "board_climb_aliases_canonical_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_aliases_canonical_fk": {
+          "name": "board_climb_aliases_canonical_fk",
+          "tableFrom": "board_climb_aliases",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["canonical_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_aliases_board_type_alias_uuid_pk": {
+          "name": "board_climb_aliases_board_type_alias_uuid_pk",
+          "columns": ["board_type", "alias_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_aliases_uuids_non_empty": {
+          "name": "board_climb_aliases_uuids_non_empty",
+          "value": "\"board_climb_aliases\".\"alias_uuid\" <> '' AND \"board_climb_aliases\".\"canonical_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "tableTo": "board_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": ["board_type", "climb_uuid", "hold_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ratings": {
+      "name": "board_climb_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_grade_id": {
+          "name": "difficulty_grade_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_ratings_user_climb_angle_idx": {
+          "name": "board_climb_ratings_user_climb_angle_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_kilter_id_unique": {
+          "name": "board_climb_ratings_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_aurora_id_unique": {
+          "name": "board_climb_ratings_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board_climb_ratings\".\"aurora_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climb_ratings_user_kilter_idx": {
+          "name": "board_climb_ratings_user_kilter_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climb_ratings_user_id_users_id_fk": {
+          "name": "board_climb_ratings_user_id_users_id_fk",
+          "tableFrom": "board_climb_ratings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_ratings_rating_range": {
+          "name": "board_climb_ratings_rating_range",
+          "value": "\"board_climb_ratings\".\"rating\" IS NULL OR (\"board_climb_ratings\".\"rating\" >= 1 AND \"board_climb_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_send_stats": {
+      "name": "board_climb_send_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_count_30d": {
+          "name": "send_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sender_count_30d": {
+          "name": "sender_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "send_count_90d": {
+          "name": "send_count_90d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_send_stats_trending_idx": {
+          "name": "board_climb_send_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "send_count_30d",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_send_stats_board_type_climb_uuid_pk": {
+          "name": "board_climb_send_stats_board_type_climb_uuid_pk",
+          "columns": ["board_type", "climb_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_ascensionist_count": {
+          "name": "aurora_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_ascensionist_count": {
+          "name": "kilter_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_ascensionist_count": {
+          "name": "boardsesh_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_normalized": {
+          "name": "quality_normalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": ["board_type", "climb_uuid", "angle"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_fingerprint": {
+          "name": "hold_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_hold_fingerprint_idx": {
+          "name": "board_climbs_hold_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": ["board_type", "difficulty"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": ["board_type", "serial_number"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layout_aliases": {
+      "name": "board_layout_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_uuid": {
+          "name": "layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_layout_aliases_layout_idx": {
+          "name": "board_layout_aliases_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_layout_aliases_layout_fk": {
+          "name": "board_layout_aliases_layout_fk",
+          "tableFrom": "board_layout_aliases",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layout_aliases_board_type_layout_uuid_pk": {
+          "name": "board_layout_aliases_board_type_layout_uuid_pk",
+          "columns": ["board_type", "layout_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_layout_aliases_uuid_non_empty": {
+          "name": "board_layout_aliases_uuid_non_empty",
+          "value": "\"board_layout_aliases\".\"layout_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_holes",
+          "columnsFrom": ["board_type", "hole_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "tableTo": "board_placement_roles",
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "tableTo": "board_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_setter_stats": {
+      "name": "board_setter_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_count": {
+          "name": "climb_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_ascents": {
+          "name": "total_ascents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_ascents_per_climb": {
+          "name": "avg_ascents_per_climb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_quality": {
+          "name": "avg_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_score": {
+          "name": "setter_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_setter_stats_score_idx": {
+          "name": "board_setter_stats_score_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_setter_stats_board_type_setter_username_pk": {
+          "name": "board_setter_stats_board_type_setter_username_pk",
+          "columns": ["board_type", "setter_username"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": ["board_type", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": ["board_type", "user_id", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_users",
+          "columnsFrom": ["board_type", "user_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_products",
+          "columnsFrom": ["board_type", "product_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_layouts",
+          "columnsFrom": ["board_type", "layout_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "tableTo": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "columnsTo": ["board_type", "id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["last_proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": ["proposer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "tableTo": "users",
+          "columnsFrom": ["granted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "nullsNotDistinct": true,
+          "columns": ["user_id", "role", "board_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "tableTo": "users",
+          "columnsFrom": ["set_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credentials": {
+      "name": "integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_name": {
+          "name": "external_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_integration": {
+          "name": "unique_user_integration",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_credentials_user_id_users_id_fk": {
+          "name": "integration_credentials_user_id_users_id_fk",
+          "tableFrom": "integration_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_exports": {
+      "name": "integration_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_activity_id": {
+          "name": "external_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_integration_export": {
+          "name": "unique_integration_export",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_user_provider_idx": {
+          "name": "integration_exports_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_exports_session_idx": {
+          "name": "integration_exports_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_exports_user_id_users_id_fk": {
+          "name": "integration_exports_user_id_users_id_fk",
+          "tableFrom": "integration_exports",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_refresh_tokens": {
+      "name": "mobile_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mobile_refresh_tokens_token_hash_idx": {
+          "name": "mobile_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_user_id_idx": {
+          "name": "mobile_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_expires_at_idx": {
+          "name": "mobile_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mobile_refresh_tokens_revoked_at_partial_idx": {
+          "name": "mobile_refresh_tokens_revoked_at_partial_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"revoked_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mobile_refresh_tokens_user_id_users_id_fk": {
+          "name": "mobile_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "mobile_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "comments",
+          "columnsFrom": ["comment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_recommendation": {
+          "name": "generated_recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_generated_recommendation_idx": {
+          "name": "playlists_generated_recommendation_idx",
+          "columns": [
+            {
+              "expression": "generated_recommendation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "climb_proposals",
+          "columnsFrom": ["proposal_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_health_kit_workouts": {
+      "name": "session_health_kit_workouts",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_health_kit_workouts_session_idx": {
+          "name": "session_health_kit_workouts_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_health_kit_workouts_user_idx": {
+          "name": "session_health_kit_workouts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_health_kit_workouts_session_id_board_sessions_id_fk": {
+          "name": "session_health_kit_workouts_session_id_board_sessions_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "board_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_health_kit_workouts_user_id_users_id_fk": {
+          "name": "session_health_kit_workouts_user_id_users_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_health_kit_workouts_session_id_user_id_pk": {
+          "name": "session_health_kit_workouts_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_level": {
+          "name": "api_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "tableTo": "user_boards",
+          "columnsFrom": ["board_uuid"],
+          "columnsTo": ["uuid"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "tableTo": "gyms",
+          "columnsFrom": ["gym_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": ["uuid"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": ["follower_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": ["following_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": ["entity_type", "entity_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": ["ascents", "bids"]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": ["admin", "community_leader"]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
+    },
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": ["logs", "attempts"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": ["open", "approved", "rejected", "superseded"]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": ["grade", "classic", "benchmark"]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": ["flash", "send", "attempt"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -869,6 +869,13 @@
       "when": 1781222169952,
       "tag": "0123_true_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 124,
+      "version": "7",
+      "when": 1781224666659,
+      "tag": "0124_clean_mephisto",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -666,6 +666,14 @@ export const boardBetaLinks = pgTable(
     //   this table could emit a migration that drops it. If you change
     //   this column, double-check the generated SQL and preserve the FK.
     createdByUserId: text('created_by_user_id'),
+    // Boardsesh tick UUID that caused this beta link to be attached (populated
+    // by the saveTick path when the user provides a videoUrl on a send/flash).
+    // NULL for links attached via the standalone attachBetaLink mutation and
+    // for Aurora-synced rows. FK managed manually — references
+    // boardsesh_ticks(uuid) ON DELETE SET NULL, added alongside this column
+    // in the migration that introduced it. Not declared via `.references()`
+    // for the same cross-package reason as createdByUserId above.
+    attachedByTickId: text('attached_by_tick_id'),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.boardType, table.climbUuid, table.link] }),
@@ -681,6 +689,10 @@ export const boardBetaLinks = pgTable(
     createdByIdx: index('board_beta_links_created_by_idx')
       .on(table.createdByUserId, table.createdAt)
       .where(sql`${table.createdByUserId} IS NOT NULL`),
+    // Partial index for tick-sourced attribution lookups.
+    attachedByTickIdx: index('board_beta_links_attached_by_tick_idx')
+      .on(table.attachedByTickId)
+      .where(sql`${table.attachedByTickId} IS NOT NULL`),
     // Note: No FK to board_climbs - beta links may arrive before their corresponding climbs during sync
   }),
 );

--- a/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDetailSheet.tsx
@@ -37,18 +37,18 @@ export function BoardDetailSheet({ board, visible, onClose, onSetActive }: Board
     }
   }, [visible, board]);
 
-  const footer = board
-    ? isActiveBoard(board, activeBoard?.uuid)
-      ? (
-        <View style={[styles.activePill, { backgroundColor: systemColors.tertiaryBackground }]}>
-          <Icon name="tick" size={16} color={systemColors.secondaryLabel} />
-          <Text variant="subheadline" color={systemColors.secondaryLabel}>
-            {t('mobile.boardDetail.alreadyActive')}
-          </Text>
-        </View>
-      )
-      : <Button title={t('mobile.boardDetail.setActive')} size="large" onPress={() => onSetActive(board)} />
-    : null;
+  const footer = board ? (
+    isActiveBoard(board, activeBoard?.uuid) ? (
+      <View style={[styles.activePill, { backgroundColor: systemColors.tertiaryBackground }]}>
+        <Icon name="tick" size={16} color={systemColors.secondaryLabel} />
+        <Text variant="subheadline" color={systemColors.secondaryLabel}>
+          {t('mobile.boardDetail.alreadyActive')}
+        </Text>
+      </View>
+    ) : (
+      <Button title={t('mobile.boardDetail.setActive')} size="large" onPress={() => onSetActive(board)} />
+    )
+  ) : null;
 
   return (
     <Sheet

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-large-title-header.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-large-title-header.test.tsx
@@ -67,8 +67,7 @@ vi.mock('../../PressableSurface', () => ({
     children?: ReactNode;
     onPress?: () => void;
     accessibilityLabel?: string;
-  }) =>
-    createElement('button', { onClick: onPress, 'data-pressable': accessibilityLabel ?? '' }, children),
+  }) => createElement('button', { onClick: onPress, 'data-pressable': accessibilityLabel ?? '' }, children),
 }));
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),

--- a/packages/mobile/src/components/play-drawer/BetaVideoCard.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideoCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useState } from 'react';
-import { Pressable, View, StyleSheet, Linking } from 'react-native';
+import { Pressable, View, StyleSheet, Linking, Alert } from 'react-native';
 import { Image } from 'expo-image';
 import * as Haptics from 'expo-haptics';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ import { useToast } from '../../providers/toast-provider';
 import { track } from '../../lib/analytics';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { useDeleteBetaLink } from '../../lib/graphql/hooks';
 
 export const BETA_CARD_WIDTH = 140;
 const BETA_CARD_ASPECT_RATIO = 9 / 16;
@@ -20,12 +21,16 @@ export const BETA_CARD_HEIGHT = BETA_CARD_WIDTH / BETA_CARD_ASPECT_RATIO;
 
 type Props = {
   link: BetaLink;
+  boardName?: string;
+  climbUuid?: string;
+  currentUserId?: string | null;
 };
 
-export const BetaVideoCard = memo(function BetaVideoCard({ link }: Props) {
+export const BetaVideoCard = memo(function BetaVideoCard({ link, boardName, climbUuid, currentUserId }: Props) {
   const { t } = useTranslation('session');
   const { showToast } = useToast();
   const [imageFailed, setImageFailed] = useState(false);
+  const deleteMutation = useDeleteBetaLink();
 
   const onPress = useCallback(async () => {
     void Haptics.selectionAsync();
@@ -45,8 +50,33 @@ export const BetaVideoCard = memo(function BetaVideoCard({ link }: Props) {
     }
   }, [link.climb_uuid, link.link, showToast, t]);
 
+  const attachedByUser = link.attached_by_user;
+  const isOwner = attachedByUser && currentUserId && attachedByUser.id === currentUserId;
+
+  const onLongPress = useCallback(() => {
+    if (!isOwner || !boardName || !climbUuid) return;
+    void Haptics.selectionAsync();
+    Alert.alert(t('mobile.betaVideos.deleteConfirmTitle'), t('mobile.betaVideos.deleteConfirmBody'), [
+      { text: t('mobile.betaVideos.deleteCancel'), style: 'cancel' },
+      {
+        text: t('mobile.betaVideos.deleteLink'),
+        style: 'destructive',
+        onPress: () => {
+          deleteMutation.mutate(
+            { boardType: boardName, climbUuid, link: link.link },
+            {
+              onSuccess: () => showToast(t('mobile.betaVideos.deleteSuccess'), 'success'),
+              onError: () => showToast(t('mobile.betaVideos.deleteError'), 'error'),
+            },
+          );
+        },
+      },
+    ]);
+  }, [isOwner, boardName, climbUuid, link.link, t, deleteMutation, showToast]);
+
   const platform = detectPlatform(link.link);
   const username = link.foreign_username?.trim();
+  const displayName = attachedByUser?.displayName;
   const accessibilityLabel = username
     ? t('mobile.betaVideos.cardLabelWithUser', { username })
     : t('mobile.betaVideos.cardLabel');
@@ -54,6 +84,7 @@ export const BetaVideoCard = memo(function BetaVideoCard({ link }: Props) {
   return (
     <Pressable
       onPress={onPress}
+      onLongPress={isOwner ? onLongPress : undefined}
       accessibilityRole="link"
       accessibilityLabel={accessibilityLabel}
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
@@ -83,11 +114,24 @@ export const BetaVideoCard = memo(function BetaVideoCard({ link }: Props) {
         </View>
       )}
 
-      {username && (
+      {(displayName || username) && (
         <View style={styles.usernamePill}>
-          <Text variant="caption2" color={iosSystemColors.white} numberOfLines={1}>
-            @{username}
-          </Text>
+          {displayName ? (
+            <>
+              <Text variant="caption2" color={iosSystemColors.white} numberOfLines={1}>
+                {displayName}
+              </Text>
+              {username && (
+                <Text variant="caption2" color={iosSystemColors.systemGray} numberOfLines={1}>
+                  {t('mobile.betaVideos.viaHandle', { handle: username })}
+                </Text>
+              )}
+            </>
+          ) : (
+            <Text variant="caption2" color={iosSystemColors.white} numberOfLines={1}>
+              @{username}
+            </Text>
+          )}
         </View>
       )}
     </Pressable>

--- a/packages/mobile/src/components/play-drawer/BetaVideosSection.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideosSection.tsx
@@ -5,7 +5,7 @@ import * as Haptics from 'expo-haptics';
 import { betaLinkIdentity } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { useBetaLinks } from '../../lib/graphql/hooks';
+import { useBetaLinks, useProfile } from '../../lib/graphql/hooks';
 import { useAuth } from '../../providers/auth-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -32,6 +32,8 @@ export const BetaVideosSection = memo(function BetaVideosSection({
   const { brandColors } = useTheme();
   const addSheetRef = useRef<BetaVideoAddSheetHandle>(null);
   const { data: links, isLoading, isError, refetch, isRefetching } = useBetaLinks(boardName, climbUuid);
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
+  const currentUserId = profile?.id ?? null;
 
   const handleOpenAddSheet = useCallback(() => {
     void Haptics.selectionAsync();
@@ -118,7 +120,13 @@ export const BetaVideosSection = memo(function BetaVideosSection({
           snapToAlignment="start"
         >
           {links.map((link) => (
-            <BetaVideoCard key={betaLinkIdentity(link.link)} link={link} />
+            <BetaVideoCard
+              key={betaLinkIdentity(link.link)}
+              link={link}
+              boardName={boardName}
+              climbUuid={climbUuid}
+              currentUserId={currentUserId}
+            />
           ))}
         </ScrollView>
       )}

--- a/packages/mobile/src/components/playlist/PlaylistFollowButton.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFollowButton.tsx
@@ -75,11 +75,7 @@ export function PlaylistFollowButton({ isFollowing, onToggle, loading, collapsed
           style={StyleSheet.absoluteFill}
           pointerEvents="none"
         />
-        {loading ? (
-          <ActivityIndicator size="small" />
-        ) : (
-          <Icon name={iconName} size={18} color={systemColors.label} />
-        )}
+        {loading ? <ActivityIndicator size="small" /> : <Icon name={iconName} size={18} color={systemColors.label} />}
         <Text variant="subheadline" color={systemColors.label} style={styles.label}>
           {label}
         </Text>

--- a/packages/mobile/src/components/playlist/__tests__/playlist-form-values.test.ts
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-form-values.test.ts
@@ -39,7 +39,10 @@ describe('buildPlaylistFormValues', () => {
       icon: undefined,
       isPublic: false,
     });
-    expect(result).toEqual({ ok: true, values: { name: 'P', description: undefined, color: undefined, icon: undefined } });
+    expect(result).toEqual({
+      ok: true,
+      values: { name: 'P', description: undefined, color: undefined, icon: undefined },
+    });
   });
 
   it('create keeps a chosen colour + emoji', () => {

--- a/packages/mobile/src/components/queue-control/LogAscentToolbarButton.tsx
+++ b/packages/mobile/src/components/queue-control/LogAscentToolbarButton.tsx
@@ -18,7 +18,11 @@ type LogAscentToolbarButtonProps = {
  * toolbar provides the visible container, so this uses the plain checkmark SF
  * Symbol instead of the circular tick glyph used by standalone FABs.
  */
-export function LogAscentToolbarButton({ climb, size = glassSize.standard, iconSize = 26 }: LogAscentToolbarButtonProps) {
+export function LogAscentToolbarButton({
+  climb,
+  size = glassSize.standard,
+  iconSize = 26,
+}: LogAscentToolbarButtonProps) {
   const { accessibilityLabel, disabled, handleLogAscentPress, iconColor, popStyle } = useLogAscentAction(climb);
 
   return (

--- a/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-queue-climb-carousel.test.tsx
@@ -183,7 +183,7 @@ describe('useQueueClimbCarousel party-preview gating', () => {
       result.current.onLayout({ nativeEvent: { layout: { width: 0 } } } as LayoutChangeEvent);
     });
 
-    expect(result.current.canPeek).toBe(true);      // configuredWidth=320 still in effect
+    expect(result.current.canPeek).toBe(true); // configuredWidth=320 still in effect
     expect(gestureCalls.last?.boardWidth).toBe(320); // widthSV not overwritten to 0
   });
 

--- a/packages/mobile/src/components/session-screen/pre-session/BoardSummaryCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/BoardSummaryCard.tsx
@@ -36,7 +36,11 @@ export function BoardSummaryCard({ onPress, board }: BoardSummaryCardProps) {
   const { systemColors } = useTheme();
 
   const summary = board
-    ? [board.name || formatBoardDisplayName(board.boardType), board.sizeName, board.angle != null ? `${board.angle}°` : null]
+    ? [
+        board.name || formatBoardDisplayName(board.boardType),
+        board.sizeName,
+        board.angle != null ? `${board.angle}°` : null,
+      ]
         .filter((part): part is string => !!part)
         .join(' · ')
     : null;

--- a/packages/mobile/src/hooks/__tests__/use-glass-capability.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-glass-capability.test.ts
@@ -52,6 +52,4 @@ describe('useGlassCapability', () => {
     const { result } = renderHook(() => useGlassCapability());
     expect(result.current).toBe(false);
   });
-
-
 });

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -17,10 +17,6 @@ export function useShareClimb({ climb, boardName, layoutId, sizeId, setIds, angl
   return useCallback(async () => {
     if (!climb) return;
     const url = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}`;
-    await Share.share(
-      Platform.OS === 'ios'
-        ? { message: climb.name, url }
-        : { message: `${climb.name}\n${url}` },
-    );
+    await Share.share(Platform.OS === 'ios' ? { message: climb.name, url } : { message: `${climb.name}\n${url}` });
   }, [climb, boardName, layoutId, sizeId, setIds, angle]);
 }

--- a/packages/mobile/src/lib/__tests__/ascent-status-utils.test.ts
+++ b/packages/mobile/src/lib/__tests__/ascent-status-utils.test.ts
@@ -89,7 +89,11 @@ describe('countSentAscents', () => {
   });
 
   it('derives flash/send from is_ascent + tries when status is absent', () => {
-    const entries = [make({ is_ascent: true, tries: 1 }), make({ is_ascent: true, tries: 5 }), make({ is_ascent: false })];
+    const entries = [
+      make({ is_ascent: true, tries: 1 }),
+      make({ is_ascent: true, tries: 5 }),
+      make({ is_ascent: false }),
+    ];
     expect(countSentAscents(entries, climb, angle)).toBe(2);
   });
 

--- a/packages/mobile/src/lib/__tests__/beta-video-url.test.ts
+++ b/packages/mobile/src/lib/__tests__/beta-video-url.test.ts
@@ -21,6 +21,7 @@ function makeRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
     thumbnail: '/static/beta-link-thumbnails/abc.jpg',
     isListed: true,
     createdAt: '2026-01-01T00:00:00Z',
+    attachedByUser: null,
     ...overrides,
   };
 }
@@ -65,6 +66,7 @@ describe('mapBetaLink (mobile)', () => {
       thumbnail: 'https://ws.boardsesh.test/static/abc.jpg?size=280',
       is_listed: true,
       created_at: '2026-01-01T00:00:00Z',
+      attached_by_user: null,
     });
   });
 

--- a/packages/mobile/src/lib/graphql/__tests__/use-search-boards-map.test.tsx
+++ b/packages/mobile/src/lib/graphql/__tests__/use-search-boards-map.test.tsx
@@ -13,7 +13,9 @@ import { useSearchBoardsMap, type SearchBoardsMapInput } from '../use-search-boa
 
 function wrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
 }
 
 /** The `input` object the hook handed to the GraphQL client on its last call. */

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -348,10 +348,13 @@ export function useFavoriteStatus(
 import {
   GET_BETA_LINKS,
   ATTACH_BETA_LINK,
+  DELETE_BETA_LINK,
   type GetBetaLinksQueryResponse,
   type GetBetaLinksQueryVariables,
   type AttachBetaLinkMutationVariables,
   type AttachBetaLinkMutationResponse,
+  type DeleteBetaLinkMutationVariables,
+  type DeleteBetaLinkMutationResponse,
 } from '@boardsesh/graphql/operations/beta-links';
 import { dedupeBetaLinks } from '@boardsesh/shared-schema';
 import { mapBetaLinks } from '../../beta-video-url';
@@ -425,6 +428,18 @@ export function useAttachBetaLink() {
       getHttpClient().request<AttachBetaLinkMutationResponse, AttachBetaLinkMutationVariables>(ATTACH_BETA_LINK, {
         input,
       }),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['betaLinks', vars.boardType, vars.climbUuid] });
+    },
+  });
+}
+
+export function useDeleteBetaLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (vars: DeleteBetaLinkMutationVariables) =>
+      getHttpClient().request<DeleteBetaLinkMutationResponse, DeleteBetaLinkMutationVariables>(DELETE_BETA_LINK, vars),
     onSuccess: (_data, vars) => {
       queryClient.invalidateQueries({ queryKey: ['betaLinks', vars.boardType, vars.climbUuid] });
     },

--- a/packages/mobile/src/providers/__tests__/tab-bar-height-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/tab-bar-height-provider.test.tsx
@@ -2,11 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
-import {
-  TabBarHeightProvider,
-  useMeasuredTabBarHeight,
-  useSetMeasuredTabBarHeight,
-} from '../tab-bar-height-provider';
+import { TabBarHeightProvider, useMeasuredTabBarHeight, useSetMeasuredTabBarHeight } from '../tab-bar-height-provider';
 
 function wrapper({ children }: { children: ReactNode }) {
   return createElement(TabBarHeightProvider, null, children);

--- a/packages/shared-schema/src/__tests__/beta-video-url.test.ts
+++ b/packages/shared-schema/src/__tests__/beta-video-url.test.ts
@@ -139,6 +139,7 @@ function makeLink(overrides: Partial<BetaLink> = {}): BetaLink {
     thumbnail: '/static/beta-link-thumbnails/abc.jpg',
     is_listed: true,
     created_at: '2026-01-01T00:00:00Z',
+    attached_by_user: null,
     ...overrides,
   };
 }
@@ -210,6 +211,7 @@ function makeRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
     thumbnail: '/static/beta-link-thumbnails/abc.jpg',
     isListed: true,
     createdAt: '2026-01-01T00:00:00Z',
+    attachedByUser: null,
     ...overrides,
   };
 }
@@ -225,7 +227,14 @@ describe('mapBetaLinkRow', () => {
       thumbnail: '/static/beta-link-thumbnails/abc.jpg',
       is_listed: true,
       created_at: '2026-01-01T00:00:00Z',
+      attached_by_user: null,
     });
+  });
+
+  it('passes through attachedByUser to attached_by_user', () => {
+    const attacher = { id: 'user-1', displayName: 'Alice Sends', avatarUrl: 'https://cdn.example.com/alice.jpg' };
+    const result = mapBetaLinkRow(makeRow({ attachedByUser: attacher }));
+    expect(result.attached_by_user).toEqual(attacher);
   });
 
   it('defaults isListed to false when null', () => {

--- a/packages/shared-schema/src/beta-video-url.ts
+++ b/packages/shared-schema/src/beta-video-url.ts
@@ -48,6 +48,16 @@ export function getTikTokVideoId(url: string): string | null {
 }
 
 /**
+ * Boardsesh user who attached a beta link. Present only on rows written after
+ * attribution was introduced; null for Aurora-synced rows and older entries.
+ */
+export type BetaLinkAttacher = {
+  id: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+/**
  * Canonical shape used by web and mobile after mapping a GraphQL response.
  * Snake-case is preserved for backwards compatibility with existing call sites
  * — Aurora's sync API uses these names and a lot of UI code already destructures
@@ -61,6 +71,7 @@ export type BetaLink = {
   thumbnail: string | null;
   is_listed: boolean;
   created_at: string;
+  attached_by_user: BetaLinkAttacher | null;
 };
 
 /**
@@ -74,6 +85,7 @@ export type BetaLinksGqlRow = {
   thumbnail: string | null;
   isListed: boolean | null;
   createdAt: string | null;
+  attachedByUser: BetaLinkAttacher | null;
 };
 
 /**
@@ -131,6 +143,7 @@ export function mapBetaLinkRow(
     thumbnail: absolutizeThumbnail(row.thumbnail),
     is_listed: row.isListed ?? false,
     created_at: row.createdAt ?? '',
+    attached_by_user: row.attachedByUser ?? null,
   };
 }
 

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3509,6 +3509,16 @@ type SimilarClimb {
 }
 
 """
+The Boardsesh user who attached a beta link, when attribution is available.
+Null for Aurora-synced rows and links attached before attribution was introduced.
+"""
+type BetaLinkAttacher {
+  id: ID!
+  displayName: String
+  avatarUrl: String
+}
+
+"""
 An external Instagram or TikTok beta link attached to a climb.
 Thumbnail (when present) is served from our own S3 bucket.
 """
@@ -3520,6 +3530,7 @@ type BetaLink {
   thumbnail: String
   isListed: Boolean
   createdAt: String
+  attachedByUser: BetaLinkAttacher
 }
 
 """
@@ -4407,6 +4418,11 @@ type Mutation {
   (boardType, climbUuid, link).
   """
   attachBetaLink(input: AttachBetaLinkInput!): Boolean!
+
+  """
+  Delete a beta link the current user attached. Only the attacher can delete.
+  """
+  deleteBetaLink(boardType: String!, climbUuid: String!, link: String!): Boolean!
 
   # ============================================
   # Climb Mutations (require auth)

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -308,12 +308,24 @@ export type AuroraCredentialStatus = {
 export type BetaLink = {
   __typename?: 'BetaLink';
   angle?: Maybe<Scalars['Int']['output']>;
+  attachedByUser?: Maybe<BetaLinkAttacher>;
   climbUuid: Scalars['String']['output'];
   createdAt?: Maybe<Scalars['String']['output']>;
   foreignUsername?: Maybe<Scalars['String']['output']>;
   isListed?: Maybe<Scalars['Boolean']['output']>;
   link: Scalars['String']['output'];
   thumbnail?: Maybe<Scalars['String']['output']>;
+};
+
+/**
+ * The Boardsesh user who attached a beta link, when attribution is available.
+ * Null for Aurora-synced rows and links attached before attribution was introduced.
+ */
+export type BetaLinkAttacher = {
+  __typename?: 'BetaLinkAttacher';
+  avatarUrl?: Maybe<Scalars['String']['output']>;
+  displayName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
 };
 
 /**
@@ -1898,6 +1910,8 @@ export type Mutation = {
   deleteAccount: Scalars['Boolean']['output'];
   /** Delete stored Aurora credentials for a board type. */
   deleteAuroraCredential: Scalars['Boolean']['output'];
+  /** Delete a beta link the current user attached. Only the attacher can delete. */
+  deleteBetaLink: Scalars['Boolean']['output'];
   /** Soft-delete a board. */
   deleteBoard: Scalars['Boolean']['output'];
   /** Delete a comment (soft-delete if it has replies). */
@@ -2227,6 +2241,13 @@ export type MutationDeleteAccountArgs = {
 /** Root mutation type for all write operations. */
 export type MutationDeleteAuroraCredentialArgs = {
   boardType: Scalars['String']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationDeleteBetaLinkArgs = {
+  boardType: Scalars['String']['input'];
+  climbUuid: Scalars['String']['input'];
+  link: Scalars['String']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -5482,6 +5503,7 @@ export type ResolversTypes = ResolversObject<{
   AuroraCredential: ResolverTypeWrapper<AuroraCredential>;
   AuroraCredentialStatus: ResolverTypeWrapper<AuroraCredentialStatus>;
   BetaLink: ResolverTypeWrapper<BetaLink>;
+  BetaLinkAttacher: ResolverTypeWrapper<BetaLinkAttacher>;
   BetaLinkPreview: ResolverTypeWrapper<BetaLinkPreview>;
   BoardLeaderboard: ResolverTypeWrapper<BoardLeaderboard>;
   BoardLeaderboardEntry: ResolverTypeWrapper<BoardLeaderboardEntry>;
@@ -5747,6 +5769,7 @@ export type ResolversParentTypes = ResolversObject<{
   AuroraCredential: AuroraCredential;
   AuroraCredentialStatus: AuroraCredentialStatus;
   BetaLink: BetaLink;
+  BetaLinkAttacher: BetaLinkAttacher;
   BetaLinkPreview: BetaLinkPreview;
   BoardLeaderboard: BoardLeaderboard;
   BoardLeaderboardEntry: BoardLeaderboardEntry;
@@ -6109,12 +6132,23 @@ export type BetaLinkResolvers<
   ParentType extends ResolversParentTypes['BetaLink'] = ResolversParentTypes['BetaLink'],
 > = ResolversObject<{
   angle?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  attachedByUser?: Resolver<Maybe<ResolversTypes['BetaLinkAttacher']>, ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   foreignUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isListed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   link?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   thumbnail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type BetaLinkAttacherResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['BetaLinkAttacher'] = ResolversParentTypes['BetaLinkAttacher'],
+> = ResolversObject<{
+  avatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -6974,6 +7008,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeleteAuroraCredentialArgs, 'boardType'>
+  >;
+  deleteBetaLink?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationDeleteBetaLinkArgs, 'boardType' | 'climbUuid' | 'link'>
   >;
   deleteBoard?: Resolver<
     ResolversTypes['Boolean'],
@@ -8955,6 +8995,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   AuroraCredential?: AuroraCredentialResolvers<ContextType>;
   AuroraCredentialStatus?: AuroraCredentialStatusResolvers<ContextType>;
   BetaLink?: BetaLinkResolvers<ContextType>;
+  BetaLinkAttacher?: BetaLinkAttacherResolvers<ContextType>;
   BetaLinkPreview?: BetaLinkPreviewResolvers<ContextType>;
   BoardLeaderboard?: BoardLeaderboardResolvers<ContextType>;
   BoardLeaderboardEntry?: BoardLeaderboardEntryResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/beta-links.ts
+++ b/packages/shared-schema/src/schema/beta-links.ts
@@ -1,5 +1,15 @@
 export const betaLinksTypeDefs = /* GraphQL */ `
   """
+  The Boardsesh user who attached a beta link, when attribution is available.
+  Null for Aurora-synced rows and links attached before attribution was introduced.
+  """
+  type BetaLinkAttacher {
+    id: ID!
+    displayName: String
+    avatarUrl: String
+  }
+
+  """
   An external Instagram or TikTok beta link attached to a climb.
   Thumbnail (when present) is served from our own S3 bucket.
   """
@@ -11,6 +21,7 @@ export const betaLinksTypeDefs = /* GraphQL */ `
     thumbnail: String
     isListed: Boolean
     createdAt: String
+    attachedByUser: BetaLinkAttacher
   }
 
   """

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -205,6 +205,11 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     attachBetaLink(input: AttachBetaLinkInput!): Boolean!
 
+    """
+    Delete a beta link the current user attached. Only the attacher can delete.
+    """
+    deleteBetaLink(boardType: String!, climbUuid: String!, link: String!): Boolean!
+
     # ============================================
     # Climb Mutations (require auth)
     # ============================================

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -16,8 +16,9 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
 type Documents = {
   '\n  query GetDeleteAccountInfo {\n    deleteAccountInfo {\n      publishedClimbCount\n    }\n  }\n': typeof types.GetDeleteAccountInfoDocument;
   '\n  mutation DeleteAccount($input: DeleteAccountInput!) {\n    deleteAccount(input: $input)\n  }\n': typeof types.DeleteAccountDocument;
-  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n': typeof types.GetBetaLinksDocument;
+  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      attachedByUser {\n        id\n        displayName\n        avatarUrl\n      }\n    }\n  }\n': typeof types.GetBetaLinksDocument;
   '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n': typeof types.AttachBetaLinkDocument;
+  '\n  mutation DeleteBetaLink($boardType: String!, $climbUuid: String!, $link: String!) {\n    deleteBetaLink(boardType: $boardType, climbUuid: $climbUuid, link: $link)\n  }\n': typeof types.DeleteBetaLinkDocument;
   '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetRecentBetaLinksDocument;
   '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetUserBetaLinksDocument;
   '\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n': typeof types.BetaLinkPreviewDocument;
@@ -129,10 +130,12 @@ const documents: Documents = {
     types.GetDeleteAccountInfoDocument,
   '\n  mutation DeleteAccount($input: DeleteAccountInput!) {\n    deleteAccount(input: $input)\n  }\n':
     types.DeleteAccountDocument,
-  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n':
+  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      attachedByUser {\n        id\n        displayName\n        avatarUrl\n      }\n    }\n  }\n':
     types.GetBetaLinksDocument,
   '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n':
     types.AttachBetaLinkDocument,
+  '\n  mutation DeleteBetaLink($boardType: String!, $climbUuid: String!, $link: String!) {\n    deleteBetaLink(boardType: $boardType, climbUuid: $climbUuid, link: $link)\n  }\n':
+    types.DeleteBetaLinkDocument,
   '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n':
     types.GetRecentBetaLinksDocument,
   '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n':
@@ -370,14 +373,20 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n',
-): (typeof documents)['\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n'];
+  source: '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      attachedByUser {\n        id\n        displayName\n        avatarUrl\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      attachedByUser {\n        id\n        displayName\n        avatarUrl\n      }\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
   source: '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n',
 ): (typeof documents)['\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n'];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  mutation DeleteBetaLink($boardType: String!, $climbUuid: String!, $link: String!) {\n    deleteBetaLink(boardType: $boardType, climbUuid: $climbUuid, link: $link)\n  }\n',
+): (typeof documents)['\n  mutation DeleteBetaLink($boardType: String!, $climbUuid: String!, $link: String!) {\n    deleteBetaLink(boardType: $boardType, climbUuid: $climbUuid, link: $link)\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -305,12 +305,24 @@ export type AuroraCredentialStatus = {
 export type BetaLink = {
   __typename?: 'BetaLink';
   angle?: Maybe<Scalars['Int']['output']>;
+  attachedByUser?: Maybe<BetaLinkAttacher>;
   climbUuid: Scalars['String']['output'];
   createdAt?: Maybe<Scalars['String']['output']>;
   foreignUsername?: Maybe<Scalars['String']['output']>;
   isListed?: Maybe<Scalars['Boolean']['output']>;
   link: Scalars['String']['output'];
   thumbnail?: Maybe<Scalars['String']['output']>;
+};
+
+/**
+ * The Boardsesh user who attached a beta link, when attribution is available.
+ * Null for Aurora-synced rows and links attached before attribution was introduced.
+ */
+export type BetaLinkAttacher = {
+  __typename?: 'BetaLinkAttacher';
+  avatarUrl?: Maybe<Scalars['String']['output']>;
+  displayName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
 };
 
 /**
@@ -1895,6 +1907,8 @@ export type Mutation = {
   deleteAccount: Scalars['Boolean']['output'];
   /** Delete stored Aurora credentials for a board type. */
   deleteAuroraCredential: Scalars['Boolean']['output'];
+  /** Delete a beta link the current user attached. Only the attacher can delete. */
+  deleteBetaLink: Scalars['Boolean']['output'];
   /** Soft-delete a board. */
   deleteBoard: Scalars['Boolean']['output'];
   /** Delete a comment (soft-delete if it has replies). */
@@ -2224,6 +2238,13 @@ export type MutationDeleteAccountArgs = {
 /** Root mutation type for all write operations. */
 export type MutationDeleteAuroraCredentialArgs = {
   boardType: Scalars['String']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationDeleteBetaLinkArgs = {
+  boardType: Scalars['String']['input'];
+  climbUuid: Scalars['String']['input'];
+  link: Scalars['String']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -5392,6 +5413,12 @@ export type GetBetaLinksQuery = {
     thumbnail?: string | null;
     isListed?: boolean | null;
     createdAt?: string | null;
+    attachedByUser?: {
+      __typename?: 'BetaLinkAttacher';
+      id: string;
+      displayName?: string | null;
+      avatarUrl?: string | null;
+    } | null;
   }>;
 };
 
@@ -5400,6 +5427,14 @@ export type AttachBetaLinkMutationVariables = Exact<{
 }>;
 
 export type AttachBetaLinkMutation = { __typename?: 'Mutation'; attachBetaLink: boolean };
+
+export type DeleteBetaLinkMutationVariables = Exact<{
+  boardType: Scalars['String']['input'];
+  climbUuid: Scalars['String']['input'];
+  link: Scalars['String']['input'];
+}>;
+
+export type DeleteBetaLinkMutation = { __typename?: 'Mutation'; deleteBetaLink: boolean };
 
 export type GetRecentBetaLinksQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -7668,6 +7703,18 @@ export const GetBetaLinksDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'thumbnail' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'isListed' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'attachedByUser' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'displayName' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'avatarUrl' } },
+                    ],
+                  },
+                },
               ],
             },
           },
@@ -7712,6 +7759,59 @@ export const AttachBetaLinkDocument = {
     },
   ],
 } as unknown as DocumentNode<AttachBetaLinkMutation, AttachBetaLinkMutationVariables>;
+export const DeleteBetaLinkDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'DeleteBetaLink' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'boardType' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'climbUuid' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'link' } },
+          type: { kind: 'NonNullType', type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } } },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'deleteBetaLink' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'boardType' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'boardType' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'climbUuid' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'climbUuid' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'link' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'link' } },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteBetaLinkMutation, DeleteBetaLinkMutationVariables>;
 export const GetRecentBetaLinksDocument = {
   kind: 'Document',
   definitions: [

--- a/packages/shared/graphql/src/operations/beta-links.ts
+++ b/packages/shared/graphql/src/operations/beta-links.ts
@@ -11,6 +11,11 @@ export const GET_BETA_LINKS = gql`
       thumbnail
       isListed
       createdAt
+      attachedByUser {
+        id
+        displayName
+        avatarUrl
+      }
     }
   }
 `;
@@ -26,6 +31,15 @@ export const ATTACH_BETA_LINK = gql`
 
 export type AttachBetaLinkMutationVariables = { input: AttachBetaLinkInput };
 export type AttachBetaLinkMutationResponse = { attachBetaLink: boolean };
+
+export const DELETE_BETA_LINK = gql`
+  mutation DeleteBetaLink($boardType: String!, $climbUuid: String!, $link: String!) {
+    deleteBetaLink(boardType: $boardType, climbUuid: $climbUuid, link: $link)
+  }
+`;
+
+export type DeleteBetaLinkMutationVariables = { boardType: string; climbUuid: string; link: string };
+export type DeleteBetaLinkMutationResponse = { deleteBetaLink: boolean };
 
 export const GET_RECENT_BETA_LINKS = gql`
   query GetRecentBetaLinks($limit: Int, $boardType: String) {

--- a/packages/shared/i18n/locales/en-US/feed.json
+++ b/packages/shared/i18n/locales/en-US/feed.json
@@ -42,7 +42,11 @@
       "step1Title": "Open Instagram and copy your caption",
       "step2Title": "From your post, copy the share link",
       "step3Title": "Paste the link below"
-    }
+    },
+    "viaHandle": "via @{{handle}}",
+    "deleteLink": "Delete",
+    "deleteSuccess": "Beta link removed",
+    "deleteError": "Couldn't remove beta link. Try again."
   },
   "commentFeed": {
     "empty": "No comments yet",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -287,7 +287,14 @@
       "shareClose": "Close",
       "shareReadingCaption": "Reading the caption…",
       "shareSuggestedTitle": "Matched from the caption",
-      "shareOtherAscents": "Your other ascents"
+      "shareOtherAscents": "Your other ascents",
+      "deleteLink": "Delete",
+      "deleteConfirmTitle": "Remove beta link?",
+      "deleteConfirmBody": "This can't be undone.",
+      "deleteCancel": "Cancel",
+      "deleteSuccess": "Beta link removed",
+      "deleteError": "Couldn't remove beta link. Try again.",
+      "viaHandle": "via @{{handle}}"
     },
     "angleSelector": {
       "title": "Choose Angle",

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -42,7 +42,11 @@
     "instagramCopyFailed": "No se pudo copiar la descripción. Inténtalo de nuevo.",
     "instagramCopiedAndOpened": "Descripción copiada — pégala en Instagram.",
     "instagramCopiedOnly": "Descripción copiada al portapapeles.",
-    "addSubmit": "Añadir"
+    "addSubmit": "Añadir",
+    "viaHandle": "vía @{{handle}}",
+    "deleteLink": "Eliminar",
+    "deleteSuccess": "Enlace de beta eliminado",
+    "deleteError": "No se pudo eliminar el enlace. Inténtalo de nuevo."
   },
   "commentFeed": {
     "empty": "Sin comentarios todavía",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -287,7 +287,14 @@
       "shareClose": "Cerrar",
       "shareReadingCaption": "Leyendo la descripción…",
       "shareSuggestedTitle": "Encontrado en la descripción",
-      "shareOtherAscents": "Tus otros ascensos"
+      "shareOtherAscents": "Tus otros ascensos",
+      "deleteLink": "Eliminar",
+      "deleteConfirmTitle": "¿Eliminar enlace de beta?",
+      "deleteConfirmBody": "Esta acción no se puede deshacer.",
+      "deleteCancel": "Cancelar",
+      "deleteSuccess": "Enlace de beta eliminado",
+      "deleteError": "No se pudo eliminar. Inténtalo de nuevo.",
+      "viaHandle": "vía @{{handle}}"
     },
     "angleSelector": {
       "title": "Elegir ángulo",

--- a/packages/shared/i18n/locales/fr/feed.json
+++ b/packages/shared/i18n/locales/fr/feed.json
@@ -42,7 +42,11 @@
       "step1Title": "Ouvrez Instagram et copiez votre légende",
       "step2Title": "Depuis votre publication, copiez le lien de partage",
       "step3Title": "Collez le lien ci-dessous"
-    }
+    },
+    "viaHandle": "via @{{handle}}",
+    "deleteLink": "Supprimer",
+    "deleteSuccess": "Lien bêta supprimé",
+    "deleteError": "Impossible de supprimer le lien. Réessayez."
   },
   "commentFeed": {
     "empty": "Aucun commentaire pour l'instant",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -287,7 +287,14 @@
       "shareClose": "Fermer",
       "shareReadingCaption": "Lecture de la description...",
       "shareSuggestedTitle": "Trouve dans la description",
-      "shareOtherAscents": "Tes autres ascensions"
+      "shareOtherAscents": "Tes autres ascensions",
+      "deleteLink": "Supprimer",
+      "deleteConfirmTitle": "Supprimer ce lien bêta ?",
+      "deleteConfirmBody": "Cette action est irréversible.",
+      "deleteCancel": "Annuler",
+      "deleteSuccess": "Lien bêta supprimé",
+      "deleteError": "Impossible de supprimer. Réessayez.",
+      "viaHandle": "via @{{handle}}"
     },
     "angleSelector": {
       "title": "Choisir l'angle",

--- a/packages/web/app/components/beta-videos/__tests__/home-recent-beta-section.test.tsx
+++ b/packages/web/app/components/beta-videos/__tests__/home-recent-beta-section.test.tsx
@@ -77,6 +77,7 @@ function makeRow(overrides: {
       thumbnail: null,
       isListed: true,
       createdAt: null,
+      attachedByUser: null,
     },
   };
 }

--- a/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-card.tsx
@@ -2,17 +2,41 @@
 
 import React, { useState } from 'react';
 import Instagram from '@mui/icons-material/Instagram';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import Avatar from '@mui/material/Avatar';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import { useSession } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { track } from '@/app/lib/analytics';
 import type { BetaLink } from '@/app/lib/api-wrappers/sync-api-types';
 import { isInstagramUrl, isTikTokUrl } from '@/app/lib/beta-video-url';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import TikTokIcon from './tiktok-icon';
 import styles from './boardsesh-beta.module.css';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import {
+  DELETE_BETA_LINK,
+  type DeleteBetaLinkMutationVariables,
+  type DeleteBetaLinkMutationResponse,
+} from '@boardsesh/graphql/operations';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 
 type BoardseshBetaCardSource = 'home' | 'drawer' | 'profile';
 
 type BoardseshBetaCardProps = {
   link: BetaLink;
+  /**
+   * Board type (e.g. "kilter", "tension"). Required to call the deleteBetaLink
+   * mutation; when omitted the delete option is not shown.
+   */
+  boardType?: string | null;
   /**
    * Optional climb label rendered as a top-anchored chip. Only the
    * home-screen slider passes this — the per-climb drawer slider omits it
@@ -31,8 +55,21 @@ type BoardseshBetaCardProps = {
   source?: BoardseshBetaCardSource;
 };
 
-const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link, climbName, climbHref, source = 'drawer' }) => {
+const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({
+  link,
+  boardType,
+  climbName,
+  climbHref,
+  source = 'drawer',
+}) => {
+  const { t } = useTranslation('feed');
+  const { data: session } = useSession();
+  const { token } = useWsAuthToken();
+  const queryClient = useQueryClient();
+  const { showMessage } = useSnackbar();
   const [thumbnailFailed, setThumbnailFailed] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+
   const thumbnailSrc = !thumbnailFailed ? link.thumbnail : null;
   const isTikTok = isTikTokUrl(link.link);
   const isInstagram = !isTikTok && isInstagramUrl(link.link);
@@ -47,10 +84,34 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link, climbName, 
 
   const climbLabel = climbName?.trim() ? climbName : null;
   const climbHrefEffective = climbLabel && climbHref ? climbHref : null;
+
+  const attachedByUser = link.attached_by_user;
+  const isOwner = attachedByUser && boardType && session?.user?.id === attachedByUser.id;
+
   const ariaLabel =
     `Open beta on ${displayPlatform}` +
     (link.foreign_username ? ` by ${link.foreign_username}` : '') +
     (climbLabel ? ` for ${climbLabel}` : '');
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      if (!token || !boardType) throw new Error('Auth token or boardType not available');
+      const client = createGraphQLHttpClient(token);
+      const variables: DeleteBetaLinkMutationVariables = {
+        boardType,
+        climbUuid: link.climb_uuid,
+        link: link.link,
+      };
+      await client.request<DeleteBetaLinkMutationResponse>(DELETE_BETA_LINK, variables);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['betaLinks'] });
+      showMessage(t('betaVideos.deleteSuccess'), 'success');
+    },
+    onError: () => {
+      showMessage(t('betaVideos.deleteError'), 'error');
+    },
+  });
 
   return (
     <article className={styles.card}>
@@ -87,8 +148,53 @@ const BoardseshBetaCard: React.FC<BoardseshBetaCardProps> = ({ link, climbName, 
           <span className={styles.platformBadge} aria-label={`From ${displayPlatform}`}>
             <PlatformIcon sx={{ fontSize: 12 }} />
           </span>
-          {link.foreign_username && <span className={styles.userChip}>@{link.foreign_username}</span>}
+          {attachedByUser ? (
+            <span className={styles.userChip}>
+              <Avatar
+                src={attachedByUser.avatarUrl ?? undefined}
+                sx={{ width: 14, height: 14, display: 'inline-flex', verticalAlign: 'middle' }}
+              />{' '}
+              {attachedByUser.displayName ?? attachedByUser.id}
+              {link.foreign_username && <> {t('betaVideos.viaHandle', { handle: link.foreign_username })}</>}
+            </span>
+          ) : (
+            link.foreign_username && <span className={styles.userChip}>@{link.foreign_username}</span>
+          )}
         </a>
+        {isOwner && (
+          <>
+            <IconButton
+              size="small"
+              className={styles.kebabButton}
+              aria-label="More options"
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuAnchor(e.currentTarget);
+              }}
+            >
+              <MoreVertIcon sx={{ fontSize: 14, color: 'white' }} />
+            </IconButton>
+            <Menu
+              anchorEl={menuAnchor}
+              open={Boolean(menuAnchor)}
+              onClose={() => setMenuAnchor(null)}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MenuItem
+                onClick={() => {
+                  setMenuAnchor(null);
+                  deleteMutation.mutate();
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                <ListItemIcon>
+                  <DeleteOutlineIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>{t('betaVideos.deleteLink')}</ListItemText>
+              </MenuItem>
+            </Menu>
+          </>
+        )}
         {climbLabel &&
           (climbHrefEffective ? (
             <LocaleLink

--- a/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
+++ b/packages/web/app/components/beta-videos/boardsesh-beta-list.tsx
@@ -13,6 +13,11 @@ type BoardseshBetaListProps = {
   links: BetaLink[];
   isLoading: boolean;
   /**
+   * Board type (e.g. "kilter", "tension"). Passed to each card so the delete
+   * action knows which board the link belongs to.
+   */
+  boardType?: string | null;
+  /**
    * When set, each card renders a top-anchored climb-name chip resolved
    * from this function. Used by the home-screen slider where the cards
    * come from many different climbs.
@@ -29,6 +34,7 @@ type BoardseshBetaListProps = {
 const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({
   links,
   isLoading,
+  boardType,
   getClimbName,
   getClimbHref,
   source = 'drawer',
@@ -51,6 +57,7 @@ const BoardseshBetaList: React.FC<BoardseshBetaListProps> = ({
               <BoardseshBetaCard
                 key={link.link}
                 link={link}
+                boardType={boardType}
                 climbName={getClimbName?.(link) ?? null}
                 climbHref={getClimbHref?.(link) ?? null}
                 source={source}

--- a/packages/web/app/components/beta-videos/boardsesh-beta.module.css
+++ b/packages/web/app/components/beta-videos/boardsesh-beta.module.css
@@ -71,11 +71,13 @@
   color: white;
   font-size: 11px;
   padding: 2px 6px;
-  text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   line-height: 1.4;
+  display: flex;
+  align-items: center;
+  gap: 3px;
 }
 
 .climbChip {
@@ -109,6 +111,18 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
+}
+
+.kebabButton {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--overlay-dark) !important;
+  border-radius: 4px !important;
+  padding: 2px !important;
+  width: 20px;
+  height: 20px;
+  z-index: 1;
 }
 
 .emptyText {

--- a/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
+++ b/packages/web/app/components/climb-detail/build-climb-detail-sections.tsx
@@ -134,7 +134,7 @@ export function useBuildClimbDetailSections({
               onSuccess={() => setIsAddingBeta(false)}
             />
           ) : (
-            <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} />
+            <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} boardType={boardType} />
           )}
         </Box>
       ),

--- a/packages/web/app/components/library/post-to-instagram-dialog.tsx
+++ b/packages/web/app/components/library/post-to-instagram-dialog.tsx
@@ -128,7 +128,7 @@ export default function PostToInstagramDialog({ open, onClose, item }: PostToIns
   } else {
     betaVideosContent = (
       <Box sx={{ mt: 1 }}>
-        <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} />
+        <BoardseshBetaList links={dedupedBetaLinks} isLoading={betaLinksLoading} boardType={item?.boardType} />
       </Box>
     );
   }

--- a/packages/web/app/lib/__tests__/beta-video-url.test.ts
+++ b/packages/web/app/lib/__tests__/beta-video-url.test.ts
@@ -21,6 +21,7 @@ describe('mapBetaLinksResponse — thumbnail absolutization', () => {
       thumbnail,
       isListed: true,
       createdAt: '2026-04-26T00:00:00Z',
+      attachedByUser: null,
     };
   }
 

--- a/packages/web/app/lib/__tests__/instagram-url.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-url.test.ts
@@ -12,6 +12,7 @@ function makeBetaLink(overrides: Partial<BetaLink>): BetaLink {
     thumbnail: null,
     is_listed: true,
     created_at: '2026-04-16T00:00:00.000Z',
+    attached_by_user: null,
     ...overrides,
   };
 }

--- a/packages/web/app/profile/[user_id]/components/__tests__/profile-beta-section.test.tsx
+++ b/packages/web/app/profile/[user_id]/components/__tests__/profile-beta-section.test.tsx
@@ -77,6 +77,7 @@ function makeRow(overrides: {
       thumbnail: null,
       isListed: true,
       createdAt: null,
+      attachedByUser: null,
     },
   };
 }

--- a/packages/web/board-controller/static/assets/index-DDv0U3S3.js
+++ b/packages/web/board-controller/static/assets/index-DDv0U3S3.js
@@ -40467,7 +40467,8 @@ const hu = (e, t, n = 3) => {
       ge.asap(() => e(...t)),
   nA = gr.hasStandardBrowserEnv
     ? ((e, t) => (n) => (
-        (n = new URL(n, gr.origin)), e.protocol === n.protocol && e.host === n.host && (t || e.port === n.port)
+        (n = new URL(n, gr.origin)),
+        e.protocol === n.protocol && e.host === n.host && (t || e.port === n.port)
       ))(new URL(gr.origin), gr.navigator && /(msie|trident)/i.test(gr.navigator.userAgent))
     : () => !0,
   rA = gr.hasStandardBrowserEnv


### PR DESCRIPTION
Fixes #1729

## Summary

- **DB**: Adds `attached_by_tick_id` column to `board_beta_links` (migration 0124); FK `ON DELETE SET NULL` mirrors the existing `created_by_user_id` pattern from migration 0093
- **GraphQL schema**: New `BetaLinkAttacher` type and `attachedByUser` field on `BetaLink`; new `deleteBetaLink(boardType, climbUuid, link)` mutation
- **Shared types**: `BetaLinkAttacher` + `attached_by_user` on `BetaLink`; `attachedByUser` on `BetaLinksGqlRow`; `mapBetaLinkRow` threads it through
- **Backend `betaLinks` resolver**: LEFT JOIN on `userProfiles` → returns `attachedByUser { id, displayName, avatarUrl }`
- **Backend `deleteBetaLink` mutation**: owner-only delete (throws `BETA_LINK_NOT_OWNER` for non-owners); invalidates recent-beta-links cache
- **`saveTick` upsert**: fills attribution when the existing row has nulls, preserves it when already set (no more silent `onConflictDoNothing`)
- **Web card** (`boardsesh-beta-card.tsx`): shows MUI `Avatar` + display name; "via @handle" for the originating platform account; kebab menu with Delete for card owner
- **Mobile card** (`BetaVideoCard.tsx`): shows display name + "via @handle" in the attribution pill; long-press → confirm alert → delete for card owner
- **i18n**: all new keys added to `en-US`, `es`, and `fr` in both `feed` and `session` namespaces

## Test plan

- [ ] All 4736 web tests pass
- [ ] All 61 shared-schema tests pass
- [ ] Mobile typecheck clean
- [ ] `vp check` formatting passes
- [ ] DB migration runs cleanly (`bunx drizzle-kit generate` from `packages/db/`)
- [ ] Web: open a climb with beta links — cards without `attachedByUser` render exactly as today
- [ ] Web: own card shows kebab menu → Delete → card removed + snackbar
- [ ] Web: non-own card has no kebab menu
- [ ] Mobile: long-press own card → confirm alert → card removed + toast
- [ ] Mobile: long-press non-own card → no action
- [ ] Log a tick with video URL → `created_by_user_id` + `attached_by_tick_id` populated

https://claude.ai/code/session_01WF2xQAr2kYTVSzUNHqawDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF2xQAr2kYTVSzUNHqawDp)_