### PR TITLE
[codex] Make board sheet climbs interactive and dedupe history

### DIFF
--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -164,7 +164,7 @@ type ClimbListRowProps = {
   sizeId: number;
   setIds: string;
   angle: number;
-  onPress: (climb: Climb) => void;
+  onPress?: (climb: Climb) => void;
   onAddToQueue?: (climb: Climb) => void;
   onOpenPlaylist?: (climb: Climb) => void;
   onOpenActions?: (climb: Climb) => void;
@@ -239,8 +239,10 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
   const handleRowPress = useCallback(() => {
     if (unsupportedRef.current) return;
+    const press = onPressRef.current;
+    if (!press) return;
     hapticLight();
-    onPressRef.current(climbRef.current);
+    press(climbRef.current);
   }, []);
 
   const handleLongPress = useCallback(() => {
@@ -257,13 +259,17 @@ const ClimbListRow = React.memo(function ClimbListRow({
   // onSwipeableOpen (handleSwipeableOpened) instead — a clean closed→open→
   // closed cycle that fires on every swipe.
   const handleAddToQueue = useCallback(() => {
+    const addToQueue = onAddToQueueRef.current;
+    if (!addToQueue) return;
     hapticSuccess();
-    onAddToQueueRef.current?.(climbRef.current);
+    addToQueue(climbRef.current);
   }, []);
 
   const handleOpenPlaylist = useCallback(() => {
+    const openPlaylist = onOpenPlaylistRef.current;
+    if (!openPlaylist) return;
     hapticMedium();
-    onOpenPlaylistRef.current?.(climbRef.current);
+    openPlaylist(climbRef.current);
   }, []);
 
   // Snap the row shut once it has fully settled open. Runs after the action
@@ -373,8 +379,8 @@ const ClimbListRow = React.memo(function ClimbListRow({
         rightThreshold={COMMIT_THRESHOLD}
         overshootLeft={false}
         overshootRight={false}
-        renderLeftActions={renderLeftActions}
-        renderRightActions={renderRightActions}
+        renderLeftActions={onAddToQueue ? renderLeftActions : undefined}
+        renderRightActions={onOpenPlaylist ? renderRightActions : undefined}
         onSwipeableOpenStartDrag={handleSwipeStartDrag}
         onSwipeableWillOpen={handleSwipeWillOpen}
         onSwipeableOpen={handleSwipeableOpened}

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { View, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useAnimatedReaction,
@@ -148,6 +148,15 @@ function PlaylistSwipeAction({ translation, active }: { translation: SharedValue
   );
 }
 
+export type ClimbListRowRenderContentArgs = {
+  climb: Climb;
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
 type ClimbListRowProps = {
   climb: Climb;
   boardName: BoardName;
@@ -161,6 +170,11 @@ type ClimbListRowProps = {
   onOpenActions?: (climb: Climb) => void;
   selected?: boolean;
   unsupported?: boolean;
+  renderContent?: (args: ClimbListRowRenderContentArgs) => ReactNode;
+  containerStyle?: StyleProp<ViewStyle>;
+  contentRowStyle?: StyleProp<ViewStyle>;
+  separatorStyle?: StyleProp<ViewStyle>;
+  showSeparator?: boolean;
 };
 
 const ClimbListRow = React.memo(function ClimbListRow({
@@ -176,6 +190,11 @@ const ClimbListRow = React.memo(function ClimbListRow({
   onOpenActions,
   selected,
   unsupported,
+  renderContent,
+  containerStyle,
+  contentRowStyle,
+  separatorStyle,
+  showSeparator = true,
 }: ClimbListRowProps) {
   const { systemColors, brandColors: brand } = useTheme();
   // Active-row highlight colours, derived from the scheme-aware brand so the wash
@@ -332,8 +351,21 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [dragArmedRef],
   );
 
+  const rowContent = renderContent ? (
+    renderContent({ climb, boardName, layoutId, sizeId, setIds, angle })
+  ) : (
+    <ClimbListItemContent
+      climb={climb}
+      boardName={boardName}
+      layoutId={layoutId}
+      sizeId={sizeId}
+      setIds={setIds}
+      angle={angle}
+    />
+  );
+
   return (
-    <View style={[styles.outerContainer, unsupported && styles.unsupported]}>
+    <View style={[styles.outerContainer, containerStyle, unsupported && styles.unsupported]}>
       <ReanimatedSwipeable
         ref={swipeableRef}
         friction={SWIPE_FRICTION}
@@ -350,7 +382,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
       >
         <GestureDetector gesture={tapGesture}>
           <View
-            style={[climbListRowStyles.contentRow, { backgroundColor: systemColors.background }]}
+            style={[climbListRowStyles.contentRow, { backgroundColor: systemColors.background }, contentRowStyle]}
             accessible
             accessibilityRole="button"
             accessibilityLabel={climb.name}
@@ -364,20 +396,15 @@ const ClimbListRow = React.memo(function ClimbListRow({
               <View style={[styles.selectedAccent, { backgroundColor: highlight.accent }]} pointerEvents="none" />
             ) : null}
 
-            <ClimbListItemContent
-              climb={climb}
-              boardName={boardName}
-              layoutId={layoutId}
-              sizeId={sizeId}
-              setIds={setIds}
-              angle={angle}
-            />
+            {rowContent}
           </View>
         </GestureDetector>
       </ReanimatedSwipeable>
 
       {/* Separator — inset to start at the text column (after the thumbnail) */}
-      <View style={[climbListRowStyles.separator, { backgroundColor: systemColors.separator }]} />
+      {showSeparator ? (
+        <View style={[climbListRowStyles.separator, { backgroundColor: systemColors.separator }, separatorStyle]} />
+      ) : null}
     </View>
   );
 });

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -24,11 +24,11 @@ import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
-import type { Climb } from '@boardsesh/queue';
+import type { BoardName, BoardPresenceClimb, Climb } from '@boardsesh/shared-schema';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { ClimbListRow } from '../ClimbListRow';
 import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
 import { useTheme } from '../../providers/theme-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
@@ -37,8 +37,7 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { track } from '../../lib/analytics';
 import { spacing, borderRadius } from '../../theme/tokens';
 
-/** Minimal Climb shape the board-art thumbnail needs from a presence climb. */
-function presenceClimbToThumbnailClimb(presenceClimb: BoardPresenceClimb): Climb {
+function presenceClimbToClimb(presenceClimb: BoardPresenceClimb): Climb {
   return {
     uuid: presenceClimb.climbUuid,
     name: presenceClimb.name ?? '',
@@ -57,6 +56,14 @@ function presenceClimbToThumbnailClimb(presenceClimb: BoardPresenceClimb): Climb
 function boardPresenceHistoryKeyExtractor(item: BoardPresenceClimb): string {
   return `${item.climbUuid}-${item.seq}`;
 }
+
+type BoardSheetRowBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
 
 /**
  * Imperative handle — the host presents/dismisses the sheet by calling these
@@ -84,10 +91,28 @@ type BoardSheetProps = {
   onDismissed?: () => void;
   /** Open the existing board switcher from the footer control. */
   onSwitchBoard: () => void;
+  /** Activate/open a climb from the wall feed. BoardSheet closes itself after this. */
+  onClimbPress?: (climb: Climb) => void;
+  /** Swipe action: append this wall-feed climb to the queue. */
+  onAddToQueue?: (climb: Climb) => void;
+  /** Swipe action: open the add-to-playlist sheet for this climb. */
+  onOpenPlaylist?: (climb: Climb) => void;
+  /** Long press action: open the existing climb actions sheet. */
+  onOpenActions?: (climb: Climb) => void;
 };
 
 export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function BoardSheet(
-  { boardLabel, boardConfig, onClose, onDismissed, onSwitchBoard },
+  {
+    boardLabel,
+    boardConfig,
+    onClose,
+    onDismissed,
+    onSwitchBoard,
+    onClimbPress,
+    onAddToQueue,
+    onOpenPlaylist,
+    onOpenActions,
+  },
   ref,
 ) {
   const { t } = useTranslation('session');
@@ -117,6 +142,28 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   }, [currentClimb?.climbUuid]);
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
+  const rowBoard = useMemo<BoardSheetRowBoard | null>(
+    () =>
+      boardConfig
+        ? {
+            boardName: boardConfig.boardName as BoardName,
+            layoutId: boardConfig.layoutId,
+            sizeId: boardConfig.sizeId,
+            setIds: boardConfig.setIds,
+            angle: boardConfig.angle,
+          }
+        : null,
+    [boardConfig],
+  );
+  const canUseInteractiveRows = !!rowBoard && !!onClimbPress;
+
+  const handleInteractiveClimbPress = useCallback(
+    (climb: Climb) => {
+      onClimbPress?.(climb);
+      onClose();
+    },
+    [onClimbPress, onClose],
+  );
 
   useImperativeHandle(ref, () => ({
     present: () => {
@@ -147,32 +194,84 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   );
 
   const renderHistoryItem = useCallback(
-    ({ item }: { item: BoardPresenceClimb }) => (
-      <HistoryRow
-        climb={item}
-        boardConfig={boardConfig}
-        labelColor={systemColors.label}
-        secondaryColor={systemColors.secondaryLabel}
-        formattedGrade={item.grade ? formatGrade(item.grade) : null}
-        gradeColor={getGradeColor(item.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-      />
-    ),
-    [boardConfig, systemColors.label, systemColors.secondaryLabel, formatGrade],
+    ({ item }: { item: BoardPresenceClimb }) => {
+      const formattedGrade = item.grade ? formatGrade(item.grade) : null;
+      const gradeColor = getGradeColor(item.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+
+      if (canUseInteractiveRows && rowBoard) {
+        return (
+          <InteractiveHistoryRow
+            climb={item}
+            rowBoard={rowBoard}
+            boardConfig={boardConfig}
+            labelColor={systemColors.label}
+            secondaryColor={systemColors.secondaryLabel}
+            formattedGrade={formattedGrade}
+            gradeColor={gradeColor}
+            onPress={handleInteractiveClimbPress}
+            onAddToQueue={onAddToQueue}
+            onOpenPlaylist={onOpenPlaylist}
+            onOpenActions={onOpenActions}
+          />
+        );
+      }
+
+      return (
+        <HistoryRow
+          climb={item}
+          boardConfig={boardConfig}
+          labelColor={systemColors.label}
+          secondaryColor={systemColors.secondaryLabel}
+          formattedGrade={formattedGrade}
+          gradeColor={gradeColor}
+        />
+      );
+    },
+    [
+      boardConfig,
+      canUseInteractiveRows,
+      rowBoard,
+      systemColors.label,
+      systemColors.secondaryLabel,
+      formatGrade,
+      handleInteractiveClimbPress,
+      onAddToQueue,
+      onOpenPlaylist,
+      onOpenActions,
+    ],
   );
 
   const listHeader = useMemo(
     () => (
       <View>
-        <NowOnTheWallHero
-          climb={currentClimb}
-          boardConfig={boardConfig}
-          labelColor={systemColors.label}
-          secondaryColor={systemColors.secondaryLabel}
-          accentColor={brandColors.warning}
-          surfaceColor={systemColors.secondaryBackground}
-          formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
-          gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-        />
+        {canUseInteractiveRows && rowBoard && currentClimb ? (
+          <InteractiveHeroRow
+            climb={currentClimb}
+            rowBoard={rowBoard}
+            boardConfig={boardConfig}
+            labelColor={systemColors.label}
+            secondaryColor={systemColors.secondaryLabel}
+            accentColor={brandColors.warning}
+            surfaceColor={systemColors.secondaryBackground}
+            formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
+            gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+            onPress={handleInteractiveClimbPress}
+            onAddToQueue={onAddToQueue}
+            onOpenPlaylist={onOpenPlaylist}
+            onOpenActions={onOpenActions}
+          />
+        ) : (
+          <NowOnTheWallHero
+            climb={currentClimb}
+            boardConfig={boardConfig}
+            labelColor={systemColors.label}
+            secondaryColor={systemColors.secondaryLabel}
+            accentColor={brandColors.warning}
+            surfaceColor={systemColors.secondaryBackground}
+            formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
+            gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+          />
+        )}
         {stats ? (
           <View style={styles.statsBlock}>
             <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
@@ -217,7 +316,22 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
         ) : null}
       </View>
     ),
-    [currentClimb, boardConfig, stats, history.length, systemColors, brandColors.warning, formatGrade, t],
+    [
+      currentClimb,
+      boardConfig,
+      stats,
+      history.length,
+      systemColors,
+      brandColors.warning,
+      formatGrade,
+      t,
+      canUseInteractiveRows,
+      rowBoard,
+      handleInteractiveClimbPress,
+      onAddToQueue,
+      onOpenPlaylist,
+      onOpenActions,
+    ],
   );
 
   const listEmpty = useMemo(
@@ -314,25 +428,37 @@ type HeroProps = {
   gradeColor: string;
 };
 
-function NowOnTheWallHero({
+type InteractiveRowActionProps = {
+  onPress: (climb: Climb) => void;
+  onAddToQueue?: (climb: Climb) => void;
+  onOpenPlaylist?: (climb: Climb) => void;
+  onOpenActions?: (climb: Climb) => void;
+};
+
+type HeroContentProps = Omit<HeroProps, 'climb'> & {
+  climb: BoardPresenceClimb;
+  renderClimb: Climb;
+  thumbnailSize?: number;
+};
+
+function NowOnTheWallHeroContent({
   climb,
+  renderClimb,
   boardConfig,
   labelColor,
   secondaryColor,
   accentColor,
-  surfaceColor,
   formattedGrade,
   gradeColor,
-}: HeroProps) {
+  thumbnailSize,
+}: HeroContentProps) {
   const { t } = useTranslation('session');
-  if (!climb) return null;
-
   const litBy = climb.sentByDisplayName?.trim();
   const setter = climb.setter?.trim();
 
   return (
-    <View style={[styles.hero, { backgroundColor: surfaceColor }]}>
-      <AccessoryClimbThumbnail climb={presenceClimbToThumbnailClimb(climb)} boardConfig={boardConfig} />
+    <>
+      <AccessoryClimbThumbnail climb={renderClimb} boardConfig={boardConfig} size={thumbnailSize} />
       <View style={styles.heroBody}>
         <View style={styles.heroNameRow}>
           <Text variant="headline" color={labelColor} numberOfLines={1} style={styles.heroName}>
@@ -355,6 +481,86 @@ function NowOnTheWallHero({
           </Text>
         ) : null}
       </View>
+    </>
+  );
+}
+
+function InteractiveHeroRow({
+  climb,
+  rowBoard,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  accentColor,
+  surfaceColor,
+  formattedGrade,
+  gradeColor,
+  onPress,
+  onAddToQueue,
+  onOpenPlaylist,
+  onOpenActions,
+}: HeroProps & { climb: BoardPresenceClimb; rowBoard: BoardSheetRowBoard } & InteractiveRowActionProps) {
+  const rowClimb = useMemo(() => presenceClimbToClimb(climb), [climb]);
+
+  return (
+    <ClimbListRow
+      climb={rowClimb}
+      boardName={rowBoard.boardName}
+      layoutId={rowBoard.layoutId}
+      sizeId={rowBoard.sizeId}
+      setIds={rowBoard.setIds}
+      angle={rowBoard.angle}
+      onPress={onPress}
+      onAddToQueue={onAddToQueue}
+      onOpenPlaylist={onOpenPlaylist}
+      onOpenActions={onOpenActions}
+      containerStyle={styles.heroInteractiveContainer}
+      contentRowStyle={[styles.heroInteractiveRow, { backgroundColor: surfaceColor }]}
+      showSeparator={false}
+      renderContent={() => (
+        <NowOnTheWallHeroContent
+          climb={climb}
+          renderClimb={rowClimb}
+          boardConfig={boardConfig}
+          labelColor={labelColor}
+          secondaryColor={secondaryColor}
+          accentColor={accentColor}
+          surfaceColor={surfaceColor}
+          formattedGrade={formattedGrade}
+          gradeColor={gradeColor}
+          thumbnailSize={52}
+        />
+      )}
+    />
+  );
+}
+
+function NowOnTheWallHero({
+  climb,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  accentColor,
+  surfaceColor,
+  formattedGrade,
+  gradeColor,
+}: HeroProps) {
+  if (!climb) return null;
+  const renderClimb = presenceClimbToClimb(climb);
+
+  return (
+    <View style={[styles.hero, { backgroundColor: surfaceColor }]}>
+      <NowOnTheWallHeroContent
+        climb={climb}
+        renderClimb={renderClimb}
+        boardConfig={boardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        accentColor={accentColor}
+        surfaceColor={surfaceColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+      />
     </View>
   );
 }
@@ -368,21 +574,25 @@ type HistoryRowProps = {
   gradeColor: string;
 };
 
-const HistoryRow = memo(function HistoryRowInner({
+type HistoryRowContentProps = HistoryRowProps & {
+  renderClimb: Climb;
+};
+
+function HistoryRowContent({
   climb,
+  renderClimb,
   boardConfig,
   labelColor,
   secondaryColor,
   formattedGrade,
   gradeColor,
-}: HistoryRowProps) {
+}: HistoryRowContentProps) {
   const { t } = useTranslation('session');
   const litBy = climb.sentByDisplayName?.trim();
-  const thumbnailClimb = useMemo(() => presenceClimbToThumbnailClimb(climb), [climb]);
 
   return (
-    <View style={styles.historyRow}>
-      <AccessoryClimbThumbnail climb={thumbnailClimb} boardConfig={boardConfig} />
+    <>
+      <AccessoryClimbThumbnail climb={renderClimb} boardConfig={boardConfig} />
       <View style={styles.historyBody}>
         <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.historyName}>
           {climb.name ?? ''}
@@ -398,6 +608,75 @@ const HistoryRow = memo(function HistoryRowInner({
           {formattedGrade}
         </Text>
       ) : null}
+    </>
+  );
+}
+
+function InteractiveHistoryRow({
+  climb,
+  rowBoard,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  formattedGrade,
+  gradeColor,
+  onPress,
+  onAddToQueue,
+  onOpenPlaylist,
+  onOpenActions,
+}: HistoryRowProps & { rowBoard: BoardSheetRowBoard } & InteractiveRowActionProps) {
+  const rowClimb = useMemo(() => presenceClimbToClimb(climb), [climb]);
+
+  return (
+    <ClimbListRow
+      climb={rowClimb}
+      boardName={rowBoard.boardName}
+      layoutId={rowBoard.layoutId}
+      sizeId={rowBoard.sizeId}
+      setIds={rowBoard.setIds}
+      angle={rowBoard.angle}
+      onPress={onPress}
+      onAddToQueue={onAddToQueue}
+      onOpenPlaylist={onOpenPlaylist}
+      onOpenActions={onOpenActions}
+      contentRowStyle={styles.historyInteractiveRow}
+      showSeparator={false}
+      renderContent={() => (
+        <HistoryRowContent
+          climb={climb}
+          renderClimb={rowClimb}
+          boardConfig={boardConfig}
+          labelColor={labelColor}
+          secondaryColor={secondaryColor}
+          formattedGrade={formattedGrade}
+          gradeColor={gradeColor}
+        />
+      )}
+    />
+  );
+}
+
+const HistoryRow = memo(function HistoryRowInner({
+  climb,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  formattedGrade,
+  gradeColor,
+}: HistoryRowProps) {
+  const thumbnailClimb = useMemo(() => presenceClimbToClimb(climb), [climb]);
+
+  return (
+    <View style={styles.historyRow}>
+      <HistoryRowContent
+        climb={climb}
+        renderClimb={thumbnailClimb}
+        boardConfig={boardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+      />
     </View>
   );
 });
@@ -464,6 +743,14 @@ const styles = StyleSheet.create({
     padding: spacing[3],
     borderRadius: borderRadius.lg,
   },
+  heroInteractiveContainer: {
+    margin: spacing[4],
+    borderRadius: borderRadius.lg,
+  },
+  heroInteractiveRow: {
+    padding: spacing[3],
+    borderRadius: borderRadius.lg,
+  },
   heroBody: {
     flex: 1,
     gap: 2,
@@ -508,6 +795,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  historyInteractiveRow: {
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[2],
   },

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -169,8 +169,17 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
   const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
   boardPresenceBoardIdRef.current = boardPresenceBoardId;
-  const historyCountRef = useRef(history.length);
-  historyCountRef.current = history.length;
+  const visibleHistory = useMemo(
+    () =>
+      currentClimb
+        ? history.filter((historyClimb) => {
+            return historyClimb.climbUuid !== currentClimb.climbUuid || historyClimb.seq !== currentClimb.seq;
+          })
+        : history,
+    [currentClimb, history],
+  );
+  const historyCountRef = useRef(visibleHistory.length);
+  historyCountRef.current = visibleHistory.length;
 
   const lastReceivedWallClimbRef = useRef<string | null>(null);
   const actionClimbCacheRef = useRef(new Map<string, Climb>());
@@ -420,7 +429,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             </View>
           </View>
         ) : null}
-        {history.length > 0 ? (
+        {visibleHistory.length > 0 ? (
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
             {t('mobile.boardPresence.historyHeader')}
           </Text>
@@ -431,7 +440,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       currentClimb,
       boardConfig,
       stats,
-      history.length,
+      visibleHistory.length,
       systemColors,
       brandColors.warning,
       formatGrade,
@@ -495,7 +504,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       </View>
 
       <BottomSheetFlatList
-        data={history}
+        data={visibleHistory}
         keyExtractor={boardPresenceHistoryKeyExtractor}
         renderItem={renderHistoryItem}
         ListHeaderComponent={listHeader}

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -35,9 +35,11 @@ import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { track } from '../../lib/analytics';
+import { getHttpClient } from '../../lib/graphql/client';
+import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 import { spacing, borderRadius } from '../../theme/tokens';
 
-function presenceClimbToClimb(presenceClimb: BoardPresenceClimb): Climb {
+function presenceClimbToPreviewClimb(presenceClimb: BoardPresenceClimb): Climb {
   return {
     uuid: presenceClimb.climbUuid,
     name: presenceClimb.name ?? '',
@@ -64,6 +66,38 @@ type BoardSheetRowBoard = {
   setIds: string;
   angle: number;
 };
+
+export type BoardSheetClimbAction = {
+  climb: Climb;
+  queueItemUuid: string | null;
+  boardConfig: BoardConfig;
+};
+
+function actionBoardConfigForPresenceClimb(boardConfig: BoardConfig, presenceClimb: BoardPresenceClimb): BoardConfig {
+  const angle = presenceClimb.angle ?? boardConfig.angle;
+  return angle === boardConfig.angle ? boardConfig : { ...boardConfig, angle };
+}
+
+function rowBoardForBoardConfig(boardConfig: BoardConfig): BoardSheetRowBoard {
+  return {
+    boardName: boardConfig.boardName as BoardName,
+    layoutId: boardConfig.layoutId,
+    sizeId: boardConfig.sizeId,
+    setIds: boardConfig.setIds,
+    angle: boardConfig.angle,
+  };
+}
+
+function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
+  return [
+    boardConfig.boardName,
+    boardConfig.layoutId,
+    boardConfig.sizeId,
+    boardConfig.setIds,
+    boardConfig.angle,
+    climbUuid,
+  ].join(':');
+}
 
 /**
  * Imperative handle — the host presents/dismisses the sheet by calling these
@@ -92,13 +126,13 @@ type BoardSheetProps = {
   /** Open the existing board switcher from the footer control. */
   onSwitchBoard: () => void;
   /** Activate/open a climb from the wall feed. BoardSheet closes itself after this. */
-  onClimbPress?: (climb: Climb) => void;
+  onClimbPress?: (action: BoardSheetClimbAction) => void;
   /** Swipe action: append this wall-feed climb to the queue. */
-  onAddToQueue?: (climb: Climb) => void;
+  onAddToQueue?: (action: BoardSheetClimbAction) => void;
   /** Swipe action: open the add-to-playlist sheet for this climb. */
-  onOpenPlaylist?: (climb: Climb) => void;
+  onOpenPlaylist?: (action: BoardSheetClimbAction) => void;
   /** Long press action: open the existing climb actions sheet. */
-  onOpenActions?: (climb: Climb) => void;
+  onOpenActions?: (action: BoardSheetClimbAction) => void;
 };
 
 export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function BoardSheet(
@@ -130,6 +164,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   historyCountRef.current = history.length;
 
   const lastReceivedWallClimbRef = useRef<string | null>(null);
+  const actionClimbCacheRef = useRef(new Map<string, Climb>());
   useEffect(() => {
     const currentClimbUuid = currentClimb?.climbUuid;
     if (!currentClimbUuid) return;
@@ -143,26 +178,93 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
   const rowBoard = useMemo<BoardSheetRowBoard | null>(
-    () =>
-      boardConfig
-        ? {
-            boardName: boardConfig.boardName as BoardName,
-            layoutId: boardConfig.layoutId,
-            sizeId: boardConfig.sizeId,
-            setIds: boardConfig.setIds,
-            angle: boardConfig.angle,
-          }
-        : null,
+    () => (boardConfig ? rowBoardForBoardConfig(boardConfig) : null),
     [boardConfig],
   );
   const canUseInteractiveRows = !!rowBoard && !!onClimbPress;
 
-  const handleInteractiveClimbPress = useCallback(
-    (climb: Climb) => {
-      onClimbPress?.(climb);
-      onClose();
+  const resolveAction = useCallback(
+    async (presenceClimb: BoardPresenceClimb): Promise<BoardSheetClimbAction | null> => {
+      if (!boardConfig) return null;
+
+      const actionBoardConfig = actionBoardConfigForPresenceClimb(boardConfig, presenceClimb);
+      const cacheKey = actionCacheKey(actionBoardConfig, presenceClimb.climbUuid);
+      const cachedClimb = actionClimbCacheRef.current.get(cacheKey);
+      if (cachedClimb) {
+        return {
+          climb: cachedClimb,
+          queueItemUuid: presenceClimb.queueItemUuid ?? null,
+          boardConfig: actionBoardConfig,
+        };
+      }
+
+      try {
+        const response = await getHttpClient().request<GetClimbQueryResponse>(GET_CLIMB, {
+          boardName: actionBoardConfig.boardName,
+          layoutId: actionBoardConfig.layoutId,
+          sizeId: actionBoardConfig.sizeId,
+          setIds: actionBoardConfig.setIds,
+          angle: actionBoardConfig.angle,
+          climbUuid: presenceClimb.climbUuid,
+        });
+        if (!response.climb) return null;
+        actionClimbCacheRef.current.set(cacheKey, response.climb);
+        return {
+          climb: response.climb,
+          queueItemUuid: presenceClimb.queueItemUuid ?? null,
+          boardConfig: actionBoardConfig,
+        };
+      } catch (error) {
+        console.warn('Failed to load board-sheet climb action', error);
+        return null;
+      }
     },
-    [onClimbPress, onClose],
+    [boardConfig],
+  );
+
+  const handleInteractiveClimbPress = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onClimbPress) return;
+      void resolveAction(presenceClimb).then((action) => {
+        if (!action) return;
+        onClimbPress(action);
+        onClose();
+      });
+    },
+    [onClimbPress, onClose, resolveAction],
+  );
+
+  const handleInteractiveAddToQueue = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onAddToQueue) return;
+      void resolveAction(presenceClimb).then((action) => {
+        if (!action) return;
+        onAddToQueue(action);
+      });
+    },
+    [onAddToQueue, resolveAction],
+  );
+
+  const handleInteractiveOpenPlaylist = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onOpenPlaylist) return;
+      void resolveAction(presenceClimb).then((action) => {
+        if (!action) return;
+        onOpenPlaylist(action);
+      });
+    },
+    [onOpenPlaylist, resolveAction],
+  );
+
+  const handleInteractiveOpenActions = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onOpenActions) return;
+      void resolveAction(presenceClimb).then((action) => {
+        if (!action) return;
+        onOpenActions(action);
+      });
+    },
+    [onOpenActions, resolveAction],
   );
 
   useImperativeHandle(ref, () => ({
@@ -209,9 +311,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             formattedGrade={formattedGrade}
             gradeColor={gradeColor}
             onPress={handleInteractiveClimbPress}
-            onAddToQueue={onAddToQueue}
-            onOpenPlaylist={onOpenPlaylist}
-            onOpenActions={onOpenActions}
+            onAddToQueue={handleInteractiveAddToQueue}
+            onOpenPlaylist={handleInteractiveOpenPlaylist}
+            onOpenActions={handleInteractiveOpenActions}
           />
         );
       }
@@ -235,9 +337,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       systemColors.secondaryLabel,
       formatGrade,
       handleInteractiveClimbPress,
-      onAddToQueue,
-      onOpenPlaylist,
-      onOpenActions,
+      handleInteractiveAddToQueue,
+      handleInteractiveOpenPlaylist,
+      handleInteractiveOpenActions,
     ],
   );
 
@@ -256,9 +358,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
             gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
             onPress={handleInteractiveClimbPress}
-            onAddToQueue={onAddToQueue}
-            onOpenPlaylist={onOpenPlaylist}
-            onOpenActions={onOpenActions}
+            onAddToQueue={handleInteractiveAddToQueue}
+            onOpenPlaylist={handleInteractiveOpenPlaylist}
+            onOpenActions={handleInteractiveOpenActions}
           />
         ) : (
           <NowOnTheWallHero
@@ -328,9 +430,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       canUseInteractiveRows,
       rowBoard,
       handleInteractiveClimbPress,
-      onAddToQueue,
-      onOpenPlaylist,
-      onOpenActions,
+      handleInteractiveAddToQueue,
+      handleInteractiveOpenPlaylist,
+      handleInteractiveOpenActions,
     ],
   );
 
@@ -429,10 +531,10 @@ type HeroProps = {
 };
 
 type InteractiveRowActionProps = {
-  onPress: (climb: Climb) => void;
-  onAddToQueue?: (climb: Climb) => void;
-  onOpenPlaylist?: (climb: Climb) => void;
-  onOpenActions?: (climb: Climb) => void;
+  onPress: (climb: BoardPresenceClimb) => void;
+  onAddToQueue?: (climb: BoardPresenceClimb) => void;
+  onOpenPlaylist?: (climb: BoardPresenceClimb) => void;
+  onOpenActions?: (climb: BoardPresenceClimb) => void;
 };
 
 type HeroContentProps = Omit<HeroProps, 'climb'> & {
@@ -500,20 +602,28 @@ function InteractiveHeroRow({
   onOpenPlaylist,
   onOpenActions,
 }: HeroProps & { climb: BoardPresenceClimb; rowBoard: BoardSheetRowBoard } & InteractiveRowActionProps) {
-  const rowClimb = useMemo(() => presenceClimbToClimb(climb), [climb]);
+  const rowClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+  const climbRowBoard = useMemo(
+    () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
+    [climbBoardConfig, rowBoard],
+  );
 
   return (
     <ClimbListRow
       climb={rowClimb}
-      boardName={rowBoard.boardName}
-      layoutId={rowBoard.layoutId}
-      sizeId={rowBoard.sizeId}
-      setIds={rowBoard.setIds}
-      angle={rowBoard.angle}
-      onPress={onPress}
-      onAddToQueue={onAddToQueue}
-      onOpenPlaylist={onOpenPlaylist}
-      onOpenActions={onOpenActions}
+      boardName={climbRowBoard.boardName}
+      layoutId={climbRowBoard.layoutId}
+      sizeId={climbRowBoard.sizeId}
+      setIds={climbRowBoard.setIds}
+      angle={climbRowBoard.angle}
+      onPress={() => onPress(climb)}
+      onAddToQueue={onAddToQueue ? () => onAddToQueue(climb) : undefined}
+      onOpenPlaylist={onOpenPlaylist ? () => onOpenPlaylist(climb) : undefined}
+      onOpenActions={onOpenActions ? () => onOpenActions(climb) : undefined}
       containerStyle={styles.heroInteractiveContainer}
       contentRowStyle={[styles.heroInteractiveRow, { backgroundColor: surfaceColor }]}
       showSeparator={false}
@@ -521,7 +631,7 @@ function InteractiveHeroRow({
         <NowOnTheWallHeroContent
           climb={climb}
           renderClimb={rowClimb}
-          boardConfig={boardConfig}
+          boardConfig={climbBoardConfig}
           labelColor={labelColor}
           secondaryColor={secondaryColor}
           accentColor={accentColor}
@@ -546,14 +656,15 @@ function NowOnTheWallHero({
   gradeColor,
 }: HeroProps) {
   if (!climb) return null;
-  const renderClimb = presenceClimbToClimb(climb);
+  const renderClimb = presenceClimbToPreviewClimb(climb);
+  const climbBoardConfig = boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null;
 
   return (
     <View style={[styles.hero, { backgroundColor: surfaceColor }]}>
       <NowOnTheWallHeroContent
         climb={climb}
         renderClimb={renderClimb}
-        boardConfig={boardConfig}
+        boardConfig={climbBoardConfig}
         labelColor={labelColor}
         secondaryColor={secondaryColor}
         accentColor={accentColor}
@@ -625,27 +736,35 @@ function InteractiveHistoryRow({
   onOpenPlaylist,
   onOpenActions,
 }: HistoryRowProps & { rowBoard: BoardSheetRowBoard } & InteractiveRowActionProps) {
-  const rowClimb = useMemo(() => presenceClimbToClimb(climb), [climb]);
+  const rowClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+  const climbRowBoard = useMemo(
+    () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
+    [climbBoardConfig, rowBoard],
+  );
 
   return (
     <ClimbListRow
       climb={rowClimb}
-      boardName={rowBoard.boardName}
-      layoutId={rowBoard.layoutId}
-      sizeId={rowBoard.sizeId}
-      setIds={rowBoard.setIds}
-      angle={rowBoard.angle}
-      onPress={onPress}
-      onAddToQueue={onAddToQueue}
-      onOpenPlaylist={onOpenPlaylist}
-      onOpenActions={onOpenActions}
+      boardName={climbRowBoard.boardName}
+      layoutId={climbRowBoard.layoutId}
+      sizeId={climbRowBoard.sizeId}
+      setIds={climbRowBoard.setIds}
+      angle={climbRowBoard.angle}
+      onPress={() => onPress(climb)}
+      onAddToQueue={onAddToQueue ? () => onAddToQueue(climb) : undefined}
+      onOpenPlaylist={onOpenPlaylist ? () => onOpenPlaylist(climb) : undefined}
+      onOpenActions={onOpenActions ? () => onOpenActions(climb) : undefined}
       contentRowStyle={styles.historyInteractiveRow}
       showSeparator={false}
       renderContent={() => (
         <HistoryRowContent
           climb={climb}
           renderClimb={rowClimb}
-          boardConfig={boardConfig}
+          boardConfig={climbBoardConfig}
           labelColor={labelColor}
           secondaryColor={secondaryColor}
           formattedGrade={formattedGrade}
@@ -664,14 +783,18 @@ const HistoryRow = memo(function HistoryRowInner({
   formattedGrade,
   gradeColor,
 }: HistoryRowProps) {
-  const thumbnailClimb = useMemo(() => presenceClimbToClimb(climb), [climb]);
+  const thumbnailClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
 
   return (
     <View style={styles.historyRow}>
       <HistoryRowContent
         climb={climb}
         renderClimb={thumbnailClimb}
-        boardConfig={boardConfig}
+        boardConfig={climbBoardConfig}
         labelColor={labelColor}
         secondaryColor={secondaryColor}
         formattedGrade={formattedGrade}
@@ -799,6 +922,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
   },
   historyInteractiveRow: {
+    backgroundColor: 'transparent',
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[2],
   },

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -11,7 +11,7 @@
 // contexts, which are inert when the `board-presence` flag is off — so this
 // sheet is only ever opened from the BoardPill when the flag is on.
 
-import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Platform, Pressable, StyleSheet, View, type ColorValue } from 'react-native';
 import {
   BottomSheetModal,
@@ -28,9 +28,11 @@ import type { BoardName, BoardPresenceClimb, Climb } from '@boardsesh/shared-sch
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { ClimbListRow } from '../ClimbListRow';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { ClimbListRow, type ClimbListRowRenderContentArgs } from '../ClimbListRow';
 import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
 import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
@@ -75,6 +77,11 @@ export type BoardSheetClimbAction = {
   boardConfig: BoardConfig;
 };
 
+type BoardSheetActionContext = {
+  actionBoardConfig: BoardConfig;
+  cacheKey: string;
+};
+
 function actionBoardConfigForPresenceClimb(boardConfig: BoardConfig, presenceClimb: BoardPresenceClimb): BoardConfig {
   const angle = presenceClimb.angle ?? boardConfig.angle;
   return angle === boardConfig.angle ? boardConfig : { ...boardConfig, angle };
@@ -101,11 +108,32 @@ function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
   ].join(':');
 }
 
+function actionContextForPresenceClimb(
+  boardConfig: BoardConfig | null,
+  presenceClimb: BoardPresenceClimb,
+): BoardSheetActionContext | null {
+  if (!boardConfig) return null;
+  const actionBoardConfig = actionBoardConfigForPresenceClimb(boardConfig, presenceClimb);
+  return {
+    actionBoardConfig,
+    cacheKey: actionCacheKey(actionBoardConfig, presenceClimb.climbUuid),
+  };
+}
+
+function getActionClimbCacheEntry(cache: Map<string, Climb>, key: string): Climb | null {
+  const cachedClimb = cache.get(key);
+  if (!cachedClimb) return null;
+  cache.delete(key);
+  cache.set(key, cachedClimb);
+  return cachedClimb;
+}
+
 function setActionClimbCacheEntry(cache: Map<string, Climb>, key: string, climb: Climb): void {
+  if (cache.has(key)) cache.delete(key);
   cache.set(key, climb);
   if (cache.size <= ACTION_CLIMB_CACHE_LIMIT) return;
   const oldestKey = cache.keys().next().value;
-  if (oldestKey) cache.delete(oldestKey);
+  if (oldestKey !== undefined) cache.delete(oldestKey);
 }
 
 /**
@@ -161,8 +189,11 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
   const { systemColors, brandColors, sheet } = useTheme();
+  const { showToast } = useToast();
   const { formatGrade } = useGradeFormat();
   const sheetRef = useRef<BottomSheetModal>(null);
+  const boardConfigRef = useRef(boardConfig);
+  boardConfigRef.current = boardConfig;
 
   const { currentClimb } = useBoardPresenceCurrent();
   const { history, stats } = useBoardPresenceFeed();
@@ -183,6 +214,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
 
   const lastReceivedWallClimbRef = useRef<string | null>(null);
   const actionClimbCacheRef = useRef(new Map<string, Climb>());
+  const actionClimbRequestRef = useRef(new Map<string, Promise<Climb | null>>());
+  const pendingActionKeysRef = useRef(new Set<string>());
+  const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
   useEffect(() => {
     const currentClimbUuid = currentClimb?.climbUuid;
     if (!currentClimbUuid) return;
@@ -201,13 +235,40 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   );
   const canUseInteractiveRows = !!rowBoard && !!onClimbPress;
 
-  const resolveAction = useCallback(
-    async (presenceClimb: BoardPresenceClimb): Promise<BoardSheetClimbAction | null> => {
-      if (!boardConfig) return null;
+  const getActionContext = useCallback((presenceClimb: BoardPresenceClimb) => {
+    return actionContextForPresenceClimb(boardConfigRef.current, presenceClimb);
+  }, []);
 
-      const actionBoardConfig = actionBoardConfigForPresenceClimb(boardConfig, presenceClimb);
-      const cacheKey = actionCacheKey(actionBoardConfig, presenceClimb.climbUuid);
-      const cachedClimb = actionClimbCacheRef.current.get(cacheKey);
+  const isActionLoading = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      const actionContext = getActionContext(presenceClimb);
+      return actionContext ? pendingActionKeys.has(actionContext.cacheKey) : false;
+    },
+    [getActionContext, pendingActionKeys],
+  );
+
+  const setActionLoading = useCallback((cacheKey: string, loading: boolean) => {
+    const pendingKeys = pendingActionKeysRef.current;
+    if (loading) {
+      if (pendingKeys.has(cacheKey)) return;
+      pendingKeys.add(cacheKey);
+    } else if (!pendingKeys.delete(cacheKey)) {
+      return;
+    }
+    setPendingActionKeys(new Set(pendingKeys));
+  }, []);
+
+  const notifyActionFailed = useCallback(() => {
+    showToast(t('mobile.boardPresence.actionFailed'), 'error');
+  }, [showToast, t]);
+
+  const resolveAction = useCallback(
+    async (
+      presenceClimb: BoardPresenceClimb,
+      actionContext: BoardSheetActionContext,
+    ): Promise<BoardSheetClimbAction | null> => {
+      const { actionBoardConfig, cacheKey } = actionContext;
+      const cachedClimb = getActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey);
       if (cachedClimb) {
         return {
           climb: cachedClimb,
@@ -216,73 +277,103 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
         };
       }
 
-      try {
-        const response = await getHttpClient().request<GetClimbQueryResponse>(GET_CLIMB, {
-          boardName: actionBoardConfig.boardName,
-          layoutId: actionBoardConfig.layoutId,
-          sizeId: actionBoardConfig.sizeId,
-          setIds: actionBoardConfig.setIds,
-          angle: actionBoardConfig.angle,
-          climbUuid: presenceClimb.climbUuid,
-        });
-        if (!response.climb) return null;
-        setActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey, response.climb);
-        return {
-          climb: response.climb,
-          queueItemUuid: presenceClimb.queueItemUuid ?? null,
-          boardConfig: actionBoardConfig,
-        };
-      } catch (error) {
-        console.warn('Failed to load board-sheet climb action', error);
-        return null;
+      let climbRequest = actionClimbRequestRef.current.get(cacheKey);
+      if (!climbRequest) {
+        climbRequest = getHttpClient()
+          .request<GetClimbQueryResponse>(GET_CLIMB, {
+            boardName: actionBoardConfig.boardName,
+            layoutId: actionBoardConfig.layoutId,
+            sizeId: actionBoardConfig.sizeId,
+            setIds: actionBoardConfig.setIds,
+            angle: actionBoardConfig.angle,
+            climbUuid: presenceClimb.climbUuid,
+          })
+          .then((response): Climb | null => {
+            if (!response.climb) {
+              console.warn('Board-sheet climb action returned no climb', presenceClimb.climbUuid);
+              return null;
+            }
+            setActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey, response.climb);
+            return response.climb;
+          })
+          .catch((error: unknown): null => {
+            console.warn('Failed to load board-sheet climb action', error);
+            return null;
+          })
+          .finally(() => {
+            actionClimbRequestRef.current.delete(cacheKey);
+          });
+        actionClimbRequestRef.current.set(cacheKey, climbRequest);
       }
+
+      const loadedClimb = await climbRequest;
+      if (!loadedClimb) return null;
+      return {
+        climb: loadedClimb,
+        queueItemUuid: presenceClimb.queueItemUuid ?? null,
+        boardConfig: actionBoardConfig,
+      };
     },
-    [boardConfig],
+    [],
+  );
+
+  const runInteractiveAction = useCallback(
+    (presenceClimb: BoardPresenceClimb, callback: (action: BoardSheetClimbAction) => void, closeOnSuccess = false) => {
+      const actionContext = getActionContext(presenceClimb);
+      if (!actionContext) {
+        notifyActionFailed();
+        return;
+      }
+
+      if (pendingActionKeysRef.current.has(actionContext.cacheKey)) return;
+
+      setActionLoading(actionContext.cacheKey, true);
+      void resolveAction(presenceClimb, actionContext)
+        .then((action) => {
+          if (!action) {
+            notifyActionFailed();
+            return;
+          }
+          callback(action);
+          if (closeOnSuccess) onClose();
+        })
+        .finally(() => {
+          setActionLoading(actionContext.cacheKey, false);
+        });
+    },
+    [getActionContext, notifyActionFailed, onClose, resolveAction, setActionLoading],
   );
 
   const handleInteractiveClimbPress = useCallback(
     (presenceClimb: BoardPresenceClimb) => {
       if (!onClimbPress) return;
-      void resolveAction(presenceClimb).then((action) => {
-        if (!action) return;
-        onClimbPress(action);
-        onClose();
-      });
+      runInteractiveAction(presenceClimb, onClimbPress, true);
     },
-    [onClimbPress, onClose, resolveAction],
+    [onClimbPress, runInteractiveAction],
   );
 
   const handleInteractiveAddToQueue = useCallback(
     (presenceClimb: BoardPresenceClimb) => {
       if (!onAddToQueue) return;
-      void resolveAction(presenceClimb).then((action) => {
-        if (!action) return;
-        onAddToQueue(action);
-      });
+      runInteractiveAction(presenceClimb, onAddToQueue);
     },
-    [onAddToQueue, resolveAction],
+    [onAddToQueue, runInteractiveAction],
   );
 
   const handleInteractiveOpenPlaylist = useCallback(
     (presenceClimb: BoardPresenceClimb) => {
       if (!onOpenPlaylist) return;
-      void resolveAction(presenceClimb).then((action) => {
-        if (!action) return;
-        onOpenPlaylist(action);
-      });
+      runInteractiveAction(presenceClimb, onOpenPlaylist);
     },
-    [onOpenPlaylist, resolveAction],
+    [onOpenPlaylist, runInteractiveAction],
   );
 
   const handleInteractiveOpenActions = useCallback(
     (presenceClimb: BoardPresenceClimb) => {
       if (!onOpenActions) return;
-      void resolveAction(presenceClimb).then((action) => {
-        if (!action) return;
-        onOpenActions(action);
-      });
+      runInteractiveAction(presenceClimb, onOpenActions);
     },
-    [onOpenActions, resolveAction],
+    [onOpenActions, runInteractiveAction],
   );
 
   useImperativeHandle(ref, () => ({
@@ -328,6 +419,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             secondaryColor={systemColors.secondaryLabel}
             formattedGrade={formattedGrade}
             gradeColor={gradeColor}
+            isActionLoading={isActionLoading(item)}
             onPress={handleInteractiveClimbPress}
             onAddToQueue={handleInteractiveAddToQueue}
             onOpenPlaylist={handleInteractiveOpenPlaylist}
@@ -358,6 +450,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       handleInteractiveAddToQueue,
       handleInteractiveOpenPlaylist,
       handleInteractiveOpenActions,
+      isActionLoading,
     ],
   );
 
@@ -375,6 +468,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             surfaceColor={systemColors.secondaryBackground}
             formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
             gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+            isActionLoading={isActionLoading(currentClimb)}
             onPress={handleInteractiveClimbPress}
             onAddToQueue={handleInteractiveAddToQueue}
             onOpenPlaylist={handleInteractiveOpenPlaylist}
@@ -451,6 +545,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       handleInteractiveAddToQueue,
       handleInteractiveOpenPlaylist,
       handleInteractiveOpenActions,
+      isActionLoading,
     ],
   );
 
@@ -559,6 +654,7 @@ type HeroContentProps = Omit<HeroProps, 'climb' | 'surfaceColor'> & {
   climb: BoardPresenceClimb;
   renderClimb: Climb;
   thumbnailSize?: number;
+  isActionLoading?: boolean;
 };
 
 function NowOnTheWallHeroContent({
@@ -571,6 +667,7 @@ function NowOnTheWallHeroContent({
   formattedGrade,
   gradeColor,
   thumbnailSize,
+  isActionLoading = false,
 }: HeroContentProps) {
   const { t } = useTranslation('session');
   const litBy = climb.sentByDisplayName?.trim();
@@ -588,6 +685,13 @@ function NowOnTheWallHeroContent({
             <Text variant="headline" style={[styles.heroGrade, { color: gradeColor }]}>
               {formattedGrade}
             </Text>
+          ) : null}
+          {isActionLoading ? (
+            <ActivityIndicator
+              size="small"
+              accessibilityLabel={t('mobile.boardPresence.actionLoading')}
+              style={styles.actionSpinner}
+            />
           ) : null}
         </View>
         {setter ? (
@@ -608,6 +712,7 @@ function NowOnTheWallHeroContent({
 type InteractiveHeroRowProps = HeroProps & {
   climb: BoardPresenceClimb;
   rowBoard: BoardSheetRowBoard;
+  isActionLoading: boolean;
 } & InteractiveRowActionProps;
 
 const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
@@ -620,6 +725,7 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
   surfaceColor,
   formattedGrade,
   gradeColor,
+  isActionLoading,
   onPress,
   onAddToQueue,
   onOpenPlaylist,
@@ -648,10 +754,10 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
     onOpenActions?.(climb);
   }, [climb, onOpenActions]);
   const renderContent = useCallback(
-    () => (
+    ({ climb: renderClimb }: ClimbListRowRenderContentArgs) => (
       <NowOnTheWallHeroContent
         climb={climb}
-        renderClimb={rowClimb}
+        renderClimb={renderClimb}
         boardConfig={climbBoardConfig}
         labelColor={labelColor}
         secondaryColor={secondaryColor}
@@ -659,9 +765,10 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
         formattedGrade={formattedGrade}
         gradeColor={gradeColor}
         thumbnailSize={52}
+        isActionLoading={isActionLoading}
       />
     ),
-    [accentColor, climb, climbBoardConfig, formattedGrade, gradeColor, labelColor, rowClimb, secondaryColor],
+    [accentColor, climb, climbBoardConfig, formattedGrade, gradeColor, isActionLoading, labelColor, secondaryColor],
   );
 
   return (
@@ -684,7 +791,7 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
   );
 });
 
-function NowOnTheWallHero({
+const NowOnTheWallHero = memo(function NowOnTheWallHeroInner({
   climb,
   boardConfig,
   labelColor,
@@ -694,9 +801,13 @@ function NowOnTheWallHero({
   formattedGrade,
   gradeColor,
 }: HeroProps) {
-  if (!climb) return null;
-  const renderClimb = presenceClimbToPreviewClimb(climb);
-  const climbBoardConfig = boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null;
+  const renderClimb = useMemo(() => (climb ? presenceClimbToPreviewClimb(climb) : null), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig && climb ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+
+  if (!climb || !renderClimb) return null;
 
   return (
     <View style={[styles.hero, { backgroundColor: surfaceColor }]}>
@@ -712,7 +823,7 @@ function NowOnTheWallHero({
       />
     </View>
   );
-}
+});
 
 type HistoryRowProps = {
   climb: BoardPresenceClimb;
@@ -725,6 +836,7 @@ type HistoryRowProps = {
 
 type HistoryRowContentProps = HistoryRowProps & {
   renderClimb: Climb;
+  isActionLoading?: boolean;
 };
 
 function HistoryRowContent({
@@ -735,6 +847,7 @@ function HistoryRowContent({
   secondaryColor,
   formattedGrade,
   gradeColor,
+  isActionLoading = false,
 }: HistoryRowContentProps) {
   const { t } = useTranslation('session');
   const litBy = climb.sentByDisplayName?.trim();
@@ -757,12 +870,20 @@ function HistoryRowContent({
           {formattedGrade}
         </Text>
       ) : null}
+      {isActionLoading ? (
+        <ActivityIndicator
+          size="small"
+          accessibilityLabel={t('mobile.boardPresence.actionLoading')}
+          style={styles.actionSpinner}
+        />
+      ) : null}
     </>
   );
 }
 
 type InteractiveHistoryRowProps = HistoryRowProps & {
   rowBoard: BoardSheetRowBoard;
+  isActionLoading: boolean;
 } & InteractiveRowActionProps;
 
 const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
@@ -773,6 +894,7 @@ const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
   secondaryColor,
   formattedGrade,
   gradeColor,
+  isActionLoading,
   onPress,
   onAddToQueue,
   onOpenPlaylist,
@@ -800,18 +922,19 @@ const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
     onOpenActions?.(climb);
   }, [climb, onOpenActions]);
   const renderContent = useCallback(
-    () => (
+    ({ climb: renderClimb }: ClimbListRowRenderContentArgs) => (
       <HistoryRowContent
         climb={climb}
-        renderClimb={rowClimb}
+        renderClimb={renderClimb}
         boardConfig={climbBoardConfig}
         labelColor={labelColor}
         secondaryColor={secondaryColor}
         formattedGrade={formattedGrade}
         gradeColor={gradeColor}
+        isActionLoading={isActionLoading}
       />
     ),
-    [climb, climbBoardConfig, formattedGrade, gradeColor, labelColor, rowClimb, secondaryColor],
+    [climb, climbBoardConfig, formattedGrade, gradeColor, isActionLoading, labelColor, secondaryColor],
   );
 
   return (
@@ -996,6 +1119,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     minWidth: 40,
     textAlign: 'right',
+  },
+  actionSpinner: {
+    width: 20,
+    height: 20,
   },
   empty: {
     alignItems: 'center',

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -39,6 +39,8 @@ import { getHttpClient } from '../../lib/graphql/client';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 import { spacing, borderRadius } from '../../theme/tokens';
 
+const ACTION_CLIMB_CACHE_LIMIT = 50;
+
 function presenceClimbToPreviewClimb(presenceClimb: BoardPresenceClimb): Climb {
   return {
     uuid: presenceClimb.climbUuid,
@@ -97,6 +99,13 @@ function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
     boardConfig.angle,
     climbUuid,
   ].join(':');
+}
+
+function setActionClimbCacheEntry(cache: Map<string, Climb>, key: string, climb: Climb): void {
+  cache.set(key, climb);
+  if (cache.size <= ACTION_CLIMB_CACHE_LIMIT) return;
+  const oldestKey = cache.keys().next().value;
+  if (oldestKey) cache.delete(oldestKey);
 }
 
 /**
@@ -208,7 +217,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
           climbUuid: presenceClimb.climbUuid,
         });
         if (!response.climb) return null;
-        actionClimbCacheRef.current.set(cacheKey, response.climb);
+        setActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey, response.climb);
         return {
           climb: response.climb,
           queueItemUuid: presenceClimb.queueItemUuid ?? null,
@@ -537,7 +546,7 @@ type InteractiveRowActionProps = {
   onOpenActions?: (climb: BoardPresenceClimb) => void;
 };
 
-type HeroContentProps = Omit<HeroProps, 'climb'> & {
+type HeroContentProps = Omit<HeroProps, 'climb' | 'surfaceColor'> & {
   climb: BoardPresenceClimb;
   renderClimb: Climb;
   thumbnailSize?: number;
@@ -587,7 +596,12 @@ function NowOnTheWallHeroContent({
   );
 }
 
-function InteractiveHeroRow({
+type InteractiveHeroRowProps = HeroProps & {
+  climb: BoardPresenceClimb;
+  rowBoard: BoardSheetRowBoard;
+} & InteractiveRowActionProps;
+
+const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
   climb,
   rowBoard,
   boardConfig,
@@ -601,7 +615,7 @@ function InteractiveHeroRow({
   onAddToQueue,
   onOpenPlaylist,
   onOpenActions,
-}: HeroProps & { climb: BoardPresenceClimb; rowBoard: BoardSheetRowBoard } & InteractiveRowActionProps) {
+}: InteractiveHeroRowProps) {
   const rowClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
   const climbBoardConfig = useMemo(
     () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
@@ -610,6 +624,35 @@ function InteractiveHeroRow({
   const climbRowBoard = useMemo(
     () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
     [climbBoardConfig, rowBoard],
+  );
+  const contentRowStyle = useMemo(() => [styles.heroInteractiveRow, { backgroundColor: surfaceColor }], [surfaceColor]);
+  const handlePress = useCallback(() => {
+    onPress(climb);
+  }, [climb, onPress]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue?.(climb);
+  }, [climb, onAddToQueue]);
+  const handleOpenPlaylist = useCallback(() => {
+    onOpenPlaylist?.(climb);
+  }, [climb, onOpenPlaylist]);
+  const handleOpenActions = useCallback(() => {
+    onOpenActions?.(climb);
+  }, [climb, onOpenActions]);
+  const renderContent = useCallback(
+    () => (
+      <NowOnTheWallHeroContent
+        climb={climb}
+        renderClimb={rowClimb}
+        boardConfig={climbBoardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        accentColor={accentColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+        thumbnailSize={52}
+      />
+    ),
+    [accentColor, climb, climbBoardConfig, formattedGrade, gradeColor, labelColor, rowClimb, secondaryColor],
   );
 
   return (
@@ -620,30 +663,17 @@ function InteractiveHeroRow({
       sizeId={climbRowBoard.sizeId}
       setIds={climbRowBoard.setIds}
       angle={climbRowBoard.angle}
-      onPress={() => onPress(climb)}
-      onAddToQueue={onAddToQueue ? () => onAddToQueue(climb) : undefined}
-      onOpenPlaylist={onOpenPlaylist ? () => onOpenPlaylist(climb) : undefined}
-      onOpenActions={onOpenActions ? () => onOpenActions(climb) : undefined}
+      onPress={handlePress}
+      onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
+      onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
+      onOpenActions={onOpenActions ? handleOpenActions : undefined}
       containerStyle={styles.heroInteractiveContainer}
-      contentRowStyle={[styles.heroInteractiveRow, { backgroundColor: surfaceColor }]}
+      contentRowStyle={contentRowStyle}
       showSeparator={false}
-      renderContent={() => (
-        <NowOnTheWallHeroContent
-          climb={climb}
-          renderClimb={rowClimb}
-          boardConfig={climbBoardConfig}
-          labelColor={labelColor}
-          secondaryColor={secondaryColor}
-          accentColor={accentColor}
-          surfaceColor={surfaceColor}
-          formattedGrade={formattedGrade}
-          gradeColor={gradeColor}
-          thumbnailSize={52}
-        />
-      )}
+      renderContent={renderContent}
     />
   );
-}
+});
 
 function NowOnTheWallHero({
   climb,
@@ -668,7 +698,6 @@ function NowOnTheWallHero({
         labelColor={labelColor}
         secondaryColor={secondaryColor}
         accentColor={accentColor}
-        surfaceColor={surfaceColor}
         formattedGrade={formattedGrade}
         gradeColor={gradeColor}
       />
@@ -723,7 +752,11 @@ function HistoryRowContent({
   );
 }
 
-function InteractiveHistoryRow({
+type InteractiveHistoryRowProps = HistoryRowProps & {
+  rowBoard: BoardSheetRowBoard;
+} & InteractiveRowActionProps;
+
+const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
   climb,
   rowBoard,
   boardConfig,
@@ -735,7 +768,7 @@ function InteractiveHistoryRow({
   onAddToQueue,
   onOpenPlaylist,
   onOpenActions,
-}: HistoryRowProps & { rowBoard: BoardSheetRowBoard } & InteractiveRowActionProps) {
+}: InteractiveHistoryRowProps) {
   const rowClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
   const climbBoardConfig = useMemo(
     () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
@@ -744,6 +777,32 @@ function InteractiveHistoryRow({
   const climbRowBoard = useMemo(
     () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
     [climbBoardConfig, rowBoard],
+  );
+  const handlePress = useCallback(() => {
+    onPress(climb);
+  }, [climb, onPress]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue?.(climb);
+  }, [climb, onAddToQueue]);
+  const handleOpenPlaylist = useCallback(() => {
+    onOpenPlaylist?.(climb);
+  }, [climb, onOpenPlaylist]);
+  const handleOpenActions = useCallback(() => {
+    onOpenActions?.(climb);
+  }, [climb, onOpenActions]);
+  const renderContent = useCallback(
+    () => (
+      <HistoryRowContent
+        climb={climb}
+        renderClimb={rowClimb}
+        boardConfig={climbBoardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+      />
+    ),
+    [climb, climbBoardConfig, formattedGrade, gradeColor, labelColor, rowClimb, secondaryColor],
   );
 
   return (
@@ -754,26 +813,16 @@ function InteractiveHistoryRow({
       sizeId={climbRowBoard.sizeId}
       setIds={climbRowBoard.setIds}
       angle={climbRowBoard.angle}
-      onPress={() => onPress(climb)}
-      onAddToQueue={onAddToQueue ? () => onAddToQueue(climb) : undefined}
-      onOpenPlaylist={onOpenPlaylist ? () => onOpenPlaylist(climb) : undefined}
-      onOpenActions={onOpenActions ? () => onOpenActions(climb) : undefined}
+      onPress={handlePress}
+      onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
+      onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
+      onOpenActions={onOpenActions ? handleOpenActions : undefined}
       contentRowStyle={styles.historyInteractiveRow}
       showSeparator={false}
-      renderContent={() => (
-        <HistoryRowContent
-          climb={climb}
-          renderClimb={rowClimb}
-          boardConfig={climbBoardConfig}
-          labelColor={labelColor}
-          secondaryColor={secondaryColor}
-          formattedGrade={formattedGrade}
-          gradeColor={gradeColor}
-        />
-      )}
+      renderContent={renderContent}
     />
   );
-}
+});
 
 const HistoryRow = memo(function HistoryRowInner({
   climb,

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -108,6 +108,13 @@ function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
   ].join(':');
 }
 
+function boardConfigActionSignature(boardConfig: BoardConfig | null): string {
+  if (!boardConfig) return 'none';
+  return [boardConfig.boardName, boardConfig.layoutId, boardConfig.sizeId, boardConfig.setIds, boardConfig.angle].join(
+    ':',
+  );
+}
+
 function actionContextForPresenceClimb(
   boardConfig: BoardConfig | null,
   presenceClimb: BoardPresenceClimb,
@@ -194,6 +201,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   const sheetRef = useRef<BottomSheetModal>(null);
   const boardConfigRef = useRef(boardConfig);
   boardConfigRef.current = boardConfig;
+  const boardConfigSignature = useMemo(() => boardConfigActionSignature(boardConfig), [boardConfig]);
+  const boardConfigSignatureRef = useRef(boardConfigSignature);
+  boardConfigSignatureRef.current = boardConfigSignature;
 
   const { currentClimb } = useBoardPresenceCurrent();
   const { history, stats } = useBoardPresenceFeed();
@@ -216,6 +226,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   const actionClimbCacheRef = useRef(new Map<string, Climb>());
   const actionClimbRequestRef = useRef(new Map<string, Promise<Climb | null>>());
   const pendingActionKeysRef = useRef(new Set<string>());
+  const actionGenerationRef = useRef(0);
   const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
   useEffect(() => {
     const currentClimbUuid = currentClimb?.climbUuid;
@@ -233,7 +244,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     () => (boardConfig ? rowBoardForBoardConfig(boardConfig) : null),
     [boardConfig],
   );
-  const canUseInteractiveRows = !!rowBoard && !!onClimbPress;
+  const canUseInteractiveRows = !!rowBoard && (!!onClimbPress || !!onAddToQueue || !!onOpenPlaylist || !!onOpenActions);
 
   const getActionContext = useCallback((presenceClimb: BoardPresenceClimb) => {
     return actionContextForPresenceClimb(boardConfigRef.current, presenceClimb);
@@ -257,6 +268,22 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     }
     setPendingActionKeys(new Set(pendingKeys));
   }, []);
+
+  const clearPendingActionKeys = useCallback(() => {
+    const pendingKeys = pendingActionKeysRef.current;
+    if (pendingKeys.size === 0) return;
+    pendingKeys.clear();
+    setPendingActionKeys(new Set());
+  }, []);
+
+  const invalidatePendingActions = useCallback(() => {
+    actionGenerationRef.current += 1;
+    clearPendingActionKeys();
+  }, [clearPendingActionKeys]);
+
+  useEffect(() => {
+    invalidatePendingActions();
+  }, [boardConfigSignature, invalidatePendingActions]);
 
   const notifyActionFailed = useCallback(() => {
     showToast(t('mobile.boardPresence.actionFailed'), 'error');
@@ -327,21 +354,37 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
 
       if (pendingActionKeysRef.current.has(actionContext.cacheKey)) return;
 
+      const actionGeneration = actionGenerationRef.current;
+      const actionBoardSignature = boardConfigSignatureRef.current;
       setActionLoading(actionContext.cacheKey, true);
       void resolveAction(presenceClimb, actionContext)
         .then((action) => {
+          if (
+            actionGeneration !== actionGenerationRef.current ||
+            actionBoardSignature !== boardConfigSignatureRef.current
+          ) {
+            return;
+          }
           if (!action) {
             notifyActionFailed();
             return;
           }
-          callback(action);
-          if (closeOnSuccess) onClose();
+          try {
+            callback(action);
+            if (closeOnSuccess) {
+              invalidatePendingActions();
+              onClose();
+            }
+          } catch (error) {
+            console.warn('Failed to run board-sheet climb action', error);
+            notifyActionFailed();
+          }
         })
         .finally(() => {
           setActionLoading(actionContext.cacheKey, false);
         });
     },
-    [getActionContext, notifyActionFailed, onClose, resolveAction, setActionLoading],
+    [getActionContext, invalidatePendingActions, notifyActionFailed, onClose, resolveAction, setActionLoading],
   );
 
   const handleInteractiveClimbPress = useCallback(
@@ -376,6 +419,21 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     [onOpenActions, runInteractiveAction],
   );
 
+  const handleClose = useCallback(() => {
+    invalidatePendingActions();
+    onClose();
+  }, [invalidatePendingActions, onClose]);
+
+  const handleDismissed = useCallback(() => {
+    invalidatePendingActions();
+    onDismissed?.();
+  }, [invalidatePendingActions, onDismissed]);
+
+  const handleSwitchBoard = useCallback(() => {
+    invalidatePendingActions();
+    onSwitchBoard();
+  }, [invalidatePendingActions, onSwitchBoard]);
+
   useImperativeHandle(ref, () => ({
     present: () => {
       if (historyCountRef.current > 0) {
@@ -387,6 +445,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       sheetRef.current?.present();
     },
     dismiss: () => {
+      invalidatePendingActions();
       sheetRef.current?.dismiss();
     },
   }));
@@ -420,7 +479,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             formattedGrade={formattedGrade}
             gradeColor={gradeColor}
             isActionLoading={isActionLoading(item)}
-            onPress={handleInteractiveClimbPress}
+            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
             onAddToQueue={handleInteractiveAddToQueue}
             onOpenPlaylist={handleInteractiveOpenPlaylist}
             onOpenActions={handleInteractiveOpenActions}
@@ -451,6 +510,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       handleInteractiveOpenPlaylist,
       handleInteractiveOpenActions,
       isActionLoading,
+      onClimbPress,
     ],
   );
 
@@ -469,7 +529,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
             gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
             isActionLoading={isActionLoading(currentClimb)}
-            onPress={handleInteractiveClimbPress}
+            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
             onAddToQueue={handleInteractiveAddToQueue}
             onOpenPlaylist={handleInteractiveOpenPlaylist}
             onOpenActions={handleInteractiveOpenActions}
@@ -546,6 +606,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       handleInteractiveOpenPlaylist,
       handleInteractiveOpenActions,
       isActionLoading,
+      onClimbPress,
     ],
   );
 
@@ -577,14 +638,14 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       stackBehavior="push"
       enablePanDownToClose
       backdropComponent={renderBackdrop}
-      onDismiss={onDismissed}
+      onDismiss={handleDismissed}
       handleIndicatorStyle={sheet.handleStyle}
       backgroundComponent={GlassSheetBackground}
       style={styles.sheet}
     >
       <View style={[styles.header, { borderBottomColor: systemColors.separator }]}>
         <Pressable
-          onPress={onClose}
+          onPress={handleClose}
           hitSlop={8}
           accessibilityRole="button"
           accessibilityLabel={t('mobile.boardPresence.close')}
@@ -608,7 +669,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       />
 
       <Pressable
-        onPress={onSwitchBoard}
+        onPress={handleSwitchBoard}
         accessibilityRole="button"
         accessibilityLabel={t('mobile.boardPresence.switchBoardAria')}
         style={[styles.footer, { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] }]}
@@ -644,7 +705,7 @@ type HeroProps = {
 };
 
 type InteractiveRowActionProps = {
-  onPress: (climb: BoardPresenceClimb) => void;
+  onPress?: (climb: BoardPresenceClimb) => void;
   onAddToQueue?: (climb: BoardPresenceClimb) => void;
   onOpenPlaylist?: (climb: BoardPresenceClimb) => void;
   onOpenActions?: (climb: BoardPresenceClimb) => void;
@@ -742,7 +803,7 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
   );
   const contentRowStyle = useMemo(() => [styles.heroInteractiveRow, { backgroundColor: surfaceColor }], [surfaceColor]);
   const handlePress = useCallback(() => {
-    onPress(climb);
+    onPress?.(climb);
   }, [climb, onPress]);
   const handleAddToQueue = useCallback(() => {
     onAddToQueue?.(climb);
@@ -779,7 +840,7 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
       sizeId={climbRowBoard.sizeId}
       setIds={climbRowBoard.setIds}
       angle={climbRowBoard.angle}
-      onPress={handlePress}
+      onPress={onPress ? handlePress : undefined}
       onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
       onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
       onOpenActions={onOpenActions ? handleOpenActions : undefined}
@@ -910,7 +971,7 @@ const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
     [climbBoardConfig, rowBoard],
   );
   const handlePress = useCallback(() => {
-    onPress(climb);
+    onPress?.(climb);
   }, [climb, onPress]);
   const handleAddToQueue = useCallback(() => {
     onAddToQueue?.(climb);
@@ -945,7 +1006,7 @@ const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
       sizeId={climbRowBoard.sizeId}
       setIds={climbRowBoard.setIds}
       angle={climbRowBoard.angle}
-      onPress={handlePress}
+      onPress={onPress ? handlePress : undefined}
       onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
       onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
       onOpenActions={onOpenActions ? handleOpenActions : undefined}
@@ -1103,7 +1164,6 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
   },
   historyInteractiveRow: {
-    backgroundColor: 'transparent',
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[2],
   },

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -349,14 +349,32 @@ describe('BoardSheet', () => {
       }),
     );
 
-    // Hero climb name + history item name both render.
-    expect(container.textContent).toContain('Climb c1');
+    // The current climb renders as the hero only; it is filtered out of history.
+    expect(container.textContent?.match(/Climb c1/g) ?? []).toHaveLength(1);
     expect(container.textContent).toContain('Older Climb');
     // Stats tiles.
     expect(container.textContent).toContain('14');
     expect(container.textContent).toContain('mobile.boardPresence.historyHeader');
     // History list rendered one node per item.
     expect(container.querySelector('[data-list="true"]')).not.toBeNull();
+  });
+
+  it('does not show a history header when the only history entry is the current climb', () => {
+    presence.currentClimb = makeClimb('c1', 3);
+    presence.history = [makeClimb('c1', 3)];
+
+    const { container } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    expect(container.textContent?.match(/Climb c1/g) ?? []).toHaveLength(1);
+    expect(container.textContent).not.toContain('mobile.boardPresence.historyHeader');
   });
 
   it('hydrates hero and lit-on-this-wall rows before invoking shared climb actions', async () => {

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, createRef, forwardRef, useImperativeHandle, type ReactNode, type Ref } from 'react';
-import type { BoardPresenceClimb, BoardPresenceStats } from '@boardsesh/shared-schema';
+import type { BoardPresenceClimb, BoardPresenceStats, Climb } from '@boardsesh/shared-schema';
 
 const presence = vi.hoisted(() => ({
   currentClimb: null as BoardPresenceClimb | null,
@@ -16,6 +16,10 @@ const presenceControls = vi.hoisted(() => ({
 
 const analytics = vi.hoisted(() => ({
   track: vi.fn(),
+}));
+
+const graphql = vi.hoisted(() => ({
+  request: vi.fn(),
 }));
 
 const sheetModal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
@@ -100,6 +104,9 @@ vi.mock('../../../providers/board-presence-provider', () => ({
 
 vi.mock('../../../lib/analytics', () => ({
   track: analytics.track,
+}));
+vi.mock('../../../lib/graphql/client', () => ({
+  getHttpClient: () => graphql,
 }));
 
 vi.mock('../../GlassSheetBackground', () => ({ GlassSheetBackground: () => createElement('div', null) }));
@@ -223,6 +230,25 @@ function makeClimb(climbUuid: string, seq: number, overrides: Partial<BoardPrese
   };
 }
 
+function makeFullClimb(uuid: string, overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid,
+    name: `Hydrated ${uuid}`,
+    frames: 'hydrated-frames',
+    setter_username: 'Hydrated Setter',
+    angle: 40,
+    ascensionist_count: 12,
+    difficulty: 'V6',
+    quality_average: '3.5',
+    stars: 4,
+    difficulty_error: '0.4',
+    benchmark_difficulty: null,
+    framesCount: 3,
+    framesPace: 700,
+    ...overrides,
+  };
+}
+
 const noop = () => {};
 const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
 
@@ -233,6 +259,7 @@ describe('BoardSheet', () => {
     presence.stats = null;
     presenceControls.boardId = 123;
     analytics.track.mockClear();
+    graphql.request.mockReset();
     sheetModal.present.mockClear();
     sheetModal.dismiss.mockClear();
     climbRows.props = [];
@@ -343,14 +370,40 @@ describe('BoardSheet', () => {
     expect(container.querySelector('[data-list="true"]')).not.toBeNull();
   });
 
-  it('wires the hero and lit-on-this-wall rows to the shared climb actions', () => {
-    presence.currentClimb = makeClimb('hero-climb', 3, { frames: 'hero-frames', grade: 'V7' });
-    presence.history = [makeClimb('old-climb', 2, { frames: 'old-frames', grade: 'V4', angle: 30 })];
+  it('hydrates hero and lit-on-this-wall rows before invoking shared climb actions', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, {
+      frames: 'hero-frames',
+      grade: 'V7',
+      queueItemUuid: 'queue-hero',
+    });
+    presence.history = [
+      makeClimb('old-climb', 2, {
+        frames: 'old-frames',
+        grade: 'V4',
+        angle: 30,
+        queueItemUuid: 'queue-old',
+      }),
+    ];
     const onClose = vi.fn();
     const onClimbPress = vi.fn();
     const onAddToQueue = vi.fn();
     const onOpenPlaylist = vi.fn();
     const onOpenActions = vi.fn();
+    const heroDetail = makeFullClimb('hero-climb', {
+      name: 'Hydrated Hero',
+      frames: 'hydrated-hero-frames',
+      difficulty: 'V8',
+      benchmark_difficulty: 'V8',
+    });
+    const oldDetail = makeFullClimb('old-climb', {
+      name: 'Hydrated Old',
+      frames: 'hydrated-old-frames',
+      angle: 30,
+      difficulty: 'V5',
+      framesCount: 2,
+      framesPace: 900,
+    });
+    graphql.request.mockResolvedValueOnce({ climb: heroDetail }).mockResolvedValueOnce({ climb: oldDetail });
 
     const { getByLabelText } = render(
       createElement(BoardSheet, {
@@ -367,34 +420,77 @@ describe('BoardSheet', () => {
     );
 
     fireEvent.click(getByLabelText('press hero-climb'));
-    expect(onClimbPress).toHaveBeenCalledWith(
-      expect.objectContaining({
-        uuid: 'hero-climb',
-        name: 'Climb hero-climb',
-        frames: 'hero-frames',
-        difficulty: 'V7',
-        setter_username: 'Some Setter',
-        angle: 40,
+    await waitFor(() =>
+      expect(onClimbPress).toHaveBeenCalledWith({
+        climb: heroDetail,
+        queueItemUuid: 'queue-hero',
+        boardConfig,
       }),
     );
+    expect(graphql.request).toHaveBeenCalledWith(expect.anything(), {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 40,
+      climbUuid: 'hero-climb',
+    });
     expect(onClose).toHaveBeenCalledTimes(1);
 
     fireEvent.click(getByLabelText('queue old-climb'));
-    expect(onAddToQueue).toHaveBeenCalledWith(
-      expect.objectContaining({ uuid: 'old-climb', frames: 'old-frames', difficulty: 'V4', angle: 30 }),
+    await waitFor(() =>
+      expect(onAddToQueue).toHaveBeenCalledWith({
+        climb: oldDetail,
+        queueItemUuid: 'queue-old',
+        boardConfig: { ...boardConfig, angle: 30 },
+      }),
     );
+    expect(graphql.request).toHaveBeenCalledWith(expect.anything(), {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 30,
+      climbUuid: 'old-climb',
+    });
 
     fireEvent.click(getByLabelText('playlist old-climb'));
-    expect(onOpenPlaylist).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'old-climb' }));
+    await waitFor(() =>
+      expect(onOpenPlaylist).toHaveBeenCalledWith({
+        climb: oldDetail,
+        queueItemUuid: 'queue-old',
+        boardConfig: { ...boardConfig, angle: 30 },
+      }),
+    );
 
     fireEvent.click(getByLabelText('actions old-climb'));
-    expect(onOpenActions).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'old-climb' }));
+    await waitFor(() =>
+      expect(onOpenActions).toHaveBeenCalledWith({
+        climb: oldDetail,
+        queueItemUuid: 'queue-old',
+        boardConfig: { ...boardConfig, angle: 30 },
+      }),
+    );
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledTimes(2);
 
     expect(thumbnails.props).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ climb: expect.objectContaining({ uuid: 'hero-climb' }), size: 52 }),
-        expect.objectContaining({ climb: expect.objectContaining({ uuid: 'old-climb' }) }),
+        expect.objectContaining({
+          climb: expect.objectContaining({ uuid: 'old-climb' }),
+          boardConfig: { ...boardConfig, angle: 30 },
+        }),
+      ]),
+    );
+    expect(climbRows.props).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          climb: expect.objectContaining({ uuid: 'old-climb' }),
+          angle: 30,
+          contentRowStyle: expect.objectContaining({ backgroundColor: 'transparent' }),
+          showSeparator: false,
+        }),
       ]),
     );
   });

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -27,6 +27,27 @@ const climbRows = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }))
 const thumbnails = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 
 type ViewMockProps = { children?: ReactNode; style?: unknown };
+type ClimbListRowMockProps = {
+  climb?: { uuid?: string; name?: string };
+  boardName?: string;
+  layoutId?: number;
+  sizeId?: number;
+  setIds?: string;
+  angle?: number;
+  renderContent?: (args: {
+    climb?: { uuid?: string; name?: string };
+    boardName?: string;
+    layoutId?: number;
+    sizeId?: number;
+    setIds?: string;
+    angle?: number;
+  }) => ReactNode;
+  onPress?: (climb?: { uuid?: string; name?: string }) => void;
+  onAddToQueue?: (climb?: { uuid?: string; name?: string }) => void;
+  onOpenPlaylist?: (climb?: { uuid?: string; name?: string }) => void;
+  onOpenActions?: (climb?: { uuid?: string; name?: string }) => void;
+  [key: string]: unknown;
+};
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
@@ -115,22 +136,10 @@ vi.mock('../../Text', () => ({
 }));
 vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
 vi.mock('../../ClimbListRow', () => ({
-  ClimbListRow: (props: Record<string, unknown>) => {
+  ClimbListRow: (props: ClimbListRowMockProps) => {
     climbRows.props.push(props);
-    const renderContent =
-      typeof props.renderContent === 'function'
-        ? (props.renderContent as (args: {
-            climb: unknown;
-            boardName: unknown;
-            layoutId: unknown;
-            sizeId: unknown;
-            setIds: unknown;
-            angle: unknown;
-          }) => ReactNode)
-        : null;
-    const climb = props.climb as { uuid?: string; name?: string } | undefined;
-    const content = renderContent
-      ? renderContent({
+    const content = props.renderContent
+      ? props.renderContent({
           climb: props.climb,
           boardName: props.boardName,
           layoutId: props.layoutId,
@@ -138,49 +147,29 @@ vi.mock('../../ClimbListRow', () => ({
           setIds: props.setIds,
           angle: props.angle,
         })
-      : climb?.name;
-    const climbUuid = climb?.uuid ?? 'unknown';
+      : props.climb?.name;
+    const climbUuid = props.climb?.uuid ?? 'unknown';
     return createElement(
       'div',
       { 'data-climb-row': climbUuid },
       createElement(
         'button',
-        {
-          'aria-label': `press ${climbUuid}`,
-          onClick: () => {
-            if (typeof props.onPress === 'function') props.onPress(props.climb);
-          },
-        },
+        { 'aria-label': `press ${climbUuid}`, onClick: () => props.onPress?.(props.climb) },
         content,
       ),
       createElement(
         'button',
-        {
-          'aria-label': `queue ${climbUuid}`,
-          onClick: () => {
-            if (typeof props.onAddToQueue === 'function') props.onAddToQueue(props.climb);
-          },
-        },
+        { 'aria-label': `queue ${climbUuid}`, onClick: () => props.onAddToQueue?.(props.climb) },
         'queue',
       ),
       createElement(
         'button',
-        {
-          'aria-label': `playlist ${climbUuid}`,
-          onClick: () => {
-            if (typeof props.onOpenPlaylist === 'function') props.onOpenPlaylist(props.climb);
-          },
-        },
+        { 'aria-label': `playlist ${climbUuid}`, onClick: () => props.onOpenPlaylist?.(props.climb) },
         'playlist',
       ),
       createElement(
         'button',
-        {
-          'aria-label': `actions ${climbUuid}`,
-          onClick: () => {
-            if (typeof props.onOpenActions === 'function') props.onOpenActions(props.climb);
-          },
-        },
+        { 'aria-label': `actions ${climbUuid}`, onClick: () => props.onOpenActions?.(props.climb) },
         'actions',
       ),
     );

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -22,6 +22,10 @@ const graphql = vi.hoisted(() => ({
   request: vi.fn(),
 }));
 
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+
 const sheetModal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
 const climbRows = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 const thumbnails = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
@@ -135,6 +139,10 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
 }));
 vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: ({ accessibilityLabel }: { accessibilityLabel?: string }) =>
+    createElement('span', { 'aria-label': accessibilityLabel, 'data-loading': 'true' }),
+}));
 vi.mock('../../ClimbListRow', () => ({
   ClimbListRow: (props: ClimbListRowMockProps) => {
     climbRows.props.push(props);
@@ -194,6 +202,9 @@ vi.mock('../../../providers/theme-provider', () => ({
     sheet: { scrimOpacity: 0.3, handleStyle: {} },
   }),
 }));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
 vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
 }));
@@ -238,6 +249,16 @@ function makeFullClimb(uuid: string, overrides: Partial<Climb> = {}): Climb {
   };
 }
 
+function createDeferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
 const noop = () => {};
 const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
 
@@ -249,6 +270,7 @@ describe('BoardSheet', () => {
     presenceControls.boardId = 123;
     analytics.track.mockClear();
     graphql.request.mockReset();
+    toast.showToast.mockClear();
     sheetModal.present.mockClear();
     sheetModal.dismiss.mockClear();
     climbRows.props = [];
@@ -500,6 +522,136 @@ describe('BoardSheet', () => {
         }),
       ]),
     );
+  });
+
+  it('shows loading feedback and ignores repeat taps while a climb action is resolving', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, {
+      frames: 'hero-frames',
+      grade: 'V7',
+      queueItemUuid: 'queue-hero',
+    });
+    const onClose = vi.fn();
+    const onClimbPress = vi.fn();
+    const heroDetail = makeFullClimb('hero-climb', { name: 'Hydrated Hero' });
+    const climbRequest = createDeferred<{ climb: Climb | null }>();
+    graphql.request.mockReturnValueOnce(climbRequest.promise);
+
+    const { getByLabelText, queryByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+
+    expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull();
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    fireEvent.click(getByLabelText('press hero-climb'));
+
+    expect(graphql.request).toHaveBeenCalledTimes(1);
+    expect(onClimbPress).not.toHaveBeenCalled();
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
+
+    climbRequest.resolve({ climb: heroDetail });
+
+    await waitFor(() => expect(onClimbPress).toHaveBeenCalledTimes(1));
+    expect(onClimbPress).toHaveBeenCalledWith({
+      climb: heroDetail,
+      queueItemUuid: 'queue-hero',
+      boardConfig,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(toast.showToast).not.toHaveBeenCalled();
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
+  });
+
+  it('shows a toast and skips the action when climb hydration throws', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3);
+    const onClimbPress = vi.fn();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const requestError = new Error('network down');
+    graphql.request.mockRejectedValueOnce(requestError);
+
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+
+    await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('mobile.boardPresence.actionFailed', 'error'));
+    expect(onClimbPress).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith('Failed to load board-sheet climb action', requestError);
+    consoleWarn.mockRestore();
+  });
+
+  it('shows a toast and skips the action when climb hydration returns no climb', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3);
+    const onClimbPress = vi.fn();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    graphql.request.mockResolvedValueOnce({ climb: null });
+
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+
+    await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('mobile.boardPresence.actionFailed', 'error'));
+    expect(onClimbPress).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith('Board-sheet climb action returned no climb', 'hero-climb');
+    consoleWarn.mockRestore();
+  });
+
+  it('shows a toast and skips stale interactive actions when board config is unavailable', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3);
+    const onClimbPress = vi.fn();
+
+    const { rerender } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+    const stalePress = climbRows.props[0]?.onPress;
+
+    rerender(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig: null,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+    expect(typeof stalePress).toBe('function');
+    (stalePress as () => void)();
+
+    await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('mobile.boardPresence.actionFailed', 'error'));
+    expect(graphql.request).not.toHaveBeenCalled();
+    expect(onClimbPress).not.toHaveBeenCalled();
   });
 
   it('fires onSwitchBoard from the footer switch control', () => {

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, createRef, forwardRef, useImperativeHandle, type ReactNode, type Ref } from 'react';
 import type { BoardPresenceClimb, BoardPresenceStats, Climb } from '@boardsesh/shared-schema';
 
@@ -215,6 +215,7 @@ vi.mock('../../../theme/tokens', () => ({
 
 import { BoardSheet, type BoardSheetHandle } from '../BoardSheet';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { GET_CLIMB } from '../../../lib/graphql/operations';
 
 function makeClimb(climbUuid: string, seq: number, overrides: Partial<BoardPresenceClimb> = {}): BoardPresenceClimb {
   return {
@@ -456,7 +457,8 @@ describe('BoardSheet', () => {
         boardConfig,
       }),
     );
-    expect(graphql.request).toHaveBeenCalledWith(expect.anything(), {
+    expect(onClimbPress).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledWith(GET_CLIMB, {
       boardName: 'kilter',
       layoutId: 1,
       sizeId: 10,
@@ -474,7 +476,8 @@ describe('BoardSheet', () => {
         boardConfig: { ...boardConfig, angle: 30 },
       }),
     );
-    expect(graphql.request).toHaveBeenCalledWith(expect.anything(), {
+    expect(onAddToQueue).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledWith(GET_CLIMB, {
       boardName: 'kilter',
       layoutId: 1,
       sizeId: 10,
@@ -491,6 +494,7 @@ describe('BoardSheet', () => {
         boardConfig: { ...boardConfig, angle: 30 },
       }),
     );
+    expect(onOpenPlaylist).toHaveBeenCalledTimes(1);
 
     fireEvent.click(getByLabelText('actions old-climb'));
     await waitFor(() =>
@@ -500,6 +504,7 @@ describe('BoardSheet', () => {
         boardConfig: { ...boardConfig, angle: 30 },
       }),
     );
+    expect(onOpenActions).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(graphql.request).toHaveBeenCalledTimes(2);
 
@@ -517,11 +522,110 @@ describe('BoardSheet', () => {
         expect.objectContaining({
           climb: expect.objectContaining({ uuid: 'old-climb' }),
           angle: 30,
-          contentRowStyle: expect.objectContaining({ backgroundColor: 'transparent' }),
+          contentRowStyle: expect.objectContaining({ paddingVertical: 8 }),
           showSeparator: false,
         }),
       ]),
     );
+  });
+
+  it('hydrates playlist actions on a cold cache without requiring a press action', async () => {
+    presence.history = [
+      makeClimb('old-climb', 2, {
+        frames: 'old-frames',
+        grade: 'V4',
+        angle: 30,
+        queueItemUuid: 'queue-old',
+      }),
+    ];
+    const onOpenPlaylist = vi.fn();
+    const oldDetail = makeFullClimb('old-climb', {
+      name: 'Hydrated Old',
+      angle: 30,
+      difficulty: 'V5',
+    });
+    graphql.request.mockResolvedValueOnce({ climb: oldDetail });
+
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onOpenPlaylist,
+      }),
+    );
+
+    expect(climbRows.props[0]?.onPress).toBeUndefined();
+    fireEvent.click(getByLabelText('playlist old-climb'));
+
+    await waitFor(() =>
+      expect(onOpenPlaylist).toHaveBeenCalledWith({
+        climb: oldDetail,
+        queueItemUuid: 'queue-old',
+        boardConfig: { ...boardConfig, angle: 30 },
+      }),
+    );
+    expect(onOpenPlaylist).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledWith(GET_CLIMB, {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 30,
+      climbUuid: 'old-climb',
+    });
+  });
+
+  it('hydrates action-sheet actions on a cold cache', async () => {
+    presence.history = [
+      makeClimb('old-climb', 2, {
+        frames: 'old-frames',
+        grade: 'V4',
+        angle: 30,
+        queueItemUuid: 'queue-old',
+      }),
+    ];
+    const onOpenActions = vi.fn();
+    const oldDetail = makeFullClimb('old-climb', {
+      name: 'Hydrated Old',
+      angle: 30,
+      difficulty: 'V5',
+    });
+    graphql.request.mockResolvedValueOnce({ climb: oldDetail });
+
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onOpenActions,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('actions old-climb'));
+
+    await waitFor(() =>
+      expect(onOpenActions).toHaveBeenCalledWith({
+        climb: oldDetail,
+        queueItemUuid: 'queue-old',
+        boardConfig: { ...boardConfig, angle: 30 },
+      }),
+    );
+    expect(onOpenActions).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledWith(GET_CLIMB, {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 30,
+      climbUuid: 'old-climb',
+    });
   });
 
   it('shows loading feedback and ignores repeat taps while a climb action is resolving', async () => {
@@ -556,7 +660,10 @@ describe('BoardSheet', () => {
     expect(onClimbPress).not.toHaveBeenCalled();
     await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
 
-    climbRequest.resolve({ climb: heroDetail });
+    await act(async () => {
+      climbRequest.resolve({ climb: heroDetail });
+      await climbRequest.promise;
+    });
 
     await waitFor(() => expect(onClimbPress).toHaveBeenCalledTimes(1));
     expect(onClimbPress).toHaveBeenCalledWith({
@@ -569,14 +676,86 @@ describe('BoardSheet', () => {
     await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
   });
 
+  it('drops stale action results after the sheet is closed', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, {
+      frames: 'hero-frames',
+      grade: 'V7',
+      queueItemUuid: 'queue-hero',
+    });
+    const onClose = vi.fn();
+    const onClimbPress = vi.fn();
+    const heroDetail = makeFullClimb('hero-climb', { name: 'Hydrated Hero' });
+    const climbRequest = createDeferred<{ climb: Climb | null }>();
+    graphql.request.mockReturnValueOnce(climbRequest.promise);
+
+    const { getByLabelText, queryByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
+
+    fireEvent.click(getByLabelText('mobile.boardPresence.close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
+
+    await act(async () => {
+      climbRequest.resolve({ climb: heroDetail });
+      await climbRequest.promise;
+    });
+
+    expect(onClimbPress).not.toHaveBeenCalled();
+    expect(toast.showToast).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast instead of leaking errors thrown by action callbacks', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3);
+    const callbackError = new Error('callback failed');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onClose = vi.fn();
+    const onClimbPress = vi.fn(() => {
+      throw callbackError;
+    });
+    const heroDetail = makeFullClimb('hero-climb', { name: 'Hydrated Hero' });
+    graphql.request.mockResolvedValueOnce({ climb: heroDetail });
+
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+
+    await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('mobile.boardPresence.actionFailed', 'error'));
+    expect(onClimbPress).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith('Failed to run board-sheet climb action', callbackError);
+    consoleWarn.mockRestore();
+  });
+
   it('shows a toast and skips the action when climb hydration throws', async () => {
     presence.currentClimb = makeClimb('hero-climb', 3);
     const onClimbPress = vi.fn();
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const requestError = new Error('network down');
-    graphql.request.mockRejectedValueOnce(requestError);
+    const retryDetail = makeFullClimb('hero-climb', { name: 'Retry Hero' });
+    const climbRequest = createDeferred<{ climb: Climb | null }>();
+    graphql.request.mockReturnValueOnce(climbRequest.promise).mockResolvedValueOnce({ climb: retryDetail });
 
-    const { getByLabelText } = render(
+    const { getByLabelText, queryByLabelText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose: noop,
@@ -588,10 +767,29 @@ describe('BoardSheet', () => {
     );
 
     fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
+
+    await act(async () => {
+      climbRequest.reject(requestError);
+      await climbRequest.promise.catch(() => undefined);
+    });
 
     await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('mobile.boardPresence.actionFailed', 'error'));
     expect(onClimbPress).not.toHaveBeenCalled();
     expect(consoleWarn).toHaveBeenCalledWith('Failed to load board-sheet climb action', requestError);
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() =>
+      expect(onClimbPress).toHaveBeenCalledWith({
+        climb: retryDetail,
+        queueItemUuid: null,
+        boardConfig,
+      }),
+    );
+    expect(onClimbPress).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledTimes(2);
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
     consoleWarn.mockRestore();
   });
 
@@ -599,9 +797,10 @@ describe('BoardSheet', () => {
     presence.currentClimb = makeClimb('hero-climb', 3);
     const onClimbPress = vi.fn();
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    graphql.request.mockResolvedValueOnce({ climb: null });
+    const retryDetail = makeFullClimb('hero-climb', { name: 'Retry Hero' });
+    graphql.request.mockResolvedValueOnce({ climb: null }).mockResolvedValueOnce({ climb: retryDetail });
 
-    const { getByLabelText } = render(
+    const { getByLabelText, queryByLabelText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose: noop,
@@ -617,6 +816,19 @@ describe('BoardSheet', () => {
     await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('mobile.boardPresence.actionFailed', 'error'));
     expect(onClimbPress).not.toHaveBeenCalled();
     expect(consoleWarn).toHaveBeenCalledWith('Board-sheet climb action returned no climb', 'hero-climb');
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() =>
+      expect(onClimbPress).toHaveBeenCalledWith({
+        climb: retryDetail,
+        queueItemUuid: null,
+        boardConfig,
+      }),
+    );
+    expect(onClimbPress).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledTimes(2);
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
     consoleWarn.mockRestore();
   });
 

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -19,6 +19,8 @@ const analytics = vi.hoisted(() => ({
 }));
 
 const sheetModal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
+const climbRows = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
+const thumbnails = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 
 type ViewMockProps = { children?: ReactNode; style?: unknown };
 vi.mock('react-native', () => ({
@@ -105,8 +107,83 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
 }));
 vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../ClimbListRow', () => ({
+  ClimbListRow: (props: Record<string, unknown>) => {
+    climbRows.props.push(props);
+    const renderContent =
+      typeof props.renderContent === 'function'
+        ? (props.renderContent as (args: {
+            climb: unknown;
+            boardName: unknown;
+            layoutId: unknown;
+            sizeId: unknown;
+            setIds: unknown;
+            angle: unknown;
+          }) => ReactNode)
+        : null;
+    const climb = props.climb as { uuid?: string; name?: string } | undefined;
+    const content = renderContent
+      ? renderContent({
+          climb: props.climb,
+          boardName: props.boardName,
+          layoutId: props.layoutId,
+          sizeId: props.sizeId,
+          setIds: props.setIds,
+          angle: props.angle,
+        })
+      : climb?.name;
+    const climbUuid = climb?.uuid ?? 'unknown';
+    return createElement(
+      'div',
+      { 'data-climb-row': climbUuid },
+      createElement(
+        'button',
+        {
+          'aria-label': `press ${climbUuid}`,
+          onClick: () => {
+            if (typeof props.onPress === 'function') props.onPress(props.climb);
+          },
+        },
+        content,
+      ),
+      createElement(
+        'button',
+        {
+          'aria-label': `queue ${climbUuid}`,
+          onClick: () => {
+            if (typeof props.onAddToQueue === 'function') props.onAddToQueue(props.climb);
+          },
+        },
+        'queue',
+      ),
+      createElement(
+        'button',
+        {
+          'aria-label': `playlist ${climbUuid}`,
+          onClick: () => {
+            if (typeof props.onOpenPlaylist === 'function') props.onOpenPlaylist(props.climb);
+          },
+        },
+        'playlist',
+      ),
+      createElement(
+        'button',
+        {
+          'aria-label': `actions ${climbUuid}`,
+          onClick: () => {
+            if (typeof props.onOpenActions === 'function') props.onOpenActions(props.climb);
+          },
+        },
+        'actions',
+      ),
+    );
+  },
+}));
 vi.mock('../../queue-control/AccessoryClimbThumbnail', () => ({
-  AccessoryClimbThumbnail: () => createElement('div', { 'data-thumb': 'true' }),
+  AccessoryClimbThumbnail: (props: Record<string, unknown>) => {
+    thumbnails.props.push(props);
+    return createElement('div', { 'data-thumb': 'true', 'data-size': props.size ?? 40 });
+  },
 }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
@@ -158,6 +235,8 @@ describe('BoardSheet', () => {
     analytics.track.mockClear();
     sheetModal.present.mockClear();
     sheetModal.dismiss.mockClear();
+    climbRows.props = [];
+    thumbnails.props = [];
   });
 
   it('presents and dismisses via the imperative ref', () => {
@@ -262,6 +341,62 @@ describe('BoardSheet', () => {
     expect(container.textContent).toContain('mobile.boardPresence.historyHeader');
     // History list rendered one node per item.
     expect(container.querySelector('[data-list="true"]')).not.toBeNull();
+  });
+
+  it('wires the hero and lit-on-this-wall rows to the shared climb actions', () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, { frames: 'hero-frames', grade: 'V7' });
+    presence.history = [makeClimb('old-climb', 2, { frames: 'old-frames', grade: 'V4', angle: 30 })];
+    const onClose = vi.fn();
+    const onClimbPress = vi.fn();
+    const onAddToQueue = vi.fn();
+    const onOpenPlaylist = vi.fn();
+    const onOpenActions = vi.fn();
+
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+        onAddToQueue,
+        onOpenPlaylist,
+        onOpenActions,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    expect(onClimbPress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uuid: 'hero-climb',
+        name: 'Climb hero-climb',
+        frames: 'hero-frames',
+        difficulty: 'V7',
+        setter_username: 'Some Setter',
+        angle: 40,
+      }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByLabelText('queue old-climb'));
+    expect(onAddToQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'old-climb', frames: 'old-frames', difficulty: 'V4', angle: 30 }),
+    );
+
+    fireEvent.click(getByLabelText('playlist old-climb'));
+    expect(onOpenPlaylist).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'old-climb' }));
+
+    fireEvent.click(getByLabelText('actions old-climb'));
+    expect(onOpenActions).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'old-climb' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    expect(thumbnails.props).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ climb: expect.objectContaining({ uuid: 'hero-climb' }), size: 52 }),
+        expect.objectContaining({ climb: expect.objectContaining({ uuid: 'old-climb' }) }),
+      ]),
+    );
   });
 
   it('fires onSwitchBoard from the footer switch control', () => {

--- a/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { StyleSheet, View, type ViewStyle } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
-import type { Climb } from '@boardsesh/queue';
 import { getBoardRenderData } from '../../lib/board-details';
 import { type BoardConfig } from '../../providers/drawer-host-provider';
 import { BoardImageNative } from '../BoardImageNative';
@@ -11,15 +10,20 @@ export const ACCESSORY_THUMBNAIL_SLOT_SIZE = 40;
 const ACCESSORY_THUMBNAIL_ART_MAX_SIZE = 40;
 const ACCESSORY_THUMBNAIL_ART_RADIUS = 10;
 
-function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number) {
+type AccessoryThumbnailClimb = {
+  frames: string;
+  mirrored?: boolean | null;
+};
+
+function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number, maxSize: number) {
   const boardAspectRatio = boardWidth / boardHeight;
   if (!Number.isFinite(boardAspectRatio) || boardAspectRatio <= 0) {
-    return { width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE, height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE };
+    return { width: maxSize, height: maxSize };
   }
   if (boardAspectRatio >= 1) {
-    return { width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE, height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE / boardAspectRatio };
+    return { width: maxSize, height: maxSize / boardAspectRatio };
   }
-  return { width: ACCESSORY_THUMBNAIL_ART_MAX_SIZE * boardAspectRatio, height: ACCESSORY_THUMBNAIL_ART_MAX_SIZE };
+  return { width: maxSize * boardAspectRatio, height: maxSize };
 }
 
 /**
@@ -40,7 +44,15 @@ function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number)
  * render uses the stroke-only style (`_s_`) at native width (`_wfull_`) and caches
  * as a separate PNG. See docs/react-native-performance.md §6.
  */
-export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; boardConfig: BoardConfig | null }) {
+export function AccessoryClimbThumbnail({
+  climb,
+  boardConfig,
+  size = ACCESSORY_THUMBNAIL_SLOT_SIZE,
+}: {
+  climb: AccessoryThumbnailClimb;
+  boardConfig: BoardConfig | null;
+  size?: number;
+}) {
   const boardRenderData = useMemo(() => {
     if (!boardConfig) return null;
     const setIdValues = boardConfig.setIds
@@ -61,16 +73,17 @@ export function AccessoryClimbThumbnail({ climb, boardConfig }: { climb: Climb; 
   // Fit the board art into the 40×40 slot at its native aspect ratio, then
   // hand BoardImageNative an explicitly-sized, rounded, clipped box. (Its
   // default `width: '100%'` would otherwise stretch the art across the slot.)
-  const fittedSize = getAccessoryThumbnailBoardSize(boardRenderData.boardWidth, boardRenderData.boardHeight);
+  const fittedSize = getAccessoryThumbnailBoardSize(boardRenderData.boardWidth, boardRenderData.boardHeight, size);
+  const radius = ACCESSORY_THUMBNAIL_ART_RADIUS * (size / ACCESSORY_THUMBNAIL_ART_MAX_SIZE);
   const thumbnailBoardStyle: ViewStyle = {
     width: fittedSize.width,
     height: fittedSize.height,
-    borderRadius: ACCESSORY_THUMBNAIL_ART_RADIUS,
+    borderRadius: radius,
     overflow: 'hidden',
   };
 
   return (
-    <View style={styles.thumbnailSlot}>
+    <View style={[styles.thumbnailSlot, { width: size, height: size }]}>
       <BoardImageNative
         frames={climb.frames}
         boardName={boardConfig.boardName as BoardName}

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -510,6 +510,83 @@ describe('BluetoothProvider wall-confirm integration', () => {
     expect(queue.confirmClimbOnWall).toHaveBeenCalledTimes(2);
   });
 
+  it('does not double-report byte-identical wall confirms while the first report is pending', async () => {
+    presence.enabled = true;
+    presence.boardId = 99;
+    queue.sessionId = null;
+    const firstItem = makeQueueItem('climb-1');
+    queue.currentClimbQueueItem = firstItem;
+    let resolveReport: (value: boolean) => void = () => {};
+    presence.reportClimbForBoard.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveReport = resolve;
+      }),
+    );
+
+    const { rerender } = renderProvider();
+
+    await waitFor(() => {
+      expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+    });
+
+    queue.currentClimbQueueItem = { ...firstItem };
+    rerender(
+      createElement(BluetoothProvider, {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        children: createElement('div', null),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(wallConfirm.emitWallConfirm).toHaveBeenCalledTimes(2);
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveReport(true);
+    });
+    expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-report a byte-identical wall confirm after acceptance while waiting for the live echo', async () => {
+    presence.enabled = true;
+    presence.boardId = 99;
+    presence.currentClimb = null;
+    queue.sessionId = null;
+    const firstItem = makeQueueItem('climb-1');
+    queue.currentClimbQueueItem = firstItem;
+    const { rerender } = renderProvider();
+
+    await waitFor(() => {
+      expect(analytics.track).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ climbUuid: 'climb-1' }),
+      );
+    });
+    expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+
+    queue.currentClimbQueueItem = { ...firstItem };
+    rerender(
+      createElement(BluetoothProvider, {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        children: createElement('div', null),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(wallConfirm.emitWallConfirm).toHaveBeenCalledTimes(2);
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    expect(presence.reportClimbForBoard).toHaveBeenCalledTimes(1);
+  });
+
   it('stores a newly connected board serial on active sessions', () => {
     renderProvider();
 

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -36,6 +36,12 @@ const climbActions = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
 }));
 
+const boardSheet = vi.hoisted(() => ({
+  props: null as null | Record<string, unknown>,
+  present: vi.fn(),
+  dismiss: vi.fn(),
+}));
+
 const activeBoard = vi.hoisted(() => {
   const defaultStored = {
     uuid: 'board-1',
@@ -145,8 +151,9 @@ vi.mock('../../components/QueueAddedSnackbar', () => ({
 vi.mock('../../components/board-presence/BoardSheet', async () => {
   const React = await vi.importActual<typeof import('react')>('react');
   return {
-    BoardSheet: React.forwardRef((_props: unknown, ref) => {
-      React.useImperativeHandle(ref, () => ({ present: () => {}, dismiss: () => {} }));
+    BoardSheet: React.forwardRef((props: Record<string, unknown>, ref) => {
+      boardSheet.props = props;
+      React.useImperativeHandle(ref, () => ({ present: boardSheet.present, dismiss: boardSheet.dismiss }));
       return React.createElement('div', { 'data-board-sheet': 'true' });
     }),
   };
@@ -353,6 +360,17 @@ describe('DrawerHostProvider board presence binding', () => {
   });
 });
 
+type BoardSheetTestProps = {
+  onClimbPress: (climb: Climb) => void;
+  onAddToQueue: (climb: Climb) => void;
+  onOpenPlaylist: (climb: Climb) => void;
+  onOpenActions: (climb: Climb) => void;
+};
+
+function getBoardSheetProps(): BoardSheetTestProps {
+  return boardSheet.props as unknown as BoardSheetTestProps;
+}
+
 describe('DrawerHostProvider queue sheet wall-control gating', () => {
   beforeEach(() => {
     queue.sessionId = 'session-1';
@@ -368,6 +386,9 @@ describe('DrawerHostProvider queue sheet wall-control gating', () => {
     queueSheet.present.mockClear();
     queueSheet.dismiss.mockClear();
     climbActions.props = null;
+    boardSheet.props = null;
+    boardSheet.present.mockClear();
+    boardSheet.dismiss.mockClear();
   });
 
   it('opens a preview without broadcasting when a party non-driver taps a queued climb', async () => {
@@ -485,6 +506,80 @@ describe('DrawerHostProvider queue sheet wall-control gating', () => {
   });
 });
 
+describe('DrawerHostProvider board sheet climb actions', () => {
+  beforeEach(() => {
+    queue.sessionId = 'session-1';
+    queue.driverParticipantId = 'participant-other';
+    queue.participantId = 'participant-self';
+    queue.sessionUserCount = 2;
+    queue.setCurrentClimb.mockClear();
+    queue.addToQueue.mockClear();
+    playDrawer.open.mockClear();
+    climbActions.props = null;
+    boardSheet.props = null;
+    boardSheet.present.mockClear();
+    boardSheet.dismiss.mockClear();
+  });
+
+  it('opens a preview without broadcasting when a party non-driver taps a board-sheet climb', async () => {
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(boardSheet.props).not.toBeNull());
+
+    const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    act(() => {
+      getBoardSheetProps().onClimbPress(climb);
+    });
+
+    expect(queue.setCurrentClimb).not.toHaveBeenCalled();
+    expect(playDrawer.open).toHaveBeenCalledWith(climb, {
+      setAsCurrent: false,
+      previewQueueItem: expect.objectContaining({ climb }),
+    });
+  });
+
+  it('sets current and opens the drawer when the party driver taps a board-sheet climb', async () => {
+    queue.driverParticipantId = 'participant-self';
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(boardSheet.props).not.toBeNull());
+
+    const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    act(() => {
+      getBoardSheetProps().onClimbPress(climb);
+    });
+
+    expect(queue.setCurrentClimb).toHaveBeenCalledWith(expect.objectContaining({ climb }));
+    expect(playDrawer.open).toHaveBeenCalledWith(climb, {
+      setAsCurrent: false,
+      previewQueueItem: expect.objectContaining({ climb }),
+    });
+  });
+
+  it('reuses queue, playlist, and climb-actions handlers for board-sheet climbs', async () => {
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    const { container } = renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(boardSheet.props).not.toBeNull());
+
+    const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    act(() => {
+      getBoardSheetProps().onAddToQueue(climb);
+    });
+    expect(queue.addToQueue).toHaveBeenCalledWith(expect.objectContaining({ climb }));
+
+    act(() => {
+      getBoardSheetProps().onOpenPlaylist(climb);
+    });
+    await waitFor(() => expect(container.querySelector('[data-add-to-playlist]')).not.toBeNull());
+
+    act(() => {
+      getBoardSheetProps().onOpenActions(climb);
+    });
+    await waitFor(() => expect(container.querySelector('[data-climb-actions]')).not.toBeNull());
+    expect(climbActions.props).toMatchObject({ climb, boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' });
+  });
+});
+
 describe('DrawerHostProvider queue sheet open / re-open', () => {
   beforeEach(() => {
     queue.sessionId = 'session-1';
@@ -494,6 +589,9 @@ describe('DrawerHostProvider queue sheet open / re-open', () => {
     queueSheet.present.mockClear();
     queueSheet.dismiss.mockClear();
     climbActions.props = null;
+    boardSheet.props = null;
+    boardSheet.present.mockClear();
+    boardSheet.dismiss.mockClear();
   });
 
   it('stays mounted and presents via the imperative handle on open', async () => {
@@ -547,6 +645,9 @@ describe('DrawerHostProvider climb actions', () => {
     queue.sessionId = 'session-1';
     queueSheet.props = null;
     climbActions.props = null;
+    boardSheet.props = null;
+    boardSheet.present.mockClear();
+    boardSheet.dismiss.mockClear();
   });
 
   it('opens the climb actions sheet for a climb against the active board, then closes it', async () => {

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -387,10 +387,7 @@ const boardSheetActionBoardConfig: BoardConfig = {
   angle: 30,
 };
 
-function makeBoardSheetAction(
-  climb: Climb,
-  overrides: Partial<BoardSheetClimbAction> = {},
-): BoardSheetClimbAction {
+function makeBoardSheetAction(climb: Climb, overrides: Partial<BoardSheetClimbAction> = {}): BoardSheetClimbAction {
   return {
     climb,
     queueItemUuid: 'wall-queue-x',

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -36,6 +36,10 @@ const climbActions = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
 }));
 
+const playlistSheet = vi.hoisted(() => ({
+  props: null as null | Record<string, unknown>,
+}));
+
 const boardSheet = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
   present: vi.fn(),
@@ -143,7 +147,10 @@ vi.mock('../../components/ClimbActionsSheet', () => ({
   },
 }));
 vi.mock('../../components/AddToPlaylistSheet', () => ({
-  AddToPlaylistSheet: () => createElement('div', { 'data-add-to-playlist': 'true' }),
+  AddToPlaylistSheet: (props: Record<string, unknown>) => {
+    playlistSheet.props = props;
+    return createElement('div', { 'data-add-to-playlist': 'true' });
+  },
 }));
 vi.mock('../../components/QueueAddedSnackbar', () => ({
   QueueAddedSnackbar: () => createElement('div', { 'data-queue-snackbar': 'true' }),
@@ -239,14 +246,15 @@ vi.mock('../../lib/analytics', () => ({
 }));
 
 vi.mock('../../lib/climb-to-queue-item', () => ({
-  climbToQueueItem: (climb: ClimbQueueItem['climb'], options?: { suggested?: boolean }) => ({
-    uuid: `queue-${climb.uuid}`,
+  climbToQueueItem: (climb: ClimbQueueItem['climb'], options?: { suggested?: boolean; uuid?: string }) => ({
+    uuid: options?.uuid ?? `queue-${climb.uuid}`,
     climb,
     suggested: options?.suggested ?? false,
   }),
 }));
 
-import { DrawerHostProvider, useDrawerHost } from '../drawer-host-provider';
+import { DrawerHostProvider, useDrawerHost, type BoardConfig } from '../drawer-host-provider';
+import type { BoardSheetClimbAction } from '../../components/board-presence/BoardSheet';
 
 function makeQueueItem(uuid: string, climbUuid = uuid): ClimbQueueItem {
   return {
@@ -361,14 +369,34 @@ describe('DrawerHostProvider board presence binding', () => {
 });
 
 type BoardSheetTestProps = {
-  onClimbPress: (climb: Climb) => void;
-  onAddToQueue: (climb: Climb) => void;
-  onOpenPlaylist: (climb: Climb) => void;
-  onOpenActions: (climb: Climb) => void;
+  onClimbPress: (action: BoardSheetClimbAction) => void;
+  onAddToQueue: (action: BoardSheetClimbAction) => void;
+  onOpenPlaylist: (action: BoardSheetClimbAction) => void;
+  onOpenActions: (action: BoardSheetClimbAction) => void;
 };
 
 function getBoardSheetProps(): BoardSheetTestProps {
   return boardSheet.props as unknown as BoardSheetTestProps;
+}
+
+const boardSheetActionBoardConfig: BoardConfig = {
+  boardName: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 30,
+};
+
+function makeBoardSheetAction(
+  climb: Climb,
+  overrides: Partial<BoardSheetClimbAction> = {},
+): BoardSheetClimbAction {
+  return {
+    climb,
+    queueItemUuid: 'wall-queue-x',
+    boardConfig: boardSheetActionBoardConfig,
+    ...overrides,
+  };
 }
 
 describe('DrawerHostProvider queue sheet wall-control gating', () => {
@@ -386,6 +414,7 @@ describe('DrawerHostProvider queue sheet wall-control gating', () => {
     queueSheet.present.mockClear();
     queueSheet.dismiss.mockClear();
     climbActions.props = null;
+    playlistSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
@@ -516,6 +545,7 @@ describe('DrawerHostProvider board sheet climb actions', () => {
     queue.addToQueue.mockClear();
     playDrawer.open.mockClear();
     climbActions.props = null;
+    playlistSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
@@ -527,15 +557,27 @@ describe('DrawerHostProvider board sheet climb actions', () => {
     await waitFor(() => expect(boardSheet.props).not.toBeNull());
 
     const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    const action = makeBoardSheetAction(climb);
     act(() => {
-      getBoardSheetProps().onClimbPress(climb);
+      getBoardSheetProps().onClimbPress(action);
     });
 
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
-    expect(playDrawer.open).toHaveBeenCalledWith(climb, {
-      setAsCurrent: false,
-      previewQueueItem: expect.objectContaining({ climb }),
-    });
+    await waitFor(() =>
+      expect(playDrawer.open).toHaveBeenCalledWith(climb, {
+        setAsCurrent: false,
+        previewQueueItem: expect.objectContaining({ uuid: 'wall-queue-x', climb }),
+      }),
+    );
+    await waitFor(() =>
+      expect(hosts.at(-1)?.boardConfig).toMatchObject({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+        angle: 30,
+      }),
+    );
   });
 
   it('sets current and opens the drawer when the party driver taps a board-sheet climb', async () => {
@@ -545,15 +587,18 @@ describe('DrawerHostProvider board sheet climb actions', () => {
     await waitFor(() => expect(boardSheet.props).not.toBeNull());
 
     const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    const action = makeBoardSheetAction(climb);
     act(() => {
-      getBoardSheetProps().onClimbPress(climb);
+      getBoardSheetProps().onClimbPress(action);
     });
 
-    expect(queue.setCurrentClimb).toHaveBeenCalledWith(expect.objectContaining({ climb }));
-    expect(playDrawer.open).toHaveBeenCalledWith(climb, {
-      setAsCurrent: false,
-      previewQueueItem: expect.objectContaining({ climb }),
-    });
+    expect(queue.setCurrentClimb).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'wall-queue-x', climb }));
+    await waitFor(() =>
+      expect(playDrawer.open).toHaveBeenCalledWith(climb, {
+        setAsCurrent: false,
+        previewQueueItem: expect.objectContaining({ uuid: 'wall-queue-x', climb }),
+      }),
+    );
   });
 
   it('reuses queue, playlist, and climb-actions handlers for board-sheet climbs', async () => {
@@ -562,21 +607,37 @@ describe('DrawerHostProvider board sheet climb actions', () => {
     await waitFor(() => expect(boardSheet.props).not.toBeNull());
 
     const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    const action = makeBoardSheetAction(climb);
     act(() => {
-      getBoardSheetProps().onAddToQueue(climb);
+      getBoardSheetProps().onAddToQueue(action);
     });
-    expect(queue.addToQueue).toHaveBeenCalledWith(expect.objectContaining({ climb }));
+    expect(queue.addToQueue).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'queue-climb-x', climb }));
 
     act(() => {
-      getBoardSheetProps().onOpenPlaylist(climb);
+      getBoardSheetProps().onOpenPlaylist(action);
     });
     await waitFor(() => expect(container.querySelector('[data-add-to-playlist]')).not.toBeNull());
+    expect(playlistSheet.props).toMatchObject({
+      climb,
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 30,
+    });
 
     act(() => {
-      getBoardSheetProps().onOpenActions(climb);
+      getBoardSheetProps().onOpenActions(action);
     });
     await waitFor(() => expect(container.querySelector('[data-climb-actions]')).not.toBeNull());
-    expect(climbActions.props).toMatchObject({ climb, boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' });
+    expect(climbActions.props).toMatchObject({
+      climb,
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 30,
+    });
   });
 });
 
@@ -589,6 +650,7 @@ describe('DrawerHostProvider queue sheet open / re-open', () => {
     queueSheet.present.mockClear();
     queueSheet.dismiss.mockClear();
     climbActions.props = null;
+    playlistSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
@@ -645,6 +707,7 @@ describe('DrawerHostProvider climb actions', () => {
     queue.sessionId = 'session-1';
     queueSheet.props = null;
     climbActions.props = null;
+    playlistSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -350,6 +350,8 @@ export function BluetoothProvider({
   // and only used to skip a byte-identical local re-broadcast while the feed
   // still shows that same signature.
   const lastAcceptedReportSignatureRef = useRef<string | null>(null);
+  const lastAcceptedWallSignatureRef = useRef<string | null>(null);
+  const pendingReportSignatureRef = useRef<string | null>(null);
   const pendingWallReportRef = useRef<PendingWallReport | null>(null);
   const pendingPresenceResolveRef = useRef(false);
   const resolvedPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
@@ -419,8 +421,14 @@ export function BluetoothProvider({
 
   useEffect(() => {
     const currentWallSignature = presenceClimbReportSignature(wallCurrentClimb);
-    if (currentWallSignature !== lastAcceptedReportSignatureRef.current) {
+    if (
+      lastAcceptedReportSignatureRef.current !== null &&
+      currentWallSignature !== null &&
+      currentWallSignature !== lastAcceptedReportSignatureRef.current &&
+      currentWallSignature !== lastAcceptedWallSignatureRef.current
+    ) {
       lastAcceptedReportSignatureRef.current = null;
+      lastAcceptedWallSignatureRef.current = null;
     }
   }, [wallCurrentClimb]);
 
@@ -432,6 +440,8 @@ export function BluetoothProvider({
     }
     if (previousBoardId !== null || presenceBoardId === null) {
       lastAcceptedReportSignatureRef.current = null;
+      lastAcceptedWallSignatureRef.current = null;
+      pendingReportSignatureRef.current = null;
       undoWallChangeTargetRef.current = null;
       clearPendingWallReportAndUndoToastArm();
     }
@@ -445,20 +455,33 @@ export function BluetoothProvider({
       undoToastArmId: number | null,
     ) => {
       const reportSignature = queueItemReportSignature(item);
-      if (
-        lastAcceptedReportSignatureRef.current === reportSignature &&
-        presenceClimbReportSignature(wallCurrentClimbRef.current) === reportSignature
-      ) {
-        consumeUndoWallChangeToastArm(undoToastArmId);
+      if (lastAcceptedReportSignatureRef.current === reportSignature) {
+        const currentWallSignature = presenceClimbReportSignature(wallCurrentClimbRef.current);
+        if (
+          currentWallSignature === null ||
+          currentWallSignature === reportSignature ||
+          currentWallSignature === lastAcceptedWallSignatureRef.current
+        ) {
+          consumeUndoWallChangeToastArm(undoToastArmId);
+          return true;
+        }
+        lastAcceptedReportSignatureRef.current = null;
+        lastAcceptedWallSignatureRef.current = null;
+      }
+      if (pendingReportSignatureRef.current === reportSignature) {
         return true;
       }
 
       const climbInput = { uuid: item.uuid, climb: toClimbInput(item.climb) };
       const angle = item.climb.angle ?? null;
+      pendingReportSignatureRef.current = reportSignature;
       const accepted = await reportClimbForBoardRef.current(boardId, climbInput, angle).catch((error: unknown) => {
         console.warn('[board-presence] reportBoardClimb failed', error);
         return false;
       });
+      if (pendingReportSignatureRef.current === reportSignature) {
+        pendingReportSignatureRef.current = null;
+      }
 
       if (!accepted) {
         lastAcceptedReportSignatureRef.current = null;
@@ -466,6 +489,7 @@ export function BluetoothProvider({
       }
 
       lastAcceptedReportSignatureRef.current = reportSignature;
+      lastAcceptedWallSignatureRef.current = presenceClimbReportSignature(wallCurrentClimbRef.current);
       undoWallChangeTargetRef.current = undoTarget;
       const showUndoToast = consumeUndoWallChangeToastArm(undoToastArmId);
       track(SHARED_EVENTS.BoardClimbReported, {
@@ -522,6 +546,8 @@ export function BluetoothProvider({
   const handleConnectSuccess = useCallback(
     (serial: string | null) => {
       lastAcceptedReportSignatureRef.current = null;
+      lastAcceptedWallSignatureRef.current = null;
+      pendingReportSignatureRef.current = null;
       pendingWallReportRef.current = null;
       undoWallChangeTargetRef.current = null;
       resolvedPresenceBoardIdRef.current = null;

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -474,6 +474,20 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     [addToQueue],
   );
 
+  const handleBoardSheetOpenPlaylist = useCallback(
+    (action: BoardSheetClimbAction) => {
+      openAddToPlaylist(action.climb, action.boardConfig);
+    },
+    [openAddToPlaylist],
+  );
+
+  const handleBoardSheetOpenActions = useCallback(
+    (action: BoardSheetClimbAction) => {
+      openClimbActions(action.climb, action.boardConfig);
+    },
+    [openClimbActions],
+  );
+
   // Undo a wall change YOU just caused. Queue navigation is untouched; the
   // Bluetooth provider re-lights the captured target over BLE first, then
   // re-reports it to board presence.
@@ -586,8 +600,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         onSwitchBoard={handleSwitchBoardFromSheet}
         onClimbPress={handleBoardSheetClimbPress}
         onAddToQueue={handleBoardSheetAddToQueue}
-        onOpenPlaylist={(action) => openAddToPlaylist(action.climb, action.boardConfig)}
-        onOpenActions={(action) => openClimbActions(action.climb, action.boardConfig)}
+        onOpenPlaylist={handleBoardSheetOpenPlaylist}
+        onOpenActions={handleBoardSheetOpenActions}
       />
       <QueueAddedSnackbar
         visible={snackbarVisible}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -23,7 +23,7 @@ import { LogAscentSheet } from '../components/LogAscentSheet';
 import { QueueSheet, type QueueSheetHandle } from '../components/play-drawer/QueueSheet';
 import { QueueAddedSnackbar } from '../components/QueueAddedSnackbar';
 import { UndoWallChangeSnackbar } from '../components/board-presence/UndoWallChangeSnackbar';
-import { BoardSheet, type BoardSheetHandle } from '../components/board-presence/BoardSheet';
+import { BoardSheet, type BoardSheetClimbAction, type BoardSheetHandle } from '../components/board-presence/BoardSheet';
 import type { QueueItemRowBoard } from '../components/QueueItemRow';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { formatActiveBoardLabel } from '../lib/boards/active-board-label';
@@ -63,6 +63,17 @@ export type LogAscentInput = {
   consensusGradeName?: string;
 };
 
+function boardConfigsMatch(left: BoardConfig | null, right: BoardConfig | null): boolean {
+  if (!left || !right) return false;
+  return (
+    left.boardName === right.boardName &&
+    left.layoutId === right.layoutId &&
+    left.sizeId === right.sizeId &&
+    left.setIds === right.setIds &&
+    left.angle === right.angle
+  );
+}
+
 export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
   /** Switch the drawer to a different board config before opening (e.g. the
    *  caller is opening a climb that belongs to a board other than the user's
@@ -79,11 +90,11 @@ type DrawerHostValue = {
   openLogAscent: (input: LogAscentInput) => void;
   /** Opens the climb actions bottom sheet for the given climb. Uses the active
    *  boardConfig at the time of opening. */
-  openClimbActions: (climb: Climb) => void;
+  openClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig) => void;
   closeClimbActions: () => void;
   /** Opens the add-to-playlist bottom sheet for the given climb. Snapshots the
    *  active boardConfig (for the angle) at open time. */
-  openAddToPlaylist: (climb: Climb) => void;
+  openAddToPlaylist: (climb: Climb, boardConfigOverride?: BoardConfig) => void;
   /** Opens the queue list sheet (from the play-drawer queue button or the
    *  "Climb added to queue" snackbar's Open action). */
   openQueueSheet: () => void;
@@ -261,8 +272,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // Snapshot the board config at open time so the sheet's per-row handlers
   // (queue / favorite / tick) keep operating on the same angle even if the
   // user switches their active board mid-interaction.
-  const openClimbActions = useCallback((climb: Climb) => {
-    const boardConfig = activeBoardConfigRef.current;
+  const openClimbActions = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
+    const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
     if (!boardConfig) return;
     setClimbActions({ climb, boardConfig });
   }, []);
@@ -271,8 +282,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     setClimbActions(null);
   }, []);
 
-  const openAddToPlaylist = useCallback((climb: Climb) => {
-    const boardConfig = activeBoardConfigRef.current;
+  const openAddToPlaylist = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
+    const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
     if (!boardConfig) return;
     setPlaylistClimb({ climb, boardConfig });
   }, []);
@@ -433,21 +444,32 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   }, [requestCloseBoardSheet]);
 
   const handleBoardSheetClimbPress = useCallback(
-    (climb: Climb) => {
-      const item = climbToQueueItem(climb);
+    (action: BoardSheetClimbAction) => {
+      const item = climbToQueueItem(action.climb, { uuid: action.queueItemUuid ?? undefined });
+      const boardConfigOverride = boardConfigsMatch(action.boardConfig, activeBoardConfigRef.current)
+        ? undefined
+        : action.boardConfig;
       if (isPartyPreviewOnly) {
-        openPlayDrawer(climb, { setAsCurrent: false, previewQueueItem: item });
+        openPlayDrawer(action.climb, {
+          setAsCurrent: false,
+          previewQueueItem: item,
+          boardConfig: boardConfigOverride,
+        });
         return;
       }
       setCurrentClimb(item);
-      openPlayDrawer(climb, { setAsCurrent: false, previewQueueItem: item });
+      openPlayDrawer(action.climb, {
+        setAsCurrent: false,
+        previewQueueItem: item,
+        boardConfig: boardConfigOverride,
+      });
     },
     [isPartyPreviewOnly, openPlayDrawer, setCurrentClimb],
   );
 
   const handleBoardSheetAddToQueue = useCallback(
-    (climb: Climb) => {
-      addToQueue(climbToQueueItem(climb));
+    (action: BoardSheetClimbAction) => {
+      addToQueue(climbToQueueItem(action.climb));
     },
     [addToQueue],
   );
@@ -564,8 +586,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         onSwitchBoard={handleSwitchBoardFromSheet}
         onClimbPress={handleBoardSheetClimbPress}
         onAddToQueue={handleBoardSheetAddToQueue}
-        onOpenPlaylist={openAddToPlaylist}
-        onOpenActions={openClimbActions}
+        onOpenPlaylist={(action) => openAddToPlaylist(action.climb, action.boardConfig)}
+        onOpenActions={(action) => openClimbActions(action.climb, action.boardConfig)}
       />
       <QueueAddedSnackbar
         visible={snackbarVisible}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -432,6 +432,26 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     router.push('/boards');
   }, [requestCloseBoardSheet]);
 
+  const handleBoardSheetClimbPress = useCallback(
+    (climb: Climb) => {
+      const item = climbToQueueItem(climb);
+      if (isPartyPreviewOnly) {
+        openPlayDrawer(climb, { setAsCurrent: false, previewQueueItem: item });
+        return;
+      }
+      setCurrentClimb(item);
+      openPlayDrawer(climb, { setAsCurrent: false, previewQueueItem: item });
+    },
+    [isPartyPreviewOnly, openPlayDrawer, setCurrentClimb],
+  );
+
+  const handleBoardSheetAddToQueue = useCallback(
+    (climb: Climb) => {
+      addToQueue(climbToQueueItem(climb));
+    },
+    [addToQueue],
+  );
+
   // Undo a wall change YOU just caused. Queue navigation is untouched; the
   // Bluetooth provider re-lights the captured target over BLE first, then
   // re-reports it to board presence.
@@ -542,6 +562,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         boardConfig={activeBoardConfig}
         onClose={requestCloseBoardSheet}
         onSwitchBoard={handleSwitchBoardFromSheet}
+        onClimbPress={handleBoardSheetClimbPress}
+        onAddToQueue={handleBoardSheetAddToQueue}
+        onOpenPlaylist={openAddToPlaylist}
+        onOpenActions={openClimbActions}
       />
       <QueueAddedSnackbar
         visible={snackbarVisible}

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -364,7 +364,9 @@
       "statTopGrade": "most sent",
       "wallChanged": "You changed the wall",
       "undo": "Undo",
-      "undoAria": "Undo the wall change"
+      "undoAria": "Undo the wall change",
+      "actionLoading": "Loading climb",
+      "actionFailed": "Couldn't load that climb. Try again."
     },
     "toast": {
       "sessionEnded": "Session ended"


### PR DESCRIPTION
## Summary
- make the board-presence hero and "Lit on this wall" history rows reuse the climb-list interaction shell
- wire tap, swipe-to-queue, swipe-to-playlist, and long-press actions through the existing drawer host paths
- hydrate wall-feed climbs before shared actions so playlist/actions/tick/playback receive full climb detail
- preserve existing wall queue item identity when setting a wall climb active, while add-to-queue still creates a fresh item
- prevent byte-identical mobile wall confirms from double-reporting to board presence while a report is pending or waiting for its live echo
- filter the current "now on the wall" climb out of the mobile history list so it does not appear as both the hero and a history row

## Root Cause
The board sheet rendered bespoke static hero/history rows, so wall-feed climbs displayed correctly but did not share the normal climb-list action handlers. The action wiring now resolves full climb detail before invoking shared handlers.

The duplicate history issue had two contributors: mobile could emit two board-presence reports for the same byte-identical wall confirm before the live feed caught up, and the sheet rendered the current climb hero plus the same current climb from `history`.

Redis confirmed the double-report path on `board:4:history`: `Alligator in Aviators` appeared twice with the same climb UUID and queue item UUID, one millisecond apart, under different seq values.

## Validation
- `vp test run packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx --reporter=agent`
- `vp test run packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx --reporter=agent`
- `vp run typecheck:mobile`
- `vp fmt --check packages/mobile/src/providers/bluetooth-provider.tsx packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx packages/mobile/src/components/board-presence/BoardSheet.tsx packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx`
- `git diff --check`

Note: full `vp check` still reports pre-existing formatting issues in unrelated files: `packages/backend/src/__tests__/board-presence.test.ts` and `packages/mobile/src/providers/board-presence-provider.tsx`.