### PR TITLE
[codex] normalize climb search sort keys and add dev hypopg

### DIFF
--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -19,7 +19,9 @@
 FROM postgres:17 AS postgres-postgis
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-17-postgis-3 && \
+    apt-get install -y --no-install-recommends \
+      postgresql-17-postgis-3 \
+      postgresql-17-hypopg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/db/docker/Dockerfile.postgres
+++ b/packages/db/docker/Dockerfile.postgres
@@ -1,6 +1,8 @@
 FROM postgres:17
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-17-postgis-3 && \
+    apt-get install -y --no-install-recommends \
+      postgresql-17-postgis-3 \
+      postgresql-17-hypopg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -116,6 +116,12 @@ void describe('createClimbFilters: size filter', () => {
     assert.match(rendered, /ARRAY\[/);
     assert.match(rendered, /::int\[\]/);
   });
+
+  void it('omits size filtering for MoonBoard', () => {
+    const filters = createClimbFilters({ ...params, board_name: 'moonboard', size_id: 1, set_ids: [] }, baseSearch);
+
+    assert.equal(filters.sizeConditions.length, 0);
+  });
 });
 
 void describe('createClimbFilters: minRating', () => {

--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { chooseSearchPath, getStatsDrivenSort, clampSearchPage, MAX_SEARCH_PAGE } from '../search-climbs';
+import { mapSearchInputToParams, normalizeSearchSortBy } from '../types';
 
 const baseInput = {
   statsDrivenSort: 'ascents' as const,
@@ -123,5 +124,29 @@ void describe('chooseSearchPath', () => {
         'standard-only',
       );
     });
+  });
+});
+
+void describe('normalizeSearchSortBy', () => {
+  void it('keeps known search sort keys', () => {
+    assert.equal(normalizeSearchSortBy('ascents'), 'ascents');
+    assert.equal(normalizeSearchSortBy('quality'), 'quality');
+    assert.equal(normalizeSearchSortBy('popular'), 'popular');
+  });
+
+  void it('maps legacy timestamp keys to creation sort', () => {
+    assert.equal(normalizeSearchSortBy('created_at'), 'creation');
+    assert.equal(normalizeSearchSortBy('published_at'), 'creation');
+  });
+
+  void it('uses ascents by default and explicit creation for unknown sort keys', () => {
+    assert.equal(normalizeSearchSortBy(undefined), 'ascents');
+    assert.equal(normalizeSearchSortBy(null), 'ascents');
+    assert.equal(normalizeSearchSortBy('newest'), 'creation');
+  });
+
+  void it('normalizes sortBy while mapping raw search input', () => {
+    assert.equal(mapSearchInputToParams({ sortBy: 'published_at' }).sortBy, 'creation');
+    assert.equal(mapSearchInputToParams({ sortBy: 'unknown' }).sortBy, 'creation');
   });
 });

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -4,7 +4,13 @@ import { boardClimbs, boardClimbStats } from '../../schema/index';
 import { createClimbFilters } from './create-climb-filters';
 import { getClimbStars } from './climb-stars';
 import { getGradeLabel } from './grade-lookup';
-import type { BoardRouteParams, ClimbSearchParams, ClimbRow, ClimbSearchResult } from './types';
+import {
+  normalizeSearchSortBy,
+  type BoardRouteParams,
+  type ClimbSearchParams,
+  type ClimbRow,
+  type ClimbSearchResult,
+} from './types';
 
 // Runtime shape of a search row. postgres.js returns numeric/bigint columns as
 // JS strings (no `types` parser is configured), so the ROUND(...::numeric) and
