### PR TITLE
Restore mobile climb type filters

### DIFF
--- a/packages/backend/src/__tests__/climb-search-validation.test.ts
+++ b/packages/backend/src/__tests__/climb-search-validation.test.ts
@@ -42,3 +42,17 @@ describe('ClimbSearchInputSchema holdsFilter cap', () => {
     }
   });
 });
+
+describe('ClimbSearchInputSchema climb type fields', () => {
+  it('leaves omitted boulders/routes undefined so callers get all climbs by default', () => {
+    const result = ClimbSearchInputSchema.parse(base);
+    expect(result.boulders).toBeUndefined();
+    expect(result.routes).toBeUndefined();
+  });
+
+  it('preserves explicit false values for boulders/routes', () => {
+    const result = ClimbSearchInputSchema.parse({ ...base, boulders: false, routes: true });
+    expect(result.boulders).toBe(false);
+    expect(result.routes).toBe(true);
+  });
+});

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -162,11 +162,10 @@ export const ClimbSearchInputSchema = z.object({
   showOnlyCompleted: z.boolean().optional(),
   onlyDrafts: z.boolean().optional(),
   projectsOnly: z.boolean().optional(),
-  // Default to boulders-only so non-web GraphQL callers (mobile, scripts)
-  // get the same shape as the web UI when the field is omitted. Web sends
-  // explicit values from URL state, so its behaviour is unchanged.
-  boulders: z.boolean().optional().default(true),
-  routes: z.boolean().optional().default(false),
+  // Omitted means all climbs. Explicit false is meaningful for the 3-way
+  // All / Boulders / Routes filter and must survive validation.
+  boulders: z.boolean().optional(),
+  routes: z.boolean().optional(),
   zoneBox: z
     .object({
       edgeLeft: z.number().int(),

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -43,7 +43,7 @@ import { type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
 import { useNativeAccessoryActive } from '../../../src/hooks/use-bottom-accessory';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
-import { useGrades } from '../../../src/lib/graphql/hooks';
+import { useGrades, useSearchClimbsCount } from '../../../src/lib/graphql/hooks';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
@@ -451,6 +451,7 @@ function ClimbListInner() {
     hasNextPage,
     refetch,
   } = useInfiniteSearchClimbs(searchInput, searchReady);
+  const { data: totalCount } = useSearchClimbsCount(searchInput, searchReady);
   const isLoadingMoreRef = useRef(false);
 
   const visibleClimbs = useMemo(() => {
@@ -607,21 +608,6 @@ function ClimbListInner() {
       .then(() => setRecentFilters([]))
       .catch(() => {});
   }, []);
-
-  // Material filter-summary chip clears the non-grade refinements (the dedicated
-  // grade chip owns the grade), keeping the typed name query. The glass variant
-  // has no chrome clear-all — it clears via the filter sheet's Reset.
-  const handleClearNonGradeFilters = useCallback(() => {
-    replaceSearch(
-      {
-        ...DEFAULT_CLIMB_FILTER_STATE,
-        minGrade: filters.minGrade,
-        maxGrade: filters.maxGrade,
-      },
-      name,
-      DEFAULT_CLIMB_BOARD_FILTER_STATE,
-    );
-  }, [replaceSearch, name, filters.minGrade, filters.maxGrade]);
 
   const handleGradeChange = useCallback(
     (next: GradeBound) => {
@@ -898,11 +884,8 @@ function ClimbListInner() {
         onCloseGrade={handleDismissGrade}
         activeFilterCount={activeFilterCount}
         onOpenFilters={handleOpenFilters}
-        filterSummary={
-          variant === 'material' && filterSummary
-            ? { text: filterSummary, onClear: handleClearNonGradeFilters }
-            : undefined
-        }
+        totalCount={totalCount}
+        filterTokens={variant === 'material' ? nonGradeFilterTokens : filterTokens}
         gradeBound={gradeBound}
         grades={grades}
         gradeRailVisible={showGrade}
@@ -915,6 +898,8 @@ function ClimbListInner() {
         <ClimbFilterFab
           activeFilterCount={activeFilterCount}
           bottom={filterFabBottom}
+          totalCount={totalCount}
+          filterTokens={filterTokens}
           bound={gradeBound}
           grades={grades}
           gradeRailVisible={showGrade}

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -22,6 +22,8 @@ import {
   hasActiveBoardFilters,
   applyStatusChange,
   normalizeRetiredStatus,
+  climbTypeOf,
+  climbTypePatch,
   toClimbSearchInput,
   mergeBoardFilters,
   formatMinAscentsFilterCount,
@@ -31,6 +33,7 @@ import {
   type SortOrder,
   type StatusFilter,
   type GradeAccuracyValue,
+  type ClimbType,
   type ClimbBoardFilterState,
   SORT_OPTIONS,
   GRADE_ACCURACY_VALUES,
@@ -339,29 +342,21 @@ export function ClimbFilterSheet({
     },
     [updateLocalFilters],
   );
-  // Climb-type toggle (main's #2496 control). A 3-way control means there's no
-  // UI path to "neither", so the never-both-off invariant is structural (see
-  // toClimbSearchInput). "Both" = show everything; boulders-only is the default.
-  const climbTypeKey = useMemo<'boulders' | 'routes' | 'both'>(() => {
-    const bouldersOn = localFilters.boulders ?? true;
-    const routesOn = localFilters.routes ?? false;
-    if (bouldersOn && !routesOn) return 'boulders';
-    if (!bouldersOn && routesOn) return 'routes';
-    return 'both';
-  }, [localFilters.boulders, localFilters.routes]);
+  const climbTypeKey = useMemo<ClimbType>(
+    () => climbTypeOf(localFilters),
+    [localFilters.boulders, localFilters.routes],
+  );
   const handleClimbTypeChange = useCallback(
     (key: string) => {
-      if (key === 'routes') setFiltersPatch({ boulders: false, routes: true });
-      else if (key === 'both') setFiltersPatch({ boulders: true, routes: true });
-      else setFiltersPatch({ boulders: true, routes: false });
+      setFiltersPatch(climbTypePatch(key as ClimbType));
     },
     [setFiltersPatch],
   );
   const climbTypeOptions = useMemo(
     () => [
-      { key: 'boulders', label: t('mobile.filter.boulders') },
-      { key: 'routes', label: t('mobile.filter.routes') },
-      { key: 'both', label: t('mobile.filter.both') },
+      { key: 'all', label: t('mobile.filter.climbType.all') },
+      { key: 'boulders', label: t('mobile.filter.climbType.boulders') },
+      { key: 'routes', label: t('mobile.filter.climbType.routes') },
     ],
     [t],
   );
@@ -496,11 +491,11 @@ export function ClimbFilterSheet({
 
   const refineSummary = useMemo(() => {
     const parts: string[] = [];
-    // Boulders-only is the default, so only surface a chip when it differs.
-    const bouldersOn = localFilters.boulders ?? true;
-    const routesOn = localFilters.routes ?? false;
-    if (routesOn && !bouldersOn) parts.push(t('mobile.filter.routes'));
-    else if (routesOn && bouldersOn) parts.push(t('mobile.filter.both'));
+    const climbType = climbTypeOf(localFilters);
+    const hasExplicitClimbType = localFilters.boulders != null || localFilters.routes != null;
+    if (climbType === 'boulders') parts.push(t('mobile.filter.climbType.boulders'));
+    else if (climbType === 'routes') parts.push(t('mobile.filter.climbType.routes'));
+    else if (hasExplicitClimbType) parts.push(t('mobile.filter.climbType.all'));
     if (localFilters.gradeAccuracy != null) parts.push(accuracyLabels[localFilters.gradeAccuracy]);
     if (localFilters.setter && localFilters.setter.length > 0) {
       parts.push(formatSetterSelection(localFilters.setter));
@@ -659,7 +654,7 @@ export function ClimbFilterSheet({
               onExpandedChange={handleRefineExpandedChange}
             >
               <Text variant="footnote" style={styles.subsectionLabel}>
-                {t('mobile.filter.climbType')}
+                {t('mobile.filter.climbType.label')}
               </Text>
               <SegmentedControl
                 options={climbTypeOptions}

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -38,8 +38,6 @@ const currentFilters: ClimbFilters = {
   sortBy: 'popular',
   sortOrder: 'desc',
   status: 'any',
-  boulders: true,
-  routes: false,
   setter: ['draft-setter'],
 };
 
@@ -125,14 +123,23 @@ vi.mock('@boardsesh/climb-filters', () => ({
     sortBy: 'popular',
     sortOrder: 'desc',
     status: 'any',
-    boulders: true,
-    routes: false,
   },
   DEFAULT_CLIMB_BOARD_FILTER_STATE: {},
   hasActiveClimbFilters: () => false,
   hasActiveBoardFilters: () => false,
   applyStatusChange: (_filters: unknown, status: string) => ({ status }),
   normalizeRetiredStatus: (filters: unknown) => filters,
+  climbTypeOf: (filters: { boulders?: boolean; routes?: boolean }) => {
+    if (filters.boulders === true && filters.routes !== true) return 'boulders';
+    if (filters.routes === true && filters.boulders !== true) return 'routes';
+    return 'all';
+  },
+  climbTypePatch: (type: 'all' | 'boulders' | 'routes') =>
+    type === 'boulders'
+      ? { boulders: true, routes: false }
+      : type === 'routes'
+        ? { boulders: false, routes: true }
+        : { boulders: undefined, routes: undefined },
   toClimbSearchInput: () => ({}),
   mergeBoardFilters: (input: unknown) => input,
   formatMinAscentsFilterCount: (count: number) => String(count),
@@ -189,7 +196,32 @@ vi.mock('../Button', () => ({
   Button: ({ title, onPress }: { title: string; onPress?: () => void }) =>
     createElement('button', { onClick: onPress }, title),
 }));
-vi.mock('../SegmentedControl', () => ({ SegmentedControl: () => null }));
+vi.mock('../SegmentedControl', () => ({
+  SegmentedControl: ({
+    options,
+    selectedKey,
+    onSelect,
+  }: {
+    options: Array<{ key: string; label: string }>;
+    selectedKey: string;
+    onSelect: (key: string) => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-testid': 'segmented-control', 'data-selected': selectedKey },
+      options.map((option) =>
+        createElement(
+          'button',
+          {
+            key: option.key,
+            onClick: () => onSelect(option.key),
+            'aria-pressed': selectedKey === option.key,
+          },
+          option.label,
+        ),
+      ),
+    ),
+}));
 vi.mock('../StarRating', () => ({ StarRating: () => null }));
 vi.mock('../CollapsibleSection', () => ({
   CollapsibleSection: ({
@@ -348,6 +380,16 @@ describe('ClimbFilterSheet child filters', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('applies climb type changes from the segmented control', () => {
+    const onApply = vi.fn();
+    const { getByText } = renderFilterSheet({ onApply });
+
+    fireEvent.click(getByText('mobile.filter.climbType.routes'));
+    fireEvent.click(getByText('mobile.filter.showCount12'));
+
+    expect(onApply).toHaveBeenCalledWith({ ...currentFilters, boulders: false, routes: true }, currentBoardFilters);
   });
 
   it('opens the setters sheet above the filter sheet and keeps draft edits local until Apply', () => {

--- a/packages/mobile/src/components/search/ActiveFilterStrip.tsx
+++ b/packages/mobile/src/components/search/ActiveFilterStrip.tsx
@@ -1,0 +1,83 @@
+import { StyleSheet, type StyleProp, View, type ViewStyle } from 'react-native';
+import { Chip } from 'react-native-paper';
+import { useTranslation } from 'react-i18next';
+import type { FilterToken } from '../../lib/filter-tokens';
+import { useTheme } from '../../providers/theme-provider';
+import { withAlpha } from '../../theme/colors';
+import { spacing } from '../../theme/tokens';
+import { iconMap } from '../icon-map';
+
+type ActiveFilterStripProps = {
+  totalCount?: number;
+  tokens: readonly FilterToken[];
+  align?: 'start' | 'end';
+  style?: StyleProp<ViewStyle>;
+};
+
+export function ActiveFilterStrip({ totalCount, tokens, align = 'start', style }: ActiveFilterStripProps) {
+  const { t } = useTranslation('climbs');
+  const { systemColors, brandColors } = useTheme();
+  const showCount = totalCount != null;
+  if (!showCount && tokens.length === 0) return null;
+
+  return (
+    <View style={[styles.row, align === 'end' ? styles.alignEnd : null, style]}>
+      {showCount ? (
+        <Chip
+          compact
+          mode="flat"
+          icon={iconMap.search.android}
+          accessibilityLabel={t('mobile.search.climbsCount', { count: totalCount })}
+          style={[
+            styles.chip,
+            styles.countChip,
+            {
+              backgroundColor: withAlpha(brandColors.primary, 0.12),
+              borderColor: withAlpha(brandColors.primary, 0.18),
+            },
+          ]}
+          textStyle={[styles.chipText, { color: brandColors.primary }]}
+        >
+          {t('mobile.search.climbsCount', { count: totalCount })}
+        </Chip>
+      ) : null}
+      {tokens.map((token) => (
+        <Chip
+          key={token.key}
+          compact
+          mode="flat"
+          onPress={token.clear}
+          onClose={token.clear}
+          closeIcon={iconMap.close.android}
+          accessibilityLabel={token.label}
+          style={[styles.chip, { backgroundColor: systemColors.fill }]}
+          textStyle={[styles.chipText, { color: systemColors.label }]}
+        >
+          {token.label}
+        </Chip>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    minHeight: 32,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  alignEnd: {
+    justifyContent: 'flex-end',
+  },
+  chip: {
+    minHeight: 30,
+  },
+  countChip: {
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  chipText: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/search/ClimbFilterFab.tsx
+++ b/packages/mobile/src/components/search/ClimbFilterFab.tsx
@@ -1,13 +1,17 @@
 import { Pressable, StyleSheet, View } from 'react-native';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
+import type { FilterToken } from '../../lib/filter-tokens';
 import { spacing } from '../../theme/tokens';
 import { FILTER_FAB_SIZE, FilterButton } from './FilterButton';
 import { GradeRangeRail } from '../grade';
+import { ActiveFilterStrip } from './ActiveFilterStrip';
 
 type ClimbFilterFabProps = {
   activeFilterCount: number;
   bottom: number;
+  totalCount?: number;
+  filterTokens?: readonly FilterToken[];
   bound: GradeBound;
   grades: readonly Grade[];
   gradeRailVisible: boolean;
@@ -20,6 +24,8 @@ type ClimbFilterFabProps = {
 export function ClimbFilterFab({
   activeFilterCount,
   bottom,
+  totalCount,
+  filterTokens = [],
   bound,
   grades,
   gradeRailVisible,
@@ -28,6 +34,8 @@ export function ClimbFilterFab({
   onCloseGrade,
   onGradeChange,
 }: ClimbFilterFabProps) {
+  const showFilterStrip = !gradeRailVisible && (totalCount != null || filterTokens.length > 0);
+
   return (
     <>
       {gradeRailVisible ? (
@@ -44,6 +52,14 @@ export function ClimbFilterFab({
           style={[styles.gradeRailSlot, { bottom: bottom + FILTER_FAB_SIZE + spacing[2] }]}
         >
           <GradeRangeRail grades={grades} bound={bound} onChange={onGradeChange} onRequestClose={onCloseGrade} />
+        </View>
+      ) : null}
+      {showFilterStrip ? (
+        <View
+          pointerEvents="box-none"
+          style={[styles.filterStripSlot, { bottom: bottom + FILTER_FAB_SIZE + spacing[2] }]}
+        >
+          <ActiveFilterStrip totalCount={totalCount} tokens={filterTokens} align="end" />
         </View>
       ) : null}
       <View pointerEvents="box-none" style={[styles.fabSlot, { bottom }]}>
@@ -63,6 +79,12 @@ const styles = StyleSheet.create({
     zIndex: 15,
   },
   gradeRailSlot: {
+    position: 'absolute',
+    left: spacing[4],
+    right: spacing[4],
+    zIndex: 20,
+  },
+  filterStripSlot: {
     position: 'absolute',
     left: spacing[4],
     right: spacing[4],

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -12,9 +12,10 @@ import { type SharedValue } from 'react-native-reanimated';
 import { useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import { Appbar, Chip } from 'react-native-paper';
+import { Appbar } from 'react-native-paper';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
+import type { FilterToken } from '../../lib/filter-tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { spacing } from '../../theme/tokens';
@@ -28,6 +29,7 @@ import { GradeRangeRail } from '../grade';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 import { FilterButton } from './FilterButton';
 import { GradeFilterControl } from './GradeFilterControl';
+import { ActiveFilterStrip } from './ActiveFilterStrip';
 
 // One 48dp baseline shared by the search field, the grade control, and the filter
 // button so the row reads as a matched set (M3 docked/inline height).
@@ -59,9 +61,10 @@ type ClimbTopChromeProps = {
    *  host). Liquid Glass keeps the bottom filter FAB instead. */
   activeFilterCount?: number;
   onOpenFilters?: () => void;
-  /** Active-filter summary shown as a chip in the Material quick row. Tapping it
-   *  clears the (non-grade) filters. Absent = no filters. */
-  filterSummary?: { text: string; onClear: () => void };
+  /** Live result count for the current committed search/filter set. */
+  totalCount?: number;
+  /** Removable non-grade filter chips for the Material quick row. */
+  filterTokens?: readonly FilterToken[];
   gradeBound?: GradeBound;
   grades?: readonly Grade[];
   gradeRailVisible?: boolean;
@@ -88,7 +91,8 @@ export function ClimbTopChrome({
   onCloseGrade,
   activeFilterCount = 0,
   onOpenFilters,
-  filterSummary,
+  totalCount,
+  filterTokens = [],
   gradeBound,
   grades = [],
   gradeRailVisible = false,
@@ -126,10 +130,8 @@ export function ClimbTopChrome({
   if (variant === 'material') {
     const hasGradeFilter = gradeChip?.active === true;
     const nonGradeFilterCount = Math.max(0, activeFilterCount - (hasGradeFilter ? 1 : 0));
-    const hasNonGradeFilters = nonGradeFilterCount > 0;
-    const shouldShowFilterSummary = filterSummary != null && hasNonGradeFilters;
-    const visibleFilterSummary = shouldShowFilterSummary ? filterSummary : null;
     const visibleGradeLabel = gradeChip?.label ?? t('mobile.filter.gradeRange');
+    const shouldShowFilterStrip = totalCount != null || filterTokens.length > 0;
 
     return (
       <View
@@ -198,21 +200,9 @@ export function ClimbTopChrome({
               {onOpenFilters ? <FilterButton activeFilterCount={nonGradeFilterCount} onPress={onOpenFilters} /> : null}
             </View>
 
-            {visibleFilterSummary ? (
+            {shouldShowFilterStrip ? (
               <View pointerEvents="box-none" style={styles.materialQuickRow}>
-                <Chip
-                  compact
-                  mode="flat"
-                  icon={iconMap.filter.android}
-                  onPress={visibleFilterSummary.onClear}
-                  onClose={visibleFilterSummary.onClear}
-                  closeIcon={iconMap.close.android}
-                  accessibilityLabel={visibleFilterSummary.text}
-                  style={styles.materialChip}
-                  textStyle={styles.materialChipText}
-                >
-                  {visibleFilterSummary.text}
-                </Chip>
+                <ActiveFilterStrip totalCount={totalCount} tokens={filterTokens} />
               </View>
             ) : null}
 
@@ -390,12 +380,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexWrap: 'wrap',
     gap: spacing[2],
-  },
-  materialChip: {
-    minHeight: 32,
-  },
-  materialChipText: {
-    fontWeight: '600',
   },
   materialGradeRail: {
     marginTop: spacing[1],

--- a/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
@@ -8,10 +8,53 @@ vi.mock('react-native', () => ({
   Pressable: ({ onPress }: { onPress?: () => void }) =>
     createElement('button', { onClick: onPress, 'data-dismiss': 'true' }),
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
 vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 4: 16 } }));
+vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string, alpha: number) => `${color}@${alpha}` }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { fill: '#eee', label: '#111' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: { count?: number }) => (params?.count != null ? `${key}:${params.count}` : key),
+  }),
+}));
+vi.mock('react-native-paper', () => ({
+  Chip: ({
+    children,
+    onPress,
+    onClose,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    onClose?: () => void;
+    accessibilityLabel?: string;
+  }) =>
+    createElement(
+      'button',
+      { onClick: onPress, 'data-chip': accessibilityLabel ?? '' },
+      children,
+      onClose
+        ? createElement(
+            'span',
+            {
+              'data-chip-close': accessibilityLabel ?? '',
+              onClick: (event: { stopPropagation: () => void }) => {
+                event.stopPropagation();
+                onClose();
+              },
+            },
+            'close',
+          )
+        : null,
+    ),
+}));
 vi.mock('../FilterButton', () => ({
   FILTER_FAB_SIZE: 48,
   FilterButton: ({
@@ -82,5 +125,30 @@ describe('ClimbFilterFab', () => {
     expect(container.querySelector('[data-grade-rail="true"]')).not.toBeNull();
     fireEvent.click(container.querySelector('[data-dismiss="true"]') as HTMLElement);
     expect(onCloseGrade).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the live count and removable filter chips above the FAB', () => {
+    const onClearRoutes = vi.fn();
+    const { container } = renderFab({
+      totalCount: 27,
+      filterTokens: [{ key: 'climbType', label: 'Routes', clear: onClearRoutes }],
+    });
+
+    expect(container.querySelector('[data-chip="mobile.search.climbsCount:27"]')?.textContent).toContain(
+      'mobile.search.climbsCount:27',
+    );
+    fireEvent.click(container.querySelector('[data-chip-close="Routes"]') as HTMLElement);
+    expect(onClearRoutes).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the chip strip while the grade rail is open', () => {
+    const { container } = renderFab({
+      gradeRailVisible: true,
+      totalCount: 27,
+      filterTokens: [{ key: 'climbType', label: 'Routes', clear: vi.fn() }],
+    });
+
+    expect(container.querySelector('[data-chip="mobile.search.climbsCount:27"]')).toBeNull();
+    expect(container.querySelector('[data-chip="Routes"]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -69,7 +69,9 @@ vi.mock('react-native-safe-area-context', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, params?: { count?: number }) => (params?.count != null ? `${key}:${params.count}` : key),
+  }),
 }));
 
 vi.mock('react-native-paper', () => ({
@@ -579,16 +581,15 @@ describe('ClimbTopChrome', () => {
     expect(container.querySelector('[data-glass-icon="filter"]')?.getAttribute('data-badge')).toBe('0');
   });
 
-  it('omits the Material summary chip when only grade is active', () => {
+  it('omits Material filter token chips when only grade is active', () => {
     ctrl.variant = 'material';
     ctrl.board = typedBoard;
-    const onClearSummary = vi.fn();
     const { container } = render(
       <ClimbTopChrome
         {...makeProps({
           onOpenFilters: vi.fn(),
           activeFilterCount: 1,
-          filterSummary: { text: 'V6+', onClear: onClearSummary },
+          filterTokens: [],
           gradeChip: { label: 'V6+', active: true, onClear: vi.fn() },
           gradeBound: { minGradeId: 20, maxGradeId: undefined },
           onOpenGrade: vi.fn(),
@@ -600,17 +601,22 @@ describe('ClimbTopChrome', () => {
     expect(container.querySelector('[data-chip="V6+"]')).toBeNull();
   });
 
-  it('clears only the Material summary chip callback for non-grade filters', () => {
+  it('renders Material result count and clears individual non-grade filter chips', () => {
     ctrl.variant = 'material';
     ctrl.board = typedBoard;
     const onClearGrade = vi.fn();
-    const onClearSummary = vi.fn();
+    const onClearBenchmark = vi.fn();
+    const onClearRoutes = vi.fn();
     const { container } = render(
       <ClimbTopChrome
         {...makeProps({
           onOpenFilters: vi.fn(),
-          activeFilterCount: 2,
-          filterSummary: { text: 'Benchmarks', onClear: onClearSummary },
+          activeFilterCount: 3,
+          totalCount: 42,
+          filterTokens: [
+            { key: 'benchmark', label: 'Benchmarks', clear: onClearBenchmark },
+            { key: 'climbType', label: 'Routes', clear: onClearRoutes },
+          ],
           gradeChip: { label: 'V6+', active: true, onClear: onClearGrade },
           gradeBound: { minGradeId: 20, maxGradeId: undefined },
           onOpenGrade: vi.fn(),
@@ -619,12 +625,17 @@ describe('ClimbTopChrome', () => {
       />,
     );
 
+    expect(container.querySelector('[data-chip="mobile.search.climbsCount:42"]')?.textContent).toContain(
+      'mobile.search.climbsCount:42',
+    );
     fireEvent.click(container.querySelector('[data-chip="Benchmarks"]') as HTMLButtonElement);
-    expect(onClearSummary).toHaveBeenCalledTimes(1);
+    expect(onClearBenchmark).toHaveBeenCalledTimes(1);
+    expect(onClearRoutes).not.toHaveBeenCalled();
     expect(onClearGrade).not.toHaveBeenCalled();
 
-    fireEvent.click(container.querySelector('[data-chip-close="Benchmarks"]') as HTMLSpanElement);
-    expect(onClearSummary).toHaveBeenCalledTimes(2);
+    fireEvent.click(container.querySelector('[data-chip-close="Routes"]') as HTMLSpanElement);
+    expect(onClearRoutes).toHaveBeenCalledTimes(1);
+    expect(onClearBenchmark).toHaveBeenCalledTimes(1);
     expect(onClearGrade).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/__tests__/filter-summary.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-summary.test.ts
@@ -22,6 +22,9 @@ const mockT = ((key: string, options?: Record<string, unknown>) => {
     'mobile.filter.sort.name': 'Name',
     'mobile.filter.sort.popular': 'Popular',
     'mobile.filter.sort.creation': 'Newest',
+    'mobile.filter.climbType.all': 'All',
+    'mobile.filter.climbType.boulders': 'Boulders',
+    'mobile.filter.climbType.routes': 'Routes',
   };
   if (translations[key]) return translations[key];
 
@@ -111,6 +114,11 @@ describe('getFilterSummary', () => {
   it('shows the setter count when multiple setters are selected', () => {
     const filters: ClimbFilters = { ...DEFAULT_FILTERS, setter: ['marco', 'jules'] };
     expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('2 setters');
+  });
+
+  it('shows explicit climb type filters', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, boulders: true, routes: false };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('Boulders');
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-tokens.test.ts
@@ -23,8 +23,9 @@ const mockT = ((key: string, options?: Record<string, unknown>) => {
   if (key === 'mobile.search.rating') return `${text(options?.count)}+ ⭐`;
   if (key === 'mobile.search.setterName') return `By ${text(options?.setter)}`;
   if (key === 'mobile.search.settersCount') return `${text(options?.count)} setters`;
-  if (key === 'search.summary.routesOnly') return 'Routes only';
-  if (key === 'search.summary.bouldersAndRoutes') return 'Boulders & routes';
+  if (key === 'mobile.filter.climbType.all') return 'All';
+  if (key === 'mobile.filter.climbType.boulders') return 'Boulders';
+  if (key === 'mobile.filter.climbType.routes') return 'Routes';
   if (key === 'mobile.filter.sort.quality') return 'Quality';
   if (key === 'mobile.filter.benchmark') return 'Benchmarks only';
   if (key === 'mobile.filter.status.drafts') return 'Drafts';
@@ -110,12 +111,17 @@ describe('getActiveFilterTokens', () => {
     expect(patchFilters).toHaveBeenCalledWith({ setter: undefined });
   });
 
-  it('builds a Routes-only climb-type token and clears to boulders-only default', () => {
+  it('builds a routes-only climb-type token and clears to all-climbs default', () => {
     const { tokens, patchFilters } = build({ ...DEFAULT_FILTERS, boulders: false, routes: true });
     const climbType = tokens.find((token) => token.key === 'climbType');
-    expect(climbType?.label).toBe('Routes only');
+    expect(climbType?.label).toBe('Routes');
     climbType?.clear();
-    expect(patchFilters).toHaveBeenCalledWith({ boulders: true, routes: false });
+    expect(patchFilters).toHaveBeenCalledWith({ boulders: undefined, routes: undefined });
+  });
+
+  it('builds a boulders-only climb-type token', () => {
+    const { tokens } = build({ ...DEFAULT_FILTERS, boulders: true, routes: false });
+    expect(tokens.find((token) => token.key === 'climbType')?.label).toBe('Boulders');
   });
 
   it('builds a benchmark token from board filters and clears via patchBoardFilters', () => {

--- a/packages/mobile/src/lib/__tests__/last-search-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/last-search-store.test.ts
@@ -156,6 +156,15 @@ describe('saveLastSearch no-op on default/empty', () => {
     expect((await getLastSearch(kilterBoard))?.filters.minGrade).toBe(15);
   });
 
+  it('persists explicit boulders-only as an active filter in the current schema', async () => {
+    const { saveLastSearch, getLastSearch } = await import('../last-search-store');
+    await saveLastSearch(kilterBoard, { ...defaultFilters, boulders: true, routes: false }, '');
+    const restored = await getLastSearch(kilterBoard);
+    expect(restored?.filterSchemaVersion).toBe(2);
+    expect(restored?.filters.boulders).toBe(true);
+    expect(restored?.filters.routes).toBe(false);
+  });
+
   it('deletes the saved entry when the search is reset to the clean default', async () => {
     const { saveLastSearch, getLastSearch } = await import('../last-search-store');
     await saveLastSearch(kilterBoard, activeFilters, 'crimps');
@@ -230,6 +239,36 @@ describe('getLastSearch defensive validation', () => {
     const restored = await getLastSearch(kilterBoard);
     expect(restored?.filters.status).toBe('any');
     expect(restored?.filters.minGrade).toBe(10);
+  });
+
+  it('strips the legacy implicit boulders-only default from unversioned entries', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any', minGrade: 10, boulders: true, routes: false },
+        searchText: 'x',
+        updatedAt: 1,
+      },
+    });
+    const restored = await getLastSearch(kilterBoard);
+    expect(restored?.filters.minGrade).toBe(10);
+    expect(restored?.filters.boulders).toBeUndefined();
+    expect(restored?.filters.routes).toBeUndefined();
+  });
+
+  it('keeps explicit boulders-only filters from current-schema entries', async () => {
+    const { boardConfigKey, getLastSearch } = await import('../last-search-store');
+    await seedRaw({
+      [boardConfigKey(kilterBoard)]: {
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any', boulders: true, routes: false },
+        searchText: 'x',
+        updatedAt: 1,
+        filterSchemaVersion: 2,
+      },
+    });
+    const restored = await getLastSearch(kilterBoard);
+    expect(restored?.filters.boulders).toBe(true);
+    expect(restored?.filters.routes).toBe(false);
   });
 
   it('keeps valid entries while dropping malformed siblings', async () => {

--- a/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/recent-filter-store.test.ts
@@ -149,6 +149,40 @@ describe('getRecentFilters sanitizer', () => {
     expect(result[0]?.filters.status).toBe('any');
   });
 
+  it('strips the legacy implicit boulders-only default from unversioned entries', async () => {
+    const { getRecentFilters } = await import('../recent-filter-store');
+    await seed([
+      {
+        id: '1',
+        label: 'legacy-boulders-default',
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any', boulders: true, routes: false, minGrade: 10 },
+        searchText: '',
+        timestamp: 0,
+      },
+    ]);
+    const result = await getRecentFilters();
+    expect(result[0]?.filters.minGrade).toBe(10);
+    expect(result[0]?.filters.boulders).toBeUndefined();
+    expect(result[0]?.filters.routes).toBeUndefined();
+  });
+
+  it('keeps explicit boulders-only filters from current-schema entries', async () => {
+    const { getRecentFilters } = await import('../recent-filter-store');
+    await seed([
+      {
+        id: '1',
+        label: 'Boulders',
+        filters: { sortBy: 'ascents', sortOrder: 'desc', status: 'any', boulders: true, routes: false },
+        searchText: '',
+        timestamp: 0,
+        filterSchemaVersion: 2,
+      },
+    ]);
+    const result = await getRecentFilters();
+    expect(result[0]?.filters.boulders).toBe(true);
+    expect(result[0]?.filters.routes).toBe(false);
+  });
+
   it('keeps auth-gated fields when isAuthenticated=true', async () => {
     const { getRecentFilters } = await import('../recent-filter-store');
     await seed([

--- a/packages/mobile/src/lib/filter-persistence.ts
+++ b/packages/mobile/src/lib/filter-persistence.ts
@@ -1,0 +1,23 @@
+import type { ClimbFilters } from './climb-filter-types';
+
+export const CURRENT_FILTER_SCHEMA_VERSION = 2;
+
+export function normalizePersistedClimbFilters(
+  filters: ClimbFilters,
+  filterSchemaVersion: number | undefined,
+): ClimbFilters {
+  if (filterSchemaVersion === CURRENT_FILTER_SCHEMA_VERSION) return filters;
+
+  if (
+    (filters.boulders === true && filters.routes === false) ||
+    (filters.boulders === true && filters.routes === true) ||
+    (filters.boulders === false && filters.routes === false)
+  ) {
+    const normalized = { ...filters };
+    delete normalized.boulders;
+    delete normalized.routes;
+    return normalized;
+  }
+
+  return filters;
+}

--- a/packages/mobile/src/lib/filter-summary.ts
+++ b/packages/mobile/src/lib/filter-summary.ts
@@ -1,6 +1,6 @@
 import type { TFunction } from 'i18next';
 import type { Grade } from '@boardsesh/shared-schema';
-import { getBaseFilterParts, formatFilterSummary } from '@boardsesh/climb-filters';
+import { getBaseFilterParts, formatFilterSummary, climbTypeOf } from '@boardsesh/climb-filters';
 import { DEFAULT_FILTERS, type ClimbFilters } from './climb-filter-types';
 import { buildFilterLabels, buildSortLabel, formatSettersLabel } from './filter-labels';
 
@@ -44,6 +44,12 @@ export function getFilterSummary(
     labels,
     buildSortLabel(t),
   );
+  const hasExplicitClimbType = filters.boulders != null || filters.routes != null;
+  if (hasExplicitClimbType) {
+    const climbType = climbTypeOf(filters);
+    // i18n-keep mobile.filter.climbType.all mobile.filter.climbType.boulders mobile.filter.climbType.routes
+    parts.push(t(`mobile.filter.climbType.${climbType}`));
+  }
 
   return formatFilterSummary(parts, labels) ?? t('mobile.filter.title');
 }

--- a/packages/mobile/src/lib/filter-tokens.ts
+++ b/packages/mobile/src/lib/filter-tokens.ts
@@ -15,6 +15,8 @@ import type { Grade } from '@boardsesh/shared-schema';
 import {
   getGradeName,
   applyStatusChange,
+  climbTypeOf,
+  climbTypePatch,
   countFilteredHolds,
   DEFAULT_CLIMB_FILTER_STATE,
   type ClimbFilterState,
@@ -189,13 +191,16 @@ export function getActiveFilterTokens({
     });
   }
 
-  // Climb type — default is boulders-only; a token appears when routes are on or
-  // boulders are off. Clearing returns to the boulders-only default.
-  const bouldersOn = filters.boulders ?? true;
-  const routesOn = filters.routes ?? false;
-  if (bouldersOn !== true || routesOn !== false) {
-    const label = routesOn && !bouldersOn ? t('search.summary.routesOnly') : t('search.summary.bouldersAndRoutes');
-    tokens.push({ key: 'climbType', label, clear: () => patchFilters({ boulders: true, routes: false }) });
+  const hasExplicitClimbType = filters.boulders != null || filters.routes != null;
+  if (hasExplicitClimbType) {
+    const climbType = climbTypeOf(filters);
+    const label =
+      climbType === 'boulders'
+        ? t('mobile.filter.climbType.boulders')
+        : climbType === 'routes'
+          ? t('mobile.filter.climbType.routes')
+          : t('mobile.filter.climbType.all');
+    tokens.push({ key: 'climbType', label, clear: () => patchFilters(climbTypePatch('all')) });
   }
 
   // Board-renderer filters: benchmark, hold types, and board region are all

--- a/packages/mobile/src/lib/last-search-store.ts
+++ b/packages/mobile/src/lib/last-search-store.ts
@@ -11,12 +11,14 @@ import {
 } from '@boardsesh/climb-filters';
 import type { ClimbFilters } from './climb-filter-types';
 import { AUTH_GATED_FIELDS } from './recent-filter-store';
+import { CURRENT_FILTER_SCHEMA_VERSION, normalizePersistedClimbFilters } from './filter-persistence';
 
 export type LastSearch = {
   filters: ClimbFilters;
   boardFilters: ClimbBoardFilterState;
   searchText: string;
   updatedAt: number;
+  filterSchemaVersion?: number;
 };
 
 // One secure-store key holds a JSON map of boardConfigKey -> LastSearch so we
@@ -69,7 +71,11 @@ function normalizeEntry(entry: LastSearch): LastSearch {
   }
   // Retire legacy status='established' → 'any' (keeping minAscents) so restored
   // state never carries a status the UI can't show / clear.
-  next = { ...next, filters: normalizeRetiredStatus(next.filters) };
+  next = {
+    ...next,
+    filterSchemaVersion: CURRENT_FILTER_SCHEMA_VERSION,
+    filters: normalizePersistedClimbFilters(normalizeRetiredStatus(next.filters), next.filterSchemaVersion),
+  };
   if (next.boardFilters == null || typeof next.boardFilters !== 'object' || Array.isArray(next.boardFilters)) {
     next = { ...next, boardFilters: DEFAULT_CLIMB_BOARD_FILTER_STATE };
   }
@@ -156,7 +162,13 @@ export async function saveLastSearch(
       return;
     }
     const map = await readMap();
-    map[key] = { filters, boardFilters, searchText, updatedAt: Date.now() };
+    map[key] = {
+      filters,
+      boardFilters,
+      searchText,
+      updatedAt: Date.now(),
+      filterSchemaVersion: CURRENT_FILTER_SCHEMA_VERSION,
+    };
     const capped = capMap(map);
     await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(capped));
   } catch {

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -1,13 +1,8 @@
 import * as SecureStore from 'expo-secure-store';
-import {
-  SORT_OPTIONS,
-  STATUS_FILTER_VALUES,
-  normalizeRetiredStatus,
-  type SortOption,
-  type StatusFilter,
-} from '@boardsesh/climb-filters';
+import { SORT_OPTIONS, STATUS_FILTER_VALUES, normalizeRetiredStatus } from '@boardsesh/climb-filters';
 import type { ClimbFilters } from './climb-filter-types';
 import { getFilterKey } from './filter-key';
+import { CURRENT_FILTER_SCHEMA_VERSION, normalizePersistedClimbFilters } from './filter-persistence';
 
 export { getFilterKey };
 
@@ -17,6 +12,7 @@ export type RecentFilter = {
   filters: ClimbFilters;
   searchText: string;
   timestamp: number;
+  filterSchemaVersion?: number;
 };
 
 const RECENT_FILTERS_KEY = 'boardsesh_recent_filters';
@@ -57,7 +53,14 @@ function normalizeEntry(entry: RecentFilter): RecentFilter {
   // Backfill a missing status and retire legacy 'established' → 'any' (the
   // Popularity control reflects minAscents), so replayed pills never carry a
   // status the UI can't show.
-  return { ...entry, filters: normalizeRetiredStatus({ ...entry.filters, status }) };
+  return {
+    ...entry,
+    filterSchemaVersion: CURRENT_FILTER_SCHEMA_VERSION,
+    filters: normalizePersistedClimbFilters(
+      normalizeRetiredStatus({ ...entry.filters, status }),
+      entry.filterSchemaVersion,
+    ),
+  };
 }
 
 function stripAuthGatedFields(filters: ClimbFilters): ClimbFilters {
@@ -104,6 +107,7 @@ export async function addRecentFilter(label: string, filters: ClimbFilters, sear
       filters,
       searchText,
       timestamp: Date.now(),
+      filterSchemaVersion: CURRENT_FILTER_SCHEMA_VERSION,
     };
 
     const updated = [newEntry, ...deduplicated].slice(0, MAX_ITEMS);

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -181,9 +181,9 @@ input ClimbSearchInput {
   onlyDrafts: Boolean
   "Show only unclimbed projects (climbs with 0 ascents)"
   projectsOnly: Boolean
-  "Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only."
+  "Include single-frame climbs (boulders). Omit both boulders and routes for all climbs; pair boulders=true with routes=false for boulders only."
   boulders: Boolean
-  "Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes."
+  "Include multi-frame climbs (routes). Omit both boulders and routes for all climbs; pair boulders=false with routes=true for routes only."
   routes: Boolean
   "Restrict results using this drawn zone"
   zoneBox: ZoneBoxInput

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -694,7 +694,7 @@ export type ClimbSearchInput = {
   angle: Scalars['Int']['input'];
   /** Board type (e.g., 'kilter', 'tension') */
   boardName: Scalars['String']['input'];
-  /** Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only. */
+  /** Include single-frame climbs (boulders). Omit both boulders and routes for all climbs; pair boulders=true with routes=false for boulders only. */
   boulders?: InputMaybe<Scalars['Boolean']['input']>;
   /** Grade accuracy filter ('tight', 'moderate', 'loose') */
   gradeAccuracy?: InputMaybe<Scalars['String']['input']>;
@@ -732,7 +732,7 @@ export type ClimbSearchInput = {
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   /** Show only unclimbed projects (climbs with 0 ascents) */
   projectsOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes. */
+  /** Include multi-frame climbs (routes). Omit both boulders and routes for all climbs; pair boulders=false with routes=true for routes only. */
   routes?: InputMaybe<Scalars['Boolean']['input']>;
   /** Comma-separated set IDs */
   setIds: Scalars['String']['input'];

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -177,9 +177,9 @@ export const climbTypeDefs = /* GraphQL */ `
     onlyDrafts: Boolean
     "Show only unclimbed projects (climbs with 0 ascents)"
     projectsOnly: Boolean
-    "Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only."
+    "Include single-frame climbs (boulders). Omit both boulders and routes for all climbs; pair boulders=true with routes=false for boulders only."
     boulders: Boolean
-    "Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes."
+    "Include multi-frame climbs (routes). Omit both boulders and routes for all climbs; pair boulders=false with routes=true for routes only."
     routes: Boolean
     "Restrict results using this drawn zone"
     zoneBox: ZoneBoxInput

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -129,8 +129,8 @@ export type ClimbSearchInput = {
   showOnlyCompleted?: boolean;
   onlyDrafts?: boolean;
   projectsOnly?: boolean;
-  // Climb-type toggles. Both undefined / both true → no frames_count filter.
-  // Boulders only → `frames_count = 1`. Routes only → `frames_count > 1`.
+  // Climb-type toggles. Both undefined or both true means all climbs.
+  // Boulders only means `frames_count = 1`. Routes only means `frames_count > 1`.
   boulders?: boolean;
   routes?: boolean;
   // Zone filter — restrict climbs based on a user-drawn bounding box.

--- a/packages/shared/climb-filters/src/__tests__/active-filter-count.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/active-filter-count.test.ts
@@ -39,4 +39,9 @@ describe('countActiveFilters', () => {
     const filters = { ...DEFAULT_CLIMB_FILTER_STATE, minGrade: 10 };
     expect(countActiveFilters(filters, { onlyBenchmarks: true })).toBe(2);
   });
+
+  it('counts an explicit climb type as one filter', () => {
+    expect(countActiveFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: true, routes: false })).toBe(1);
+    expect(countActiveFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: true })).toBe(1);
+  });
 });

--- a/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
   DEFAULT_CLIMB_FILTER_STATE,
+  climbTypeOf,
+  climbTypePatch,
   hasActiveClimbFilters,
   toClimbSearchInput,
   type ClimbFilterState,
@@ -14,44 +16,51 @@ function inputFor(overrides: Partial<ClimbFilterState>) {
 }
 
 describe('climb-type (boulders/routes) filter', () => {
-  it('defaults to boulders-only', () => {
-    expect(DEFAULT_CLIMB_FILTER_STATE.boulders).toBe(true);
-    expect(DEFAULT_CLIMB_FILTER_STATE.routes).toBe(false);
+  it('defaults to all climbs', () => {
+    expect(DEFAULT_CLIMB_FILTER_STATE.boulders).toBeUndefined();
+    expect(DEFAULT_CLIMB_FILTER_STATE.routes).toBeUndefined();
   });
 
-  it('does not count the boulders-only default as an active filter', () => {
+  it('does not count the all-climbs default as an active filter', () => {
     expect(hasActiveClimbFilters(DEFAULT_CLIMB_FILTER_STATE)).toBe(false);
   });
 
-  it('maps boulders-only to boulders=true with routes omitted', () => {
+  it('maps boulders-only to explicit boulders=true/routes=false', () => {
     const input = inputFor({ boulders: true, routes: false });
     expect(input.boulders).toBe(true);
-    expect(input.routes).toBeUndefined();
+    expect(input.routes).toBe(false);
   });
 
-  it('maps routes-only to routes=true with boulders omitted', () => {
+  it('maps routes-only to explicit boulders=false/routes=true', () => {
     const input = inputFor({ boulders: false, routes: true });
     expect(input.routes).toBe(true);
-    expect(input.boulders).toBeUndefined();
+    expect(input.boulders).toBe(false);
   });
 
-  it('omits both fields when both are selected (no frames_count constraint)', () => {
+  it('preserves explicit both-selected values', () => {
     const input = inputFor({ boulders: true, routes: true });
-    expect(input.boulders).toBeUndefined();
-    expect(input.routes).toBeUndefined();
+    expect(input.boulders).toBe(true);
+    expect(input.routes).toBe(true);
   });
 
-  it('omits both fields when neither is selected (widened to all climbs)', () => {
+  it('preserves explicit neither-selected values', () => {
     const input = inputFor({ boulders: false, routes: false });
-    expect(input.boulders).toBeUndefined();
-    expect(input.routes).toBeUndefined();
+    expect(input.boulders).toBe(false);
+    expect(input.routes).toBe(false);
   });
 
-  it('treats routes-on as an active filter', () => {
+  it('treats explicit routes-only as an active filter', () => {
     expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: true })).toBe(true);
   });
 
-  it('treats boulders-off as an active filter', () => {
-    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: false, routes: false })).toBe(true);
+  it('treats explicit boulders-only as an active filter', () => {
+    expect(hasActiveClimbFilters({ ...DEFAULT_CLIMB_FILTER_STATE, boulders: true, routes: false })).toBe(true);
+  });
+
+  it('maps UI climb type patches through a single 3-way helper', () => {
+    expect(climbTypeOf(DEFAULT_CLIMB_FILTER_STATE)).toBe('all');
+    expect(climbTypePatch('all')).toEqual({ boulders: undefined, routes: undefined });
+    expect(climbTypePatch('boulders')).toEqual({ boulders: true, routes: false });
+    expect(climbTypePatch('routes')).toEqual({ boulders: false, routes: true });
   });
 });

--- a/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-state.test.ts
@@ -28,8 +28,6 @@ describe('DEFAULT_CLIMB_FILTER_STATE', () => {
       sortBy: 'ascents',
       sortOrder: 'desc',
       status: 'any',
-      boulders: true,
-      routes: false,
     });
   });
 });
@@ -116,8 +114,6 @@ describe('toClimbSearchInput', () => {
       pageSize: 30,
       sortBy: 'ascents',
       sortOrder: 'desc',
-      // Default is boulders-only (routes hidden), matching web.
-      boulders: true,
     });
   });
 

--- a/packages/shared/climb-filters/src/active-filter-count.ts
+++ b/packages/shared/climb-filters/src/active-filter-count.ts
@@ -21,8 +21,7 @@ export function countActiveFiltersBeyondGrade(filters: ClimbFilterState, boardFi
   if (filters.hideCompleted) count += 1;
   if (filters.showOnlyAttempted) count += 1;
   if (filters.showOnlyCompleted) count += 1;
-  // Climb-type defaults to boulders-only; "active" = routes on or boulders off.
-  if ((filters.boulders ?? true) !== true || (filters.routes ?? false) !== false) count += 1;
+  if (filters.boulders != null || filters.routes != null) count += 1;
   if (
     filters.sortBy !== DEFAULT_CLIMB_FILTER_STATE.sortBy ||
     filters.sortOrder !== DEFAULT_CLIMB_FILTER_STATE.sortOrder

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -35,11 +35,10 @@ export type ClimbFilterState = {
   onlyTallClimbs?: boolean;
   onlyWideClimbs?: boolean;
   onlyWithBetaVideos?: boolean;
-  // Climb-type toggles. Default is boulders-only (routes hidden) — see
-  // DEFAULT_CLIMB_FILTER_STATE. Both-on or both-off means "no preference" and
-  // omits the frames_count constraint. Maps to ClimbSearchInput.boulders/routes,
-  // whose SQL lives in @boardsesh/db create-climb-filters.ts (boulders →
-  // frames_count = 1 or NULL, routes → frames_count > 1).
+  // Climb-type filter. Both undefined = show everything (no frames_count
+  // filter); boulders=true/routes=false = boulders only; boulders=false/
+  // routes=true = routes only. Explicit false is meaningful, so callers must
+  // null-check rather than truthy-check.
   boulders?: boolean;
   routes?: boolean;
   status: StatusFilter;
@@ -53,9 +52,6 @@ export const DEFAULT_CLIMB_FILTER_STATE: ClimbFilterState = {
   sortBy: 'ascents',
   sortOrder: 'desc',
   status: 'any',
-  // Match web: show boulders, hide routes until the user opts in.
-  boulders: true,
-  routes: false,
 };
 
 /**
@@ -78,9 +74,8 @@ export function hasActiveClimbFilters(state: ClimbFilterState): boolean {
   if (state.hideCompleted) return true;
   if (state.showOnlyAttempted) return true;
   if (state.showOnlyCompleted) return true;
-  // Default is boulders-only, so "active" means routes turned on or boulders off.
-  if ((state.boulders ?? true) !== true) return true;
-  if ((state.routes ?? false) !== false) return true;
+  if (state.boulders != null) return true;
+  if (state.routes != null) return true;
   return false;
 }
 
@@ -130,6 +125,25 @@ export function normalizeRetiredStatus(state: ClimbFilterState): ClimbFilterStat
   return state.status === 'established' ? { ...state, status: 'any' } : state;
 }
 
+/**
+ * Climb-type as a single 3-way choice for the UI, mapping to the boulders/
+ * routes pair the DB expects: 'all' = no filter, 'boulders' = single-frame,
+ * 'routes' = multi-frame. Avoids the two-switch "at least one on" invariant.
+ */
+export type ClimbType = 'all' | 'boulders' | 'routes';
+
+export function climbTypeOf(state: Pick<ClimbFilterState, 'boulders' | 'routes'>): ClimbType {
+  if (state.boulders === true && state.routes !== true) return 'boulders';
+  if (state.routes === true && state.boulders !== true) return 'routes';
+  return 'all';
+}
+
+export function climbTypePatch(type: ClimbType): Pick<ClimbFilterState, 'boulders' | 'routes'> {
+  if (type === 'boulders') return { boulders: true, routes: false };
+  if (type === 'routes') return { boulders: false, routes: true };
+  return { boulders: undefined, routes: undefined };
+}
+
 export type BoardSearchConfig = {
   boardName: string;
   layoutId: number;
@@ -176,16 +190,8 @@ export function toClimbSearchInput(
   if (state.showOnlyAttempted) input.showOnlyAttempted = true;
   if (state.showOnlyCompleted) input.showOnlyCompleted = true;
 
-  // Climb-type filter: apply only when exactly one of boulders/routes is
-  // selected. Both-on and both-off mean "no preference" → omit entirely (the
-  // backend treats a missing frames_count constraint as all climbs). Mirrors
-  // create-climb-filters.ts and web's never-both-off toggle behaviour.
-  const bouldersOn = state.boulders ?? true;
-  const routesOn = state.routes ?? false;
-  if (bouldersOn !== routesOn) {
-    if (bouldersOn) input.boulders = true;
-    if (routesOn) input.routes = true;
-  }
+  if (state.boulders != null) input.boulders = state.boulders;
+  if (state.routes != null) input.routes = state.routes;
 
   const statusFlags = statusToFlags(state.status);
   if (statusFlags.onlyDrafts) input.onlyDrafts = true;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -691,7 +691,7 @@ export type ClimbSearchInput = {
   angle: Scalars['Int']['input'];
   /** Board type (e.g., 'kilter', 'tension') */
   boardName: Scalars['String']['input'];
-  /** Include single-frame climbs (boulders). Default true. Set to false (paired with routes=true) to filter to routes only. */
+  /** Include single-frame climbs (boulders). Omit both boulders and routes for all climbs; pair boulders=true with routes=false for boulders only. */
   boulders?: InputMaybe<Scalars['Boolean']['input']>;
   /** Grade accuracy filter ('tight', 'moderate', 'loose') */
   gradeAccuracy?: InputMaybe<Scalars['String']['input']>;
@@ -729,7 +729,7 @@ export type ClimbSearchInput = {
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   /** Show only unclimbed projects (climbs with 0 ascents) */
   projectsOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Include multi-frame climbs (routes). Default false. Set to true to include or filter to routes. */
+  /** Include multi-frame climbs (routes). Omit both boulders and routes for all climbs; pair boulders=false with routes=true for routes only. */
   routes?: InputMaybe<Scalars['Boolean']['input']>;
   /** Comma-separated set IDs */
   setIds: Scalars['String']['input'];

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -568,10 +568,12 @@
       "savedToast": "Tick saved"
     },
     "filter": {
-      "climbType": "Climb Type",
-      "boulders": "Boulders",
-      "routes": "Routes",
-      "both": "Both",
+      "climbType": {
+        "label": "Climb type",
+        "all": "All",
+        "boulders": "Boulders",
+        "routes": "Routes"
+      },
       "title": "Filters",
       "sortBy": "Sort by",
       "gradeRange": "Grade range",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -568,10 +568,12 @@
       "savedToast": "Tick guardado"
     },
     "filter": {
-      "climbType": "Tipo",
-      "boulders": "Bloques",
-      "routes": "Rutas",
-      "both": "Ambos",
+      "climbType": {
+        "label": "Tipo",
+        "all": "Todo",
+        "boulders": "Bloques",
+        "routes": "Rutas"
+      },
       "title": "Filtros",
       "sortBy": "Ordenar por",
       "gradeRange": "Rango de grado",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -568,10 +568,12 @@
       "savedToast": "Tick enregistré"
     },
     "filter": {
-      "climbType": "Type",
-      "boulders": "Blocs",
-      "routes": "Voies",
-      "both": "Les deux",
+      "climbType": {
+        "label": "Type",
+        "all": "Toutes",
+        "boulders": "Blocs",
+        "routes": "Voies"
+      },
       "title": "Filtres",
       "sortBy": "Trier par",
       "gradeRange": "Plage de cotation",


### PR DESCRIPTION
## Summary
- Restores mobile climb-type filtering to a 3-way All / Boulders / Routes model with All as the default.
- Preserves explicit `false` values through shared filter state and backend validation so Routes-only and Boulders-only searches survive validation.
- Normalizes legacy unversioned mobile saved searches/recent filters so the old implicit Boulders default does not reappear as an active filter, while preserving current-schema explicit Boulders.
- Reconnects live result counts and removable active-filter chips in the current mobile climb chrome/FAB flow.
- Migrates mobile climb-type i18n keys to `mobile.filter.climbType.{label,all,boulders,routes}`.

Fixes #2636

## Validation
- `vp test run --reporter=agent packages/shared/climb-filters/src/__tests__/climb-type-filter.test.ts packages/shared/climb-filters/src/__tests__/filter-state.test.ts packages/shared/climb-filters/src/__tests__/active-filter-count.test.ts packages/backend/src/__tests__/climb-search-validation.test.ts`
- `vp test run --project mobile --reporter=agent packages/mobile/src/lib/__tests__/filter-summary.test.ts packages/mobile/src/lib/__tests__/filter-tokens.test.ts packages/mobile/src/lib/__tests__/last-search-store.test.ts packages/mobile/src/lib/__tests__/recent-filter-store.test.ts packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx`
- `vp run typecheck:shared`
- `vp run typecheck:backend`
- `vp run typecheck:mobile`
- `vp run check:i18n`
- `vp check <changed files>`

## QA / Review Follow-up
- Fixed QA/code-review finding: legacy persisted `{ boulders: true, routes: false }` entries now migrate back to All instead of surfacing as active Boulders.
- Fixed QA finding: the sheet-level test now exercises the segmented control route and verifies the Routes patch.
- Noted QA observation: count chips can briefly retain the previous count while placeholder data is loading; this is existing query placeholder behavior, not a correctness issue.

## Notes
- Full `vp check` still reports existing unrelated formatting issues in other repo files, so I scoped the final check to the changed files to avoid unrelated formatting churn.
- Mobile dev server is running at `http://vibetunnel-2.tailedd9d5.ts.net:8087`.