### PR TITLE
[codex] Fix board presence review feedback

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -792,6 +792,7 @@ sequenceDiagram
 - Session events: `boardsesh:session:{sessionId}`
 - Notification events: `boardsesh:notifications:{userId}` (per-user, authenticated)
 - Comment live updates: `boardsesh:comments:{entityType}:{entityId}` (per-entity, public)
+- Board presence: `boardsesh:board:{boardId}` (per physical or shared board feed, authenticated publish)
 
 ### Event Buffer for Delta Sync
 
@@ -1251,7 +1252,24 @@ boardsesh:instance:{id}:heartbeat   # String - instance heartbeat timestamp (60s
 ```
 boardsesh:queue:{sessionId}         # Queue events (add, remove, reorder, etc.)
 boardsesh:session:{sessionId}       # Session events (join, leave, leader change)
+boardsesh:board:{boardId}           # Board-presence "now on the wall" events
 ```
+
+**Board Presence (PubSub):**
+
+These PubSub data keys are intentionally documented as implemented. Unlike the
+pub/sub channels above and the `DistributedStateManager` keys, they currently
+omit the `boardsesh:` namespace prefix.
+
+```
+board:{boardId}:history             # List - latest BoardPresenceClimb payloads, newest first
+board:{boardId}:seq                 # String/integer - per-board monotonic event sequence
+presence:board:{boardId}:user:{id}  # String - proof-of-presence stamp for report authorization
+```
+
+Board presence is a separate pub/sub domain from party sessions. `resolveBoardForSerial` maps a BLE serial to one active `user_boards.id`; `resolveBoardForConfig` maps serial-less hardware to one hidden system-owned board per normalized `(boardType, layoutId, sizeId, setIds)` config. `reportBoardClimb` requires a live proof-of-presence stamp for that board before it publishes a `BoardClimbSet` event.
+
+Redis-backed deployments keep the last 50 climbs for 24 hours so late subscribers can backfill before listening to `boardsesh:board:{boardId}`. Local-only deployments dispatch live board-presence events in process and keep proof-of-presence in memory with scheduled TTL cleanup; they do not provide board history backfill across process restarts.
 
 ### Graceful Shutdown
 
@@ -1542,24 +1560,27 @@ Requires user authentication and controller ownership.
 
 ### Timeouts and Limits
 
-| Setting                 | Value   | Purpose                                   |
-| ----------------------- | ------- | ----------------------------------------- |
-| Retry attempts          | 10      | WebSocket reconnection                    |
-| Max retry delay         | 30s     | Exponential backoff cap                   |
-| Keep-alive interval     | 10s     | Connection health check                   |
-| Mutation timeout        | 30s     | Prevent hanging mutations                 |
-| Redis TTL               | 4 hours | Session cache expiry                      |
-| Postgres debounce       | 30s     | Batch writes                              |
-| Event buffer size       | 100     | Delta sync limit                          |
-| Event buffer TTL        | 5 min   | Old events cleanup                        |
-| Hash verification       | 60s     | State drift detection                     |
-| Subscription queue      | 1000    | Max pending events                        |
-| Connection TTL          | 1 hour  | Distributed connection expiry             |
-| WebSocket ping interval | 30s     | Dead connection detection                 |
-| Instance heartbeat      | 30s     | Heartbeat update interval                 |
-| Instance heartbeat TTL  | 60s     | Dead instance detection                   |
-| Session members TTL     | 4 hours | Matches session TTL                       |
-| Session grace period    | 60s     | In-memory retention after last disconnect |
+| Setting                 | Value    | Purpose                                   |
+| ----------------------- | -------- | ----------------------------------------- |
+| Retry attempts          | 10       | WebSocket reconnection                    |
+| Max retry delay         | 30s      | Exponential backoff cap                   |
+| Keep-alive interval     | 10s      | Connection health check                   |
+| Mutation timeout        | 30s      | Prevent hanging mutations                 |
+| Redis TTL               | 4 hours  | Session cache expiry                      |
+| Postgres debounce       | 30s      | Batch writes                              |
+| Event buffer size       | 100      | Delta sync limit                          |
+| Event buffer TTL        | 5 min    | Old events cleanup                        |
+| Board history size      | 50       | Board-presence backfill limit             |
+| Board history TTL       | 24 hours | Board-presence history expiry             |
+| Board membership TTL    | 12 hours | Proof-of-presence report window           |
+| Hash verification       | 60s      | State drift detection                     |
+| Subscription queue      | 1000     | Max pending events                        |
+| Connection TTL          | 1 hour   | Distributed connection expiry             |
+| WebSocket ping interval | 30s      | Dead connection detection                 |
+| Instance heartbeat      | 30s      | Heartbeat update interval                 |
+| Instance heartbeat TTL  | 60s      | Dead instance detection                   |
+| Session members TTL     | 4 hours  | Matches session TTL                       |
+| Session grace period    | 60s      | In-memory retention after last disconnect |
 
 ---
 

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -37,6 +37,7 @@ const SENDER_DISPLAY_NAME = 'Crusher Carla';
 const SENDER_AVATAR_URL = 'https://example.com/carla.jpg';
 const TEST_CLIMB_UUID = 'board-presence-test-climb-uuid';
 const OTHER_TEST_CLIMB_UUID = 'board-presence-other-climb-uuid';
