### PR TITLE
[codex] Rebase Liquid Glass review fixes on main

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -322,12 +322,13 @@ lightbulb:       { ios: 'lightbulb',       android: 'lightbulb-on-outline' },
 Filled/outline pairs follow the `name` / `name.fill` convention (e.g. `boards` / `boards.fill`). A
 typo'd SF Symbol fails `vp run typecheck:mobile`.
 
-**Liquid Glass chrome icon colour.** Bottom tabs, floating glass toolbars, glass header controls and
+**Liquid Glass chrome icon colour.** Bottom tabs, neutral glass header controls and ordinary
 action-sheet row icons should use adaptive neutral glyphs: `systemColors.label` for selected or
 primary actions, `systemColors.secondaryLabel` for inactive actions. Carry state with icon shape,
 labels, badges, filled surfaces or selection affordances before reaching for brand colour. Keep
 semantic colour for cases where colour is the content: destructive actions, warnings/errors, success
-status summaries, grade colours, chart series and filled primary buttons.
+status summaries, connected-light state, grade colours, chart series, filled primary buttons and
+glass controls floating over coloured/photo content where white is required for contrast.
 
 ---
 

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -10,7 +10,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 // exposes the present/dismiss it would call through the forwarded ref.
 const modal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
-const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material', canUpdate: false }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -49,7 +49,7 @@ vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock('expo-clipboard', () => ({ setStringAsync: vi.fn() }));
 vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn() }));
 vi.mock('@boardsesh/play-view', () => ({ buildClimbViewPath: () => '/view/x' }));
-vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => false }));
+vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => ctrl.canUpdate }));
 vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../providers/theme-provider', () => ({
@@ -74,6 +74,12 @@ const climb = {
   quality_average: '3.0',
 } as unknown as Climb;
 
+const ownerClimb = {
+  ...climb,
+  userId: 'user-1',
+  is_draft: true,
+} as unknown as Climb;
+
 const baseProps = {
   climb,
   boardName: 'kilter' as const,
@@ -89,6 +95,7 @@ beforeEach(() => {
   modal.dismiss.mockClear();
   preview.props = null;
   ctrl.variant = 'liquidGlass';
+  ctrl.canUpdate = false;
 });
 
 describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
@@ -135,11 +142,15 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
     });
   });
 
