### PR TITLE
[codex] Add playlist action to mobile climb sheet

### DIFF
--- a/docs/mobile-play-view-roadmap.md
+++ b/docs/mobile-play-view-roadmap.md
@@ -77,7 +77,7 @@ Adds queue management and deferred content sections.
 - **Nested queue bottom sheet** -- second bottom sheet stacked over the play drawer, opened via the queue action bar button; dismissed by swipe-down or tap-outside
 - **Queue list** -- three regions (history, current, up-next) with drag-to-reorder, swipe-to-remove, edit mode for bulk operations
 - **Below-fold deferred sections** -- logbook entries, similar climbs, and community data loaded via `InteractionManager.runAfterInteractions()` to avoid blocking the initial drawer render
-- **Climb actions sheet** -- action sheet triggered by long-press or the overflow button, with options: share, add to playlist, copy link, report
+- **Climb actions sheet** -- action sheet triggered by long-press or the overflow button, with options: share, add to playlist, copy link, and remix
 - **Angle selector sheet** -- bottom sheet with angle slider or segmented control, updating the board renderer and persisting the selection
 
 ### Phase 4: Advanced Interactions

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -31,6 +31,7 @@ type ClimbActionsSheetProps = {
   /** Current signed-in user id — gates the owner-only Edit row. */
   currentUserId?: string | null;
   onAddToQueue?: () => void;
+  onOpenPlaylist?: () => void;
   onToggleFavorite?: () => void;
   /** When provided, shows a "Log a tick" row that opens the LogAscent sheet. */
   onTick?: () => void;
@@ -54,6 +55,7 @@ function ClimbActionsSheet({
   angle,
   currentUserId,
   onAddToQueue,
+  onOpenPlaylist,
   onToggleFavorite,
   onTick,
   onClose,
@@ -83,6 +85,11 @@ function ClimbActionsSheet({
     onAddToQueue?.();
     onClose();
   }, [onAddToQueue, onClose]);
+
+  const handleOpenPlaylist = useCallback(() => {
+    onOpenPlaylist?.();
+    onClose();
+  }, [onOpenPlaylist, onClose]);
 
   const handleToggleFavorite = useCallback(() => {
     onToggleFavorite?.();
@@ -117,16 +124,6 @@ function ClimbActionsSheet({
       onClose();
     }
   }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose, showToast, t]);
-
-  const handleReport = useCallback(async () => {
-    if (!climb) return;
-    try {
-      const reportUrl = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}?report=true`;
-      await WebBrowser.openBrowserAsync(reportUrl);
-    } finally {
-      onClose();
-    }
-  }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose]);
 
   const handleDismiss = useCallback(() => {
     isPresentedRef.current = false;
@@ -191,7 +188,6 @@ function ClimbActionsSheet({
   const successActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : theme.brandColors.success;
   const favoriteActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : iosSystemColors.systemRed;
   const accentActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : theme.systemColors.accent;
-  const reportActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : iosSystemColors.systemOrange;
 
   return (
     <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose>
@@ -211,6 +207,14 @@ function ClimbActionsSheet({
             title={t('mobile.climbRow.addToQueue')}
             leading={<Icon name="add" size={22} color={successActionIconColor} />}
             onPress={handleAddToQueue}
+            showSeparator
+          />
+        )}
+        {onOpenPlaylist && (
+          <ListRow
+            title={t('actions.playlist.popover.title')}
+            leading={<Icon name="playlist" size={22} color={accentActionIconColor} />}
+            onPress={handleOpenPlaylist}
             showSeparator
           />
         )}
@@ -248,12 +252,6 @@ function ClimbActionsSheet({
           title={t('mobile.climbActions.copyLink')}
           leading={<Icon name="copy" size={22} color={accentActionIconColor} />}
           onPress={handleCopyLink}
-          showSeparator
-        />
-        <ListRow
-          title={t('mobile.climbActions.report')}
-          leading={<Icon name="flag" size={22} color={reportActionIconColor} />}
-          onPress={handleReport}
           showSeparator={!!auroraAppUrl}
         />
         {auroraAppUrl && (

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { createElement, type ReactNode, type Ref } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 
@@ -37,8 +37,8 @@ vi.mock('../ClimbPreviewCard', () => ({
 }));
 
 vi.mock('../ListRow', () => ({
-  ListRow: ({ title, leading }: { title: string; leading?: ReactNode }) =>
-    createElement('div', { 'data-row': title }, leading),
+  ListRow: ({ title, leading, onPress }: { title: string; leading?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { 'data-row': title, onClick: onPress }, leading, title),
 }));
 vi.mock('../Icon', () => ({
   Icon: ({ name, color }: { name: string; color?: unknown }) =>
@@ -141,17 +141,18 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
         visible={true}
         {...baseProps}
         onAddToQueue={vi.fn()}
+        onOpenPlaylist={vi.fn()}
         onToggleFavorite={vi.fn()}
         onTick={vi.fn()}
       />,
     );
 
     expect(container.querySelector('[data-icon="add"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="playlist"]')?.getAttribute('data-color')).toBe('#fff');
     expect(container.querySelector('[data-icon="favorite"]')?.getAttribute('data-color')).toBe('#fff');
     expect(container.querySelector('[data-icon="tick"]')?.getAttribute('data-color')).toBe('#fff');
     expect(container.querySelector('[data-icon="branch"]')?.getAttribute('data-color')).toBe('#fff');
     expect(container.querySelector('[data-icon="copy"]')?.getAttribute('data-color')).toBe('#fff');
-    expect(container.querySelector('[data-icon="flag"]')?.getAttribute('data-color')).toBe('#fff');
   });
 
   it('keeps Material action rows on their semantic/action colors', () => {
@@ -161,16 +162,33 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
         visible={true}
         {...baseProps}
         onAddToQueue={vi.fn()}
+        onOpenPlaylist={vi.fn()}
         onToggleFavorite={vi.fn()}
         onTick={vi.fn()}
       />,
     );
 
     expect(container.querySelector('[data-icon="add"]')?.getAttribute('data-color')).toBe('#0a0');
+    expect(container.querySelector('[data-icon="playlist"]')?.getAttribute('data-color')).toBe('#00f');
     expect(container.querySelector('[data-icon="favorite"]')?.getAttribute('data-color')).toBe('#f00');
     expect(container.querySelector('[data-icon="tick"]')?.getAttribute('data-color')).toBe('#0a0');
     expect(container.querySelector('[data-icon="branch"]')?.getAttribute('data-color')).toBe('#00f');
     expect(container.querySelector('[data-icon="copy"]')?.getAttribute('data-color')).toBe('#00f');
-    expect(container.querySelector('[data-icon="flag"]')?.getAttribute('data-color')).toBe('#f80');
+  });
+
+  it('shows add to playlist and removes report from the action list', () => {
+    render(<ClimbActionsSheet visible={true} {...baseProps} onOpenPlaylist={vi.fn()} />);
+
+    expect(screen.getByText('actions.playlist.popover.title')).toBeTruthy();
+    expect(screen.queryByText('mobile.climbActions.report')).toBeNull();
+  });
+
+  it('opens the playlist sheet callback from the add-to-playlist row', () => {
+    const onOpenPlaylist = vi.fn();
+    render(<ClimbActionsSheet visible={true} {...baseProps} onOpenPlaylist={onOpenPlaylist} />);
+
+    fireEvent.click(screen.getByText('actions.playlist.popover.title'));
+
+    expect(onOpenPlaylist).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -166,7 +166,7 @@ describe('useCreateClimbScreen autosave flush', () => {
       useCreateClimbScreen({ board: BOARD, forkFrames: 'p1r12', forkName: 'Original' }),
     );
     // A fork seeds its own holds/name; let any restore settle.
-    await waitFor(() => expect(result.current.name).toBe('Original fork'));
+    await waitFor(() => expect(result.current.name).toBe('Original remix'));
 
     vi.useFakeTimers();
     act(() => result.current.setDescription('forked beta'));

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -131,7 +131,7 @@ export function useCreateClimbScreen({
   } = useCreateClimb(board.boardName, { initialHoldsMap });
 
   const [selectedBrush, setSelectedBrush] = useState<BrushRole>('HAND');
-  const [name, setName] = useState(isForking && forkName ? `${forkName} fork` : '');
+  const [name, setName] = useState(isForking && forkName ? `${forkName} remix` : '');
   const [description, setDescription] = useState(
     isForking && forkDescription ? withNoMatch(forkDescription, false) : '',
   );

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -740,4 +740,31 @@ describe('DrawerHostProvider climb actions', () => {
     });
     await waitFor(() => expect(container.querySelector('[data-climb-actions]')).toBeNull());
   });
+
+  it('opens add-to-playlist from climb actions with the same climb and board snapshot', async () => {
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    const { container } = renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openClimbActions(climb);
+    });
+    await waitFor(() => expect(climbActions.props).not.toBeNull());
+
+    act(() => {
+      (climbActions.props?.onOpenPlaylist as (() => void) | undefined)?.();
+    });
+
+    await waitFor(() => expect(container.querySelector('[data-add-to-playlist]')).not.toBeNull());
+    expect(playlistSheet.props).toMatchObject({
+      visible: true,
+      climb,
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 40,
+    });
+  });
 });

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -331,6 +331,14 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     });
   }, [climbActions]);
 
+  const handleClimbActionsOpenPlaylist = useCallback(() => {
+    if (!climbActions) return;
+    setPlaylistClimb({
+      climb: climbActions.climb,
+      boardConfig: climbActions.boardConfig,
+    });
+  }, [climbActions]);
+
   // Present the always-mounted queue sheet imperatively. Calling `present()`
   // synchronously from the handler (rather than from a `visible`-prop effect)
   // is what actually shows the sheet — see QueueSheetHandle for the gorhom
@@ -565,6 +573,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           angle={climbActions.boardConfig.angle}
           currentUserId={profile?.id ?? null}
           onAddToQueue={handleClimbActionsAddToQueue}
+          onOpenPlaylist={handleClimbActionsOpenPlaylist}
           onToggleFavorite={handleClimbActionsToggleFavorite}
           onTick={handleClimbActionsTick}
           onClose={closeClimbActions}

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -695,11 +695,10 @@
     },
     "climbActions": {
       "copyLink": "Copy link",
-      "report": "Report",
       "linkCopied": "Link copied",
       "tick": "Log a tick",
       "openInApp": "Open in Aurora app",
-      "fork": "Fork this climb",
+      "fork": "Remix this climb",
       "edit": "Edit climb"
     },
     "create": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -695,11 +695,10 @@
     },
     "climbActions": {
       "copyLink": "Copiar enlace",
-      "report": "Reportar",
       "linkCopied": "Enlace copiado",
       "tick": "Registrar un envío",
       "openInApp": "Abrir en la app Aurora",
-      "fork": "Bifurcar esta vía",
+      "fork": "Remix this climb",
       "edit": "Editar vía"
     },
     "create": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -695,11 +695,10 @@
     },
     "climbActions": {
       "copyLink": "Copier le lien",
-      "report": "Signaler",
       "linkCopied": "Lien copié",
       "tick": "Enregistrer une croix",
       "openInApp": "Ouvrir dans l'app Aurora",
-      "fork": "Dupliquer cette voie",
+      "fork": "Remix this climb",
       "edit": "Modifier la voie"
     },
     "create": {

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -960,10 +960,10 @@ describe('CreateClimbForm — forkName prop', () => {
     mockRequest.mockResolvedValue({ checkMoonBoardClimbDuplicates: [] });
   });
 
-  it('initialises the climb name input with "<forkName> fork" when forkName provided', () => {
+  it('initialises the climb name input with "<forkName> remix" when forkName provided', () => {
     renderMoonboard({ forkName: 'Original Climb' });
     fireEvent.click(screen.getByRole('button', { name: /settings/i }));
-    expect(screen.getByDisplayValue('Original Climb fork')).toBeTruthy();
+    expect(screen.getByDisplayValue('Original Climb remix')).toBeTruthy();
   });
 
   it('initialises the climb name input as empty when forkName is absent', () => {

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -339,13 +339,13 @@ export default function CreateClimbForm({
   } | null>(null);
   const [showDuplicateMatchDrawer, setShowDuplicateMatchDrawer] = useState(false);
 
-  // Common state — in edit mode use the original name, not "{name} fork"
+  // Common state — in edit mode use the original name, not "{name} remix"
   const isEditMode = !!editClimb;
   let initialClimbName: string;
   if (isEditMode) {
     initialClimbName = forkName || '';
   } else if (forkName) {
-    initialClimbName = `${forkName} fork`;
+    initialClimbName = `${forkName} remix`;
   } else {
     initialClimbName = '';
   }


### PR DESCRIPTION
## What changed

- Added an Add to playlist row to the React Native climb actions sheet and wired it to the existing add-to-playlist sheet.
- Removed the Report action from the mobile climb actions sheet.
- Renamed visible climb remix copy from fork language and changed duplicated climb names from `Original fork` to `Original remix` in mobile and web create flows.
- Updated focused tests and the mobile play-view roadmap note.

## Impact

Mobile users can add a climb to a playlist from the same actions sheet used for queue, favorite, tick, remix, and copy-link actions. Report is no longer offered there. Remix naming is now consistent across the visible action copy and seeded duplicate climb names.

## Validation

- `vp test run --project mobile --reporter=agent packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx`
- `vp test run --project web --reporter=agent packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx`
- `vp run typecheck:mobile`
- `vp run typecheck:web`
- Path-scoped `vp lint` on changed files

`vp check` format passed, but the full command failed on existing unrelated repo-wide lint/type findings and a Vite+ stdout panic; none of the reported files were part of this change.