### PR TITLE
[codex] Mobile user drawer

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -14,12 +14,10 @@ import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
 import { Icon } from '../../../src/components/Icon';
 import { Text } from '../../../src/components/Text';
 import { ListRow } from '../../../src/components/ListRow';
-import { SwitchRow } from '../../../src/components/SwitchRow';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { HoldColorAccessibilitySection } from '../../../src/components/settings/HoldColorAccessibilitySection';
-import { useSessionRecordingPreference } from '../../../src/lib/session-recording-preference';
-import { setSessionRecordingEnabled } from '../../../src/lib/analytics';
+import { SessionRecordingSwitchRow } from '../../../src/components/settings/SessionRecordingSwitchRow';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
@@ -38,8 +36,6 @@ export default function MoreScreen() {
   const { gradeFormat, setGradeFormat } = useGradeFormat();
   const glassCapable = useGlassCapability();
   const { localePreference, setLocalePreference } = useLocalePreference();
-  const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
-    useSessionRecordingPreference();
   const { showToast } = useToast();
 
   // 'System' follows the device language; the rest are the supported locales,
@@ -195,16 +191,9 @@ export default function MoreScreen() {
       <View style={styles.section}>
         <SectionHeader title={t('mobile.more.diagnostics.title')} />
         <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <SwitchRow
+          <SessionRecordingSwitchRow
             label={t('mobile.more.diagnostics.recording')}
             description={t('mobile.more.diagnostics.recordingDescription')}
-            value={sessionRecordingEnabled}
-            onValueChange={(next) => {
-              // Persist the choice and apply it live: start/stop the PostHog
-              // recording immediately rather than waiting for the next launch.
-              setSessionRecordingPreference(next);
-              setSessionRecordingEnabled(next);
-            }}
           />
         </View>
       </View>

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -38,6 +38,7 @@ import { PlaylistsAdapterWrapper } from '../src/providers/playlists-adapter';
 import { BoardProvider } from '@boardsesh/board-react';
 import { toBoardName } from '@boardsesh/board-config';
 import { PersistentQueueBar } from '../src/components/queue-control/persistent-queue-bar';
+import { UserDrawerProvider } from '../src/components/user-drawer/UserDrawerProvider';
 import { useMobileClimbActionsData } from '../src/lib/graphql/hooks';
 import { useActiveBoard } from '../src/lib/graphql/use-active-board';
 import { Text } from '../src/components/Text';
@@ -267,50 +268,52 @@ function RootLayout() {
                                               <DeepLinkProvider>
                                                 <ShareTargetProvider>
                                                   <TabBarHeightProvider>
-                                                    <ThemedNavigation>
-                                                      <Stack
-                                                        screenOptions={{ headerShown: false }}
-                                                        initialRouteName="index"
-                                                      >
-                                                        <Stack.Screen name="index" />
-                                                        <Stack.Screen name="(tabs)" />
-                                                        <Stack.Screen
-                                                          name="auth"
-                                                          options={{ headerShown: false, gestureEnabled: false }}
-                                                        />
-                                                        <Stack.Screen name="session/[sessionId]" />
-                                                        <Stack.Screen
-                                                          name="join/[sessionId]"
-                                                          options={{ presentation: 'modal', headerShown: false }}
-                                                        />
-                                                        <Stack.Screen
-                                                          name="share-beta"
-                                                          options={{ presentation: 'modal', headerShown: false }}
-                                                        />
-                                                        {/* Board selection is a modal off the Climbs capsule /
+                                                    <UserDrawerProvider>
+                                                      <ThemedNavigation>
+                                                        <Stack
+                                                          screenOptions={{ headerShown: false }}
+                                                          initialRouteName="index"
+                                                        >
+                                                          <Stack.Screen name="index" />
+                                                          <Stack.Screen name="(tabs)" />
+                                                          <Stack.Screen
+                                                            name="auth"
+                                                            options={{ headerShown: false, gestureEnabled: false }}
+                                                          />
+                                                          <Stack.Screen name="session/[sessionId]" />
+                                                          <Stack.Screen
+                                                            name="join/[sessionId]"
+                                                            options={{ presentation: 'modal', headerShown: false }}
+                                                          />
+                                                          <Stack.Screen
+                                                            name="share-beta"
+                                                            options={{ presentation: 'modal', headerShown: false }}
+                                                          />
+                                                          {/* Board selection is a modal off the Climbs capsule /
                                                       no-board CTA — board switching is rare, so it doesn't
                                                       earn a tab. Its own _layout owns the headers. */}
-                                                        <Stack.Screen
-                                                          name="boards"
-                                                          options={{ presentation: 'modal', headerShown: false }}
-                                                        />
-                                                        {/* First-run welcome walkthrough. Full-screen cover
+                                                          <Stack.Screen
+                                                            name="boards"
+                                                            options={{ presentation: 'modal', headerShown: false }}
+                                                          />
+                                                          {/* First-run welcome walkthrough. Full-screen cover
                                                       over the Climbs tab; gesture disabled so the user
                                                       leaves only via Skip / finish / the final CTA, never
                                                       an accidental swipe-dismiss. */}
-                                                        <Stack.Screen
-                                                          name="onboarding"
-                                                          options={{
-                                                            presentation: 'fullScreenModal',
-                                                            headerShown: false,
-                                                            gestureEnabled: false,
-                                                            animation: 'fade',
-                                                          }}
-                                                        />
-                                                      </Stack>
-                                                    </ThemedNavigation>
-                                                    <PersistentQueueBar />
-                                                    <OnboardingGate ready={authReady && fontsReady} />
+                                                          <Stack.Screen
+                                                            name="onboarding"
+                                                            options={{
+                                                              presentation: 'fullScreenModal',
+                                                              headerShown: false,
+                                                              gestureEnabled: false,
+                                                              animation: 'fade',
+                                                            }}
+                                                          />
+                                                        </Stack>
+                                                      </ThemedNavigation>
+                                                      <PersistentQueueBar />
+                                                      <OnboardingGate ready={authReady && fontsReady} />
+                                                    </UserDrawerProvider>
                                                   </TabBarHeightProvider>
                                                   <AnalyticsScreenTracker />
                                                 </ShareTargetProvider>

--- a/packages/mobile/app/about.tsx
+++ b/packages/mobile/app/about.tsx
@@ -1,0 +1,170 @@
+import { Stack } from 'expo-router';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '../src/components/Icon';
+import { SectionHeader } from '../src/components/SectionHeader';
+import { Text } from '../src/components/Text';
+import { useTheme } from '../src/providers/theme-provider';
+import { borderRadius, spacing } from '../src/theme/tokens';
+import type { IconName } from '../src/components/icon-map';
+
+type AboutCard = {
+  icon: IconName;
+  title: string;
+  body: string;
+};
+
+export default function AboutScreen() {
+  const { t } = useTranslation('common');
+  const { systemColors, brandColors } = useTheme();
+  const cards: AboutCard[] = [
+    {
+      icon: 'lightbulb',
+      title: t('mobile.about.whatItDoesTitle'),
+      body: t('mobile.about.whatItDoesBody'),
+    },
+    {
+      icon: 'boards',
+      title: t('mobile.about.boardsTitle'),
+      body: t('mobile.about.boardsBody'),
+    },
+    {
+      icon: 'people',
+      title: t('mobile.about.openTitle'),
+      body: t('mobile.about.openBody'),
+    },
+  ];
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: t('mobile.about.title'),
+          headerShown: true,
+          headerLargeTitle: false,
+          headerTransparent: Platform.OS === 'ios',
+          headerBlurEffect: 'systemMaterial',
+          contentStyle: { backgroundColor: 'transparent' },
+        }}
+      />
+      <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container}>
+        <View style={[styles.hero, { backgroundColor: systemColors.secondaryBackground }]}>
+          <View style={[styles.heroIcon, { backgroundColor: brandColors.primaryFill }]}>
+            <Icon name="boards.fill" size={32} color={brandColors.onPrimary} />
+          </View>
+          <Text variant="title1" style={styles.heroTitle}>
+            {t('mobile.about.heroTitle')}
+          </Text>
+          <Text variant="body" color={systemColors.secondaryLabel} style={styles.heroBody}>
+            {t('mobile.about.heroBody')}
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <SectionHeader title={t('mobile.about.sectionTitle')} />
+          <View style={styles.cardStack}>
+            {cards.map((card) => (
+              <View key={card.title} style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
+                <View style={[styles.cardIcon, { backgroundColor: systemColors.fill }]}>
+                  <Icon name={card.icon} size={22} color={systemColors.accent} />
+                </View>
+                <View style={styles.cardText}>
+                  <Text variant="headline" style={styles.cardTitle}>
+                    {card.title}
+                  </Text>
+                  <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.cardBody}>
+                    {card.body}
+                  </Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={[styles.notice, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Text variant="headline" style={styles.noticeTitle}>
+            {t('mobile.about.independentTitle')}
+          </Text>
+          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.noticeBody}>
+            {t('mobile.about.independentBody')}
+          </Text>
+        </View>
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[8],
+    gap: spacing[6],
+  },
+  hero: {
+    alignItems: 'center',
+    borderRadius: borderRadius.xl,
+    paddingHorizontal: spacing[5],
+    paddingVertical: spacing[8],
+  },
+  heroIcon: {
+    width: 64,
+    height: 64,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: borderRadius.full,
+    marginBottom: spacing[4],
+  },
+  heroTitle: {
+    textAlign: 'center',
+    fontWeight: '800',
+  },
+  heroBody: {
+    marginTop: spacing[3],
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  section: {
+    gap: spacing[2],
+  },
+  cardStack: {
+    gap: spacing[3],
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    gap: spacing[3],
+  },
+  cardIcon: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: borderRadius.full,
+  },
+  cardText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  cardTitle: {
+    fontWeight: '700',
+  },
+  cardBody: {
+    marginTop: spacing[1],
+    lineHeight: 20,
+  },
+  notice: {
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+  },
+  noticeTitle: {
+    fontWeight: '700',
+  },
+  noticeBody: {
+    marginTop: spacing[2],
+    lineHeight: 20,
+  },
+});

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -29,8 +29,9 @@ export default function BoardSelection() {
   const { isAuthenticated, refreshAuthState } = useAuth();
   const bottomChrome = useBottomChromeMetrics();
   const router = useRouter();
-  const { returnTo } = useLocalSearchParams<{ returnTo?: string }>();
+  const { returnTo, focus } = useLocalSearchParams<{ returnTo?: string; focus?: string }>();
   const boardReturnTo = resolveBoardReturnTo(returnTo);
+  const shouldFocusMyBoards = focus === 'myBoards';
   const { t } = useTranslation('boards');
   const { showToast } = useToast();
 
@@ -127,6 +128,18 @@ export default function BoardSelection() {
     },
     [myBoards, nearby?.boards, activateBoard, showToast, t],
   );
+  const nearbySection =
+    nearbyItems.length > 0 ? (
+      <Section title={t('mobile.discovery.nearbyTitle')}>
+        <BoardCarousel items={nearbyItems} onSelect={onSelectMyBoard} />
+      </Section>
+    ) : null;
+  const myBoardsSection =
+    myBoardItems.length > 0 ? (
+      <Section title={t('mobile.discovery.yourBoardsTitle')}>
+        <BoardCarousel items={myBoardItems} onSelect={onSelectMyBoard} />
+      </Section>
+    ) : null;
 
   const requestLocation = location.request;
   const onModeFindNearby = useCallback(() => {
@@ -254,17 +267,8 @@ export default function BoardSelection() {
           />
         </View>
 
-        {nearbyItems.length > 0 ? (
-          <Section title={t('mobile.discovery.nearbyTitle')}>
-            <BoardCarousel items={nearbyItems} onSelect={onSelectMyBoard} />
-          </Section>
-        ) : null}
-
-        {myBoardItems.length > 0 ? (
-          <Section title={t('mobile.discovery.yourBoardsTitle')}>
-            <BoardCarousel items={myBoardItems} onSelect={onSelectMyBoard} />
-          </Section>
-        ) : null}
+        {shouldFocusMyBoards ? myBoardsSection : nearbySection}
+        {shouldFocusMyBoards ? nearbySection : myBoardsSection}
 
         {popularItems.length > 0 ? (
           <Section title={t('mobile.discovery.popularTitle')}>

--- a/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
@@ -13,6 +13,7 @@ import { GlassActionToolbar, GlassToolbarAction, TOP_ACTION_SIZE } from './Glass
 import { AngleToolbarAction } from './AngleToolbarAction';
 import { LightbulbToolbarAction } from './LightbulbToolbarAction';
 import { CollapsingLargeTitleHeader, useCollapseProgress } from './CollapsingLargeTitleHeader';
+import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 
 const TOP_TOOLBAR_RADIUS = TOP_ACTION_SIZE / 2;
 
@@ -102,7 +103,7 @@ export function CollapsingTopChrome({
   // A fragment/element of leading actions reads as one element, so callers passing
   // several supply the explicit count; otherwise reserve a slot only for a real one.
   const leadingActions = leadingActionCount ?? (isValidElement(leadingAction) ? 1 : 0);
-  const leftActionCount = leadingActions + (canCreate ? 1 : 0) + (canOpenAngle ? 1 : 0);
+  const leftActionCount = 1 + leadingActions + (canCreate ? 1 : 0) + (canOpenAngle ? 1 : 0);
 
   // The right glass toolbar holds the lightbulb (and an optional trailing action)
   // at rest, and grows to also hold a compact board glyph once collapsed (board
@@ -126,18 +127,18 @@ export function CollapsingTopChrome({
     opacity: interpolate(progress.value, [0.55, 1], [0, 1], Extrapolation.CLAMP),
   }));
 
-  const leftActions =
-    leftActionCount > 0 ? (
-      <GlassActionToolbar actionCount={leftActionCount}>
-        {leadingAction}
-        {canCreate ? (
-          <GlassToolbarAction onPress={onCreate} accessibilityLabel={createAccessibilityLabel}>
-            <Icon name="plus" size={24} color={systemColors.label} />
-          </GlassToolbarAction>
-        ) : null}
-        <AngleToolbarAction />
-      </GlassActionToolbar>
-    ) : null;
+  const leftActions = (
+    <GlassActionToolbar actionCount={leftActionCount}>
+      <UserAvatarToolbarAction variant="glass" />
+      {leadingAction}
+      {canCreate ? (
+        <GlassToolbarAction onPress={onCreate} accessibilityLabel={createAccessibilityLabel}>
+          <Icon name="plus" size={24} color={systemColors.label} />
+        </GlassToolbarAction>
+      ) : null}
+      <AngleToolbarAction />
+    </GlassActionToolbar>
+  );
 
   // Right glass toolbar: lightbulb (+ trailing action) at rest, widening to dock
   // the board glyph once collapsed. The glass surface stays at full opacity (its

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
@@ -106,6 +106,10 @@ vi.mock('../../play-drawer/AngleSelectorSheet', () => ({
   AngleSelectorSheet: ({ visible }: { visible: boolean }) =>
     visible ? createElement('div', { 'data-angle-selector': 'true' }) : null,
 }));
+vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
+  UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) =>
+    createElement('button', { 'data-pressable': 'ariaLabels.userMenu', 'data-avatar-variant': variant }),
+}));
 
 import { CollapsingTopChrome } from '../CollapsingTopChrome';
 

--- a/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
@@ -106,6 +106,10 @@ vi.mock('../../play-drawer/AngleSelectorSheet', () => ({
   AngleSelectorSheet: ({ visible }: { visible: boolean }) =>
     visible ? createElement('div', { 'data-angle-selector': 'true' }) : null,
 }));
+vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
+  UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) =>
+    createElement('button', { 'data-pressable': 'ariaLabels.userMenu', 'data-avatar-variant': variant }),
+}));
 
 import { DiscoverTopChrome } from '../DiscoverTopChrome';
 

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -19,7 +19,6 @@ export const iconMap = {
   settings: { ios: 'gearshape', android: 'cog-outline' },
   'settings.fill': { ios: 'gearshape.fill', android: 'cog' },
   server: { ios: 'server.rack', android: 'server-network' },
-  help: { ios: 'questionmark.circle', android: 'help-circle-outline' },
   logout: { ios: 'rectangle.portrait.and.arrow.right', android: 'logout' },
 
   // Navigation

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -19,6 +19,8 @@ export const iconMap = {
   settings: { ios: 'gearshape', android: 'cog-outline' },
   'settings.fill': { ios: 'gearshape.fill', android: 'cog' },
   server: { ios: 'server.rack', android: 'server-network' },
+  help: { ios: 'questionmark.circle', android: 'help-circle-outline' },
+  logout: { ios: 'rectangle.portrait.and.arrow.right', android: 'logout' },
 
   // Navigation
   'chevron.right': { ios: 'chevron.right', android: 'chevron-right' },

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -26,6 +26,7 @@ import { iconMap } from '../icon-map';
 import { BoardSwitcherButton, CollapsingTopChrome, TOP_ACTION_SIZE } from '../chrome';
 import { GradeRangeRail } from '../grade';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
+import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 import { FilterButton } from './FilterButton';
 import { GradeFilterControl } from './GradeFilterControl';
 
@@ -150,6 +151,7 @@ export function ClimbTopChrome({
           elevated
           style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
         >
+          <UserAvatarToolbarAction variant="material" />
           <BoardSwitcherButton onPress={onOpenBoardDetail} accessibilityHint={t('mobile.search.boardSwitcherHint')} />
           {canCreate ? (
             <Appbar.Action

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -312,6 +312,14 @@ vi.mock('../../play-drawer/AngleSelectorSheet', () => ({
         )
       : null,
 }));
+vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
+  UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) =>
+    createElement('button', {
+      'data-pressable': variant === 'glass' ? 'ariaLabels.userMenu' : undefined,
+      'data-appbar-action': variant === 'material' ? 'ariaLabels.userMenu' : undefined,
+      'data-avatar-variant': variant,
+    }),
+}));
 
 import { ClimbTopChrome } from '../ClimbTopChrome';
 

--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -9,6 +9,7 @@ import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { PressableSurface } from '../PressableSurface';
 import { iconMap } from '../icon-map';
+import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
 
@@ -94,6 +95,7 @@ export function RecordTopChrome({
         >
           {/* Invite/share docks on the LEFT (leading) while a session is live; the
               destructive Stop sits on the right. */}
+          <UserAvatarToolbarAction variant="material" />
           {onShare ? (
             <Appbar.Action
               icon={iconMap['person.badge.plus'].android}

--- a/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
@@ -97,6 +97,18 @@ vi.mock('../../PressableSurface', () => ({
   }) => createElement('button', { onClick: onPress, 'data-pressable': accessibilityLabel ?? '' }, children),
 }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 3: 12 } }));
+vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
+  UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) => {
+    if (variant === 'material') {
+      appbar.actions.push('ariaLabels.userMenu');
+    }
+    return createElement('button', {
+      'data-action': variant === 'glass' ? 'ariaLabels.userMenu' : undefined,
+      'data-appbar-action': variant === 'material' ? 'ariaLabels.userMenu' : undefined,
+      'data-avatar-variant': variant,
+    });
+  },
+}));
 
 import { RecordTopChrome } from '../RecordTopChrome';
 