-  it('uses neutral adaptive icons for Liquid Glass action rows', () => {
+  it('uses neutral adaptive icons for ordinary Liquid Glass action rows', () => {
+    ctrl.canUpdate = true;
     const { container } = render(
       <ClimbActionsSheet
         visible={true}
         {...baseProps}
+        climb={ownerClimb}
+        boardName="tension"
+        currentUserId="user-1"
         onAddToQueue={vi.fn()}
         onOpenPlaylist={vi.fn()}
         onToggleFavorite={vi.fn()}
@@ -153,14 +164,20 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
     expect(container.querySelector('[data-icon="tick"]')?.getAttribute('data-color')).toBe('#fff');
     expect(container.querySelector('[data-icon="branch"]')?.getAttribute('data-color')).toBe('#fff');
     expect(container.querySelector('[data-icon="copy"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="edit"]')?.getAttribute('data-color')).toBe('#fff');
+    expect(container.querySelector('[data-icon="open.external"]')?.getAttribute('data-color')).toBe('#fff');
   });
 
   it('keeps Material action rows on their semantic/action colors', () => {
     ctrl.variant = 'material';
+    ctrl.canUpdate = true;
     const { container } = render(
       <ClimbActionsSheet
         visible={true}
         {...baseProps}
+        climb={ownerClimb}
+        boardName="tension"
+        currentUserId="user-1"
         onAddToQueue={vi.fn()}
         onOpenPlaylist={vi.fn()}
         onToggleFavorite={vi.fn()}
@@ -174,6 +191,8 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
     expect(container.querySelector('[data-icon="tick"]')?.getAttribute('data-color')).toBe('#0a0');
     expect(container.querySelector('[data-icon="branch"]')?.getAttribute('data-color')).toBe('#00f');
     expect(container.querySelector('[data-icon="copy"]')?.getAttribute('data-color')).toBe('#00f');
+    expect(container.querySelector('[data-icon="edit"]')?.getAttribute('data-color')).toBe('#00f');
+    expect(container.querySelector('[data-icon="open.external"]')?.getAttribute('data-color')).toBe('#00f');
   });
 
   it('shows add to playlist and removes report from the action list', () => {

--- a/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
@@ -29,15 +29,16 @@ type PlaylistEditDoneButtonProps = {
  */
 export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneButtonProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   const nativeGlass = useNativeGlass();
   const label = t('editClimbs.done');
+  const actionColor = variant === 'liquidGlass' ? systemColors.label : brandColors.primary;
 
   if (collapsed) {
     return (
       <GlassIconButton
         iconName="check.small"
-        iconColor={systemColors.label}
+        iconColor={actionColor}
         onPress={onPress}
         accessibilityLabel={label}
         fallbackColor={systemColors.fill}
@@ -69,8 +70,8 @@ export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneB
           style={StyleSheet.absoluteFill}
           pointerEvents="none"
         />
-        <Icon name="check.small" size={18} color={systemColors.label} />
-        <Text variant="subheadline" color={systemColors.label} style={styles.label}>
+        <Icon name="check.small" size={18} color={actionColor} />
+        <Text variant="subheadline" color={actionColor} style={styles.label}>
           {label}
         </Text>
       </View>

--- a/packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode, type Ref } from 'react';
+
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+const modal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+vi.mock('@gorhom/bottom-sheet', () => ({ BottomSheetModal: function BottomSheetModal() {} }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../ModalSheet', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    ModalSheet: React.forwardRef(({ children }: { children?: ReactNode }, ref: Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({ present: modal.present, dismiss: modal.dismiss }));
+      return React.createElement('div', { 'data-modal-sheet': 'true' }, children);
+    }),
+  };
+});
+vi.mock('../../ListRow', () => ({
+  ListRow: ({ title, leading }: { title: string; leading?: ReactNode }) =>
+    createElement('div', { 'data-row': title }, leading),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: unknown }) =>
+    createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    systemColors: { label: '#000', accent: '#007AFF' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemRed: '#FF3B30' } }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8 } }));
+
+import { PlaylistActionsMenu } from '../PlaylistActionsMenu';
+
+const baseProps = {
+  visible: true,
+  onTogglePin: vi.fn(),
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  ctrl.variant = 'liquidGlass';
+  modal.present.mockClear();
+  modal.dismiss.mockClear();
+});
+
+describe('PlaylistActionsMenu', () => {
+  it('uses neutral pin/edit icons and destructive delete in Liquid Glass', () => {
+    const { container } = render(<PlaylistActionsMenu {...baseProps} isPinned />);
+
+    expect(container.querySelector('[data-icon="pin.fill"]')?.getAttribute('data-color')).toBe('#000');
+    expect(container.querySelector('[data-icon="edit"]')?.getAttribute('data-color')).toBe('#000');
+    expect(container.querySelector('[data-icon="delete"]')?.getAttribute('data-color')).toBe('#FF3B30');
+  });
+
+  it('keeps Material pin/edit actions on primary/accent colors', () => {
+    ctrl.variant = 'material';
+    const { container, rerender } = render(<PlaylistActionsMenu {...baseProps} isPinned />);
+
+    expect(container.querySelector('[data-icon="pin.fill"]')?.getAttribute('data-color')).toBe('#6D28D9');
+    expect(container.querySelector('[data-icon="edit"]')?.getAttribute('data-color')).toBe('#007AFF');
+
+    rerender(<PlaylistActionsMenu {...baseProps} isPinned={false} />);
+    expect(container.querySelector('[data-icon="pin"]')?.getAttribute('data-color')).toBe('#007AFF');
+  });
+});

--- a/packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -9,7 +11,11 @@ vi.mock('react-native', () => ({
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { label: '#000', fill: '#eee', separator: '#ccc' } }),
+  useTheme: () => ({
+    variant: ctrl.variant,
+    systemColors: { label: '#000', fill: '#eee', separator: '#ccc' },
+    brandColors: { primary: '#6D28D9' },
+  }),
 }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} } }));