@@ -128,7 +134,7 @@ export const searchClimbs = async (
   const isDraftsQuery = filters.isOnlyDrafts;
 
   // Drafts never have stats, so force creation sort (stats-based sorts would be meaningless)
-  const sortBy = isDraftsQuery ? 'creation' : searchParams.sortBy || 'ascents';
+  const sortBy = isDraftsQuery ? 'creation' : normalizeSearchSortBy(searchParams.sortBy);
   const sortOrder = searchParams.sortOrder === 'asc' ? 'asc' : 'desc';
   const statsDrivenSort = getStatsDrivenSort(sortBy, sortOrder);
 

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -111,6 +111,22 @@ export type ClimbSearchInputLike = {
   zoneMode?: ZoneMatchMode | null;
 };
 
+const SEARCH_SORT_ALIASES: Record<string, NonNullable<ClimbSearchParams['sortBy']>> = {
+  ascents: 'ascents',
+  difficulty: 'difficulty',
+  name: 'name',
+  quality: 'quality',
+  popular: 'popular',
+  creation: 'creation',
+  created_at: 'creation',
+  published_at: 'creation',
+};
+
+export function normalizeSearchSortBy(sortBy: string | null | undefined): NonNullable<ClimbSearchParams['sortBy']> {
+  if (!sortBy) return 'ascents';
+  return SEARCH_SORT_ALIASES[sortBy] ?? 'creation';
+}
+
 /**
  * Map an input shape (GraphQL `ClimbSearchInput` or web
  * `SearchRequestPagination`) onto the `ClimbSearchParams` shape consumed by
@@ -141,7 +157,7 @@ export function mapSearchInputToParams(input: ClimbSearchInputLike): ClimbSearch
     maxGrade: input.maxGrade || undefined,
     minAscents: input.minAscents || undefined,
     minRating: input.minRating || undefined,
-    sortBy: input.sortBy || 'ascents',
+    sortBy: normalizeSearchSortBy(input.sortBy),
     sortOrder: input.sortOrder || 'desc',
     name: input.name || undefined,
     settername: setter && setter.length > 0 ? setter : undefined,


### PR DESCRIPTION
## Summary

Rebased onto latest `origin/main`; the heavy search/index work from this branch is now already on `main` via the newer database migrations, including the quality search covering index and v2 covering indexes.

This PR now keeps the remaining compatibility/dev tooling fixes:

- normalize raw/legacy climb search sort keys such as `created_at`, `published_at`, and unknown values to the supported `creation` sort
- apply the same normalization for direct `searchClimbs` callers, not only mapped GraphQL/SSR input
- add regression coverage for sort normalization and MoonBoard size-filter behavior
- install `postgresql-17-hypopg` in the dev Postgres Docker images so hypothetical indexes can be tested locally without creating persistent indexes

## Query notes

Representative default/regular search (`ascents DESC`) on the broad Kilter layout 1 / size 10 / sets 1,20 / angle 40 case uses the latest `main` v2 ascents covering index and returns the first page in about 5.8 ms. The remaining slow part for that broad search shape is the separate total-count query, which was still about 324-348 ms in the sampled EXPLAIN runs.

For the product-typical grade-filter path, the result list is also fast, but exact live counts are not:

- single V6 / difficulty 22 list: about 3.6 ms
- V5-V7-ish / difficulty 20-23 list: about 1.5 ms
- single V6 exact count: about 544 ms in the original sampled plan, about 451-484 ms after warm reruns
- V5-V7-ish exact count: about 598 ms
- grade + name `%red%`: list about 62 ms, exact count about 49 ms
- grade + hide-completed for a high-volume user: list about 38 ms, exact count about 630 ms

So the current hot issue is not default sorting. It is exact `totalCount` work for broad grade-only and grade-plus-logbook preview counts. Mobile's main search query already requests `climbs` + `hasMore`; the slow count is from the separate filter-sheet preview count query.

On the full-data dev Postgres container, HypoPG is now installed/enabled. Dev has about 649k `board_climbs` rows and 678k `board_climb_stats` rows. The same broad single-grade exact count was about 391 ms on dev; grade + hide-completed was about 408 ms. A materialized stats-first capped preview probe was about 39-80 ms depending on cache warmth and oversample size.

The larger speedup from the merged migration work is on quality-sort search: the new stats-driven path was about 10 ms in the same broad sample, while the old left-join quality path failed under parallel execution with a shared-memory resize error and took about 907 ms with parallelism disabled.

## Follow-up Direction

Given analytics showing grade as the dominant search action and sort changes as rare, the next performance work should target the preview/count path, not more sort tuning. Two promising directions from EXPLAIN:

- use a capped preview count (`1000+`) for the filter sheet instead of exact counts; a materialized stats-first oversample returned enough rows for the tested grade cases in about 22-46 ms on the earlier DB_URL sample and about 39-80 ms on dev
- add a sent-climb partial index for `hideCompleted`, keyed to match the personalized anti-join; on dev the local tick table is much smaller than the earlier DB_URL sample, so HypoPG did not materially change that plan there

## Validation

- `bun run --filter=@boardsesh/db test -- src/queries/climbs/__tests__/search-climbs.test.ts src/queries/climbs/__tests__/create-climb-filters.test.ts`
- `vp run typecheck:db`
- `vp run typecheck:backend`
- `git diff --check`
- dev Postgres container: installed `postgresql-17-hypopg`, ran `CREATE EXTENSION IF NOT EXISTS hypopg`, verified `hypopg:1.4.2`, and smoke-tested `hypopg_create_index`