--- a/packages/mobile/src/components/settings/SessionRecordingSwitchRow.tsx
+++ b/packages/mobile/src/components/settings/SessionRecordingSwitchRow.tsx
@@ -1,0 +1,27 @@
+import { SwitchRow } from '../SwitchRow';
+import { setSessionRecordingEnabled } from '../../lib/analytics';
+import { useSessionRecordingPreference } from '../../lib/session-recording-preference';
+
+type SessionRecordingSwitchRowProps = {
+  label: string;
+  description: string;
+};
+
+export function SessionRecordingSwitchRow({ label, description }: SessionRecordingSwitchRowProps) {
+  const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
+    useSessionRecordingPreference();
+
+  return (
+    <SwitchRow
+      label={label}
+      description={description}
+      value={sessionRecordingEnabled}
+      onValueChange={(next) => {
+        // Persist the choice and apply it live: start/stop the PostHog
+        // recording immediately rather than waiting for the next launch.
+        setSessionRecordingPreference(next);
+        setSessionRecordingEnabled(next);
+      }}
+    />
+  );
+}

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState, type RefObject } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { BottomSheetModal, BottomSheetTextInput } from '@gorhom/bottom-sheet';
+import { useTranslation } from 'react-i18next';
+import { ModalSheet } from '../ModalSheet';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { PressableSurface } from '../PressableSurface';
+import { SessionRecordingSwitchRow } from '../settings/SessionRecordingSwitchRow';
+import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useSubmitMobileAppFeedback } from '../../lib/feedback/use-submit-app-feedback';
+
+export type FeedbackSheetMode = 'rating' | 'bug';
+
+const BUG_COMMENT_MIN_LENGTH = 10;
+const COMMENT_MAX_LENGTH = 2000;
+const STAR_RATING_VALUES = [1, 2, 3, 4, 5] as const;
+
+type FeedbackSheetProps = {
+  sheetRef: RefObject<BottomSheetModal | null>;
+  mode: FeedbackSheetMode;
+};
+
+export function FeedbackSheet({ sheetRef, mode }: FeedbackSheetProps) {
+  const { t } = useTranslation('settings');
+  const { systemColors, brandColors } = useTheme();
+  const { showToast } = useToast();
+  const { mutateAsync, isPending, reset } = useSubmitMobileAppFeedback();
+  const [selectedRating, setSelectedRating] = useState<number | null>(null);
+  const [comment, setComment] = useState('');
+
+  const isBugReport = mode === 'bug';
+  const trimmedComment = comment.trim();
+  const remainingBugChars = Math.max(0, BUG_COMMENT_MIN_LENGTH - trimmedComment.length);
+  const canSubmit = isBugReport ? remainingBugChars === 0 : selectedRating !== null;
+  const title = isBugReport ? t('feedbackDialog.titleBug') : t('feedbackDialog.titleRating');
+  const submitLabel = isBugReport ? t('feedbackDialog.submitBug') : t('feedbackDialog.submitRating');
+  const inputPlaceholder = isBugReport ? t('feedbackForm.bugPlaceholder') : t('feedbackForm.ratingPlaceholder');
+
+  useEffect(() => {
+    setSelectedRating(null);
+    setComment('');
+    reset();
+  }, [mode, reset]);
+
+  const snapPoints = useMemo(() => (isBugReport ? ['54%', '82%'] : ['44%', '72%']), [isBugReport]);
+
+  const handleDismiss = () => {
+    sheetRef.current?.dismiss();
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit || isPending) return;
+
+    try {
+      await mutateAsync({
+        source: isBugReport ? 'drawer-bug' : 'drawer-feedback',
+        rating: isBugReport ? null : selectedRating,
+        comment: trimmedComment.length > 0 ? trimmedComment : null,
+      });
+      sheetRef.current?.dismiss();
+      showToast(isBugReport ? t('feedbackDialog.successBug') : t('feedbackDialog.successRating'), 'success');
+      setSelectedRating(null);
+      setComment('');
+    } catch {
+      showToast(t('feedbackDialog.errorRating'), 'error');
+    }
+  };
+
+  return (
+    <ModalSheet ref={sheetRef} snapPoints={snapPoints} scrollable contentContainerStyle={styles.content} glass={false}>
+      <View style={styles.headerRow}>
+        <Text variant="title3" style={styles.title}>
+          {title}
+        </Text>
+        <PressableSurface
+          onPress={handleDismiss}
+          feedback="opacity"
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('feedbackDialog.closeAria')}
+          style={styles.closeButton}
+        >
+          <Icon name="close" size={20} color={systemColors.secondaryLabel} />
+        </PressableSurface>
+      </View>
+
+      {!isBugReport ? (
+        <View style={styles.starRow}>
+          {STAR_RATING_VALUES.map((starRating) => {
+            const selected = selectedRating !== null && starRating <= selectedRating;
+            return (
+              <PressableSurface
+                key={starRating}
+                onPress={() => setSelectedRating(starRating)}
+                feedback="scale"
+                hitSlop={6}
+                accessibilityRole="button"
+                accessibilityLabel={t('feedbackForm.starRating', { count: starRating })}
+                accessibilityState={{ selected }}
+                style={styles.starButton}
+              >
+                <Icon name={selected ? 'star.fill' : 'star'} size={34} color={brandColors.warning} />
+              </PressableSurface>
+            );
+          })}
+        </View>
+      ) : null}
+
+      <BottomSheetTextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: systemColors.fill,
+            borderColor: systemColors.separator,
+            color: systemColors.label,
+          },
+        ]}
+        placeholder={inputPlaceholder}
+        placeholderTextColor={systemColors.tertiaryLabel}
+        value={comment}
+        onChangeText={setComment}
+        multiline
+        maxLength={COMMENT_MAX_LENGTH}
+        textAlignVertical="top"
+      />
+
+      {isBugReport && remainingBugChars > 0 ? (
+        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.helperText}>
+          {t('feedbackForm.remainingChars', { count: remainingBugChars })}
+        </Text>
+      ) : null}
+
+      {isBugReport ? (
+        <View style={[styles.recordingCard, { backgroundColor: systemColors.secondaryBackground }]}>
+          <SessionRecordingSwitchRow
+            label={t('feedbackForm.sessionRecordingLabel')}
+            description={t('feedbackForm.sessionRecordingDescription')}
+          />
+        </View>
+      ) : null}
+
+      <Button
+        title={submitLabel}
+        onPress={() => {
+          void handleSubmit();
+        }}
+        variant="filled"
+        size="large"
+        disabled={!canSubmit}
+        loading={isPending}
+        style={styles.submitButton}
+      />
+    </ModalSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[6],
+    gap: spacing[4],
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing[3],
+  },
+  title: {
+    flex: 1,
+    fontWeight: '700',
+  },
+  closeButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  starRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: spacing[2],
+  },
+  starButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  input: {
+    minHeight: 116,
+    maxHeight: 220,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    fontSize: 16,
+  },
+  helperText: {
+    marginTop: -spacing[2],
+  },
+  recordingCard: {
+    overflow: 'hidden',
+    borderRadius: borderRadius.lg,
+  },
+  submitButton: {
+    marginTop: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/user-drawer/UserAvatarToolbarAction.tsx
+++ b/packages/mobile/src/components/user-drawer/UserAvatarToolbarAction.tsx
@@ -1,0 +1,54 @@
+import { StyleSheet, View } from 'react-native';
+import { Appbar } from 'react-native-paper';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../../providers/theme-provider';
+import { useProfile } from '../../lib/graphql/hooks';
+import { Avatar } from '../Avatar';
+import { GlassToolbarAction, TOP_ACTION_SIZE } from '../chrome/GlassActionToolbar';
+import { useUserDrawer } from './UserDrawerProvider';
+
+const GLASS_AVATAR_SIZE = 34;
+const MATERIAL_AVATAR_SIZE = 32;
+
+type UserAvatarToolbarActionProps = {
+  variant: 'glass' | 'material';
+};
+
+export function UserAvatarToolbarAction({ variant }: UserAvatarToolbarActionProps) {
+  const { t } = useTranslation('common');
+  const { systemColors } = useTheme();
+  const { openUserDrawer } = useUserDrawer();
+  const profileQuery = useProfile();
+  const profile = profileQuery.data;
+  const avatarName = profile?.displayName ?? profile?.email ?? null;
+  const accessibilityLabel = t('ariaLabels.userMenu');
+
+  if (variant === 'material') {
+    return (
+      <Appbar.Action
+        icon={() => <Avatar uri={profile?.avatarUrl} name={avatarName} size={MATERIAL_AVATAR_SIZE} />}
+        color={systemColors.label as string}
+        onPress={openUserDrawer}
+        accessibilityLabel={accessibilityLabel}
+      />
+    );
+  }
+
+  return (
+    <GlassToolbarAction onPress={openUserDrawer} accessibilityLabel={accessibilityLabel}>
+      <View style={[styles.glassAvatarFrame, { borderColor: systemColors.separator }]}>
+        <Avatar uri={profile?.avatarUrl} name={avatarName} size={GLASS_AVATAR_SIZE} />
+      </View>
+    </GlassToolbarAction>
+  );
+}
+
+const styles = StyleSheet.create({
+  glassAvatarFrame: {
+    width: TOP_ACTION_SIZE,
+    height: TOP_ACTION_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -2,11 +2,9 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { Modal, Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
 import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { router, useSegments } from 'expo-router';
-import * as WebBrowser from 'expo-web-browser';
 import type { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
-import { WEB_BASE_URL } from '../../lib/env';
 import { reportError } from '../../lib/error-reporting';
 import { useProfile } from '../../lib/graphql/hooks';
 import { useAuth } from '../../providers/auth-provider';
@@ -118,13 +116,10 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     router.push('/(tabs)/discover/all');
   }, [closeUserDrawer]);
 
-  const openExternalPage = useCallback(
-    (path: '/help' | '/about') => {
-      closeUserDrawer();
-      void WebBrowser.openBrowserAsync(`${WEB_BASE_URL}${path}`).catch(reportError);
-    },
-    [closeUserDrawer],
-  );
+  const openAbout = useCallback(() => {
+    closeUserDrawer();
+    router.push('/about');
+  }, [closeUserDrawer]);
 
   const openFeedback = useCallback(
     (mode: FeedbackSheetMode) => {
@@ -196,13 +191,7 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
               <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
                 <DrawerRow icon="settings" title={t('ariaLabels.settings')} onPress={openProfileSettings} />
                 <DrawerRow icon="playlist" title={t('userDrawer.myPlaylists')} onPress={openPlaylists} />
-                <DrawerRow icon="help" title={t('userDrawer.help')} onPress={() => openExternalPage('/help')} />
-                <DrawerRow
-                  icon="info"
-                  title={t('userDrawer.about')}
-                  onPress={() => openExternalPage('/about')}
-                  showSeparator={false}
-                />
+                <DrawerRow icon="info" title={t('userDrawer.about')} onPress={openAbout} showSeparator={false} />
               </View>
 
               <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -1,0 +1,301 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
+import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { router, useSegments } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { WEB_BASE_URL } from '../../lib/env';
+import { reportError } from '../../lib/error-reporting';
+import { useProfile } from '../../lib/graphql/hooks';
+import { useAuth } from '../../providers/auth-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing, borderRadius, shadows, overlays } from '../../theme/tokens';
+import type { IconName } from '../icon-map';
+import { Avatar } from '../Avatar';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { ListRow } from '../ListRow';
+import { FeedbackSheet, type FeedbackSheetMode } from './FeedbackSheet';
+
+type UserDrawerContextValue = {
+  openUserDrawer: () => void;
+  closeUserDrawer: () => void;
+};
+
+const UserDrawerContext = createContext<UserDrawerContextValue | null>(null);
+const DRAWER_MAX_WIDTH = 320;
+const DRAWER_SCREEN_FRACTION = 0.86;
+const DRAWER_ANIMATION_MS = 220;
+
+export function useUserDrawer(): UserDrawerContextValue {
+  const context = useContext(UserDrawerContext);
+  if (!context) throw new Error('useUserDrawer must be used within UserDrawerProvider');
+  return context;
+}
+
+function currentBoardReturnTo(segments: readonly string[]): '/(tabs)/discover' | '/(tabs)/climbs' {
+  return segments.includes('discover') ? '/(tabs)/discover' : '/(tabs)/climbs';
+}
+
+export function UserDrawerProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation('common');
+  const { systemColors, brandColors } = useTheme();
+  const { isAuthenticated, signOut } = useAuth();
+  const profileQuery = useProfile({ enabled: isAuthenticated });
+  const profile = profileQuery.data;
+  const segments = useSegments();
+  const insets = useSafeAreaInsets();
+  const windowDimensions = useWindowDimensions();
+  const drawerWidth = Math.min(DRAWER_MAX_WIDTH, windowDimensions.width * DRAWER_SCREEN_FRACTION);
+  const drawerProgress = useSharedValue(0);
+  const [drawerMounted, setDrawerMounted] = useState(false);
+  const feedbackSheetRef = useRef<BottomSheetModal>(null);
+  const [feedbackMode, setFeedbackMode] = useState<FeedbackSheetMode>('rating');
+  const [feedbackOpenNonce, setFeedbackOpenNonce] = useState(0);
+
+  const profileDisplayName = profile?.displayName ?? profile?.email ?? t('header.you');
+  const profileEmail = profile?.email ?? null;
+
+  const openUserDrawer = useCallback(() => {
+    setDrawerMounted(true);
+  }, []);
+
+  const closeUserDrawer = useCallback(() => {
+    drawerProgress.value = withTiming(
+      0,
+      {
+        duration: DRAWER_ANIMATION_MS,
+        easing: Easing.out(Easing.cubic),
+      },
+      (finished) => {
+        if (finished) runOnJS(setDrawerMounted)(false);
+      },
+    );
+  }, [drawerProgress]);
+
+  useEffect(() => {
+    if (!drawerMounted) return;
+    drawerProgress.value = withTiming(1, {
+      duration: DRAWER_ANIMATION_MS,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [drawerMounted, drawerProgress]);
+
+  useEffect(() => {
+    if (feedbackOpenNonce === 0) return;
+    feedbackSheetRef.current?.present();
+  }, [feedbackOpenNonce]);
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: drawerProgress.value,
+  }));
+
+  const drawerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: -drawerWidth + drawerWidth * drawerProgress.value }],
+  }));
+
+  const openBoards = useCallback(
+    (focus?: 'myBoards') => {
+      closeUserDrawer();
+      const returnTo = currentBoardReturnTo(segments);
+      router.push({
+        pathname: '/boards',
+        params: focus ? { returnTo, focus } : { returnTo },
+      });
+    },
+    [closeUserDrawer, segments],
+  );
+
+  const openProfileSettings = useCallback(() => {
+    closeUserDrawer();
+    router.push('/(tabs)/profile/more');
+  }, [closeUserDrawer]);
+
+  const openPlaylists = useCallback(() => {
+    closeUserDrawer();
+    router.push('/(tabs)/discover/all');
+  }, [closeUserDrawer]);
+
+  const openExternalPage = useCallback(
+    (path: '/help' | '/about') => {
+      closeUserDrawer();
+      void WebBrowser.openBrowserAsync(`${WEB_BASE_URL}${path}`).catch(reportError);
+    },
+    [closeUserDrawer],
+  );
+
+  const openFeedback = useCallback(
+    (mode: FeedbackSheetMode) => {
+      closeUserDrawer();
+      setFeedbackMode(mode);
+      setFeedbackOpenNonce((previousNonce) => previousNonce + 1);
+    },
+    [closeUserDrawer],
+  );
+
+  const handleSignOut = useCallback(() => {
+    closeUserDrawer();
+    void signOut('manual').catch(reportError);
+  }, [closeUserDrawer, signOut]);
+
+  const contextValue = useMemo(() => ({ openUserDrawer, closeUserDrawer }), [openUserDrawer, closeUserDrawer]);
+
+  return (
+    <UserDrawerContext.Provider value={contextValue}>
+      {children}
+      <Modal visible={drawerMounted} transparent animationType="none" onRequestClose={closeUserDrawer}>
+        <View style={styles.modalRoot}>
+          <Animated.View style={[styles.backdrop, { backgroundColor: overlays.scrim }, backdropStyle]}>
+            <Pressable
+              style={StyleSheet.absoluteFill}
+              onPress={closeUserDrawer}
+              accessibilityRole="button"
+              accessibilityLabel={t('ariaLabels.close')}
+            />
+          </Animated.View>
+          <Animated.View
+            style={[
+              styles.drawer,
+              {
+                width: drawerWidth,
+                paddingTop: insets.top + spacing[4],
+                paddingBottom: insets.bottom + spacing[4],
+                backgroundColor: systemColors.secondaryBackground,
+                borderRightColor: systemColors.separator,
+              },
+              shadows.lg,
+              drawerStyle,
+            ]}
+          >
+            <ScrollView
+              contentContainerStyle={styles.drawerContent}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            >
+              <View style={styles.profileHeader}>
+                <Avatar uri={profile?.avatarUrl} name={profileDisplayName} size={60} />
+                <View style={styles.profileText}>
+                  <Text variant="headline" numberOfLines={1} style={styles.profileName}>
+                    {profileDisplayName}
+                  </Text>
+                  {profileEmail ? (
+                    <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
+                      {profileEmail}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+
+              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+                <DrawerRow icon="boards" title={t('userDrawer.changeBoard')} onPress={() => openBoards()} />
+                <DrawerRow icon="boards.fill" title={t('myBoards.title')} onPress={() => openBoards('myBoards')} />
+              </View>
+
+              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+                <DrawerRow icon="settings" title={t('ariaLabels.settings')} onPress={openProfileSettings} />
+                <DrawerRow icon="playlist" title={t('userDrawer.myPlaylists')} onPress={openPlaylists} />
+                <DrawerRow icon="help" title={t('userDrawer.help')} onPress={() => openExternalPage('/help')} />
+                <DrawerRow
+                  icon="info"
+                  title={t('userDrawer.about')}
+                  onPress={() => openExternalPage('/about')}
+                  showSeparator={false}
+                />
+              </View>
+
+              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+                <DrawerRow icon="star" title={t('userDrawer.rateBoardsesh')} onPress={() => openFeedback('rating')} />
+                <DrawerRow
+                  icon="flag"
+                  title={t('userDrawer.reportBug')}
+                  onPress={() => openFeedback('bug')}
+                  showSeparator={false}
+                />
+              </View>
+
+              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+                <DrawerRow
+                  icon="logout"
+                  title={t('userDrawer.logout')}
+                  tintColor={brandColors.error}
+                  onPress={handleSignOut}
+                  showSeparator={false}
+                />
+              </View>
+            </ScrollView>
+          </Animated.View>
+        </View>
+      </Modal>
+      <FeedbackSheet sheetRef={feedbackSheetRef} mode={feedbackMode} />
+    </UserDrawerContext.Provider>
+  );
+}
+
+type DrawerRowProps = {
+  icon: IconName;
+  title: string;
+  onPress: () => void;
+  showSeparator?: boolean;
+  tintColor?: string;
+};
+
+function DrawerRow({ icon, title, onPress, showSeparator = true, tintColor }: DrawerRowProps) {
+  const { systemColors } = useTheme();
+  const iconColor = tintColor ?? systemColors.label;
+  return (
+    <ListRow
+      title={title}
+      leading={<Icon name={icon} size={22} color={iconColor} />}
+      showChevron
+      showSeparator={showSeparator}
+      separatorInset={16}
+      onPress={onPress}
+      accessibilityLabel={title}
+      style={styles.drawerRow}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  modalRoot: {
+    flex: 1,
+  },
+  backdrop: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  drawer: {
+    height: '100%',
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  drawerContent: {
+    paddingHorizontal: spacing[3],
+    gap: spacing[3],
+  },
+  profileHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[2],
+    paddingBottom: spacing[3],
+  },
+  profileText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  profileName: {
+    fontWeight: '700',
+  },
+  menuGroup: {
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  drawerRow: {
+    minHeight: 48,
+  },
+});

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -1,20 +1,19 @@
 // Top chrome for the Profile ("You") tab, routed by UI variant.
 //
 // Liquid Glass: the board-agnostic CollapsingLargeTitleHeader (no board pill —
-// unlike Climbs/Discover) with a settings-gear island on the left, an optional
+// unlike Climbs/Discover) with an account-avatar island on the left, an optional
 // filter island on the right (the Progress sub-tab only), and the
 // Progress/Sessions/Logbook segmented control (glass-track-wrapped) as its
 // below-row content.
 //
 // Material: an absolutely-positioned, onHeightChange-measured M3 small app bar
-// (mirroring ClimbTopChrome) — the dashboard title via Appbar.Content, settings
-// + (Progress-only) filter Appbar.Actions, and the MaterialTabs primary tabs as
+// (mirroring ClimbTopChrome) — the account avatar, dashboard title via
+// Appbar.Content, the Progress-only filter Appbar.Action, and the MaterialTabs primary tabs as
 // the app bar's bottom row.
 
 import { useCallback, useMemo } from 'react';
 import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { type SharedValue } from 'react-native-reanimated';
-import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Appbar } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -27,6 +26,7 @@ import { GlassSurface } from '../GlassSurface';
 import { SegmentedControl } from '../SegmentedControl';
 import { MaterialTabs } from '../navigation/MaterialTabs';
 import { CollapsingLargeTitleHeader, GlassActionToolbar, GlassToolbarAction } from '../chrome';
+import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 
 // The segmented control floats over the chrome's faded scrim with scrolling
 // content behind it, so it needs its own glass track to stay legible and to give
@@ -78,16 +78,11 @@ function ProfileTopChromeMaterial({
   onHeightChange,
 }: ProfileTopChromeProps) {
   const { t } = useTranslation('you');
-  const router = useRouter();
   const { systemColors, brandColors, m3 } = useTheme();
   const insets = useSafeAreaInsets();
 
   const dashboardTitle = t('metadata.dashboard.title');
   const tabOptions = useSegmentOptions();
-
-  const handleOpenSettings = useCallback(() => {
-    router.push('/(tabs)/profile/more');
-  }, [router]);
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
@@ -117,13 +112,8 @@ function ProfileTopChromeMaterial({
         elevated
         style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
       >
+        <UserAvatarToolbarAction variant="material" />
         <Appbar.Content title={dashboardTitle} color={systemColors.label as string} />
-        <Appbar.Action
-          icon={iconMap.settings.android}
-          color={systemColors.label as string}
-          onPress={handleOpenSettings}
-          accessibilityLabel={t('mobile.settings')}
-        />
         {activeTab === 'progress' ? (
           <Appbar.Action
             icon={iconMap.filter.android}
@@ -156,22 +146,15 @@ function ProfileTopChromeGlass({
   onHeightChange,
 }: ProfileTopChromeProps) {
   const { t } = useTranslation('you');
-  const router = useRouter();
   const { systemColors, brandColors } = useTheme();
   const nativeGlass = useNativeGlass();
 
   const dashboardTitle = t('metadata.dashboard.title');
   const segmentOptions = useSegmentOptions();
 
-  const handleOpenSettings = useCallback(() => {
-    router.push('/(tabs)/profile/more');
-  }, [router]);
-
   const leftActions = (
     <GlassActionToolbar actionCount={1}>
-      <GlassToolbarAction onPress={handleOpenSettings} accessibilityLabel={t('mobile.settings')}>
-        <Icon name="settings" size={22} color={systemColors.label} />
-      </GlassToolbarAction>
+      <UserAvatarToolbarAction variant="glass" />
     </GlassActionToolbar>
   );
 

--- a/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
@@ -7,7 +7,6 @@ import type { ProfileTabKey } from '../ProfileTopChrome';
 const ctrl = vi.hoisted(() => ({
   variant: 'glass' as 'glass' | 'material',
 }));
-const router = vi.hoisted(() => ({ push: vi.fn() }));
 // Captures the props the SegmentedControl receives so the test can assert its
 // option set / selected key / which variant branch rendered it.
 const segments = vi.hoisted(() => ({
@@ -36,7 +35,6 @@ vi.mock('react-native-reanimated', () => ({}));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
-vi.mock('expo-router', () => ({ useRouter: () => router }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
 vi.mock('../../../providers/theme-provider', () => ({
@@ -84,6 +82,10 @@ vi.mock('../../navigation/MaterialTabs', () => ({
     materialTabs.entries.push({ options, selectedKey, onSelect });
     return createElement('div', { 'data-material-tabs': 'true' });
   },
+}));
+vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
+  UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) =>
+    createElement('button', { 'data-action': 'ariaLabels.userMenu', 'data-avatar-variant': variant }),
 }));
 // Paper Appbar: render the title + actions so the material-branch cases can query
 // them via the accessibility label (mirroring the glass islands).
@@ -160,8 +162,8 @@ function makeProps(over: Partial<Parameters<typeof ProfileTopChrome>[0]> = {}) {
   };
 }
 
-const settingsAction = (root: HTMLElement) =>
-  root.querySelector('[data-action="mobile.settings"]') as HTMLButtonElement | null;
+const userMenuAction = (root: HTMLElement) =>
+  root.querySelector('[data-action="ariaLabels.userMenu"]') as HTMLButtonElement | null;
 const filterAction = (root: HTMLElement) =>
   root.querySelector('[data-action="mobile.filter.title"]') as HTMLButtonElement | null;
 const filterIcon = (root: HTMLElement) => root.querySelector('[data-icon="filter"]') as HTMLElement | null;
@@ -169,16 +171,14 @@ const filterIcon = (root: HTMLElement) => root.querySelector('[data-icon="filter
 describe('ProfileTopChrome', () => {
   beforeEach(() => {
     ctrl.variant = 'glass';
-    router.push.mockClear();
     segments.entries = [];
     materialTabs.entries = [];
   });
 
   describe('glass variant', () => {
-    it('pushes the settings route when the settings island is pressed', () => {
+    it('renders the avatar menu in the left island', () => {
       const { container } = render(<ProfileTopChrome {...makeProps()} />);
-      fireEvent.click(settingsAction(container)!);
-      expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/more');
+      expect(userMenuAction(container)?.getAttribute('data-avatar-variant')).toBe('glass');
     });
 
     it('renders the filter island only on the Progress sub-tab', () => {
@@ -250,10 +250,9 @@ describe('ProfileTopChrome', () => {
       expect(container.querySelector('[data-glass="true"]')).toBeNull();
     });
 
-    it('pushes the settings route from the settings Appbar.Action', () => {
+    it('renders the avatar menu before the dashboard title', () => {
       const { container } = render(<ProfileTopChrome {...makeProps()} />);
-      fireEvent.click(settingsAction(container)!);
-      expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/more');
+      expect(userMenuAction(container)?.getAttribute('data-avatar-variant')).toBe('material');
     });
 
     it('renders the filter Appbar.Action only on the Progress sub-tab', () => {

--- a/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
+++ b/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { buildMobileFeedbackEnrichment, clipFeedbackString } from '../feedback-enrichment';
+
+const activeBoard: UserBoard = {
+  uuid: 'board-uuid',
+  slug: 'home-board',
+  ownerId: 'user-1',
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 2,
+  setIds: '10,12',
+  name: 'Home board',
+  isPublic: true,
+  isUnlisted: false,
+  hideLocation: false,
+  isOwned: true,
+  angle: 40,
+  isAngleAdjustable: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  totalAscents: 0,
+  uniqueClimbers: 0,
+  followerCount: 0,
+  commentCount: 0,
+  isFollowedByMe: false,
+};
+
+const currentClimbQueueItem: ClimbQueueItem = {
+  uuid: 'queue-item-1',
+  climb: {
+    uuid: 'climb-uuid',
+    setter_username: 'setter',
+    name: 'Orbit',
+    frames: 'p1r12',
+    angle: 40,
+    ascensionist_count: 12,
+    difficulty: 'V6',
+    quality_average: '3.5',
+    stars: 4,
+    difficulty_error: '0.3',
+    benchmark_difficulty: null,
+  },
+};
+
+describe('buildMobileFeedbackEnrichment', () => {
+  it('derives board, climb, session, and route context', () => {
+    expect(
+      buildMobileFeedbackEnrichment({
+        activeBoard,
+        currentClimbQueueItem,
+        sessionId: 'session-1',
+        pathname: '/(tabs)/climbs',
+      }),
+    ).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: [10, 12],
+      angle: 40,
+      context: {
+        climbUuid: 'climb-uuid',
+        climbName: 'Orbit',
+        difficulty: 'V6',
+        sessionId: 'session-1',
+        url: '/(tabs)/climbs',
+      },
+    });
+  });
+
+  it('returns null board and context fields when no useful context exists', () => {
+    expect(
+      buildMobileFeedbackEnrichment({
+        activeBoard: null,
+        currentClimbQueueItem: null,
+        sessionId: null,
+        pathname: ' ',
+      }),
+    ).toEqual({
+      boardName: null,
+      layoutId: null,
+      sizeId: null,
+      setIds: null,
+      angle: null,
+      context: null,
+    });
+  });
+});
+
+describe('clipFeedbackString', () => {
+  it('trims empty values and clips long strings', () => {
+    expect(clipFeedbackString('   ', 10)).toBeUndefined();
+    expect(clipFeedbackString('abcdefghijkl', 5)).toBe('abcde');
+  });
+});

--- a/packages/mobile/src/lib/feedback/feedback-enrichment.ts
+++ b/packages/mobile/src/lib/feedback/feedback-enrichment.ts
@@ -1,0 +1,63 @@
+import type { FeedbackContextInput, SubmitAppFeedbackInput, UserBoard } from '@boardsesh/shared-schema';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+const BOARD_NAME_MAX = 100;
+const URL_MAX = 1000;
+
+type MobileFeedbackEnrichment = Pick<
+  SubmitAppFeedbackInput,
+  'boardName' | 'layoutId' | 'sizeId' | 'setIds' | 'angle' | 'context'
+>;
+
+export type BuildMobileFeedbackEnrichmentArgs = {
+  activeBoard: UserBoard | null | undefined;
+  currentClimbQueueItem: ClimbQueueItem | null;
+  sessionId: string | null;
+  pathname: string | null | undefined;
+};
+
+export function clipFeedbackString(value: string | null | undefined, maxLength: number): string | undefined {
+  if (!value) return undefined;
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) return undefined;
+  return trimmedValue.length > maxLength ? trimmedValue.slice(0, maxLength) : trimmedValue;
+}
+
+function compactFeedbackContext(input: FeedbackContextInput): FeedbackContextInput | null {
+  const context: FeedbackContextInput = {};
+  for (const [contextKey, contextValue] of Object.entries(input) as Array<[keyof FeedbackContextInput, unknown]>) {
+    if (typeof contextValue === 'string' && contextValue.length > 0) {
+      context[contextKey] = contextValue;
+    }
+  }
+  return Object.keys(context).length > 0 ? context : null;
+}
+
+function parseBoardSetIds(setIds: string | null | undefined): number[] | null {
+  if (!setIds) return null;
+  const parsedSetIds = setIds
+    .split(',')
+    .map((rawSetId) => Number.parseInt(rawSetId, 10))
+    .filter((setId) => Number.isFinite(setId));
+  return parsedSetIds.length > 0 ? parsedSetIds : null;
+}
+
+export function buildMobileFeedbackEnrichment(args: BuildMobileFeedbackEnrichmentArgs): MobileFeedbackEnrichment {
+  const currentClimb = args.currentClimbQueueItem?.climb;
+  const activeBoard = args.activeBoard ?? null;
+
+  return {
+    boardName: clipFeedbackString(activeBoard?.boardType, BOARD_NAME_MAX) ?? null,
+    layoutId: activeBoard?.layoutId ?? null,
+    sizeId: activeBoard?.sizeId ?? null,
+    setIds: parseBoardSetIds(activeBoard?.setIds),
+    angle: activeBoard?.angle ?? null,
+    context: compactFeedbackContext({
+      climbUuid: currentClimb?.uuid,
+      climbName: currentClimb?.name,
+      difficulty: currentClimb?.difficulty,
+      sessionId: args.sessionId,
+      url: clipFeedbackString(args.pathname, URL_MAX),
+    }),
+  };
+}

--- a/packages/mobile/src/lib/feedback/use-submit-app-feedback.ts
+++ b/packages/mobile/src/lib/feedback/use-submit-app-feedback.ts
@@ -1,0 +1,60 @@
+import { Platform } from 'react-native';
+import * as Application from 'expo-application';
+import { usePathname } from 'expo-router';
+import { useMutation } from '@tanstack/react-query';
+import {
+  SUBMIT_APP_FEEDBACK,
+  type SubmitAppFeedbackMutationResponse,
+  type SubmitAppFeedbackMutationVariables,
+} from '@boardsesh/graphql/operations';
+import type { SubmitAppFeedbackInput } from '@boardsesh/shared-schema';
+import { getHttpClient } from '../graphql/client';
+import { useActiveBoard } from '../graphql/use-active-board';
+import { useQueue, useQueueSessionId } from '../../providers/queue-provider';
+import { buildMobileFeedbackEnrichment } from './feedback-enrichment';
+
+export type MobileSubmitAppFeedbackPayload = Omit<
+  SubmitAppFeedbackInput,
+  'platform' | 'appVersion' | 'boardName' | 'layoutId' | 'sizeId' | 'setIds' | 'angle' | 'context'
+>;
+
+function getMobilePlatform(): SubmitAppFeedbackInput['platform'] {
+  return Platform.OS === 'android' ? 'android' : Platform.OS === 'ios' ? 'ios' : 'web';
+}
+
+function getNativeAppVersion(): string | null {
+  const nativeVersion = Application.nativeApplicationVersion;
+  const nativeBuild = Application.nativeBuildVersion;
+  if (nativeVersion && nativeBuild) return `${nativeVersion} (${nativeBuild})`;
+  return nativeVersion ?? nativeBuild ?? null;
+}
+
+async function submitMobileAppFeedback(payload: SubmitAppFeedbackInput): Promise<boolean> {
+  const variables: SubmitAppFeedbackMutationVariables = { input: payload };
+  const response = await getHttpClient().request<SubmitAppFeedbackMutationResponse>(SUBMIT_APP_FEEDBACK, variables);
+  return response.submitAppFeedback;
+}
+
+export function useSubmitMobileAppFeedback() {
+  const activeBoardQuery = useActiveBoard();
+  const queueContext = useQueue();
+  const { sessionId } = useQueueSessionId();
+  const pathname = usePathname();
+
+  return useMutation({
+    mutationFn: (payload: MobileSubmitAppFeedbackPayload): Promise<boolean> => {
+      const enrichment = buildMobileFeedbackEnrichment({
+        activeBoard: activeBoardQuery.data,
+        currentClimbQueueItem: queueContext.state.currentClimbQueueItem,
+        sessionId,
+        pathname,
+      });
+      return submitMobileAppFeedback({
+        ...payload,
+        ...enrichment,
+        platform: getMobilePlatform(),
+        appVersion: getNativeAppVersion(),
+      });
+    },
+  });
+}

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -74,6 +74,20 @@
         "subtitle": "Apple Health, Strava"
       }
     },
+    "about": {
+      "title": "About",
+      "heroTitle": "Boardsesh",
+      "heroBody": "Run your board from your phone: find climbs, line up sends, light the wall, and keep the session moving.",
+      "sectionTitle": "What Boardsesh is for",
+      "whatItDoesTitle": "Climb without app-hopping",
+      "whatItDoesBody": "Search, queue, light, log, and share climbs from one place while you stay focused on the wall.",
+      "boardsTitle": "For your boards",
+      "boardsBody": "Boardsesh supports sessions on your Kilter, Tension, and MoonBoard setups without pretending to be an official app.",
+      "openTitle": "Built in the open",
+      "openBody": "The project is open source so climbers can report rough edges, request features, and help steer what comes next.",
+      "independentTitle": "Independent project",
+      "independentBody": "Boardsesh is not affiliated with or endorsed by Aurora Climbing, Kilter, Tension, Moon Climbing, or any board manufacturer."
+    },
     "onboarding": {
       "skip": "Skip",
       "next": "Next",
@@ -215,7 +229,6 @@
     "classifyHolds": "Classify holds",
     "myPlaylists": "My playlists",
     "recentSessions": "Recent sessions",
-    "help": "Help",
     "about": "About",
     "rateBoardsesh": "Rate Boardsesh",
     "reportBug": "Report a bug",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -295,6 +295,10 @@
     "bugPlaceholder": "What were you doing? What did you expect vs see?",
     "ratingPlaceholder": "What's on your mind?",
     "remainingChars": "{{count}} more characters to go",
+    "sessionRecordingLabel": "Turn on session recording",
+    "sessionRecordingDescription": "Help us fix your bug faster by turning on session recording and reproducing the bug. You can turn it off after.",
+    "starRating_one": "{{count}} star",
+    "starRating_other": "{{count}} stars",
     "nextAria": "Next"
   },
   "feedbackBanner": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -73,7 +73,6 @@
     "classifyHolds": "Clasificar presas",
     "myPlaylists": "Mis listas",
     "recentSessions": "Sesiones recientes",
-    "help": "Ayuda",
     "about": "Sobre",
     "rateBoardsesh": "Valorar Boardsesh",
     "reportBug": "Reportar un bug",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -295,6 +295,8 @@
     "bugPlaceholder": "¿Qué estabas haciendo? ¿Qué esperabas y qué viste?",
     "ratingPlaceholder": "¿Qué piensas?",
     "remainingChars": "Faltan {{count}} caracteres",
+    "starRating_one": "{{count}} estrella",
+    "starRating_other": "{{count}} estrellas",
     "nextAria": "Siguiente"
   },
   "feedbackBanner": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -215,7 +215,6 @@
     "classifyHolds": "Classer les prises",
     "myPlaylists": "Mes playlists",
     "recentSessions": "Sessions récentes",
-    "help": "Aide",
     "about": "À propos",
     "rateBoardsesh": "Noter Boardsesh",
     "reportBug": "Signaler un bug",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -295,6 +295,8 @@
     "bugPlaceholder": "Que faisiez-vous ? Qu'attendiez-vous et qu'avez-vous vu ?",
     "ratingPlaceholder": "Qu'avez-vous en tête ?",
     "remainingChars": "Encore {{count}} caractères à écrire",
+    "starRating_one": "{{count}} étoile",
+    "starRating_other": "{{count}} étoiles",
     "nextAria": "Suivant"
   },
   "feedbackBanner": {


### PR DESCRIPTION
## What changed

- Added a top-left avatar action to mobile chrome surfaces and wired it to a left-side user drawer.
- Moved settings access into the drawer and added the current web sidebar actions: board switching, boards, playlists, about, rating, bug report, and logout.
- Added a native mobile About screen and routes the drawer About row to it.
- Removed the temporary Help drawer link; native Help is tracked separately in #2823.
- Added mobile feedback submission for ratings and bug reports with context enrichment.
- Reused the PostHog session recording toggle in settings and the bug report flow with bug-specific copy.

## Why

This brings the React Native navigation/account menu closer to the web sidebar while keeping About native. Bug reporters also get an obvious way to opt into session recording while reproducing an issue.

## Validation

- `vp run typecheck:mobile`
- `vp run test:mobile`
- `vp fmt packages/mobile/src/components/settings/SessionRecordingSwitchRow.tsx packages/mobile/src/components/user-drawer/FeedbackSheet.tsx 'packages/mobile/app/(tabs)/profile/more.tsx' packages/shared/i18n/locales/en-US/settings.json`
- `vp lint packages/mobile/src/components/settings/SessionRecordingSwitchRow.tsx packages/mobile/src/components/user-drawer/FeedbackSheet.tsx 'packages/mobile/app/(tabs)/profile/more.tsx' packages/shared/i18n/locales/en-US/settings.json`
- `vp fmt packages/mobile/app/about.tsx packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx packages/mobile/src/components/icon-map.ts packages/shared/i18n/locales/en-US/common.json packages/shared/i18n/locales/es/common.json packages/shared/i18n/locales/fr/common.json`
- `vp lint packages/mobile/app/about.tsx packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx packages/mobile/src/components/icon-map.ts packages/shared/i18n/locales/en-US/common.json packages/shared/i18n/locales/es/common.json packages/shared/i18n/locales/fr/common.json`