### PR TITLE
[codex] relax session rate limits and audit buckets

### DIFF
--- a/mobile/ios/App/App/SessionWebSocketManager.swift
+++ b/mobile/ios/App/App/SessionWebSocketManager.swift
@@ -552,8 +552,7 @@ final class SessionWebSocketManager {
                 self.listenForMessages(for: task)
 
             case .failure(let error):
-                print("[SessionWS] Receive failed: \(error.localizedDescription)")
-                self.handleDisconnect(for: task)
+                self.handleReceiveFailure(error, for: task)
             }
         }
     }
@@ -734,40 +733,56 @@ final class SessionWebSocketManager {
     private func handleDisconnect(for task: URLSessionWebSocketTask) {
         stateQueue.async { [weak self] in
             guard let self = self else { return }
-
-            // Only process disconnect if this is still the current task.
-            // A stale task from a previous connection must not tear down the
-            // active connection.
-            guard self.webSocketTask === task else {
-                print("[SessionWS] Ignoring stale disconnect for superseded task")
-                return
-            }
-
-            self.isConnected = false
-            self.webSocketTask = nil
-            self.pingTimeoutTimer?.cancel()
-            self.pingTimeoutTimer = nil
-
-            guard !self.intentionalDisconnect else { return }
-
-            guard self.reconnectAttempt < self.maxReconnectAttempts else {
-                print("[SessionWS] Max reconnect attempts (\(self.maxReconnectAttempts)) reached, giving up")
-                return
-            }
-
-            let delay = self.reconnectDelay()
-            self.reconnectAttempt += 1
-
-            // Cancel any previously scheduled reconnect to prevent duplicate
-            // connections piling up (e.g. rapid disconnect/reconnect during background).
-            self.reconnectWorkItem?.cancel()
-
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.openConnection()
-            }
-            self.reconnectWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            self.handleDisconnectOnQueue(for: task)
         }
+    }
+
+    private func handleReceiveFailure(_ error: Error, for task: URLSessionWebSocketTask) {
+        stateQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.webSocketTask === task && !self.intentionalDisconnect {
+                print("[SessionWS] Receive failed: \(error.localizedDescription)")
+            }
+            self.handleDisconnectOnQueue(for: task)
+        }
+    }
+
+    /// Must be called on `stateQueue`.
+    private func handleDisconnectOnQueue(for task: URLSessionWebSocketTask) {
+        // Only process disconnect if this is still the current task.
+        // A stale task from a previous connection must not tear down the
+        // active connection.
+        guard self.webSocketTask === task else {
+            if !self.intentionalDisconnect {
+                print("[SessionWS] Ignoring stale disconnect for superseded task")
+            }
+            return
+        }
+
+        self.isConnected = false
+        self.webSocketTask = nil
+        self.pingTimeoutTimer?.cancel()
+        self.pingTimeoutTimer = nil
+
+        guard !self.intentionalDisconnect else { return }
+
+        guard self.reconnectAttempt < self.maxReconnectAttempts else {
+            print("[SessionWS] Max reconnect attempts (\(self.maxReconnectAttempts)) reached, giving up")
+            return
+        }
+
+        let delay = self.reconnectDelay()
+        self.reconnectAttempt += 1
+
+        // Cancel any previously scheduled reconnect to prevent duplicate
+        // connections piling up (e.g. rapid disconnect/reconnect during background).
+        self.reconnectWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.openConnection()
+        }
+        self.reconnectWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     func reconnectDelay(attempt: Int? = nil) -> TimeInterval {

--- a/packages/backend/src/__tests__/apply-rate-limit.test.ts
+++ b/packages/backend/src/__tests__/apply-rate-limit.test.ts
@@ -6,6 +6,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
 import {
   applyRateLimit,
   RATE_LIMIT_SESSION,
@@ -16,8 +19,25 @@ import {
   RATE_LIMIT_CREATE_SESSION_OP,
   RATE_LIMIT_END_SESSION,
   RATE_LIMIT_END_SESSION_OP,
+  RATE_LIMIT_CONFIRM_CLIMB_ON_WALL,
+  RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP,
+  RATE_LIMIT_SET_QUEUE,
+  RATE_LIMIT_SET_QUEUE_OP,
 } from '../graphql/resolvers/shared/helpers';
 import { RateLimitError } from '../utils/rate-limiter';
+
+function listResolverFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) return listResolverFiles(path);
+    return path.endsWith('.ts') ? [path] : [];
+  });
+}
+
+function stripTypeScriptComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
 
 // Mock rate limiter utilities so we can inspect which keys are used. Spread the
 // real module so the genuine RateLimitError class survives — applyRateLimit
@@ -177,11 +197,34 @@ describe('applyRateLimit structured RATE_LIMITED error (#2763)', () => {
     expect(RATE_LIMIT_JOIN_SESSION_OP).toBe('joinSession');
     expect(RATE_LIMIT_CREATE_SESSION_OP).toBe('createSession');
     expect(RATE_LIMIT_END_SESSION_OP).toBe('endSession');
-    expect(new Set([RATE_LIMIT_JOIN_SESSION_OP, RATE_LIMIT_CREATE_SESSION_OP, RATE_LIMIT_END_SESSION_OP]).size).toBe(
-      3,
-    );
-    expect(RATE_LIMIT_JOIN_SESSION).toBeGreaterThanOrEqual(30);
-    expect(RATE_LIMIT_CREATE_SESSION).toBeGreaterThanOrEqual(10);
-    expect(RATE_LIMIT_END_SESSION).toBeGreaterThanOrEqual(10);
+    expect(RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP).toBe('confirmClimbOnWall');
+    expect(RATE_LIMIT_SET_QUEUE_OP).toBe('setQueue');
+    expect(
+      new Set([
+        RATE_LIMIT_JOIN_SESSION_OP,
+        RATE_LIMIT_CREATE_SESSION_OP,
+        RATE_LIMIT_END_SESSION_OP,
+        RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP,
+        RATE_LIMIT_SET_QUEUE_OP,
+      ]).size,
+    ).toBe(5);
+    expect(RATE_LIMIT_JOIN_SESSION).toBeGreaterThanOrEqual(120);
+    expect(RATE_LIMIT_CREATE_SESSION).toBeGreaterThanOrEqual(30);
+    expect(RATE_LIMIT_END_SESSION).toBeGreaterThanOrEqual(30);
+    expect(RATE_LIMIT_CONFIRM_CLIMB_ON_WALL).toBeGreaterThanOrEqual(120);
+    expect(RATE_LIMIT_SET_QUEUE).toBeGreaterThanOrEqual(60);
+  });
+});
+
+describe('GraphQL resolver rate-limit bucket audit', () => {
+  it('requires explicit operation names for every resolver applyRateLimit call', () => {
+    const resolversDir = fileURLToPath(new URL('../graphql/resolvers', import.meta.url));
+    const implicitCalls = listResolverFiles(resolversDir).flatMap((file) => {
+      const source = stripTypeScriptComments(readFileSync(file, 'utf8'));
+      const matches = source.match(/applyRateLimit\(\s*ctx\s*(?:,\s*(?:\d+|[A-Z0-9_]+))?\s*\)/g) ?? [];
+      return matches.map((match) => `${file.replace(`${resolversDir}/`, '')}: ${match}`);
+    });
+
+    expect(implicitCalls).toEqual([]);
   });
 });

