### PR TITLE
Improve mobile chart visibility

### DIFF
--- a/packages/mobile/src/components/session-screen/in-session/SessionGradeChart.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionGradeChart.tsx
@@ -21,5 +21,5 @@ export function SessionGradeChart({ distribution }: SessionGradeChartProps) {
 
   if (!bars) return null;
 
-  return <StackedBarChart bars={bars} colorBy="grade" height={120} />;
+  return <StackedBarChart bars={bars} colorBy="grade" height={120} fitYAxisToData />;
 }

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -66,7 +66,15 @@ function WorkoutTypeTile({ item }: { item: WorkoutTypeShelfItem }) {
     >
       <View pointerEvents="none" style={styles.chartSlot}>
         {item.bars ? (
-          <StackedBarChart bars={item.bars} colorBy="grade" height={CHART_HEIGHT} maxXLabels={5} />
+          <StackedBarChart
+            bars={item.bars}
+            colorBy="grade"
+            height={CHART_HEIGHT}
+            maxXLabels={5}
+            fitYAxisToData
+            interactive={false}
+            zoomable={false}
+          />
         ) : (
           <View style={[styles.emptyChart, { backgroundColor: systemColors.fill }]}>
             <Icon name={item.emptyIcon ?? 'chart.bar'} size={24} color={systemColors.secondaryLabel} />

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -9,6 +9,10 @@ type ViewProps = {
   pointerEvents?: string;
 };
 
+const chartProps = vi.hoisted(() => ({
+  latest: null as Record<string, unknown> | null,
+}));
+
 vi.mock('react-native', () => ({
   View: ({ children, pointerEvents }: ViewProps) =>
     createElement('div', { 'data-pointer-events': pointerEvents ?? '' }, children),
@@ -33,7 +37,10 @@ vi.mock('../../../Icon', () => ({
 }));
 
 vi.mock('../../../you/YouCharts', () => ({
-  StackedBarChart: () => createElement('div', { 'data-testid': 'chart' }),
+  StackedBarChart: (props: Record<string, unknown>) => {
+    chartProps.latest = props;
+    return createElement('div', { 'data-testid': 'chart' });
+  },
 }));
 
 vi.mock('../../../../providers/theme-provider', () => ({
@@ -80,5 +87,8 @@ describe('WorkoutTypeShelf', () => {
     const { getByTestId } = render(createElement(WorkoutTypeShelf, { items: [item()] }));
 
     expect(getByTestId('chart').parentElement?.getAttribute('data-pointer-events')).toBe('none');
+    expect(chartProps.latest?.fitYAxisToData).toBe(true);
+    expect(chartProps.latest?.interactive).toBe(false);
+    expect(chartProps.latest?.zoomable).toBe(false);
   });
 });

--- a/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
+++ b/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
@@ -42,9 +42,9 @@ export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] 
     () =>
       viewModel?.aggregatedStackedBars?.legend.map((entry) => ({
         label: entry.label,
-        color: layoutChartColor(entry.key),
+        color: layoutChartColor(entry.key, colorScheme),
       })),
-    [viewModel],
+    [colorScheme, viewModel],
   );
   const flashRedpointLegend = useMemo<ChartLegendItem[] | undefined>(
     () =>
@@ -65,6 +65,7 @@ export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] 
           bars={viewModel.aggregatedStackedBars?.bars ?? null}
           colorBy="layout"
           legend={gradeDistLegend}
+          fitYAxisToData
         />
       </Card>
 
@@ -72,7 +73,7 @@ export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] 
         <>
           <SectionHeader title={t('stats.flashVsRedpoint')} />
           <Card style={styles.chartCard}>
-            <GroupedBarChart bars={viewModel.aggregatedFlashRedpointBars} legend={flashRedpointLegend} />
+            <GroupedBarChart bars={viewModel.aggregatedFlashRedpointBars} legend={flashRedpointLegend} fitYAxisToData />
           </Card>
         </>
       )}

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -55,8 +55,11 @@ export const ProgressTab = memo(function ProgressTab({
   // flash-vs-redpoint pairs can be decoded (charts are color-only otherwise).
   const gradeDistLegend = useMemo<ChartLegendItem[] | undefined>(
     () =>
-      data.aggregatedStackedBars?.legend.map((entry) => ({ label: entry.label, color: layoutChartColor(entry.key) })),
-    [data.aggregatedStackedBars],
+      data.aggregatedStackedBars?.legend.map((entry) => ({
+        label: entry.label,
+        color: layoutChartColor(entry.key, colorScheme),
+      })),
+    [colorScheme, data.aggregatedStackedBars],
   );
   const flashRedpointLegend = useMemo<ChartLegendItem[] | undefined>(
     () =>
@@ -118,7 +121,13 @@ export const ProgressTab = memo(function ProgressTab({
           <Card style={styles.chartCard}>
             {/* Weekly labels ("W23 '24") are wide, so cap to ~6 evenly-spaced
                 markers — horizontal labels stay readable instead of colliding. */}
-            <StackedBarChart bars={data.weeklyBars} colorBy="grade" emptyLabel={noAscentData} maxXLabels={6} />
+            <StackedBarChart
+              bars={data.weeklyBars}
+              colorBy="grade"
+              emptyLabel={noAscentData}
+              maxXLabels={6}
+              showYAxisScale
+            />
           </Card>
 
           <SectionHeader title={t('stats.gradeDistribution')} />
@@ -128,6 +137,7 @@ export const ProgressTab = memo(function ProgressTab({
               colorBy="layout"
               emptyLabel={noAscentData}
               legend={gradeDistLegend}
+              showYAxisScale
             />
           </Card>
 

--- a/packages/mobile/src/components/you/SessionFeedCard.tsx
+++ b/packages/mobile/src/components/you/SessionFeedCard.tsx
@@ -115,11 +115,18 @@ export const SessionFeedCard = memo(function SessionFeedCard({
           )}
         </View>
 
-        {gradeBars && (
-          <View style={styles.chart}>
-            <StackedBarChart bars={gradeBars} colorBy="grade" height={84} />
+        {gradeBars ? (
+          <View pointerEvents="none" style={styles.chart}>
+            <StackedBarChart
+              bars={gradeBars}
+              colorBy="grade"
+              height={84}
+              fitYAxisToData
+              interactive={false}
+              zoomable={false}
+            />
           </View>
-        )}
+        ) : null}
 
         <View style={styles.boardRow}>
           <Text variant="caption1" color={systemColors.tertiaryLabel} numberOfLines={1} style={styles.flex}>

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -1,16 +1,28 @@
-import { memo, useMemo, useState, type ReactNode } from 'react';
-import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Pressable, View, StyleSheet, type GestureResponderEvent, type LayoutChangeEvent } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { BarChart, LineChart } from 'react-native-gifted-charts';
 import type { RawGroupedBar, RawVPointsTimeline } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
+import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { useTheme } from '../../providers/theme-provider';
 import { androidFallbackColors, materialSurfaces } from '../../theme/colors';
+import { hapticSelection } from '../../lib/haptics';
 import { gradeChartColor, layoutChartColor, flashRedpointColor, type ColoredBar } from './profile-chart-colors';
+import {
+  createGroupedTooltipModel,
+  createStackedTooltipModel,
+  getGroupedBarsMaxValue,
+  getStackedBarsMaxValue,
+  type ChartTooltipModel,
+} from './chart-model';
 
 const MAX_X_LABELS = 12;
-const AXIS_LABEL_SIZE = 10;
+const AXIS_LABEL_SIZE = 11;
 const STACK_BAR_RADIUS = 3;
+const MIN_ZOOM_SCALE = 1;
+const MAX_ZOOM_SCALE = 2.75;
 
 export type ChartLegendItem = { color: string; label: string };
 
@@ -36,6 +48,16 @@ function formatThousands(value: number): string {
   return value >= 1000 ? `${Math.round(value / 100) / 10}k` : `${Math.round(value)}`;
 }
 
+function clampZoomScale(value: number): number {
+  return Math.max(MIN_ZOOM_SCALE, Math.min(MAX_ZOOM_SCALE, value));
+}
+
+function touchDistance(event: GestureResponderEvent): number | null {
+  const [firstTouch, secondTouch] = event.nativeEvent.touches;
+  if (!firstTouch || !secondTouch) return null;
+  return Math.hypot(secondTouch.pageX - firstTouch.pageX, secondTouch.pageY - firstTouch.pageY);
+}
+
 /** Color-dot + label row beneath a chart so its colors can be decoded. */
 function Legend({ items }: { items: ChartLegendItem[] }) {
   const { systemColors } = useTheme();
@@ -58,17 +80,83 @@ type FrameProps = {
   loading?: boolean;
   emptyLabel?: string;
   isEmpty?: boolean;
-  children: (width: number) => ReactNode;
+  zoomable?: boolean;
+  children: (width: number, zoomScale: number, scrollEnabled: boolean) => ReactNode;
 };
 
 /** Measures available width and renders loading / empty / chart states. */
-function ChartFrame({ height, loading, emptyLabel, isEmpty, children }: FrameProps) {
+function ChartFrame({ height, loading, emptyLabel, isEmpty, zoomable, children }: FrameProps) {
   const { systemColors } = useTheme();
+  const { t } = useTranslation('common');
   const [width, setWidth] = useState(0);
+  const [zoomScale, setZoomScale] = useState(MIN_ZOOM_SCALE);
+  const pinchStartDistanceRef = useRef<number | null>(null);
+  const pinchStartScaleRef = useRef(MIN_ZOOM_SCALE);
   const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+  const updateZoomScale = useCallback((nextScale: number) => {
+    setZoomScale((currentScale) => {
+      const clampedScale = clampZoomScale(nextScale);
+      return Math.abs(currentScale - clampedScale) < 0.01 ? currentScale : clampedScale;
+    });
+  }, []);
+  const canZoom = zoomable === true && !loading && !isEmpty && width > 0;
+  const resetZoom = useCallback(() => {
+    pinchStartDistanceRef.current = null;
+    pinchStartScaleRef.current = MIN_ZOOM_SCALE;
+    setZoomScale(MIN_ZOOM_SCALE);
+  }, []);
+  const shouldCapturePinch = useCallback(
+    (event: GestureResponderEvent) => canZoom && event.nativeEvent.touches.length >= 2,
+    [canZoom],
+  );
+  const startPinch = useCallback(
+    (event: GestureResponderEvent) => {
+      const distance = touchDistance(event);
+      if (!distance) return;
+      pinchStartDistanceRef.current = distance;
+      pinchStartScaleRef.current = zoomScale;
+    },
+    [zoomScale],
+  );
+  const updatePinch = useCallback(
+    (event: GestureResponderEvent) => {
+      const distance = touchDistance(event);
+      if (!distance) return;
+
+      if (pinchStartDistanceRef.current == null) {
+        pinchStartDistanceRef.current = distance;
+        pinchStartScaleRef.current = zoomScale;
+      }
+
+      const nextScale = pinchStartScaleRef.current * (distance / pinchStartDistanceRef.current);
+      updateZoomScale(nextScale);
+    },
+    [updateZoomScale, zoomScale],
+  );
+  const endPinch = useCallback(() => {
+    pinchStartDistanceRef.current = null;
+    pinchStartScaleRef.current = zoomScale;
+  }, [zoomScale]);
+  const shouldReleaseResponder = useCallback(() => pinchStartDistanceRef.current == null, []);
+
+  useEffect(() => {
+    if (!canZoom) resetZoom();
+  }, [canZoom, resetZoom]);
+
+  const isZoomed = zoomScale > MIN_ZOOM_SCALE + 0.01;
 
   return (
-    <View style={[styles.frame, { height }]} onLayout={onLayout}>
+    <View
+      style={[styles.frame, { height }]}
+      onLayout={onLayout}
+      onStartShouldSetResponderCapture={shouldCapturePinch}
+      onMoveShouldSetResponderCapture={shouldCapturePinch}
+      onResponderGrant={startPinch}
+      onResponderMove={updatePinch}
+      onResponderRelease={endPinch}
+      onResponderTerminate={endPinch}
+      onResponderTerminationRequest={shouldReleaseResponder}
+    >
       {loading ? (
         <ActivityIndicator size="small" />
       ) : isEmpty ? (
@@ -76,8 +164,65 @@ function ChartFrame({ height, loading, emptyLabel, isEmpty, children }: FramePro
           {emptyLabel}
         </Text>
       ) : width > 0 ? (
-        children(width)
+        children(width, zoomScale, canZoom && isZoomed)
       ) : null}
+      {canZoom && isZoomed ? (
+        <Pressable
+          onPress={resetZoom}
+          style={[
+            styles.resetZoomButton,
+            {
+              backgroundColor: systemColors.elevatedSurface,
+              borderColor: systemColors.separator,
+            },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={t('resetZoom')}
+          hitSlop={8}
+        >
+          <Icon name="crop.free" size={15} color={systemColors.label} />
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function TooltipBubble({ model, totalLabel }: { model: ChartTooltipModel | undefined; totalLabel: string }) {
+  const { systemColors } = useTheme();
+  if (!model) return null;
+
+  return (
+    <View
+      style={[
+        styles.tooltip,
+        {
+          backgroundColor: systemColors.elevatedSurface,
+          borderColor: systemColors.separator,
+        },
+      ]}
+    >
+      <Text variant="caption1" style={styles.tooltipTitle} numberOfLines={1}>
+        {model.title}
+      </Text>
+      <View style={styles.tooltipTotal}>
+        <Text variant="caption2" color={systemColors.secondaryLabel}>
+          {totalLabel}
+        </Text>
+        <Text variant="caption2" style={styles.tooltipValue}>
+          {formatThousands(model.total)}
+        </Text>
+      </View>
+      {model.rows.slice(0, 4).map((row) => (
+        <View key={`${row.label}-${row.value}`} style={styles.tooltipRow}>
+          <View style={[styles.tooltipDot, { backgroundColor: row.color }]} />
+          <Text variant="caption2" color={systemColors.secondaryLabel} style={styles.tooltipRowLabel} numberOfLines={1}>
+            {row.label}
+          </Text>
+          <Text variant="caption2" style={styles.tooltipValue}>
+            {formatThousands(row.value)}
+          </Text>
+        </View>
+      ))}
     </View>
   );
 }
@@ -100,6 +245,11 @@ type StackedBarsProps = {
    * Lower it for long labels (weekly "W23 '24") that would overlap horizontally.
    */
   maxXLabels?: number;
+  interactive?: boolean;
+  zoomable?: boolean;
+  fitYAxisToData?: boolean;
+  showYAxisScale?: boolean;
+  minBarWidth?: number;
 };
 
 /** Stacked bars (weekly activity, grade distribution). */
@@ -111,8 +261,15 @@ export const StackedBarChart = memo(function StackedBarChart({
   emptyLabel,
   legend,
   maxXLabels,
+  interactive = true,
+  zoomable = true,
+  fitYAxisToData,
+  showYAxisScale,
+  minBarWidth = 4,
 }: StackedBarsProps) {
   const { colorScheme, variant } = useTheme();
+  const { t } = useTranslation('profile');
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const isEmpty = !bars || bars.length === 0;
   // gifted-charts color props require plain strings (not PlatformColor). On the
   // Material variant resolveSystemColors pulls from materialSurfaces; on glass/
@@ -122,6 +279,30 @@ export const StackedBarChart = memo(function StackedBarChart({
   const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
 
   // Color resolution is width-independent, so memoize it off the data.
+  const tooltipModels = useMemo(
+    () =>
+      (bars ?? []).map((bar) =>
+        createStackedTooltipModel(
+          bar,
+          (segment) =>
+            segment.color ??
+            (colorBy === 'grade'
+              ? gradeChartColor(segment.key, colorScheme)
+              : layoutChartColor(segment.key, colorScheme)),
+        ),
+      ),
+    [bars, colorBy, colorScheme],
+  );
+  const yAxisMaxValue = fitYAxisToData ? getStackedBarsMaxValue(bars) : undefined;
+  const handlePress = useCallback(
+    (index: number) => {
+      if (!interactive) return;
+      setSelectedIndex(index);
+      hapticSelection();
+    },
+    [interactive],
+  );
+
   const stackData = useMemo(
     () =>
       (bars ?? []).map((bar, index) => {
@@ -131,7 +312,10 @@ export const StackedBarChart = memo(function StackedBarChart({
             value: segment.value,
             // An explicit segment colour wins; otherwise fall back to colorBy.
             color:
-              segment.color ?? (colorBy === 'grade' ? gradeChartColor(segment.key) : layoutChartColor(segment.key)),
+              segment.color ??
+              (colorBy === 'grade'
+                ? gradeChartColor(segment.key, colorScheme)
+                : layoutChartColor(segment.key, colorScheme)),
           }));
         const stacks = filled.length > 0 ? filled : [{ value: 0, color: 'transparent' }];
         // Round only the stack's outer corners (bottom of the bottom segment,
@@ -148,36 +332,64 @@ export const StackedBarChart = memo(function StackedBarChart({
         return {
           stacks: rounded,
           label: downsampleLabel(index, bars!.length, bar.label, maxXLabels),
+          onPress: interactive ? () => handlePress(index) : undefined,
         };
       }),
-    [bars, colorBy, maxXLabels],
+    [bars, colorBy, colorScheme, handlePress, interactive, maxXLabels],
   );
+  const selectedTooltip = selectedIndex == null ? undefined : tooltipModels[selectedIndex];
 
   return (
     <View>
-      <ChartFrame height={height} loading={loading} isEmpty={isEmpty} emptyLabel={emptyLabel}>
-        {(width) => {
-          const { barWidth, spacing } = fitBars(width, stackData.length);
-          return (
-            <BarChart
-              stackData={stackData}
-              width={width - 8}
-              height={height - 28}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={8}
-              hideRules
-              hideYAxisText
-              yAxisThickness={0}
-              xAxisThickness={StyleSheet.hairlineWidth}
-              xAxisColor={chartColors.separator}
-              xAxisLabelTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
-              isAnimated={false}
-              disableScroll
-            />
-          );
-        }}
-      </ChartFrame>
+      <View style={styles.chartShell}>
+        <ChartFrame
+          height={height}
+          loading={loading}
+          isEmpty={isEmpty}
+          emptyLabel={emptyLabel}
+          zoomable={interactive && zoomable}
+        >
+          {(width, zoomScale, scrollEnabled) => {
+            const fitted = fitBars(width, stackData.length, minBarWidth);
+            const barWidth = Math.max(minBarWidth, Math.round(fitted.barWidth * zoomScale));
+            const spacing = Math.max(2, Math.round(fitted.spacing * zoomScale));
+            return (
+              <BarChart
+                stackData={stackData}
+                width={width - 8}
+                height={height - 28}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={8}
+                hideRules={!showYAxisScale}
+                hideYAxisText={!showYAxisScale}
+                yAxisLabelWidth={showYAxisScale ? 32 : 0}
+                maxValue={yAxisMaxValue}
+                yAxisThickness={0}
+                xAxisThickness={StyleSheet.hairlineWidth}
+                xAxisColor={chartColors.separator}
+                xAxisLabelTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
+                yAxisTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
+                rulesColor={chartColors.separator}
+                rulesType="solid"
+                focusBarOnPress={interactive}
+                highlightedBarIndex={selectedIndex ?? -1}
+                highlightEnabled={interactive && selectedIndex != null}
+                lowlightOpacity={0.42}
+                onBackgroundPress={interactive ? () => setSelectedIndex(null) : undefined}
+                isAnimated={false}
+                disableScroll={!scrollEnabled}
+                disablePress={!interactive}
+              />
+            );
+          }}
+        </ChartFrame>
+        {interactive && selectedTooltip ? (
+          <View pointerEvents="none" style={styles.tooltipOverlay}>
+            <TooltipBubble model={selectedTooltip} totalLabel={t('stats.chartTooltipTotal')} />
+          </View>
+        ) : null}
+      </View>
       {legend && !isEmpty ? <Legend items={legend} /> : null}
     </View>
   );
@@ -189,6 +401,9 @@ type GroupedBarsProps = {
   loading?: boolean;
   emptyLabel?: string;
   legend?: ChartLegendItem[];
+  interactive?: boolean;
+  zoomable?: boolean;
+  fitYAxisToData?: boolean;
 };
 
 /**
@@ -202,52 +417,95 @@ export const GroupedBarChart = memo(function GroupedBarChart({
   loading,
   emptyLabel,
   legend,
+  interactive = true,
+  zoomable = true,
+  fitYAxisToData,
 }: GroupedBarsProps) {
   const { colorScheme, variant } = useTheme();
+  const { t } = useTranslation('profile');
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const isEmpty = !bars || bars.length === 0;
   const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
   const groupGap = 14;
   const innerGap = 2;
+  const tooltipModels = useMemo(
+    () => (bars ?? []).map((bar) => createGroupedTooltipModel(bar, (key) => flashRedpointColor(key, colorScheme))),
+    [bars, colorScheme],
+  );
+  const yAxisMaxValue = fitYAxisToData ? getGroupedBarsMaxValue(bars) : undefined;
+  const handlePress = useCallback(
+    (index: number) => {
+      if (!interactive) return;
+      setSelectedIndex(index);
+      hapticSelection();
+    },
+    [interactive],
+  );
+  const selectedTooltip = selectedIndex == null ? undefined : tooltipModels[selectedIndex];
 
   return (
     <View>
-      <ChartFrame height={height} loading={loading} isEmpty={isEmpty} emptyLabel={emptyLabel}>
-        {(width) => {
-          const list = bars ?? [];
-          const initial = 8;
-          const barWidth = Math.max(
-            4,
-            Math.floor((width - initial * 2 - groupGap * list.length - innerGap * list.length) / (list.length * 2)),
-          );
-          const data = list.flatMap((bar) =>
-            bar.values.map((value, valueIndex) => ({
-              value: value.value,
-              frontColor: flashRedpointColor(value.key, colorScheme),
-              spacing: valueIndex === 0 ? innerGap : groupGap,
-              label: valueIndex === 0 ? bar.label : undefined,
-              labelWidth: barWidth * 2 + innerGap,
-            })),
-          );
-          return (
-            <BarChart
-              data={data}
-              width={width - 8}
-              height={height - 28}
-              barWidth={barWidth}
-              initialSpacing={initial}
-              barBorderRadius={2}
-              hideRules
-              hideYAxisText
-              yAxisThickness={0}
-              xAxisThickness={StyleSheet.hairlineWidth}
-              xAxisColor={chartColors.separator}
-              xAxisLabelTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
-              isAnimated={false}
-              disableScroll
-            />
-          );
-        }}
-      </ChartFrame>
+      <View style={styles.chartShell}>
+        <ChartFrame
+          height={height}
+          loading={loading}
+          isEmpty={isEmpty}
+          emptyLabel={emptyLabel}
+          zoomable={interactive && zoomable}
+        >
+          {(width, zoomScale, scrollEnabled) => {
+            const list = bars ?? [];
+            const initial = 8;
+            const baseBarWidth = Math.max(
+              4,
+              Math.floor((width - initial * 2 - groupGap * list.length - innerGap * list.length) / (list.length * 2)),
+            );
+            const barWidth = Math.max(4, Math.round(baseBarWidth * zoomScale));
+            const zoomedGroupGap = Math.max(groupGap, Math.round(groupGap * zoomScale));
+            const zoomedInnerGap = Math.max(innerGap, Math.round(innerGap * zoomScale));
+            const data = list.flatMap((bar, barIndex) =>
+              bar.values.map((value, valueIndex) => ({
+                value: value.value,
+                frontColor: flashRedpointColor(value.key, colorScheme),
+                spacing: valueIndex === 0 ? zoomedInnerGap : zoomedGroupGap,
+                label: valueIndex === 0 ? bar.label : undefined,
+                labelWidth: barWidth * 2 + zoomedInnerGap,
+                onPress: interactive ? () => handlePress(barIndex) : undefined,
+              })),
+            );
+            return (
+              <BarChart
+                data={data}
+                width={width - 8}
+                height={height - 28}
+                barWidth={barWidth}
+                initialSpacing={initial}
+                barBorderRadius={2}
+                hideRules
+                hideYAxisText
+                maxValue={yAxisMaxValue}
+                yAxisThickness={0}
+                xAxisThickness={StyleSheet.hairlineWidth}
+                xAxisColor={chartColors.separator}
+                xAxisLabelTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
+                focusBarOnPress={interactive}
+                highlightedBarIndex={selectedIndex == null ? -1 : [selectedIndex * 2, selectedIndex * 2 + 1]}
+                highlightEnabled={interactive && selectedIndex != null}
+                lowlightOpacity={0.42}
+                onBackgroundPress={interactive ? () => setSelectedIndex(null) : undefined}
+                isAnimated={false}
+                disableScroll={!scrollEnabled}
+                disablePress={!interactive}
+              />
+            );
+          }}
+        </ChartFrame>
+        {interactive && selectedTooltip ? (
+          <View pointerEvents="none" style={styles.tooltipOverlay}>
+            <TooltipBubble model={selectedTooltip} totalLabel={t('stats.chartTooltipTotal')} />
+          </View>
+        ) : null}
+      </View>
       {legend && !isEmpty ? <Legend items={legend} /> : null}
     </View>
   );
@@ -259,6 +517,8 @@ type AreaProps = {
   height?: number;
   loading?: boolean;
   emptyLabel?: string;
+  interactive?: boolean;
+  zoomable?: boolean;
 };
 
 /**
@@ -273,6 +533,8 @@ export const TotalAreaChart = memo(function TotalAreaChart({
   height = 170,
   loading,
   emptyLabel,
+  interactive = true,
+  zoomable = true,
 }: AreaProps) {
   const { colorScheme, variant } = useTheme();
   const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
@@ -298,10 +560,17 @@ export const TotalAreaChart = memo(function TotalAreaChart({
   }, [timeline]);
 
   return (
-    <ChartFrame height={height} loading={loading} isEmpty={isEmpty} emptyLabel={emptyLabel}>
-      {(width) => {
+    <ChartFrame
+      height={height}
+      loading={loading}
+      isEmpty={isEmpty}
+      emptyLabel={emptyLabel}
+      zoomable={interactive && zoomable}
+    >
+      {(width, zoomScale, scrollEnabled) => {
         if (!model) return null;
-        const spacing = Math.max(1, Math.floor((width - 48) / Math.max(1, model.pointCount - 1)));
+        const baseSpacing = Math.max(1, Math.floor((width - 48) / Math.max(1, model.pointCount - 1)));
+        const spacing = Math.max(1, Math.round(baseSpacing * zoomScale));
         return (
           <LineChart
             areaChart
@@ -329,7 +598,7 @@ export const TotalAreaChart = memo(function TotalAreaChart({
             yAxisTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
             xAxisLabelTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
             isAnimated={false}
-            disableScroll
+            disableScroll={!scrollEnabled}
           />
         );
       }}
@@ -339,8 +608,31 @@ export const TotalAreaChart = memo(function TotalAreaChart({
 
 const styles = StyleSheet.create({
   frame: {
+    position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  resetZoomButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    zIndex: 5,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chartShell: {
+    position: 'relative',
+  },
+  tooltipOverlay: {
+    position: 'absolute',
+    top: 8,
+    left: 12,
+    right: 12,
+    alignItems: 'center',
   },
   legend: {
     flexDirection: 'row',
@@ -358,5 +650,38 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
+  },
+  tooltip: {
+    minWidth: 128,
+    maxWidth: 168,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    gap: 4,
+  },
+  tooltipTitle: {
+    fontWeight: '700',
+  },
+  tooltipTotal: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  tooltipRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  tooltipDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+  },
+  tooltipRowLabel: {
+    flex: 1,
+  },
+  tooltipValue: {
+    fontWeight: '700',
   },
 });

--- a/packages/mobile/src/components/you/__tests__/chart-model.test.ts
+++ b/packages/mobile/src/components/you/__tests__/chart-model.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { RawGroupedBar } from '@boardsesh/profile-stats';
+import type { ColoredBar } from '../profile-chart-colors';
+import {
+  createGroupedTooltipModel,
+  createStackedTooltipModel,
+  getGroupedBarsMaxValue,
+  getStackedBarsMaxValue,
+} from '../chart-model';
+
+describe('chart-model', () => {
+  const stackedBars: ColoredBar[] = [
+    {
+      key: 'week-1',
+      label: 'W1',
+      segments: [
+        { key: 'V2', label: 'V2', value: 2, color: '#111111' },
+        { key: 'V3', label: 'V3', value: 3, color: '#222222' },
+      ],
+    },
+    {
+      key: 'week-2',
+      label: 'W2',
+      segments: [
+        { key: 'V2', label: 'V2', value: 1, color: '#111111' },
+        { key: 'V3', label: 'V3', value: 0, color: '#222222' },
+      ],
+    },
+  ];
+
+  it('fits stacked y-axis max to the tallest rendered stack', () => {
+    expect(getStackedBarsMaxValue(stackedBars)).toBe(5);
+    expect(getStackedBarsMaxValue([])).toBe(1);
+    expect(getStackedBarsMaxValue(null)).toBe(1);
+  });
+
+  it('builds stacked tooltip rows from non-zero segments', () => {
+    const tooltip = createStackedTooltipModel(stackedBars[0], (segment) => segment.color ?? '#000000');
+    expect(tooltip).toEqual({
+      title: 'W1',
+      total: 5,
+      rows: [
+        { label: 'V2', value: 2, color: '#111111' },
+        { label: 'V3', value: 3, color: '#222222' },
+      ],
+    });
+  });
+
+  it('fits grouped y-axis max to the largest individual grouped value', () => {
+    const groupedBars: RawGroupedBar[] = [
+      {
+        key: 'V4',
+        label: 'V4',
+        values: [
+          { key: 'flash', label: 'Flash', value: 2 },
+          { key: 'redpoint', label: 'Redpoint', value: 7 },
+        ],
+      },
+    ];
+
+    expect(getGroupedBarsMaxValue(groupedBars)).toBe(7);
+    expect(getGroupedBarsMaxValue([])).toBe(1);
+  });
+
+  it('builds grouped tooltip rows from non-zero grouped values', () => {
+    const tooltip = createGroupedTooltipModel(
+      {
+        key: 'V5',
+        label: 'V5',
+        values: [
+          { key: 'flash', label: 'Flash', value: 0 },
+          { key: 'redpoint', label: 'Redpoint', value: 4 },
+        ],
+      },
+      (key) => (key === 'flash' ? '#00aa00' : '#cc0000'),
+    );
+
+    expect(tooltip).toEqual({
+      title: 'V5',
+      total: 4,
+      rows: [{ label: 'Redpoint', value: 4, color: '#cc0000' }],
+    });
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/profile-chart-colors.test.ts
+++ b/packages/mobile/src/components/you/__tests__/profile-chart-colors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+
+import { gradeChartColor, layoutChartColor } from '../profile-chart-colors';
+
+describe('profile chart colors', () => {
+  it('uses opaque grade chart colors for light and dark schemes', () => {
+    expect(gradeChartColor('V4', 'light')).toMatch(/^hsl\(/);
+    expect(gradeChartColor('V4', 'dark')).toMatch(/^hsl\(/);
+    expect(gradeChartColor('V4', 'light')).not.toContain('0.');
+    expect(gradeChartColor('V4', 'dark')).not.toContain('0.');
+  });
+
+  it('uses scheme-aware categorical layout colors', () => {
+    expect(layoutChartColor('kilter-1', 'light')).toBe('#007C92');
+    expect(layoutChartColor('kilter-1', 'dark')).toBe('#22D3EE');
+    expect(layoutChartColor('unknown-layout', 'light')).toMatch(/^#/);
+    expect(layoutChartColor('unknown-layout', 'dark')).toMatch(/^#/);
+    expect(layoutChartColor('unknown-layout', 'light')).not.toBe(layoutChartColor('unknown-layout', 'dark'));
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/session-feed-card-chart.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/session-feed-card-chart.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionFeedItem } from '@boardsesh/shared-schema';
+import { SessionFeedCard } from '../SessionFeedCard';
+
+type ViewProps = {
+  children?: ReactNode;
+  pointerEvents?: string;
+};
+
+const chartProps = vi.hoisted(() => ({
+  latest: null as Record<string, unknown> | null,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children, pointerEvents }: ViewProps) =>
+    createElement('div', { 'data-pointer-events': pointerEvents ?? '' }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/profile-stats', () => ({ formatTickRelativeTime: () => 'now' }));
+vi.mock('@boardsesh/play-view', () => ({ getGradeTextColor: () => '#000000' }));
+vi.mock('../../Card', () => ({
+  Card: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', null) }));
+vi.mock('../AvatarGroup', () => ({ AvatarGroup: () => createElement('span', null) }));
+vi.mock('../FeedSocialRow', () => ({ FeedSocialRow: () => createElement('span', null) }));
+vi.mock('../YouCharts', () => ({
+  StackedBarChart: (props: Record<string, unknown>) => {
+    chartProps.latest = props;
+    return createElement('div', { 'data-testid': 'session-chart' });
+  },
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#888888',
+    },
+    brandColors: {
+      success: '#047857',
+      warning: '#B45309',
+    },
+  }),
+}));
+vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => color }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#808080' } }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16 }, borderRadius: { full: 999 } }));
+
+function session(overrides?: Partial<SessionFeedItem>): SessionFeedItem {
+  return {
+    sessionId: 'session-1',
+    sessionType: 'party',
+    participants: [],
+    totalSends: 3,
+    totalFlashes: 1,
+    totalAttempts: 2,
+    tickCount: 5,
+    gradeDistribution: [{ grade: 'V4', flash: 1, send: 2, attempt: 0 }],
+    boardTypes: ['kilter'],
+    hardestGrade: 'V4',
+    firstTickAt: '2026-06-12T00:00:00.000Z',
+    lastTickAt: '2026-06-12T00:00:00.000Z',
+    upvotes: 0,
+    downvotes: 0,
+    voteScore: 0,
+    commentCount: 0,
+    ...overrides,
+  };
+}
+
+describe('SessionFeedCard chart', () => {
+  it('keeps the embedded chart from stealing the card press target', () => {
+    const { getByTestId } = render(
+      createElement(SessionFeedCard, {
+        session: session(),
+        onOpenComments: vi.fn(),
+        onPress: vi.fn(),
+      }),
+    );
+
+    expect(getByTestId('session-chart').parentElement?.getAttribute('data-pointer-events')).toBe('none');
+    expect(chartProps.latest?.fitYAxisToData).toBe(true);
+    expect(chartProps.latest?.interactive).toBe(false);
+    expect(chartProps.latest?.zoomable).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/you/chart-model.ts
+++ b/packages/mobile/src/components/you/chart-model.ts
@@ -1,0 +1,65 @@
+import type { RawGroupedBar } from '@boardsesh/profile-stats';
+import type { ColoredBar, ColoredBarSegment } from './profile-chart-colors';
+
+export type ChartTooltipRow = {
+  label: string;
+  value: number;
+  color: string;
+};
+
+export type ChartTooltipModel = {
+  title: string;
+  total: number;
+  rows: ChartTooltipRow[];
+};
+
+export function sumSegments(segments: readonly Pick<ColoredBarSegment, 'value'>[]): number {
+  return segments.reduce((total, segment) => total + Math.max(segment.value, 0), 0);
+}
+
+export function getStackedBarTotal(bar: ColoredBar): number {
+  return sumSegments(bar.segments);
+}
+
+export function getStackedBarsMaxValue(bars: readonly ColoredBar[] | null | undefined): number {
+  if (!bars || bars.length === 0) return 1;
+  return Math.max(1, ...bars.map(getStackedBarTotal));
+}
+
+export function getGroupedBarsMaxValue(bars: readonly RawGroupedBar[] | null | undefined): number {
+  if (!bars || bars.length === 0) return 1;
+  return Math.max(1, ...bars.flatMap((bar) => bar.values.map((value) => Math.max(value.value, 0))));
+}
+
+export function createStackedTooltipModel(
+  bar: ColoredBar,
+  resolveColor: (segment: ColoredBarSegment) => string,
+): ChartTooltipModel {
+  const rows = bar.segments
+    .filter((segment) => segment.value > 0)
+    .map((segment) => ({
+      label: segment.label,
+      value: segment.value,
+      color: resolveColor(segment),
+    }));
+  return {
+    title: bar.label,
+    total: rows.reduce((sum, row) => sum + row.value, 0),
+    rows,
+  };
+}
+
+export function createGroupedTooltipModel(bar: RawGroupedBar, resolveColor: (key: 'flash' | 'redpoint') => string) {
+  const rows = bar.values
+    .filter((value) => value.value > 0)
+    .map((value) => ({
+      label: value.label,
+      value: value.value,
+      color: resolveColor(value.key),
+    }));
+  return {
+    title: bar.label,
+    total: rows.reduce((sum, row) => sum + row.value, 0),
+    rows,
+  };
+}

--- a/packages/mobile/src/components/you/profile-chart-colors.ts
+++ b/packages/mobile/src/components/you/profile-chart-colors.ts
@@ -25,28 +25,51 @@ export type ColoredBar = Omit<RawBar, 'segments'> & { segments: ColoredBarSegmen
 // @boardsesh/profile-stats. Mirrors the web adapter's palette so the two
 // platforms read the same. Charts never import these from web.
 
-// Layout palette — same soft, muted hsla values the web stats charts use,
-// keyed by `${boardType}-${layoutId}`.
-const layoutColors: Record<string, string> = {
-  'kilter-1': 'hsla(190, 55%, 52%, 0.7)',
-  'kilter-8': 'hsla(160, 40%, 50%, 0.7)',
-  'tension-9': 'hsla(350, 50%, 58%, 0.7)',
-  'tension-10': 'hsla(20, 55%, 58%, 0.7)',
-  'tension-11': 'hsla(42, 50%, 55%, 0.7)',
-  'moonboard-1': 'hsla(270, 40%, 58%, 0.7)',
-  'moonboard-2': 'hsla(250, 40%, 55%, 0.7)',
-  'moonboard-3': 'hsla(290, 35%, 55%, 0.7)',
-  'moonboard-4': 'hsla(230, 40%, 58%, 0.7)',
-  'moonboard-5': 'hsla(210, 45%, 55%, 0.7)',
-  'decoy-2': 'hsla(100, 40%, 52%, 0.7)',
-  'touchstone-1': 'hsla(30, 50%, 55%, 0.7)',
-  'grasshopper-1': 'hsla(75, 45%, 50%, 0.7)',
+type ColorSchemeName = 'light' | 'dark';
+
+// Mobile charts need stronger marks than the softer web palette. Keep layout
+// colours stable by key, but use opaque light/dark pairs with larger hue
+// separation so stacked segments remain readable on M3 white and dark violet
+// cards.
+const layoutColors: Record<string, Record<ColorSchemeName, string>> = {
+  'kilter-1': { light: '#007C92', dark: '#22D3EE' },
+  'kilter-8': { light: '#087F5B', dark: '#34D399' },
+  'tension-9': { light: '#B42318', dark: '#FB7185' },
+  'tension-10': { light: '#C2410C', dark: '#FDBA74' },
+  'tension-11': { light: '#A16207', dark: '#FDE047' },
+  'moonboard-1': { light: '#7E22CE', dark: '#C084FC' },
+  'moonboard-2': { light: '#4338CA', dark: '#818CF8' },
+  'moonboard-3': { light: '#BE185D', dark: '#F472B6' },
+  'moonboard-4': { light: '#0F5FB8', dark: '#60A5FA' },
+  'moonboard-5': { light: '#047A7A', dark: '#2DD4BF' },
+  'decoy-2': { light: '#3F7A1F', dark: '#A3E635' },
+  'touchstone-1': { light: '#B45309', dark: '#FBBF24' },
+  'grasshopper-1': { light: '#4D7C0F', dark: '#BEF264' },
 };
 
+const fallbackLayoutPalette: Array<Record<ColorSchemeName, string>> = [
+  { light: '#007C92', dark: '#22D3EE' },
+  { light: '#087F5B', dark: '#34D399' },
+  { light: '#B45309', dark: '#FBBF24' },
+  { light: '#B42318', dark: '#FB7185' },
+  { light: '#7E22CE', dark: '#C084FC' },
+  { light: '#0F5FB8', dark: '#60A5FA' },
+  { light: '#BE185D', dark: '#F472B6' },
+  { light: '#047A7A', dark: '#2DD4BF' },
+];
+
+function stablePaletteIndex(key: string): number {
+  let hash = 0;
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  }
+  return hash % fallbackLayoutPalette.length;
+}
+
 /** Color for a `${boardType}-${layoutId}` layout key. */
-export function layoutChartColor(layoutKey: string): string {
-  if (layoutColors[layoutKey]) return layoutColors[layoutKey];
-  return layoutKey.startsWith('kilter') ? 'rgba(6, 182, 212, 0.5)' : 'rgba(239, 68, 68, 0.5)';
+export function layoutChartColor(layoutKey: string, colorScheme: ColorSchemeName = 'light'): string {
+  if (layoutColors[layoutKey]) return layoutColors[layoutKey][colorScheme];
+  return fallbackLayoutPalette[stablePaletteIndex(layoutKey)][colorScheme];
 }
 
 /**
@@ -54,10 +77,10 @@ export function layoutChartColor(layoutKey: string): string {
  * and raises lightness for a cohesive, muted look. Mirrors web's
  * `getGradeChartColor`. `gradeKey` is a grade label (e.g. "V6" or "6A").
  */
-export function gradeChartColor(gradeKey: string): string {
+export function gradeChartColor(gradeKey: string, colorScheme: ColorSchemeName = 'light'): string {
   const normalized = gradeKey.replace(/\+$/, '');
   const hexColor = V_GRADE_COLORS[normalized] ?? FONT_GRADE_COLORS[gradeKey.toLowerCase()];
-  if (!hexColor) return 'hsla(0, 0%, 78%, 0.7)';
+  if (!hexColor) return colorScheme === 'dark' ? '#B8B2C4' : '#5F5868';
 
   const hex = hexColor.replace('#', '');
   const r = parseInt(hex.substring(0, 2), 16) / 255;
@@ -77,9 +100,14 @@ export function gradeChartColor(gradeKey: string): string {
   }
 
   const hDeg = Math.round(h * 360);
-  const sMuted = Math.min(Math.round(s * 100), 50);
-  const lMuted = Math.max(Math.round(l * 100), 48);
-  return `hsla(${hDeg}, ${sMuted}%, ${lMuted}%, 0.75)`;
+  const sourceSaturation = Math.round(s * 100);
+  const sourceLightness = Math.round(l * 100);
+  const saturation = Math.max(sourceSaturation, colorScheme === 'dark' ? 78 : 82);
+  const lightness =
+    colorScheme === 'dark'
+      ? Math.min(Math.max(sourceLightness, 58), 72)
+      : Math.min(Math.max(sourceLightness - 6, 34), 48);
+  return `hsl(${hDeg}, ${saturation}%, ${lightness}%)`;
 }
 
 /**

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -60,6 +60,7 @@
     "flashVsRedpoint": "Flash vs Redpoint",
     "vPoints": "V-Points",
     "vPointsTotal": "{{value}} total",
+    "chartTooltipTotal": "Total",
     "gradeDistributionAria": "Grade distribution across boards",
     "weeklyAttemptsAria": "Weekly attempts by difficulty",
     "flashRedpointAria": "Flash vs redpoint by grade",

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -22,7 +22,6 @@
     "title": "Progress"
   },
   "mobile": {
-    "settings": "Settings",
     "unknownName": "Climber",
     "cancel": "Cancel",
     "sessions": {

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -22,7 +22,6 @@
     "title": "Progreso"
   },
   "mobile": {
-    "settings": "Ajustes",
     "unknownName": "Escalador",
     "cancel": "Cancelar",
     "sessions": {

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -22,7 +22,6 @@
     "title": "Progression"
   },
   "mobile": {
-    "settings": "Réglages",
     "unknownName": "Grimpeur",
     "cancel": "Annuler",
     "sessions": {


### PR DESCRIPTION
## Summary

- Fixes #2825.
- Makes shared mobile bar charts pinch-zoomable and touch-inspectable with selected-value overlays.
- Replaces the flat mobile chart palette with stronger scheme-aware grade/layout colors.
- Fits session/pre-session compact grade charts to the tallest rendered bar so differences are easier to read.
- Removes an orphaned `you.mobile.settings` i18n key that blocked the staged orphan-key check.

## Validation

- `vp run test:mobile`
- `vp run typecheck:mobile`
- targeted `vp check` on changed files
- `vp run check:i18n:orphans`
- `vp staged`

## QA

- Mobile dev server started with QA notes loaded from `.boardsesh/qa-notes.md`.
- Metro URL: `http://marcos-macbook-pro-2-1.tailedd9d5.ts.net:8086`