### PR TITLE
[codex] Fix mobile board sheet stats loading

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -7,17 +7,18 @@ This document describes the WebSocket implementation used for real-time party se
 1. [Architecture Overview](#architecture-overview)
 2. [Technology Stack](#technology-stack)
 3. [Connection Flow](#connection-flow)
-4. [Backend URL Resolution](#backend-url-resolution)
-5. [Session Management](#session-management)
-6. [Queue State Synchronization](#queue-state-synchronization)
-7. [Multi-Instance Support](#multi-instance-support)
-8. [Failure States and Recovery](#failure-states-and-recovery)
-9. [Client-Side Connection Supervisor](#client-side-connection-supervisor)
-10. [Data Persistence Strategy](#data-persistence-strategy)
-11. [iOS Live Activity Integration](#ios-live-activity-integration)
-12. [Live Activity Push Notifications (APNs)](#live-activity-push-notifications-apns)
-13. [Activity Push Token Lifecycle](#activity-push-token-lifecycle)
-14. [Widget Navigation REST Endpoint](#widget-navigation-rest-endpoint)
+4. [Board Presence Wall Feed](#board-presence-wall-feed)
+5. [Backend URL Resolution](#backend-url-resolution)
+6. [Session Management](#session-management)
+7. [Queue State Synchronization](#queue-state-synchronization)
+8. [Multi-Instance Support](#multi-instance-support)
+9. [Failure States and Recovery](#failure-states-and-recovery)
+10. [Client-Side Connection Supervisor](#client-side-connection-supervisor)
+11. [Data Persistence Strategy](#data-persistence-strategy)
+12. [iOS Live Activity Integration](#ios-live-activity-integration)
+13. [Live Activity Push Notifications (APNs)](#live-activity-push-notifications-apns)
+14. [Activity Push Token Lifecycle](#activity-push-token-lifecycle)
+15. [Widget Navigation REST Endpoint](#widget-navigation-rest-endpoint)
 
 ---
 
@@ -305,6 +306,20 @@ The `getBaseBoardPath()` utility in `url-utils.ts` extracts the stable board con
 - `/{angle}` - board angle (numeric segment at end)
 
 This ensures `BoardSessionBridge` only calls `activateSession()` when the actual board configuration changes, not when users swipe between climbs or adjust the board angle.
+
+---
+
+## Board Presence Wall Feed
+
+Board presence powers the mobile "now on the wall" feed, board sheet history, and board sheet stats. It is independent of party-session join: the mobile app resolves a board id for the wall feed before subscribing to `boardNowPlaying` or fetching board-presence history/stats.
+
+Mobile resolves the feed board id in this order:
+
+1. `resolveBoardForUuid(boardUuid)` for the selected named board. This is the default board-sheet path and binds to the actual `user_boards` row, so stats/history are available before Bluetooth connects and stay aligned with board-scoped ticks.
+2. `resolveBoardForSerial(serial, boardType, layoutId, sizeId, setIds)` after a BLE connection when the controller exposes a serial. This keeps everyone at the same physical wall converged on the same board id.
+3. `resolveBoardForConfig(boardType, layoutId, sizeId, setIds)` only when no serial is available, giving serial-less boards a per-config fallback feed.
+
+Each resolver stamps short-lived proof-of-presence for the authenticated user before `reportBoardClimb` will accept a wall-feed report. On the mobile client, starting a newer UUID/config/serial resolve clears the previous board id and stale async results are ignored by a resolve-generation guard, so the sheet does not temporarily show another selected board's feed.
 
 ---
 

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vite-plus/test';
 import Redis from 'ioredis';
+import { v4 as uuidv4 } from 'uuid';
 import { sql } from 'drizzle-orm';
 import type {
   ConnectionContext,
@@ -401,6 +402,37 @@ describe('board-presence resolvers', () => {
       // The original board still owns the serial.
       const [orig] = await db.execute(sql`SELECT serial_number FROM user_boards WHERE id = ${resolved.boardId}`);
       expect((orig as { serial_number: string }).serial_number).toBe(serialA);
+    });
+  });
+
+  describe('resolveBoardForUuid', () => {
+    it('resolves the selected named board and stamps proof-of-presence', async () => {
+      const boardUuid = uuidv4();
+      const slug = `presence-uuid-${Date.now()}`;
+      await db.execute(sql`
+        INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, serial_number, is_public)
+        VALUES (${boardUuid}, ${slug}, ${TEST_USER_ID}, 'kilter', 4, 12, '1,2', 'Named Wall', null, false)
+      `);
+
+      const resolved = await boardPresenceMutations.resolveBoardForUuid(undefined, { boardUuid }, authCtx());
+
+      expect(resolved.boardName).toBe('Named Wall');
+      expect(resolved.boardType).toBe('kilter');
+      expect(resolved.layoutId).toBe(4);
+      expect(await pubsub.hasBoardMembership(String(resolved.boardId), TEST_USER_ID)).toBe(true);
+    });
+
+    it('rejects a private board owned by another user', async () => {
+      const boardUuid = uuidv4();
+      const slug = `presence-private-${Date.now()}`;
+      await db.execute(sql`
+        INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, serial_number, is_public)
+        VALUES (${boardUuid}, ${slug}, ${SECOND_USER_ID}, 'kilter', 4, 12, '1,2', 'Private Wall', null, false)
+      `);
+
+      await expect(
+        boardPresenceMutations.resolveBoardForUuid(undefined, { boardUuid }, authCtx()),
+      ).rejects.toThrow('Board not found');
     });
   });
 

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -434,6 +434,12 @@ describe('board-presence resolvers', () => {
         boardPresenceMutations.resolveBoardForUuid(undefined, { boardUuid }, authCtx()),
       ).rejects.toThrow('Board not found');
     });
+
+    it('rejects a board uuid that does not exist', async () => {
+      await expect(
+        boardPresenceMutations.resolveBoardForUuid(undefined, { boardUuid: uuidv4() }, authCtx()),
+      ).rejects.toThrow('Board not found');
+    });
   });
 
   describe('reportBoardClimb', () => {

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -10,7 +10,7 @@ import type {
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
-import { BoardSerialSchema } from '../../../validation/schemas/primitives';
+import { BoardSerialSchema, UUIDSchema } from '../../../validation/schemas/primitives';
 import {
   BoardPresenceAngleSchema,
   BoardPresenceConfigInputSchema,
@@ -23,6 +23,7 @@ import {
   defaultBoardName,
   findActiveBoardBySerial,
   findOwnActiveBoardByConfig,
+  findReachableActiveBoardByUuid,
   isDuplicateBoardSerialError,
   requireActiveBoardById,
   requireBoardPresenceEnabled,
@@ -163,6 +164,30 @@ export const boardPresenceMutations = {
   },
 
   /**
+   * Resolve the board-presence feed for a selected named board. Unlike the
+   * per-config fallback, this binds to the actual UserBoard row so durable board
+   * stats and live presence share the same board_id before any BLE connection.
+   */
+  resolveBoardForUuid: async (
+    _: unknown,
+    { boardUuid }: { boardUuid: string },
+    ctx: ConnectionContext,
+  ): Promise<ResolvedBoard> => {
+    requireBoardPresenceEnabled();
+    requireAuthenticated(ctx);
+    await applyRateLimit(ctx, 30, 'resolveBoardForUuid');
+
+    const validBoardUuid = validateInput(UUIDSchema, boardUuid, 'boardUuid');
+    const board = await findReachableActiveBoardByUuid(ctx.userId!, validBoardUuid);
+    if (!board) {
+      throw new GraphQLError('Board not found', { extensions: { code: 'NOT_FOUND' } });
+    }
+    const resolved = toResolvedBoard(board);
+    await pubsub.stampBoardMembership(String(resolved.boardId), ctx.userId!);
+    return resolved;
+  },
+
+  /**
    * Resolve the shared board feed for boards that do not expose a BLE serial
    * (MoonBoard and any future serial-less hardware). This is per-config in v1:
    * every caller with the same board config converges on the same hidden,
@@ -203,9 +228,10 @@ export const boardPresenceMutations = {
     await applyRateLimit(ctx, 60, 'reportBoardClimb');
     const board = await requireActiveBoardById(boardId);
 
-    // Proof-of-presence: only a user who connected to this board (stamped in
-    // resolveBoardForSerial / resolveBoardForConfig) may post to its feed. This
-    // stops a logged-in user from injecting climbs onto any board id they guess.
+    // Proof-of-presence: only a user who selected or connected to this board
+    // (stamped in resolveBoardForUuid / resolveBoardForSerial /
+    // resolveBoardForConfig) may post to its feed. This stops a logged-in user
+    // from injecting climbs onto any board id they guess.
     const isConnected = await pubsub.hasBoardMembership(String(boardId), ctx.userId!);
     if (!isConnected) {
       throw new GraphQLError('Not connected to this board');

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -1,5 +1,5 @@
 import { GraphQLError } from 'graphql';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, or } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import type { ResolvedBoard } from '@boardsesh/shared-schema';
@@ -86,6 +86,33 @@ export async function findActiveBoardById(boardId: number): Promise<ActivePresen
     })
     .from(dbSchema.userBoards)
     .where(and(eq(dbSchema.userBoards.id, boardId), isNull(dbSchema.userBoards.deletedAt)))
+    .limit(1);
+  return board;
+}
+
+export async function findReachableActiveBoardByUuid(
+  userId: string,
+  boardUuid: string,
+): Promise<ActivePresenceBoard | undefined> {
+  const [board] = await db
+    .select({
+      id: dbSchema.userBoards.id,
+      name: dbSchema.userBoards.name,
+      boardType: dbSchema.userBoards.boardType,
+      layoutId: dbSchema.userBoards.layoutId,
+      sizeId: dbSchema.userBoards.sizeId,
+      setIds: dbSchema.userBoards.setIds,
+      serialNumber: dbSchema.userBoards.serialNumber,
+      angle: dbSchema.userBoards.angle,
+    })
+    .from(dbSchema.userBoards)
+    .where(
+      and(
+        eq(dbSchema.userBoards.uuid, boardUuid),
+        isNull(dbSchema.userBoards.deletedAt),
+        or(eq(dbSchema.userBoards.ownerId, userId), eq(dbSchema.userBoards.isPublic, true)),
+      ),
+    )
     .limit(1);
   return board;
 }

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -4,7 +4,7 @@
 // split, GlassSheetBackground, stackBehavior="push". (No FullWindowOverlay — it
 // prevented the sheet from presenting in this app; QueueSheet/PlayDrawer omit it.)
 // Renders the wall's now-on-the-wall hero, a VIRTUALIZED history list
-// (BottomSheetFlatList — never .map), light stat tiles, and a SEPARATE
+// (BottomSheetFlatList — never .map), light stat tiles, and a discoverable
 // "Switch board" footer row that opens the existing board switcher.
 //
 // State comes from `@boardsesh/board-presence-react`'s split current/feed
@@ -69,7 +69,7 @@ export type BoardSheetHandle = {
 };
 
 type BoardSheetProps = {
-  /** The active board label, shown as the sheet title + footer subtitle. */
+  /** The active board label, shown as the sheet title. */
   boardLabel: string | null;
   /**
    * Active board config for the climb thumbnails. Passed by the host (NOT read
@@ -78,11 +78,11 @@ type BoardSheetProps = {
    * interfering with gorhom's `present()`, so the sheet never appeared.
    */
   boardConfig: BoardConfig | null;
-  /** Request an animated close (header X) — the host calls `dismiss()`. */
+  /** Request an animated close (header chevron) — the host calls `dismiss()`. */
   onClose: () => void;
   /** Optional: fired AFTER the dismiss animation finishes (gorhom `onDismiss`). */
   onDismissed?: () => void;
-  /** Open the existing board switcher (the separated "Switch board" control). */
+  /** Open the existing board switcher from the footer control. */
   onSwitchBoard: () => void;
 };
 
@@ -254,17 +254,19 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       style={styles.sheet}
     >
       <View style={[styles.header, { borderBottomColor: systemColors.separator }]}>
-        <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
-          {boardLabel ?? t('mobile.boardPresence.title')}
-        </Text>
         <Pressable
           onPress={onClose}
           hitSlop={8}
           accessibilityRole="button"
           accessibilityLabel={t('mobile.boardPresence.close')}
+          style={styles.headerAction}
         >
-          <Icon name="close" size={20} color={systemColors.secondaryLabel} />
+          <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
         </Pressable>
+        <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
+          {boardLabel ?? t('mobile.boardPresence.title')}
+        </Text>
+        <View pointerEvents="none" style={styles.headerAction} />
       </View>
 
       <BottomSheetFlatList
@@ -282,6 +284,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
         accessibilityLabel={t('mobile.boardPresence.switchBoardAria')}
         style={[styles.footer, { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] }]}
       >
+        <View style={[styles.footerIcon, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Icon name="transfer" size={20} color={systemColors.label} />
+        </View>
         <View style={styles.footerText}>
           <Text variant="body" color={systemColors.label}>
             {t('mobile.boardPresence.switchBoard')}
@@ -435,14 +440,21 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing[4],
+    paddingHorizontal: spacing[3],
     paddingBottom: spacing[3],
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
+  headerAction: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   headerTitle: {
     flex: 1,
-    marginRight: spacing[3],
+    marginHorizontal: spacing[2],
+    textAlign: 'center',
   },
   hero: {
     flexDirection: 'row',
@@ -527,12 +539,20 @@ const styles = StyleSheet.create({
   footer: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    gap: spacing[3],
     paddingHorizontal: spacing[4],
     paddingTop: spacing[3],
     borderTopWidth: StyleSheet.hairlineWidth,
   },
+  footerIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   footerText: {
+    flex: 1,
     gap: 2,
   },
 });

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -264,9 +264,9 @@ describe('BoardSheet', () => {
     expect(container.querySelector('[data-list="true"]')).not.toBeNull();
   });
 
-  it('fires onSwitchBoard from the separated footer control', () => {
+  it('fires onSwitchBoard from the footer switch control', () => {
     const onSwitchBoard = vi.fn();
-    const { getByLabelText } = render(
+    const { container, getByLabelText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose: noop,
@@ -275,13 +275,15 @@ describe('BoardSheet', () => {
         onSwitchBoard,
       }),
     );
+    expect(container.querySelector('[data-icon="transfer"]')).not.toBeNull();
+    expect(container.textContent).toContain('mobile.boardPresence.switchBoard');
     fireEvent.click(getByLabelText('mobile.boardPresence.switchBoardAria'));
     expect(onSwitchBoard).toHaveBeenCalledTimes(1);
   });
 
-  it('fires onClose from the header X', () => {
+  it('fires onClose from the header chevron', () => {
     const onClose = vi.fn();
-    const { getByLabelText } = render(
+    const { container, getByLabelText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose,
@@ -290,6 +292,8 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
+    expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="close"]')).toBeNull();
     fireEvent.click(getByLabelText('mobile.boardPresence.close'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -45,6 +45,7 @@ export const iconMap = {
   edit: { ios: 'pencil', android: 'pencil-outline' },
   pin: { ios: 'pin', android: 'pin-outline' },
   'pin.fill': { ios: 'pin.fill', android: 'pin' },
+  transfer: { ios: 'arrow.left.arrow.right', android: 'swap-horizontal' },
   tag: { ios: 'tag', android: 'tag-outline' },
   'check.small': { ios: 'checkmark', android: 'check' },
   flash: { ios: 'bolt.fill', android: 'flash' },

--- a/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
@@ -162,6 +162,29 @@ describe('createMobileBoardPresenceClient', () => {
     expect(operation.query).toContain('resolveBoardForSerial');
   });
 
+  it('resolves a selected named board by uuid', async () => {
+    const resolved = {
+      boardId: 13,
+      boardName: 'Named Board',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+    transport.execute.mockResolvedValue({ resolveBoardForUuid: resolved });
+
+    const result = await createMobileBoardPresenceClient(getClient).resolveBoardForUuid?.({
+      boardUuid: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(result).toEqual(resolved);
+    const [, operation] = transport.execute.mock.calls[0];
+    expect(operation.variables).toEqual({
+      boardUuid: '11111111-1111-4111-8111-111111111111',
+    });
+    expect(operation.query).toContain('resolveBoardForUuid');
+  });
+
   it('resolves a board by config for serial-less boards', async () => {
     const resolved = {
       boardId: 12,

--- a/packages/mobile/src/lib/board-presence/board-presence-client.ts
+++ b/packages/mobile/src/lib/board-presence/board-presence-client.ts
@@ -22,6 +22,7 @@ import {
   REPORT_BOARD_CLIMB,
   RESOLVE_BOARD_FOR_CONFIG,
   RESOLVE_BOARD_FOR_SERIAL,
+  RESOLVE_BOARD_FOR_UUID,
 } from '@boardsesh/graphql/operations/board-presence';
 import type { BoardPresenceClient } from '@boardsesh/board-presence-react';
 import type {
@@ -37,6 +38,7 @@ type BoardRecentClimbsData = { boardRecentClimbs: BoardPresenceClimb[] };
 type BoardPresenceStatsData = { boardPresenceStats: BoardPresenceStats };
 type ReportBoardClimbData = { reportBoardClimb: boolean };
 type ResolveBoardForSerialData = { resolveBoardForSerial: ResolvedBoard };
+type ResolveBoardForUuidData = { resolveBoardForUuid: ResolvedBoard };
 type ResolveBoardForConfigData = { resolveBoardForConfig: ResolvedBoard };
 
 /**
@@ -97,6 +99,14 @@ export function createMobileBoardPresenceClient(getClient: () => Client): BoardP
         variables: args,
       });
       return data.resolveBoardForSerial;
+    },
+
+    async resolveBoardForUuid(args) {
+      const data = await execute<ResolveBoardForUuidData>(getClient(), {
+        query: RESOLVE_BOARD_FOR_UUID,
+        variables: args,
+      });
+      return data.resolveBoardForUuid;
     },
 
     async resolveBoardForConfig(args) {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -70,6 +70,7 @@ const presence = vi.hoisted(() => ({
   currentClimb: null as BoardPresenceClimb | null,
   resolveAndBindBoard: vi.fn(async (): Promise<TestResolvedBoard | null> => null),
   resolveAndBindBoardByConfig: vi.fn(async (): Promise<TestResolvedBoard | null> => null),
+  resolveAndBindBoardByUuid: vi.fn(async (): Promise<TestResolvedBoard | null> => null),
   reportClimbForBoard: vi.fn(async () => true),
   showUndoWallChangeSnackbar: vi.fn(),
 }));
@@ -109,6 +110,7 @@ vi.mock('../board-presence-provider', () => ({
     boardId: presence.boardId,
     resolveAndBindBoard: presence.resolveAndBindBoard,
     resolveAndBindBoardByConfig: presence.resolveAndBindBoardByConfig,
+    resolveAndBindBoardByUuid: presence.resolveAndBindBoardByUuid,
     reportClimbForBoard: presence.reportClimbForBoard,
   }),
 }));
@@ -298,6 +300,8 @@ describe('BluetoothProvider wall-confirm integration', () => {
     presence.resolveAndBindBoard.mockResolvedValue(null);
     presence.resolveAndBindBoardByConfig.mockClear();
     presence.resolveAndBindBoardByConfig.mockResolvedValue(null);
+    presence.resolveAndBindBoardByUuid.mockClear();
+    presence.resolveAndBindBoardByUuid.mockResolvedValue(null);
     presence.reportClimbForBoard.mockClear();
     presence.reportClimbForBoard.mockResolvedValue(true);
     presence.showUndoWallChangeSnackbar.mockClear();
@@ -646,9 +650,9 @@ describe('BluetoothProvider wall-confirm integration', () => {
       expect(presence.reportClimbForBoard).not.toHaveBeenCalled();
     });
 
-    it('buffers the first wall-confirm while connect board resolution is pending', async () => {
+    it('buffers the first wall-confirm while connect board resolution is pending, ignoring stale board ids', async () => {
       presence.enabled = true;
-      presence.boardId = null;
+      presence.boardId = 88;
       bluetooth.state.isConnected = false;
       let resolveBoard: (value: { boardId: number }) => void = () => {};
       presence.resolveAndBindBoard.mockReturnValue(
@@ -785,6 +789,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     it('does not include raw serial values in board-presence analytics', async () => {
       presence.enabled = true;
       presence.boardId = 99;
+      presence.resolveAndBindBoard.mockResolvedValueOnce({ boardId: 99 });
       renderProvider();
 
       bluetooth.options?.onConnectSuccess?.('SERIAL-SECRET-123');

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -190,6 +190,43 @@ describe('MobileBoardPresenceProvider', () => {
     });
   });
 
+  it('does not start a second uuid resolve while the same uuid is pending', async () => {
+    flags.value = true;
+    let resolveBoard: ((value: ResolvedBoard) => void) | null = null;
+    transport.resolveBoardForUuid.mockImplementationOnce(
+      () =>
+        new Promise<ResolvedBoard>((resolve) => {
+          resolveBoard = resolve;
+        }),
+    );
+    renderProvider();
+
+    let firstPromise: Promise<ResolvedBoard | null> | undefined;
+    act(() => {
+      firstPromise = capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '11111111-1111-4111-8111-111111111111',
+      });
+    });
+
+    let secondResult: ResolvedBoard | null | undefined;
+    await act(async () => {
+      secondResult = await capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '11111111-1111-4111-8111-111111111111',
+      });
+    });
+
+    expect(secondResult).toBeNull();
+    expect(transport.resolveBoardForUuid).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveBoard?.({ boardId: 44, boardName: 'Named Board' } as unknown as ResolvedBoard);
+      await firstPromise;
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(44);
+    });
+  });
+
   it('does not re-resolve an unchanged config once bound', async () => {
     flags.value = true;
     renderProvider();

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -9,6 +9,9 @@ const transport = vi.hoisted(() => ({
   resolveBoardForSerial: vi.fn(
     async (_args: unknown) => ({ boardId: 42, boardName: 'Garage Wall' }) as unknown as ResolvedBoard,
   ),
+  resolveBoardForUuid: vi.fn(
+    async (_args: unknown) => ({ boardId: 44, boardName: 'Named Board' }) as unknown as ResolvedBoard,
+  ),
   resolveBoardForConfig: vi.fn(
     async (_args: unknown) => ({ boardId: 43, boardName: 'MoonBoard 40' }) as unknown as ResolvedBoard,
   ),
@@ -23,6 +26,7 @@ vi.mock('../feature-flags-provider', () => ({
 vi.mock('../../lib/board-presence/board-presence-client', () => ({
   createMobileBoardPresenceClient: () => ({
     resolveBoardForSerial: transport.resolveBoardForSerial,
+    resolveBoardForUuid: transport.resolveBoardForUuid,
     resolveBoardForConfig: transport.resolveBoardForConfig,
     subscribeNowPlaying: () => () => {},
     fetchRecentClimbs: async () => [],
@@ -69,6 +73,11 @@ describe('MobileBoardPresenceProvider', () => {
     transport.resolveBoardForConfig.mockResolvedValue({
       boardId: 43,
       boardName: 'MoonBoard 40',
+    } as unknown as ResolvedBoard);
+    transport.resolveBoardForUuid.mockClear();
+    transport.resolveBoardForUuid.mockResolvedValue({
+      boardId: 44,
+      boardName: 'Named Board',
     } as unknown as ResolvedBoard);
     transport.reportClimb.mockClear();
     transport.reportClimb.mockResolvedValue(true);
@@ -162,6 +171,25 @@ describe('MobileBoardPresenceProvider', () => {
     });
   });
 
+  it('resolves+binds by board uuid for selected named boards', async () => {
+    flags.value = true;
+    renderProvider();
+
+    await act(async () => {
+      const resolved = await capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '11111111-1111-4111-8111-111111111111',
+      });
+      expect(resolved?.boardId).toBe(44);
+    });
+
+    expect(transport.resolveBoardForUuid).toHaveBeenCalledWith({
+      boardUuid: '11111111-1111-4111-8111-111111111111',
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(44);
+    });
+  });
+
   it('does not re-resolve an unchanged config once bound', async () => {
     flags.value = true;
     renderProvider();
@@ -235,6 +263,82 @@ describe('MobileBoardPresenceProvider', () => {
     });
 
     expect(firstResult).toBeNull();
+    expect(sharedProvider.lastBoardId).toBe(44);
+  });
+
+  it('clears the bound board while a different uuid resolve is pending', async () => {
+    flags.value = true;
+    let resolveNext: ((value: ResolvedBoard) => void) | null = null;
+    renderProvider();
+
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '11111111-1111-4111-8111-111111111111',
+      });
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(44);
+    });
+
+    transport.resolveBoardForUuid.mockImplementationOnce(
+      () =>
+        new Promise<ResolvedBoard>((resolve) => {
+          resolveNext = resolve;
+        }),
+    );
+
+    act(() => {
+      void capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '22222222-2222-4222-8222-222222222222',
+      });
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBeNull();
+    });
+
+    await act(async () => {
+      resolveNext?.({ boardId: 45, boardName: 'Next Board' } as unknown as ResolvedBoard);
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(45);
+    });
+  });
+
+  it('ignores stale serial resolve results after a newer uuid resolve wins', async () => {
+    flags.value = true;
+    let resolveSerial: ((value: ResolvedBoard) => void) | null = null;
+    transport.resolveBoardForSerial.mockImplementationOnce(
+      () =>
+        new Promise<ResolvedBoard>((resolve) => {
+          resolveSerial = resolve;
+        }),
+    );
+    renderProvider();
+
+    let serialPromise: Promise<ResolvedBoard | null> | undefined;
+    await act(async () => {
+      serialPromise = capturedControls?.resolveAndBindBoard({
+        serial: 'SERIAL-1',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+      await capturedControls?.resolveAndBindBoardByUuid({
+        boardUuid: '11111111-1111-4111-8111-111111111111',
+      });
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(44);
+    });
+
+    let serialResult: ResolvedBoard | null | undefined;
+    await act(async () => {
+      resolveSerial?.({ boardId: 42, boardName: 'Serial Board' } as unknown as ResolvedBoard);
+      serialResult = await serialPromise;
+    });
+
+    expect(serialResult).toBeNull();
     expect(sharedProvider.lastBoardId).toBe(44);
   });
 

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -6,8 +6,12 @@ import type { ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schem
 
 const flags = vi.hoisted(() => ({ value: false as boolean }));
 const transport = vi.hoisted(() => ({
-  resolveBoardForSerial: vi.fn(async () => ({ boardId: 42, boardName: 'Garage Wall' }) as unknown as ResolvedBoard),
-  resolveBoardForConfig: vi.fn(async () => ({ boardId: 43, boardName: 'MoonBoard 40' }) as unknown as ResolvedBoard),
+  resolveBoardForSerial: vi.fn(
+    async (_args: unknown) => ({ boardId: 42, boardName: 'Garage Wall' }) as unknown as ResolvedBoard,
+  ),
+  resolveBoardForConfig: vi.fn(
+    async (_args: unknown) => ({ boardId: 43, boardName: 'MoonBoard 40' }) as unknown as ResolvedBoard,
+  ),
   reportClimb: vi.fn(async () => true),
 }));
 const sharedProvider = vi.hoisted(() => ({ lastBoardId: undefined as number | null | undefined }));
@@ -156,6 +160,82 @@ describe('MobileBoardPresenceProvider', () => {
     await waitFor(() => {
       expect(sharedProvider.lastBoardId).toBe(43);
     });
+  });
+
+  it('does not re-resolve an unchanged config once bound', async () => {
+    flags.value = true;
+    renderProvider();
+
+    const args = {
+      boardType: 'moonboard',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '2019',
+    };
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoardByConfig(args);
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(43);
+    });
+
+    await act(async () => {
+      const resolved = await capturedControls?.resolveAndBindBoardByConfig(args);
+      expect(resolved).toBeNull();
+    });
+    expect(transport.resolveBoardForConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores stale config resolve results after a newer selected config resolves', async () => {
+    flags.value = true;
+    let resolveFirst: ((value: ResolvedBoard) => void) | null = null;
+    let resolveSecond: ((value: ResolvedBoard) => void) | null = null;
+    transport.resolveBoardForConfig.mockImplementation(
+      (args: unknown) =>
+        new Promise<ResolvedBoard>((resolve) => {
+          const boardType = (args as { boardType: string }).boardType;
+          if (boardType === 'moonboard') {
+            resolveFirst = resolve;
+            return;
+          }
+          resolveSecond = resolve;
+        }),
+    );
+    renderProvider();
+
+    let firstPromise: Promise<ResolvedBoard | null> | undefined;
+    let secondPromise: Promise<ResolvedBoard | null> | undefined;
+    act(() => {
+      firstPromise = capturedControls?.resolveAndBindBoardByConfig({
+        boardType: 'moonboard',
+        layoutId: 1,
+        sizeId: 1,
+        setIds: '2019',
+      });
+      secondPromise = capturedControls?.resolveAndBindBoardByConfig({
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+
+    await act(async () => {
+      resolveSecond?.({ boardId: 44, boardName: 'Kilter' } as unknown as ResolvedBoard);
+      await secondPromise;
+    });
+    await waitFor(() => {
+      expect(sharedProvider.lastBoardId).toBe(44);
+    });
+
+    let firstResult: ResolvedBoard | null | undefined;
+    await act(async () => {
+      resolveFirst?.({ boardId: 43, boardName: 'MoonBoard 40' } as unknown as ResolvedBoard);
+      firstResult = await firstPromise;
+    });
+
+    expect(firstResult).toBeNull();
+    expect(sharedProvider.lastBoardId).toBe(44);
   });
 
   it('returns null instead of leaking a rejected serial resolve', async () => {

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -67,6 +67,7 @@ const presence = vi.hoisted(() => ({
   boardId: null as number | null,
   resolveAndBindBoard: vi.fn(async () => null),
   resolveAndBindBoardByConfig: vi.fn(async () => null),
+  resolveAndBindBoardByUuid: vi.fn(async () => null),
   resetPresence: vi.fn(),
 }));
 
@@ -165,6 +166,7 @@ vi.mock('../board-presence-provider', () => ({
     boardId: presence.boardId,
     resolveAndBindBoard: presence.resolveAndBindBoard,
     resolveAndBindBoardByConfig: presence.resolveAndBindBoardByConfig,
+    resolveAndBindBoardByUuid: presence.resolveAndBindBoardByUuid,
     resetPresence: presence.resetPresence,
   }),
 }));
@@ -271,6 +273,7 @@ beforeEach(() => {
   presence.boardId = null;
   presence.resolveAndBindBoard.mockClear();
   presence.resolveAndBindBoardByConfig.mockClear();
+  presence.resolveAndBindBoardByUuid.mockClear();
   presence.resetPresence.mockClear();
 });
 
@@ -282,14 +285,10 @@ describe('DrawerHostProvider board presence binding', () => {
     await waitFor(() => expect(hosts.at(-1)).toBeDefined());
 
     await waitFor(() => {
-      expect(presence.resolveAndBindBoardByConfig).toHaveBeenCalledWith({
-        boardType: 'kilter',
-        layoutId: 1,
-        sizeId: 10,
-        setIds: '1,2',
-      });
+      expect(presence.resolveAndBindBoardByUuid).toHaveBeenCalledWith({ boardUuid: 'board-1' });
     });
     expect(presence.resolveAndBindBoard).not.toHaveBeenCalled();
+    expect(presence.resolveAndBindBoardByConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -309,6 +309,26 @@ describe('DrawerHostProvider board presence binding', () => {
     expect(presence.resolveAndBindBoardByUuid).not.toHaveBeenCalled();
   });
 
+  it('resets board presence when the selected active board is cleared', async () => {
+    presence.enabled = true;
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    const onHost = (host: ReturnType<typeof useDrawerHost>) => hosts.push(host);
+    const { rerender } = renderHost(onHost);
+    await waitFor(() => {
+      expect(presence.resolveAndBindBoardByUuid).toHaveBeenCalledWith({ boardUuid: 'board-1' });
+    });
+
+    presence.resolveAndBindBoardByUuid.mockClear();
+    presence.resetPresence.mockClear();
+    activeBoard.stored = null;
+    rerender(createElement(DrawerHostProvider, null, createElement(Probe, { onHost })));
+
+    await waitFor(() => {
+      expect(presence.resetPresence).toHaveBeenCalledTimes(1);
+    });
+    expect(presence.resolveAndBindBoardByUuid).not.toHaveBeenCalled();
+  });
+
   it('rebinds board presence when the selected active board changes', async () => {
     presence.enabled = true;
     const hosts: Array<ReturnType<typeof useDrawerHost>> = [];

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -62,6 +62,14 @@ const activeBoard = vi.hoisted(() => ({
   setActiveBoard: vi.fn(async () => {}),
 }));
 
+const presence = vi.hoisted(() => ({
+  enabled: false,
+  boardId: null as number | null,
+  resolveAndBindBoard: vi.fn(async () => null),
+  resolveAndBindBoardByConfig: vi.fn(async () => null),
+  resetPresence: vi.fn(),
+}));
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
@@ -152,7 +160,13 @@ vi.mock('@boardsesh/board-presence-react', () => ({
 }));
 
 vi.mock('../board-presence-provider', () => ({
-  useBoardPresenceControls: () => ({ enabled: false, boardId: null, resolveAndBindBoard: vi.fn(async () => null) }),
+  useBoardPresenceControls: () => ({
+    enabled: presence.enabled,
+    boardId: presence.boardId,
+    resolveAndBindBoard: presence.resolveAndBindBoard,
+    resolveAndBindBoardByConfig: presence.resolveAndBindBoardByConfig,
+    resetPresence: presence.resetPresence,
+  }),
 }));
 
 vi.mock('../bluetooth-provider', () => ({
@@ -251,6 +265,33 @@ function Probe({ onHost }: { onHost: (host: ReturnType<typeof useDrawerHost>) =>
 function renderHost(onHost: (host: ReturnType<typeof useDrawerHost>) => void) {
   return render(createElement(DrawerHostProvider, null, createElement(Probe, { onHost })));
 }
+
+beforeEach(() => {
+  presence.enabled = false;
+  presence.boardId = null;
+  presence.resolveAndBindBoard.mockClear();
+  presence.resolveAndBindBoardByConfig.mockClear();
+  presence.resetPresence.mockClear();
+});
+
+describe('DrawerHostProvider board presence binding', () => {
+  it('resolves board presence from the selected active board without Bluetooth', async () => {
+    presence.enabled = true;
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    await waitFor(() => {
+      expect(presence.resolveAndBindBoardByConfig).toHaveBeenCalledWith({
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+    expect(presence.resolveAndBindBoard).not.toHaveBeenCalled();
+  });
+});
 
 describe('DrawerHostProvider queue sheet wall-control gating', () => {
   beforeEach(() => {

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -36,8 +36,8 @@ const climbActions = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
 }));
 
-const activeBoard = vi.hoisted(() => ({
-  stored: {
+const activeBoard = vi.hoisted(() => {
+  const defaultStored = {
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',
@@ -58,9 +58,13 @@ const activeBoard = vi.hoisted(() => ({
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
-  } satisfies UserBoard,
-  setActiveBoard: vi.fn(async () => {}),
-}));
+  } satisfies UserBoard;
+  return {
+    defaultStored,
+    stored: { ...defaultStored } as UserBoard | null,
+    setActiveBoard: vi.fn(async () => {}),
+  };
+});
 
 const presence = vi.hoisted(() => ({
   enabled: false,
@@ -269,6 +273,7 @@ function renderHost(onHost: (host: ReturnType<typeof useDrawerHost>) => void) {
 }
 
 beforeEach(() => {
+  activeBoard.stored = { ...activeBoard.defaultStored };
   presence.enabled = false;
   presence.boardId = null;
   presence.resolveAndBindBoard.mockClear();
@@ -289,6 +294,42 @@ describe('DrawerHostProvider board presence binding', () => {
     });
     expect(presence.resolveAndBindBoard).not.toHaveBeenCalled();
     expect(presence.resolveAndBindBoardByConfig).not.toHaveBeenCalled();
+  });
+
+  it('resets board presence when no active board is selected', async () => {
+    presence.enabled = true;
+    activeBoard.stored = null;
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    await waitFor(() => {
+      expect(presence.resetPresence).toHaveBeenCalledTimes(1);
+    });
+    expect(presence.resolveAndBindBoardByUuid).not.toHaveBeenCalled();
+  });
+
+  it('rebinds board presence when the selected active board changes', async () => {
+    presence.enabled = true;
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    const onHost = (host: ReturnType<typeof useDrawerHost>) => hosts.push(host);
+    const { rerender } = renderHost(onHost);
+    await waitFor(() => {
+      expect(presence.resolveAndBindBoardByUuid).toHaveBeenCalledWith({ boardUuid: 'board-1' });
+    });
+
+    presence.resolveAndBindBoardByUuid.mockClear();
+    activeBoard.stored = {
+      ...activeBoard.defaultStored,
+      uuid: 'board-2',
+      slug: 'board-2',
+      name: 'Second board',
+    };
+    rerender(createElement(DrawerHostProvider, null, createElement(Probe, { onHost })));
+
+    await waitFor(() => {
+      expect(presence.resolveAndBindBoardByUuid).toHaveBeenCalledWith({ boardUuid: 'board-2' });
+    });
   });
 });
 

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -434,7 +434,9 @@ export function BluetoothProvider({
       // session. Dedup is feed/signature-aware and only arms after an accepted
       // report, so failed reports and two-phone relights can retry.
       if (!presenceEnabledRef.current) return;
-      const boardId = presenceBoardIdRef.current ?? resolvedPresenceBoardIdRef.current;
+      const boardId = pendingPresenceResolveRef.current
+        ? null
+        : (presenceBoardIdRef.current ?? resolvedPresenceBoardIdRef.current);
       const undoTarget = wallCurrentClimbRef.current;
       if (boardId === null) {
         if (pendingPresenceResolveRef.current) {

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -153,7 +153,7 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
       if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForUuid) {
         return null;
       }
-      if (lastResolvedBoardUuidRef.current === args.boardUuid && boardIdRef.current !== null) {
+      if (lastResolvedBoardUuidRef.current === args.boardUuid) {
         return null;
       }
       const resolveGeneration = resolveGenerationRef.current + 1;
@@ -164,19 +164,13 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
       setBoardId(null);
       try {
         const resolved = await activeClient.resolveBoardForUuid(args);
-        if (
-          resolveGenerationRef.current !== resolveGeneration ||
-          lastResolvedBoardUuidRef.current !== args.boardUuid
-        ) {
+        if (resolveGenerationRef.current !== resolveGeneration) {
           return null;
         }
         setBoardId(resolved.boardId);
         return resolved;
       } catch (error) {
-        if (
-          resolveGenerationRef.current === resolveGeneration &&
-          lastResolvedBoardUuidRef.current === args.boardUuid
-        ) {
+        if (resolveGenerationRef.current === resolveGeneration) {
           lastResolvedBoardUuidRef.current = null;
         }
         console.warn('[board-presence] resolveBoardForUuid failed', error);

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -38,6 +38,10 @@ export type ResolveBoardArgs = {
 
 export type ResolveBoardConfigArgs = Omit<ResolveBoardArgs, 'serial'>;
 
+function boardConfigResolveKey({ boardType, layoutId, sizeId, setIds }: ResolveBoardConfigArgs): string {
+  return `${boardType}:${layoutId}:${sizeId}:${setIds}`;
+}
+
 type BoardPresenceControlsValue = {
   /** True when the `board-presence` flag is on. All wall surfaces gate on this. */
   enabled: boolean;
@@ -80,6 +84,8 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
 
   // The serial last resolved, so a reconnect to the same wall doesn't re-resolve.
   const lastResolvedSerialRef = useRef<string | null>(null);
+  const lastResolvedConfigKeyRef = useRef<string | null>(null);
+  const configResolveGenerationRef = useRef(0);
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
   // Mirror boardId into a ref so the empty-dep callback can read it without
@@ -89,6 +95,8 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
 
   const resetPresence = useCallback(() => {
     lastResolvedSerialRef.current = null;
+    lastResolvedConfigKeyRef.current = null;
+    configResolveGenerationRef.current += 1;
     setBoardId(null);
   }, []);
 
@@ -106,6 +114,8 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     if (lastResolvedSerialRef.current === args.serial && boardIdRef.current !== null) {
       return null;
     }
+    configResolveGenerationRef.current += 1;
+    lastResolvedConfigKeyRef.current = null;
     lastResolvedSerialRef.current = args.serial;
     try {
       const resolved = await activeClient.resolveBoardForSerial(args);
@@ -124,11 +134,25 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
       if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForConfig) {
         return null;
       }
+      const configKey = boardConfigResolveKey(args);
+      if (lastResolvedConfigKeyRef.current === configKey && boardIdRef.current !== null) {
+        return null;
+      }
+      const resolveGeneration = configResolveGenerationRef.current + 1;
+      configResolveGenerationRef.current = resolveGeneration;
+      lastResolvedConfigKeyRef.current = configKey;
+      lastResolvedSerialRef.current = null;
       try {
         const resolved = await activeClient.resolveBoardForConfig(args);
+        if (configResolveGenerationRef.current !== resolveGeneration || lastResolvedConfigKeyRef.current !== configKey) {
+          return null;
+        }
         setBoardId(resolved.boardId);
         return resolved;
       } catch (error) {
+        if (configResolveGenerationRef.current === resolveGeneration && lastResolvedConfigKeyRef.current === configKey) {
+          lastResolvedConfigKeyRef.current = null;
+        }
         console.warn('[board-presence] resolveBoardForConfig failed', error);
         return null;
       }

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -38,6 +38,10 @@ export type ResolveBoardArgs = {
 
 export type ResolveBoardConfigArgs = Omit<ResolveBoardArgs, 'serial'>;
 
+export type ResolveBoardUuidArgs = {
+  boardUuid: string;
+};
+
 function boardConfigResolveKey({ boardType, layoutId, sizeId, setIds }: ResolveBoardConfigArgs): string {
   return `${boardType}:${layoutId}:${sizeId}:${setIds}`;
 }
@@ -58,6 +62,11 @@ type BoardPresenceControlsValue = {
    * boardId. No-op when the active transport does not support config fallback.
    */
   resolveAndBindBoardByConfig: (args: ResolveBoardConfigArgs) => Promise<ResolvedBoard | null>;
+  /**
+   * Resolve a selected named board by UUID, then store its boardId. This is the
+   * preferred non-BLE path for board sheet stats/history.
+   */
+  resolveAndBindBoardByUuid: (args: ResolveBoardUuidArgs) => Promise<ResolvedBoard | null>;
   /**
    * Report directly to a specific board id. Used immediately after a connect
    * resolve when the React boardId context has not re-rendered yet.
@@ -85,7 +94,8 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   // The serial last resolved, so a reconnect to the same wall doesn't re-resolve.
   const lastResolvedSerialRef = useRef<string | null>(null);
   const lastResolvedConfigKeyRef = useRef<string | null>(null);
-  const configResolveGenerationRef = useRef(0);
+  const lastResolvedBoardUuidRef = useRef<string | null>(null);
+  const resolveGenerationRef = useRef(0);
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
   // Mirror boardId into a ref so the empty-dep callback can read it without
@@ -96,7 +106,8 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   const resetPresence = useCallback(() => {
     lastResolvedSerialRef.current = null;
     lastResolvedConfigKeyRef.current = null;
-    configResolveGenerationRef.current += 1;
+    lastResolvedBoardUuidRef.current = null;
+    resolveGenerationRef.current += 1;
     setBoardId(null);
   }, []);
 
@@ -114,19 +125,66 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     if (lastResolvedSerialRef.current === args.serial && boardIdRef.current !== null) {
       return null;
     }
-    configResolveGenerationRef.current += 1;
+    const resolveGeneration = resolveGenerationRef.current + 1;
+    resolveGenerationRef.current = resolveGeneration;
     lastResolvedConfigKeyRef.current = null;
+    lastResolvedBoardUuidRef.current = null;
     lastResolvedSerialRef.current = args.serial;
+    setBoardId(null);
     try {
       const resolved = await activeClient.resolveBoardForSerial(args);
+      if (resolveGenerationRef.current !== resolveGeneration || lastResolvedSerialRef.current !== args.serial) {
+        return null;
+      }
       setBoardId(resolved.boardId);
       return resolved;
     } catch (error) {
-      lastResolvedSerialRef.current = null;
+      if (resolveGenerationRef.current === resolveGeneration && lastResolvedSerialRef.current === args.serial) {
+        lastResolvedSerialRef.current = null;
+      }
       console.warn('[board-presence] resolveBoardForSerial failed', error);
       return null;
     }
   }, []);
+
+  const resolveAndBindBoardByUuid = useCallback(
+    async (args: ResolveBoardUuidArgs): Promise<ResolvedBoard | null> => {
+      const activeClient = clientRef.current;
+      if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForUuid) {
+        return null;
+      }
+      if (lastResolvedBoardUuidRef.current === args.boardUuid && boardIdRef.current !== null) {
+        return null;
+      }
+      const resolveGeneration = resolveGenerationRef.current + 1;
+      resolveGenerationRef.current = resolveGeneration;
+      lastResolvedBoardUuidRef.current = args.boardUuid;
+      lastResolvedConfigKeyRef.current = null;
+      lastResolvedSerialRef.current = null;
+      setBoardId(null);
+      try {
+        const resolved = await activeClient.resolveBoardForUuid(args);
+        if (
+          resolveGenerationRef.current !== resolveGeneration ||
+          lastResolvedBoardUuidRef.current !== args.boardUuid
+        ) {
+          return null;
+        }
+        setBoardId(resolved.boardId);
+        return resolved;
+      } catch (error) {
+        if (
+          resolveGenerationRef.current === resolveGeneration &&
+          lastResolvedBoardUuidRef.current === args.boardUuid
+        ) {
+          lastResolvedBoardUuidRef.current = null;
+        }
+        console.warn('[board-presence] resolveBoardForUuid failed', error);
+        return null;
+      }
+    },
+    [],
+  );
 
   const resolveAndBindBoardByConfig = useCallback(
     async (args: ResolveBoardConfigArgs): Promise<ResolvedBoard | null> => {
@@ -138,19 +196,21 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
       if (lastResolvedConfigKeyRef.current === configKey && boardIdRef.current !== null) {
         return null;
       }
-      const resolveGeneration = configResolveGenerationRef.current + 1;
-      configResolveGenerationRef.current = resolveGeneration;
+      const resolveGeneration = resolveGenerationRef.current + 1;
+      resolveGenerationRef.current = resolveGeneration;
       lastResolvedConfigKeyRef.current = configKey;
+      lastResolvedBoardUuidRef.current = null;
       lastResolvedSerialRef.current = null;
+      setBoardId(null);
       try {
         const resolved = await activeClient.resolveBoardForConfig(args);
-        if (configResolveGenerationRef.current !== resolveGeneration || lastResolvedConfigKeyRef.current !== configKey) {
+        if (resolveGenerationRef.current !== resolveGeneration || lastResolvedConfigKeyRef.current !== configKey) {
           return null;
         }
         setBoardId(resolved.boardId);
         return resolved;
       } catch (error) {
-        if (configResolveGenerationRef.current === resolveGeneration && lastResolvedConfigKeyRef.current === configKey) {
+        if (resolveGenerationRef.current === resolveGeneration && lastResolvedConfigKeyRef.current === configKey) {
           lastResolvedConfigKeyRef.current = null;
         }
         console.warn('[board-presence] resolveBoardForConfig failed', error);
@@ -182,10 +242,19 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
       boardId,
       resolveAndBindBoard,
       resolveAndBindBoardByConfig,
+      resolveAndBindBoardByUuid,
       reportClimbForBoard,
       resetPresence,
     }),
-    [enabled, boardId, resolveAndBindBoard, resolveAndBindBoardByConfig, reportClimbForBoard, resetPresence],
+    [
+      enabled,
+      boardId,
+      resolveAndBindBoard,
+      resolveAndBindBoardByConfig,
+      resolveAndBindBoardByUuid,
+      reportClimbForBoard,
+      resetPresence,
+    ],
   );
 
   return (
@@ -213,6 +282,7 @@ const DISABLED_CONTROLS: BoardPresenceControlsValue = {
   boardId: null,
   resolveAndBindBoard: async () => null,
   resolveAndBindBoardByConfig: async () => null,
+  resolveAndBindBoardByUuid: async () => null,
   reportClimbForBoard: async () => false,
   resetPresence: () => {},
 };

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -133,13 +133,13 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     setBoardId(null);
     try {
       const resolved = await activeClient.resolveBoardForSerial(args);
-      if (resolveGenerationRef.current !== resolveGeneration || lastResolvedSerialRef.current !== args.serial) {
+      if (resolveGenerationRef.current !== resolveGeneration) {
         return null;
       }
       setBoardId(resolved.boardId);
       return resolved;
     } catch (error) {
-      if (resolveGenerationRef.current === resolveGeneration && lastResolvedSerialRef.current === args.serial) {
+      if (resolveGenerationRef.current === resolveGeneration) {
         lastResolvedSerialRef.current = null;
       }
       console.warn('[board-presence] resolveBoardForSerial failed', error);

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -35,7 +35,7 @@ import { favoritesStore } from '@boardsesh/climb-actions';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useIsPartyPreviewOnly, useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
-import { useBoardPresenceControls, type ResolveBoardConfigArgs } from './board-presence-provider';
+import { useBoardPresenceControls, type ResolveBoardUuidArgs } from './board-presence-provider';
 import { useOptionalBluetoothContext } from './bluetooth-provider';
 
 export type BoardConfig = {
@@ -130,7 +130,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const {
     enabled: boardPresenceEnabled,
     boardId: boardPresenceBoardId,
-    resolveAndBindBoardByConfig,
+    resolveAndBindBoardByUuid,
     resetPresence,
   } = useBoardPresenceControls();
   const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
@@ -159,25 +159,19 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     };
   }, [boardConfigOverride, activeBoard]);
 
-  const selectedBoardPresenceConfig = useMemo<ResolveBoardConfigArgs | null>(() => {
+  const selectedBoardPresenceBoard = useMemo<ResolveBoardUuidArgs | null>(() => {
     if (!activeBoard) return null;
-    if (!activeBoard.boardType || activeBoard.layoutId <= 0 || activeBoard.sizeId <= 0) return null;
-    return {
-      boardType: activeBoard.boardType,
-      layoutId: activeBoard.layoutId,
-      sizeId: activeBoard.sizeId,
-      setIds: activeBoard.setIds,
-    };
-  }, [activeBoard?.boardType, activeBoard?.layoutId, activeBoard?.sizeId, activeBoard?.setIds]);
+    return { boardUuid: activeBoard.uuid };
+  }, [activeBoard?.uuid]);
 
   useEffect(() => {
     if (!boardPresenceEnabled) return;
-    if (!selectedBoardPresenceConfig) {
+    if (!selectedBoardPresenceBoard) {
       resetPresence();
       return;
     }
-    void resolveAndBindBoardByConfig(selectedBoardPresenceConfig);
-  }, [boardPresenceEnabled, selectedBoardPresenceConfig, resolveAndBindBoardByConfig, resetPresence]);
+    void resolveAndBindBoardByUuid(selectedBoardPresenceBoard);
+  }, [boardPresenceEnabled, selectedBoardPresenceBoard, resolveAndBindBoardByUuid, resetPresence]);
 
   // Keep a ref so the otherwise empty-dep `openClimbActions` callback can
   // snapshot the current board config without churning its identity.

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -35,7 +35,7 @@ import { favoritesStore } from '@boardsesh/climb-actions';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useIsPartyPreviewOnly, useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
-import { useBoardPresenceControls } from './board-presence-provider';
+import { useBoardPresenceControls, type ResolveBoardConfigArgs } from './board-presence-provider';
 import { useOptionalBluetoothContext } from './bluetooth-provider';
 
 export type BoardConfig = {
@@ -127,7 +127,12 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     dismissUndoWallChangeSnackbar,
   } = useQueueSnackbar();
   const bluetooth = useOptionalBluetoothContext();
-  const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
+  const {
+    enabled: boardPresenceEnabled,
+    boardId: boardPresenceBoardId,
+    resolveAndBindBoardByConfig,
+    resetPresence,
+  } = useBoardPresenceControls();
   const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
   boardPresenceBoardIdRef.current = boardPresenceBoardId;
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
@@ -153,6 +158,26 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       angle: activeBoard.angle,
     };
   }, [boardConfigOverride, activeBoard]);
+
+  const selectedBoardPresenceConfig = useMemo<ResolveBoardConfigArgs | null>(() => {
+    if (!activeBoard) return null;
+    if (!activeBoard.boardType || activeBoard.layoutId <= 0 || activeBoard.sizeId <= 0) return null;
+    return {
+      boardType: activeBoard.boardType,
+      layoutId: activeBoard.layoutId,
+      sizeId: activeBoard.sizeId,
+      setIds: activeBoard.setIds,
+    };
+  }, [activeBoard?.boardType, activeBoard?.layoutId, activeBoard?.sizeId, activeBoard?.setIds]);
+
+  useEffect(() => {
+    if (!boardPresenceEnabled) return;
+    if (!selectedBoardPresenceConfig) {
+      resetPresence();
+      return;
+    }
+    void resolveAndBindBoardByConfig(selectedBoardPresenceConfig);
+  }, [boardPresenceEnabled, selectedBoardPresenceConfig, resolveAndBindBoardByConfig, resetPresence]);
 
   // Keep a ref so the otherwise empty-dep `openClimbActions` callback can
   // snapshot the current board config without churning its identity.

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4375,6 +4375,13 @@ type Mutation {
   ): ResolvedBoard!
 
   """
+  Resolve the wall feed for the selected named board. This binds to the actual
+  board entity, so board sheet stats/history are available before Bluetooth
+  connects and stay aligned with board-scoped ticks.
+  """
+  resolveBoardForUuid(boardUuid: ID!): ResolvedBoard!
+
+  """
   Resolve the shared board feed for boards without a BLE serial. This is a
   per-config fallback in v1: every caller with the same board type, layout,
   size, and set IDs gets the same shared board id.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2110,6 +2110,12 @@ export type Mutation = {
    * config args are used only to create the board the first time a serial is seen.
    */
   resolveBoardForSerial: ResolvedBoard;
+  /**
+   * Resolve the wall feed for the selected named board. This binds to the actual
+   * board entity, so board sheet stats/history are available before Bluetooth
+   * connects and stay aligned with board-scoped ticks.
+   */
+  resolveBoardForUuid: ResolvedBoard;
   /** Resolve a proposal (admin/leader only). */
   resolveProposal: Proposal;
   /** Revoke a community role from a user (admin only). */
@@ -2547,6 +2553,11 @@ export type MutationResolveBoardForSerialArgs = {
   serial: Scalars['String']['input'];
   setIds: Scalars['String']['input'];
   sizeId: Scalars['Int']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationResolveBoardForUuidArgs = {
+  boardUuid: Scalars['ID']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -7464,6 +7475,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationResolveBoardForSerialArgs, 'boardType' | 'layoutId' | 'serial' | 'setIds' | 'sizeId'>
+  >;
+  resolveBoardForUuid?: Resolver<
+    ResolversTypes['ResolvedBoard'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationResolveBoardForUuidArgs, 'boardUuid'>
   >;
   resolveProposal?: Resolver<
     ResolversTypes['Proposal'],

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -157,6 +157,13 @@ export const mutationsTypeDefs = /* GraphQL */ `
     ): ResolvedBoard!
 
     """
+    Resolve the wall feed for the selected named board. This binds to the actual
+    board entity, so board sheet stats/history are available before Bluetooth
+    connects and stay aligned with board-scoped ticks.
+    """
+    resolveBoardForUuid(boardUuid: ID!): ResolvedBoard!
+
+    """
     Resolve the shared board feed for boards without a BLE serial. This is a
     per-config fallback in v1: every caller with the same board type, layout,
     size, and set IDs gets the same shared board id.

--- a/packages/shared/board-presence-react/src/types.ts
+++ b/packages/shared/board-presence-react/src/types.ts
@@ -48,6 +48,9 @@ export interface BoardPresenceClient {
     setIds: string;
   }): Promise<ResolvedBoard>;
 
+  /** Resolve the selected named board's wall feed before BLE connects. */
+  resolveBoardForUuid?(args: { boardUuid: string }): Promise<ResolvedBoard>;
+
   /**
    * Resolve the shared board by configuration when the BLE controller exposes no
    * serial. Aurora boards should use `resolveBoardForSerial`; serial-less boards

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2107,6 +2107,12 @@ export type Mutation = {
    * config args are used only to create the board the first time a serial is seen.
    */
   resolveBoardForSerial: ResolvedBoard;
+  /**
+   * Resolve the wall feed for the selected named board. This binds to the actual
+   * board entity, so board sheet stats/history are available before Bluetooth
+   * connects and stay aligned with board-scoped ticks.
+   */
+  resolveBoardForUuid: ResolvedBoard;
   /** Resolve a proposal (admin/leader only). */
   resolveProposal: Proposal;
   /** Revoke a community role from a user (admin only). */
@@ -2544,6 +2550,11 @@ export type MutationResolveBoardForSerialArgs = {
   serial: Scalars['String']['input'];
   setIds: Scalars['String']['input'];
   sizeId: Scalars['Int']['input'];
+};
+
+/** Root mutation type for all write operations. */
+export type MutationResolveBoardForUuidArgs = {
+  boardUuid: Scalars['ID']['input'];
 };
 
 /** Root mutation type for all write operations. */

--- a/packages/shared/graphql/src/operations/board-presence.ts
+++ b/packages/shared/graphql/src/operations/board-presence.ts
@@ -101,6 +101,22 @@ export const RESOLVE_BOARD_FOR_SERIAL = `
   }
 `;
 
+// Mutation — resolve the selected named board's wall feed before BLE connects.
+// Unlike the per-config fallback, this uses the actual UserBoard row so durable
+// board stats and live presence stay on the same board_id.
+export const RESOLVE_BOARD_FOR_UUID = `
+  mutation ResolveBoardForUuid($boardUuid: ID!) {
+    resolveBoardForUuid(boardUuid: $boardUuid) {
+      boardId
+      boardName
+      boardType
+      layoutId
+      sizeId
+      setIds
+    }
+  }
+`;
+
 // Mutation — resolve a shared board by configuration when a BLE controller
 // exposes no serial. This gives serial-less boards a per-config wall feed.
 export const RESOLVE_BOARD_FOR_CONFIG = `


### PR DESCRIPTION
## Summary
- bind board sheet presence/stats to the selected named board UUID so stats/history load before Bluetooth and stay on the same board row as board-scoped ticks
- keep BLE serial resolution for connected walls, with stale-result guards across UUID/config/serial binding paths
- buffer the first wall-confirm while serial resolution is pending so it cannot report to a stale pre-BLE board id
- keep the board sheet title centered with a left chevron close control, and keep the Switch board footer row with a transfer icon

## Root Cause
The mobile board-presence provider only had a board id after Bluetooth resolved the connected board. The initial non-BLE fix used config resolution, but that can create or bind to a per-config presence board instead of the selected named board, splitting stats/history from the actual board. The sheet now resolves the selected `UserBoard` by UUID before BLE connects.

## Validation
- `vp test run packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts`
- `vp test run packages/backend/src/__tests__/board-presence.test.ts`
- `vp test run packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx`
- `vp run codegen`
- `vp run typecheck:mobile`
- `vp run typecheck:backend`
- `git diff --check`