--- a/packages/backend/src/__tests__/apply-rate-limit.test.ts
+++ b/packages/backend/src/__tests__/apply-rate-limit.test.ts
@@ -186,8 +186,8 @@ describe('applyRateLimit structured RATE_LIMITED error (#2763)', () => {
   it('gives interactive session + playback traffic far more headroom than the 60/min default', () => {
     // The crux of the fix: queue/wall mutations and playback no longer share the
     // 60/min `default` bucket that a two-person session exhausted by switching.
-    expect(RATE_LIMIT_SESSION).toBeGreaterThan(60);
-    expect(RATE_LIMIT_PLAYBACK).toBeGreaterThanOrEqual(RATE_LIMIT_SESSION);
+    expect(RATE_LIMIT_SESSION).toBeGreaterThanOrEqual(1200);
+    expect(RATE_LIMIT_PLAYBACK).toBeGreaterThanOrEqual(3600);
   });
 
   it('keeps session lifecycle traffic out of the shared default bucket', () => {
@@ -208,11 +208,11 @@ describe('applyRateLimit structured RATE_LIMITED error (#2763)', () => {
         RATE_LIMIT_SET_QUEUE_OP,
       ]).size,
     ).toBe(5);
-    expect(RATE_LIMIT_JOIN_SESSION).toBeGreaterThanOrEqual(120);
-    expect(RATE_LIMIT_CREATE_SESSION).toBeGreaterThanOrEqual(30);
-    expect(RATE_LIMIT_END_SESSION).toBeGreaterThanOrEqual(30);
-    expect(RATE_LIMIT_CONFIRM_CLIMB_ON_WALL).toBeGreaterThanOrEqual(120);
-    expect(RATE_LIMIT_SET_QUEUE).toBeGreaterThanOrEqual(60);
+    expect(RATE_LIMIT_JOIN_SESSION).toBeGreaterThanOrEqual(600);
+    expect(RATE_LIMIT_CREATE_SESSION).toBeGreaterThanOrEqual(180);
+    expect(RATE_LIMIT_END_SESSION).toBeGreaterThanOrEqual(180);
+    expect(RATE_LIMIT_CONFIRM_CLIMB_ON_WALL).toBeGreaterThanOrEqual(600);
+    expect(RATE_LIMIT_SET_QUEUE).toBeGreaterThanOrEqual(300);
   });
 });
 

--- a/packages/backend/src/__tests__/apply-rate-limit.test.ts
+++ b/packages/backend/src/__tests__/apply-rate-limit.test.ts
@@ -6,7 +6,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
-import { applyRateLimit, RATE_LIMIT_SESSION, RATE_LIMIT_PLAYBACK } from '../graphql/resolvers/shared/helpers';
+import {
+  applyRateLimit,
+  RATE_LIMIT_SESSION,
+  RATE_LIMIT_PLAYBACK,
+  RATE_LIMIT_JOIN_SESSION,
+  RATE_LIMIT_JOIN_SESSION_OP,
+  RATE_LIMIT_CREATE_SESSION,
+  RATE_LIMIT_CREATE_SESSION_OP,
+  RATE_LIMIT_END_SESSION,
+  RATE_LIMIT_END_SESSION_OP,
+} from '../graphql/resolvers/shared/helpers';
 import { RateLimitError } from '../utils/rate-limiter';
 
 // Mock rate limiter utilities so we can inspect which keys are used. Spread the
@@ -158,5 +168,20 @@ describe('applyRateLimit structured RATE_LIMITED error (#2763)', () => {
     // 60/min `default` bucket that a two-person session exhausted by switching.
     expect(RATE_LIMIT_SESSION).toBeGreaterThan(60);
     expect(RATE_LIMIT_PLAYBACK).toBeGreaterThanOrEqual(RATE_LIMIT_SESSION);
+  });
+
+  it('keeps session lifecycle traffic out of the shared default bucket', () => {
+    // Native Live Activity keeps its own websocket and rejoins on reconnect.
+    // Those joins must not spend the same `default` bucket that createSession
+    // previously used, or websocket churn can make a later explicit Start fail.
+    expect(RATE_LIMIT_JOIN_SESSION_OP).toBe('joinSession');
+    expect(RATE_LIMIT_CREATE_SESSION_OP).toBe('createSession');
+    expect(RATE_LIMIT_END_SESSION_OP).toBe('endSession');
+    expect(new Set([RATE_LIMIT_JOIN_SESSION_OP, RATE_LIMIT_CREATE_SESSION_OP, RATE_LIMIT_END_SESSION_OP]).size).toBe(
+      3,
+    );
+    expect(RATE_LIMIT_JOIN_SESSION).toBeGreaterThanOrEqual(30);
+    expect(RATE_LIMIT_CREATE_SESSION).toBeGreaterThanOrEqual(10);
+    expect(RATE_LIMIT_END_SESSION).toBeGreaterThanOrEqual(10);
   });
 });

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -99,7 +99,7 @@ export const climbMutations = {
    */
   saveClimb: async (_: unknown, { input }: SaveClimbArgs, ctx: ConnectionContext): Promise<SaveClimbResult> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'saveClimb');
 
     const validated = validateInput(SaveClimbInputSchema, input, 'input');
     const isListed = !validated.isDraft;
