### PR TITLE
[codex] add mobile hold color accessibility overrides

### DIFF
--- a/docs/ui/12-bluetooth.md
+++ b/docs/ui/12-bluetooth.md
@@ -14,7 +14,7 @@ The BLE connection is managed by `useBoardBluetooth` hook and exposed via `Bluet
 4. **Existing adapter cleanup** -- if a prior connection exists, emits `Bluetooth Disconnected` event with `reason: 'reconnect'`, then disconnects.
 5. **Device request and connect** -- `adapter.requestAndConnect(targetSerial)` opens the device picker (OS native on web, custom dialog on Capacitor with RSSI-based signal indicators).
 6. **Device name parsing** -- `parseApiLevel(deviceName)` extracts the Aurora API level from the device name (e.g., `Kilter Board#751737@3` yields API level 3). `parseSerialNumber(deviceName)` extracts the serial (e.g., `751737`).
-7. **Board configuration** -- `adapter.configureBoard()` is called with board name, layout ID, size ID, API level, device name, and colour overrides. Configuration is keyed and cached so reconfiguration is skipped when the key matches.
+7. **Board configuration** -- adapters with a native background writer call `adapter.configureBoard()` with board name, layout ID, size ID, API level, device name, and colour overrides.
 8. **Disconnection listener** -- `adapter.onDisconnect(handleDisconnection)` is registered.
 9. **Initial frames** -- if provided, `sendFramesToBoard(initialFrames, mirrored)` sends the first climb immediately.
 10. **Serial recording** -- for Aurora boards, `recordBoardSerial()` POSTs the serial-to-config mapping to `/api/internal/board-serials` for future auto-matching.
