### PR TITLE
[codex] add mobile board sheet hardest send

### DIFF
--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -816,6 +816,15 @@ describe('board-presence resolvers', () => {
         expect(statsEvent?.stats.distinctClimbersCount).toBe(2);
         // Hardest/top grade come from the SEND (V5), not the harder attempt.
         expect(statsEvent?.stats.hardestGrade).toBe('V5');
+        expect(statsEvent?.stats.hardestSend).toMatchObject({
+          climbUuid: TEST_CLIMB_UUID,
+          name: 'Real Catalog Climb',
+          grade: 'V5',
+          sentByUserId: TEST_USER_ID,
+          sentByDisplayName: SENDER_DISPLAY_NAME,
+          sentByAvatarUrl: SENDER_AVATAR_URL,
+        });
+        expect(statsEvent?.stats.hardestSend?.sentAt).toMatch(/T.*Z$/);
         expect(statsEvent?.stats.topGrade).toBe('V5');
         expect(statsEvent?.stats.lastSentAt).not.toBeNull();
         expect(statsEvent?.seq).toBeGreaterThan(0);
@@ -887,6 +896,7 @@ describe('board-presence resolvers', () => {
         // No tick was written, so the durable stats stay at zero sends.
         const stats = await boardPresenceQueries.boardPresenceStats(undefined, { boardId: sharedBoardId }, authCtx());
         expect(stats.climbsSentCount).toBe(0);
+        expect(stats.hardestSend).toBeNull();
       } finally {
         unsubscribe();
       }
@@ -924,10 +934,49 @@ describe('board-presence resolvers', () => {
       expect(stats.climbsSentCount).toBe(1);
       expect(stats.distinctClimbersCount).toBe(2);
       expect(stats.hardestGrade).toBe('V5');
+      expect(stats.hardestSend).toMatchObject({
+        climbUuid: TEST_CLIMB_UUID,
+        name: 'Real Catalog Climb',
+        grade: 'V5',
+        sentByUserId: TEST_USER_ID,
+        sentByDisplayName: SENDER_DISPLAY_NAME,
+        sentByAvatarUrl: SENDER_AVATAR_URL,
+        sentAt: new Date(oldClimbedAt).toISOString(),
+      });
       expect(stats.topGrade).toBe('V5');
       expect(stats.lastSentAt).not.toBeNull();
       // ISO 8601 normalised.
       expect(stats.lastSentAt).toMatch(/T.*Z$/);
+    });
+
+    it('uses the first send when multiple climbers share the hardest grade', async () => {
+      const resolved = await boardPresenceMutations.resolveBoardForSerial(
+        undefined,
+        { serial: `TIE-${Date.now()}`, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+        authCtx(),
+      );
+
+      const firstHardestClimbedAt = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+      const laterHardestClimbedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      await db.execute(sql`
+        INSERT INTO boardsesh_ticks
+          (uuid, user_id, board_type, climb_uuid, angle, is_mirror, status, attempt_count, difficulty, is_benchmark, comment, climbed_at, created_at, updated_at, board_id)
+        VALUES
+          (${`tick-first-hardest-${Date.now()}`}, ${SECOND_USER_ID}, 'kilter', ${OTHER_TEST_CLIMB_UUID}, 40, false, 'send', 1, 18, false, '', ${firstHardestClimbedAt}, now(), now(), ${resolved.boardId}),
+          (${`tick-later-hardest-${Date.now()}`}, ${TEST_USER_ID}, 'kilter', ${TEST_CLIMB_UUID}, 40, false, 'flash', 1, 18, false, '', ${laterHardestClimbedAt}, now(), now(), ${resolved.boardId})
+      `);
+
+      const stats = await boardPresenceQueries.boardPresenceStats(undefined, { boardId: resolved.boardId }, authCtx());
+      expect(stats.hardestGrade).toBe('V6');
+      expect(stats.hardestSend).toMatchObject({
+        climbUuid: OTHER_TEST_CLIMB_UUID,
+        name: 'Other Catalog Climb',
+        grade: 'V6',
+        sentByUserId: SECOND_USER_ID,
+        sentByDisplayName: 'Second Sender',
+        sentByAvatarUrl: null,
+        sentAt: new Date(firstHardestClimbedAt).toISOString(),
+      });
     });
 
     it('returns zeroes for a board with no ticks', async () => {
@@ -940,6 +989,7 @@ describe('board-presence resolvers', () => {
       expect(stats.climbsSentCount).toBe(0);
       expect(stats.distinctClimbersCount).toBe(0);
       expect(stats.hardestGrade).toBeNull();
+      expect(stats.hardestSend).toBeNull();
       expect(stats.topGrade).toBeNull();
       expect(stats.lastSentAt).toBeNull();
     });

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -38,6 +38,7 @@ const SENDER_AVATAR_URL = 'https://example.com/carla.jpg';
 const TEST_CLIMB_UUID = 'board-presence-test-climb-uuid';
 const OTHER_TEST_CLIMB_UUID = 'board-presence-other-climb-uuid';
 const BOARD_MEMBERSHIP_TTL_MS = 43_200_000;
+const ALIAS_TEST_CLIMB_UUID = 'board-presence-alias-climb-uuid';
 
 function authCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
   return {
@@ -109,6 +110,14 @@ async function seedCatalogClimb(): Promise<void> {
       ('kilter', ${OTHER_TEST_CLIMB_UUID}, 40, 18, 5, 18, 3)
     ON CONFLICT (board_type, climb_uuid, angle) DO UPDATE SET display_difficulty = EXCLUDED.display_difficulty
   `);
+  await db.execute(sql`
+    INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
+    VALUES ('kilter', ${ALIAS_TEST_CLIMB_UUID}, ${TEST_CLIMB_UUID}, 'board-presence-test')
+    ON CONFLICT (board_type, alias_uuid) DO UPDATE
+      SET canonical_uuid = EXCLUDED.canonical_uuid,
+          source = EXCLUDED.source,
+          last_seen_at = now()
+  `);
 }
 
 async function cleanup(): Promise<void> {
@@ -121,6 +130,11 @@ async function cleanup(): Promise<void> {
   await db.execute(
     sql`DELETE FROM board_climb_stats WHERE climb_uuid IN (${TEST_CLIMB_UUID}, ${OTHER_TEST_CLIMB_UUID})`,
   );
+  await db.execute(sql`
+    DELETE FROM board_climb_aliases
+    WHERE alias_uuid IN (${TEST_CLIMB_UUID}, ${OTHER_TEST_CLIMB_UUID}, ${ALIAS_TEST_CLIMB_UUID})
+       OR canonical_uuid IN (${TEST_CLIMB_UUID}, ${OTHER_TEST_CLIMB_UUID}, ${ALIAS_TEST_CLIMB_UUID})
+  `);
   await db.execute(sql`DELETE FROM board_climbs WHERE uuid IN (${TEST_CLIMB_UUID}, ${OTHER_TEST_CLIMB_UUID})`);
   await db.execute(sql`DELETE FROM user_profiles WHERE user_id = ${TEST_USER_ID}`);
   await db.execute(sql`DELETE FROM users WHERE id IN (${TEST_USER_ID}, ${SECOND_USER_ID})`);
@@ -976,6 +990,36 @@ describe('board-presence resolvers', () => {
         sentByDisplayName: 'Second Sender',
         sentByAvatarUrl: null,
         sentAt: new Date(firstHardestClimbedAt).toISOString(),
+      });
+    });
+
+    it('resolves aliased climb UUIDs before hardest-send name and consensus grade joins', async () => {
+      const resolved = await boardPresenceMutations.resolveBoardForSerial(
+        undefined,
+        { serial: `ALIAS-${Date.now()}`, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+        authCtx(),
+      );
+
+      const climbedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      await db.execute(sql`
+        INSERT INTO boardsesh_ticks
+          (uuid, user_id, board_type, climb_uuid, angle, is_mirror, status, attempt_count, difficulty, is_benchmark, comment, climbed_at, created_at, updated_at, board_id)
+        VALUES
+          (${`tick-alias-hardest-${Date.now()}`}, ${TEST_USER_ID}, 'kilter', ${ALIAS_TEST_CLIMB_UUID}, 40, false, 'send', 1, NULL, false, '', ${climbedAt}, now(), now(), ${resolved.boardId})
+      `);
+
+      const stats = await boardPresenceQueries.boardPresenceStats(undefined, { boardId: resolved.boardId }, authCtx());
+      expect(stats.climbsSentCount).toBe(1);
+      expect(stats.hardestGrade).toBe('V5');
+      expect(stats.topGrade).toBe('V5');
+      expect(stats.hardestSend).toMatchObject({
+        climbUuid: TEST_CLIMB_UUID,
+        name: 'Real Catalog Climb',
+        grade: 'V5',
+        sentByUserId: TEST_USER_ID,
+        sentByDisplayName: SENDER_DISPLAY_NAME,
+        sentByAvatarUrl: SENDER_AVATAR_URL,
+        sentAt: new Date(climbedAt).toISOString(),
       });
     });
 

--- a/packages/backend/src/graphql/resolvers/board-presence/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/queries.ts
@@ -26,11 +26,8 @@ export const boardPresenceQueries = {
    * Durable stats for a board's wall feed, derived from `boardsesh_ticks`
    * stamped with this board_id.
    *
-   * v1 keeps it to what a single grouped query over the ticks table can
-   * answer cheaply: distinct climbs, distinct climbers, and the most recent
-   * send. `hardestGrade` / `topGrade` need a grade-name join across the
-   * board-specific difficulty tables (the same TODO the board leaderboard
-   * carries) — left null for now rather than shipping an approximate label.
+   * Includes the representative hardest send so the board sheet can show the
+   * climber + climb that established the wall's hardest logged grade.
    */
   boardPresenceStats: async (
     _: unknown,

--- a/packages/backend/src/graphql/resolvers/board-presence/stats.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/stats.ts
@@ -10,7 +10,7 @@
 
 import { randomUUID } from 'crypto';
 import { and, eq, inArray, sql } from 'drizzle-orm';
-import type { BoardPresenceStats } from '@boardsesh/shared-schema';
+import type { BoardPresenceHardestSend, BoardPresenceStats } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { pubsub } from '../../../pubsub/index';
@@ -21,11 +21,37 @@ type DifficultyRow = {
   difficulty: number | null;
 };
 
-function parsePostgresUtcTimestamp(timestamp: string | null | undefined): string | null {
+type HardestSendRow = {
+  climbUuid: string;
+  name: string | null;
+  grade: string;
+  sentByUserId: string;
+  sentByDisplayName: string | null;
+  sentByAvatarUrl: string | null;
+  sentAt: string | Date;
+};
+
+function parsePostgresUtcTimestamp(timestamp: string | Date | null | undefined): string | null {
   if (!timestamp) return null;
+  if (timestamp instanceof Date) return timestamp.toISOString();
   const isoLikeTimestamp = timestamp.includes('T') ? timestamp : timestamp.replace(' ', 'T');
   const zonedTimestamp = /(?:Z|[+-]\d{2}:?\d{2})$/.test(isoLikeTimestamp) ? isoLikeTimestamp : `${isoLikeTimestamp}Z`;
   return new Date(zonedTimestamp).toISOString();
+}
+
+function toHardestSend(row: HardestSendRow | undefined): BoardPresenceHardestSend | null {
+  if (!row) return null;
+  const sentAt = parsePostgresUtcTimestamp(row.sentAt);
+  if (!sentAt) return null;
+  return {
+    climbUuid: row.climbUuid,
+    name: row.name,
+    grade: row.grade,
+    sentByUserId: row.sentByUserId,
+    sentByDisplayName: row.sentByDisplayName,
+    sentByAvatarUrl: row.sentByAvatarUrl,
+    sentAt,
+  };
 }
 
 async function resolveGradeNames(
@@ -103,12 +129,53 @@ export async function computeBoardPresenceStats(boardId: number, boardType: stri
     LIMIT 1
   `);
   const topGradeRow = topGradeRows[0] as DifficultyRow | undefined;
+  const hardestSendRows = await db.execute(sql<HardestSendRow>`
+    SELECT
+      ranked.climb_uuid AS "climbUuid",
+      c.name AS "name",
+      COALESCE(g.boulder_name, ranked.difficulty::text) AS "grade",
+      ranked.user_id AS "sentByUserId",
+      COALESCE(p.display_name, u.name) AS "sentByDisplayName",
+      COALESCE(p.avatar_url, u.image) AS "sentByAvatarUrl",
+      ranked.climbed_at AS "sentAt"
+    FROM (
+      SELECT
+        t.id,
+        t.climb_uuid,
+        t.user_id,
+        t.board_type,
+        t.climbed_at,
+        COALESCE(t.difficulty, ROUND(s.display_difficulty)::int) AS difficulty
+      FROM boardsesh_ticks t
+      LEFT JOIN board_climb_stats s
+        ON s.board_type = t.board_type
+       AND s.climb_uuid = t.climb_uuid
+       AND s.angle = t.angle
+      WHERE t.board_id = ${boardId}
+        AND t.status IN ('send', 'flash')
+    ) ranked
+    LEFT JOIN board_climbs c
+      ON c.board_type = ranked.board_type
+     AND c.uuid = ranked.climb_uuid
+    LEFT JOIN board_difficulty_grades g
+      ON g.board_type = ranked.board_type
+     AND g.difficulty = ranked.difficulty
+    LEFT JOIN users u
+      ON u.id = ranked.user_id
+    LEFT JOIN user_profiles p
+      ON p.user_id = ranked.user_id
+    WHERE ranked.difficulty IS NOT NULL
+    ORDER BY ranked.difficulty DESC, ranked.climbed_at ASC, ranked.id ASC
+    LIMIT 1
+  `);
+  const hardestSendRow = hardestSendRows[0] as HardestSendRow | undefined;
   const gradeNames = await resolveGradeNames(boardType, [stats?.hardestDifficulty, topGradeRow?.difficulty]);
 
   return {
     climbsSentCount: Number(stats?.climbsSentCount ?? 0),
     distinctClimbersCount: Number(stats?.distinctClimbersCount ?? 0),
     hardestGrade: gradeNameFor(stats?.hardestDifficulty, gradeNames),
+    hardestSend: toHardestSend(hardestSendRow),
     topGrade: gradeNameFor(topGradeRow?.difficulty, gradeNames),
     lastSentAt: parsePostgresUtcTimestamp(stats?.lastSentAt),
   };

--- a/packages/backend/src/graphql/resolvers/board-presence/stats.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/stats.ts
@@ -9,26 +9,26 @@
 // a later cold fetch never disagree.
 
 import { randomUUID } from 'crypto';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import type { BoardPresenceHardestSend, BoardPresenceStats } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
-import * as dbSchema from '@boardsesh/db/schema';
 import { pubsub } from '../../../pubsub/index';
 import { redisClientManager } from '../../../redis/client';
 import { logger } from '../../../utils/logger';
 
-type DifficultyRow = {
-  difficulty: number | null;
-};
-
-type HardestSendRow = {
-  climbUuid: string;
+type BoardPresenceStatsRow = {
+  climbsSentCount: number;
+  distinctClimbersCount: number;
+  hardestGrade: string | null;
+  topGrade: string | null;
+  lastSentAt: string | Date | null;
+  hardestSendClimbUuid: string | null;
   name: string | null;
-  grade: string;
-  sentByUserId: string;
+  grade: string | null;
+  sentByUserId: string | null;
   sentByDisplayName: string | null;
   sentByAvatarUrl: string | null;
-  sentAt: string | Date;
+  sentAt: string | Date | null;
 };
 
 function parsePostgresUtcTimestamp(timestamp: string | Date | null | undefined): string | null {
@@ -39,12 +39,12 @@ function parsePostgresUtcTimestamp(timestamp: string | Date | null | undefined):
   return new Date(zonedTimestamp).toISOString();
 }
 
-function toHardestSend(row: HardestSendRow | undefined): BoardPresenceHardestSend | null {
-  if (!row) return null;
+function toHardestSend(row: BoardPresenceStatsRow | undefined): BoardPresenceHardestSend | null {
+  if (!row?.hardestSendClimbUuid || !row.grade || !row.sentByUserId) return null;
   const sentAt = parsePostgresUtcTimestamp(row.sentAt);
   if (!sentAt) return null;
   return {
-    climbUuid: row.climbUuid,
+    climbUuid: row.hardestSendClimbUuid,
     name: row.name,
     grade: row.grade,
     sentByUserId: row.sentByUserId,
@@ -54,129 +54,106 @@ function toHardestSend(row: HardestSendRow | undefined): BoardPresenceHardestSen
   };
 }
 
-async function resolveGradeNames(
-  boardType: string,
-  difficulties: Array<number | null | undefined>,
-): Promise<Map<number, string>> {
-  const uniqueDifficulties = [
-    ...new Set(difficulties.filter((difficulty): difficulty is number => difficulty != null)),
-  ];
-  if (uniqueDifficulties.length === 0) return new Map();
-
-  const rows = await db
-    .select({
-      difficulty: dbSchema.boardDifficultyGrades.difficulty,
-      boulderName: dbSchema.boardDifficultyGrades.boulderName,
-    })
-    .from(dbSchema.boardDifficultyGrades)
-    .where(
-      and(
-        eq(dbSchema.boardDifficultyGrades.boardType, boardType),
-        inArray(dbSchema.boardDifficultyGrades.difficulty, uniqueDifficulties),
-      ),
-    );
-
-  return new Map(rows.map((row) => [row.difficulty, row.boulderName ?? String(row.difficulty)]));
-}
-
-function gradeNameFor(difficulty: number | null | undefined, gradeNames: Map<number, string>): string | null {
-  if (difficulty == null) return null;
-  return gradeNames.get(difficulty) ?? String(difficulty);
-}
-
 /**
  * Compute a board's durable wall stats from `boardsesh_ticks`. The single
  * source of truth for both the `boardPresenceStats` query and the live push.
  */
 export async function computeBoardPresenceStats(boardId: number, boardType: string): Promise<BoardPresenceStats> {
-  const [stats] = await db
-    .select({
-      climbsSentCount: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.climbUuid}) FILTER (WHERE ${dbSchema.boardseshTicks.status} IN ('send', 'flash'))`,
-      distinctClimbersCount: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId})`,
-      lastSentAt: sql<
-        string | null
-      >`MAX(${dbSchema.boardseshTicks.climbedAt}) FILTER (WHERE ${dbSchema.boardseshTicks.status} IN ('send', 'flash'))`,
-      hardestDifficulty: sql<
-        number | null
-      >`MAX(COALESCE(${dbSchema.boardseshTicks.difficulty}, ROUND(${dbSchema.boardClimbStats.displayDifficulty})::int)) FILTER (WHERE ${dbSchema.boardseshTicks.status} IN ('send', 'flash'))`,
-    })
-    .from(dbSchema.boardseshTicks)
-    .leftJoin(
-      dbSchema.boardClimbStats,
-      and(
-        eq(dbSchema.boardClimbStats.boardType, dbSchema.boardseshTicks.boardType),
-        eq(dbSchema.boardClimbStats.climbUuid, dbSchema.boardseshTicks.climbUuid),
-        eq(dbSchema.boardClimbStats.angle, dbSchema.boardseshTicks.angle),
-      ),
-    )
-    .where(eq(dbSchema.boardseshTicks.boardId, boardId));
-
-  const topGradeRows = await db.execute(sql<DifficultyRow>`
-    SELECT tick_difficulties.difficulty
-    FROM (
-      SELECT COALESCE(t.difficulty, ROUND(s.display_difficulty)::int) AS difficulty
-      FROM boardsesh_ticks t
-      LEFT JOIN board_climb_stats s
-        ON s.board_type = t.board_type
-       AND s.climb_uuid = t.climb_uuid
-       AND s.angle = t.angle
-      WHERE t.board_id = ${boardId}
-        AND t.status IN ('send', 'flash')
-    ) tick_difficulties
-    WHERE tick_difficulties.difficulty IS NOT NULL
-    GROUP BY tick_difficulties.difficulty
-    ORDER BY COUNT(*) DESC, tick_difficulties.difficulty DESC
-    LIMIT 1
-  `);
-  const topGradeRow = topGradeRows[0] as DifficultyRow | undefined;
-  const hardestSendRows = await db.execute(sql<HardestSendRow>`
-    SELECT
-      ranked.climb_uuid AS "climbUuid",
-      c.name AS "name",
-      COALESCE(g.boulder_name, ranked.difficulty::text) AS "grade",
-      ranked.user_id AS "sentByUserId",
-      COALESCE(p.display_name, u.name) AS "sentByDisplayName",
-      COALESCE(p.avatar_url, u.image) AS "sentByAvatarUrl",
-      ranked.climbed_at AS "sentAt"
-    FROM (
+  const rows = await db.execute(sql<BoardPresenceStatsRow>`
+    WITH tick_difficulties AS (
       SELECT
         t.id,
-        t.climb_uuid,
         t.user_id,
         t.board_type,
+        t.climb_uuid,
+        COALESCE(a.canonical_uuid, t.climb_uuid) AS canonical_climb_uuid,
         t.climbed_at,
+        t.status,
         COALESCE(t.difficulty, ROUND(s.display_difficulty)::int) AS difficulty
       FROM boardsesh_ticks t
+      LEFT JOIN board_climb_aliases a
+        ON a.board_type = t.board_type
+       AND a.alias_uuid = t.climb_uuid
       LEFT JOIN board_climb_stats s
         ON s.board_type = t.board_type
-       AND s.climb_uuid = t.climb_uuid
+       AND s.climb_uuid = COALESCE(a.canonical_uuid, t.climb_uuid)
        AND s.angle = t.angle
       WHERE t.board_id = ${boardId}
-        AND t.status IN ('send', 'flash')
-    ) ranked
+    ),
+    aggregate_stats AS (
+      SELECT
+        (COUNT(DISTINCT canonical_climb_uuid) FILTER (WHERE status IN ('send', 'flash')))::int AS climbs_sent_count,
+        COUNT(DISTINCT user_id)::int AS distinct_climbers_count,
+        MAX(climbed_at) FILTER (WHERE status IN ('send', 'flash')) AS last_sent_at,
+        MAX(difficulty) FILTER (WHERE status IN ('send', 'flash')) AS hardest_difficulty
+      FROM tick_difficulties
+    ),
+    top_grade AS (
+      SELECT difficulty
+      FROM tick_difficulties
+      WHERE status IN ('send', 'flash')
+        AND difficulty IS NOT NULL
+      GROUP BY difficulty
+      ORDER BY COUNT(*) DESC, difficulty DESC
+      LIMIT 1
+    ),
+    hardest_send AS (
+      SELECT
+        id,
+        user_id,
+        board_type,
+        canonical_climb_uuid,
+        climbed_at,
+        difficulty
+      FROM tick_difficulties
+      WHERE status IN ('send', 'flash')
+        AND difficulty IS NOT NULL
+      ORDER BY difficulty DESC, climbed_at ASC, id ASC
+      LIMIT 1
+    )
+    SELECT
+      stats.climbs_sent_count AS "climbsSentCount",
+      stats.distinct_climbers_count AS "distinctClimbersCount",
+      COALESCE(hardest_grade.boulder_name, stats.hardest_difficulty::text) AS "hardestGrade",
+      COALESCE(top_grade_name.boulder_name, top_grade.difficulty::text) AS "topGrade",
+      stats.last_sent_at AS "lastSentAt",
+      hardest_send.canonical_climb_uuid AS "hardestSendClimbUuid",
+      c.name AS "name",
+      COALESCE(hardest_send_grade.boulder_name, hardest_send.difficulty::text) AS "grade",
+      hardest_send.user_id AS "sentByUserId",
+      COALESCE(p.display_name, u.name) AS "sentByDisplayName",
+      COALESCE(p.avatar_url, u.image) AS "sentByAvatarUrl",
+      hardest_send.climbed_at AS "sentAt"
+    FROM aggregate_stats stats
+    LEFT JOIN board_difficulty_grades hardest_grade
+      ON hardest_grade.board_type = ${boardType}
+     AND hardest_grade.difficulty = stats.hardest_difficulty
+    LEFT JOIN top_grade
+      ON TRUE
+    LEFT JOIN board_difficulty_grades top_grade_name
+      ON top_grade_name.board_type = ${boardType}
+     AND top_grade_name.difficulty = top_grade.difficulty
+    LEFT JOIN hardest_send
+      ON TRUE
     LEFT JOIN board_climbs c
-      ON c.board_type = ranked.board_type
-     AND c.uuid = ranked.climb_uuid
-    LEFT JOIN board_difficulty_grades g
-      ON g.board_type = ranked.board_type
-     AND g.difficulty = ranked.difficulty
+      ON c.board_type = hardest_send.board_type
+     AND c.uuid = hardest_send.canonical_climb_uuid
+    LEFT JOIN board_difficulty_grades hardest_send_grade
+      ON hardest_send_grade.board_type = hardest_send.board_type
+     AND hardest_send_grade.difficulty = hardest_send.difficulty
     LEFT JOIN users u
-      ON u.id = ranked.user_id
+      ON u.id = hardest_send.user_id
     LEFT JOIN user_profiles p
-      ON p.user_id = ranked.user_id
-    WHERE ranked.difficulty IS NOT NULL
-    ORDER BY ranked.difficulty DESC, ranked.climbed_at ASC, ranked.id ASC
-    LIMIT 1
+      ON p.user_id = hardest_send.user_id
   `);
-  const hardestSendRow = hardestSendRows[0] as HardestSendRow | undefined;
-  const gradeNames = await resolveGradeNames(boardType, [stats?.hardestDifficulty, topGradeRow?.difficulty]);
+  const stats = rows[0] as BoardPresenceStatsRow | undefined;
 
   return {
     climbsSentCount: Number(stats?.climbsSentCount ?? 0),
     distinctClimbersCount: Number(stats?.distinctClimbersCount ?? 0),
-    hardestGrade: gradeNameFor(stats?.hardestDifficulty, gradeNames),
-    hardestSend: toHardestSend(hardestSendRow),
-    topGrade: gradeNameFor(topGradeRow?.difficulty, gradeNames),
+    hardestGrade: stats?.hardestGrade ?? null,
+    hardestSend: toHardestSend(stats),
+    topGrade: stats?.topGrade ?? null,
     lastSentAt: parsePostgresUtcTimestamp(stats?.lastSentAt),
   };
 }

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -24,12 +24,13 @@ import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import type { BoardName, BoardPresenceClimb, Climb } from '@boardsesh/shared-schema';
+import type { BoardName, BoardPresenceClimb, BoardPresenceHardestSend, Climb } from '@boardsesh/shared-schema';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { ClimbListRow, type ClimbListRowRenderContentArgs } from '../ClimbListRow';
+import { Avatar } from '../Avatar';
 import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -40,6 +41,7 @@ import { track } from '../../lib/analytics';
 import { getHttpClient } from '../../lib/graphql/client';
 import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
 import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
+import { withAlpha } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 const ACTION_CLIMB_CACHE_LIMIT = 50;
@@ -565,6 +567,17 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
                 valueColor={systemColors.label}
               />
             </View>
+            {stats.hardestSend ? (
+              <HardestSendRow
+                hardestSend={stats.hardestSend}
+                labelColor={systemColors.label}
+                secondaryColor={systemColors.secondaryLabel}
+                surfaceColor={systemColors.secondaryBackground}
+                crownColor={brandColors.warning}
+                formattedGrade={formatGrade(stats.hardestSend.grade) ?? stats.hardestSend.grade}
+                gradeColor={getGradeColor(stats.hardestSend.grade) ?? DEFAULT_GRADE_COLOR}
+              />
+            ) : null}
           </View>
         ) : null}
         {visibleHistory.length > 0 ? (
@@ -1051,6 +1064,56 @@ function StatTile({ value, label, surfaceColor, labelColor, valueColor }: StatTi
   );
 }
 
+type HardestSendRowProps = {
+  hardestSend: BoardPresenceHardestSend;
+  labelColor: ColorValue;
+  secondaryColor: ColorValue;
+  surfaceColor: ColorValue;
+  crownColor: string;
+  formattedGrade: string;
+  gradeColor: string;
+};
+
+function HardestSendRow({
+  hardestSend,
+  labelColor,
+  secondaryColor,
+  surfaceColor,
+  crownColor,
+  formattedGrade,
+  gradeColor,
+}: HardestSendRowProps) {
+  const { t } = useTranslation('session');
+  const climberName = hardestSend.sentByDisplayName?.trim();
+
+  return (
+    <View style={[styles.hardestSendRow, { backgroundColor: surfaceColor }]}>
+      <View style={styles.hardestAvatar}>
+        <Avatar uri={hardestSend.sentByAvatarUrl} name={climberName} size={34} />
+        <View style={[styles.crownBadge, { backgroundColor: withAlpha(crownColor, 0.18) }]}>
+          <Icon name="crown" size={11} color={crownColor} />
+        </View>
+      </View>
+      <View style={styles.hardestBody}>
+        <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
+          {t('mobile.boardPresence.hardestSendLabel')}
+        </Text>
+        <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.hardestName}>
+          {hardestSend.name ?? ''}
+        </Text>
+        {climberName ? (
+          <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
+            {t('mobile.boardPresence.litByLine', { name: climberName })}
+          </Text>
+        ) : null}
+      </View>
+      <Text variant="headline" style={[styles.historyGrade, { color: gradeColor }]}>
+        {formattedGrade}
+      </Text>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   sheet: {
     ...Platform.select({
@@ -1139,6 +1202,38 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[3],
     borderRadius: borderRadius.md,
     gap: 2,
+  },
+  hardestSendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginHorizontal: spacing[4],
+    marginTop: spacing[2],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+  },
+  hardestAvatar: {
+    width: 42,
+    height: 42,
+    justifyContent: 'flex-end',
+  },
+  crownBadge: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  hardestBody: {
+    flex: 1,
+    gap: 2,
+  },
+  hardestName: {
+    fontWeight: '600',
   },
   historyRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -1103,7 +1103,7 @@ function HardestSendRow({
         </Text>
         {climberName ? (
           <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
-            {t('mobile.boardPresence.litByLine', { name: climberName })}
+            {t('mobile.boardPresence.sentByLine', { name: climberName })}
           </Text>
         ) : null}
       </View>

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -394,7 +394,7 @@ describe('BoardSheet', () => {
     expect(container.textContent).toContain('14');
     expect(container.textContent).toContain('mobile.boardPresence.hardestSendLabel');
     expect(container.textContent).toContain('Hard Rig');
-    expect(container.textContent).toContain('mobile.boardPresence.litByLine:Mina');
+    expect(container.textContent).toContain('mobile.boardPresence.sentByLine:Mina');
     expect(container.querySelector('[data-avatar="Mina"]')).not.toBeNull();
     expect(container.querySelector('[data-icon="crown"]')).not.toBeNull();
     expect(container.textContent).toContain('mobile.boardPresence.historyHeader');

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -139,6 +139,9 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
 }));
 vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../Avatar', () => ({
+  Avatar: ({ name }: { name?: string | null }) => createElement('span', { 'data-avatar': name ?? '' }),
+}));
 vi.mock('../../ActivityIndicator', () => ({
   ActivityIndicator: ({ accessibilityLabel }: { accessibilityLabel?: string }) =>
     createElement('span', { 'aria-label': accessibilityLabel, 'data-loading': 'true' }),
@@ -207,6 +210,9 @@ vi.mock('../../../providers/toast-provider', () => ({
 }));
 vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+vi.mock('../../../theme/colors', () => ({
+  withAlpha: (color: string, alpha: number) => `${color}|${alpha}`,
 }));
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
@@ -358,6 +364,15 @@ describe('BoardSheet', () => {
       climbsSentCount: 14,
       distinctClimbersCount: 5,
       hardestGrade: 'V9',
+      hardestSend: {
+        climbUuid: 'hard-c1',
+        name: 'Hard Rig',
+        grade: 'V9',
+        sentByUserId: 'user-1',
+        sentByDisplayName: 'Mina',
+        sentByAvatarUrl: 'https://example.com/mina.jpg',
+        sentAt: '2026-06-09T00:00:00.000Z',
+      },
       topGrade: 'V5',
       lastSentAt: null,
     };
@@ -377,6 +392,11 @@ describe('BoardSheet', () => {
     expect(container.textContent).toContain('Older Climb');
     // Stats tiles.
     expect(container.textContent).toContain('14');
+    expect(container.textContent).toContain('mobile.boardPresence.hardestSendLabel');
+    expect(container.textContent).toContain('Hard Rig');
+    expect(container.textContent).toContain('mobile.boardPresence.litByLine:Mina');
+    expect(container.querySelector('[data-avatar="Mina"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="crown"]')).not.toBeNull();
     expect(container.textContent).toContain('mobile.boardPresence.historyHeader');
     // History list rendered one node per item.
     expect(container.querySelector('[data-list="true"]')).not.toBeNull();

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -121,6 +121,7 @@ export const iconMap = {
   // Misc
   star: { ios: 'star', android: 'star-outline' },
   'star.fill': { ios: 'star.fill', android: 'star' },
+  crown: { ios: 'crown.fill', android: 'crown' },
   location: { ios: 'location', android: 'map-marker-outline' },
   'location.fill': { ios: 'location.fill', android: 'map-marker' },
   calendar: { ios: 'calendar', android: 'calendar-outline' },

--- a/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
@@ -98,6 +98,15 @@ describe('createMobileBoardPresenceClient', () => {
       climbsSentCount: 3,
       distinctClimbersCount: 2,
       hardestGrade: 'V7',
+      hardestSend: {
+        climbUuid: 'c7',
+        name: 'Hard Thing',
+        grade: 'V7',
+        sentByUserId: 'user-1',
+        sentByDisplayName: 'Mina',
+        sentByAvatarUrl: 'https://example.com/mina.jpg',
+        sentAt: '2026-06-09T00:00:00.000Z',
+      },
       topGrade: 'V4',
       lastSentAt: null,
     };

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -147,38 +147,35 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     }
   }, []);
 
-  const resolveAndBindBoardByUuid = useCallback(
-    async (args: ResolveBoardUuidArgs): Promise<ResolvedBoard | null> => {
-      const activeClient = clientRef.current;
-      if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForUuid) {
+  const resolveAndBindBoardByUuid = useCallback(async (args: ResolveBoardUuidArgs): Promise<ResolvedBoard | null> => {
+    const activeClient = clientRef.current;
+    if (!enabledRef.current || activeClient === null || !activeClient.resolveBoardForUuid) {
+      return null;
+    }
+    if (lastResolvedBoardUuidRef.current === args.boardUuid) {
+      return null;
+    }
+    const resolveGeneration = resolveGenerationRef.current + 1;
+    resolveGenerationRef.current = resolveGeneration;
+    lastResolvedBoardUuidRef.current = args.boardUuid;
+    lastResolvedConfigKeyRef.current = null;
+    lastResolvedSerialRef.current = null;
+    setBoardId(null);
+    try {
+      const resolved = await activeClient.resolveBoardForUuid(args);
+      if (resolveGenerationRef.current !== resolveGeneration) {
         return null;
       }
-      if (lastResolvedBoardUuidRef.current === args.boardUuid) {
-        return null;
+      setBoardId(resolved.boardId);
+      return resolved;
+    } catch (error) {
+      if (resolveGenerationRef.current === resolveGeneration) {
+        lastResolvedBoardUuidRef.current = null;
       }
-      const resolveGeneration = resolveGenerationRef.current + 1;
-      resolveGenerationRef.current = resolveGeneration;
-      lastResolvedBoardUuidRef.current = args.boardUuid;
-      lastResolvedConfigKeyRef.current = null;
-      lastResolvedSerialRef.current = null;
-      setBoardId(null);
-      try {
-        const resolved = await activeClient.resolveBoardForUuid(args);
-        if (resolveGenerationRef.current !== resolveGeneration) {
-          return null;
-        }
-        setBoardId(resolved.boardId);
-        return resolved;
-      } catch (error) {
-        if (resolveGenerationRef.current === resolveGeneration) {
-          lastResolvedBoardUuidRef.current = null;
-        }
-        console.warn('[board-presence] resolveBoardForUuid failed', error);
-        return null;
-      }
-    },
-    [],
-  );
+      console.warn('[board-presence] resolveBoardForUuid failed', error);
+      return null;
+    }
+  }, []);
 
   const resolveAndBindBoardByConfig = useCallback(
     async (args: ResolveBoardConfigArgs): Promise<ResolvedBoard | null> => {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -5478,6 +5478,26 @@ Union of board-presence events streamed by `boardNowPlaying`.
 union BoardPresenceEvent = BoardClimbSet | BoardClimbCleared | BoardStatsUpdated
 
 """
+The first climber to send the hardest grade logged on this wall.
+"""
+type BoardPresenceHardestSend {
+  "UUID of the hardest sent climb"
+  climbUuid: String!
+  "Climb name"
+  name: String
+  "Grade name (e.g. V6 / 7A+)"
+  grade: String!
+  "Boardsesh user id of the climber"
+  sentByUserId: String!
+  "Display name of the climber"
+  sentByDisplayName: String
+  "Avatar URL of the climber"
+  sentByAvatarUrl: String
+  "ISO 8601 timestamp of the send"
+  sentAt: String!
+}
+
+"""
 A board resolved from a BLE serial — the one shared board everyone at this
 physical wall sees. `boardId` is the shared key for the presence channel.
 """
@@ -5508,6 +5528,8 @@ type BoardPresenceStats {
   distinctClimbersCount: Int!
   "Hardest grade sent on this wall (name), if any"
   hardestGrade: String
+  "First send at the hardest grade logged on this wall, if any"
+  hardestSend: BoardPresenceHardestSend
   "Most-sent grade on this wall (name), if any"
   topGrade: String
   "ISO 8601 timestamp of the most recent send on this wall"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -435,6 +435,25 @@ export type BoardPresenceClimb = {
 /** Union of board-presence events streamed by `boardNowPlaying`. */
 export type BoardPresenceEvent = BoardClimbCleared | BoardClimbSet | BoardStatsUpdated;
 
+/** The first climber to send the hardest grade logged on this wall. */
+export type BoardPresenceHardestSend = {
+  __typename?: 'BoardPresenceHardestSend';
+  /** UUID of the hardest sent climb */
+  climbUuid: Scalars['String']['output'];
+  /** Grade name (e.g. V6 / 7A+) */
+  grade: Scalars['String']['output'];
+  /** Climb name */
+  name?: Maybe<Scalars['String']['output']>;
+  /** ISO 8601 timestamp of the send */
+  sentAt: Scalars['String']['output'];
+  /** Avatar URL of the climber */
+  sentByAvatarUrl?: Maybe<Scalars['String']['output']>;
+  /** Display name of the climber */
+  sentByDisplayName?: Maybe<Scalars['String']['output']>;
+  /** Boardsesh user id of the climber */
+  sentByUserId: Scalars['String']['output'];
+};
+
 /**
  * Lightweight live + durable stats for a board's wall feed. Durable counts are
  * derived from `boardsesh_ticks` stamped with this board_id; "right now" comes
@@ -448,6 +467,8 @@ export type BoardPresenceStats = {
   distinctClimbersCount: Scalars['Int']['output'];
   /** Hardest grade sent on this wall (name), if any */
   hardestGrade?: Maybe<Scalars['String']['output']>;
+  /** First send at the hardest grade logged on this wall, if any */
+  hardestSend?: Maybe<BoardPresenceHardestSend>;
   /** ISO 8601 timestamp of the most recent send on this wall */
   lastSentAt?: Maybe<Scalars['String']['output']>;
   /** Most-sent grade on this wall (name), if any */
@@ -5688,6 +5709,7 @@ export type ResolversTypes = ResolversObject<{
   BoardLeaderboardInput: BoardLeaderboardInput;
   BoardPresenceClimb: ResolverTypeWrapper<BoardPresenceClimb>;
   BoardPresenceEvent: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['BoardPresenceEvent']>;
+  BoardPresenceHardestSend: ResolverTypeWrapper<BoardPresenceHardestSend>;
   BoardPresenceStats: ResolverTypeWrapper<BoardPresenceStats>;
   BoardSerialConfig: ResolverTypeWrapper<BoardSerialConfig>;
   BoardStatsUpdated: ResolverTypeWrapper<BoardStatsUpdated>;
@@ -5960,6 +5982,7 @@ export type ResolversParentTypes = ResolversObject<{
   BoardLeaderboardInput: BoardLeaderboardInput;
   BoardPresenceClimb: BoardPresenceClimb;
   BoardPresenceEvent: ResolversUnionTypes<ResolversParentTypes>['BoardPresenceEvent'];
+  BoardPresenceHardestSend: BoardPresenceHardestSend;
   BoardPresenceStats: BoardPresenceStats;
   BoardSerialConfig: BoardSerialConfig;
   BoardStatsUpdated: BoardStatsUpdated;
@@ -6412,6 +6435,21 @@ export type BoardPresenceEventResolvers<
   __resolveType: TypeResolveFn<'BoardClimbCleared' | 'BoardClimbSet' | 'BoardStatsUpdated', ParentType, ContextType>;
 }>;
 
+export type BoardPresenceHardestSendResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['BoardPresenceHardestSend'] =
+    ResolversParentTypes['BoardPresenceHardestSend'],
+> = ResolversObject<{
+  climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  grade?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sentAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sentByAvatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sentByDisplayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  sentByUserId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type BoardPresenceStatsResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['BoardPresenceStats'] = ResolversParentTypes['BoardPresenceStats'],
@@ -6419,6 +6457,7 @@ export type BoardPresenceStatsResolvers<
   climbsSentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   distinctClimbersCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   hardestGrade?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hardestSend?: Resolver<Maybe<ResolversTypes['BoardPresenceHardestSend']>, ParentType, ContextType>;
   lastSentAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   topGrade?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -9294,6 +9333,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   BoardLeaderboardEntry?: BoardLeaderboardEntryResolvers<ContextType>;
   BoardPresenceClimb?: BoardPresenceClimbResolvers<ContextType>;
   BoardPresenceEvent?: BoardPresenceEventResolvers<ContextType>;
+  BoardPresenceHardestSend?: BoardPresenceHardestSendResolvers<ContextType>;
   BoardPresenceStats?: BoardPresenceStatsResolvers<ContextType>;
   BoardSerialConfig?: BoardSerialConfigResolvers<ContextType>;
   BoardStatsUpdated?: BoardStatsUpdatedResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/board-presence.ts
+++ b/packages/shared-schema/src/schema/board-presence.ts
@@ -76,6 +76,26 @@ export const boardPresenceTypeDefs = /* GraphQL */ `
   union BoardPresenceEvent = BoardClimbSet | BoardClimbCleared | BoardStatsUpdated
 
   """
+  The first climber to send the hardest grade logged on this wall.
+  """
+  type BoardPresenceHardestSend {
+    "UUID of the hardest sent climb"
+    climbUuid: String!
+    "Climb name"
+    name: String
+    "Grade name (e.g. V6 / 7A+)"
+    grade: String!
+    "Boardsesh user id of the climber"
+    sentByUserId: String!
+    "Display name of the climber"
+    sentByDisplayName: String
+    "Avatar URL of the climber"
+    sentByAvatarUrl: String
+    "ISO 8601 timestamp of the send"
+    sentAt: String!
+  }
+
+  """
   A board resolved from a BLE serial — the one shared board everyone at this
   physical wall sees. \`boardId\` is the shared key for the presence channel.
   """
@@ -106,6 +126,8 @@ export const boardPresenceTypeDefs = /* GraphQL */ `
     distinctClimbersCount: Int!
     "Hardest grade sent on this wall (name), if any"
     hardestGrade: String
+    "First send at the hardest grade logged on this wall, if any"
+    hardestSend: BoardPresenceHardestSend
     "Most-sent grade on this wall (name), if any"
     topGrade: String
     "ISO 8601 timestamp of the most recent send on this wall"

--- a/packages/shared-schema/src/types/board-presence.ts
+++ b/packages/shared-schema/src/types/board-presence.ts
@@ -39,6 +39,16 @@ export type BoardStatsUpdated = {
 
 export type BoardPresenceEvent = BoardClimbSet | BoardClimbCleared | BoardStatsUpdated;
 
+export type BoardPresenceHardestSend = {
+  climbUuid: string;
+  name?: string | null;
+  grade: string;
+  sentByUserId: string;
+  sentByDisplayName?: string | null;
+  sentByAvatarUrl?: string | null;
+  sentAt: string;
+};
+
 export type ResolvedBoard = {
   boardId: number;
   boardName: string;
@@ -52,6 +62,7 @@ export type BoardPresenceStats = {
   climbsSentCount: number;
   distinctClimbersCount: number;
   hardestGrade?: string | null;
+  hardestSend?: BoardPresenceHardestSend | null;
   topGrade?: string | null;
   lastSentAt?: string | null;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -432,6 +432,25 @@ export type BoardPresenceClimb = {
 /** Union of board-presence events streamed by `boardNowPlaying`. */
 export type BoardPresenceEvent = BoardClimbCleared | BoardClimbSet | BoardStatsUpdated;
 
+/** The first climber to send the hardest grade logged on this wall. */
+export type BoardPresenceHardestSend = {
+  __typename?: 'BoardPresenceHardestSend';
+  /** UUID of the hardest sent climb */
+  climbUuid: Scalars['String']['output'];
+  /** Grade name (e.g. V6 / 7A+) */
+  grade: Scalars['String']['output'];
+  /** Climb name */
+  name?: Maybe<Scalars['String']['output']>;
+  /** ISO 8601 timestamp of the send */
+  sentAt: Scalars['String']['output'];
+  /** Avatar URL of the climber */
+  sentByAvatarUrl?: Maybe<Scalars['String']['output']>;
+  /** Display name of the climber */
+  sentByDisplayName?: Maybe<Scalars['String']['output']>;
+  /** Boardsesh user id of the climber */
+  sentByUserId: Scalars['String']['output'];
+};
+
 /**
  * Lightweight live + durable stats for a board's wall feed. Durable counts are
  * derived from `boardsesh_ticks` stamped with this board_id; "right now" comes
@@ -445,6 +464,8 @@ export type BoardPresenceStats = {
   distinctClimbersCount: Scalars['Int']['output'];
   /** Hardest grade sent on this wall (name), if any */
   hardestGrade?: Maybe<Scalars['String']['output']>;
+  /** First send at the hardest grade logged on this wall, if any */
+  hardestSend?: Maybe<BoardPresenceHardestSend>;
   /** ISO 8601 timestamp of the most recent send on this wall */
   lastSentAt?: Maybe<Scalars['String']['output']>;
   /** Most-sent grade on this wall (name), if any */

--- a/packages/shared/graphql/src/operations/board-presence.ts
+++ b/packages/shared/graphql/src/operations/board-presence.ts
@@ -32,6 +32,15 @@ const BOARD_PRESENCE_STATS_FIELDS = `
   climbsSentCount
   distinctClimbersCount
   hardestGrade
+  hardestSend {
+    climbUuid
+    name
+    grade
+    sentByUserId
+    sentByDisplayName
+    sentByAvatarUrl
+    sentAt
+  }
   topGrade
   lastSentAt
 `;

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -361,6 +361,7 @@
       "statSent": "sends",
       "statClimbers": "climbers",
       "statHardest": "hardest",
+      "hardestSendLabel": "Hardest send",
       "statTopGrade": "most sent",
       "wallChanged": "You changed the wall",
       "undo": "Undo",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -354,6 +354,7 @@
       "close": "Close",
       "setByLine": "Set by {{setter}}",
       "litByLine": "Lit by {{name}}",
+      "sentByLine": "Sent by {{name}}",
       "emptyTitle": "Nobody's on this wall yet",
       "emptyBody": "Connect and send a climb to kick off the history.",
       "historyHeader": "Lit on this wall",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -361,6 +361,7 @@
       "statSent": "encadenes",
       "statClimbers": "escaladores",
       "statHardest": "más difícil",
+      "hardestSendLabel": "Encadene más duro",
       "statTopGrade": "más repetido",
       "wallChanged": "Has cambiado el muro",
       "undo": "Deshacer",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -354,6 +354,7 @@
       "close": "Cerrar",
       "setByLine": "Abierto por {{setter}}",
       "litByLine": "Encendido por {{name}}",
+      "sentByLine": "Encadenado por {{name}}",
       "emptyTitle": "Aún no hay nadie en este muro",
       "emptyBody": "Conéctate y envía un bloque para empezar el historial.",
       "historyHeader": "Encendidos en este muro",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -361,6 +361,7 @@
       "statSent": "enchaînements",
       "statClimbers": "grimpeurs",
       "statHardest": "le plus dur",
+      "hardestSendLabel": "Plus dure enchaînée",
       "statTopGrade": "la plus fréquente",
       "wallChanged": "Tu as changé le mur",
       "undo": "Annuler",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -354,6 +354,7 @@
       "close": "Fermer",
       "setByLine": "Ouvert par {{setter}}",
       "litByLine": "Allumé par {{name}}",
+      "sentByLine": "Enchaîné par {{name}}",
       "emptyTitle": "Personne sur ce mur pour l'instant",
       "emptyBody": "Connecte-toi et envoie un bloc pour lancer l'historique.",
       "historyHeader": "Allumés sur ce mur",


### PR DESCRIPTION
## Summary

Adds a compact hardest-send row to the React Native board sheet's "This wall" section. The row shows the climber avatar, a crown badge, the climb name, the sent-by line, and the grade.

## Changes

- Extends board-presence stats with a `BoardPresenceHardestSend` payload.
- Computes the hardest send from durable `boardsesh_ticks`, scoped to the wall's `board_id`.
- Uses highest resolved difficulty first, then the first send by earliest `climbed_at` when multiple sends share the hardest grade.
- Computes board stats, top grade, and hardest send in one SQL snapshot and resolves climb aliases before joining climb stats/details.
- Wires the new stats field through shared GraphQL operations and generated types.
- Renders the row in the mobile board sheet and adds localized copy plus a semantic crown icon.

## Review follow-up

Two read-only code review subagents reviewed this PR. Their findings are addressed in the rebased review-fix commit `003cbbc83`:

- Backend review: fixed mixed-snapshot risk by moving board stats/top-grade/hardest-send computation into one SQL statement.
- Backend review: fixed aliased climb UUID handling before hardest-send name and consensus-grade joins, with a regression test.
- Mobile review: replaced reused "Lit by" copy with dedicated "Sent by" copy for logged sends.

## Rebase

Rebased onto `origin/main` at `24aa5f78e`. GitHub now reports the PR as mergeable.

## Local QA

Current branch/head: `codex/mobile-board-hardest-send` at `003cbbc83`.

Running dev URLs:

- Metro: `http://vibetunnel-2.tailedd9d5.ts.net:8081`
- Web: `https://vibetunnel-2.tailedd9d5.ts.net:3000`
- Backend HTTP GraphQL: `https://vibetunnel-2.tailedd9d5.ts.net:8080/graphql`
- Backend WS GraphQL: `wss://vibetunnel-2.tailedd9d5.ts.net:8080/graphql`

Feature flags/env used for local QA:

- `BOARD_PRESENCE_ENABLED=true` on backend/web
- `EXPO_PUBLIC_BOARD_PRESENCE=true` on Metro
- `EXPO_PUBLIC_BACKEND_URL=https://vibetunnel-2.tailedd9d5.ts.net:8080`
- `EXPO_PUBLIC_WS_URL=wss://vibetunnel-2.tailedd9d5.ts.net:8080/graphql`
- `EXPO_PUBLIC_WEB_URL=https://vibetunnel-2.tailedd9d5.ts.net:3000`

## Validation

Post-rebase:

- `vp test run packages/backend/src/__tests__/board-presence.test.ts --reporter=agent` — 35 passed
- `vp test run packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts --reporter=agent` — 27 passed
- `vp run typecheck:backend`
- `vp run typecheck:mobile`
- `git diff --check`

Earlier on this PR:

- `vp run codegen`
- `vp run typecheck`

`vp check` formatting passed before the rebase, but the lint/type phase still reports existing repo-wide backlog outside this change, including `mobile/capacitor.config.ts` missing `@capacitor/cli` types and other unrelated lint findings.