### PR TITLE
[codex] Fix board undo toast gating

### DIFF
--- a/packages/mobile/src/components/ble/use-lightbulb-toggle.ts
+++ b/packages/mobile/src/components/ble/use-lightbulb-toggle.ts
@@ -22,6 +22,7 @@ export function useLightbulbToggle() {
     if (bluetooth.isConnected) {
       void bluetooth.disconnect();
     } else {
+      bluetooth.armUndoWallChangeToast();
       void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
     }
   }, [bluetooth]);

--- a/packages/mobile/src/components/board-presence/UndoWallChangeSnackbar.tsx
+++ b/packages/mobile/src/components/board-presence/UndoWallChangeSnackbar.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
-import { Snackbar } from 'react-native-paper';
+import { Portal, Snackbar } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { borderRadius, spacing, shadowColor } from '../../theme/tokens';
@@ -32,10 +32,14 @@ type UndoWallChangeSnackbarProps = {
  */
 export function UndoWallChangeSnackbar(props: UndoWallChangeSnackbarProps) {
   const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? (
-    <UndoWallChangeSnackbarMaterial {...props} />
-  ) : (
-    <UndoWallChangeSnackbarGlass {...props} />
+  return (
+    <Portal>
+      {uiVariant === 'material' ? (
+        <UndoWallChangeSnackbarMaterial {...props} />
+      ) : (
+        <UndoWallChangeSnackbarGlass {...props} />
+      )}
+    </Portal>
   );
 }
 

--- a/packages/mobile/src/components/board-presence/UndoWallChangeSnackbar.tsx
+++ b/packages/mobile/src/components/board-presence/UndoWallChangeSnackbar.tsx
@@ -32,28 +32,33 @@ type UndoWallChangeSnackbarProps = {
  */
 export function UndoWallChangeSnackbar(props: UndoWallChangeSnackbarProps) {
   const { variant: uiVariant } = useTheme();
+  const bottomChrome = useBottomChromeMetrics();
+  const bottom = bottomChrome.floatingControlBottom + spacing[2];
   return (
     <Portal>
       {uiVariant === 'material' ? (
-        <UndoWallChangeSnackbarMaterial {...props} />
+        <UndoWallChangeSnackbarMaterial {...props} bottom={bottom} />
       ) : (
-        <UndoWallChangeSnackbarGlass {...props} />
+        <UndoWallChangeSnackbarGlass {...props} bottom={bottom} />
       )}
     </Portal>
   );
 }
+
+type PortaledUndoWallChangeSnackbarProps = UndoWallChangeSnackbarProps & {
+  bottom: number;
+};
 
 function UndoWallChangeSnackbarMaterial({
   visible,
   nonce,
   onDismiss,
   onUndo,
+  bottom,
   duration = UNDO_DURATION,
-}: UndoWallChangeSnackbarProps) {
+}: PortaledUndoWallChangeSnackbarProps) {
   const { t } = useTranslation('session');
-  const bottomChrome = useBottomChromeMetrics();
 
-  const bottom = bottomChrome.floatingControlBottom + spacing[2];
   const wrapperStyle: ViewStyle = { bottom };
 
   return (
@@ -79,19 +84,17 @@ function UndoWallChangeSnackbarGlass({
   nonce,
   onDismiss,
   onUndo,
+  bottom,
   duration = UNDO_DURATION,
-}: UndoWallChangeSnackbarProps) {
+}: PortaledUndoWallChangeSnackbarProps) {
   const { systemColors, brandColors } = useTheme();
   const { t } = useTranslation('session');
-  const bottomChrome = useBottomChromeMetrics();
 
   useEffect(() => {
     if (!visible) return undefined;
     const timer = setTimeout(onDismiss, duration);
     return () => clearTimeout(timer);
   }, [visible, nonce, duration, onDismiss]);
-
-  const bottom = bottomChrome.floatingControlBottom + spacing[2];
 
   return (
     <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>

--- a/packages/mobile/src/components/board-presence/__tests__/undo-wall-change-snackbar.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/undo-wall-change-snackbar.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+
+type ViewMockProps = { children?: ReactNode; accessibilityRole?: string };
+vi.mock('react-native', () => ({
+  View: ({ children, accessibilityRole }: ViewMockProps) =>
+    createElement('div', { 'data-view': 'true', 'data-role': accessibilityRole ?? '' }, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'data-label': accessibilityLabel ?? '' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {} },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
+      createElement('div', { 'data-animated': 'true', 'data-role': accessibilityRole ?? '' }, children),
+  },
+  FadeInDown: { duration: () => ({}) },
+  FadeOutDown: { duration: () => ({}) },
+}));
+
+type SnackbarAction = { label: string; onPress?: () => void; accessibilityLabel?: string };
+type SnackbarMockProps = {
+  visible?: boolean;
+  duration?: number;
+  onDismiss?: () => void;
+  action?: SnackbarAction;
+  wrapperStyle?: unknown;
+  children?: ReactNode;
+};
+vi.mock('react-native-paper', () => ({
+  Portal: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-portal': 'true' }, children),
+  Snackbar: ({ visible, duration, onDismiss, action, wrapperStyle, children }: SnackbarMockProps) =>
+    createElement(
+      'div',
+      {
+        'data-paper-snackbar': 'true',
+        'data-visible': visible ? 'true' : 'false',
+        'data-duration': String(duration ?? ''),
+        'data-wrapper-style': JSON.stringify(wrapperStyle),
+        onClick: onDismiss,
+      },
+      children,
+      action
+        ? createElement(
+            'button',
+            { 'data-action': 'true', 'data-action-label': action.accessibilityLabel ?? '', onClick: action.onPress },
+            action.label,
+          )
+        : null,
+    ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  borderRadius: { lg: 12 },
+  spacing: { 2: 8, 3: 12, 4: 16 },
+  shadowColor: '#000',
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    brandColors: { primary: '#6D28D9' },
+    systemColors: { secondaryBackground: '#EEE', label: '#000' },
+  }),
+}));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ floatingControlBottom: 100 }),
+}));
+
+import { UndoWallChangeSnackbar } from '../UndoWallChangeSnackbar';
+
+const base = { visible: true, nonce: 1, onDismiss: () => {}, onUndo: () => {} };
+
+describe('UndoWallChangeSnackbar', () => {
+  it('renders the Material snackbar inside the Paper portal', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<UndoWallChangeSnackbar {...base} />);
+    expect(container.querySelector('[data-portal] [data-paper-snackbar]')).not.toBeNull();
+    expect(container.textContent).toContain('mobile.boardPresence.wallChanged');
+    expect(container.querySelector('[data-action]')?.textContent).toBe('mobile.boardPresence.undo');
+  });
+
+  it('positions the Material snackbar above the shared floating-control offset', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<UndoWallChangeSnackbar {...base} />);
+    expect(container.querySelector('[data-paper-snackbar]')?.getAttribute('data-wrapper-style')).toContain(
+      '"bottom":108',
+    );
+  });
+
+  it('routes the Material action to onUndo', () => {
+    ctrl.variant = 'material';
+    const onUndo = vi.fn();
+    const { container } = render(<UndoWallChangeSnackbar {...base} onUndo={onUndo} />);
+    (container.querySelector('[data-action]') as HTMLElement).click();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the Liquid Glass snackbar inside the Paper portal', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container } = render(<UndoWallChangeSnackbar {...base} />);
+    expect(container.querySelector('[data-portal] [data-animated]')).not.toBeNull();
+    expect(container.querySelector('[data-animated]')?.getAttribute('data-role')).toBe('alert');
+    expect(container.textContent).toContain('mobile.boardPresence.wallChanged');
+  });
+});

