### PR TITLE
[codex] Fix mobile HealthKit plist usage strings

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -3,6 +3,9 @@ import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
 const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? DEFAULT_EAS_PROJECT_ID;
+const HEALTH_UPDATE_USAGE_DESCRIPTION = 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.';
+const HEALTH_SHARE_USAGE_DESCRIPTION =
+  'Boardsesh reads your body weight to estimate calories burned during climbing sessions.';
 
 function resolveDevMetadata(): {
   branchName: string | null;
@@ -158,6 +161,8 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       },
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
+        NSHealthUpdateUsageDescription: HEALTH_UPDATE_USAGE_DESCRIPTION,
+        NSHealthShareUsageDescription: HEALTH_SHARE_USAGE_DESCRIPTION,
         NSBluetoothAlwaysUsageDescription:
           'Boardsesh uses Bluetooth to connect to your Kilter Board, Tension Board, or MoonBoard and light up climbing holds. No personal data is sent over Bluetooth.',
         NSBluetoothPeripheralUsageDescription:

--- a/packages/mobile/src/lib/__tests__/healthkit-config.test.ts
+++ b/packages/mobile/src/lib/__tests__/healthkit-config.test.ts
@@ -1,0 +1,42 @@
+import type { ConfigContext, ExpoConfig } from 'expo/config';
+import { describe, expect, it } from 'vitest';
+
+import createExpoConfig from '../../../app.config';
+
+function buildConfig(): ExpoConfig & { newArchEnabled?: boolean } {
+  const previousTailscaleHosts = process.env.TAILSCALE_HOSTS;
+  process.env.TAILSCALE_HOSTS = '';
+
+  try {
+    return createExpoConfig({
+      config: {
+        name: 'Boardsesh',
+        slug: 'boardsesh',
+      },
+    } as ConfigContext);
+  } finally {
+    if (previousTailscaleHosts === undefined) {
+      delete process.env.TAILSCALE_HOSTS;
+    } else {
+      process.env.TAILSCALE_HOSTS = previousTailscaleHosts;
+    }
+  }
+}
+
+describe('mobile HealthKit native config', () => {
+  it('declares the HealthKit usage descriptions in the static Expo plist config', () => {
+    const config = buildConfig();
+
+    expect(config.ios?.infoPlist).toMatchObject({
+      NSHealthUpdateUsageDescription: 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.',
+      NSHealthShareUsageDescription:
+        'Boardsesh reads your body weight to estimate calories burned during climbing sessions.',
+    });
+  });
+
+  it('registers the HealthKit config plugin for the entitlement', () => {
+    const config = buildConfig();
+
+    expect(config.plugins).toContain('./plugins/with-healthkit');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the Apple Health usage descriptions directly to the Expo iOS `infoPlist` config for `packages/mobile`, so generated native builds include the keys required before requesting HealthKit write authorization.

Also adds a focused regression test that asserts the static Expo config contains the HealthKit plist descriptions and still registers the HealthKit config plugin for the entitlement.

## Root cause

The React Native/Expo app could request authorization for workouts and active energy, but an installed native build could be missing `NSHealthUpdateUsageDescription` in its generated `Info.plist`. iOS terminates the app when HealthKit write authorization is requested without that key.

## Impact

Finishing a session should no longer crash when Apple Health export requests write access, once users install a fresh native build. This cannot be fixed by OTA update alone because `Info.plist` is baked into the iOS binary.

## Validation

- `vp test run packages/mobile/src/lib/__tests__/healthkit-config.test.ts --reporter=agent`
- `vp run typecheck:mobile`

`vp check` was also run, but it failed on pre-existing formatting issues in clean files: `packages/backend/src/__tests__/board-presence.test.ts` and `packages/mobile/src/providers/board-presence-provider.tsx`.