@@ -255,7 +255,7 @@ export const climbMutations = {
     ctx: ConnectionContext,
   ): Promise<SaveClimbResult> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'saveMoonBoardClimb');
 
     const validated = validateInput(SaveMoonBoardClimbInputSchema, input, 'input');
     const isDraft = validated.isDraft ?? false;
@@ -412,7 +412,7 @@ export const climbMutations = {
     ctx: ConnectionContext,
   ): Promise<UpdateClimbResult> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'updateClimb');
 
     const validated = validateInput(UpdateClimbInputSchema, input, 'input');
 
@@ -667,7 +667,7 @@ export const climbMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'deleteDraftClimb');
 
     const validatedUuid = validateInput(ExternalUUIDSchema, uuid, 'uuid');
     const validatedBoardType = validateInput(BoardNameSchema, boardType, 'boardType');

--- a/packages/backend/src/graphql/resolvers/controller/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/controller/mutations.ts
@@ -46,7 +46,7 @@ export const controllerMutations = {
     ctx: ConnectionContext,
   ): Promise<ControllerRegistration> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10); // Lower limit for controller registration
+    await applyRateLimit(ctx, 10, 'registerController'); // Lower limit for controller registration
 
     if (!ctx.userId) {
       throw new Error('User ID not available');
@@ -84,7 +84,7 @@ export const controllerMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, 60, 'deleteController');
 
     if (!ctx.userId) {
       throw new Error('User ID not available');
@@ -118,7 +118,7 @@ export const controllerMutations = {
     },
     ctx: ConnectionContext,
   ): Promise<ClimbMatchResult> => {
-    await applyRateLimit(ctx, 30); // Moderate limit for LED position updates
+    await applyRateLimit(ctx, 30, 'setClimbFromLedPositions'); // Moderate limit for LED position updates
 
     // Verify controller is authenticated and authorized for this session
     const { controllerId } = await requireControllerAuthorizedForSession(ctx, sessionId);
@@ -287,7 +287,7 @@ export const controllerMutations = {
     { sessionId: _sessionId }: { sessionId: string },
     ctx: ConnectionContext,
   ): Promise<boolean> => {
-    await applyRateLimit(ctx, 120); // Allow frequent heartbeats
+    await applyRateLimit(ctx, 120, 'controllerHeartbeat'); // Allow frequent heartbeats
 
     // Validate API key authentication via context
     const { controllerApiKey } = requireControllerAuth(ctx);
@@ -312,7 +312,7 @@ export const controllerMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx);
+    await applyRateLimit(ctx, 60, 'authorizeControllerForSession');
 
     if (!ctx.userId) {
       throw new Error('User ID not available');
@@ -359,7 +359,7 @@ export const controllerMutations = {
     }: { sessionId: string; direction: string; currentClimbUuid?: string; queueItemUuid?: string },
     ctx: ConnectionContext,
   ): Promise<ClimbQueueItem | null> => {
-    await applyRateLimit(ctx, 30);
+    await applyRateLimit(ctx, 30, 'navigateQueue');
 
     // Verify controller is authenticated and authorized for this session
     await requireControllerAuthorizedForSession(ctx, sessionId);
@@ -480,7 +480,7 @@ export const controllerMutations = {
     { input }: { input: SendDeviceLogsInput },
     ctx: ConnectionContext,
   ): Promise<SendDeviceLogsResponse> => {
-    await applyRateLimit(ctx, 100); // Allow frequent log batches
+    await applyRateLimit(ctx, 100, 'sendDeviceLogs'); // Allow frequent log batches
 
     const { controllerId } = requireControllerAuth(ctx);
 

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -11,6 +11,8 @@ import {
   RATE_LIMIT_SESSION_OP,
   RATE_LIMIT_PLAYBACK,
   RATE_LIMIT_PLAYBACK_OP,
+  RATE_LIMIT_SET_QUEUE,
+  RATE_LIMIT_SET_QUEUE_OP,
 } from '../shared/helpers';
 import {
   ClimbQueueItemSchema,
@@ -365,7 +367,7 @@ export const queueMutations = {
     ctx: ConnectionContext,
   ) => {
     const startTime = performance.now();
-    await applyRateLimit(ctx, 30); // Lower limit for bulk operations
+    await applyRateLimit(ctx, RATE_LIMIT_SET_QUEUE, RATE_LIMIT_SET_QUEUE_OP);
     const sessionId = requireSession(ctx);
 
     // Validate queue size to prevent memory exhaustion

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -18,6 +18,8 @@ import {
   RATE_LIMIT_CREATE_SESSION_OP,
   RATE_LIMIT_END_SESSION,
   RATE_LIMIT_END_SESSION_OP,
+  RATE_LIMIT_CONFIRM_CLIMB_ON_WALL,
+  RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP,
 } from '../shared/helpers';
 import {
   SessionIdSchema,
@@ -474,7 +476,7 @@ export const sessionMutations = {
     // 2 s picker timeout. 60/min covers worst-case rapid swiping with
     // headroom while still choking off replay storms from a misbehaving
     // client.
-    await applyRateLimit(ctx, 60, 'confirmClimbOnWall');
+    await applyRateLimit(ctx, RATE_LIMIT_CONFIRM_CLIMB_ON_WALL, RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP);
     // Session identity comes from the WebSocket connection context (the
     // "WS-implicit" pattern used by takeControl / releaseControl) — clients
     // no longer pass `sessionId` as an argument.

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -12,6 +12,12 @@ import {
   validateInput,
   RATE_LIMIT_SESSION,
   RATE_LIMIT_SESSION_OP,
+  RATE_LIMIT_JOIN_SESSION,
+  RATE_LIMIT_JOIN_SESSION_OP,
+  RATE_LIMIT_CREATE_SESSION,
+  RATE_LIMIT_CREATE_SESSION_OP,
+  RATE_LIMIT_END_SESSION,
+  RATE_LIMIT_END_SESSION_OP,
 } from '../shared/helpers';
 import {
   SessionIdSchema,
@@ -113,7 +119,7 @@ export const sessionMutations = {
         `[joinSession] START - connectionId: ${ctx.connectionId}, sessionId: ${sessionId}, username: ${username}, sessionName: ${sessionName}, initialQueueLength: ${initialQueue?.length || 0}`,
       );
 
-    await applyRateLimit(ctx, 10); // Limit session joins to prevent abuse
+    await applyRateLimit(ctx, RATE_LIMIT_JOIN_SESSION, RATE_LIMIT_JOIN_SESSION_OP);
 
     // Validate inputs
     validateInput(SessionIdSchema, sessionId, 'sessionId');
@@ -197,7 +203,7 @@ export const sessionMutations = {
       if (DEBUG)
         logger.info(`[createSession] START - connectionId: ${ctx.connectionId}, boardPath: ${input.boardPath}`);
 
-      await applyRateLimit(ctx, 5); // Limit session creation to prevent abuse
+      await applyRateLimit(ctx, RATE_LIMIT_CREATE_SESSION, RATE_LIMIT_CREATE_SESSION_OP);
 
       // Validate input
       validateInput(CreateSessionInputSchema, input, 'createSession input');
@@ -688,7 +694,7 @@ export const sessionMutations = {
     { sessionId, timezone }: { sessionId: string; timezone?: string | null },
     ctx: ConnectionContext,
   ) => {
-    await applyRateLimit(ctx, 5);
+    await applyRateLimit(ctx, RATE_LIMIT_END_SESSION, RATE_LIMIT_END_SESSION_OP);
     validateInput(SessionIdSchema, sessionId, 'sessionId');
     // Ending a session is destructive (terminates every subscriber, generates
     // a summary row, marks the session ended in Postgres). The pre-#2128 code

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -51,6 +51,12 @@ export const RATE_LIMIT_SESSION_OP = 'session';
 export const RATE_LIMIT_SESSION = 240;
 export const RATE_LIMIT_PLAYBACK_OP = 'playback';
 export const RATE_LIMIT_PLAYBACK = 600;
+export const RATE_LIMIT_JOIN_SESSION_OP = 'joinSession';
+export const RATE_LIMIT_JOIN_SESSION = 30;
+export const RATE_LIMIT_CREATE_SESSION_OP = 'createSession';
+export const RATE_LIMIT_CREATE_SESSION = 10;
+export const RATE_LIMIT_END_SESSION_OP = 'endSession';
+export const RATE_LIMIT_END_SESSION = 10;
 
 /**
  * Helper to require a session context.

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -48,15 +48,19 @@ export const SESSION_MEMBER_RETRY_CONFIG = {
  * `confirmClimbOnWall` and `search-climbs`.
  */
 export const RATE_LIMIT_SESSION_OP = 'session';
-export const RATE_LIMIT_SESSION = 240;
+export const RATE_LIMIT_SESSION = 360;
 export const RATE_LIMIT_PLAYBACK_OP = 'playback';
-export const RATE_LIMIT_PLAYBACK = 600;
+export const RATE_LIMIT_PLAYBACK = 900;
 export const RATE_LIMIT_JOIN_SESSION_OP = 'joinSession';
-export const RATE_LIMIT_JOIN_SESSION = 30;
+export const RATE_LIMIT_JOIN_SESSION = 120;
 export const RATE_LIMIT_CREATE_SESSION_OP = 'createSession';
-export const RATE_LIMIT_CREATE_SESSION = 10;
+export const RATE_LIMIT_CREATE_SESSION = 30;
 export const RATE_LIMIT_END_SESSION_OP = 'endSession';
-export const RATE_LIMIT_END_SESSION = 10;
+export const RATE_LIMIT_END_SESSION = 30;
+export const RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP = 'confirmClimbOnWall';
+export const RATE_LIMIT_CONFIRM_CLIMB_ON_WALL = 120;
+export const RATE_LIMIT_SET_QUEUE_OP = 'setQueue';
+export const RATE_LIMIT_SET_QUEUE = 60;
 
 /**
  * Helper to require a session context.

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -44,23 +44,25 @@ export const SESSION_MEMBER_RETRY_CONFIG = {
  * mutations; `RATE_LIMIT_PLAYBACK` isolates the per-frame publishPlaybackState
  * broadcast so a playing variable-speed climb can't starve climb switching.
  * Both are well above any human gesture rate (with fan-out) yet still cap a
- * runaway client. Mirrors the existing per-operation buckets for
+ * runaway client. Playback allows up to 60 publishes/sec so route playback
+ * sync can follow fast frame cadences without tripping the limiter. Mirrors
+ * the existing per-operation buckets for
  * `confirmClimbOnWall` and `search-climbs`.
  */
 export const RATE_LIMIT_SESSION_OP = 'session';
-export const RATE_LIMIT_SESSION = 360;
+export const RATE_LIMIT_SESSION = 1200;
 export const RATE_LIMIT_PLAYBACK_OP = 'playback';
-export const RATE_LIMIT_PLAYBACK = 900;
+export const RATE_LIMIT_PLAYBACK = 3600;
 export const RATE_LIMIT_JOIN_SESSION_OP = 'joinSession';
-export const RATE_LIMIT_JOIN_SESSION = 120;
+export const RATE_LIMIT_JOIN_SESSION = 600;
 export const RATE_LIMIT_CREATE_SESSION_OP = 'createSession';
-export const RATE_LIMIT_CREATE_SESSION = 30;
+export const RATE_LIMIT_CREATE_SESSION = 180;
 export const RATE_LIMIT_END_SESSION_OP = 'endSession';
-export const RATE_LIMIT_END_SESSION = 30;
+export const RATE_LIMIT_END_SESSION = 180;
 export const RATE_LIMIT_CONFIRM_CLIMB_ON_WALL_OP = 'confirmClimbOnWall';
-export const RATE_LIMIT_CONFIRM_CLIMB_ON_WALL = 120;
+export const RATE_LIMIT_CONFIRM_CLIMB_ON_WALL = 600;
 export const RATE_LIMIT_SET_QUEUE_OP = 'setQueue';
-export const RATE_LIMIT_SET_QUEUE = 60;
+export const RATE_LIMIT_SET_QUEUE = 300;
 
 /**
  * Helper to require a session context.

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -665,7 +665,7 @@ export const socialBoardQueries = {
    * Unauthenticated callers receive stripped responses (no GPS/owner data).
    */
   boardsBySerialNumbers: async (_: unknown, { serialNumbers }: { serialNumbers: string[] }, ctx: ConnectionContext) => {
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'boardsBySerialNumbers');
 
     // Behaviour change: this used to silently `.slice(0, 20)` on overflow, now
     // it throws via Zod (`SerialNumberLookupSchema.max(20)`). Callers MUST cap
@@ -741,7 +741,7 @@ export const socialBoardQueries = {
    */
   myBoardSerialConfigs: async (_: unknown, { serialNumbers }: { serialNumbers: string[] }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'myBoardSerialConfigs');
 
     const validated = validateInput(SerialNumberLookupSchema, { serialNumbers }, 'serialNumbers');
     const cleaned = validated.serialNumbers.filter((s) => s.length > 0);
@@ -840,7 +840,7 @@ export const socialBoardQueries = {
    * Search public boards
    */
   searchBoards: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'searchBoards');
     const validatedInput = validateInput(SearchBoardsInputSchema, input, 'input');
     const { query, boardType, latitude, longitude, radiusKm } = validatedInput;
     const limit = validatedInput.limit ?? 20;
@@ -1321,7 +1321,7 @@ export const socialBoardMutations = {
    */
   createBoard: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'createBoard');
 
     const validatedInput = validateInput(CreateBoardInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -1510,7 +1510,7 @@ export const socialBoardMutations = {
    */
   updateBoard: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'updateBoard');
 
     const validatedInput = validateInput(UpdateBoardInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -1656,7 +1656,7 @@ export const socialBoardMutations = {
    */
   deleteBoard: async (_: unknown, { boardUuid }: { boardUuid: string }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'deleteBoard');
 
     validateInput(UUIDSchema, boardUuid, 'boardUuid');
     const userId = ctx.userId!;
@@ -1689,7 +1689,7 @@ export const socialBoardMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'followBoard');
 
     const validatedInput = validateInput(FollowBoardInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -1733,7 +1733,7 @@ export const socialBoardMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'unfollowBoard');
 
     const validatedInput = validateInput(FollowBoardInputSchema, input, 'input');
     const userId = ctx.userId!;

--- a/packages/backend/src/graphql/resolvers/social/comments.ts
+++ b/packages/backend/src/graphql/resolvers/social/comments.ts
@@ -328,7 +328,7 @@ export const socialCommentQueries = {
 export const socialCommentMutations = {
   addComment: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10, 'comment');
+    await applyRateLimit(ctx, 10, 'addComment');
 
     const validated = validateInput(AddCommentInputSchema, input, 'input');
     const { entityType, entityId, parentCommentUuid, body } = validated;
@@ -432,7 +432,7 @@ export const socialCommentMutations = {
 
   updateComment: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10, 'comment');
+    await applyRateLimit(ctx, 10, 'updateComment');
 
     const validated = validateInput(UpdateCommentInputSchema, input, 'input');
     const { commentUuid, body } = validated;

--- a/packages/backend/src/graphql/resolvers/social/community-settings.ts
+++ b/packages/backend/src/graphql/resolvers/social/community-settings.ts
@@ -103,7 +103,7 @@ export const socialCommunitySettingsQueries = {
 export const socialCommunitySettingsMutations = {
   setCommunitySettings: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     await requireAdminOrLeader(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'setCommunitySettings');
 
     const validated = validateInput(SetCommunitySettingInputSchema, input, 'input');
     const { scope, scopeKey, key, value } = validated;

--- a/packages/backend/src/graphql/resolvers/social/follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/follows.ts
@@ -199,7 +199,7 @@ export const socialFollowMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 30, 'follow');
+    await applyRateLimit(ctx, 30, 'followUser');
 
     const validatedInput = validateInput(FollowInputSchema, input, 'input');
     const myUserId = ctx.userId!;
@@ -254,7 +254,7 @@ export const socialFollowMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 30, 'follow');
+    await applyRateLimit(ctx, 30, 'unfollowUser');
 
     const validatedInput = validateInput(FollowInputSchema, input, 'input');
     const myUserId = ctx.userId!;

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -451,7 +451,7 @@ export const socialGymQueries = {
 export const socialGymMutations = {
   createGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'createGym');
 
     const validatedInput = validateInput(CreateGymInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -502,7 +502,7 @@ export const socialGymMutations = {
 
   updateGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'updateGym');
 
     const validatedInput = validateInput(UpdateGymInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -563,7 +563,7 @@ export const socialGymMutations = {
 
   deleteGym: async (_: unknown, { gymUuid }: { gymUuid: string }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'deleteGym');
 
     validateInput(UUIDSchema, gymUuid, 'gymUuid');
     const userId = ctx.userId!;
@@ -593,7 +593,7 @@ export const socialGymMutations = {
 
   addGymMember: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'addGymMember');
 
     const validatedInput = validateInput(AddGymMemberInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -625,7 +625,7 @@ export const socialGymMutations = {
 
   removeGymMember: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'removeGymMember');
 
     const validatedInput = validateInput(RemoveGymMemberInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -646,7 +646,7 @@ export const socialGymMutations = {
 
   followGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'followGym');
 
     const validatedInput = validateInput(FollowGymInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -682,7 +682,7 @@ export const socialGymMutations = {
 
   unfollowGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'unfollowGym');
 
     const validatedInput = validateInput(FollowGymInputSchema, input, 'input');
     const userId = ctx.userId!;
@@ -707,7 +707,7 @@ export const socialGymMutations = {
 
   linkBoardToGym: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'linkBoardToGym');
 
     const validatedInput = validateInput(LinkBoardToGymInputSchema, input, 'input');
     const userId = ctx.userId!;

--- a/packages/backend/src/graphql/resolvers/social/new-climb-subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/social/new-climb-subscriptions.ts
@@ -128,7 +128,7 @@ export const newClimbSubscriptionResolvers = {
       ctx: ConnectionContext,
     ): Promise<boolean> => {
       requireAuthenticated(ctx);
-      await applyRateLimit(ctx, 20);
+      await applyRateLimit(ctx, 20, 'subscribeNewClimbs');
       const validated = validateInput(NewClimbSubscriptionInputSchema, input, 'input');
 
       await db
@@ -149,7 +149,7 @@ export const newClimbSubscriptionResolvers = {
       ctx: ConnectionContext,
     ): Promise<boolean> => {
       requireAuthenticated(ctx);
-      await applyRateLimit(ctx, 20);
+      await applyRateLimit(ctx, 20, 'unsubscribeNewClimbs');
       const validated = validateInput(NewClimbSubscriptionInputSchema, input, 'input');
 
       await db

--- a/packages/backend/src/graphql/resolvers/social/notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/notifications.ts
@@ -361,7 +361,7 @@ export const socialNotificationMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 60, 'notification_read');
+    await applyRateLimit(ctx, 60, 'markNotificationRead');
     const userId = ctx.userId!;
 
     await db
@@ -378,7 +378,7 @@ export const socialNotificationMutations = {
     ctx: ConnectionContext,
   ): Promise<number> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 60, 'notification_read');
+    await applyRateLimit(ctx, 60, 'markGroupNotificationsRead');
     const userId = ctx.userId!;
 
     // Build conditions for the group
@@ -411,7 +411,7 @@ export const socialNotificationMutations = {
 
   markAllNotificationsRead: async (_: unknown, __: unknown, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 5, 'notification_read_all');
+    await applyRateLimit(ctx, 5, 'markAllNotificationsRead');
     const userId = ctx.userId!;
 
     await db

--- a/packages/backend/src/graphql/resolvers/social/proposals/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals/mutations.ts
@@ -25,7 +25,7 @@ import { setterOverrideCommunityStatus, freezeClimb } from './setter-overrides';
 export const socialProposalMutations = {
   createProposal: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 5);
+    await applyRateLimit(ctx, 5, 'createProposal');
 
     const validated = validateInput(CreateProposalInputSchema, input, 'input');
     const { climbUuid, boardType, angle, type, proposedValue, reason } = validated;
@@ -197,7 +197,7 @@ export const socialProposalMutations = {
 
   voteOnProposal: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'voteOnProposal');
 
     const validated = validateInput(VoteOnProposalInputSchema, input, 'input');
     const { proposalUuid, value } = validated;

--- a/packages/backend/src/graphql/resolvers/social/proposals/setter-overrides.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals/setter-overrides.ts
@@ -12,7 +12,7 @@ import { notifyClimbRevalidated } from '../../../../lib/web-revalidate';
  */
 export async function setterOverrideCommunityStatus(_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) {
   requireAuthenticated(ctx);
-  await applyRateLimit(ctx, 10);
+  await applyRateLimit(ctx, 10, 'setterOverrideCommunityStatus');
 
   const validated = validateInput(SetterOverrideInputSchema, input, 'input');
   const { climbUuid, boardType, angle, communityGrade, isBenchmark } = validated;

--- a/packages/backend/src/graphql/resolvers/social/roles.ts
+++ b/packages/backend/src/graphql/resolvers/social/roles.ts
@@ -122,7 +122,7 @@ export const socialRoleQueries = {
 export const socialRoleMutations = {
   grantRole: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     await requireAdmin(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'grantRole');
 
     const validated = validateInput(GrantRoleInputSchema, input, 'input');
     const { userId, role, boardType } = validated;
@@ -171,7 +171,7 @@ export const socialRoleMutations = {
 
   revokeRole: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     await requireAdmin(ctx);
-    await applyRateLimit(ctx, 10);
+    await applyRateLimit(ctx, 10, 'revokeRole');
 
     const validated = validateInput(RevokeRoleInputSchema, input, 'input');
     const { userId, role, boardType } = validated;

--- a/packages/backend/src/graphql/resolvers/social/search.ts
+++ b/packages/backend/src/graphql/resolvers/social/search.ts
@@ -14,7 +14,7 @@ export const socialSearchQueries = {
     { input }: { input: { query: string; boardType?: string; limit?: number; offset?: number } },
     ctx: ConnectionContext,
   ) => {
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'searchUsers');
 
     const validatedInput = validateInput(SearchUsersInputSchema, input, 'input');
     const query = validatedInput.query;

--- a/packages/backend/src/graphql/resolvers/social/setter-follows.ts
+++ b/packages/backend/src/graphql/resolvers/social/setter-follows.ts
@@ -605,7 +605,7 @@ export const setterFollowQueries = {
     { input }: { input: { query: string; boardType?: string; limit?: number; offset?: number } },
     ctx: ConnectionContext,
   ) => {
-    await applyRateLimit(ctx, 20);
+    await applyRateLimit(ctx, 20, 'searchUsersAndSetters');
 
     const validatedInput = validateInput(SearchUsersInputSchema, input, 'input');
     const query = validatedInput.query;
@@ -784,7 +784,7 @@ export const setterFollowMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 30, 'follow');
+    await applyRateLimit(ctx, 30, 'followSetter');
 
     const validatedInput = validateInput(FollowSetterInputSchema, input, 'input');
     const myUserId = ctx.userId!;
@@ -852,7 +852,7 @@ export const setterFollowMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
-    await applyRateLimit(ctx, 30, 'follow');
+    await applyRateLimit(ctx, 30, 'unfollowSetter');
 
     const validatedInput = validateInput(FollowSetterInputSchema, input, 'input');
     const myUserId = ctx.userId!;

--- a/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
@@ -557,8 +557,7 @@ final class SessionWebSocketManager {
                 self.listenForMessages(for: task)
 
             case .failure(let error):
-                print("[SessionWS] Receive failed: \(error.localizedDescription)")
-                self.handleDisconnect(for: task)
+                self.handleReceiveFailure(error, for: task)
             }
         }
     }
@@ -739,40 +738,56 @@ final class SessionWebSocketManager {
     private func handleDisconnect(for task: URLSessionWebSocketTask) {
         stateQueue.async { [weak self] in
             guard let self = self else { return }
-
-            // Only process disconnect if this is still the current task.
-            // A stale task from a previous connection must not tear down the
-            // active connection.
-            guard self.webSocketTask === task else {
-                print("[SessionWS] Ignoring stale disconnect for superseded task")
-                return
-            }
-
-            self.isConnected = false
-            self.webSocketTask = nil
-            self.pingTimeoutTimer?.cancel()
-            self.pingTimeoutTimer = nil
-
-            guard !self.intentionalDisconnect else { return }
-
-            guard self.reconnectAttempt < self.maxReconnectAttempts else {
-                print("[SessionWS] Max reconnect attempts (\(self.maxReconnectAttempts)) reached, giving up")
-                return
-            }
-
-            let delay = self.reconnectDelay()
-            self.reconnectAttempt += 1
-
-            // Cancel any previously scheduled reconnect to prevent duplicate
-            // connections piling up (e.g. rapid disconnect/reconnect during background).
-            self.reconnectWorkItem?.cancel()
-
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.openConnection()
-            }
-            self.reconnectWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            self.handleDisconnectOnQueue(for: task)
         }
+    }
+
+    private func handleReceiveFailure(_ error: Error, for task: URLSessionWebSocketTask) {
+        stateQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.webSocketTask === task && !self.intentionalDisconnect {
+                print("[SessionWS] Receive failed: \(error.localizedDescription)")
+            }
+            self.handleDisconnectOnQueue(for: task)
+        }
+    }
+
+    /// Must be called on `stateQueue`.
+    private func handleDisconnectOnQueue(for task: URLSessionWebSocketTask) {
+        // Only process disconnect if this is still the current task.
+        // A stale task from a previous connection must not tear down the
+        // active connection.
+        guard self.webSocketTask === task else {
+            if !self.intentionalDisconnect {
+                print("[SessionWS] Ignoring stale disconnect for superseded task")
+            }
+            return
+        }
+
+        self.isConnected = false
+        self.webSocketTask = nil
+        self.pingTimeoutTimer?.cancel()
+        self.pingTimeoutTimer = nil
+
+        guard !self.intentionalDisconnect else { return }
+
+        guard self.reconnectAttempt < self.maxReconnectAttempts else {
+            print("[SessionWS] Max reconnect attempts (\(self.maxReconnectAttempts)) reached, giving up")
+            return
+        }
+
+        let delay = self.reconnectDelay()
+        self.reconnectAttempt += 1
+
+        // Cancel any previously scheduled reconnect to prevent duplicate
+        // connections piling up (e.g. rapid disconnect/reconnect during background).
+        self.reconnectWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.openConnection()
+        }
+        self.reconnectWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
     func reconnectDelay(attempt: Int? = nil) -> TimeInterval {

--- a/packages/mobile/src/lib/graphql/__tests__/extract-error-message.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/extract-error-message.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { extractGraphqlMessage, isGraphqlRateLimitedError } from '../extract-error-message';
+
+describe('GraphQL error extraction', () => {
+  it('extracts the first graphql-request response message', () => {
+    const error = {
+      response: {
+        errors: [{ message: 'Server guidance' }],
+      },
+    };
+
+    expect(extractGraphqlMessage(error)).toBe('Server guidance');
+  });
+
+  it('detects RATE_LIMITED graphql-request response errors', () => {
+    const error = {
+      response: {
+        errors: [
+          {
+            message: 'Rate limit exceeded. Try again in 7 seconds.',
+            extensions: { code: 'RATE_LIMITED', operation: 'createSession', retryAfterSeconds: 7 },
+          },
+        ],
+      },
+    };
+
+    expect(isGraphqlRateLimitedError(error)).toBe(true);
+  });
+
+  it('detects RATE_LIMITED operation errors with direct extensions', () => {
+    const error = {
+      extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 3 },
+    };
+
+    expect(isGraphqlRateLimitedError(error)).toBe(true);
+  });
+
+  it('ignores non-rate-limit GraphQL errors', () => {
+    const error = {
+      response: {
+        errors: [{ message: 'Nope', extensions: { code: 'UNAUTHENTICATED' } }],
+      },
+    };
+
+    expect(isGraphqlRateLimitedError(error)).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -4,11 +4,34 @@
 // to <other climb>", "Instagram is temporarily blocking us"); otherwise return
 // null so the caller can fall back to a generic toast string. Never leaks fetch
 // internals.
+type GraphqlErrorLike = {
+  message?: string;
+  extensions?: {
+    code?: unknown;
+    retryAfterSeconds?: unknown;
+    [key: string]: unknown;
+  } | null;
+};
+
+function getGraphqlErrors(error: unknown): GraphqlErrorLike[] {
+  if (!error || typeof error !== 'object') return [];
+  const response = (error as { response?: { errors?: GraphqlErrorLike[] } }).response;
+  if (Array.isArray(response?.errors)) return response.errors;
+  const graphqlErrors = (error as { graphqlErrors?: GraphqlErrorLike[] }).graphqlErrors;
+  return Array.isArray(graphqlErrors) ? graphqlErrors : [];
+}
+
 export function extractGraphqlMessage(error: unknown): string | null {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const response = (error as { response?: { errors?: { message?: string }[] } }).response;
-    const first = response?.errors?.[0]?.message;
-    if (typeof first === 'string' && first.length > 0) return first;
-  }
+  const first = getGraphqlErrors(error)[0]?.message;
+  if (typeof first === 'string' && first.length > 0) return first;
   return null;
+}
+
+export function isGraphqlRateLimitedError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const directExtensions = (error as { extensions?: GraphqlErrorLike['extensions'] }).extensions;
+  if (directExtensions?.code === 'RATE_LIMITED') return true;
+
+  return getGraphqlErrors(error).some((graphqlError) => graphqlError.extensions?.code === 'RATE_LIMITED');
 }

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -88,13 +88,24 @@ const queueSnapshotStore = vi.hoisted(() => ({
   clearStoredQueueSnapshot: vi.fn(async () => {}),
 }));
 
+const sentry = vi.hoisted(() => ({
+  reportError: vi.fn(),
+}));
+
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
   AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
 }));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-correlation-id' }));
-vi.mock('@boardsesh/graphql-client', () => ({ execute: graph.execute }));
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
 vi.mock('@boardsesh/queue-react', () => ({
   useQueueMutations: (deps: CapturedMutationDeps) => {
     capturedMutationDeps.current = deps;
@@ -115,8 +126,8 @@ vi.mock('../../lib/graphql/use-active-board', () => ({
 }));
 vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
-vi.mock('../../lib/sentry', () => ({ reportError: vi.fn() }));
-vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../lib/sentry', () => ({ reportError: sentry.reportError }));
+vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
 
 import { QueueProvider, usePlaylistSuggestionSource, useQueue } from '../queue-provider';
@@ -207,6 +218,8 @@ describe('QueueProvider local solo queue', () => {
     queueSnapshotStore.getStoredQueueSnapshot.mockResolvedValue(null);
     queueSnapshotStore.setStoredQueueSnapshot.mockClear();
     queueSnapshotStore.clearStoredQueueSnapshot.mockClear();
+    sentry.reportError.mockClear();
+    toast.showToast.mockClear();
     graph.execute.mockReset();
     graph.execute.mockResolvedValue({
       joinSession: {
@@ -390,6 +403,36 @@ describe('QueueProvider local solo queue', () => {
 
     expect(queueMutations.setQueue).not.toHaveBeenCalled();
     expect(sessionStore.setStoredSessionId).toHaveBeenCalledWith('session-new');
+  });
+
+  it('does not report createSession rate limits to Sentry', async () => {
+    http.request.mockRejectedValueOnce({
+      response: {
+        status: 200,
+        errors: [
+          {
+            message: 'Rate limit exceeded. Try again in 7 seconds.',
+            extensions: { code: 'RATE_LIMITED', operation: 'createSession', retryAfterSeconds: 7 },
+          },
+        ],
+      },
+    });
+
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+    await waitFor(() => {
+      expect(snapshots.length).toBeGreaterThan(0);
+    });
+
+    await act(async () => {
+      await expect(snapshots.at(-1)?.startSession()).resolves.toBeNull();
+    });
+
+    expect(toast.showToast).toHaveBeenCalledWith('mobile.queue.rateLimited', 'error');
+    expect(toast.showToast).not.toHaveBeenCalledWith('mobile.queue.sessionCreateError', 'error');
+    expect(sentry.reportError).not.toHaveBeenCalled();
+    expect(sessionStore.setStoredSessionId).not.toHaveBeenCalled();
+    expect(graph.execute).not.toHaveBeenCalled();
   });
 
   it('joinSession persists the id and drops the solo snapshot', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -76,7 +76,7 @@ import { toMobileSessionRuntimeEvent } from '../lib/session-runtime-event';
 import { climbToQueueItem, toClimbInput } from '../lib/climb-to-queue-item';
 import { track } from '../lib/analytics';
 import { reportError } from '../lib/sentry';
-import { extractGraphqlMessage } from '../lib/graphql/extract-error-message';
+import { extractGraphqlMessage, isGraphqlRateLimitedError } from '../lib/graphql/extract-error-message';
 import { useToast } from './toast-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 
@@ -965,6 +965,10 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           });
           return newId;
         } catch (error) {
+          if (isGraphqlRateLimitedError(error)) {
+            showToast(t('mobile.queue.rateLimited'), 'error');
+            return null;
+          }
           // Production masks the GraphQL message to "Unexpected error", but the
           // graphql-request ClientError still carries the HTTP status — so Sentry
           // can distinguish network-down from a 4xx/5xx from a masked server


### PR DESCRIPTION
## Summary

Fixes the production `createSession` rate-limit failure path seen in Sentry/PostHog by separating session lifecycle rate-limit buckets, making live-session limits generous, and handling expected create-session throttles on mobile without reporting them to Sentry.

## Root Cause

`createSession`, `joinSession`, and `endSession` were using tight session lifecycle limits, while other resolver calls still had several implicit/default rate-limit buckets. During native Live Activity websocket reconnect churn, lifecycle calls could spend capacity before an explicit mobile Start Session needed it. When `createSession` returned a structured GraphQL `RATE_LIMITED` error, the React Native HTTP path saw the raw `graphql-request` error shape, did not classify it as expected throttling, and reported it to Sentry.

The native websocket also logged `Receive failed: Socket is not connected` before checking whether the socket was intentionally closed or stale, so expected teardown appeared as an error in recordings.

## Changes

- Add named backend buckets for `joinSession`, `createSession`, `endSession`, `confirmClimbOnWall`, and `setQueue`.
- Raise live-session ceilings generously: session gestures `1200/min`, playback `3600/min`, join session `600/min`, create session `180/min`, end session `180/min`, confirm-on-wall `600/min`, and set-queue `300/min`.
- Audit GraphQL resolver rate-limit calls so live resolver calls use explicit operation names instead of sharing the default bucket.
- Add static regression coverage that fails if a resolver adds an implicit `applyRateLimit(ctx...)` bucket again.
- Classify `graphql-request` GraphQL errors with `extensions.code === RATE_LIMITED` in the mobile HTTP error helper.
- Make mobile `startSession` show the existing gentle rate-limit toast and skip Sentry for expected create-session throttles.
- Suppress native SessionWS receive-failure logs for intentional or stale websocket teardown in both iOS copies.
- Rebase the PR branch on latest `origin/main` (`931234e2b`).

## Validation

- `vp install`
- `vp test run packages/mobile/src/lib/graphql/__tests__/extract-error-message.test.ts`
- `vp test run packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx`
- `vp test run packages/backend/src/__tests__/apply-rate-limit.test.ts`
- `vp run typecheck:mobile`
- `vp run typecheck:backend`
- `git diff --check`

Note: I did not run an Xcode/iOS native build in this environment.