### PR TITLE
[codex] Add mobile Discord CTAs

### DIFF
--- a/packages/mobile/app/__tests__/about.test.tsx
+++ b/packages/mobile/app/__tests__/about.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const browser = vi.hoisted(() => ({ openBrowserAsync: vi.fn().mockResolvedValue(undefined) }));
+const scrollView = vi.hoisted(() => ({ contentContainerStyle: null as unknown }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (colorName: string) => colorName,
+  ScrollView: ({ children, contentContainerStyle }: { children?: ReactNode; contentContainerStyle?: unknown }) => {
+    scrollView.contentContainerStyle = contentContainerStyle;
+    return createElement('section', { 'data-testid': 'about-scroll' }, children);
+  },
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('expo-router', () => ({ Stack: { Screen: () => null } }));
+vi.mock('expo-web-browser', () => browser);
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'mobile.about.joinDiscord': 'Join Discord',
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock('../../src/components/Button', () => ({
+  Button: ({ icon, onPress, title }: { icon?: string; onPress: () => void; title: string }) =>
+    createElement('button', { 'data-icon': icon, onClick: onPress, type: 'button' }, title),
+}));
+vi.mock('../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../src/components/SectionHeader', () => ({
+  SectionHeader: ({ title }: { title: string }) => createElement('h2', null, title),
+}));
+vi.mock('../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../src/hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 80 }),
+}));
+vi.mock('../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    brandColors: { onPrimary: '#fff', primaryFill: '#6D28D9' },
+    systemColors: {
+      accent: '#6D28D9',
+      fill: '#eee',
+      secondaryBackground: '#fff',
+      secondaryLabel: '#666',
+    },
+  }),
+}));
+
+import { DISCORD_INVITE_URL } from '../../src/lib/discord';
+import AboutScreen from '../about';
+
+beforeEach(() => {
+  browser.openBrowserAsync.mockClear();
+  scrollView.contentContainerStyle = null;
+});
+
+describe('AboutScreen Discord CTA', () => {
+  it('renders a Discord button that opens the invite', () => {
+    render(<AboutScreen />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Join Discord' }));
+
+    expect(browser.openBrowserAsync).toHaveBeenCalledWith(DISCORD_INVITE_URL);
+  });
+
+  it('adds bottom chrome padding to the ScrollView content', () => {
+    render(<AboutScreen />);
+
+    expect(scrollView.contentContainerStyle).toContainEqual({ paddingBottom: 104 });
+  });
+});

--- a/packages/mobile/app/about.tsx
+++ b/packages/mobile/app/about.tsx
@@ -1,9 +1,13 @@
+import { useCallback } from 'react';
 import { Stack } from 'expo-router';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
 import { SectionHeader } from '../src/components/SectionHeader';
 import { Text } from '../src/components/Text';
+import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
+import { openDiscordInvite } from '../src/lib/discord';
 import { useTheme } from '../src/providers/theme-provider';
 import { borderRadius, spacing } from '../src/theme/tokens';
 import type { IconName } from '../src/components/icon-map';
@@ -17,6 +21,10 @@ type AboutCard = {
 export default function AboutScreen() {
   const { t } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
+  const bottomChrome = useBottomChromeMetrics();
+  const handleJoinDiscord = useCallback(() => {
+    void openDiscordInvite('about');
+  }, []);
   const cards: AboutCard[] = [
     {
       icon: 'lightbulb',
@@ -47,7 +55,10 @@ export default function AboutScreen() {
           contentStyle: { backgroundColor: 'transparent' },
         }}
       />
-      <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}
+      >
         <View style={[styles.hero, { backgroundColor: systemColors.secondaryBackground }]}>
           <View style={[styles.heroIcon, { backgroundColor: brandColors.primaryFill }]}>
             <Icon name="boards.fill" size={32} color={brandColors.onPrimary} />
@@ -89,6 +100,7 @@ export default function AboutScreen() {
             {t('mobile.about.independentBody')}
           </Text>
         </View>
+        <Button title={t('mobile.about.joinDiscord')} icon="open.external" size="large" onPress={handleJoinDiscord} />
       </ScrollView>
     </>
   );
@@ -99,7 +111,6 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingHorizontal: spacing[4],
     paddingTop: spacing[4],
-    paddingBottom: spacing[8],
     gap: spacing[6],
   },
   hero: {

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -5,6 +5,7 @@ import { router, useSegments } from 'expo-router';
 import type { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { openDiscordInvite } from '../../lib/discord';
 import { reportError } from '../../lib/error-reporting';
 import { useProfile } from '../../lib/graphql/hooks';
 import { useAuth } from '../../providers/auth-provider';
@@ -130,6 +131,11 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     [closeUserDrawer],
   );
 
+  const openDiscord = useCallback(() => {
+    closeUserDrawer();
+    void openDiscordInvite('user-drawer');
+  }, [closeUserDrawer]);
+
   const handleSignOut = useCallback(() => {
     closeUserDrawer();
     void signOut('manual').catch(reportError);
@@ -196,10 +202,12 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
 
               <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
                 <DrawerRow icon="star" title={t('userDrawer.rateBoardsesh')} onPress={() => openFeedback('rating')} />
+                <DrawerRow icon="flag" title={t('userDrawer.reportBug')} onPress={() => openFeedback('bug')} />
                 <DrawerRow
-                  icon="flag"
-                  title={t('userDrawer.reportBug')}
-                  onPress={() => openFeedback('bug')}
+                  icon="open.external"
+                  title={t('userDrawer.joinDiscord')}
+                  tintColor={brandColors.primary}
+                  onPress={openDiscord}
                   showSeparator={false}
                 />
               </View>

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const browser = vi.hoisted(() => ({ openBrowserAsync: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('react-native', () => ({
+  Modal: ({ children, visible }: { children?: ReactNode; visible: boolean }) =>
+    visible ? createElement('div', { 'data-modal': 'true' }, children) : null,
+  Pressable: ({
+    accessibilityLabel,
+    children,
+    onPress,
+  }: {
+    accessibilityLabel?: string;
+    children?: ReactNode;
+    onPress?: () => void;
+  }) => createElement('button', { 'aria-label': accessibilityLabel, onClick: onPress, type: 'button' }, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { absoluteFill: {}, create: (styles: unknown) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 390 }),
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  },
+  Easing: { cubic: 'cubic', out: () => 'ease' },
+  runOnJS: (callback: () => void) => callback,
+  useAnimatedStyle: (factory: () => unknown) => factory(),
+  useSharedValue: (initialValue: number) => ({ value: initialValue }),
+  withTiming: (value: number, _config: unknown, callback?: (finished: boolean) => void) => {
+    callback?.(true);
+    return value;
+  },
+}));
+
+vi.mock('expo-router', () => ({
+  router: { push: vi.fn() },
+  useSegments: () => [],
+}));
+
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+vi.mock('expo-web-browser', () => browser);
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'ariaLabels.close': 'Close',
+        'ariaLabels.settings': 'Settings',
+        'header.you': 'You',
+        'myBoards.title': 'My boards',
+        'userDrawer.about': 'About',
+        'userDrawer.changeBoard': 'Change board',
+        'userDrawer.joinDiscord': 'Join Discord',
+        'userDrawer.logout': 'Log out',
+        'userDrawer.myPlaylists': 'My playlists',
+        'userDrawer.rateBoardsesh': 'Rate Boardsesh',
+        'userDrawer.reportBug': 'Report a bug',
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock('../../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
+}));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: true, signOut: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    brandColors: { error: '#c00', primary: '#6D28D9' },
+    systemColors: {
+      elevatedSurface: '#fff',
+      label: '#111',
+      secondaryBackground: '#f7f7f7',
+      secondaryLabel: '#666',
+      separator: '#ddd',
+    },
+  }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  borderRadius: { lg: 12 },
+  overlays: { scrim: 'rgba(0,0,0,0.4)' },
+  shadows: { lg: {} },
+  spacing: { 2: 8, 3: 12, 4: 16 },
+}));
+
+vi.mock('../../Avatar', () => ({
+  Avatar: ({ name }: { name: string }) => createElement('span', { 'data-avatar': name }),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../ListRow', () => ({
+  ListRow: ({ leading, onPress, title }: { leading?: ReactNode; onPress?: () => void; title: string }) =>
+    createElement('button', { 'data-row-title': title, onClick: onPress, type: 'button' }, leading, title),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../FeedbackSheet', () => ({ FeedbackSheet: () => null }));
+
+import { DISCORD_INVITE_URL } from '../../../lib/discord';
+import { UserDrawerProvider, useUserDrawer } from '../UserDrawerProvider';
+
+function DrawerTrigger() {
+  const { openUserDrawer } = useUserDrawer();
+  return (
+    <button onClick={openUserDrawer} type="button">
+      Open drawer
+    </button>
+  );
+}
+
+beforeEach(() => {
+  browser.openBrowserAsync.mockClear();
+});
+
+describe('UserDrawerProvider Discord CTA', () => {
+  it('renders Join Discord directly below Report a bug and opens the invite', () => {
+    const { container } = render(
+      <UserDrawerProvider>
+        <DrawerTrigger />
+      </UserDrawerProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open drawer'));
+
+    const rowTitles = Array.from(container.querySelectorAll('[data-row-title]')).map((row) =>
+      row.getAttribute('data-row-title'),
+    );
+    const reportBugIndex = rowTitles.indexOf('Report a bug');
+
+    expect(reportBugIndex).toBeGreaterThan(-1);
+    expect(rowTitles[reportBugIndex + 1]).toBe('Join Discord');
+
+    fireEvent.click(screen.getByText('Join Discord'));
+
+    expect(browser.openBrowserAsync).toHaveBeenCalledWith(DISCORD_INVITE_URL);
+  });
+});

--- a/packages/mobile/src/lib/discord.ts
+++ b/packages/mobile/src/lib/discord.ts
@@ -1,0 +1,14 @@
+import * as WebBrowser from 'expo-web-browser';
+import { reportError } from './error-reporting';
+
+export const DISCORD_INVITE_URL = 'https://discord.gg/YXA8GsXfQK';
+
+type DiscordInviteSource = 'about' | 'user-drawer';
+
+export async function openDiscordInvite(source: DiscordInviteSource): Promise<void> {
+  try {
+    await WebBrowser.openBrowserAsync(DISCORD_INVITE_URL);
+  } catch (error) {
+    reportError(error, { tags: { source } });
+  }
+}

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -86,7 +86,8 @@
       "openTitle": "Built in the open",
       "openBody": "The project is open source so climbers can report rough edges, request features, and help steer what comes next.",
       "independentTitle": "Independent project",
-      "independentBody": "Boardsesh is not affiliated with or endorsed by Aurora Climbing, Kilter, Tension, Moon Climbing, or any board manufacturer."
+      "independentBody": "Boardsesh is not affiliated with or endorsed by Aurora Climbing, Kilter, Tension, Moon Climbing, or any board manufacturer.",
+      "joinDiscord": "Join Discord"
     },
     "onboarding": {
       "skip": "Skip",
@@ -232,6 +233,7 @@
     "about": "About",
     "rateBoardsesh": "Rate Boardsesh",
     "reportBug": "Report a bug",
+    "joinDiscord": "Join Discord",
     "logout": "Log out"
   },
   "loading": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -76,6 +76,7 @@
     "about": "Sobre",
     "rateBoardsesh": "Valorar Boardsesh",
     "reportBug": "Reportar un bug",
+    "joinDiscord": "Únete a Discord",
     "logout": "Cerrar sesión",
     "devBuild": "Build de dev",
     "branch": "Rama",
@@ -270,6 +271,9 @@
         "title": "Aplicaciones conectadas",
         "subtitle": "Apple Health y Strava"
       }
+    },
+    "about": {
+      "joinDiscord": "Únete a Discord"
     },
     "onboarding": {
       "skip": "Omitir",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -74,6 +74,9 @@
         "subtitle": "Apple Health et Strava"
       }
     },
+    "about": {
+      "joinDiscord": "Rejoindre Discord"
+    },
     "onboarding": {
       "skip": "Passer",
       "next": "Suivant",
@@ -218,6 +221,7 @@
     "about": "À propos",
     "rateBoardsesh": "Noter Boardsesh",
     "reportBug": "Signaler un bug",
+    "joinDiscord": "Rejoindre Discord",
     "logout": "Se déconnecter"
   },
   "loading": {


### PR DESCRIPTION
## What changed

- Added a shared mobile Discord invite helper using `expo-web-browser`.
- Added a primary `Join Discord` CTA to the About screen and a stronger `Join Discord` row below `Report a bug` in the user drawer.
- Updated About screen bottom padding to account for bottom chrome via `useBottomChromeMetrics()`.
- Added English, Spanish, and French common-catalog keys for the new labels.
- Added focused mobile tests for the drawer CTA and About CTA/padding behavior.

## Why

Mobile users needed clearer entry points into the Boardsesh Discord from the drawer support area and the About page. The About page also needed enough scroll padding so its final content clears the current-climb accessory/tab chrome.

## Validation

- `vp run typecheck:mobile`
- `vp test run --project mobile`
- `vp run check:i18n`
- `git diff --check --no-ext-diff`

Note: `vp check --fix` formatted the touched files, then full repo `vp check` failed on existing unrelated repo-wide lint/type backlog, including `mobile/capacitor.config.ts` missing `@capacitor/cli` and unrelated lint findings outside this change.