@@ -20,7 +26,8 @@ vi.mock('../../Icon', () => ({
     createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
 }));
 vi.mock('../../Text', () => ({
-  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  Text: ({ children, color }: { children?: ReactNode; color?: unknown }) =>
+    createElement('span', { 'data-text-color': typeof color === 'string' ? color : '' }, children),
 }));
 
 vi.mock('../../PressableSurface', () => ({
@@ -39,10 +46,15 @@ vi.mock('../../GlassIconButton', () => ({
 import { PlaylistEditDoneButton } from '../PlaylistEditDoneButton';
 
 describe('PlaylistEditDoneButton', () => {
+  beforeEach(() => {
+    ctrl.variant = 'liquidGlass';
+  });
+
   it('uses neutral glyph and label colors in expanded glass mode', () => {
     const { container } = render(<PlaylistEditDoneButton onPress={vi.fn()} />);
 
     expect(container.querySelector('[data-icon="check.small"]')?.getAttribute('data-color')).toBe('#000');
+    expect(container.querySelector('[data-text-color]')?.getAttribute('data-text-color')).toBe('#000');
     expect(container.textContent).toContain('editClimbs.done');
   });
 
@@ -50,5 +62,16 @@ describe('PlaylistEditDoneButton', () => {
     const { container } = render(<PlaylistEditDoneButton onPress={vi.fn()} collapsed />);
 
     expect(container.querySelector('[data-fab="true"]')?.getAttribute('data-icon-color')).toBe('#000');
+  });
+
+  it('keeps the Material Done affordance on primary color', () => {
+    ctrl.variant = 'material';
+    const { container, rerender } = render(<PlaylistEditDoneButton onPress={vi.fn()} />);
+
+    expect(container.querySelector('[data-icon="check.small"]')?.getAttribute('data-color')).toBe('#6D28D9');
+    expect(container.querySelector('[data-text-color]')?.getAttribute('data-text-color')).toBe('#6D28D9');
+
+    rerender(<PlaylistEditDoneButton onPress={vi.fn()} collapsed />);
+    expect(container.querySelector('[data-fab="true"]')?.getAttribute('data-icon-color')).toBe('#6D28D9');
   });
 });

--- a/packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx
@@ -21,7 +21,8 @@ vi.mock('react-native-gesture-handler', () => ({
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../Text', () => ({
-  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  Text: ({ children, color }: { children?: ReactNode; color?: unknown }) =>
+    createElement('span', { 'data-text-color': typeof color === 'string' ? color : '' }, children),
 }));
 vi.mock('../../Icon', () => ({
   Icon: ({ name, color }: { name: string; color?: unknown }) =>
@@ -62,10 +63,11 @@ describe('SessionScreenHeader', () => {
 
   it('docks the share control (calling onShare) when onShare is provided', () => {
     const onShare = vi.fn();
-    const { container } = render(<SessionScreenHeader sessionActive onShare={onShare} />);
+    const { container } = render(<SessionScreenHeader sessionActive onShare={onShare} inviteHint />);
     const share = container.querySelector(SHARE) as HTMLButtonElement | null;
     expect(share).not.toBeNull();
     expect(share?.querySelector('[data-icon="share"]')?.getAttribute('data-color')).toBe('#000');
+    expect(share?.querySelector('[data-text-color]')?.getAttribute('data-text-color')).toBe('#000');
     share!.click();
     expect(onShare).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

- Rebases the Liquid Glass review fixes directly onto latest `main` after the stacked follow-up PR merged into its old base.
- Keeps the HIG-style Liquid Glass guidance focused on neutral chrome, while preserving explicit color exceptions like connected light state, warnings, grade colors, and charts.
- Preserves Material's primary Done affordance, keeps Liquid Glass Done neutral, and adds coverage for climb action, playlist action, and session header icon colors.

## Validation

- `vp check docs/ai-design-guidelines.md packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx`
- `vp test --project mobile packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx`
- `vp run typecheck:mobile`