### PR TITLE
[codex] Make mobile session recording opt-in

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -57,11 +57,6 @@ jobs:
       # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
       # false, so every track() silently no-ops (the app shipped zero events before).
       EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
-      # Opt this build (the open TestFlight beta) into session recording ON by
-      # default. session-recording-preference reads this to set the default; an
-      # explicit off from the Privacy toggle still wins. Production App Store
-      # builds omit this var, so recording stays opt-in there.
-      EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON: 'true'
 
     steps:
       - name: Checkout repository
@@ -84,7 +79,6 @@ jobs:
           EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
-          EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON=$EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON
           EOF
 
       - name: Expo prebuild (generate ios/)

--- a/packages/mobile/src/components/analytics/AnalyticsProvider.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsProvider.tsx
@@ -18,11 +18,10 @@ const styles = StyleSheet.create({ root: { flex: 1 } });
 export function AnalyticsProvider({ children }: { children: ReactNode }) {
   const client = getAnalyticsClient();
 
-  // Apply the session-recording preference at startup. The default follows the
-  // build: ON in the open TestFlight beta, OFF (opt-in) elsewhere — and an
-  // explicit choice from the Privacy toggle overrides it. Starts recording when
-  // the resolved preference is on. No-op when analytics is disabled
-  // (setSessionRecordingEnabled guards on a null client). Runs once.
+  // Apply the session-recording preference at startup. Recording is opt-in only:
+  // absent an explicit Privacy-toggle choice, the resolved preference is OFF.
+  // Starts recording when the resolved preference is on. No-op when analytics is
+  // disabled (setSessionRecordingEnabled guards on a null client). Runs once.
   useEffect(() => {
     loadSessionRecordingEnabled()
       .then((enabled) => {

--- a/packages/mobile/src/lib/__tests__/session-recording-preference.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-recording-preference.test.ts
@@ -21,10 +21,10 @@ vi.mock('@react-native-async-storage/async-storage', () => {
   };
 });
 
-const FLAG = 'EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON';
+const LEGACY_DEFAULT_ON_FLAG = 'EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON';
 
 describe('session-recording-preference', () => {
-  const originalFlag = process.env[FLAG];
+  const originalFlag = process.env[LEGACY_DEFAULT_ON_FLAG];
 
   beforeEach(async () => {
     vi.resetModules();
@@ -35,24 +35,23 @@ describe('session-recording-preference', () => {
   });
 
   afterEach(() => {
-    if (originalFlag === undefined) delete process.env[FLAG];
-    else process.env[FLAG] = originalFlag;
+    if (originalFlag === undefined) delete process.env[LEGACY_DEFAULT_ON_FLAG];
+    else process.env[LEGACY_DEFAULT_ON_FLAG] = originalFlag;
   });
 
-  it('defaults ON when the build flag is set and nothing is stored', async () => {
-    process.env[FLAG] = 'true';
-    const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
-    await expect(loadSessionRecordingEnabled()).resolves.toBe(true);
-  });
-
-  it('defaults OFF when the build flag is unset and nothing is stored', async () => {
-    delete process.env[FLAG];
+  it('defaults OFF when nothing is stored', async () => {
+    delete process.env[LEGACY_DEFAULT_ON_FLAG];
     const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
     await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
   });
 
-  it('honours an explicit OFF choice even when the build flag is on', async () => {
-    process.env[FLAG] = 'true';
+  it('ignores the legacy default-on build flag when nothing is stored', async () => {
+    process.env[LEGACY_DEFAULT_ON_FLAG] = 'true';
+    const { loadSessionRecordingEnabled } = await import('../session-recording-preference');
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
+  });
+
+  it('honours an explicit OFF choice', async () => {
     const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
       __setRaw: (key: string, value: string) => void;
     };
@@ -62,8 +61,7 @@ describe('session-recording-preference', () => {
     await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
   });
 
-  it('honours an explicit ON choice when the build flag is off', async () => {
-    delete process.env[FLAG];
+  it('honours an explicit ON choice', async () => {
     const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
       __setRaw: (key: string, value: string) => void;
     };
@@ -73,11 +71,10 @@ describe('session-recording-preference', () => {
     await expect(loadSessionRecordingEnabled()).resolves.toBe(true);
   });
 
-  it('persists the user choice over the build default', async () => {
-    process.env[FLAG] = 'true';
+  it('persists the user opt-in', async () => {
     const { loadSessionRecordingEnabled, setSessionRecordingEnabledPreference } =
       await import('../session-recording-preference');
-    await setSessionRecordingEnabledPreference(false);
-    await expect(loadSessionRecordingEnabled()).resolves.toBe(false);
+    await setSessionRecordingEnabledPreference(true);
+    await expect(loadSessionRecordingEnabled()).resolves.toBe(true);
   });
 });

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -49,12 +49,11 @@ function getClient(): PostHog | null {
     // `enableSessionReplay` defaults false, so the SDK never auto-records —
     // capture only begins when we call setSessionRecordingEnabled() →
     // startSessionRecording(), which lazily initialises the native replay SDK.
-    // We drive that at startup from the resolved preference (on by default in the
-    // open TestFlight beta, opt-in otherwise — see session-recording-preference).
-    // The masking below is what gets applied at that point: text inputs + images
-    // stay masked (the app has auth forms and white dark-mode input fields), and
-    // console capture is left on so the BLE console.warn/error lines land on the
-    // replay timeline.
+    // We drive that at startup from the resolved preference: absent a stored
+    // user opt-in, recording stays off. The masking below is what gets applied
+    // once recording starts: text inputs + images stay masked (the app has auth
+    // forms and white dark-mode input fields), and console capture is left on so
+    // the BLE console.warn/error lines land on the replay timeline.
     sessionReplayConfig: {
       maskAllTextInputs: true,
       maskAllImages: true,
@@ -65,12 +64,11 @@ function getClient(): PostHog | null {
 }
 
 // Start/stop session recording. The resolved preference decides whether it runs
-// (on by default in the open TestFlight beta, opt-in otherwise — see
-// session-recording-preference); this just applies it. startSessionRecording()
-// lazily initialises the native replay SDK with the masking config above;
-// stopSessionRecording() halts it. No-op when analytics is disabled (dev / no
-// key) because getClient() returns null. Safe to call before the client is built
-// — getClient() constructs it on demand.
+// (opt-in only — see session-recording-preference); this just applies it.
+// startSessionRecording() lazily initialises the native replay SDK with the
+// masking config above; stopSessionRecording() halts it. No-op when analytics is
+// disabled (dev / no key) because getClient() returns null. Safe to call before
+// the client is built — getClient() constructs it on demand.
 export function setSessionRecordingEnabled(enabled: boolean): void {
   const client = getClient();
   if (!client) return;

--- a/packages/mobile/src/lib/env.ts
+++ b/packages/mobile/src/lib/env.ts
@@ -1,8 +1,2 @@
 export const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL ?? 'https://ws.boardsesh.com';
 export const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://www.boardsesh.com';
-
-// Whether session recording is ON by default. Only builds that opt in set this —
-// the open TestFlight beta does, via ios-testflight-rn.yml. Production App Store
-// builds leave it unset, so recording stays opt-in there. The shipped value is
-// inlined at build time (EXPO_PUBLIC_* vars bake into the JS bundle).
-export const SESSION_RECORDING_DEFAULTS_ON = process.env.EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON === 'true';

--- a/packages/mobile/src/lib/session-recording-preference.ts
+++ b/packages/mobile/src/lib/session-recording-preference.ts
@@ -1,28 +1,25 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { getPreference, setPreference } from './preference-store';
-import { SESSION_RECORDING_DEFAULTS_ON } from './env';
 
-// Whether the user has opted in to PostHog session recording. The default
-// follows the build: ON in opted-in builds (the open TestFlight beta sets
-// EXPO_PUBLIC_SESSION_RECORDING_DEFAULT_ON), OFF (opt-in) everywhere else. An
-// explicit choice from the Privacy toggle always wins over the default and is
-// persisted so it survives restarts; the value is restored and applied at app
-// startup.
+// Whether the user has opted in to PostHog session recording. Recording is
+// opt-in only: the default is always OFF, and only an explicit choice from the
+// Privacy toggle is persisted, restored, and applied at app startup.
 //
 // Structure mirrors `grade-format-preference.ts`: a module-level store read via
 // `useSyncExternalStore` with a referentially-stable cached snapshot (rebuilt
 // only inside `notify()`), plus a promise-singleton one-time load so any number
 // of mounted consumers trigger the AsyncStorage read exactly once.
 const STORAGE_KEY = 'sessionRecordingEnabled';
+const DEFAULT_SESSION_RECORDING_ENABLED = false;
 
 type SessionRecordingSnapshot = { enabled: boolean; loaded: boolean };
 
-let current = SESSION_RECORDING_DEFAULTS_ON;
+let current = DEFAULT_SESSION_RECORDING_ENABLED;
 let hasLoaded = false;
 let snapshot: SessionRecordingSnapshot = { enabled: current, loaded: hasLoaded };
 const listeners = new Set<() => void>();
 
-const SERVER_SNAPSHOT: SessionRecordingSnapshot = { enabled: SESSION_RECORDING_DEFAULTS_ON, loaded: false };
+const SERVER_SNAPSHOT: SessionRecordingSnapshot = { enabled: DEFAULT_SESSION_RECORDING_ENABLED, loaded: false };
 
 function notify(): void {
   snapshot = { enabled: current, loaded: hasLoaded };
@@ -36,8 +33,8 @@ export async function loadSessionRecordingEnabled(): Promise<boolean> {
   // storage; honour the user's choice over the (now stale) persisted value.
   if (hasLoaded) return current;
   // An explicit stored choice (true/false) wins; an absent value falls back to
-  // the build default (on in the beta, off otherwise).
-  current = typeof stored === 'boolean' ? stored : SESSION_RECORDING_DEFAULTS_ON;
+  // OFF so session recording is opt-in only.
+  current = typeof stored === 'boolean' ? stored : DEFAULT_SESSION_RECORDING_ENABLED;
   hasLoaded = true;
   notify();
   return current;


### PR DESCRIPTION
## What changed

- Makes mobile PostHog session recording default to off unless the user has explicitly opted in through the diagnostics/privacy toggle.
- Removes the TestFlight workflow env var that previously enabled session recording by default for beta builds.
- Updates comments and preference tests so the old build-time default-on flag cannot re-enable recording.

## Impact

Product analytics still initializes when configured, but session replay only starts after a persisted user opt-in. Users who already opted in keep recording enabled; users without a stored preference stay off.

## Validation

- `vp test run --project mobile packages/mobile/src/lib/__tests__/session-recording-preference.test.ts --reporter=agent`
- `vp run typecheck:mobile`
- `vp check .github/workflows/ios-testflight-rn.yml packages/mobile/src/components/analytics/AnalyticsProvider.tsx packages/mobile/src/lib/__tests__/session-recording-preference.test.ts packages/mobile/src/lib/analytics.ts packages/mobile/src/lib/env.ts packages/mobile/src/lib/session-recording-preference.ts` exited 0; it still reports existing unbound-method warnings on `packages/mobile/src/lib/analytics.ts:155`.