+const BOARD_MEMBERSHIP_TTL_MS = 43_200_000;
 
 function authCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
   return {
@@ -163,6 +164,53 @@ describe('board-presence pubsub', () => {
     const otherNext = await pubsub.nextBoardSeq('seq-board-b');
     expect(otherNext).toBeGreaterThan(other);
   });
+
+  it('evicts expired local proof-of-presence stamps without a membership read', async () => {
+    const boardId = `local-membership-${Math.random().toString(36).slice(2)}`;
+    const userId = `user-${Math.random().toString(36).slice(2)}`;
+    const localKey = `${boardId}:${userId}`;
+
+    pubsub.resetLocalBoardMembershipForTest();
+    vi.useFakeTimers();
+
+    try {
+      await pubsub.stampBoardMembership(boardId, userId);
+      expect(pubsub.hasLocalBoardMembershipForTest(localKey)).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(BOARD_MEMBERSHIP_TTL_MS + 1);
+
+      expect(pubsub.hasLocalBoardMembershipForTest(localKey)).toBe(false);
+    } finally {
+      pubsub.resetLocalBoardMembershipForTest();
+      vi.useRealTimers();
+    }
+  });
+
+  it('reschedules local proof-of-presence cleanup when an earlier expiry is added', async () => {
+    const laterLocalKey = `local-membership-later-${Math.random().toString(36).slice(2)}`;
+    const earlierLocalKey = `local-membership-earlier-${Math.random().toString(36).slice(2)}`;
+
+    pubsub.resetLocalBoardMembershipForTest();
+    vi.useFakeTimers();
+
+    try {
+      const currentTime = Date.now();
+      pubsub.setLocalBoardMembershipForTest(laterLocalKey, currentTime + 1000);
+      pubsub.setLocalBoardMembershipForTest(earlierLocalKey, currentTime + 100);
+
+      await vi.advanceTimersByTimeAsync(101);
+
+      expect(pubsub.hasLocalBoardMembershipForTest(earlierLocalKey)).toBe(false);
+      expect(pubsub.hasLocalBoardMembershipForTest(laterLocalKey)).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(900);
+
+      expect(pubsub.hasLocalBoardMembershipForTest(laterLocalKey)).toBe(false);
+    } finally {
+      pubsub.resetLocalBoardMembershipForTest();
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ============================================================
@@ -251,11 +299,12 @@ describe('board-presence resolvers', () => {
       const serial = `SER-${Date.now()}`;
       const first = await boardPresenceMutations.resolveBoardForSerial(
         undefined,
-        { serial, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+        { serial, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '2,1' },
         authCtx(),
       );
       expect(first.boardId).toBeGreaterThan(0);
       expect(first.boardType).toBe('kilter');
+      expect(first.setIds).toBe('1,2');
 
       // Second call (same serial) returns the already-bound shared board.
       const second = await boardPresenceMutations.resolveBoardForSerial(
@@ -299,6 +348,28 @@ describe('board-presence resolvers', () => {
       expect(resolved.boardName).toBe('My Garage');
 
       const [row] = await db.execute(sql`SELECT serial_number FROM user_boards WHERE id = ${resolved.boardId}`);
+      expect((row as { serial_number: string }).serial_number).toBe(serial);
+    });
+
+    it('normalizes setIds before binding a serial to an own config board', async () => {
+      await db.execute(sql`
+        INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, serial_number)
+        VALUES (${`uuid-normalized-${Date.now()}`}, ${`slug-normalized-${Date.now()}`}, ${TEST_USER_ID}, 'kilter', 17, 21, '3,4', 'My Normalized Garage', null)
+      `);
+
+      const serial = `NORM-${Date.now()}`;
+      const resolved = await boardPresenceMutations.resolveBoardForSerial(
+        undefined,
+        { serial, boardType: 'kilter', layoutId: 17, sizeId: 21, setIds: '4,3' },
+        authCtx(),
+      );
+      expect(resolved.boardName).toBe('My Normalized Garage');
+      expect(resolved.setIds).toBe('3,4');
+
+      const [row] = await db.execute(sql`
+        SELECT serial_number FROM user_boards
+        WHERE owner_id = ${TEST_USER_ID} AND layout_id = 17 AND size_id = 21
+      `);
       expect((row as { serial_number: string }).serial_number).toBe(serial);
     });
 
@@ -376,6 +447,38 @@ describe('board-presence resolvers', () => {
       expect((row as { is_unlisted: boolean }).is_unlisted).toBe(true);
     });
 
+    it('converges concurrent serial-less config creates onto one normalized shared board', async () => {
+      const layoutId = 9000 + Math.floor(Math.random() * 10_000);
+      const [first, second] = await Promise.all([
+        boardPresenceMutations.resolveBoardForConfig(
+          undefined,
+          { boardType: 'moonboard', layoutId, sizeId: 1, setIds: '3,1' },
+          authCtx(),
+        ),
+        boardPresenceMutations.resolveBoardForConfig(
+          undefined,
+          { boardType: 'moonboard', layoutId, sizeId: 1, setIds: '1,3' },
+          authCtx({ userId: SECOND_USER_ID }),
+        ),
+      ]);
+
+      expect(second.boardId).toBe(first.boardId);
+      expect(first.setIds).toBe('1,3');
+      expect(second.setIds).toBe('1,3');
+
+      const [row] = await db.execute(sql`
+        SELECT count(*)::int AS count, min(set_ids) AS set_ids
+        FROM user_boards
+        WHERE owner_id = '00000000-0000-0000-0000-000000000000'
+          AND board_type = 'moonboard'
+          AND layout_id = ${layoutId}
+          AND size_id = 1
+          AND deleted_at IS NULL
+      `);
+      expect(Number((row as { count: number }).count)).toBe(1);
+      expect((row as { set_ids: string }).set_ids).toBe('1,3');
+    });
+
     it('rejects binding a second serial onto an already-bound board via the unique index', async () => {
       const serialA = `UNIQ-A-${Date.now()}`;
       const resolved = await boardPresenceMutations.resolveBoardForSerial(
@@ -430,9 +533,9 @@ describe('board-presence resolvers', () => {
         VALUES (${boardUuid}, ${slug}, ${SECOND_USER_ID}, 'kilter', 4, 12, '1,2', 'Private Wall', null, false)
       `);
 
-      await expect(
-        boardPresenceMutations.resolveBoardForUuid(undefined, { boardUuid }, authCtx()),
-      ).rejects.toThrow('Board not found');
+      await expect(boardPresenceMutations.resolveBoardForUuid(undefined, { boardUuid }, authCtx())).rejects.toThrow(
+        'Board not found',
+      );
     });
 
     it('rejects a board uuid that does not exist', async () => {

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -384,6 +384,9 @@ export const schemaSQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS "user_boards_unique_owner_config"
     ON "user_boards" ("owner_id", "board_type", "layout_id", "size_id", "set_ids")
     WHERE "deleted_at" IS NULL AND "owner_id" != '00000000-0000-0000-0000-000000000000';
+  CREATE UNIQUE INDEX IF NOT EXISTS "user_boards_unique_slug"
+    ON "user_boards" ("slug")
+    WHERE "deleted_at" IS NULL;
 
   DROP TABLE IF EXISTS "integration_exports" CASCADE;
   DROP TABLE IF EXISTS "integration_credentials" CASCADE;

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -25,6 +25,7 @@ import {
   findOwnActiveBoardByConfig,
   findReachableActiveBoardByUuid,
   isDuplicateBoardSerialError,
+  normalizeSetIds,
   requireActiveBoardById,
   requireBoardPresenceEnabled,
   resolveSharedBoardForConfig,
@@ -60,6 +61,7 @@ export const boardPresenceMutations = {
 
     const validSerial = validateInput(BoardSerialSchema, serial, 'serial');
     const config = validateInput(BoardPresenceConfigInputSchema, { boardType, layoutId, sizeId, setIds }, 'input');
+    const normalizedSetIds = normalizeSetIds(config.setIds);
 
     const userId = ctx.userId!;
 
@@ -143,7 +145,7 @@ export const boardPresenceMutations = {
           boardType: config.boardType,
           layoutId: config.layoutId,
           sizeId: config.sizeId,
-          setIds: config.setIds,
+          setIds: normalizedSetIds,
           name,
           serialNumber: validSerial,
         })
@@ -302,6 +304,8 @@ export const boardPresenceMutations = {
       queueItemUuid: validatedClimb.uuid,
       name: catalogClimb.name ?? null,
       grade: catalogClimb.grade ?? null,
+      // Grade palettes are still client/theme-specific, so the server leaves
+      // this nullable until a shared color contract exists.
       gradeColor: null,
       frames: catalogClimb.frames ?? null,
       angle: effectiveAngle,

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -152,6 +152,7 @@ export async function findOwnActiveBoardByConfig(
   sizeId: number,
   setIds: string,
 ): Promise<ActivePresenceBoard | undefined> {
+  const normalizedSetIds = normalizeSetIds(setIds);
   const [board] = await db
     .select({
       id: dbSchema.userBoards.id,
@@ -170,7 +171,7 @@ export async function findOwnActiveBoardByConfig(
         eq(dbSchema.userBoards.boardType, boardType),
         eq(dbSchema.userBoards.layoutId, layoutId),
         eq(dbSchema.userBoards.sizeId, sizeId),
-        eq(dbSchema.userBoards.setIds, setIds),
+        eq(dbSchema.userBoards.setIds, normalizedSetIds),
         isNull(dbSchema.userBoards.deletedAt),
       ),
     )
@@ -238,7 +239,8 @@ export async function resolveSharedBoardForConfig(
   sizeId: number,
   setIds: string,
 ): Promise<ResolvedBoard> {
-  const slug = boardConfigPresenceSlug(boardType, layoutId, sizeId, setIds);
+  const normalizedSetIds = normalizeSetIds(setIds);
+  const slug = boardConfigPresenceSlug(boardType, layoutId, sizeId, normalizedSetIds);
 
   const [existing] = await db
     .select()
@@ -261,7 +263,7 @@ export async function resolveSharedBoardForConfig(
         boardType,
         layoutId,
         sizeId,
-        setIds,
+        setIds: normalizedSetIds,
         name: `${defaultBoardName(boardType)} Shared Feed`,
         serialNumber: null,
         isPublic: false,
@@ -272,6 +274,9 @@ export async function resolveSharedBoardForConfig(
       .returning();
     return toResolvedBoard(created);
   } catch (error) {
+    if (!isUniqueViolation(error, 'user_boards_unique_slug')) {
+      throw error;
+    }
     logger.warn(`[board-presence] resolveSharedBoardForConfig create race: ${String(error)}`);
     const [winner] = await db
       .select()

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -61,6 +61,8 @@ class PubSub {
   private localBoardSeq = new Map<string, number>();
   // Local-only proof-of-presence: `${boardId}:${userId}` → expiry epoch ms.
   private localBoardMembership = new Map<string, number>();
+  private localBoardMembershipCleanupTimer: ReturnType<typeof setTimeout> | null = null;
+  private localBoardMembershipCleanupExpiry: number | null = null;
   private redisAdapter: RedisPubSubAdapter | null = null;
   private initialized = false;
   private redisRequired = false;
@@ -817,7 +819,7 @@ class PubSub {
         logger.error('[PubSub] Failed to stamp board membership, falling back to local:', error);
       }
     }
-    this.localBoardMembership.set(`${boardId}:${userId}`, Date.now() + BOARD_MEMBERSHIP_TTL * 1000);
+    this.setLocalBoardMembership(`${boardId}:${userId}`, Date.now() + BOARD_MEMBERSHIP_TTL * 1000);
   }
 
   /** True if the user has a live proof-of-presence stamp for the board. */
@@ -843,6 +845,76 @@ class PubSub {
       return false;
     }
     return true;
+  }
+
+  private setLocalBoardMembership(localKey: string, expiry: number): void {
+    this.localBoardMembership.set(localKey, expiry);
+    if (this.localBoardMembershipCleanupExpiry !== null && expiry >= this.localBoardMembershipCleanupExpiry) {
+      return;
+    }
+    this.scheduleLocalBoardMembershipCleanup();
+  }
+
+  /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
+  resetLocalBoardMembershipForTest(): void {
+    this.clearLocalBoardMembershipCleanupTimer();
+    this.localBoardMembership.clear();
+  }
+
+  /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
+  setLocalBoardMembershipForTest(localKey: string, expiry: number): void {
+    this.setLocalBoardMembership(localKey, expiry);
+  }
+
+  /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
+  hasLocalBoardMembershipForTest(localKey: string): boolean {
+    return this.localBoardMembership.has(localKey);
+  }
+
+  private scheduleLocalBoardMembershipCleanup(): void {
+    this.clearLocalBoardMembershipCleanupTimer();
+
+    if (this.localBoardMembership.size === 0) {
+      return;
+    }
+
+    // Local-only mode is single-process and expected to stay small; keep the
+    // scheduler simple unless proof-of-presence cardinality becomes material.
+    let nextExpiry: number | null = null;
+    for (const expiry of this.localBoardMembership.values()) {
+      nextExpiry = nextExpiry === null ? expiry : Math.min(nextExpiry, expiry);
+    }
+    if (nextExpiry === null) return;
+
+    this.localBoardMembershipCleanupExpiry = nextExpiry;
+    const cleanupDelay = Math.max(0, nextExpiry - Date.now());
+    const cleanupTimer = setTimeout(() => {
+      this.localBoardMembershipCleanupTimer = null;
+      this.localBoardMembershipCleanupExpiry = null;
+      this.evictExpiredLocalBoardMemberships();
+      this.scheduleLocalBoardMembershipCleanup();
+    }, cleanupDelay);
+    this.localBoardMembershipCleanupTimer = cleanupTimer;
+    if (typeof cleanupTimer === 'object') {
+      cleanupTimer.unref?.();
+    }
+  }
+
+  private clearLocalBoardMembershipCleanupTimer(): void {
+    if (this.localBoardMembershipCleanupTimer === null) {
+      return;
+    }
+    clearTimeout(this.localBoardMembershipCleanupTimer);
+    this.localBoardMembershipCleanupTimer = null;
+    this.localBoardMembershipCleanupExpiry = null;
+  }
+
+  private evictExpiredLocalBoardMemberships(now = Date.now()): void {
+    for (const [localKey, expiry] of this.localBoardMembership) {
+      if (expiry <= now) {
+        this.localBoardMembership.delete(localKey);
+      }
+    }
   }
 
   /**

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -39,26 +39,10 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { track } from '../../lib/analytics';
 import { getHttpClient } from '../../lib/graphql/client';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
+import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 const ACTION_CLIMB_CACHE_LIMIT = 50;
-
-function presenceClimbToPreviewClimb(presenceClimb: BoardPresenceClimb): Climb {
-  return {
-    uuid: presenceClimb.climbUuid,
-    name: presenceClimb.name ?? '',
-    frames: presenceClimb.frames ?? '',
-    setter_username: presenceClimb.setter ?? '',
-    angle: presenceClimb.angle ?? 0,
-    ascensionist_count: 0,
-    difficulty: presenceClimb.grade ?? '',
-    quality_average: '',
-    stars: 0,
-    difficulty_error: '',
-    benchmark_difficulty: null,
-  };
-}
-
 function boardPresenceHistoryKeyExtractor(item: BoardPresenceClimb): string {
   return `${item.climbUuid}-${item.seq}`;
 }
@@ -792,7 +776,7 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
   onOpenPlaylist,
   onOpenActions,
 }: InteractiveHeroRowProps) {
-  const rowClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
+  const rowClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
   const climbBoardConfig = useMemo(
     () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
     [boardConfig, climb],
@@ -862,7 +846,7 @@ const NowOnTheWallHero = memo(function NowOnTheWallHeroInner({
   formattedGrade,
   gradeColor,
 }: HeroProps) {
-  const renderClimb = useMemo(() => (climb ? presenceClimbToPreviewClimb(climb) : null), [climb]);
+  const renderClimb = useMemo(() => (climb ? boardPresenceClimbToClimb(climb) : null), [climb]);
   const climbBoardConfig = useMemo(
     () => (boardConfig && climb ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
     [boardConfig, climb],
@@ -961,7 +945,7 @@ const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
   onOpenPlaylist,
   onOpenActions,
 }: InteractiveHistoryRowProps) {
-  const rowClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
+  const rowClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
   const climbBoardConfig = useMemo(
     () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
     [boardConfig, climb],
@@ -1025,7 +1009,7 @@ const HistoryRow = memo(function HistoryRowInner({
   formattedGrade,
   gradeColor,
 }: HistoryRowProps) {
-  const thumbnailClimb = useMemo(() => presenceClimbToPreviewClimb(climb), [climb]);
+  const thumbnailClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
   const climbBoardConfig = useMemo(
     () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
     [boardConfig, climb],

--- a/packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts
+++ b/packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts
@@ -10,26 +10,9 @@
 
 import { useMemo } from 'react';
 import type { Climb } from '@boardsesh/queue';
-import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
-
-/** Map a wall presence climb to the minimal `Climb` the accessory row renders. */
-function presenceClimbToClimb(presenceClimb: BoardPresenceClimb): Climb {
-  return {
-    uuid: presenceClimb.climbUuid,
-    name: presenceClimb.name ?? '',
-    frames: presenceClimb.frames ?? '',
-    setter_username: presenceClimb.setter ?? '',
-    angle: presenceClimb.angle ?? 0,
-    ascensionist_count: 0,
-    difficulty: presenceClimb.grade ?? '',
-    quality_average: '',
-    stars: 0,
-    difficulty_error: '',
-    benchmark_difficulty: null,
-  };
-}
+import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
 
 /**
  * Returns the climb the accessory should show. With the flag off (or no live
@@ -50,7 +33,7 @@ export function useWallOrQueueCurrentClimb(localClimb: Climb | null): Climb | nu
       if (localClimb?.uuid === wallClimb.climbUuid) {
         return localClimb;
       }
-      return presenceClimbToClimb(wallClimb);
+      return boardPresenceClimbToClimb(wallClimb);
     }
     return localClimb;
     // `wallClimb` only changes on a wall event (bounded, not per-frame), so

--- a/packages/mobile/src/lib/board-presence/presence-climb.ts
+++ b/packages/mobile/src/lib/board-presence/presence-climb.ts
@@ -1,0 +1,19 @@
+import type { Climb } from '@boardsesh/queue';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+
+/** Minimal Climb shape the queue accessory and board-art thumbnail need. */
+export function boardPresenceClimbToClimb(presenceClimb: BoardPresenceClimb): Climb {
+  return {
+    uuid: presenceClimb.climbUuid,
+    name: presenceClimb.name ?? '',
+    frames: presenceClimb.frames ?? '',
+    setter_username: presenceClimb.setter ?? '',
+    angle: presenceClimb.angle ?? 0,
+    ascensionist_count: 0,
+    difficulty: presenceClimb.grade ?? '',
+    quality_average: '',
+    stars: 0,
+    difficulty_error: '',
+    benchmark_difficulty: null,
+  };
+}


### PR DESCRIPTION
## Summary

Addresses the board-presence review feedback around local proof-of-presence cleanup, config normalization, shared-board create races, duplicate mobile mapping code, and websocket docs.

## What changed

- Added scheduled TTL cleanup for local-only board membership stamps so stale entries are evicted without waiting for a later membership check.
- Made local cleanup reschedule only when a newly stamped entry expires earlier than the currently scheduled cleanup, with a note about the intentionally simple O(N) local-only scan.
- Replaced private-shape casts in timer tests with typed `PubSub` test hooks.
- Extended the reschedule regression to verify the later entry is also cleaned up by the chained timer.
- Documented that board-presence PubSub data keys currently omit the `boardsesh:` namespace prefix, matching the implementation.
- Normalized board-presence `setIds` before owner-board lookup and serial/shared-board creation, including reordered serial-less config creates.
- Limited `resolveSharedBoardForConfig` race recovery to the expected `user_boards_unique_slug` unique violation.
- Aligned the backend test schema with production by adding the `user_boards_unique_slug` index needed to exercise the concurrent create race.
- Documented why board-presence `gradeColor` is intentionally nullable server-side.
- Extracted the duplicated mobile `BoardPresenceClimb` to `Climb` mapper into a shared mobile helper.
- Updated `docs/websocket-implementation.md` for the board-presence pub/sub channel, Redis keys, and TTLs.

## Validation

- `vp test run --project backend packages/backend/src/__tests__/board-presence.test.ts --reporter=agent`
- `vp run typecheck:backend`
- `vp run typecheck:mobile`
- `vp check docs/websocket-implementation.md packages/backend/src/pubsub/index.ts packages/backend/src/graphql/resolvers/board-presence/shared.ts packages/backend/src/graphql/resolvers/board-presence/mutations.ts packages/backend/src/__tests__/board-presence.test.ts packages/mobile/src/components/board-presence/BoardSheet.tsx packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts packages/mobile/src/lib/board-presence/presence-climb.ts`
- `vp check packages/backend/src/pubsub/index.ts packages/backend/src/graphql/resolvers/board-presence/mutations.ts packages/backend/src/__tests__/board-presence.test.ts packages/backend/src/__tests__/schema-sql.ts`
- `vp check packages/backend/src/pubsub/index.ts packages/backend/src/__tests__/board-presence.test.ts`
- `vp check packages/backend/src/pubsub/index.ts packages/backend/src/__tests__/board-presence.test.ts docs/websocket-implementation.md`

Note: full `vp check --fix` fixed Markdown formatting, then hit existing unrelated repo lint/type findings and a Vite+ stdout panic.