@@ -61,6 +61,14 @@ The BLE connection is managed by `useBoardBluetooth` hook and exposed via `Bluet
 2. `getMoonboardBluetoothPacket(frames)` produces the packet.
 3. If all placements are skipped, shows error snackbar and returns `false`.
 4. Partial skips are logged to Sentry.
+5. User colour overrides are not sent to MoonBoard controllers because the protocol does not carry arbitrary RGB colours; they still affect in-app rendering.
+
+**Mobile accessibility colour overrides:**
+
+- Mobile stores hold-role colour overrides in `useHoldColorOverrides()` for STARTING, HAND, FINISH, and FOOT.
+- Default mode stores no value, so Aurora-family packets use the canonical board colours.
+- User mode stores RGB colours as hex strings, passes them to `getAuroraBluetoothPacket()`, and pushes the same map through native iOS `configureBoard()` so widget/background sends match the app.
+- The auto-sender includes the colour override signature in its dedupe key so changing a colour repaints the currently loaded climb even when the frames did not change.
 
 **Error handling:**
 

--- a/docs/ui/18-settings.md
+++ b/docs/ui/18-settings.md
@@ -72,6 +72,13 @@ The mobile More tab contains appearance and UI-style controls that have no direc
 
 - `SegmentedControl` persisted via `useGradeFormat()`.
 
+**Accessibility**:
+
+- Adds hold-role colour overrides for STARTING, HAND, FINISH, and FOOT.
+- Each role has a Default/User mode. Default stores no override and uses the board's canonical colour.
+- User mode opens a bottom sheet with RGB channel inputs and a live swatch preview.
+- Overrides are persisted in AsyncStorage via `useHoldColorOverrides()` and shared with board rendering plus Bluetooth payload encoding.
+
 ---
 
 ### 11.3 Password Management

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -17,6 +17,7 @@ import { ListRow } from '../../../src/components/ListRow';
 import { SwitchRow } from '../../../src/components/SwitchRow';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { SegmentedControl } from '../../../src/components/SegmentedControl';
+import { HoldColorAccessibilitySection } from '../../../src/components/settings/HoldColorAccessibilitySection';
 import { useSessionRecordingPreference } from '../../../src/lib/session-recording-preference';
 import { setSessionRecordingEnabled } from '../../../src/lib/analytics';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
@@ -166,6 +167,8 @@ export default function MoreScreen() {
           </Text>
         </View>
       </View>
+
+      <HoldColorAccessibilitySection />
 
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.language.title')} />

--- a/packages/mobile/src/components/ListRow.tsx
+++ b/packages/mobile/src/components/ListRow.tsx
@@ -18,6 +18,8 @@ type ListRowProps = {
   showSeparator?: boolean;
   separatorInset?: number;
   style?: ViewStyle;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
 };
 
 export function ListRow({
@@ -31,6 +33,8 @@ export function ListRow({
   showSeparator = true,
   separatorInset = 16,
   style,
+  accessibilityLabel,
+  accessibilityHint,
 }: ListRowProps) {
   const { systemColors } = useTheme();
 
@@ -78,7 +82,8 @@ export function ListRow({
         feedback="opacity"
         opacityTo={0.7}
         accessibilityRole="button"
-        accessibilityLabel={title}
+        accessibilityLabel={accessibilityLabel ?? title}
+        accessibilityHint={accessibilityHint}
         style={[styles.container, style]}
       >
         {content}

--- a/packages/mobile/src/components/board-renderer/__tests__/use-parse-frames.test.ts
+++ b/packages/mobile/src/components/board-renderer/__tests__/use-parse-frames.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
+import { setHoldColorOverridesPreference } from '../../../lib/hold-color-overrides';
 import { useParseFrames } from '../use-parse-frames';
 import type { HoldPlacement } from '../types';
 
@@ -13,6 +14,10 @@ const HOLD_RIGHT: HoldPlacement = { id: 200, mirroredHoldId: 100, cx: 950, cy: 1
 const HOLD_NO_MIRROR: HoldPlacement = { id: 300, mirroredHoldId: null, cx: 500, cy: 500, r: 25 };
 
 describe('useParseFrames mirroring', () => {
+  afterEach(async () => {
+    await setHoldColorOverridesPreference({});
+  });
+
   it('returns original position when mirrored=false', () => {
     const { result } = renderHook(() => useParseFrames('p100r12', 'kilter', [HOLD_LEFT, HOLD_RIGHT], false));
 
@@ -54,5 +59,13 @@ describe('useParseFrames mirroring', () => {
     // Frame references hold 999 which is not in holdsData
     const { result } = renderHook(() => useParseFrames('p999r12', 'kilter', [HOLD_LEFT], false));
     expect(result.current).toEqual([]);
+  });
+
+  it('applies configured role colour overrides to parsed holds', async () => {
+    await setHoldColorOverridesPreference({ STARTING: '#123456' });
+
+    const { result } = renderHook(() => useParseFrames('p100r12', 'kilter', [HOLD_LEFT], false));
+
+    expect(result.current[0]?.color).toBe('#123456');
   });
 });

--- a/packages/mobile/src/components/board-renderer/use-parse-frames.ts
+++ b/packages/mobile/src/components/board-renderer/use-parse-frames.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { convertLitUpHoldsStringToMap, HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
 import type { BoardHold, HoldPlacement } from './types';
+import { getEffectiveHoldStateColor, useHoldColorOverrides } from '../../lib/hold-color-overrides';
 
 /**
  * Parses a climb's `frames` string into an array of BoardHold objects ready for rendering.
@@ -23,6 +24,8 @@ export function useParseFrames(
   holdsData: HoldPlacement[],
   mirrored: boolean = false,
 ): BoardHold[] {
+  const { overrides: holdColorOverrides } = useHoldColorOverrides();
+
   return useMemo(() => {
     if (!frames) return [];
 
@@ -78,7 +81,7 @@ export function useParseFrames(
           cx: renderCx,
           cy: renderCy,
           radius: renderRadius,
-          color: holdInfo.displayColor,
+          color: getEffectiveHoldStateColor(holdInfo.state, holdInfo.displayColor, holdColorOverrides),
           role: holdInfo.state,
           renderStyle,
         });
@@ -86,5 +89,5 @@ export function useParseFrames(
     }
 
     return result;
-  }, [frames, boardName, holdsData, mirrored]);
+  }, [frames, boardName, holdsData, mirrored, holdColorOverrides]);
 }

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -8,6 +8,7 @@ import { Button } from '../Button';
 import { ActionButton, drawerActionBarStyles } from '../drawer-action-bar/DrawerActionBar';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticSelection } from '../../lib/haptics';
+import { useHoldColorOverrides } from '../../lib/hold-color-overrides';
 import { brandColors } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { brushRoleColor, getPaintRoles, useBrushRoleLabels, type BrushRole } from './brush-roles';
@@ -59,11 +60,17 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const roleLabels = useBrushRoleLabels();
+  const { overrides: holdColorOverrides } = useHoldColorOverrides();
 
   const paintRoles = useMemo(() => getPaintRoles(boardName), [boardName]);
   const roleChips = useMemo(
-    () => paintRoles.map((role) => ({ role, label: roleLabels[role], color: brushRoleColor(boardName, role) })),
-    [boardName, paintRoles, roleLabels],
+    () =>
+      paintRoles.map((role) => ({
+        role,
+        label: roleLabels[role],
+        color: brushRoleColor(boardName, role, holdColorOverrides),
+      })),
+    [boardName, holdColorOverrides, paintRoles, roleLabels],
   );
 
   const handleSelect = (role: BrushRole) => {

--- a/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
+++ b/packages/mobile/src/components/create-climb/HoldRoleSheet.tsx
@@ -8,6 +8,7 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticSelection } from '../../lib/haptics';
+import { useHoldColorOverrides } from '../../lib/hold-color-overrides';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { brushRoleColor, getPaintRoles, useBrushRoleLabels, type BrushRole } from './brush-roles';
 
@@ -40,6 +41,7 @@ export function HoldRoleSheet({
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const roleLabels = useBrushRoleLabels();
+  const { overrides: holdColorOverrides } = useHoldColorOverrides();
   const sheetRef = useRef<BottomSheet>(null);
 
   useEffect(() => {
@@ -73,7 +75,7 @@ export function HoldRoleSheet({
             const isCurrent = currentState === role;
             const atCap = (role === 'STARTING' && startingCount >= 2) || (role === 'FINISH' && finishCount >= 2);
             const disabled = atCap && !isCurrent;
-            const color = brushRoleColor(boardName, role);
+            const color = brushRoleColor(boardName, role, holdColorOverrides);
             return (
               <Pressable
                 key={role}

--- a/packages/mobile/src/components/create-climb/PaintedHoldsLayer.tsx
+++ b/packages/mobile/src/components/create-climb/PaintedHoldsLayer.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { getEffectiveHoldStateColor, useHoldColorOverrides } from '../../lib/hold-color-overrides';
 import { holdGeometry } from './holdLayout';
 import { PaintedRing } from './PaintedRing';
 
@@ -27,6 +28,8 @@ export const PaintedHoldsLayer = React.memo(function PaintedHoldsLayer({
   measuredWidth,
   mirrored,
 }: PaintedHoldsLayerProps) {
+  const { overrides: holdColorOverrides } = useHoldColorOverrides();
+
   const rings = useMemo(() => {
     if (measuredWidth <= 0) return [];
     return Object.entries(litUpHoldsMap)
@@ -41,12 +44,12 @@ export const PaintedHoldsLayer = React.memo(function PaintedHoldsLayer({
             leftPct={geometry.leftPct}
             topPct={geometry.topPct}
             diameter={geometry.ringDiameter}
-            color={hold.displayColor || hold.color}
+            color={getEffectiveHoldStateColor(hold.state, hold.displayColor || hold.color, holdColorOverrides)}
           />
         );
       })
       .filter(Boolean);
-  }, [litUpHoldsMap, holdById, boardWidth, boardHeight, measuredWidth, mirrored]);
+  }, [litUpHoldsMap, holdById, boardWidth, boardHeight, measuredWidth, mirrored, holdColorOverrides]);
 
   return (
     <View pointerEvents="none" style={StyleSheet.absoluteFill}>

--- a/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getPaintRoles } from '../brush-roles';
+import { brushRoleColor, getPaintRoles } from '../brush-roles';
 
 describe('getPaintRoles', () => {
   it('excludes FOOT for MoonBoard saved-climb roles', () => {
@@ -8,5 +8,9 @@ describe('getPaintRoles', () => {
 
   it('returns all four paint roles for Kilter', () => {
     expect(getPaintRoles('kilter')).toEqual(['STARTING', 'HAND', 'FINISH', 'FOOT']);
+  });
+
+  it('uses configured role colour overrides when painting a role', () => {
+    expect(brushRoleColor('kilter', 'HAND', { HAND: '#123456' })).toBe('#123456');
   });
 });

--- a/packages/mobile/src/components/create-climb/brush-roles.ts
+++ b/packages/mobile/src/components/create-climb/brush-roles.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '@boardsesh/board-constants/hold-states';
 import type { BoardName, HoldState } from '@boardsesh/shared-schema';
+import { getEffectiveHoldRoleColor, type HoldColorOverrides } from '../../lib/hold-color-overrides';
 
 // The four paintable roles plus the eraser. `'OFF'` clears a hold; the four
 // named roles map straight onto the create-climb hold-state machine's
@@ -22,12 +23,16 @@ export function getPaintRoles(boardName: BoardName): ReadonlyArray<Exclude<Brush
  * Tycho-style colour-only product has no STARTING/FINISH) so the chip stays
  * visible rather than rendering an undefined colour.
  */
-export function brushRoleColor(boardName: BoardName, role: Exclude<BrushRole, 'OFF'>): string {
+export function brushRoleColor(
+  boardName: BoardName,
+  role: Exclude<BrushRole, 'OFF'>,
+  overrides: HoldColorOverrides = {},
+): string {
   const code = STATE_TO_PRIMARY_CODE[boardName]?.[role];
   if (code === undefined) return '#8E8E93';
   const info = HOLD_STATE_MAP[boardName]?.[code];
   if (!info) return '#8E8E93';
-  return info.displayColor || info.color;
+  return getEffectiveHoldRoleColor(boardName, role, overrides);
 }
 
 /**

--- a/packages/mobile/src/components/search/HoldFilterPicker.tsx
+++ b/packages/mobile/src/components/search/HoldFilterPicker.tsx
@@ -10,6 +10,7 @@ import { Icon } from '../Icon';
 import { SegmentedControl } from '../SegmentedControl';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticSelection } from '../../lib/haptics';
+import { useHoldColorOverrides } from '../../lib/hold-color-overrides';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 type HoldFilterPickerProps = {
@@ -45,6 +46,7 @@ export function HoldFilterPicker({
 }: HoldFilterPickerProps) {
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
+  const { overrides: holdColorOverrides } = useHoldColorOverrides();
   const sheetRef = useRef<BottomSheetModal>(null);
 
   useEffect(() => {
@@ -55,7 +57,7 @@ export function HoldFilterPicker({
     }
   }, [holdId]);
 
-  const options = useMemo(() => buildHoldFilterOptions(boardName), [boardName]);
+  const options = useMemo(() => buildHoldFilterOptions(boardName, holdColorOverrides), [boardName, holdColorOverrides]);
   const snapPoints = useMemo(() => ['42%'], []);
 
   const typeLabels = useMemo<Record<HoldFilterType, string>>(

--- a/packages/mobile/src/components/search/SearchHoldFilterRings.tsx
+++ b/packages/mobile/src/components/search/SearchHoldFilterRings.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
 import { ANY_HOLD_COLOR, buildHoldFilterOptions } from '@boardsesh/climb-filters';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { useHoldColorOverrides } from '../../lib/hold-color-overrides';
 import { holdGeometry } from '../create-climb/holdLayout';
 
 type SearchHoldFilterRingsProps = {
@@ -47,11 +48,12 @@ export const SearchHoldFilterRings = React.memo(function SearchHoldFilterRings({
   measuredWidth,
   mirrored,
 }: SearchHoldFilterRingsProps) {
+  const { overrides: holdColorOverrides } = useHoldColorOverrides();
   const colorByType = useMemo(() => {
     const map = new Map<HoldFilterType, string>();
-    for (const option of buildHoldFilterOptions(boardName)) map.set(option.type, option.color);
+    for (const option of buildHoldFilterOptions(boardName, holdColorOverrides)) map.set(option.type, option.color);
     return map;
-  }, [boardName]);
+  }, [boardName, holdColorOverrides]);
 
   const holdById = useMemo(() => {
     const map = new Map<number, BoardHoldTarget>();

--- a/packages/mobile/src/components/settings/HoldColorAccessibilitySection.tsx
+++ b/packages/mobile/src/components/settings/HoldColorAccessibilitySection.tsx
@@ -1,0 +1,389 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Pressable, StyleSheet, View, type StyleProp, type TextStyle } from 'react-native';
+import { BottomSheetModal, BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { toBoardName } from '@boardsesh/board-config';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { ListRow } from '../ListRow';
+import { ModalSheet } from '../ModalSheet';
+import { SectionHeader } from '../SectionHeader';
+import { SegmentedControl } from '../SegmentedControl';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import {
+  DEFAULT_HOLD_COLOR_SIGNATURE,
+  HOLD_COLOR_OVERRIDE_ROLES,
+  getDefaultHoldRoleColor,
+  getEffectiveHoldRoleColor,
+  hasHoldColorOverrides,
+  hexToRgb,
+  normalizeHexColor,
+  parseRgbChannel,
+  rgbToHex,
+  useHoldColorOverrides,
+  type HoldColorOverrideRole,
+  type RgbColor,
+} from '../../lib/hold-color-overrides';
+import { borderRadius, spacing } from '../../theme/tokens';
+
+type ColorMode = 'default' | 'user';
+
+function labelForRole(t: TFunction<'common'>, role: HoldColorOverrideRole): string {
+  switch (role) {
+    case 'STARTING':
+      return t('mobile.more.accessibility.roles.starting');
+    case 'HAND':
+      return t('mobile.more.accessibility.roles.hand');
+    case 'FINISH':
+      return t('mobile.more.accessibility.roles.finish');
+    case 'FOOT':
+      return t('mobile.more.accessibility.roles.foot');
+  }
+}
+
+function rgbTextFromHex(color: string): RgbColorText {
+  const rgb = hexToRgb(color) ?? { red: 0, green: 0, blue: 0 };
+  return {
+    red: String(rgb.red),
+    green: String(rgb.green),
+    blue: String(rgb.blue),
+  };
+}
+
+type RgbColorText = {
+  red: string;
+  green: string;
+  blue: string;
+};
+
+function rgbFromText(rgbText: RgbColorText): RgbColor | null {
+  const red = parseRgbChannel(rgbText.red);
+  const green = parseRgbChannel(rgbText.green);
+  const blue = parseRgbChannel(rgbText.blue);
+  if (red === null || green === null || blue === null) return null;
+  return { red, green, blue };
+}
+
+function boardNameFromActiveBoard(boardType: string | undefined): BoardName {
+  return toBoardName(boardType) ?? 'kilter';
+}
+
+export function HoldColorAccessibilitySection() {
+  const { t } = useTranslation('common');
+  const { systemColors } = useTheme();
+  const { data: activeBoard } = useActiveBoard();
+  const boardName = boardNameFromActiveBoard(activeBoard?.boardType);
+  const { overrides, setRoleOverride, resetOverrides, signature } = useHoldColorOverrides();
+  const [selectedRole, setSelectedRole] = useState<HoldColorOverrideRole | null>(null);
+  const hasOverrides = signature !== DEFAULT_HOLD_COLOR_SIGNATURE && hasHoldColorOverrides(overrides);
+
+  const handleSaveRole = useCallback(
+    (role: HoldColorOverrideRole, color: string | null) => {
+      setRoleOverride(role, color);
+      setSelectedRole(null);
+    },
+    [setRoleOverride],
+  );
+
+  return (
+    <View style={styles.section}>
+      <SectionHeader title={t('mobile.more.accessibility.title')} />
+      <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
+        <View style={styles.header}>
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.description}>
+            {t('mobile.more.accessibility.description')}
+          </Text>
+          {hasOverrides ? (
+            <Pressable accessibilityRole="button" onPress={resetOverrides} style={styles.resetButton}>
+              <Text variant="footnote" color={systemColors.accent}>
+                {t('mobile.more.accessibility.resetAll')}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+        {HOLD_COLOR_OVERRIDE_ROLES.map((role, index) => {
+          const roleOverride = overrides[role];
+          const swatchColor = getEffectiveHoldRoleColor(boardName, role, overrides);
+          return (
+            <ListRow
+              key={role}
+              title={labelForRole(t, role)}
+              subtitle={
+                roleOverride ? t('mobile.more.accessibility.mode.user') : t('mobile.more.accessibility.mode.default')
+              }
+              leading={<ColorSwatch color={swatchColor} />}
+              trailing={roleOverride ? <Icon name="check.small" size={20} color={systemColors.accent} /> : undefined}
+              showChevron
+              showSeparator={index < HOLD_COLOR_OVERRIDE_ROLES.length - 1}
+              onPress={() => setSelectedRole(role)}
+            />
+          );
+        })}
+      </View>
+      <HoldColorPickerSheet
+        role={selectedRole}
+        boardName={boardName}
+        currentColor={selectedRole ? (overrides[selectedRole] ?? null) : null}
+        onSave={handleSaveRole}
+        onClose={() => setSelectedRole(null)}
+      />
+    </View>
+  );
+}
+
+function ColorSwatch({ color }: { color: string }) {
+  const { systemColors } = useTheme();
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={[styles.swatch, { backgroundColor: color, borderColor: systemColors.separator }]}
+    />
+  );
+}
+
+type HoldColorPickerSheetProps = {
+  role: HoldColorOverrideRole | null;
+  boardName: BoardName;
+  currentColor: string | null;
+  onSave: (role: HoldColorOverrideRole, color: string | null) => void;
+  onClose: () => void;
+};
+
+function HoldColorPickerSheet({ role, boardName, currentColor, onSave, onClose }: HoldColorPickerSheetProps) {
+  const { t } = useTranslation('common');
+  const { systemColors } = useTheme();
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const [mode, setMode] = useState<ColorMode>('default');
+  const [rgbText, setRgbText] = useState<RgbColorText>({ red: '0', green: '0', blue: '0' });
+  const isPresentedRef = useRef(false);
+
+  const modeOptions = useMemo<{ key: ColorMode; label: string }[]>(
+    () => [
+      { key: 'default', label: t('mobile.more.accessibility.mode.default') },
+      { key: 'user', label: t('mobile.more.accessibility.mode.user') },
+    ],
+    [t],
+  );
+
+  useEffect(() => {
+    if (role && !isPresentedRef.current) {
+      const seedColor = currentColor ?? getDefaultHoldRoleColor(boardName, role, 'led');
+      setMode(currentColor ? 'user' : 'default');
+      setRgbText(rgbTextFromHex(seedColor));
+      sheetRef.current?.present();
+      isPresentedRef.current = true;
+    } else if (!role && isPresentedRef.current) {
+      sheetRef.current?.dismiss();
+      isPresentedRef.current = false;
+    }
+  }, [boardName, currentColor, role]);
+
+  const resolvedRgb = mode === 'user' ? rgbFromText(rgbText) : null;
+  const resolvedHex = resolvedRgb ? rgbToHex(resolvedRgb) : null;
+  const previewColor =
+    mode === 'user' && resolvedHex && role ? resolvedHex : role ? getDefaultHoldRoleColor(boardName, role) : '#000000';
+  const showValidationError = mode === 'user' && resolvedHex === null;
+
+  const handleDismiss = useCallback(() => {
+    isPresentedRef.current = false;
+    onClose();
+  }, [onClose]);
+
+  const handleModeSelect = useCallback(
+    (nextMode: ColorMode) => {
+      setMode(nextMode);
+      if (nextMode === 'user' && role) {
+        const seedColor = currentColor ?? getDefaultHoldRoleColor(boardName, role, 'led');
+        const normalizedSeed = normalizeHexColor(seedColor);
+        if (normalizedSeed) setRgbText(rgbTextFromHex(normalizedSeed));
+      }
+    },
+    [boardName, currentColor, role],
+  );
+
+  const handleSave = useCallback(() => {
+    if (!role) return;
+    if (mode === 'default') {
+      onSave(role, null);
+      return;
+    }
+    if (!resolvedHex) return;
+    onSave(role, resolvedHex);
+  }, [mode, onSave, resolvedHex, role]);
+
+  const footer = (
+    <Button
+      title={t('mobile.more.accessibility.save')}
+      onPress={handleSave}
+      disabled={mode === 'user' && resolvedHex === null}
+      size="large"
+    />
+  );
+
+  const inputStyle = [
+    styles.channelInput,
+    {
+      backgroundColor: systemColors.fill,
+      color: systemColors.label,
+      borderColor: showValidationError ? systemColors.accent : systemColors.separator,
+    },
+  ];
+
+  return (
+    <ModalSheet ref={sheetRef} snapPoints={['58%']} onDismiss={handleDismiss} footer={footer} stackBehavior="push">
+      <View style={styles.pickerBody}>
+        <View style={styles.pickerHeader}>
+          <ColorSwatch color={previewColor} />
+          <View style={styles.pickerTitleColumn}>
+            <Text variant="headline">{role ? labelForRole(t, role) : t('mobile.more.accessibility.title')}</Text>
+            <Text variant="footnote" color={systemColors.secondaryLabel}>
+              {t('mobile.more.accessibility.pickerSubtitle')}
+            </Text>
+          </View>
+        </View>
+
+        <SegmentedControl
+          options={modeOptions}
+          selectedKey={mode}
+          onSelect={handleModeSelect}
+          trackColor={systemColors.fill}
+          accessibilityLabel={t('mobile.more.accessibility.modeLabel')}
+        />
+
+        {mode === 'user' ? (
+          <View style={styles.rgbGrid}>
+            <RgbChannelInput
+              label={t('mobile.more.accessibility.channels.red')}
+              value={rgbText.red}
+              onChangeText={(red) => setRgbText((previous) => ({ ...previous, red }))}
+              inputStyle={inputStyle}
+            />
+            <RgbChannelInput
+              label={t('mobile.more.accessibility.channels.green')}
+              value={rgbText.green}
+              onChangeText={(green) => setRgbText((previous) => ({ ...previous, green }))}
+              inputStyle={inputStyle}
+            />
+            <RgbChannelInput
+              label={t('mobile.more.accessibility.channels.blue')}
+              value={rgbText.blue}
+              onChangeText={(blue) => setRgbText((previous) => ({ ...previous, blue }))}
+              inputStyle={inputStyle}
+            />
+          </View>
+        ) : (
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.defaultCopy}>
+            {t('mobile.more.accessibility.defaultCopy')}
+          </Text>
+        )}
+
+        {showValidationError ? (
+          <Text variant="footnote" color={systemColors.accent}>
+            {t('mobile.more.accessibility.invalidRgb')}
+          </Text>
+        ) : null}
+      </View>
+    </ModalSheet>
+  );
+}
+
+function RgbChannelInput({
+  label,
+  value,
+  onChangeText,
+  inputStyle,
+}: {
+  label: string;
+  value: string;
+  onChangeText: (value: string) => void;
+  inputStyle: StyleProp<TextStyle>;
+}) {
+  const { systemColors } = useTheme();
+  return (
+    <View style={styles.channelColumn}>
+      <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.channelLabel}>
+        {label}
+      </Text>
+      <BottomSheetTextInput
+        value={value}
+        onChangeText={onChangeText}
+        keyboardType="number-pad"
+        maxLength={3}
+        selectTextOnFocus
+        returnKeyType="done"
+        style={inputStyle}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    gap: spacing[2],
+  },
+  card: {
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  header: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
+    gap: spacing[2],
+  },
+  description: {
+    lineHeight: 18,
+  },
+  resetButton: {
+    alignSelf: 'flex-start',
+    paddingVertical: spacing[1],
+  },
+  swatch: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  pickerBody: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    gap: spacing[4],
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  pickerTitleColumn: {
+    flex: 1,
+    gap: spacing[1],
+  },
+  rgbGrid: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+  channelColumn: {
+    flex: 1,
+    gap: spacing[1],
+  },
+  channelLabel: {
+    textAlign: 'center',
+  },
+  channelInput: {
+    minHeight: 46,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3],
+    textAlign: 'center',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  defaultCopy: {
+    lineHeight: 18,
+  },
+});

--- a/packages/mobile/src/components/settings/HoldColorAccessibilitySection.tsx
+++ b/packages/mobile/src/components/settings/HoldColorAccessibilitySection.tsx
@@ -107,14 +107,20 @@ export function HoldColorAccessibilitySection() {
         </View>
         {HOLD_COLOR_OVERRIDE_ROLES.map((role, index) => {
           const roleOverride = overrides[role];
+          const roleLabel = labelForRole(t, role);
+          const modeLabel = roleOverride
+            ? t('mobile.more.accessibility.mode.user')
+            : t('mobile.more.accessibility.mode.default');
           const swatchColor = getEffectiveHoldRoleColor(boardName, role, overrides);
           return (
             <ListRow
               key={role}
-              title={labelForRole(t, role)}
-              subtitle={
-                roleOverride ? t('mobile.more.accessibility.mode.user') : t('mobile.more.accessibility.mode.default')
-              }
+              title={roleLabel}
+              subtitle={modeLabel}
+              accessibilityLabel={t('mobile.more.accessibility.rowAccessibility', {
+                role: roleLabel,
+                mode: modeLabel,
+              })}
               leading={<ColorSwatch color={swatchColor} />}
               trailing={roleOverride ? <Icon name="check.small" size={20} color={systemColors.accent} /> : undefined}
               showChevron
@@ -262,18 +268,21 @@ function HoldColorPickerSheet({ role, boardName, currentColor, onSave, onClose }
               value={rgbText.red}
               onChangeText={(red) => setRgbText((previous) => ({ ...previous, red }))}
               inputStyle={inputStyle}
+              invalid={showValidationError}
             />
             <RgbChannelInput
               label={t('mobile.more.accessibility.channels.green')}
               value={rgbText.green}
               onChangeText={(green) => setRgbText((previous) => ({ ...previous, green }))}
               inputStyle={inputStyle}
+              invalid={showValidationError}
             />
             <RgbChannelInput
               label={t('mobile.more.accessibility.channels.blue')}
               value={rgbText.blue}
               onChangeText={(blue) => setRgbText((previous) => ({ ...previous, blue }))}
               inputStyle={inputStyle}
+              invalid={showValidationError}
             />
           </View>
         ) : (
@@ -297,12 +306,15 @@ function RgbChannelInput({
   value,
   onChangeText,
   inputStyle,
+  invalid,
 }: {
   label: string;
   value: string;
   onChangeText: (value: string) => void;
   inputStyle: StyleProp<TextStyle>;
+  invalid: boolean;
 }) {
+  const { t } = useTranslation('common');
   const { systemColors } = useTheme();
   return (
     <View style={styles.channelColumn}>
@@ -316,6 +328,8 @@ function RgbChannelInput({
         maxLength={3}
         selectTextOnFocus
         returnKeyType="done"
+        accessibilityLabel={label}
+        accessibilityHint={invalid ? t('mobile.more.accessibility.invalidRgb') : undefined}
         style={inputStyle}
       />
     </View>

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -100,6 +100,13 @@ describe('buildCacheKey', () => {
     expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).not.toBe(buildCacheKey('kilter', 1, 10, '24', 'p2r43'));
   });
 
+  it('uses custom colour override signatures in the frame hash', () => {
+    const defaultKey = buildCacheKey('kilter', 1, 10, '24', 'p1r42');
+    const customKey = buildCacheKey('kilter', 1, 10, '24', 'p1r42', false, undefined, 'hand-123456');
+    expect(customKey).not.toBe(defaultKey);
+    expect(customKey).toMatch(/^v\d+_s_wfull_kilter_1_10_24_[0-9a-f]{8}$/);
+  });
+
   it('produces different keys for different boards', () => {
     expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).not.toBe(buildCacheKey('tension', 1, 10, '24', 'p1r42'));
   });

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -9,6 +9,12 @@ import {
   type BackgroundVariant,
 } from '../lib/background-image-cache';
 import { reportError } from '../lib/sentry';
+import {
+  DEFAULT_HOLD_COLOR_SIGNATURE,
+  getEffectiveHoldStateColor,
+  useHoldColorOverrides,
+  type HoldColorOverrides,
+} from '../lib/hold-color-overrides';
 
 /**
  * Bump when the Rust renderer output format changes. v2 marks the
@@ -265,8 +271,10 @@ export function buildCacheKey(
   frames: string,
   filledStyle = false,
   renderWidth?: number,
+  colorSignature = DEFAULT_HOLD_COLOR_SIGNATURE,
 ): string {
-  const framesHash = fnv1aHex(frames);
+  const framesHash =
+    colorSignature === DEFAULT_HOLD_COLOR_SIGNATURE ? fnv1aHex(frames) : fnv1aHex(`${frames}|${colorSignature}`);
   const canonicalSetIds = canonicalizeSetIds(setIds);
   // Style token sits right after the version prefix so the warm-up scan
   // (which matches on `v${RENDERER_VERSION}_`) still loads both styles and
@@ -312,9 +320,11 @@ function getBoardConfig(
   setIds: string,
   filledStyle: boolean,
   renderWidth?: number,
+  colorOverrides: HoldColorOverrides = {},
+  colorSignature = DEFAULT_HOLD_COLOR_SIGNATURE,
 ) {
   const widthKey = renderWidth != null ? `${renderWidth}` : 'full';
-  const configKey = `${boardName}-${layoutId}-${sizeId}-${setIds}-${filledStyle ? 'f' : 's'}-w${widthKey}`;
+  const configKey = `${boardName}-${layoutId}-${sizeId}-${setIds}-${filledStyle ? 'f' : 's'}-w${widthKey}-${colorSignature}`;
   const cached = boardConfigCache.get(configKey);
   if (cached) return cached;
 
@@ -328,7 +338,7 @@ function getBoardConfig(
   const holdStateMap: Record<number, { color: string; render_style?: string }> = {};
   for (const [codeStr, stateInfo] of Object.entries(stateMap)) {
     holdStateMap[Number(codeStr)] = {
-      color: stateInfo.color,
+      color: getEffectiveHoldStateColor(stateInfo.name, stateInfo.color, colorOverrides),
       ...(stateInfo.renderStyle ? { render_style: stateInfo.renderStyle } : {}),
     };
   }
@@ -425,6 +435,7 @@ function getNativeModule() {
  */
 export function useNativeClimbRender(params: NativeClimbRenderParams): NativeClimbRenderResult {
   const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth } = params;
+  const { overrides: holdColorOverrides, signature: holdColorSignature } = useHoldColorOverrides();
 
   // Small surfaces that pass a renderWidth want the bundled thumb-sized
   // background too, so neither the overlay nor the photo is a large source
@@ -435,7 +446,16 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // render — the function self-guards via `warmupRun`.
   warmupRenderedOverlaysOnce();
 
-  const currentCacheKey = buildCacheKey(boardName, layoutId, sizeId, setIds, frames, filledStyle, renderWidth);
+  const currentCacheKey = buildCacheKey(
+    boardName,
+    layoutId,
+    sizeId,
+    setIds,
+    frames,
+    filledStyle,
+    renderWidth,
+    holdColorSignature,
+  );
   const currentBoardKey = buildBoardKey(boardName, layoutId, sizeId, setIds, variant);
 
   // Seed both pieces of state synchronously so the first paint already
@@ -573,7 +593,16 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     const nativeModule = getNativeModule();
     if (!nativeModule) return;
 
-    const boardConfig = getBoardConfig(boardName, layoutId, sizeId, setIds, filledStyle, renderWidth);
+    const boardConfig = getBoardConfig(
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      filledStyle,
+      renderWidth,
+      holdColorOverrides,
+      holdColorSignature,
+    );
     if (!boardConfig) return;
 
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
@@ -618,7 +647,18 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // nativeRender is intentionally excluded from deps: this effect *sets* it,
     // and the only meaningful re-trigger is a cacheKey change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentCacheKey, frames, boardName, layoutId, sizeId, setIds, filledStyle, renderWidth]);
+  }, [
+    currentCacheKey,
+    frames,
+    boardName,
+    layoutId,
+    sizeId,
+    setIds,
+    filledStyle,
+    renderWidth,
+    holdColorOverrides,
+    holdColorSignature,
+  ]);
 
   // Only surface the native URI if it matches the *current* cache key —
   // a stale render (from before a prop change) would otherwise show.

--- a/packages/mobile/src/lib/__tests__/hold-color-overrides.test.ts
+++ b/packages/mobile/src/lib/__tests__/hold-color-overrides.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AsyncStorageStub = {
+  clear: () => Promise<void>;
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+};
+
+async function getAsyncStorage(): Promise<AsyncStorageStub> {
+  return (await import('@react-native-async-storage/async-storage')).default as unknown as AsyncStorageStub;
+}
+
+describe('hold-color-overrides', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    await (await getAsyncStorage()).clear();
+  });
+
+  it('normalizes and sanitizes role colour overrides', async () => {
+    const { sanitizeHoldColorOverrides } = await import('../hold-color-overrides');
+
+    expect(
+      sanitizeHoldColorOverrides({
+        STARTING: 'ABCDEF',
+        HAND: '#123456',
+        FINISH: '#bad',
+        ANY: '#ffffff',
+        FOOT: 42,
+      }),
+    ).toEqual({ STARTING: '#abcdef', HAND: '#123456' });
+  });
+
+  it('builds a stable default-or-custom signature', async () => {
+    const { DEFAULT_HOLD_COLOR_SIGNATURE, buildHoldColorOverrideSignature } = await import('../hold-color-overrides');
+
+    expect(buildHoldColorOverrideSignature({})).toBe(DEFAULT_HOLD_COLOR_SIGNATURE);
+    expect(buildHoldColorOverrideSignature({ HAND: '#123456', STARTING: '#abcdef' })).toBe(
+      'starting-abcdef.hand-123456',
+    );
+  });
+
+  it('persists configured overrides and removes the preference when reset', async () => {
+    const asyncStorage = await getAsyncStorage();
+    const { setHoldColorOverridesPreference } = await import('../hold-color-overrides');
+
+    await setHoldColorOverridesPreference({ HAND: '#123456' });
+    expect(await asyncStorage.getItem('holdColorOverrides')).toBe(JSON.stringify({ HAND: '#123456' }));
+
+    await setHoldColorOverridesPreference({});
+    expect(await asyncStorage.getItem('holdColorOverrides')).toBeNull();
+  });
+
+  it('loads sanitized stored overrides', async () => {
+    const asyncStorage = await getAsyncStorage();
+    await asyncStorage.setItem('holdColorOverrides', JSON.stringify({ FOOT: '#654321', ANY: '#ffffff' }));
+    const { loadHoldColorOverrides } = await import('../hold-color-overrides');
+
+    expect(await loadHoldColorOverrides()).toEqual({ FOOT: '#654321' });
+  });
+
+  it('exposes Bluetooth overrides only when at least one custom colour is configured', async () => {
+    const { getBluetoothColorOverrides } = await import('../hold-color-overrides');
+
+    expect(getBluetoothColorOverrides({})).toBeUndefined();
+    expect(getBluetoothColorOverrides({ FINISH: '#abcdef' })).toEqual({ FINISH: '#abcdef' });
+  });
+
+  it('converts between hex colours and editable RGB channels', async () => {
+    const { hexToRgb, parseRgbChannel, rgbToHex } = await import('../hold-color-overrides');
+
+    expect(hexToRgb('#0a10ff')).toEqual({ red: 10, green: 16, blue: 255 });
+    expect(rgbToHex({ red: 10, green: 16, blue: 255 })).toBe('#0a10ff');
+    expect(parseRgbChannel('255')).toBe(255);
+    expect(parseRgbChannel('256')).toBeNull();
+    expect(parseRgbChannel('1.5')).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/hold-color-overrides.test.ts
+++ b/packages/mobile/src/lib/__tests__/hold-color-overrides.test.ts
@@ -58,6 +58,16 @@ describe('hold-color-overrides', () => {
     expect(await loadHoldColorOverrides()).toEqual({ FOOT: '#654321' });
   });
 
+  it('merges single-role edits with stored overrides before the first load completes', async () => {
+    const asyncStorage = await getAsyncStorage();
+    await asyncStorage.setItem('holdColorOverrides', JSON.stringify({ HAND: '#111111', FOOT: '#222222' }));
+    const { setHoldColorOverridePreference } = await import('../hold-color-overrides');
+
+    await setHoldColorOverridePreference('HAND', '#333333');
+
+    expect(await asyncStorage.getItem('holdColorOverrides')).toBe(JSON.stringify({ HAND: '#333333', FOOT: '#222222' }));
+  });
+
   it('exposes Bluetooth overrides only when at least one custom colour is configured', async () => {
     const { getBluetoothColorOverrides } = await import('../hold-color-overrides');
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { Alert } from 'react-native';
 import type { HoldPlacement } from '../../../components/board-renderer/types';
 import {
@@ -371,6 +371,45 @@ describe('useBoardBluetooth', () => {
     expect(mockGetAuroraBluetoothPacket).toHaveBeenCalledWith('p99r12', expect.anything(), 'tension', 3, undefined);
   });
 
+  it('passes configured Aurora role colours to the packet builder', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'dev-1', deviceName: 'Kilter A1#0042@3' }),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockParseApiLevel.mockReturnValue(3);
+    mockParseSerialNumber.mockReturnValue('0042');
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([0x01]),
+      skippedPositionCount: 0,
+      skippedRoleCount: 0,
+      totalPlacements: 1,
+    });
+    const ledColorOverrides = { HAND: '#123456' };
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, ledColorOverrides }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    await act(async () => {
+      await result.current.sendFramesToBoard('p100r13');
+    });
+
+    expect(mockGetAuroraBluetoothPacket).toHaveBeenCalledWith(
+      'p100r13',
+      expect.anything(),
+      'kilter',
+      3,
+      ledColorOverrides,
+    );
+  });
+
   it('aborts queued and in-flight writes on disconnect', async () => {
     const write = vi.fn(
       (_packet: Uint8Array, signal?: AbortSignal) =>
@@ -529,6 +568,43 @@ describe('useBoardBluetooth native connection adoption', () => {
 
     expect(adapter.adoptConnection).toHaveBeenCalledWith('native-dev');
     expect(result.current.isConnected).toBe(true);
+  });
+
+  it('reconfigures adopted native boards when role colour overrides change', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+
+    const { rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: {
+        boardName: 'kilter' as const,
+        layoutId: 1,
+        sizeId: 1,
+        ledColorOverrides: { HAND: '#111111' },
+      },
+    });
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(adapter.configureBoard).toHaveBeenCalledWith(
+        expect.objectContaining({ colorOverrides: { HAND: '#111111' } }),
+      );
+    });
+
+    rerender({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 1,
+      ledColorOverrides: { HAND: '#222222' },
+    });
+
+    await waitFor(() => {
+      expect(adapter.configureBoard).toHaveBeenCalledWith(
+        expect.objectContaining({ colorOverrides: { HAND: '#222222' } }),
+      );
+    });
   });
 
   it('refuses to adopt a device it cannot positively identify as the active board type', async () => {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -27,6 +27,7 @@ import { requestBleRuntimePermissions } from './use-ble-permissions';
 import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
+import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
 //
@@ -267,7 +268,8 @@ export function useBoardBluetooth({
   // (mounted right after isConnected flips true) reads this one-shot seed so a
   // byte-identical current climb doesn't get re-sent immediately on connect —
   // a redundant full-frame write plus a doubled success haptic.
-  const connectInitialSendRef = useRef<{ frames: string; mirrored: boolean } | null>(null);
+  const connectInitialSendRef = useRef<{ frames: string; mirrored: boolean; colorSignature: string } | null>(null);
+  const configuredDeviceNameRef = useRef<string | undefined>(undefined);
 
   // ledColorOverrides narrowed to string values, shared by the connect and
   // adoption configureBoard calls so both push identical overrides natively.
@@ -277,6 +279,10 @@ export function useBoardBluetooth({
       Object.entries(ledColorOverrides).filter(([, value]) => typeof value === 'string') as [string, string][],
     );
   }, [ledColorOverrides]);
+  const colorSignature = useMemo(
+    () => buildHoldColorOverrideSignature((sanitizedColorOverrides ?? {}) as HoldColorOverrides),
+    [sanitizedColorOverrides],
+  );
 
   const [pickerState, setPickerState] = useState<PickerState | null>(null);
   const pickerRejectRef = useRef<((error: Error) => void) | null>(null);
@@ -332,6 +338,7 @@ export function useBoardBluetooth({
     unsubDisconnectRef.current = null;
     const adapter = adapterRef.current;
     adapterRef.current = null;
+    configuredDeviceNameRef.current = undefined;
     connectedConfigKeyRef.current = null;
     writeAbortRef.current?.abort();
     writeAbortRef.current = null;
@@ -589,6 +596,7 @@ export function useBoardBluetooth({
 
         const connection = await adapter.requestAndConnect(targetSerial);
         apiLevelRef.current = parseApiLevel(connection.deviceName);
+        configuredDeviceNameRef.current = connection.deviceName;
 
         unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
         adapterRef.current = adapter;
@@ -597,7 +605,12 @@ export function useBoardBluetooth({
         // Dynamic Island widget intent path (next/prev tapped while the app
         // is backgrounded) can encode wall packets from queue items stored in
         // the App Group without going through JS. No-op on Android.
-        if (isNativeIosBleAdapter(adapter) && layoutId !== undefined && sizeId !== undefined) {
+        if (
+          isNativeIosBleAdapter(adapter) &&
+          typeof adapter.configureBoard === 'function' &&
+          layoutId !== undefined &&
+          sizeId !== undefined
+        ) {
           try {
             await adapter.configureBoard({
               boardName,
@@ -645,7 +658,7 @@ export function useBoardBluetooth({
         // frame (and its success haptic) when it mounts on isConnected.
         if (initialFrames) {
           await sendFramesToBoard(initialFrames, mirrored);
-          connectInitialSendRef.current = { frames: initialFrames, mirrored: !!mirrored };
+          connectInitialSendRef.current = { frames: initialFrames, mirrored: !!mirrored, colorSignature };
         } else {
           connectInitialSendRef.current = null;
         }
@@ -737,6 +750,7 @@ export function useBoardBluetooth({
       onConnectSuccess,
       sendFramesToBoard,
       sanitizedColorOverrides,
+      colorSignature,
       devicePicker,
       t,
       tCommon,
@@ -753,6 +767,7 @@ export function useBoardBluetooth({
     unsubDisconnectRef.current = null;
     const adapter = adapterRef.current;
     adapterRef.current = null;
+    configuredDeviceNameRef.current = undefined;
     connectedConfigKeyRef.current = null;
     // Cancel every in-flight and queued write of this connection generation,
     // and unblock the write chain for the next connect.
@@ -832,9 +847,10 @@ export function useBoardBluetooth({
       }
 
       const adapter = createBluetoothAdapter(devicePicker, scanFamilyForBoard(boardName));
-      if (!isNativeIosBleAdapter(adapter)) return;
+      if (!isNativeIosBleAdapter(adapter) || typeof adapter.configureBoard !== 'function') return;
       adapter.adoptConnection(deviceId);
       apiLevelRef.current = parseApiLevel(deviceName);
+      configuredDeviceNameRef.current = deviceName;
       unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
       adapterRef.current = adapter;
       void adapter
@@ -896,6 +912,24 @@ export function useBoardBluetooth({
     onConnectSuccess,
     sanitizedColorOverrides,
   ]);
+
+  useEffect(() => {
+    const adapter = adapterRef.current;
+    if (!adapter || !isNativeIosBleAdapter(adapter) || typeof adapter.configureBoard !== 'function' || !isConnected) {
+      return;
+    }
+    if (!boardName || layoutId === undefined || sizeId === undefined) return;
+    void adapter
+      .configureBoard({
+        boardName,
+        layoutId,
+        sizeId,
+        apiLevel: apiLevelRef.current,
+        deviceName: configuredDeviceNameRef.current,
+        colorOverrides: sanitizedColorOverrides,
+      })
+      .catch(() => {});
+  }, [boardName, layoutId, sizeId, isConnected, sanitizedColorOverrides]);
 
   // Serial to silently reconnect to for the board currently in view, or null
   // when nothing is remembered or the user switched boards (in which case the

--- a/packages/mobile/src/lib/hold-color-overrides.ts
+++ b/packages/mobile/src/lib/hold-color-overrides.ts
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '@boardsesh/board-constants/hold-states';
+import type { BoardName, HoldState } from '@boardsesh/shared-schema';
+import { getPreference, removePreference, setPreference } from './preference-store';
+
+export type HoldColorOverrideRole = Extract<HoldState, 'STARTING' | 'HAND' | 'FINISH' | 'FOOT'>;
+export type HoldColorOverrides = Partial<Record<HoldColorOverrideRole, string>>;
+
+export type RgbColor = {
+  red: number;
+  green: number;
+  blue: number;
+};
+
+export const HOLD_COLOR_OVERRIDE_ROLES = ['STARTING', 'HAND', 'FINISH', 'FOOT'] as const;
+export const DEFAULT_HOLD_COLOR_SIGNATURE = 'default';
+
+const STORAGE_KEY = 'holdColorOverrides';
+const HEX_COLOR_PATTERN = /^#?[0-9a-fA-F]{6}$/;
+const HOLD_COLOR_OVERRIDE_ROLE_SET = new Set<string>(HOLD_COLOR_OVERRIDE_ROLES);
+const FALLBACK_ROLE_COLOR = '#8e8e93';
+
+type HoldColorSnapshot = {
+  overrides: HoldColorOverrides;
+  loaded: boolean;
+  signature: string;
+};
+
+let currentOverrides: HoldColorOverrides = {};
+let hasLoaded = false;
+let snapshot: HoldColorSnapshot = {
+  overrides: currentOverrides,
+  loaded: hasLoaded,
+  signature: DEFAULT_HOLD_COLOR_SIGNATURE,
+};
+const listeners = new Set<() => void>();
+const SERVER_SNAPSHOT: HoldColorSnapshot = {
+  overrides: {},
+  loaded: false,
+  signature: DEFAULT_HOLD_COLOR_SIGNATURE,
+};
+
+function isHoldColorOverrideRole(value: unknown): value is HoldColorOverrideRole {
+  return typeof value === 'string' && HOLD_COLOR_OVERRIDE_ROLE_SET.has(value);
+}
+
+export function normalizeHexColor(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!HEX_COLOR_PATTERN.test(trimmed)) return null;
+  const withoutHash = trimmed.replace('#', '').toLowerCase();
+  return `#${withoutHash}`;
+}
+
+export function sanitizeHoldColorOverrides(rawOverrides: unknown): HoldColorOverrides {
+  if (!rawOverrides || typeof rawOverrides !== 'object' || Array.isArray(rawOverrides)) return {};
+
+  const nextOverrides: HoldColorOverrides = {};
+  for (const [role, rawColor] of Object.entries(rawOverrides)) {
+    if (!isHoldColorOverrideRole(role)) continue;
+    const color = normalizeHexColor(rawColor);
+    if (color) nextOverrides[role] = color;
+  }
+  return nextOverrides;
+}
+
+export function buildHoldColorOverrideSignature(overrides: HoldColorOverrides): string {
+  const parts: string[] = [];
+  for (const role of HOLD_COLOR_OVERRIDE_ROLES) {
+    const color = normalizeHexColor(overrides[role]);
+    if (color) parts.push(`${role.toLowerCase()}-${color.slice(1)}`);
+  }
+  return parts.length > 0 ? parts.join('.') : DEFAULT_HOLD_COLOR_SIGNATURE;
+}
+
+export function hasHoldColorOverrides(overrides: HoldColorOverrides): boolean {
+  return buildHoldColorOverrideSignature(overrides) !== DEFAULT_HOLD_COLOR_SIGNATURE;
+}
+
+function notify(): void {
+  snapshot = {
+    overrides: currentOverrides,
+    loaded: hasLoaded,
+    signature: buildHoldColorOverrideSignature(currentOverrides),
+  };
+  for (const listener of listeners) listener();
+}
+
+export async function loadHoldColorOverrides(): Promise<HoldColorOverrides> {
+  if (hasLoaded) return currentOverrides;
+  const storedOverrides = await getPreference<unknown>(STORAGE_KEY);
+  if (hasLoaded) return currentOverrides;
+  currentOverrides = sanitizeHoldColorOverrides(storedOverrides);
+  hasLoaded = true;
+  notify();
+  return currentOverrides;
+}
+
+export async function setHoldColorOverridesPreference(nextOverrides: HoldColorOverrides): Promise<void> {
+  currentOverrides = sanitizeHoldColorOverrides(nextOverrides);
+  hasLoaded = true;
+  notify();
+
+  if (hasHoldColorOverrides(currentOverrides)) {
+    await setPreference(STORAGE_KEY, currentOverrides);
+  } else {
+    await removePreference(STORAGE_KEY);
+  }
+}
+
+export async function setHoldColorOverridePreference(role: HoldColorOverrideRole, color: string | null): Promise<void> {
+  const nextOverrides: HoldColorOverrides = { ...currentOverrides };
+  const normalizedColor = normalizeHexColor(color);
+  if (normalizedColor) {
+    nextOverrides[role] = normalizedColor;
+  } else {
+    delete nextOverrides[role];
+  }
+  await setHoldColorOverridesPreference(nextOverrides);
+}
+
+let loadPromise: Promise<HoldColorOverrides> | null = null;
+function ensureHoldColorOverridesLoaded(): Promise<HoldColorOverrides> {
+  if (!loadPromise) {
+    loadPromise = loadHoldColorOverrides().catch((error: unknown) => {
+      loadPromise = null;
+      throw error;
+    });
+  }
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): HoldColorSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): HoldColorSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useHoldColorOverrides(): {
+  overrides: HoldColorOverrides;
+  loaded: boolean;
+  signature: string;
+  setRoleOverride: (role: HoldColorOverrideRole, color: string | null) => void;
+  setOverrides: (nextOverrides: HoldColorOverrides) => void;
+  resetOverrides: () => void;
+} {
+  const { overrides, loaded, signature } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    ensureHoldColorOverridesLoaded().catch(() => {});
+  }, []);
+
+  const setRoleOverride = useCallback((role: HoldColorOverrideRole, color: string | null) => {
+    void setHoldColorOverridePreference(role, color);
+  }, []);
+
+  const setOverrides = useCallback((nextOverrides: HoldColorOverrides) => {
+    void setHoldColorOverridesPreference(nextOverrides);
+  }, []);
+
+  const resetOverrides = useCallback(() => {
+    void setHoldColorOverridesPreference({});
+  }, []);
+
+  return { overrides, loaded, signature, setRoleOverride, setOverrides, resetOverrides };
+}
+
+export function getDefaultHoldRoleColor(
+  boardName: BoardName,
+  role: HoldColorOverrideRole,
+  variant: 'display' | 'led' = 'display',
+): string {
+  const roleCode = STATE_TO_PRIMARY_CODE[boardName]?.[role];
+  if (roleCode === undefined) return FALLBACK_ROLE_COLOR;
+  const roleInfo = HOLD_STATE_MAP[boardName]?.[roleCode];
+  if (!roleInfo) return FALLBACK_ROLE_COLOR;
+  return variant === 'display' ? (roleInfo.displayColor ?? roleInfo.color) : roleInfo.color;
+}
+
+export function getEffectiveHoldRoleColor(
+  boardName: BoardName,
+  role: HoldColorOverrideRole,
+  overrides: HoldColorOverrides,
+  variant: 'display' | 'led' = 'display',
+): string {
+  return overrides[role] ?? getDefaultHoldRoleColor(boardName, role, variant);
+}
+
+export function getEffectiveHoldStateColor(
+  state: HoldState,
+  fallbackColor: string,
+  overrides: HoldColorOverrides,
+): string {
+  return isHoldColorOverrideRole(state) ? (overrides[state] ?? fallbackColor) : fallbackColor;
+}
+
+export function getBluetoothColorOverrides(overrides: HoldColorOverrides): HoldColorOverrides | undefined {
+  const sanitizedOverrides = sanitizeHoldColorOverrides(overrides);
+  return hasHoldColorOverrides(sanitizedOverrides) ? sanitizedOverrides : undefined;
+}
+
+export function hexToRgb(hexColor: string): RgbColor | null {
+  const normalizedColor = normalizeHexColor(hexColor);
+  if (!normalizedColor) return null;
+  const hex = normalizedColor.slice(1);
+  return {
+    red: parseInt(hex.slice(0, 2), 16),
+    green: parseInt(hex.slice(2, 4), 16),
+    blue: parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+export function rgbToHex({ red, green, blue }: RgbColor): string | null {
+  if (!isRgbChannel(red) || !isRgbChannel(green) || !isRgbChannel(blue)) return null;
+  const hex = [red, green, blue].map((channel) => channel.toString(16).padStart(2, '0')).join('');
+  return `#${hex}`;
+}
+
+export function parseRgbChannel(value: string): number | null {
+  if (!/^\d{1,3}$/.test(value.trim())) return null;
+  const channel = Number(value);
+  return isRgbChannel(channel) ? channel : null;
+}
+
+function isRgbChannel(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= 255;
+}

--- a/packages/mobile/src/lib/hold-color-overrides.ts
+++ b/packages/mobile/src/lib/hold-color-overrides.ts
@@ -109,6 +109,7 @@ export async function setHoldColorOverridesPreference(nextOverrides: HoldColorOv
 }
 
 export async function setHoldColorOverridePreference(role: HoldColorOverrideRole, color: string | null): Promise<void> {
+  if (!hasLoaded) await loadHoldColorOverrides();
   const nextOverrides: HoldColorOverrides = { ...currentOverrides };
   const normalizedColor = normalizeHexColor(color);
   if (normalizedColor) {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -40,7 +40,7 @@ const bluetooth = vi.hoisted(() => {
       sendFramesToBoard: vi.fn(async () => true as boolean | undefined),
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
-      connectInitialSendRef: { current: null as { frames: string; mirrored: boolean } | null },
+      connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -54,7 +54,7 @@ const bluetooth = vi.hoisted(() => {
       sendFramesToBoard: vi.fn<SendFramesToBoard>(async () => true),
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
-      connectInitialSendRef: { current: null as { frames: string; mirrored: boolean } | null },
+      connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -328,7 +328,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     // connect(initialFrames) wrote the current climb before the AutoSender
     // mounted; the seed must suppress the byte-identical re-send (and its
     // doubled haptic) while still confirming the wall state.
-    bluetooth.state.connectInitialSendRef.current = { frames: 'p1r12', mirrored: false };
+    bluetooth.state.connectInitialSendRef.current = { frames: 'p1r12', mirrored: false, colorSignature: 'default' };
 
     renderProvider();
 
@@ -344,7 +344,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   it('still sends when connect() wrote different frames than the current climb', async () => {
     // e.g. the create-climb editor connected with its in-progress frames; the
     // queue's current climb differs, so the AutoSender must not be suppressed.
-    bluetooth.state.connectInitialSendRef.current = { frames: 'p9r15', mirrored: false };
+    bluetooth.state.connectInitialSendRef.current = { frames: 'p9r15', mirrored: false, colorSignature: 'default' };
 
     renderProvider();
 

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -8,6 +8,7 @@ import { derivePreviewOnly } from '@boardsesh/queue-runtime';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { PickerState } from '../../lib/ble/use-board-bluetooth';
+import { setHoldColorOverridesPreference } from '../../lib/hold-color-overrides';
 
 type TestResolvedBoard = { boardId: number };
 
@@ -270,7 +271,8 @@ function makeSerialConfig(overrides: Partial<BoardSerialConfig> = {}): BoardSeri
 }
 
 describe('BluetoothProvider wall-confirm integration', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await setHoldColorOverridesPreference({});
     queue.currentClimbQueueItem = makeQueueItem('climb-1');
     queue.sessionId = 'session-1';
     queue.driverParticipantId = 'participant-self';
@@ -448,6 +450,38 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     expect(wallConfirm.emitWallConfirm).not.toHaveBeenCalled();
     expect(queue.confirmClimbOnWall).not.toHaveBeenCalled();
+  });
+
+  it('re-sends the current climb when hold colours change during an in-flight auto-send', async () => {
+    let resolveWrite: ((value: boolean) => void) | undefined;
+    bluetooth.state.sendFramesToBoard
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveWrite = resolve;
+          }),
+      )
+      .mockResolvedValue(true);
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await setHoldColorOverridesPreference({ HAND: '#123456' });
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveWrite?.(true);
+    });
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(2);
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenNthCalledWith(2, 'p1r12', false, expect.any(AbortSignal));
   });
 
   it('keeps auto-sending while a restored session is waiting for JOIN to resolve identity', async () => {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -30,6 +30,7 @@ import { toClimbInput } from '../lib/climb-to-queue-item';
 import { hapticSuccess } from '../lib/haptics';
 import { DevicePickerSheet } from '../components/ble/DevicePickerSheet';
 import { track } from '../lib/analytics';
+import { getBluetoothColorOverrides, useHoldColorOverrides } from '../lib/hold-color-overrides';
 
 type BluetoothContextValue = {
   isConnected: boolean;
@@ -126,14 +127,16 @@ function presenceClimbToQueueInput(climb: BoardPresenceClimb): ClimbQueueItemInp
  * - When a new climb arrives during a write, it replaces the pending climb
  * - When the current write completes, the drain loop picks up whatever's pending
  * - Deduplicates byte-identical broadcasts via `lastSentSignatureRef` (keyed on
- *   uuid + frames + mirror, so a mirror toggle or hold edit on the same climb
- *   re-pushes), and a `reassertNonce` bump punches through the dedup once.
+ *   uuid + frames + mirror + color signature, so a mirror toggle, hold edit, or
+ *   colour override change on the same climb re-pushes), and a `reassertNonce`
+ *   bump punches through the dedup once.
  */
 function BluetoothAutoSender({
   sendFramesToBoard,
   onWallConfirmed,
   reassertNonce,
   connectInitialSendRef,
+  colorSignature,
 }: {
   sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
   /**
@@ -145,7 +148,8 @@ function BluetoothAutoSender({
   reassertNonce: number;
   // One-shot seed: what connect() already wrote as initialFrames, so the
   // freshly mounted AutoSender doesn't repeat a byte-identical first send.
-  connectInitialSendRef: React.MutableRefObject<{ frames: string; mirrored: boolean } | null>;
+  connectInitialSendRef: React.MutableRefObject<{ frames: string; mirrored: boolean; colorSignature: string } | null>;
+  colorSignature: string;
 }) {
   const { state } = useQueue();
   const { currentClimbQueueItem } = state;
@@ -157,9 +161,9 @@ function BluetoothAutoSender({
   const isWritingRef = useRef(false);
   const pendingClimbRef = useRef<ClimbQueueItem | null>(null);
   // The signature of the last climb actually pushed to the wall: uuid + rendered
-  // frames + mirror state. Re-broadcasts with the same signature skip the
-  // physical write (the board is idempotent, but we'd double-fire haptics);
-  // changing any of the three re-pushes.
+  // frames + mirror state + colour override state. Re-broadcasts with the same
+  // signature skip the physical write (the board is idempotent, but we'd
+  // double-fire haptics); changing any piece re-pushes.
   const lastSentSignatureRef = useRef<string | null>(null);
   // Last `reassertNonce` acted on. When the incoming nonce differs, a one-shot
   // re-push is requested so the current climb re-fires even if unchanged.
@@ -224,9 +228,10 @@ function BluetoothAutoSender({
             if (
               lastSentSignatureRef.current === null &&
               connectSend.frames === item.climb.frames &&
-              connectSend.mirrored === !!item.climb.mirrored
+              connectSend.mirrored === !!item.climb.mirrored &&
+              connectSend.colorSignature === colorSignature
             ) {
-              lastSentSignatureRef.current = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}`;
+              lastSentSignatureRef.current = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}::${colorSignature}`;
             }
           }
 
@@ -238,11 +243,11 @@ function BluetoothAutoSender({
             lastSentSignatureRef.current = null;
           }
 
-          // Deduplicate byte-identical re-broadcasts (same climb, frames and
-          // mirror). The board is idempotent so a re-send is functionally fine,
-          // but we'd double-fire haptics. A mirror toggle or hold edit changes
-          // the signature and re-pushes.
-          const sendSignature = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}`;
+          // Deduplicate byte-identical re-broadcasts (same climb, frames,
+          // mirror, and colours). The board is idempotent so a re-send is
+          // functionally fine, but we'd double-fire haptics. A mirror toggle,
+          // hold edit, or colour change updates the signature and re-pushes.
+          const sendSignature = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}::${colorSignature}`;
           if (sendSignature === lastSentSignatureRef.current) {
             onWallConfirmedRef.current(item);
             toSend = pendingClimbRef.current;
@@ -276,7 +281,7 @@ function BluetoothAutoSender({
     };
 
     void drain();
-  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce]);
+  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, colorSignature]);
 
   return null;
 }
@@ -314,6 +319,8 @@ export function BluetoothProvider({
   } = useBoardPresenceControls();
   const { currentClimb: wallCurrentClimb } = useBoardPresenceCurrent();
   const { showUndoWallChangeSnackbar } = useQueueSnackbar();
+  const { overrides: holdColorOverrides, signature: holdColorSignature } = useHoldColorOverrides();
+  const bluetoothColorOverrides = useMemo(() => getBluetoothColorOverrides(holdColorOverrides), [holdColorOverrides]);
 
   // Mirror the board config props so the empty-dep-ish connect callback resolves
   // the serial against the board currently in view without churning identity.
@@ -633,6 +640,7 @@ export function BluetoothProvider({
     boardUuid,
     holdsData,
     analyticsBoardId: presenceBoardId,
+    ledColorOverrides: bluetoothColorOverrides,
     onConnectSuccess: handleConnectSuccess,
   });
 
@@ -962,6 +970,7 @@ export function BluetoothProvider({
           onWallConfirmed={handleWallConfirmed}
           reassertNonce={reassertNonce}
           connectInitialSendRef={connectInitialSendRef}
+          colorSignature={holdColorSignature}
         />
       )}
       {children}

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -123,8 +123,8 @@ function presenceClimbToQueueInput(climb: BoardPresenceClimb): ClimbQueueItemInp
  *
  * Uses a latest-wins drain loop for writes:
  * - `isWritingRef` tracks if a write is in progress
- * - `pendingClimbRef` stores the most recent pending climb
- * - When a new climb arrives during a write, it replaces the pending climb
+ * - `pendingSendRef` stores the most recent pending climb plus colour state
+ * - When a new climb or colour state arrives during a write, it replaces the pending send
  * - When the current write completes, the drain loop picks up whatever's pending
  * - Deduplicates byte-identical broadcasts via `lastSentSignatureRef` (keyed on
  *   uuid + frames + mirror + color signature, so a mirror toggle, hold edit, or
@@ -151,6 +151,12 @@ function BluetoothAutoSender({
   connectInitialSendRef: React.MutableRefObject<{ frames: string; mirrored: boolean; colorSignature: string } | null>;
   colorSignature: string;
 }) {
+  type AutoSendRequest = {
+    item: ClimbQueueItem;
+    sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
+    colorSignature: string;
+  };
+
   const { state } = useQueue();
   const { currentClimbQueueItem } = state;
   const onWallConfirmedRef = useRef(onWallConfirmed);
@@ -159,7 +165,7 @@ function BluetoothAutoSender({
   }, [onWallConfirmed]);
 
   const isWritingRef = useRef(false);
-  const pendingClimbRef = useRef<ClimbQueueItem | null>(null);
+  const pendingSendRef = useRef<AutoSendRequest | null>(null);
   // The signature of the last climb actually pushed to the wall: uuid + rendered
   // frames + mirror state + colour override state. Re-broadcasts with the same
   // signature skip the physical write (the board is idempotent, but we'd
@@ -202,19 +208,25 @@ function BluetoothAutoSender({
       reassertPendingRef.current = true;
     }
 
+    const sendRequest: AutoSendRequest = {
+      item: currentClimbQueueItem,
+      sendFramesToBoard,
+      colorSignature,
+    };
+
     if (isWritingRef.current) {
-      pendingClimbRef.current = currentClimbQueueItem;
+      pendingSendRef.current = sendRequest;
       return;
     }
 
     isWritingRef.current = true;
 
     const drain = async () => {
-      let toSend: ClimbQueueItem | null = currentClimbQueueItem;
+      let toSend: AutoSendRequest | null = sendRequest;
       try {
         while (toSend) {
           if (signal?.aborted) return;
-          const item = toSend;
+          const { item, sendFramesToBoard: requestSendFramesToBoard, colorSignature: requestColorSignature } = toSend;
 
           // connect() may have just written these exact frames as its
           // initialFrames (connect-and-light flows like the play drawer).
@@ -229,9 +241,9 @@ function BluetoothAutoSender({
               lastSentSignatureRef.current === null &&
               connectSend.frames === item.climb.frames &&
               connectSend.mirrored === !!item.climb.mirrored &&
-              connectSend.colorSignature === colorSignature
+              connectSend.colorSignature === requestColorSignature
             ) {
-              lastSentSignatureRef.current = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}::${colorSignature}`;
+              lastSentSignatureRef.current = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}::${requestColorSignature}`;
             }
           }
 
@@ -247,16 +259,16 @@ function BluetoothAutoSender({
           // mirror, and colours). The board is idempotent so a re-send is
           // functionally fine, but we'd double-fire haptics. A mirror toggle,
           // hold edit, or colour change updates the signature and re-pushes.
-          const sendSignature = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}::${colorSignature}`;
+          const sendSignature = `${item.climb.uuid}::${item.climb.frames}::${item.climb.mirrored ? 1 : 0}::${requestColorSignature}`;
           if (sendSignature === lastSentSignatureRef.current) {
             onWallConfirmedRef.current(item);
-            toSend = pendingClimbRef.current;
-            pendingClimbRef.current = null;
+            toSend = pendingSendRef.current;
+            pendingSendRef.current = null;
             continue;
           }
 
           try {
-            const result = await sendFramesToBoard(item.climb.frames, !!item.climb.mirrored, signal);
+            const result = await requestSendFramesToBoard(item.climb.frames, !!item.climb.mirrored, signal);
 
             // After the await, the AutoSender may have unmounted — skip
             // post-send side effects.
@@ -272,8 +284,8 @@ function BluetoothAutoSender({
             console.error('Error sending climb to board:', error);
           }
 
-          toSend = pendingClimbRef.current;
-          pendingClimbRef.current = null;
+          toSend = pendingSendRef.current;
+          pendingSendRef.current = null;
         }
       } finally {
         isWritingRef.current = false;

--- a/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts
@@ -29,6 +29,11 @@ describe('buildHoldFilterOptions', () => {
     expect(starting?.color).not.toBe(ANY_HOLD_COLOR);
   });
 
+  it('applies hold colour overrides to named filter swatches', () => {
+    const hand = buildHoldFilterOptions('kilter', { HAND: '#123456' }).find((option) => option.type === 'HAND');
+    expect(hand?.color).toBe('#123456');
+  });
+
   it('never surfaces non-setter hold states (OFF / NOT / AUX) as options', () => {
     // MoonBoard's HOLD_STATE_MAP carries an AUX live-preview role; the membership
     // guard must keep it (and any OFF/NOT) out of the filter options.

--- a/packages/shared/climb-filters/src/hold-filter-options.ts
+++ b/packages/shared/climb-filters/src/hold-filter-options.ts
@@ -41,11 +41,16 @@ export type HoldFilterOption = {
   color: string;
 };
 
+type HoldFilterColorOverrides = Partial<Record<Exclude<HoldFilterType, 'ANY'>, string>>;
+
 /**
  * Build the ordered list of hold-type filter options for a board: the named
  * setting roles (board-filtered) followed by the `ANY` wildcard.
  */
-export function buildHoldFilterOptions(boardName: BoardName): HoldFilterOption[] {
+export function buildHoldFilterOptions(
+  boardName: BoardName,
+  colorOverrides: HoldFilterColorOverrides = {},
+): HoldFilterOption[] {
   const boardMap = HOLD_STATE_MAP[boardName];
   const colorByState = new Map<HoldFilterType, string>();
   if (boardMap) {
@@ -53,8 +58,8 @@ export function buildHoldFilterOptions(boardName: BoardName): HoldFilterOption[]
       // Skip non-selectable states (OFF / NOT / AUX / ANY) so the narrowing to
       // HoldFilterType is sound — no unsafe cast.
       if (!SETTER_STATE_ORDER_SET.has(entry.name)) continue;
-      const name = entry.name as HoldFilterType;
-      if (!colorByState.has(name)) colorByState.set(name, entry.displayColor ?? entry.color);
+      const name = entry.name as Exclude<HoldFilterType, 'ANY'>;
+      if (!colorByState.has(name)) colorByState.set(name, colorOverrides[name] ?? entry.displayColor ?? entry.color);
     }
   }
 

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -12,6 +12,31 @@
       "development": "Development",
       "metroServersTitle": "Metro servers",
       "metroServersSubtitle": "Switch between Tailnet bundlers",
+      "accessibility": {
+        "title": "Accessibility",
+        "description": "Pick hold colours that are easier to tell apart. Default uses each board's normal colours and sends no Bluetooth override.",
+        "resetAll": "Reset hold colours",
+        "save": "Save colour",
+        "pickerSubtitle": "Use any RGB colour.",
+        "modeLabel": "Hold colour mode",
+        "defaultCopy": "Boardsesh will use the default colour for this hold type and skip it in Bluetooth overrides.",
+        "invalidRgb": "Use numbers from 0 to 255.",
+        "mode": {
+          "default": "Default",
+          "user": "User colour"
+        },
+        "channels": {
+          "red": "Red",
+          "green": "Green",
+          "blue": "Blue"
+        },
+        "roles": {
+          "starting": "Start",
+          "hand": "Mid",
+          "finish": "Finish",
+          "foot": "Foot"
+        }
+      },
       "appearance": {
         "title": "Appearance",
         "system": "System",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -17,6 +17,7 @@
         "description": "Pick hold colours that are easier to tell apart. Default uses each board's normal colours and sends no Bluetooth override.",
         "resetAll": "Reset hold colours",
         "save": "Save colour",
+        "rowAccessibility": "{{role}}, {{mode}}",
         "pickerSubtitle": "Use any RGB colour.",
         "modeLabel": "Hold colour mode",
         "defaultCopy": "Boardsesh will use the default colour for this hold type and skip it in Bluetooth overrides.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -210,6 +210,32 @@
       "development": "Desarrollo",
       "metroServersTitle": "Servidores Metro",
       "metroServersSubtitle": "Cambia entre bundlers de Tailnet",
+      "accessibility": {
+        "title": "Accesibilidad",
+        "description": "Elige colores de presas que sean más fáciles de distinguir. Predeterminado usa los colores normales de cada tabla y no envía cambios por Bluetooth.",
+        "resetAll": "Restablecer colores de presas",
+        "save": "Guardar color",
+        "rowAccessibility": "{{role}}, {{mode}}",
+        "pickerSubtitle": "Usa cualquier color RGB.",
+        "modeLabel": "Modo de color de presa",
+        "defaultCopy": "Boardsesh usará el color predeterminado de este tipo de presa y lo omitirá en los cambios de Bluetooth.",
+        "invalidRgb": "Usa números del 0 al 255.",
+        "mode": {
+          "default": "Predeterminado",
+          "user": "Color personalizado"
+        },
+        "channels": {
+          "red": "Rojo",
+          "green": "Verde",
+          "blue": "Azul"
+        },
+        "roles": {
+          "starting": "Inicio",
+          "hand": "Medio",
+          "finish": "Final",
+          "foot": "Pie"
+        }
+      },
       "appearance": {
         "title": "Apariencia",
         "system": "Sistema",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -12,6 +12,32 @@
       "development": "Développement",
       "metroServersTitle": "Serveurs Metro",
       "metroServersSubtitle": "Basculer entre les bundlers Tailnet",
+      "accessibility": {
+        "title": "Accessibilité",
+        "description": "Choisis des couleurs de prises plus faciles à distinguer. Par défaut utilise les couleurs normales de chaque board et n'envoie aucune surcharge Bluetooth.",
+        "resetAll": "Réinitialiser les couleurs des prises",
+        "save": "Enregistrer la couleur",
+        "rowAccessibility": "{{role}}, {{mode}}",
+        "pickerSubtitle": "Utilise n'importe quelle couleur RGB.",
+        "modeLabel": "Mode de couleur des prises",
+        "defaultCopy": "Boardsesh utilisera la couleur par défaut pour ce type de prise et l'omettra des surcharges Bluetooth.",
+        "invalidRgb": "Utilise des nombres de 0 à 255.",
+        "mode": {
+          "default": "Par défaut",
+          "user": "Couleur personnalisée"
+        },
+        "channels": {
+          "red": "Rouge",
+          "green": "Vert",
+          "blue": "Bleu"
+        },
+        "roles": {
+          "starting": "Départ",
+          "hand": "Milieu",
+          "finish": "Top",
+          "foot": "Pied"
+        }
+      },
       "appearance": {
         "title": "Apparence",
         "system": "Système",


### PR DESCRIPTION
## Summary

- Adds a mobile Accessibility section in the More tab for STARTING, HAND, FINISH, and FOOT colour overrides.
- Persists default/user RGB choices and reuses them across board rendering, create-climb painting, search hold filters, and native render cache keys.
- Threads the same overrides into Aurora-family Bluetooth payloads and iOS native board configuration for background/widget sends.
- Adds English, Spanish, and French copy for the new mobile accessibility controls.
- Documents the mobile settings and Bluetooth behaviour, including MoonBoard's in-app-only limitation for arbitrary RGB colours.

## Review follow-up

- Fixed screen-reader labels for hold colour rows and RGB inputs.
- Fixed single-role preference writes so they hydrate stored overrides before merging.
- Fixed in-flight auto-send handling so colour changes repaint the current climb after the active BLE write completes.

## Validation

- `vp test run --project mobile packages/mobile/src/lib/__tests__/hold-color-overrides.test.ts packages/mobile/src/components/board-renderer/__tests__/use-parse-frames.test.ts packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx`
- `vp test run --project climb-filters packages/shared/climb-filters/src/__tests__/hold-filter-options.test.ts`
- `vp test run --project mobile packages/mobile/src/lib/__tests__/hold-color-overrides.test.ts packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx`
- `vp run typecheck:mobile`
- `vp run typecheck:climb-filters`
- `vp run check:i18n`
- `git diff --check`
- File-scoped `vp check --no-lint ...` for the changed files

Note: repo-wide `vp check` still reports unrelated existing lint/type warnings and Vite+ panicked while printing the long report; the changed files passed formatting and the focused validations above.