--- a/packages/mobile/src/components/board-presence/__tests__/undo-wall-change-snackbar.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/undo-wall-change-snackbar.test.tsx
@@ -123,4 +123,12 @@ describe('UndoWallChangeSnackbar', () => {
     expect(container.querySelector('[data-animated]')?.getAttribute('data-role')).toBe('alert');
     expect(container.textContent).toContain('mobile.boardPresence.wallChanged');
   });
+
+  it('routes the Liquid Glass action to onUndo', () => {
+    ctrl.variant = 'liquidGlass';
+    const onUndo = vi.fn();
+    const { container } = render(<UndoWallChangeSnackbar {...base} onUndo={onUndo} />);
+    (container.querySelector('[data-label="mobile.boardPresence.undoAria"]') as HTMLElement).click();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
@@ -8,7 +8,12 @@ type BoardFields = Pick<
   UserBoard,
   'name' | 'angle' | 'boardType' | 'sizeName' | 'layoutName' | 'layoutId' | 'isAngleAdjustable'
 >;
-type BluetoothCtx = { isConnected: boolean; connect: () => Promise<boolean>; disconnect: () => Promise<void> } | null;
+type BluetoothCtx = {
+  isConnected: boolean;
+  connect: () => Promise<boolean>;
+  disconnect: () => Promise<void>;
+  armUndoWallChangeToast: () => void;
+} | null;
 
 const ctrl = vi.hoisted(() => ({
   board: null as BoardFields | null,
@@ -189,14 +194,24 @@ describe('CollapsingTopChrome', () => {
     const { container, rerender } = render(<CollapsingTopChrome {...makeProps()} />);
     expect(lightbulb(container)).toBeNull();
 
-    ctrl.bluetooth = { isConnected: true, connect: vi.fn(), disconnect: vi.fn().mockResolvedValue(undefined) };
+    ctrl.bluetooth = {
+      isConnected: true,
+      connect: vi.fn(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      armUndoWallChangeToast: vi.fn(),
+    };
     rerender(<CollapsingTopChrome {...makeProps()} />);
     expect(lightbulb(container)).not.toBeNull();
   });
 
   it('hides the lightbulb when hideLight is set, even with bluetooth available', () => {
     ctrl.board = board;
-    ctrl.bluetooth = { isConnected: true, connect: vi.fn(), disconnect: vi.fn().mockResolvedValue(undefined) };
+    ctrl.bluetooth = {
+      isConnected: true,
+      connect: vi.fn(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      armUndoWallChangeToast: vi.fn(),
+    };
     const { container } = render(<CollapsingTopChrome {...makeProps({ hideLight: true })} />);
     expect(lightbulb(container)).toBeNull();
   });

--- a/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
@@ -8,7 +8,12 @@ type BoardFields = Pick<
   UserBoard,
   'name' | 'angle' | 'boardType' | 'sizeName' | 'layoutName' | 'layoutId' | 'isAngleAdjustable'
 >;
-type BluetoothCtx = { isConnected: boolean; connect: () => Promise<boolean>; disconnect: () => Promise<void> } | null;
+type BluetoothCtx = {
+  isConnected: boolean;
+  connect: () => Promise<boolean>;
+  disconnect: () => Promise<void>;
+  armUndoWallChangeToast: () => void;
+} | null;
 
 const ctrl = vi.hoisted(() => ({
   board: null as BoardFields | null,
@@ -172,7 +177,12 @@ describe('DiscoverTopChrome', () => {
     const { container, rerender } = render(<DiscoverTopChrome {...makeProps()} />);
     expect(lightbulb(container)).toBeNull();
 
-    ctrl.bluetooth = { isConnected: true, connect: vi.fn(), disconnect: vi.fn().mockResolvedValue(undefined) };
+    ctrl.bluetooth = {
+      isConnected: true,
+      connect: vi.fn(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      armUndoWallChangeToast: vi.fn(),
+    };
     rerender(<DiscoverTopChrome {...makeProps()} />);
     expect(lightbulb(container)).not.toBeNull();
     expect(container.querySelector('[data-icon="lightbulb.fill"]')).not.toBeNull();

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -970,7 +970,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       {bluetooth && (
         <BleControlSheet
           visible={bleControlOpen}
-          onReassert={bluetooth.reassertWall}
+          onReassert={() => {
+            bluetooth.armUndoWallChangeToast();
+            bluetooth.reassertWall();
+          }}
           onClearLights={() => void bluetooth.clearBoard()}
           supportsClearLights={boardName !== 'moonboard'}
           onDisconnect={disconnectAllBluetooth}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -168,6 +168,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
   const bluetoothConnected = bluetooth?.isConnected ?? false;
   const bluetoothLoading = bluetooth?.loading ?? false;
+  const bluetoothArmUndoWallChangeToast = bluetooth?.armUndoWallChangeToast;
+  const bluetoothReassertWall = bluetooth?.reassertWall;
+  const bluetoothClearBoard = bluetooth?.clearBoard;
   // Single source for "is a board's BLE available at all" so the lightbulb's
   // accessibility label and its press action stay in lockstep — both read this
   // instead of one checking `bluetooth` and the other `bluetooth !== null`.
@@ -656,6 +659,19 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setBleControlOpen(true);
   }, [bluetooth]);
 
+  const handleBleReassert = useCallback(() => {
+    bluetoothArmUndoWallChangeToast?.();
+    bluetoothReassertWall?.();
+  }, [bluetoothArmUndoWallChangeToast, bluetoothReassertWall]);
+
+  const handleBleClearLights = useCallback(() => {
+    void bluetoothClearBoard?.();
+  }, [bluetoothClearBoard]);
+
+  const handleBleControlClose = useCallback(() => {
+    setBleControlOpen(false);
+  }, []);
+
   // Close the BLE controls sheet if the link drops while it's open — otherwise
   // it lingers showing Re-light / Disconnect actions that no-op on a dead link.
   useEffect(() => {
@@ -970,14 +986,11 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       {bluetooth && (
         <BleControlSheet
           visible={bleControlOpen}
-          onReassert={() => {
-            bluetooth.armUndoWallChangeToast();
-            bluetooth.reassertWall();
-          }}
-          onClearLights={() => void bluetooth.clearBoard()}
+          onReassert={handleBleReassert}
+          onClearLights={handleBleClearLights}
           supportsClearLights={boardName !== 'moonboard'}
           onDisconnect={disconnectAllBluetooth}
-          onClose={() => setBleControlOpen(false)}
+          onClose={handleBleControlClose}
         />
       )}
     </>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -534,6 +534,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       // without releasing wall control, so it relights in one tap. No control
       // changes hands here, and connect() already emits BluetoothConnectionSuccess,
       // so we don't fire 'Wall Control Taken' (which would inflate party-take counts).
+      bluetooth.armUndoWallChangeToast();
       void bluetooth.connect(undefined, undefined, bluetooth.reconnectSerialForCurrentBoard ?? undefined);
       return;
     }
@@ -548,6 +549,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         climbUuid: displayedClimb?.uuid ?? null,
       });
       const reconnectSerialForBoard = bluetooth.reconnectSerialForCurrentBoard;
+      bluetooth.armUndoWallChangeToast();
       if (reconnectSerialForBoard) {
         void bluetooth.connect(undefined, undefined, reconnectSerialForBoard);
       } else {
@@ -562,6 +564,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       if (!bluetooth) return;
       // Already connected — re-light the current climb. Re-tapping the lightbulb
       // re-pushes the wall (and trips disconnect detection if the link is dead).
+      bluetooth.armUndoWallChangeToast();
       bluetooth.reassertWall();
       setDrawerPreviewItem(null);
       track('Wall Control Taken', {
@@ -584,6 +587,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     wallControlPressOperationRef.current = operationId;
     setDrawerPreviewItem(null);
     setPendingClimbUuid(displayedClimb.uuid);
+    bluetooth?.armUndoWallChangeToast();
     const takeControlOptions = drawerPreviewSuggestionSource
       ? { playlistSuggestionSource: drawerPreviewSuggestionSource }
       : undefined;

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -14,6 +14,7 @@ type BluetoothCtx = {
   isConnected: boolean;
   connect: () => Promise<boolean>;
   disconnect: () => Promise<void>;
+  armUndoWallChangeToast: () => void;
 } | null;
 
 const ctrl = vi.hoisted(() => ({
@@ -467,14 +468,24 @@ describe('ClimbTopChrome', () => {
   });
 
   it('shows a disconnected lightbulb when not connected', () => {
-    ctrl.bluetooth = { isConnected: false, connect: vi.fn().mockResolvedValue(true), disconnect: vi.fn() };
+    ctrl.bluetooth = {
+      isConnected: false,
+      connect: vi.fn().mockResolvedValue(true),
+      disconnect: vi.fn(),
+      armUndoWallChangeToast: vi.fn(),
+    };
     const { container } = render(<ClimbTopChrome {...makeProps()} />);
     expect(lightbulb(container)).not.toBeNull();
     expect(container.querySelector('[data-icon="lightbulb"]')).not.toBeNull();
   });
 
   it('shows a connected lightbulb when connected', () => {
-    ctrl.bluetooth = { isConnected: true, connect: vi.fn(), disconnect: vi.fn().mockResolvedValue(undefined) };
+    ctrl.bluetooth = {
+      isConnected: true,
+      connect: vi.fn(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      armUndoWallChangeToast: vi.fn(),
+    };
     const { container } = render(<ClimbTopChrome {...makeProps()} />);
     expect(lightbulb(container)).not.toBeNull();
     expect(container.querySelector('[data-icon="lightbulb.fill"]')).not.toBeNull();
@@ -483,9 +494,11 @@ describe('ClimbTopChrome', () => {
   it('connects on lightbulb press when disconnected', () => {
     const connect = vi.fn().mockResolvedValue(true);
     const disconnect = vi.fn().mockResolvedValue(undefined);
-    ctrl.bluetooth = { isConnected: false, connect, disconnect };
+    const armUndoWallChangeToast = vi.fn();
+    ctrl.bluetooth = { isConnected: false, connect, disconnect, armUndoWallChangeToast };
     const { container } = render(<ClimbTopChrome {...makeProps()} />);
     fireEvent.click(lightbulb(container)!);
+    expect(armUndoWallChangeToast).toHaveBeenCalledTimes(1);
     expect(connect).toHaveBeenCalledTimes(1);
     expect(disconnect).not.toHaveBeenCalled();
     expect(haptics.light).toHaveBeenCalledTimes(1);
@@ -494,11 +507,13 @@ describe('ClimbTopChrome', () => {
   it('disconnects on lightbulb press when connected', () => {
     const connect = vi.fn().mockResolvedValue(true);
     const disconnect = vi.fn().mockResolvedValue(undefined);
-    ctrl.bluetooth = { isConnected: true, connect, disconnect };
+    const armUndoWallChangeToast = vi.fn();
+    ctrl.bluetooth = { isConnected: true, connect, disconnect, armUndoWallChangeToast };
     const { container } = render(<ClimbTopChrome {...makeProps()} />);
     fireEvent.click(lightbulb(container)!);
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect(connect).not.toHaveBeenCalled();
+    expect(armUndoWallChangeToast).not.toHaveBeenCalled();
   });
 
   it('reports its measured height through onHeightChange via onLayout', () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createElement, type ReactNode } from 'react';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
-import type { UserBoard } from '@boardsesh/shared-schema';
+import type { BoardPresenceClimb, UserBoard } from '@boardsesh/shared-schema';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { PickerState } from '../../lib/ble/use-board-bluetooth';
 
@@ -40,6 +40,7 @@ const bluetooth = vi.hoisted(() => {
       sendFramesToBoard: vi.fn(async () => true as boolean | undefined),
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
+      connectInitialSendRef: { current: null as { frames: string; mirrored: boolean } | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -48,6 +49,14 @@ const bluetooth = vi.hoisted(() => {
   };
   return mock;
 });
+
+const presence = vi.hoisted(() => ({
+  enabled: false,
+  boardId: null as number | null,
+  currentClimb: null as BoardPresenceClimb | null,
+  reportClimbForBoard: vi.fn(async () => true),
+  showUndoWallChangeSnackbar: vi.fn(),
+}));
 
 type PickerSheetProps = {
   onSelect: (deviceId: string) => void;
@@ -135,30 +144,78 @@ vi.mock('../../lib/board-details', () => ({
   })),
 }));
 
-// BluetoothProvider now reads board presence; mock it (and the wall context +
-// undo snackbar) so the test doesn't pull in the ws-client → expo-secure-store
-// chain. This suite doesn't exercise board presence.
+// BluetoothProvider reads board presence; mock it (and the wall context + undo
+// snackbar) so the suite doesn't pull in the ws-client → expo-secure-store
+// chain. Most tests keep board presence off; the auto-connect undo regression
+// opts into the mocked state below.
 vi.mock('@boardsesh/board-presence-react', () => ({
-  useBoardPresenceCurrent: () => ({ currentClimb: null, previousClimb: null, undoTarget: null, isLive: false }),
+  useBoardPresenceCurrent: () => ({
+    currentClimb: presence.currentClimb,
+    previousClimb: null,
+    undoTarget: null,
+    isLive: false,
+  }),
 }));
 vi.mock('../board-presence-provider', () => ({
   useBoardPresenceControls: () => ({
-    enabled: false,
-    boardId: null,
+    enabled: presence.enabled,
+    boardId: presence.boardId,
     resolveAndBindBoard: vi.fn(async () => null),
     resolveAndBindBoardByConfig: vi.fn(async () => null),
-    reportClimbForBoard: vi.fn(async () => true),
+    reportClimbForBoard: presence.reportClimbForBoard,
   }),
 }));
 vi.mock('../queue-snackbar-provider', () => ({
-  useQueueSnackbar: () => ({ showUndoWallChangeSnackbar: vi.fn() }),
+  useQueueSnackbar: () => ({ showUndoWallChangeSnackbar: presence.showUndoWallChangeSnackbar }),
 }));
 // toClimbInput pulls in expo-crypto (randomUUID); stub it (board presence is off here).
 vi.mock('../../lib/climb-to-queue-item', () => ({
   toClimbInput: (climb: { uuid: string }) => ({ uuid: climb.uuid }),
 }));
 
-import { BluetoothProvider } from '../bluetooth-provider';
+import { BluetoothProvider, useBluetoothContext } from '../bluetooth-provider';
+
+let capturedBluetooth: ReturnType<typeof useBluetoothContext> | null = null;
+
+function BluetoothProbe() {
+  capturedBluetooth = useBluetoothContext();
+  return null;
+}
+
+function makeQueueItem(uuid: string, frames = 'p1r12', mirrored = false): ClimbQueueItem {
+  return {
+    uuid: `queue-${uuid}`,
+    climb: {
+      uuid,
+      name: `Climb ${uuid}`,
+      frames,
+      mirrored,
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+function makePresenceClimb(overrides: Partial<BoardPresenceClimb> = {}): BoardPresenceClimb {
+  return {
+    climbUuid: 'previous-climb',
+    queueItemUuid: 'queue-previous-climb',
+    name: 'Previous climb',
+    grade: 'V4',
+    frames: 'previous-frames',
+    angle: 35,
+    setter: 'setter',
+    sentAt: '2026-06-10T00:00:00.000Z',
+    seq: 7,
+    ...overrides,
+  };
+}
 
 function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
   return {
@@ -258,7 +315,17 @@ describe('BluetoothProvider mismatch switch', () => {
     bluetooth.state.reconnectSerialForCurrentBoard = null;
     bluetooth.state.connect.mockClear();
     bluetooth.state.connect.mockResolvedValue(true);
+    bluetooth.state.sendFramesToBoard.mockClear();
+    bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
+    bluetooth.state.connectInitialSendRef.current = null;
     bluetooth.useBoardBluetooth.mockClear();
+    presence.enabled = false;
+    presence.boardId = null;
+    presence.currentClimb = null;
+    presence.reportClimbForBoard.mockClear();
+    presence.reportClimbForBoard.mockResolvedValue(true);
+    presence.showUndoWallChangeSnackbar.mockClear();
+    capturedBluetooth = null;
   });
 
   afterEach(() => {
@@ -321,6 +388,51 @@ describe('BluetoothProvider mismatch switch', () => {
       }),
     );
     expect(bluetooth.state.connect).toHaveBeenCalledOnce();
+  });
+
+  it('carries an armed undo toast through switch-to-board auto-connect', async () => {
+    const pickerState = makeMismatchingPickerState();
+    bluetooth.state.pickerState = pickerState;
+    const savedBoard = makeBoard();
+    resolvedBoards.value = new Map([['SN-2', { kind: 'saved', board: savedBoard }]]);
+    presence.enabled = true;
+    presence.boardId = 99;
+    presence.currentClimb = makePresenceClimb();
+    queue.currentClimbQueueItem = makeQueueItem('climb-1');
+
+    const { rerender } = renderProvider(KILTER_PROPS, createElement(BluetoothProbe));
+    capturedBluetooth?.armUndoWallChangeToast();
+    pickerSheet.props?.onSelect('device-2');
+
+    lastAlertButtons()[2]?.onPress?.();
+    await waitFor(() => {
+      expect(activeBoard.setActiveBoard).toHaveBeenCalledWith(savedBoard);
+    });
+
+    // The config change clears the original arm; the pending auto-connect
+    // request should re-arm immediately before it calls connect().
+    rerender(
+      createElement(BluetoothProvider, {
+        ...TENSION_PROPS,
+        children: createElement(BluetoothProbe),
+      }),
+    );
+    await waitFor(() => {
+      expect(bluetooth.state.connect).toHaveBeenCalledWith(undefined, undefined, 'SN-2');
+    });
+
+    bluetooth.state.isConnected = true;
+    rerender(
+      createElement(BluetoothProvider, {
+        ...TENSION_PROPS,
+        children: createElement(BluetoothProbe),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+    });
+    expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
   });
 
   it('drops a pending auto-connect whose switched config never propagates', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -664,6 +664,52 @@ describe('BluetoothProvider wall-confirm integration', () => {
       expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps the armed Undo snackbar for a retry after the first wall report is rejected', async () => {
+      presence.enabled = true;
+      presence.boardId = 99;
+      presence.currentClimb = makePresenceClimb();
+      presence.reportClimbForBoard.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      queue.sessionId = null;
+      bluetooth.state.isConnected = false;
+      const firstItem = makeQueueItem('climb-1');
+      queue.currentClimbQueueItem = firstItem;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      capturedBluetooth?.armUndoWallChangeToast();
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+      });
+      expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
+
+      queue.currentClimbQueueItem = { ...firstItem };
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(2);
+      });
+      expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
+    });
+
     it('does not show the Undo snackbar after the control-gain arm expires', async () => {
       vi.useFakeTimers();
       presence.enabled = true;
@@ -827,6 +873,50 @@ describe('BluetoothProvider wall-confirm integration', () => {
         expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
       });
       expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops an armed pending wall report when the board disconnects before resolution completes', async () => {
+      presence.enabled = true;
+      presence.boardId = null;
+      presence.currentClimb = makePresenceClimb();
+      bluetooth.state.isConnected = false;
+      let resolveBoard: (value: { boardId: number }) => void = () => {};
+      presence.resolveAndBindBoard.mockReturnValue(
+        new Promise((resolve) => {
+          resolveBoard = resolve;
+        }),
+      );
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING');
+      capturedBluetooth?.armUndoWallChangeToast();
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
+      });
+      expect(presence.reportClimbForBoard).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await capturedBluetooth?.disconnect();
+      });
+
+      await act(async () => {
+        resolveBoard({ boardId: 123 });
+      });
+
+      expect(presence.reportClimbForBoard).not.toHaveBeenCalled();
+      expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
     });
 
     it('does not poison same-climb retries when a report is rejected', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -305,6 +305,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
@@ -598,7 +599,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
       expect(queue.setSessionBoardSerial).not.toHaveBeenCalled();
     });
 
-    it('reports the lit climb to the wall on wall-confirm, in a SOLO flow, then shows the Undo snackbar', async () => {
+    it('reports the lit climb to the wall on wall-confirm in a SOLO flow without showing an unarmed Undo snackbar', async () => {
       presence.enabled = true;
       presence.boardId = 99;
       presence.currentClimb = makePresenceClimb();
@@ -616,9 +617,111 @@ describe('BluetoothProvider wall-confirm integration', () => {
       );
       expect(queue.confirmClimbOnWall).not.toHaveBeenCalled();
 
+      expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
+    });
+
+    it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {
+      presence.enabled = true;
+      presence.boardId = 99;
+      presence.currentClimb = makePresenceClimb();
+      queue.sessionId = null;
+      bluetooth.state.isConnected = false;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      capturedBluetooth?.armUndoWallChangeToast();
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
       await waitFor(() => {
-        expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
       });
+      expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
+
+      presence.currentClimb = makePresenceClimb({ climbUuid: 'reported-first', frames: 'p1r12', seq: 8 });
+      queue.currentClimbQueueItem = makeQueueItem('climb-2', 'p2r12');
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(2);
+      });
+      expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show the Undo snackbar after the control-gain arm expires', async () => {
+      vi.useFakeTimers();
+      presence.enabled = true;
+      presence.boardId = 99;
+      presence.currentClimb = makePresenceClimb();
+      queue.sessionId = null;
+      bluetooth.state.isConnected = false;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      capturedBluetooth?.armUndoWallChangeToast();
+
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+      });
+      vi.useRealTimers();
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+      });
+      expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
+    });
+
+    it('does not show the Undo snackbar when the armed report has no restorable frames', async () => {
+      presence.enabled = true;
+      presence.boardId = 99;
+      presence.currentClimb = makePresenceClimb({ frames: null });
+      queue.sessionId = null;
+      bluetooth.state.isConnected = false;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      capturedBluetooth?.armUndoWallChangeToast();
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+      });
+      expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
     });
 
     it('does NOT report to the wall when no board is bound', async () => {
@@ -684,6 +787,46 @@ describe('BluetoothProvider wall-confirm integration', () => {
           40,
         );
       });
+    });
+
+    it('preserves the armed Undo snackbar while a wall report waits for board resolution', async () => {
+      presence.enabled = true;
+      presence.boardId = null;
+      presence.currentClimb = makePresenceClimb();
+      bluetooth.state.isConnected = false;
+      let resolveBoard: (value: { boardId: number }) => void = () => {};
+      presence.resolveAndBindBoard.mockReturnValue(
+        new Promise((resolve) => {
+          resolveBoard = resolve;
+        }),
+      );
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      bluetooth.options?.onConnectSuccess?.('SERIAL-PENDING');
+      capturedBluetooth?.armUndoWallChangeToast();
+
+      bluetooth.state.isConnected = true;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
+      });
+      expect(presence.reportClimbForBoard).not.toHaveBeenCalled();
+
+      resolveBoard({ boardId: 123 });
+
+      await waitFor(() => {
+        expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+      });
+      expect(presence.showUndoWallChangeSnackbar).toHaveBeenCalledTimes(1);
     });
 
     it('does not poison same-climb retries when a report is rejected', async () => {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -398,6 +398,7 @@ export function BluetoothProvider({
     clearUndoWallChangeToastArm();
   }, [clearUndoWallChangeToastArm]);
 
+  // Cleanup-only effect: drop any one-shot arm timer when the provider unmounts.
   useEffect(() => clearUndoWallChangeToastArm, [clearUndoWallChangeToastArm]);
 
   useEffect(() => {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -83,7 +83,7 @@ function formatPickerBoardConfig(t: TFunction<'settings'>, config: BleBoardConfi
 type PendingWallReport = {
   item: ClimbQueueItem;
   undoTarget: BoardPresenceClimb | null;
-  showUndoToast: boolean;
+  undoToastArmId: number | null;
 };
 
 function queueItemReportSignature(item: ClimbQueueItem): string {
@@ -357,11 +357,12 @@ export function BluetoothProvider({
   const previousPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
   const boardConfigIdentity = `${boardName ?? ''}:${layoutId ?? ''}:${sizeId ?? ''}:${setIds ?? ''}`;
   const previousBoardConfigIdentityRef = useRef(boardConfigIdentity);
-  const undoWallChangeToastArmedRef = useRef(false);
+  const undoWallChangeToastArmIdRef = useRef<number | null>(null);
+  const nextUndoWallChangeToastArmIdRef = useRef(0);
   const undoWallChangeToastArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearUndoWallChangeToastArm = useCallback(() => {
-    undoWallChangeToastArmedRef.current = false;
+    undoWallChangeToastArmIdRef.current = null;
     if (undoWallChangeToastArmTimeoutRef.current) {
       clearTimeout(undoWallChangeToastArmTimeoutRef.current);
       undoWallChangeToastArmTimeoutRef.current = null;
@@ -370,17 +371,31 @@ export function BluetoothProvider({
 
   const armUndoWallChangeToast = useCallback(() => {
     clearUndoWallChangeToastArm();
-    undoWallChangeToastArmedRef.current = true;
+    const armId = nextUndoWallChangeToastArmIdRef.current + 1;
+    nextUndoWallChangeToastArmIdRef.current = armId;
+    undoWallChangeToastArmIdRef.current = armId;
     undoWallChangeToastArmTimeoutRef.current = setTimeout(() => {
-      undoWallChangeToastArmedRef.current = false;
+      undoWallChangeToastArmIdRef.current = null;
       undoWallChangeToastArmTimeoutRef.current = null;
     }, UNDO_WALL_CHANGE_TOAST_ARM_TTL_MS);
   }, [clearUndoWallChangeToastArm]);
 
-  const consumeUndoWallChangeToastArm = useCallback(() => {
-    const wasArmed = undoWallChangeToastArmedRef.current;
+  const getUndoWallChangeToastArmId = useCallback(() => undoWallChangeToastArmIdRef.current, []);
+
+  const consumeUndoWallChangeToastArm = useCallback(
+    (armId: number | null) => {
+      if (armId === null || undoWallChangeToastArmIdRef.current !== armId) {
+        return false;
+      }
+      clearUndoWallChangeToastArm();
+      return true;
+    },
+    [clearUndoWallChangeToastArm],
+  );
+
+  const clearPendingWallReportAndUndoToastArm = useCallback(() => {
+    pendingWallReportRef.current = null;
     clearUndoWallChangeToastArm();
-    return wasArmed;
   }, [clearUndoWallChangeToastArm]);
 
   useEffect(() => clearUndoWallChangeToastArm, [clearUndoWallChangeToastArm]);
@@ -389,9 +404,9 @@ export function BluetoothProvider({
     const previousBoardConfigIdentity = previousBoardConfigIdentityRef.current;
     previousBoardConfigIdentityRef.current = boardConfigIdentity;
     if (previousBoardConfigIdentity !== boardConfigIdentity) {
-      clearUndoWallChangeToastArm();
+      clearPendingWallReportAndUndoToastArm();
     }
-  }, [boardConfigIdentity, clearUndoWallChangeToastArm]);
+  }, [boardConfigIdentity, clearPendingWallReportAndUndoToastArm]);
 
   useEffect(() => {
     if (presenceBoardId !== null) {
@@ -416,19 +431,24 @@ export function BluetoothProvider({
     }
     if (previousBoardId !== null || presenceBoardId === null) {
       lastAcceptedReportSignatureRef.current = null;
-      pendingWallReportRef.current = null;
       undoWallChangeTargetRef.current = null;
-      clearUndoWallChangeToastArm();
+      clearPendingWallReportAndUndoToastArm();
     }
-  }, [clearUndoWallChangeToastArm, presenceBoardId]);
+  }, [clearPendingWallReportAndUndoToastArm, presenceBoardId]);
 
   const reportWallClimb = useCallback(
-    async (item: ClimbQueueItem, boardId: number, undoTarget: BoardPresenceClimb | null, showUndoToast: boolean) => {
+    async (
+      item: ClimbQueueItem,
+      boardId: number,
+      undoTarget: BoardPresenceClimb | null,
+      undoToastArmId: number | null,
+    ) => {
       const reportSignature = queueItemReportSignature(item);
       if (
         lastAcceptedReportSignatureRef.current === reportSignature &&
         presenceClimbReportSignature(wallCurrentClimbRef.current) === reportSignature
       ) {
+        consumeUndoWallChangeToastArm(undoToastArmId);
         return true;
       }
 
@@ -446,6 +466,7 @@ export function BluetoothProvider({
 
       lastAcceptedReportSignatureRef.current = reportSignature;
       undoWallChangeTargetRef.current = undoTarget;
+      const showUndoToast = consumeUndoWallChangeToastArm(undoToastArmId);
       track(SHARED_EVENTS.BoardClimbReported, {
         boardId,
         climbUuid: item.climb.uuid,
@@ -456,7 +477,7 @@ export function BluetoothProvider({
       }
       return true;
     },
-    [],
+    [consumeUndoWallChangeToastArm],
   );
 
   const replayPendingWallReport = useCallback(
@@ -464,7 +485,7 @@ export function BluetoothProvider({
       const pendingReport = pendingWallReportRef.current;
       if (!pendingReport) return;
       pendingWallReportRef.current = null;
-      void reportWallClimb(pendingReport.item, boardId, pendingReport.undoTarget, pendingReport.showUndoToast);
+      void reportWallClimb(pendingReport.item, boardId, pendingReport.undoTarget, pendingReport.undoToastArmId);
     },
     [reportWallClimb],
   );
@@ -481,16 +502,18 @@ export function BluetoothProvider({
       if (!presenceEnabledRef.current) return;
       const boardId = presenceBoardIdRef.current ?? resolvedPresenceBoardIdRef.current;
       const undoTarget = wallCurrentClimbRef.current;
-      const showUndoToast = consumeUndoWallChangeToastArm();
+      const undoToastArmId = getUndoWallChangeToastArmId();
       if (boardId === null) {
         if (pendingPresenceResolveRef.current) {
-          pendingWallReportRef.current = { item, undoTarget, showUndoToast };
+          pendingWallReportRef.current = { item, undoTarget, undoToastArmId };
+        } else {
+          consumeUndoWallChangeToastArm(undoToastArmId);
         }
         return;
       }
-      void reportWallClimb(item, boardId, undoTarget, showUndoToast);
+      void reportWallClimb(item, boardId, undoTarget, undoToastArmId);
     },
-    [confirmClimbOnWall, consumeUndoWallChangeToastArm, reportWallClimb],
+    [confirmClimbOnWall, consumeUndoWallChangeToastArm, getUndoWallChangeToastArmId, reportWallClimb],
   );
 
   const handleConnectSuccess = useCallback(
@@ -639,7 +662,11 @@ export function BluetoothProvider({
   // deliberate (last writer wins): each successful switch cancels the picker
   // that produced it, so a second request can only come from a newer flow whose
   // intent supersedes the first.
-  const [pendingAutoConnect, setPendingAutoConnect] = useState<{ serial: string; configKey: string } | null>(null);
+  const [pendingAutoConnect, setPendingAutoConnect] = useState<{
+    serial: string;
+    configKey: string;
+    armUndoToast: boolean;
+  } | null>(null);
 
   // The switched config normally propagates within one re-render, so a request
   // still pending after this window means it can no longer complete (e.g. the
@@ -671,15 +698,19 @@ export function BluetoothProvider({
     // connectInFlightRef is set (which tracks `loading`), so a new connect fired
     // now would be silently swallowed — wait for it to clear first.
     if (loading) return;
-    const { serial } = pendingAutoConnect;
+    const { serial, armUndoToast } = pendingAutoConnect;
     setPendingAutoConnect(null);
+    if (armUndoToast) {
+      armUndoWallChangeToast();
+    }
     // connect's third param does a silent serial auto-select, falling back to the
     // picker only if that serial never advertises.
     void connect(undefined, undefined, serial);
-  }, [pendingAutoConnect, boardName, layoutId, sizeId, loading, connect]);
+  }, [pendingAutoConnect, boardName, layoutId, sizeId, loading, armUndoWallChangeToast, connect]);
 
   const handleMismatchSwitch = useCallback(
     async (decision: Extract<PickerSelectionDecision, { kind: 'mismatch' }>) => {
+      const armUndoToastAfterSwitch = undoWallChangeToastArmIdRef.current !== null;
       try {
         let board: UserBoard;
         if (decision.entry.kind === 'saved') {
@@ -708,6 +739,7 @@ export function BluetoothProvider({
         setPendingAutoConnect({
           serial: decision.serial,
           configKey: boardConfigKey(decision.config.boardName, decision.config.layoutId, decision.config.sizeId),
+          armUndoToast: armUndoToastAfterSwitch,
         });
       } catch (error) {
         console.error('Failed to switch to correct board config:', error);
@@ -820,7 +852,7 @@ export function BluetoothProvider({
 
   // Wrap disconnect to track user-initiated disconnects
   const wrappedDisconnect = useCallback(async () => {
-    clearUndoWallChangeToastArm();
+    clearPendingWallReportAndUndoToastArm();
     isUserDisconnectRef.current = true;
     track(SHARED_EVENTS.BluetoothDisconnected, { boardName, reason: 'user', inSession: sessionIdRef.current != null });
     try {
@@ -834,7 +866,7 @@ export function BluetoothProvider({
     } finally {
       isUserDisconnectRef.current = false;
     }
-  }, [clearUndoWallChangeToastArm, disconnect, boardName]);
+  }, [clearPendingWallReportAndUndoToastArm, disconnect, boardName]);
 
   // Register with the module-level status store so consumers rendered outside
   // this provider (e.g. the root tab bar, the long-press BLE controls sheet) can
@@ -856,7 +888,7 @@ export function BluetoothProvider({
   // drop frequency stays visible in analytics.
   useEffect(() => {
     if (wasConnectedRef.current && !isConnected && !isUserDisconnectRef.current) {
-      clearUndoWallChangeToastArm();
+      clearPendingWallReportAndUndoToastArm();
       track(SHARED_EVENTS.BluetoothDisconnected, {
         boardName,
         reason: 'unexpected',
@@ -864,7 +896,7 @@ export function BluetoothProvider({
       });
     }
     wasConnectedRef.current = isConnected;
-  }, [clearUndoWallChangeToastArm, isConnected, boardName]);
+  }, [clearPendingWallReportAndUndoToastArm, isConnected, boardName]);
 
   const value = useMemo<BluetoothContextValue>(
     () => ({

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -52,6 +52,11 @@ type BluetoothContextValue = {
    */
   undoWallChange: () => Promise<boolean>;
   /**
+   * Show the undo affordance for the next accepted wall report only. UI control
+   * surfaces call this immediately before a deliberate control-gain action.
+   */
+  armUndoWallChangeToast: () => void;
+  /**
    * Serial to silently reconnect to for the board currently in view, or null
    * when nothing is remembered or the user switched boards — in which case
    * callers open the device picker instead.
@@ -64,6 +69,7 @@ const EMPTY_PICKER_DEVICES: [] = [];
 // How long a switch-to-config auto-connect request stays armed waiting for the
 // switched board's props to reach this provider before it is dropped.
 const PENDING_AUTO_CONNECT_TTL_MS = 15_000;
+const UNDO_WALL_CHANGE_TOAST_ARM_TTL_MS = 10_000;
 
 function formatPickerBoardConfig(t: TFunction<'settings'>, config: BleBoardConfig): string {
   return t('boardConfigMismatch.mobileConfigValue', {
@@ -77,6 +83,7 @@ function formatPickerBoardConfig(t: TFunction<'settings'>, config: BleBoardConfi
 type PendingWallReport = {
   item: ClimbQueueItem;
   undoTarget: BoardPresenceClimb | null;
+  showUndoToast: boolean;
 };
 
 function queueItemReportSignature(item: ClimbQueueItem): string {
@@ -348,6 +355,43 @@ export function BluetoothProvider({
   const resolvedPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
   const undoWallChangeTargetRef = useRef<BoardPresenceClimb | null>(null);
   const previousPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
+  const boardConfigIdentity = `${boardName ?? ''}:${layoutId ?? ''}:${sizeId ?? ''}:${setIds ?? ''}`;
+  const previousBoardConfigIdentityRef = useRef(boardConfigIdentity);
+  const undoWallChangeToastArmedRef = useRef(false);
+  const undoWallChangeToastArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearUndoWallChangeToastArm = useCallback(() => {
+    undoWallChangeToastArmedRef.current = false;
+    if (undoWallChangeToastArmTimeoutRef.current) {
+      clearTimeout(undoWallChangeToastArmTimeoutRef.current);
+      undoWallChangeToastArmTimeoutRef.current = null;
+    }
+  }, []);
+
+  const armUndoWallChangeToast = useCallback(() => {
+    clearUndoWallChangeToastArm();
+    undoWallChangeToastArmedRef.current = true;
+    undoWallChangeToastArmTimeoutRef.current = setTimeout(() => {
+      undoWallChangeToastArmedRef.current = false;
+      undoWallChangeToastArmTimeoutRef.current = null;
+    }, UNDO_WALL_CHANGE_TOAST_ARM_TTL_MS);
+  }, [clearUndoWallChangeToastArm]);
+
+  const consumeUndoWallChangeToastArm = useCallback(() => {
+    const wasArmed = undoWallChangeToastArmedRef.current;
+    clearUndoWallChangeToastArm();
+    return wasArmed;
+  }, [clearUndoWallChangeToastArm]);
+
+  useEffect(() => clearUndoWallChangeToastArm, [clearUndoWallChangeToastArm]);
+
+  useEffect(() => {
+    const previousBoardConfigIdentity = previousBoardConfigIdentityRef.current;
+    previousBoardConfigIdentityRef.current = boardConfigIdentity;
+    if (previousBoardConfigIdentity !== boardConfigIdentity) {
+      clearUndoWallChangeToastArm();
+    }
+  }, [boardConfigIdentity, clearUndoWallChangeToastArm]);
 
   useEffect(() => {
     if (presenceBoardId !== null) {
@@ -374,11 +418,12 @@ export function BluetoothProvider({
       lastAcceptedReportSignatureRef.current = null;
       pendingWallReportRef.current = null;
       undoWallChangeTargetRef.current = null;
+      clearUndoWallChangeToastArm();
     }
-  }, [presenceBoardId]);
+  }, [clearUndoWallChangeToastArm, presenceBoardId]);
 
   const reportWallClimb = useCallback(
-    async (item: ClimbQueueItem, boardId: number, undoTarget: BoardPresenceClimb | null) => {
+    async (item: ClimbQueueItem, boardId: number, undoTarget: BoardPresenceClimb | null, showUndoToast: boolean) => {
       const reportSignature = queueItemReportSignature(item);
       if (
         lastAcceptedReportSignatureRef.current === reportSignature &&
@@ -406,7 +451,7 @@ export function BluetoothProvider({
         climbUuid: item.climb.uuid,
         inSession: sessionIdRef.current != null,
       });
-      if (undoTarget?.frames) {
+      if (showUndoToast && undoTarget?.frames) {
         showUndoWallChangeSnackbarRef.current();
       }
       return true;
@@ -419,7 +464,7 @@ export function BluetoothProvider({
       const pendingReport = pendingWallReportRef.current;
       if (!pendingReport) return;
       pendingWallReportRef.current = null;
-      void reportWallClimb(pendingReport.item, boardId, pendingReport.undoTarget);
+      void reportWallClimb(pendingReport.item, boardId, pendingReport.undoTarget, pendingReport.showUndoToast);
     },
     [reportWallClimb],
   );
@@ -436,15 +481,16 @@ export function BluetoothProvider({
       if (!presenceEnabledRef.current) return;
       const boardId = presenceBoardIdRef.current ?? resolvedPresenceBoardIdRef.current;
       const undoTarget = wallCurrentClimbRef.current;
+      const showUndoToast = consumeUndoWallChangeToastArm();
       if (boardId === null) {
         if (pendingPresenceResolveRef.current) {
-          pendingWallReportRef.current = { item, undoTarget };
+          pendingWallReportRef.current = { item, undoTarget, showUndoToast };
         }
         return;
       }
-      void reportWallClimb(item, boardId, undoTarget);
+      void reportWallClimb(item, boardId, undoTarget, showUndoToast);
     },
-    [confirmClimbOnWall, reportWallClimb],
+    [confirmClimbOnWall, consumeUndoWallChangeToastArm, reportWallClimb],
   );
 
   const handleConnectSuccess = useCallback(
@@ -774,6 +820,7 @@ export function BluetoothProvider({
 
   // Wrap disconnect to track user-initiated disconnects
   const wrappedDisconnect = useCallback(async () => {
+    clearUndoWallChangeToastArm();
     isUserDisconnectRef.current = true;
     track(SHARED_EVENTS.BluetoothDisconnected, { boardName, reason: 'user', inSession: sessionIdRef.current != null });
     try {
@@ -787,7 +834,7 @@ export function BluetoothProvider({
     } finally {
       isUserDisconnectRef.current = false;
     }
-  }, [disconnect, boardName]);
+  }, [clearUndoWallChangeToastArm, disconnect, boardName]);
 
   // Register with the module-level status store so consumers rendered outside
   // this provider (e.g. the root tab bar, the long-press BLE controls sheet) can
@@ -809,6 +856,7 @@ export function BluetoothProvider({
   // drop frequency stays visible in analytics.
   useEffect(() => {
     if (wasConnectedRef.current && !isConnected && !isUserDisconnectRef.current) {
+      clearUndoWallChangeToastArm();
       track(SHARED_EVENTS.BluetoothDisconnected, {
         boardName,
         reason: 'unexpected',
@@ -816,7 +864,7 @@ export function BluetoothProvider({
       });
     }
     wasConnectedRef.current = isConnected;
-  }, [isConnected, boardName]);
+  }, [clearUndoWallChangeToastArm, isConnected, boardName]);
 
   const value = useMemo<BluetoothContextValue>(
     () => ({
@@ -828,6 +876,7 @@ export function BluetoothProvider({
       clearBoard,
       reassertWall,
       undoWallChange,
+      armUndoWallChangeToast,
       reconnectSerialForCurrentBoard,
     }),
     [
@@ -839,6 +888,7 @@ export function BluetoothProvider({
       clearBoard,
       reassertWall,
       undoWallChange,
+      armUndoWallChangeToast,
       reconnectSerialForCurrentBoard,
     ],
   );


### PR DESCRIPTION
## Summary

Fixes the board-presence undo toast so it only appears for the next accepted wall report after a deliberate control-gain action, instead of appearing after every sent climb. The toast is now armed from the React Native control surfaces that take or reassert board control, consumed once by the Bluetooth provider, and cleared on expiry, board/config changes, or disconnect.

Also renders the undo toast through a React Native Paper `Portal` so it appears above the play sheet instead of underneath it. The provider-dependent bottom offset is computed before entering the portal so the portaled snackbar does not depend on `QueueProvider` context.

## Root Cause

The previous implementation showed the undo affordance whenever a wall report had restorable frames, regardless of whether the user had just taken control. The snackbar also rendered in the normal tree below the bottom-sheet layer.

Review follow-up fixed edge cases where rejected reports consumed the one-shot arm too early, pending reports could survive disconnect/config invalidation, mismatch switch auto-connect could lose the arm, and the long-press BLE re-light action bypassed arming.

The final polish pass stabilizes the BLE sheet callbacks, adds Liquid Glass undo action coverage, and documents the provider's cleanup-only timer effect.

## Validation

- `vp test run --project mobile packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx packages/mobile/src/components/board-presence/__tests__/undo-wall-change-snackbar.test.tsx packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx --reporter=agent` — 87 passed
- `vp run typecheck:mobile`
- `vp run test:mobile -- --reporter=agent` — 260 files / 1905 tests passed
- `vp run check:mobile-bundle`
- `git diff --check`
