### PR TITLE
[codex] Neutralize Liquid Glass chrome icons

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -322,6 +322,13 @@ lightbulb:       { ios: 'lightbulb',       android: 'lightbulb-on-outline' },
 Filled/outline pairs follow the `name` / `name.fill` convention (e.g. `boards` / `boards.fill`). A
 typo'd SF Symbol fails `vp run typecheck:mobile`.
 
+**Liquid Glass chrome icon colour.** Bottom tabs, floating glass toolbars, glass header controls and
+action-sheet row icons should use adaptive neutral glyphs: `systemColors.label` for selected or
+primary actions, `systemColors.secondaryLabel` for inactive actions. Carry state with icon shape,
+labels, badges, filled surfaces or selection affordances before reaching for brand colour. Keep
+semantic colour for cases where colour is the content: destructive actions, warnings/errors, success
+status summaries, grade colours, chart series and filled primary buttons.
+
 ---
 
 ## Theme consumption pattern

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -43,7 +43,13 @@ vi.mock('../../../src/theme/colors', () => ({
 }));
 
 vi.mock('../../../src/providers/theme-provider', () => ({
-  useTheme: () => ({ variant: cfg.variant }),
+  useTheme: () => ({
+    variant: cfg.variant,
+    systemColors: {
+      label: '#F5F2FB',
+      secondaryLabel: '#A9A2B6',
+    },
+  }),
 }));
 
 vi.mock('../../../src/hooks/use-bottom-accessory', () => ({
@@ -88,8 +94,30 @@ vi.mock('expo-router/unstable-native-tabs', () => {
   );
 
   const NativeTabs = Object.assign(
-    ({ children, minimizeBehavior }: { children?: ReactNode; minimizeBehavior?: string }) =>
-      createElement('nav', { 'data-tabs': 'true', 'data-minimize-behavior': minimizeBehavior ?? '' }, children),
+    ({
+      children,
+      minimizeBehavior,
+      iconColor,
+      labelStyle,
+      tintColor,
+    }: {
+      children?: ReactNode;
+      minimizeBehavior?: string;
+      iconColor?: unknown;
+      labelStyle?: unknown;
+      tintColor?: unknown;
+    }) =>
+      createElement(
+        'nav',
+        {
+          'data-tabs': 'true',
+          'data-minimize-behavior': minimizeBehavior ?? '',
+          'data-icon-color': JSON.stringify(iconColor),
+          'data-label-style': JSON.stringify(labelStyle),
+          'data-tint-color': typeof tintColor === 'string' ? tintColor : '',
+        },
+        children,
+      ),
     {
       BottomAccessory: ({ children }: { children?: ReactNode }) =>
         createElement('div', { 'data-bottom-accessory': 'true' }, children),
@@ -128,6 +156,17 @@ describe('TabLayout', () => {
     const { container } = render(<TabLayout />);
 
     expect(container.querySelector('[data-tabs="true"]')?.getAttribute('data-minimize-behavior')).toBe('onScrollDown');
+  });
+
+  it('uses adaptive neutral colors for native Liquid Glass tab icons and labels', () => {
+    const { container } = render(<TabLayout />);
+    const tabs = container.querySelector('[data-tabs="true"]');
+
+    expect(tabs?.getAttribute('data-icon-color')).toBe(JSON.stringify({ default: '#A9A2B6', selected: '#F5F2FB' }));
+    expect(tabs?.getAttribute('data-label-style')).toBe(
+      JSON.stringify({ default: { color: '#A9A2B6' }, selected: { color: '#F5F2FB' } }),
+    );
+    expect(tabs?.getAttribute('data-tint-color')).toBe('#F5F2FB');
   });
 
   it('mounts the native bottom accessory when active and a climb is current', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -40,7 +40,7 @@ export default function TabLayout() {
   const { t } = useTranslation('common');
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSession } = useTranslation('session');
-  const { variant } = useTheme();
+  const { variant, systemColors } = useTheme();
   const nativeAccessoryActive = useNativeAccessoryActive();
 
   // Record-tab status cue: a badge when a board is connected over Bluetooth or a
@@ -98,7 +98,12 @@ export default function TabLayout() {
     // FlashList's nested scroll view, which it can't by default — that fallback
     // lives in patches/react-native-screens@4.25.2.patch. `vp run check:mobile-patches`
     // (CI) fails the build if that patch ever stops applying after a dep bump.
-    <NativeTabs minimizeBehavior="onScrollDown">
+    <NativeTabs
+      minimizeBehavior="onScrollDown"
+      iconColor={{ default: systemColors.secondaryLabel, selected: systemColors.label }}
+      labelStyle={{ default: { color: systemColors.secondaryLabel }, selected: { color: systemColors.label } }}
+      tintColor={systemColors.label}
+    >
       {nativeAccessoryActive && hasCurrentClimb ? (
         <NativeTabs.BottomAccessory>
           <QueueBottomAccessory />

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -385,7 +385,7 @@ export default function PlaylistDetail() {
   // the pending ref so the sheet's exit animation doesn't fight the top-bar swap).
   const menuTogglePin = useCallback(() => {
     setActionsVisible(false);
-    handleTogglePin();
+    void handleTogglePin();
   }, [handleTogglePin]);
 
   const menuEnterEdit = useCallback(() => {
@@ -450,10 +450,10 @@ export default function PlaylistDetail() {
           {isAuthenticated ? (
             <GlassIconButton
               iconName={isPinned ? 'pin.fill' : 'pin'}
-              iconColor={isPinned ? brandColors.primary : systemColors.label}
+              iconColor={systemColors.label}
               onPress={() => {
                 hapticSelection();
-                handleTogglePin();
+                void handleTogglePin();
               }}
               accessibilityLabel={isPinned ? t('library.pin.unpinAriaLabel') : t('library.pin.pinAriaLabel')}
               fallbackColor={systemColors.fill}

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -187,6 +187,11 @@ function ClimbActionsSheet({
   // Sized for the climb preview row plus the action list (a couple more rows show
   // for owners / Aurora-app climbs); the modal pans down to close.
   const snapPoints = useMemo(() => ['55%'], []);
+  const neutralActionIconColor = theme.systemColors.label;
+  const successActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : theme.brandColors.success;
+  const favoriteActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : iosSystemColors.systemRed;
+  const accentActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : theme.systemColors.accent;
+  const reportActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : iosSystemColors.systemOrange;
 
   return (
     <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose>
@@ -204,7 +209,7 @@ function ClimbActionsSheet({
         {onAddToQueue && (
           <ListRow
             title={t('mobile.climbRow.addToQueue')}
-            leading={<Icon name="add" size={22} color={theme.brandColors.success} />}
+            leading={<Icon name="add" size={22} color={successActionIconColor} />}
             onPress={handleAddToQueue}
             showSeparator
           />
@@ -212,7 +217,7 @@ function ClimbActionsSheet({
         {onToggleFavorite && (
           <ListRow
             title={t('mobile.climbRow.toggleFavorite')}
-            leading={<Icon name="favorite" size={22} color={iosSystemColors.systemRed} />}
+            leading={<Icon name="favorite" size={22} color={favoriteActionIconColor} />}
             onPress={handleToggleFavorite}
             showSeparator
           />
@@ -220,7 +225,7 @@ function ClimbActionsSheet({
         {onTick && (
           <ListRow
             title={t('mobile.climbActions.tick')}
-            leading={<Icon name="tick" size={22} color={theme.brandColors.success} />}
+            leading={<Icon name="tick" size={22} color={successActionIconColor} />}
             onPress={handleTick}
             showSeparator
           />
@@ -228,33 +233,33 @@ function ClimbActionsSheet({
         {canEdit && (
           <ListRow
             title={t('mobile.climbActions.edit')}
-            leading={<Icon name="edit" size={22} color={theme.systemColors.accent} />}
+            leading={<Icon name="edit" size={22} color={accentActionIconColor} />}
             onPress={handleEdit}
             showSeparator
           />
         )}
         <ListRow
           title={t('mobile.climbActions.fork')}
-          leading={<Icon name="branch" size={22} color={theme.systemColors.accent} />}
+          leading={<Icon name="branch" size={22} color={accentActionIconColor} />}
           onPress={handleFork}
           showSeparator
         />
         <ListRow
           title={t('mobile.climbActions.copyLink')}
-          leading={<Icon name="copy" size={22} color={theme.systemColors.accent} />}
+          leading={<Icon name="copy" size={22} color={accentActionIconColor} />}
           onPress={handleCopyLink}
           showSeparator
         />
         <ListRow
           title={t('mobile.climbActions.report')}
-          leading={<Icon name="flag" size={22} color={iosSystemColors.systemOrange} />}
+          leading={<Icon name="flag" size={22} color={reportActionIconColor} />}
           onPress={handleReport}
           showSeparator={!!auroraAppUrl}
         />
         {auroraAppUrl && (
           <ListRow
             title={t('mobile.climbActions.openInApp')}
-            leading={<Icon name="open.external" size={22} color={theme.systemColors.accent} />}
+            leading={<Icon name="open.external" size={22} color={accentActionIconColor} />}
             onPress={handleOpenInApp}
             showSeparator={false}
           />

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -10,6 +10,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 // exposes the present/dismiss it would call through the forwarded ref.
 const modal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -35,8 +36,14 @@ vi.mock('../ClimbPreviewCard', () => ({
   },
 }));
 
-vi.mock('../ListRow', () => ({ ListRow: () => null }));
-vi.mock('../Icon', () => ({ Icon: () => null }));
+vi.mock('../ListRow', () => ({
+  ListRow: ({ title, leading }: { title: string; leading?: ReactNode }) =>
+    createElement('div', { 'data-row': title }, leading),
+}));
+vi.mock('../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: unknown }) =>
+    createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
+}));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock('expo-clipboard', () => ({ setStringAsync: vi.fn() }));
@@ -46,7 +53,11 @@ vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => false 
 vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ brandColors: { success: '#0a0' }, systemColors: { accent: '#00f' } }),
+  useTheme: () => ({
+    variant: ctrl.variant,
+    brandColors: { success: '#0a0' },
+    systemColors: { accent: '#00f', label: '#fff' },
+  }),
 }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { systemRed: '#f00', systemOrange: '#f80' } }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8 } }));
@@ -77,6 +88,7 @@ beforeEach(() => {
   modal.present.mockClear();
   modal.dismiss.mockClear();
   preview.props = null;
+  ctrl.variant = 'liquidGlass';
 });
 
 describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
@@ -121,5 +133,44 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
       setIds: '1,2',
       angle: 40,
     });
+  });
+
+  it('uses neutral adaptive icons for Liquid Glass action rows', () => {
+    const { container } = render(
+      <ClimbActionsSheet
+        visible={true}
+        {...baseProps}
+        onAddToQueue={vi.fn()}
+        onToggleFavorite={vi.fn()}
+        onTick={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('[data-icon="add"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="favorite"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="tick"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="branch"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="copy"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="flag"]')?.getAttribute('data-color')).toBe('#fff');
+  });
+
+  it('keeps Material action rows on their semantic/action colors', () => {
+    ctrl.variant = 'material';
+    const { container } = render(
+      <ClimbActionsSheet
+        visible={true}
+        {...baseProps}
+        onAddToQueue={vi.fn()}
+        onToggleFavorite={vi.fn()}
+        onTick={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('[data-icon="add"]')?.getAttribute('data-color')).toBe('#0a0');
+    expect(container.querySelector('[data-icon="favorite"]')?.getAttribute('data-color')).toBe('#f00');
+    expect(container.querySelector('[data-icon="tick"]')?.getAttribute('data-color')).toBe('#0a0');
+    expect(container.querySelector('[data-icon="branch"]')?.getAttribute('data-color')).toBe('#00f');
+    expect(container.querySelector('[data-icon="copy"]')?.getAttribute('data-color')).toBe('#00f');
+    expect(container.querySelector('[data-icon="flag"]')?.getAttribute('data-color')).toBe('#f80');
   });
 });

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
@@ -101,7 +101,10 @@ vi.mock('../../PressableSurface', () => ({
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: unknown }) =>
+    createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
+}));
 vi.mock('../../play-drawer/AngleSelectorSheet', () => ({
   AngleSelectorSheet: ({ visible }: { visible: boolean }) =>
     visible ? createElement('div', { 'data-angle-selector': 'true' }) : null,
@@ -202,6 +205,7 @@ describe('CollapsingTopChrome', () => {
     };
     rerender(<CollapsingTopChrome {...makeProps()} />);
     expect(lightbulb(container)).not.toBeNull();
+    expect(container.querySelector('[data-icon="lightbulb.fill"]')?.getAttribute('data-color')).toBe('#FF9500');
   });
 
   it('hides the lightbulb when hideLight is set, even with bluetooth available', () => {

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -34,7 +34,7 @@ export function PlaylistActionsMenu({
   onClose,
 }: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
   // Track presented state so we never call dismiss() on a not-presented modal
   // (which leaves gorhom in a state where the next present() is a no-op — the
@@ -57,6 +57,9 @@ export function PlaylistActionsMenu({
     isPresentedRef.current = false;
     onClose();
   }, [onClose]);
+  const neutralActionIconColor = systemColors.label;
+  const accentActionIconColor = variant === 'liquidGlass' ? neutralActionIconColor : systemColors.accent;
+  const pinActionIconColor = variant === 'liquidGlass' ? neutralActionIconColor : brandColors.primary;
 
   return (
     <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss}>
@@ -67,7 +70,7 @@ export function PlaylistActionsMenu({
             <Icon
               name={isPinned ? 'pin.fill' : 'pin'}
               size={22}
-              color={isPinned ? brandColors.primary : systemColors.accent}
+              color={isPinned ? pinActionIconColor : accentActionIconColor}
             />
           }
           onPress={onTogglePin}
@@ -75,7 +78,7 @@ export function PlaylistActionsMenu({
         />
         <ListRow
           title={t('detail.menu.editClimbs')}
-          leading={<Icon name="edit" size={22} color={systemColors.accent} />}
+          leading={<Icon name="edit" size={22} color={accentActionIconColor} />}
           onPress={onEdit}
           showSeparator
         />

--- a/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
@@ -29,7 +29,7 @@ type PlaylistEditDoneButtonProps = {
  */
 export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneButtonProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors } = useTheme();
   const nativeGlass = useNativeGlass();
   const label = t('editClimbs.done');
 
@@ -37,7 +37,7 @@ export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneB
     return (
       <GlassIconButton
         iconName="check.small"
-        iconColor={brandColors.primary}
+        iconColor={systemColors.label}
         onPress={onPress}
         accessibilityLabel={label}
         fallbackColor={systemColors.fill}
@@ -69,8 +69,8 @@ export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneB
           style={StyleSheet.absoluteFill}
           pointerEvents="none"
         />
-        <Icon name="check.small" size={18} color={brandColors.primary} />
-        <Text variant="subheadline" color={brandColors.primary} style={styles.label}>
+        <Icon name="check.small" size={18} color={systemColors.label} />
+        <Text variant="subheadline" color={systemColors.label} style={styles.label}>
           {label}
         </Text>
       </View>

--- a/packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000', fill: '#eee', separator: '#ccc' } }),
+}));
+vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
+vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} } }));
+vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 48 } }));
+vi.mock('../../GlassSurface', () => ({ GlassSurface: () => createElement('div', { 'data-glass': 'true' }) }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: unknown }) =>
+    createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children }: { children?: ReactNode }) =>
+    createElement('button', { 'data-pill': 'true' }, children),
+}));
+vi.mock('../../GlassIconButton', () => ({
+  GlassIconButton: ({ iconName, iconColor }: { iconName: string; iconColor?: unknown }) =>
+    createElement('button', {
+      'data-fab': 'true',
+      'data-icon': iconName,
+      'data-icon-color': typeof iconColor === 'string' ? iconColor : '',
+    }),
+}));
+
+import { PlaylistEditDoneButton } from '../PlaylistEditDoneButton';
+
+describe('PlaylistEditDoneButton', () => {
+  it('uses neutral glyph and label colors in expanded glass mode', () => {
+    const { container } = render(<PlaylistEditDoneButton onPress={vi.fn()} />);
+
+    expect(container.querySelector('[data-icon="check.small"]')?.getAttribute('data-color')).toBe('#000');
+    expect(container.textContent).toContain('editClimbs.done');
+  });
+
+  it('uses a neutral glyph color when collapsed to a glass icon button', () => {
+    const { container } = render(<PlaylistEditDoneButton onPress={vi.fn()} collapsed />);
+
+    expect(container.querySelector('[data-fab="true"]')?.getAttribute('data-icon-color')).toBe('#000');
+  });
+});

--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -124,7 +124,7 @@ export function RecordTopChrome({
   const inSession = onEndSession !== undefined;
   const leadingAction = onShare ? (
     <GlassToolbarAction onPress={onShare} accessibilityLabel={t('mobile.session.invite')}>
-      <Icon name="person.badge.plus" size={22} color={brandColors.primary} />
+      <Icon name="person.badge.plus" size={22} color={systemColors.label} />
     </GlassToolbarAction>
   ) : undefined;
   // Stop is a labelled glass pill (icon + "Stop"), not an icon-only slot, so it reads

--- a/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
@@ -77,11 +77,11 @@ export function SessionScreenHeader({
               style={styles.shareButton}
             >
               {inviteHint ? (
-                <Text variant="subheadline" color={brandColors.primary} style={styles.shareLabel}>
+                <Text variant="subheadline" color={systemColors.label} style={styles.shareLabel}>
                   {t('mobile.session.inviteAction')}
                 </Text>
               ) : null}
-              <Icon name="share" size={22} color={brandColors.primary} />
+              <Icon name="share" size={22} color={systemColors.label} />
             </Pressable>
           ) : null}
           {onEndSession ? (

--- a/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
@@ -65,7 +65,10 @@ vi.mock('../../icon-map', () => ({
     flag: { ios: 'flag', android: 'flag-outline' },
   },
 }));
-vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: unknown }) =>
+    createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
+}));
 vi.mock('../../chrome', () => ({
   CollapsingTopChrome: (props: ChromeProps) => {
     chrome.props = props;
@@ -158,6 +161,7 @@ describe('RecordTopChrome', () => {
     expect(chrome.props?.leadingActionCount).toBe(1);
     const shareButton = container.querySelector('[data-action="mobile.session.invite"]') as HTMLButtonElement | null;
     expect(shareButton).not.toBeNull();
+    expect(shareButton?.querySelector('[data-icon="person.badge.plus"]')?.getAttribute('data-color')).toBe('#000');
     shareButton!.click();
     expect(onShare).toHaveBeenCalledTimes(1);
   });

--- a/packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx
@@ -23,7 +23,10 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: unknown }) =>
+    createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
+}));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#000', tertiaryLabel: '#999' },
@@ -62,6 +65,7 @@ describe('SessionScreenHeader', () => {
     const { container } = render(<SessionScreenHeader sessionActive onShare={onShare} />);
     const share = container.querySelector(SHARE) as HTMLButtonElement | null;
     expect(share).not.toBeNull();
+    expect(share?.querySelector('[data-icon="share"]')?.getAttribute('data-color')).toBe('#000');
     share!.click();
     expect(onShare).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

- Sets Liquid Glass native tab icons and labels to adaptive neutral system colors instead of accent tint.
- Neutralizes ordinary Liquid Glass action glyphs in climb actions, playlist controls, and session invite chrome while preserving semantic/destructive color where it carries meaning.
- Documents the Liquid Glass chrome icon color rule and adds focused regression coverage.

## Validation

- `vp check ...` on touched files
- `vp test --project mobile ...` focused mobile tests: 6 files, 44 tests
- `vp run typecheck:mobile`

## Notes

- Connected lightbulb remains colorized with the warning tint; disconnected lightbulb remains neutral.