### PR TITLE
[codex] Improve Apple Health exports

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -8,7 +8,8 @@ Two integration kinds exist, with different trust models:
   disconnect / toggle UI over GraphQL.
 - **Device integrations** (Apple Health today): device-local. The phone writes
   workouts through a native module; the server never holds credentials and
-  only stores a workout id for dedupe (`board_sessions.health_kit_workout_id`).
+  only stores a per-user workout id for dedupe
+  (`session_health_kit_workouts.workout_id`).
 
 v1 exports explicit (party/recorded) sessions only. `integration_exports.
 session_type` already accommodates inferred solo sessions for later.
@@ -110,14 +111,21 @@ within 5 minutes, and is concurrency-safe:
 `runSessionEndExports` fires after `endSession` resolves on the phone. The
 auto-save orchestration (`apple-health.ts`) mirrors the legacy web
 `healthkit-auto-save.ts` semantics: a module-level per-session state map
-(`saving`/`saved`/`failed`) doubles as the dedupe guard and powers the summary
-button UI. Authorization is probed with the read-only
+(`saving`/`saved`/`savedWithoutEnergy`/`failed`) doubles as the dedupe guard
+and powers the summary button UI. Authorization is probed with the read-only
 `getAuthorizationStatus` native call; the consent sheet only ever appears for
 a never-decided user (first session end, or an explicit toggle/button tap).
-The workout itself (`HealthWorkoutsModule.swift`) writes an `HKWorkout`
-(.climbing) with MET-estimated active energy (latest HealthKit body mass,
-70 kg fallback) and per-climb `.lap` events. Workout ids persist via
-`setInferredSessionHealthKitWorkoutId` for dedupe.
+Before it writes, mobile loads `sessionHealthExport(sessionId)`, which is
+filtered to the authenticated viewer's own ticks and includes any existing
+per-user workout id. That keeps party sessions from exporting another
+climber's sends into a personal Apple Health workout and lets manual saves
+after app restart keep lap data. The native module also checks HealthKit for
+an existing workout with `HKMetadataKeyExternalUUID = sessionId` before
+creating one. The workout itself (`HealthWorkoutsModule.swift`) writes an
+`HKWorkout` (.climbing) with indoor + Boardsesh brand metadata, MET-estimated
+active energy (latest HealthKit body mass, 70 kg fallback), and per-climb
+`.lap` events carrying climb name, grade, status, attempt count, board type,
+and angle. Workout ids persist via `setSessionHealthKitWorkoutId` for dedupe.
 
 ## Adding a provider
 

--- a/mobile/ios/App/App/Info.plist
+++ b/mobile/ios/App/App/Info.plist
@@ -65,9 +65,9 @@
 		<string>tailedd9d5.ts.net</string>
 	</array>
 	<key>NSHealthShareUsageDescription</key>
-	<string>Boardsesh reads your Apple Health data to avoid duplicate workout entries when saving climbing sessions.</string>
+	<string>Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>Boardsesh saves your climbing sessions to Apple Health as workouts so they count toward your activity rings.</string>
+	<string>Boardsesh saves your finished climbing sessions to Apple Health as workouts.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Boardsesh uses Bluetooth to connect to your Kilter Board, Tension Board, or MoonBoard and light up climbing holds. No personal data is sent over Bluetooth.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/packages/backend/src/__tests__/session-summary.test.ts
+++ b/packages/backend/src/__tests__/session-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { generateSessionSummary } from '../graphql/resolvers/sessions/session-summary';
+import { generateSessionHealthExport, generateSessionSummary } from '../graphql/resolvers/sessions/session-summary';
 
 // Shared mock state, declared with vi.hoisted to ensure availability before mock setup
 const mockState = vi.hoisted(() => ({
@@ -8,6 +8,7 @@ const mockState = vi.hoisted(() => ({
   gradeDistRows: [] as Record<string, unknown>[],
   hardestRows: [] as Record<string, unknown>[],
   participantRows: [] as Record<string, unknown>[],
+  getSessionHealthExport: vi.fn(),
 }));
 
 // Chainable mock builder, also hoisted for use in mock factory
@@ -17,6 +18,7 @@ const { createChainableMock } = vi.hoisted(() => ({
     for (const method of ['select', 'from', 'where', 'leftJoin', 'groupBy', 'orderBy', 'limit']) {
       chain[method] = (..._args: unknown[]) => chain;
     }
+    // oxlint-disable-next-line unicorn/no-thenable -- Drizzle query builders are thenable, so this mock mirrors that contract.
     chain.then = (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
       Promise.resolve(resolveData).then(resolve, reject);
     return chain;
@@ -53,6 +55,10 @@ vi.mock('@boardsesh/db/schema', () => ({
   boardClimbAliases: {},
 }));
 
+vi.mock('@boardsesh/db/queries', () => ({
+  getSessionHealthExport: mockState.getSessionHealthExport,
+}));
+
 // Mock drizzle-orm functions to prevent errors from passing mock schema objects
 vi.mock('drizzle-orm', () => ({
   eq: (..._args: unknown[]) => ({}),
@@ -71,6 +77,7 @@ describe('generateSessionSummary', () => {
     mockState.gradeDistRows = [];
     mockState.hardestRows = [];
     mockState.participantRows = [];
+    mockState.getSessionHealthExport.mockReset();
   });
 
   it('returns null when session is not found', async () => {
@@ -330,5 +337,113 @@ describe('generateSessionSummary', () => {
     expect(result!.totalSends).toBe(15);
     expect(result!.totalAttempts).toBe(38);
     expect(result!.participants).toHaveLength(3);
+  });
+});
+
+describe('generateSessionHealthExport', () => {
+  beforeEach(() => {
+    mockState.getSessionHealthExport.mockReset();
+  });
+
+  it('returns null when the export read model is missing', async () => {
+    mockState.getSessionHealthExport.mockResolvedValueOnce(null);
+
+    await expect(generateSessionHealthExport('missing-session', 'user-1')).resolves.toBeNull();
+  });
+
+  it('returns null for a viewer who neither created nor ticked in the session', async () => {
+    mockState.getSessionHealthExport.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      createdByUserId: 'owner-user',
+      startedAt: '2026-06-01T10:00:00.000Z',
+      endedAt: '2026-06-01T11:00:00.000Z',
+      durationMinutes: 60,
+      boardType: 'kilter',
+      totalSends: 0,
+      totalAttempts: 0,
+      hardestClimb: null,
+      laps: [],
+      healthKitWorkoutId: null,
+    });
+
+    await expect(generateSessionHealthExport('session-1', 'other-user')).resolves.toBeNull();
+  });
+
+  it('allows the session creator before they have ticks', async () => {
+    mockState.getSessionHealthExport.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      createdByUserId: 'creator-user',
+      startedAt: '2026-06-01T10:00:00.000Z',
+      endedAt: '2026-06-01T11:00:00.000Z',
+      durationMinutes: 60,
+      boardType: 'kilter',
+      totalSends: 0,
+      totalAttempts: 0,
+      hardestClimb: null,
+      laps: [],
+      healthKitWorkoutId: null,
+    });
+
+    await expect(generateSessionHealthExport('session-1', 'creator-user')).resolves.toMatchObject({
+      sessionId: 'session-1',
+      boardType: 'kilter',
+      totalSends: 0,
+      totalAttempts: 0,
+      laps: [],
+      healthKitWorkoutId: null,
+    });
+  });
+
+  it('returns only the viewer-owned export record', async () => {
+    mockState.getSessionHealthExport.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      createdByUserId: 'owner-user',
+      startedAt: '2026-06-01T10:00:00.000Z',
+      endedAt: '2026-06-01T11:00:00.000Z',
+      durationMinutes: 60,
+      boardType: 'kilter',
+      totalSends: 1,
+      totalAttempts: 3,
+      hardestClimb: { climbUuid: 'climb-1', climbName: 'Test Climb', grade: 'V5' },
+      laps: [
+        {
+          tickUuid: 'tick-1',
+          climbUuid: 'climb-1',
+          climbName: 'Test Climb',
+          grade: 'V5',
+          status: 'send',
+          attemptCount: 3,
+          boardType: 'kilter',
+          angle: 40,
+          climbedAt: '2026-06-01T10:20:00.000Z',
+        },
+      ],
+      healthKitWorkoutId: 'healthkit-workout-1',
+    });
+
+    await expect(generateSessionHealthExport('session-1', 'participant-user')).resolves.toEqual({
+      sessionId: 'session-1',
+      startedAt: '2026-06-01T10:00:00.000Z',
+      endedAt: '2026-06-01T11:00:00.000Z',
+      durationMinutes: 60,
+      boardType: 'kilter',
+      totalSends: 1,
+      totalAttempts: 3,
+      hardestClimb: { climbUuid: 'climb-1', climbName: 'Test Climb', grade: 'V5' },
+      laps: [
+        {
+          tickUuid: 'tick-1',
+          climbUuid: 'climb-1',
+          climbName: 'Test Climb',
+          grade: 'V5',
+          status: 'send',
+          attemptCount: 3,
+          boardType: 'kilter',
+          angle: 40,
+          climbedAt: '2026-06-01T10:20:00.000Z',
+        },
+      ],
+      healthKitWorkoutId: 'healthkit-workout-1',
+    });
   });
 });

--- a/packages/backend/src/graphql/resolvers/integrations/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/integrations/mutations.ts
@@ -118,8 +118,8 @@ export const integrationMutations = {
     const providerName = providerEnumToDb(provider);
 
     // Authorize: the caller must be the session creator or have logged at least
-    // one tick in it (the creator-or-has-ticks rule from
-    // setInferredSessionHealthKitWorkoutId, adapted to party ticks). The tick
+    // one tick in it (the same creator-or-has-ticks rule used by
+    // setSessionHealthKitWorkoutId, adapted to party ticks). The tick
     // check rides the session SELECT as an EXISTS so authorization reads one
     // consistent snapshot — two sequential queries would leave a window where
     // membership changes between them.

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -1,10 +1,15 @@
-import type { ConnectionContext, EventsReplayResponse, SessionStatus } from '@boardsesh/shared-schema';
+import type {
+  ConnectionContext,
+  EventsReplayResponse,
+  SessionHealthExport,
+  SessionStatus,
+} from '@boardsesh/shared-schema';
 import { eq } from 'drizzle-orm';
 import { roomManager, type DiscoverableSession } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
 import { validateInput, requireSessionMember, requireAuthenticated } from '../shared/helpers';
 import { SessionIdSchema, LatitudeSchema, LongitudeSchema, RadiusMetersSchema } from '../../../validation/schemas';
-import { generateSessionSummary } from './session-summary';
+import { generateSessionHealthExport, generateSessionSummary } from './session-summary';
 import { getDistributedState } from '../../../services/distributed-state';
 import { buildSessionPayload } from './helpers';
 import { dbRead } from '../../../db/client';
@@ -130,6 +135,21 @@ export const sessionQueries = {
     requireAuthenticated(ctx);
     validateInput(SessionIdSchema, sessionId, 'sessionId');
     return generateSessionSummary(sessionId);
+  },
+
+  /**
+   * Get viewer-specific session data for Apple Health. This is narrower than
+   * sessionSummary by design: Health workouts are personal records.
+   */
+  sessionHealthExport: async (
+    _: unknown,
+    { sessionId }: { sessionId: string },
+    ctx: ConnectionContext,
+  ): Promise<SessionHealthExport | null> => {
+    requireAuthenticated(ctx);
+    validateInput(SessionIdSchema, sessionId, 'sessionId');
+    if (!ctx.userId) throw new Error('Authentication required to perform this operation');
+    return generateSessionHealthExport(sessionId, ctx.userId);
   },
 
   /**

--- a/packages/backend/src/graphql/resolvers/sessions/session-summary.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/session-summary.ts
@@ -2,8 +2,9 @@ import { db } from '../../../db/client';
 import { sessions } from '../../../db/schema';
 import * as dbSchema from '@boardsesh/db/schema';
 import { eq, and, inArray, sql, count, desc, isNotNull } from 'drizzle-orm';
-import type { SessionSummary } from '@boardsesh/shared-schema';
+import type { SessionHealthExport, SessionSummary } from '@boardsesh/shared-schema';
 import { rowsFromResult } from '@boardsesh/db/client';
+import { getSessionHealthExport } from '@boardsesh/db/queries';
 import { logger } from '../../../utils/logger';
 
 /**
@@ -173,5 +174,32 @@ export async function generateSessionSummary(sessionId: string): Promise<Session
     endedAt: session.endedAt?.toISOString() || null,
     durationMinutes,
     goal: session.goal || null,
+  };
+}
+
+/**
+ * Generate a viewer-specific Apple Health export payload. Unlike
+ * generateSessionSummary, this intentionally filters to the authenticated
+ * viewer so a personal Health workout never includes another climber's stats.
+ */
+export async function generateSessionHealthExport(
+  sessionId: string,
+  viewerUserId: string,
+): Promise<SessionHealthExport | null> {
+  const exportRecord = await getSessionHealthExport(db, { sessionId, viewerUserId });
+  if (!exportRecord) return null;
+  if (exportRecord.createdByUserId !== viewerUserId && exportRecord.laps.length === 0) return null;
+
+  return {
+    sessionId: exportRecord.sessionId,
+    startedAt: exportRecord.startedAt,
+    endedAt: exportRecord.endedAt,
+    durationMinutes: exportRecord.durationMinutes,
+    boardType: exportRecord.boardType,
+    totalSends: exportRecord.totalSends,
+    totalAttempts: exportRecord.totalAttempts,
+    hardestClimb: exportRecord.hardestClimb,
+    laps: exportRecord.laps,
+    healthKitWorkoutId: exportRecord.healthKitWorkoutId,
   };
 }

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -1,4 +1,5 @@
 export * from './climbs/index';
 export * from './aliases';
 export * from './recommendations/index';
+export * from './sessions/index';
 export * from './util/rows';

--- a/packages/db/src/queries/sessions/apple-health-export.ts
+++ b/packages/db/src/queries/sessions/apple-health-export.ts
@@ -1,0 +1,177 @@
+import { and, asc, eq, sql } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import {
+  boardClimbAliases,
+  boardClimbs,
+  boardDifficultyGrades,
+  boardSessions,
+  boardseshTicks,
+  sessionHealthKitWorkouts,
+} from '../../schema';
+import { getGradeLabel } from '../climbs/grade-lookup';
+
+type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+export type SessionHealthExportLapRecord = {
+  tickUuid: string;
+  climbUuid: string;
+  climbName: string | null;
+  grade: string | null;
+  status: string;
+  attemptCount: number;
+  boardType: string;
+  angle: number | null;
+  climbedAt: string;
+};
+
+export type SessionHealthExportHardestClimbRecord = {
+  climbUuid: string;
+  climbName: string;
+  grade: string;
+};
+
+export type SessionHealthExportRecord = {
+  sessionId: string;
+  createdByUserId: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  durationMinutes: number | null;
+  boardType: string;
+  totalSends: number;
+  totalAttempts: number;
+  hardestClimb: SessionHealthExportHardestClimbRecord | null;
+  laps: SessionHealthExportLapRecord[];
+  healthKitWorkoutId: string | null;
+};
+
+export type GetSessionHealthExportParams = {
+  sessionId: string;
+  viewerUserId: string;
+};
+
+function boardTypeFromPath(boardPath: string | null | undefined): string {
+  const [boardType] = (boardPath ?? '').split('/');
+  return boardType || 'unknown';
+}
+
+function attemptUnits(status: string, attemptCount: number): number {
+  if (status === 'flash') return 1;
+  if (status === 'send') return Math.max(attemptCount, 1);
+  if (status === 'attempt') return Math.max(attemptCount, 0);
+  return 0;
+}
+
+function dateToIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
+}
+
+function gradeForDifficulty(difficulty: number | null): string | null {
+  if (difficulty === null) return null;
+  return getGradeLabel(difficulty) ?? `V${difficulty}`;
+}
+
+/**
+ * Viewer-scoped Apple Health workout export read model.
+ *
+ * The backend stores only Boardsesh session/tick facts and the HealthKit
+ * workout UUID used for dedupe. Native HealthKit-only fields such as samples,
+ * body mass, calories, permissions, and raw workouts stay on-device.
+ */
+export async function getSessionHealthExport(
+  db: DrizzleDb,
+  { sessionId, viewerUserId }: GetSessionHealthExportParams,
+): Promise<SessionHealthExportRecord | null> {
+  const [sessionRows, tickRows, healthKitWorkoutRows] = await Promise.all([
+    db.select().from(boardSessions).where(eq(boardSessions.id, sessionId)).limit(1),
+    db
+      .select({
+        tickUuid: boardseshTicks.uuid,
+        climbUuid: boardseshTicks.climbUuid,
+        climbName: boardClimbs.name,
+        grade: boardDifficultyGrades.boulderName,
+        status: boardseshTicks.status,
+        attemptCount: boardseshTicks.attemptCount,
+        boardType: boardseshTicks.boardType,
+        angle: boardseshTicks.angle,
+        difficulty: boardseshTicks.difficulty,
+        climbedAt: boardseshTicks.climbedAt,
+      })
+      .from(boardseshTicks)
+      .leftJoin(
+        boardClimbAliases,
+        and(
+          eq(boardseshTicks.climbUuid, boardClimbAliases.aliasUuid),
+          eq(boardseshTicks.boardType, boardClimbAliases.boardType),
+        ),
+      )
+      .leftJoin(
+        boardClimbs,
+        and(
+          sql`COALESCE(${boardClimbAliases.canonicalUuid}, ${boardseshTicks.climbUuid}) = ${boardClimbs.uuid}`,
+          eq(boardClimbs.boardType, boardseshTicks.boardType),
+        ),
+      )
+      .leftJoin(
+        boardDifficultyGrades,
+        and(
+          eq(boardDifficultyGrades.difficulty, boardseshTicks.difficulty),
+          eq(boardDifficultyGrades.boardType, boardseshTicks.boardType),
+        ),
+      )
+      .where(and(eq(boardseshTicks.sessionId, sessionId), eq(boardseshTicks.userId, viewerUserId)))
+      .orderBy(asc(boardseshTicks.climbedAt)),
+    db
+      .select({ workoutId: sessionHealthKitWorkouts.workoutId })
+      .from(sessionHealthKitWorkouts)
+      .where(and(eq(sessionHealthKitWorkouts.sessionId, sessionId), eq(sessionHealthKitWorkouts.userId, viewerUserId)))
+      .limit(1),
+  ]);
+
+  const session = sessionRows[0];
+  if (!session) return null;
+
+  const laps: SessionHealthExportLapRecord[] = tickRows.map((tick) => ({
+    tickUuid: tick.tickUuid,
+    climbUuid: tick.climbUuid,
+    climbName: tick.climbName ?? null,
+    grade: tick.grade ?? gradeForDifficulty(tick.difficulty),
+    status: tick.status,
+    attemptCount: tick.attemptCount,
+    boardType: tick.boardType,
+    angle: tick.angle,
+    climbedAt: tick.climbedAt,
+  }));
+
+  const totalSends = tickRows.filter((tick) => tick.status === 'flash' || tick.status === 'send').length;
+  const totalAttempts = tickRows.reduce((sum, tick) => sum + attemptUnits(tick.status, tick.attemptCount), 0);
+  const hardestTick = tickRows
+    .filter((tick) => (tick.status === 'flash' || tick.status === 'send') && tick.difficulty != null)
+    .sort((firstTick, secondTick) => (secondTick.difficulty ?? -Infinity) - (firstTick.difficulty ?? -Infinity))[0];
+
+  let durationMinutes: number | null = null;
+  if (session.startedAt && session.endedAt) {
+    durationMinutes = Math.round((session.endedAt.getTime() - session.startedAt.getTime()) / 60000);
+  }
+
+  return {
+    sessionId,
+    createdByUserId: session.createdByUserId,
+    startedAt: dateToIso(session.startedAt),
+    endedAt: dateToIso(session.endedAt),
+    durationMinutes,
+    boardType: laps[0]?.boardType ?? boardTypeFromPath(session.boardPath),
+    totalSends,
+    totalAttempts,
+    hardestClimb: hardestTick
+      ? {
+          climbUuid: hardestTick.climbUuid,
+          climbName: hardestTick.climbName || 'Unknown climb',
+          grade: hardestTick.grade ?? gradeForDifficulty(hardestTick.difficulty) ?? `V${hardestTick.difficulty}`,
+        }
+      : null,
+    laps,
+    healthKitWorkoutId: healthKitWorkoutRows[0]?.workoutId ?? null,
+  };
+}

--- a/packages/db/src/queries/sessions/index.ts
+++ b/packages/db/src/queries/sessions/index.ts
@@ -1,0 +1,1 @@
+export * from './apple-health-export';

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -5,7 +5,7 @@ const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
 const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? DEFAULT_EAS_PROJECT_ID;
 const HEALTH_UPDATE_USAGE_DESCRIPTION = 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.';
 const HEALTH_SHARE_USAGE_DESCRIPTION =
-  'Boardsesh reads your body weight to estimate calories burned during climbing sessions.';
+  'Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.';
 
 function resolveDevMetadata(): {
   branchName: string | null;

--- a/packages/mobile/app/(tabs)/record/summary.tsx
+++ b/packages/mobile/app/(tabs)/record/summary.tsx
@@ -10,11 +10,9 @@ import { SectionHeader } from '../../../src/components/SectionHeader';
 import { Separator } from '../../../src/components/Separator';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useSessionSummary } from '../../../src/lib/graphql/hooks';
-import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { SaveToAppleHealthButton } from '../../../src/components/integrations/SaveToAppleHealthButton';
 import { ShareToStravaButton } from '../../../src/components/integrations/ShareToStravaButton';
-import type { SessionExportContext } from '../../../src/lib/integrations';
 import { brandColors } from '../../../src/theme/colors';
 import { spacing, borderRadius as br } from '../../../src/theme/tokens';
 
@@ -58,7 +56,6 @@ export default function SessionSummaryScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { formatGrade } = useGradeFormat();
-  const { data: activeBoard } = useActiveBoard();
 
   // Still loading: query hasn't settled yet (first fetch in flight or refetching
   // after a retry). isPending covers the disabled (no sessionId) case too.
@@ -92,14 +89,6 @@ export default function SessionSummaryScreen() {
   }
 
   const maxGradeCount = Math.max(...summary.gradeDistribution.map((gradeItem) => gradeItem.count), 1);
-
-  // Context for a manual Apple Health save from this screen. Auto-save at session
-  // end passes the real per-lap timestamps; a manual save here (e.g. after an app
-  // restart) can't reconstruct them, so the workout is written without laps.
-  const exportContext: SessionExportContext = {
-    boardType: activeBoard?.boardType ?? '',
-    lapTimestamps: [],
-  };
 
   return (
     <ScrollView
@@ -221,7 +210,7 @@ export default function SessionSummaryScreen() {
       {/* External integration actions: save this session to Apple Health / share
           to Strava. Each renders only when applicable (iOS / connected account). */}
       <View style={styles.integrationActions}>
-        <SaveToAppleHealthButton summary={summary} exportContext={exportContext} />
+        <SaveToAppleHealthButton summary={summary} />
         <ShareToStravaButton sessionId={summary.sessionId} />
       </View>
 

--- a/packages/mobile/modules/health-workouts/ios/HealthWorkoutsModule.swift
+++ b/packages/mobile/modules/health-workouts/ios/HealthWorkoutsModule.swift
@@ -55,21 +55,26 @@ public class HealthWorkoutsModule: Module {
 
         AsyncFunction("getAuthorizationStatus") { () -> [String: Any] in
             guard HKHealthStore.isHealthDataAvailable() else {
-                return ["status": "denied"]
+                return [
+                    "status": "denied",
+                    "workoutStatus": "denied",
+                    "activeEnergyStatus": "denied",
+                ]
             }
             // Read-only probe — never presents the consent sheet. UI uses this
             // on mount; requestAuthorization is reserved for explicit user
             // intent (it prompts undecided users).
-            switch self.healthStore.authorizationStatus(for: HKObjectType.workoutType()) {
-            case .sharingAuthorized:
-                return ["status": "authorized"]
-            case .sharingDenied:
-                return ["status": "denied"]
-            case .notDetermined:
-                return ["status": "notDetermined"]
-            @unknown default:
-                return ["status": "notDetermined"]
-            }
+            let workoutStatus = Self.statusString(
+                self.healthStore.authorizationStatus(for: HKObjectType.workoutType())
+            )
+            let activeEnergyStatus = Self.statusString(
+                self.healthStore.authorizationStatus(for: HKQuantityType(.activeEnergyBurned))
+            )
+            return [
+                "status": workoutStatus,
+                "workoutStatus": workoutStatus,
+                "activeEnergyStatus": activeEnergyStatus,
+            ]
         }
 
         AsyncFunction("requestAuthorization") { (promise: Promise) in
@@ -95,6 +100,7 @@ public class HealthWorkoutsModule: Module {
             HKQuantityType(.activeEnergyBurned),
         ]
         let read: Set<HKObjectType> = [
+            workoutType,
             HKQuantityType(.bodyMass),
         ]
 
@@ -119,7 +125,9 @@ public class HealthWorkoutsModule: Module {
                     "HealthKit auth not granted. success=\(success), status=\(String(describing: status.rawValue))"
                 )
             }
-            promise.resolve(["granted": granted])
+            let activeEnergyGranted =
+                self.healthStore.authorizationStatus(for: HKQuantityType(.activeEnergyBurned)) == .sharingAuthorized
+            promise.resolve(["granted": granted, "activeEnergyGranted": activeEnergyGranted])
         }
     }
 
@@ -151,6 +159,8 @@ public class HealthWorkoutsModule: Module {
 
         var metadata: [String: Any] = [
             HKMetadataKeyExternalUUID: options.sessionId,
+            HKMetadataKeyIndoorWorkout: true,
+            HKMetadataKeyWorkoutBrandName: "Boardsesh",
             "BoardseshSessionId": options.sessionId,
             "BoardseshTotalSends": options.totalSends,
             "BoardseshTotalAttempts": options.totalAttempts,
@@ -160,19 +170,35 @@ public class HealthWorkoutsModule: Module {
             metadata["BoardseshHardestGrade"] = hardestGrade
         }
 
-        // Parse lap timestamps up front; keep only those strictly inside the
+        // Parse lap events up front; keep only those strictly inside the
         // session window. Out-of-range or unparseable entries are dropped.
-        let lapDates: [Date] = options.lapTimestamps
-            .compactMap { Self.parseISO8601($0) }
-            .filter { $0 > startDate && $0 < endDate }
+        let laps: [WorkoutLap] = options.laps.filter { lap in
+            guard let lapDate = Self.parseISO8601(lap.climbedAt) else { return false }
+            return lapDate > startDate && lapDate < endDate
+        }
 
         Task {
             do {
+                if let existingWorkout = await self.findExistingWorkout(sessionId: options.sessionId) {
+                    self.logger.info(
+                        "Found existing climbing workout for session \(options.sessionId, privacy: .public)"
+                    )
+                    promise.resolve([
+                        "workoutId": existingWorkout.uuid.uuidString,
+                        "created": false,
+                        "energyKilocalories": NSNull(),
+                        "energySaved": false,
+                        "lapCount": 0,
+                    ])
+                    return
+                }
+
                 let bodyMassKg = await self.latestBodyMassKilograms()
                 let energyKilocalories = self.estimatedActiveEnergyKilocalories(
                     durationSeconds: durationSeconds,
                     bodyMassKg: bodyMassKg
                 )
+                var energySaved = false
 
                 let configuration = HKWorkoutConfiguration()
                 configuration.activityType = .climbing
@@ -197,18 +223,36 @@ public class HealthWorkoutsModule: Module {
                 )
                 do {
                     try await builder.addSamples([energySample])
+                    energySaved = true
                 } catch {
                     self.logger.warning(
                         "Skipping active-energy sample (not authorized?): \(error.localizedDescription, privacy: .public)"
                     )
                 }
 
-                if !lapDates.isEmpty {
-                    let lapEvents = lapDates.map { lapDate in
+                if !laps.isEmpty {
+                    let lapEvents = laps.compactMap { lap -> HKWorkoutEvent? in
+                        guard let lapDate = Self.parseISO8601(lap.climbedAt) else { return nil }
+                        var lapMetadata: [String: Any] = [
+                            "BoardseshTickUuid": lap.tickUuid,
+                            "BoardseshClimbUuid": lap.climbUuid,
+                            "BoardseshStatus": lap.status,
+                            "BoardseshAttemptCount": lap.attemptCount,
+                            "BoardseshBoardType": lap.boardType,
+                        ]
+                        if let climbName = lap.climbName, !climbName.isEmpty {
+                            lapMetadata["BoardseshClimbName"] = climbName
+                        }
+                        if let grade = lap.grade, !grade.isEmpty {
+                            lapMetadata["BoardseshGrade"] = grade
+                        }
+                        if let angle = lap.angle {
+                            lapMetadata["BoardseshAngle"] = angle
+                        }
                         HKWorkoutEvent(
                             type: .lap,
                             dateInterval: DateInterval(start: lapDate, duration: 0),
-                            metadata: nil
+                            metadata: lapMetadata
                         )
                     }
                     try await builder.addWorkoutEvents(lapEvents)
@@ -222,11 +266,54 @@ public class HealthWorkoutsModule: Module {
                 }
 
                 self.logger.info("Saved climbing workout for session \(options.sessionId, privacy: .public)")
-                promise.resolve(["workoutId": workout.uuid.uuidString])
+                promise.resolve([
+                    "workoutId": workout.uuid.uuidString,
+                    "created": true,
+                    "energyKilocalories": energyKilocalories,
+                    "energySaved": energySaved,
+                    "lapCount": laps.count,
+                ])
             } catch {
                 self.logger.error("Failed to save workout: \(error.localizedDescription, privacy: .public)")
                 promise.reject("E_SAVE_FAILED", "Failed to save workout: \(error.localizedDescription)")
             }
+        }
+    }
+
+    private static func statusString(_ status: HKAuthorizationStatus) -> String {
+        switch status {
+        case .sharingAuthorized:
+            return "authorized"
+        case .sharingDenied:
+            return "denied"
+        case .notDetermined:
+            return "notDetermined"
+        @unknown default:
+            return "notDetermined"
+        }
+    }
+
+    private func findExistingWorkout(sessionId: String) async -> HKWorkout? {
+        await withCheckedContinuation { continuation in
+            let predicate = HKQuery.predicateForObjects(
+                withMetadataKey: HKMetadataKeyExternalUUID,
+                allowedValues: [sessionId]
+            )
+            let sortByStartDate = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
+            let query = HKSampleQuery(
+                sampleType: HKObjectType.workoutType(),
+                predicate: predicate,
+                limit: 1,
+                sortDescriptors: [sortByStartDate]
+            ) { [weak self] _, samples, error in
+                if let error {
+                    self?.logger.warning(
+                        "Existing workout lookup failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+                continuation.resume(returning: samples?.first as? HKWorkout)
+            }
+            healthStore.execute(query)
         }
     }
 
@@ -297,5 +384,17 @@ struct SaveWorkoutOptions: Record {
     @Field var totalAttempts: Int = 0
     @Field var hardestGrade: String?
     @Field var boardType: String = ""
-    @Field var lapTimestamps: [String] = []
+    @Field var laps: [WorkoutLap] = []
+}
+
+struct WorkoutLap: Record {
+    @Field var tickUuid: String = ""
+    @Field var climbedAt: String = ""
+    @Field var climbUuid: String = ""
+    @Field var climbName: String?
+    @Field var grade: String?
+    @Field var status: String = ""
+    @Field var attemptCount: Int = 0
+    @Field var boardType: String = ""
+    @Field var angle: Int?
 }

--- a/packages/mobile/modules/health-workouts/src/index.ts
+++ b/packages/mobile/modules/health-workouts/src/index.ts
@@ -8,15 +8,39 @@ export type SaveWorkoutOptions = {
   totalAttempts: number;
   hardestGrade?: string;
   boardType: string;
-  lapTimestamps: string[];
+  laps: WorkoutLap[];
+};
+
+export type WorkoutLap = {
+  tickUuid: string;
+  climbedAt: string;
+  climbUuid: string;
+  climbName?: string | null;
+  grade?: string | null;
+  status: string;
+  attemptCount: number;
+  boardType: string;
+  angle?: number | null;
+};
+
+export type SaveWorkoutResult = {
+  workoutId: string;
+  created: boolean;
+  energyKilocalories: number | null;
+  energySaved: boolean;
+  lapCount: number;
 };
 
 export type HealthWorkoutsNativeModule = {
   isAvailable(): Promise<{ available: boolean }>;
   /** Workout-share authorization state; never presents the consent sheet. */
-  getAuthorizationStatus(): Promise<{ status: 'notDetermined' | 'denied' | 'authorized' }>;
-  requestAuthorization(): Promise<{ granted: boolean }>;
-  saveWorkout(options: SaveWorkoutOptions): Promise<{ workoutId: string }>;
+  getAuthorizationStatus(): Promise<{
+    status: 'notDetermined' | 'denied' | 'authorized';
+    workoutStatus: 'notDetermined' | 'denied' | 'authorized';
+    activeEnergyStatus: 'notDetermined' | 'denied' | 'authorized';
+  }>;
+  requestAuthorization(): Promise<{ granted: boolean; activeEnergyGranted: boolean }>;
+  saveWorkout(options: SaveWorkoutOptions): Promise<SaveWorkoutResult>;
 };
 
 // requireOptionalNativeModule returns null in Expo Go, on Android (this module

--- a/packages/mobile/plugins/with-healthkit.js
+++ b/packages/mobile/plugins/with-healthkit.js
@@ -6,7 +6,8 @@ const { createRunOncePlugin, withEntitlementsPlist, withInfoPlist } = require('e
 // (or a double-registered plugin) leaves both plists unchanged because we set
 // the same keys to the same values.
 const HEALTH_UPDATE_USAGE = 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.';
-const HEALTH_SHARE_USAGE = 'Boardsesh reads your body weight to estimate calories burned during climbing sessions.';
+const HEALTH_SHARE_USAGE =
+  'Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.';
 
 function withHealthKitEntitlement(config) {
   return withEntitlementsPlist(config, (modConfig) => {

--- a/packages/mobile/src/components/integrations/SaveToAppleHealthButton.tsx
+++ b/packages/mobile/src/components/integrations/SaveToAppleHealthButton.tsx
@@ -8,7 +8,7 @@ import { manualSaveToAppleHealth, useHealthKitSaveState, type SessionExportConte
 
 type SaveToAppleHealthButtonProps = {
   summary: SessionSummary;
-  exportContext: SessionExportContext;
+  exportContext?: SessionExportContext;
 };
 
 /**
@@ -19,7 +19,7 @@ type SaveToAppleHealthButtonProps = {
  * manual button stay in sync — pressing the button while an auto-save is
  * running shows the same "Saving…" state.
  */
-export function SaveToAppleHealthButton({ summary, exportContext }: SaveToAppleHealthButtonProps) {
+export function SaveToAppleHealthButton({ summary, exportContext = {} }: SaveToAppleHealthButtonProps) {
   const { t } = useTranslation('session');
   const { t: tSettings } = useTranslation('settings');
   const { showToast } = useToast();
@@ -46,10 +46,14 @@ export function SaveToAppleHealthButton({ summary, exportContext }: SaveToAppleH
     );
   }
 
-  if (saveState === 'saved') {
+  if (saveState === 'saved' || saveState === 'savedWithoutEnergy') {
     return (
       <Button
-        title={t('summary.savedToAppleHealth')}
+        title={
+          saveState === 'savedWithoutEnergy'
+            ? t('summary.savedToAppleHealthWithoutCalories')
+            : t('summary.savedToAppleHealth')
+        }
         variant="outlined"
         icon="check.small"
         onPress={handlePress}

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../../providers/queue-provider';
 import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
-import { useActiveBoard } from '../../../lib/graphql/use-active-board';
 import { runSessionEndExports } from '../../../lib/integrations';
 import { climbToQueueItem } from '../../../lib/climb-to-queue-item';
 import { getBoardConfigForPlaylist } from '../../../lib/playlists/board-details-for-playlist';
@@ -288,8 +287,6 @@ export function InSessionView({
   // Board type for the session-end integration exports (Apple Health workout
   // metadata + lap mapping). Falls back to '' when the active board hasn't
   // resolved — the export still records a workout, just without a board label.
-  const { data: activeBoard } = useActiveBoard();
-  const exportBoardType = activeBoard?.boardType ?? '';
 
   // Refresh detail whenever live tick aggregates move so the history list and
   // hardest-send names catch the newly logged tick. The live push only carries
@@ -374,20 +371,6 @@ export function InSessionView({
   const selfUserId = useMemo(
     () => sessionUsers.find((user) => user.id === participantId)?.userId ?? null,
     [sessionUsers, participantId],
-  );
-
-  // climbedAt timestamps of THIS user's ascents, mapped to HealthKit `.lap`
-  // events by the session-end Apple Health export. In a party session the tick
-  // list spans every climber, so we filter to our own (selfUserId). If we can't
-  // resolve selfUserId (rare; roster not yet hydrated) we fall back to every
-  // tick rather than recording zero laps — an over-broad lap set is harmless,
-  // a missing one loses data.
-  const selfLapTimestamps = useMemo(
-    () =>
-      sessionHistoryTicks
-        .filter((tick) => selfUserId == null || tick.userId === selfUserId)
-        .map((tick) => tick.climbedAt),
-    [sessionHistoryTicks, selfUserId],
   );
 
   // History-tick taps mutate the shared queue (setCurrentClimb) — gate them on
@@ -517,7 +500,7 @@ export function InSessionView({
         // never block or derail the summary navigation; the registry swallows any
         // rejection. The manual save button on the summary screen shares the same
         // dedup guard, so this won't double-write.
-        runSessionEndExports(summary, { boardType: exportBoardType, lapTimestamps: selfLapTimestamps });
+        runSessionEndExports(summary, {});
         router.push({ pathname: '/(tabs)/record/summary', params: { sessionId: summary.sessionId } });
       }
     } catch (error) {
@@ -529,7 +512,7 @@ export function InSessionView({
       // confirm button spinning forever and the sheet undismissable.
       setIsEnding(false);
     }
-  }, [endSession, router, onEndDismiss, exportBoardType, selfLapTimestamps]);
+  }, [endSession, router, onEndDismiss]);
 
   // Stable dismiss handler so the always-mounted EndSessionSheet doesn't get a fresh
   // onDismiss ref every render (onEndDismiss is optional, hence the wrapper).

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -243,11 +243,6 @@ describe('InSessionView footer', () => {
       await Promise.resolve();
     });
 
-    // Mocked session detail has no ticks and no active board, so the export
-    // context is empty — the assertion pins the handoff, not the contents.
-    expect(integrations.runSessionEndExports).toHaveBeenCalledWith(summary, {
-      boardType: '',
-      lapTimestamps: [],
-    });
+    expect(integrations.runSessionEndExports).toHaveBeenCalledWith(summary, {});
   });
 });

--- a/packages/mobile/src/lib/__tests__/healthkit-config.test.ts
+++ b/packages/mobile/src/lib/__tests__/healthkit-config.test.ts
@@ -30,7 +30,7 @@ describe('mobile HealthKit native config', () => {
     expect(config.ios?.infoPlist).toMatchObject({
       NSHealthUpdateUsageDescription: 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.',
       NSHealthShareUsageDescription:
-        'Boardsesh reads your body weight to estimate calories burned during climbing sessions.',
+        'Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.',
     });
   });
 

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -13,6 +13,7 @@ import type {
   SetterStatsInput,
   UserProfile,
   SessionSummary,
+  SessionHealthExport,
 } from '@boardsesh/shared-schema';
 import {
   SIMILAR_CLIMBS_QUERY,
@@ -47,6 +48,7 @@ import {
   GET_SETTER_STATS,
   GET_CLIMB,
   GET_SESSION_SUMMARY,
+  GET_SESSION_HEALTH_EXPORT,
   END_SESSION,
   TOGGLE_FAVORITE,
   type GetProfileQueryResponse,
@@ -65,6 +67,8 @@ import {
   type GetClimbQueryVariables,
   type GetSessionSummaryQueryResponse,
   type GetSessionSummaryQueryVariables,
+  type GetSessionHealthExportQueryResponse,
+  type GetSessionHealthExportQueryVariables,
   type EndSessionMutationVariables,
   type EndSessionMutationResponse,
   type ToggleFavoriteMutationVariables,
@@ -277,6 +281,22 @@ export function useSessionSummary(sessionId: string | null) {
         sessionId,
       } as GetSessionSummaryQueryVariables),
     select: (data) => data.sessionSummary,
+    enabled: !!sessionId,
+  });
+}
+
+export function useSessionHealthExport(sessionId: string | null) {
+  return useQuery<SessionHealthExport | null>({
+    queryKey: ['sessionHealthExport', sessionId],
+    queryFn: async () => {
+      const response = await getHttpClient().request<
+        GetSessionHealthExportQueryResponse,
+        GetSessionHealthExportQueryVariables
+      >(GET_SESSION_HEALTH_EXPORT, {
+        sessionId: sessionId!,
+      });
+      return response.sessionHealthExport;
+    },
     enabled: !!sessionId,
   });
 }

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -22,6 +22,7 @@ import type {
   SessionStatus,
   SessionFeedParticipant,
   SessionGradeDistributionItem,
+  SessionHealthExport,
 } from '@boardsesh/shared-schema';
 import type { SubscriptionQueueItem } from '../queue-conversion';
 
@@ -441,6 +442,33 @@ const SESSION_SUMMARY_FIELDS = `
   goal
 `;
 
+const SESSION_HEALTH_EXPORT_FIELDS = `
+  sessionId
+  startedAt
+  endedAt
+  durationMinutes
+  boardType
+  totalSends
+  totalAttempts
+  hardestClimb {
+    climbUuid
+    climbName
+    grade
+  }
+  laps {
+    tickUuid
+    climbedAt
+    climbUuid
+    climbName
+    grade
+    status
+    attemptCount
+    boardType
+    angle
+  }
+  healthKitWorkoutId
+`;
+
 export const CREATE_SESSION = gql`
   mutation CreateSession($input: CreateSessionInput!) {
     createSession(input: $input) {
@@ -515,6 +543,22 @@ export type GetSessionSummaryQueryVariables = {
 
 export type GetSessionSummaryQueryResponse = {
   sessionSummary: SessionSummary | null;
+};
+
+export const GET_SESSION_HEALTH_EXPORT = gql`
+  query GetSessionHealthExport($sessionId: ID!) {
+    sessionHealthExport(sessionId: $sessionId) {
+      ${SESSION_HEALTH_EXPORT_FIELDS}
+    }
+  }
+`;
+
+export type GetSessionHealthExportQueryVariables = {
+  sessionId: string;
+};
+
+export type GetSessionHealthExportQueryResponse = {
+  sessionHealthExport: SessionHealthExport | null;
 };
 
 export const GET_NEARBY_SESSIONS = gql`

--- a/packages/mobile/src/lib/integrations/__tests__/apple-health-auto-save.test.ts
+++ b/packages/mobile/src/lib/integrations/__tests__/apple-health-auto-save.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { SessionSummary } from '@boardsesh/shared-schema';
+import type { SessionHealthExport, SessionSummary } from '@boardsesh/shared-schema';
 
 // ── Mock native module, preference store, analytics, graphql client ──────────
 // `vi.hoisted` is required: bare `vi.mock` factories are hoisted above top-level
@@ -65,12 +65,56 @@ const makeSummary = (overrides?: Partial<SessionSummary>): SessionSummary => ({
   ...overrides,
 });
 
-const ctx: SessionExportContext = { boardType: 'kilter', lapTimestamps: [] };
+const makeHealthExport = (overrides?: Partial<SessionHealthExport>): SessionHealthExport => ({
+  sessionId: 'session-1',
+  totalSends: 5,
+  totalAttempts: 10,
+  boardType: 'kilter',
+  laps: [
+    {
+      tickUuid: 'tick-1',
+      climbedAt: '2026-04-20T10:30:00Z',
+      climbUuid: 'climb-1',
+      climbName: 'Test Climb',
+      grade: 'V5',
+      status: 'send',
+      attemptCount: 2,
+      boardType: 'kilter',
+      angle: 40,
+    },
+  ],
+  hardestClimb: {
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    grade: 'V5',
+  },
+  startedAt: '2026-04-20T10:00:00Z',
+  endedAt: '2026-04-20T11:00:00Z',
+  durationMinutes: 60,
+  healthKitWorkoutId: null,
+  ...overrides,
+});
+
+const ctx: SessionExportContext = {};
 
 // Default-ON preference: only an explicit `false` disables. Tests that need it
 // off override getPreferenceMock per case.
 function autoSaveOn() {
   getPreferenceMock.mockResolvedValue(null);
+}
+
+function mockGraphqlResponses(healthExport: SessionHealthExport | null = makeHealthExport()) {
+  requestMock.mockImplementation(async (operation: unknown, variables?: { sessionId?: string; workoutId?: string }) => {
+    if (operation === 'SET_SESSION_HEALTHKIT_WORKOUT_ID') return {};
+    return {
+      sessionHealthExport: healthExport
+        ? {
+            ...healthExport,
+            sessionId: variables?.sessionId ?? healthExport.sessionId,
+          }
+        : null,
+    };
+  });
 }
 
 describe('autoSaveToAppleHealth', () => {
@@ -82,8 +126,14 @@ describe('autoSaveToAppleHealth', () => {
     isAvailableMock.mockResolvedValue({ available: true });
     getAuthorizationStatusMock.mockResolvedValue({ status: 'authorized' });
     requestAuthorizationMock.mockResolvedValue({ granted: true });
-    saveWorkoutMock.mockResolvedValue({ workoutId: 'hk-workout-1' });
-    requestMock.mockResolvedValue({});
+    saveWorkoutMock.mockResolvedValue({
+      workoutId: 'hk-workout-1',
+      created: true,
+      energyKilocalories: 100,
+      energySaved: true,
+      lapCount: 1,
+    });
+    mockGraphqlResponses();
   });
 
   it('skips and releases the guard when auto-save preference is off', async () => {
@@ -104,6 +154,7 @@ describe('autoSaveToAppleHealth', () => {
     const result = await autoSaveToAppleHealth(makeSummary({ sessionId: 'unavailable' }), ctx);
 
     expect(result).toBeNull();
+    expect(requestMock).toHaveBeenCalled();
     expect(requestAuthorizationMock).not.toHaveBeenCalled();
   });
 
@@ -134,7 +185,13 @@ describe('autoSaveToAppleHealth', () => {
   });
 
   it('saves once, persists the workout id, and marks state saved', async () => {
-    saveWorkoutMock.mockResolvedValue({ workoutId: 'hk-workout-7' });
+    saveWorkoutMock.mockResolvedValue({
+      workoutId: 'hk-workout-7',
+      created: true,
+      energyKilocalories: 120,
+      energySaved: true,
+      lapCount: 1,
+    });
 
     const result = await autoSaveToAppleHealth(makeSummary(), ctx);
 
@@ -144,6 +201,16 @@ describe('autoSaveToAppleHealth', () => {
       sessionId: 'session-1',
       workoutId: 'hk-workout-7',
     });
+    expect(saveWorkoutMock).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      startDate: '2026-04-20T10:00:00Z',
+      endDate: '2026-04-20T11:00:00Z',
+      totalSends: 5,
+      totalAttempts: 10,
+      hardestGrade: 'V5',
+      boardType: 'kilter',
+      laps: makeHealthExport().laps,
+    });
     expect(trackMock).toHaveBeenCalledWith('Session Exported to Integration', {
       integration: 'apple_health',
       trigger: 'auto',
@@ -151,8 +218,17 @@ describe('autoSaveToAppleHealth', () => {
   });
 
   it('still resolves saved when the backend persist fails', async () => {
-    saveWorkoutMock.mockResolvedValue({ workoutId: 'hk-workout-8' });
-    requestMock.mockRejectedValue(new Error('network error'));
+    saveWorkoutMock.mockResolvedValue({
+      workoutId: 'hk-workout-8',
+      created: true,
+      energyKilocalories: 110,
+      energySaved: true,
+      lapCount: 1,
+    });
+    requestMock.mockImplementation(async (operation: unknown, variables?: { sessionId?: string }) => {
+      if (operation === 'SET_SESSION_HEALTHKIT_WORKOUT_ID') throw new Error('network error');
+      return { sessionHealthExport: { ...makeHealthExport(), sessionId: variables?.sessionId ?? 'session-1' } };
+    });
 
     const result = await autoSaveToAppleHealth(makeSummary(), ctx);
 
@@ -166,24 +242,62 @@ describe('autoSaveToAppleHealth', () => {
     expect(first).toBeNull();
 
     // 'failed' is retryable: a manual save overwrites it and succeeds.
-    saveWorkoutMock.mockResolvedValueOnce({ workoutId: 'hk-workout-retry' });
+    saveWorkoutMock.mockResolvedValueOnce({
+      workoutId: 'hk-workout-retry',
+      created: true,
+      energyKilocalories: 100,
+      energySaved: true,
+      lapCount: 1,
+    });
     const retry = await manualSaveToAppleHealth(makeSummary({ sessionId: 'retry' }), ctx);
     expect(retry).toBe('saved');
     expect(saveWorkoutMock).toHaveBeenCalledTimes(2);
   });
 
-  it('skips and releases the guard when the session lacks start/end timestamps', async () => {
-    const result = await autoSaveToAppleHealth(
-      makeSummary({ sessionId: 'no-dates', startedAt: null, endedAt: null }),
-      ctx,
-    );
+  it('skips and releases the guard when the health export lacks start/end timestamps', async () => {
+    const result = await autoSaveToAppleHealth(makeSummary({ sessionId: 'no-dates' }), {
+      healthExport: makeHealthExport({ sessionId: 'no-dates', startedAt: null, endedAt: null }),
+    });
 
     expect(result).toBeNull();
     expect(saveWorkoutMock).not.toHaveBeenCalled();
   });
 
+  it('marks saved without prompting when the backend already has a workout id', async () => {
+    mockGraphqlResponses(makeHealthExport({ healthKitWorkoutId: 'hk-existing' }));
+
+    const result = await autoSaveToAppleHealth(makeSummary({ sessionId: 'existing' }), ctx);
+
+    expect(result).toBe('hk-existing');
+    expect(isAvailableMock).not.toHaveBeenCalled();
+    expect(requestAuthorizationMock).not.toHaveBeenCalled();
+    expect(saveWorkoutMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the saved state distinct when active-energy was not written', async () => {
+    saveWorkoutMock.mockResolvedValueOnce({
+      workoutId: 'hk-without-energy',
+      created: true,
+      energyKilocalories: 100,
+      energySaved: false,
+      lapCount: 1,
+    });
+
+    const result = await manualSaveToAppleHealth(makeSummary({ sessionId: 'no-energy' }), ctx);
+
+    expect(result).toBe('savedWithoutEnergy');
+    expect(await manualSaveToAppleHealth(makeSummary({ sessionId: 'no-energy' }), ctx)).toBe('savedWithoutEnergy');
+    expect(saveWorkoutMock).toHaveBeenCalledTimes(1);
+  });
+
   it('runs the native save once under concurrent auto + manual', async () => {
-    saveWorkoutMock.mockResolvedValue({ workoutId: 'hk-workout-concurrent' });
+    saveWorkoutMock.mockResolvedValue({
+      workoutId: 'hk-workout-concurrent',
+      created: true,
+      energyKilocalories: 100,
+      energySaved: true,
+      lapCount: 1,
+    });
 
     const summary = makeSummary({ sessionId: 'concurrent' });
     const [autoResult, manualResult] = await Promise.all([

--- a/packages/mobile/src/lib/integrations/__tests__/registry.test.ts
+++ b/packages/mobile/src/lib/integrations/__tests__/registry.test.ts
@@ -37,7 +37,7 @@ const summary: SessionSummary = {
   goal: null,
 };
 
-const ctx = { boardType: 'kilter', lapTimestamps: [] };
+const ctx = {};
 
 describe('integration registry', () => {
   beforeEach(() => {

--- a/packages/mobile/src/lib/integrations/apple-health.ts
+++ b/packages/mobile/src/lib/integrations/apple-health.ts
@@ -11,7 +11,7 @@
 // surface.
 
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
-import type { SessionSummary } from '@boardsesh/shared-schema';
+import type { SessionHealthExport, SessionSummary } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { SET_SESSION_HEALTHKIT_WORKOUT_ID } from '@boardsesh/graphql/operations/activity-feed';
 // Imported by relative path (not the package name) to match the live-activity
@@ -19,9 +19,14 @@ import { SET_SESSION_HEALTHKIT_WORKOUT_ID } from '@boardsesh/graphql/operations/
 // via modules/health-workouts/expo-module.config.json, while the JS wrapper is
 // pulled in directly from its source so Metro + vitest resolve it without the
 // package needing a dependency entry.
-import { healthWorkoutsNative } from '../../../modules/health-workouts/src/index';
+import { healthWorkoutsNative, type SaveWorkoutResult } from '../../../modules/health-workouts/src/index';
 import { track } from '../analytics';
 import { getHttpClient } from '../graphql/client';
+import {
+  GET_SESSION_HEALTH_EXPORT,
+  type GetSessionHealthExportQueryResponse,
+  type GetSessionHealthExportQueryVariables,
+} from '../graphql/operations';
 import { getPreference, setPreference } from '../preference-store';
 import type { SessionExportContext } from './types';
 
@@ -157,15 +162,15 @@ export function useHealthKitAutoSavePreference(): {
 }
 
 // ============================================
-// Per-session save state (saving / saved / failed)
+// Per-session save state (saving / saved / savedWithoutEnergy / failed)
 // ============================================
 
-export type HealthKitSaveState = 'saving' | 'saved' | 'failed';
+export type HealthKitSaveState = 'saving' | 'saved' | 'savedWithoutEnergy' | 'failed';
 
 // Module-level Map doubles as the dedup guard (the web file's
 // `savedOrInFlight` Set) AND the source for the per-session save-state UI. A
-// sessionId present with 'saving' or 'saved' means a save is claimed; 'failed'
-// is releasable so a manual retry can overwrite it.
+// sessionId present with 'saving' or a saved state means a save is claimed;
+// 'failed' is releasable so a manual retry can overwrite it.
 const saveStateBySession = new Map<string, HealthKitSaveState>();
 const saveStateListeners = new Set<() => void>();
 
@@ -223,20 +228,36 @@ async function persistWorkoutId(sessionId: string, workoutId: string): Promise<v
   }
 }
 
-/** Map a SessionSummary + context to the native saveWorkout options, or null
+async function loadSessionHealthExport(
+  sessionId: string,
+  ctx: SessionExportContext,
+): Promise<SessionHealthExport | null> {
+  if (ctx.healthExport !== undefined) return ctx.healthExport;
+  const response = await getHttpClient().request<
+    GetSessionHealthExportQueryResponse,
+    GetSessionHealthExportQueryVariables
+  >(GET_SESSION_HEALTH_EXPORT, { sessionId });
+  return response.sessionHealthExport;
+}
+
+/** Map a viewer-specific export payload to the native saveWorkout options, or null
  *  when the session lacks the start/end timestamps the workout requires. */
-function buildSaveOptions(summary: SessionSummary, ctx: SessionExportContext) {
-  if (!summary.startedAt || !summary.endedAt) return null;
+function buildSaveOptions(healthExport: SessionHealthExport) {
+  if (!healthExport.startedAt || !healthExport.endedAt) return null;
   return {
-    sessionId: summary.sessionId,
-    startDate: summary.startedAt,
-    endDate: summary.endedAt,
-    totalSends: summary.totalSends,
-    totalAttempts: summary.totalAttempts,
-    hardestGrade: summary.hardestClimb?.grade,
-    boardType: ctx.boardType,
-    lapTimestamps: ctx.lapTimestamps,
+    sessionId: healthExport.sessionId,
+    startDate: healthExport.startedAt,
+    endDate: healthExport.endedAt,
+    totalSends: healthExport.totalSends,
+    totalAttempts: healthExport.totalAttempts,
+    hardestGrade: healthExport.hardestClimb?.grade,
+    boardType: healthExport.boardType,
+    laps: healthExport.laps,
   };
+}
+
+function setSavedStateFromResult(sessionId: string, result: SaveWorkoutResult): void {
+  setSaveState(sessionId, result.created && !result.energySaved ? 'savedWithoutEnergy' : 'saved');
 }
 
 /**
@@ -244,12 +265,12 @@ function buildSaveOptions(summary: SessionSummary, ctx: SessionExportContext) {
  * `autoSaveToHealthKit`:
  *
  * - Claims the dedup guard synchronously at entry (sets 'saving'); a session
- *   already 'saving' or 'saved' returns null without a second native call.
+ *   already 'saving' or saved returns null without a second native call.
  * - Auto-save preference off / unavailable / authorization denied / missing
  *   timestamps all RELEASE the guard (delete the entry) and return null, so the
  *   manual save button still works.
- * - On success: marks 'saved', best-effort persists the workout id, tracks the
- *   export, returns the workout id.
+ * - On success: marks a saved state, best-effort persists the workout id,
+ *   tracks the export, returns the workout id.
  * - On a thrown native error: marks 'failed' and returns null (a manual retry
  *   can overwrite the 'failed' entry).
  *
@@ -264,7 +285,7 @@ export async function autoSaveToAppleHealth(
   // Claim synchronously — prevents a concurrent auto + manual save from both
   // reaching the native bridge.
   const existing = saveStateBySession.get(sessionId);
-  if (existing === 'saving' || existing === 'saved') return null;
+  if (existing === 'saving' || existing === 'saved' || existing === 'savedWithoutEnergy') return null;
   setSaveState(sessionId, 'saving');
 
   try {
@@ -272,6 +293,16 @@ export async function autoSaveToAppleHealth(
     if (!enabled) {
       clearSaveState(sessionId);
       return null;
+    }
+
+    const healthExport = await loadSessionHealthExport(sessionId, ctx);
+    if (!healthExport) {
+      clearSaveState(sessionId);
+      return null;
+    }
+    if (healthExport.healthKitWorkoutId) {
+      setSaveState(sessionId, 'saved');
+      return healthExport.healthKitWorkoutId;
     }
 
     const available = await isAppleHealthAvailable();
@@ -292,7 +323,7 @@ export async function autoSaveToAppleHealth(
       return null;
     }
 
-    const options = buildSaveOptions(summary, ctx);
+    const options = buildSaveOptions(healthExport);
     // `!healthWorkoutsNative` is unreachable at runtime (isAppleHealthAvailable
     // above already bailed when the module is null) — it's here purely to
     // narrow the type for the call below.
@@ -301,11 +332,11 @@ export async function autoSaveToAppleHealth(
       return null;
     }
 
-    const { workoutId } = await healthWorkoutsNative.saveWorkout(options);
-    setSaveState(sessionId, 'saved');
-    await persistWorkoutId(sessionId, workoutId);
+    const result = await healthWorkoutsNative.saveWorkout(options);
+    setSavedStateFromResult(sessionId, result);
+    await persistWorkoutId(sessionId, result.workoutId);
     track(SHARED_EVENTS.SessionExportedToIntegration, { integration: 'apple_health', trigger: 'auto' });
-    return workoutId;
+    return result.workoutId;
   } catch (error) {
     setSaveState(sessionId, 'failed');
     console.warn('[AppleHealth] Auto-save failed:', error);
@@ -318,29 +349,40 @@ export async function autoSaveToAppleHealth(
  * screen). Like the auto path but skips the preference check and reports a
  * coarse outcome the UI can render.
  *
- * - Already 'saved' → returns 'saved'. A save still in flight ('saving') →
- *   returns 'inFlight' — NOT 'saved', the running task may yet fail; the
- *   button keeps rendering the store's live state. Either way no second
+ * - Already saved → returns that saved state. A save still in flight
+ *   ('saving') returns 'inFlight' — NOT 'saved', the running task may yet fail;
+ *   the button keeps rendering the store's live state. Either way no second
  *   native write starts: whoever claims 'saving' first wins.
  * - A previous 'failed' (retryable) or no prior entry → claims 'saving' and
  *   proceeds, so a manual retry after a failed save works.
  * - unavailable / denied delete the entry and return that outcome.
- * - success marks 'saved', persists the workout id, tracks (trigger 'manual').
+ * - success marks a saved state, persists the workout id, tracks (trigger
+ *   'manual').
  * - a thrown native error marks 'failed' and returns 'failed'.
  */
 export async function manualSaveToAppleHealth(
   summary: SessionSummary,
   ctx: SessionExportContext,
-): Promise<'saved' | 'inFlight' | 'denied' | 'unavailable' | 'failed'> {
+): Promise<'saved' | 'savedWithoutEnergy' | 'inFlight' | 'denied' | 'unavailable' | 'failed'> {
   const { sessionId } = summary;
 
   const existing = saveStateBySession.get(sessionId);
-  if (existing === 'saved') return 'saved';
+  if (existing === 'saved' || existing === 'savedWithoutEnergy') return existing;
   if (existing === 'saving') return 'inFlight';
   // 'failed' (retryable) or no entry proceed by claiming.
   setSaveState(sessionId, 'saving');
 
   try {
+    const healthExport = await loadSessionHealthExport(sessionId, ctx);
+    if (!healthExport) {
+      setSaveState(sessionId, 'failed');
+      return 'failed';
+    }
+    if (healthExport.healthKitWorkoutId) {
+      setSaveState(sessionId, 'saved');
+      return 'saved';
+    }
+
     const available = await isAppleHealthAvailable();
     if (!available) {
       clearSaveState(sessionId);
@@ -358,7 +400,7 @@ export async function manualSaveToAppleHealth(
       return 'denied';
     }
 
-    const options = buildSaveOptions(summary, ctx);
+    const options = buildSaveOptions(healthExport);
     // `!healthWorkoutsNative` is unreachable at runtime (isAppleHealthAvailable
     // above already bailed when the module is null) — it's here purely to
     // narrow the type for the call below.
@@ -367,11 +409,11 @@ export async function manualSaveToAppleHealth(
       return 'failed';
     }
 
-    const { workoutId } = await healthWorkoutsNative.saveWorkout(options);
-    setSaveState(sessionId, 'saved');
-    await persistWorkoutId(sessionId, workoutId);
+    const result = await healthWorkoutsNative.saveWorkout(options);
+    setSavedStateFromResult(sessionId, result);
+    await persistWorkoutId(sessionId, result.workoutId);
     track(SHARED_EVENTS.SessionExportedToIntegration, { integration: 'apple_health', trigger: 'manual' });
-    return 'saved';
+    return result.created && !result.energySaved ? 'savedWithoutEnergy' : 'saved';
   } catch (error) {
     setSaveState(sessionId, 'failed');
     console.warn('[AppleHealth] Manual save failed:', error);

--- a/packages/mobile/src/lib/integrations/types.ts
+++ b/packages/mobile/src/lib/integrations/types.ts
@@ -1,4 +1,4 @@
-import type { SessionSummary } from '@boardsesh/shared-schema';
+import type { SessionHealthExport, SessionSummary } from '@boardsesh/shared-schema';
 
 // Stable identifier for an integration surface. Distinct from the GraphQL
 // `IntegrationProvider` ('STRAVA'): device-local integrations (Apple Health)
@@ -6,12 +6,12 @@ import type { SessionSummary } from '@boardsesh/shared-schema';
 // enum value. This id is what the UI and the registry key off.
 export type IntegrationId = 'apple-health' | 'strava';
 
-// Per-session context the session-end trigger gathers that isn't carried on the
-// `SessionSummary` itself: the active board type and the climbedAt timestamps of
-// the current user's ascents (mapped to HealthKit `.lap` events).
+// Optional per-session context gathered by the session-end trigger. Apple
+// Health now loads the viewer-specific export payload from GraphQL so manual
+// saves after app restart have the same lap data as auto-saves.
 export type SessionExportContext = {
-  boardType: string;
-  lapTimestamps: string[];
+  boardType?: string;
+  healthExport?: SessionHealthExport | null;
 };
 
 export type IntegrationDefinition = {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -514,6 +514,57 @@ type SessionSummary {
   goal: String
 }
 
+"""
+One viewer-owned lap/event included in an Apple Health workout export.
+"""
+type SessionHealthExportLap {
+  "Tick UUID"
+  tickUuid: ID!
+  "Climb UUID"
+  climbUuid: String!
+  "Climb name"
+  climbName: String
+  "Grade name"
+  grade: String
+  "Tick status (flash, send, attempt)"
+  status: String!
+  "Number of attempts represented by this tick"
+  attemptCount: Int!
+  "Board type"
+  boardType: String!
+  "Climb angle"
+  angle: Int
+  "When the lap was logged"
+  climbedAt: String!
+}
+
+"""
+Viewer-specific export payload for writing a finished session to Apple Health.
+It intentionally contains only the requesting user's ticks and saved workout id.
+"""
+type SessionHealthExport {
+  "Session ID"
+  sessionId: ID!
+  "When the session started"
+  startedAt: String
+  "When the session ended"
+  endedAt: String
+  "Duration in minutes"
+  durationMinutes: Int
+  "Primary board type for this viewer's workout"
+  boardType: String!
+  "Viewer-owned sends"
+  totalSends: Int!
+  "Viewer-owned attempts, including the successful attempt on sends"
+  totalAttempts: Int!
+  "Hardest climb the viewer sent during the session"
+  hardestClimb: SessionHardestClimb
+  "Viewer-owned lap events"
+  laps: [SessionHealthExportLap!]!
+  "Existing Apple Health workout id saved for this viewer/session"
+  healthKitWorkoutId: String
+}
+
 # ============================================
 # Board Configuration Types
 # ============================================
@@ -3634,6 +3685,12 @@ type Query {
   Available for ended sessions or active sessions with ticks.
   """
   sessionSummary(sessionId: ID!): SessionSummary
+
+  """
+  Get viewer-specific session data for an Apple Health workout export.
+  Requires authentication and returns only the requesting user's ticks.
+  """
+  sessionHealthExport(sessionId: ID!): SessionHealthExport
 
   """
   Lightweight, presence-independent lifecycle check for a session.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3480,6 +3480,11 @@ export type Query = {
    */
   sessionGroupedFeed: SessionFeedResult;
   /**
+   * Get viewer-specific session data for an Apple Health workout export.
+   * Requires authentication and returns only the requesting user's ticks.
+   */
+  sessionHealthExport?: Maybe<SessionHealthExport>;
+  /**
    * Lightweight, presence-independent lifecycle check for a session.
    * Reads the durable session row (not live Redis presence), so it tells an
    * ended session apart from one that is merely empty. Returns null when the
@@ -3920,6 +3925,11 @@ export type QuerySessionDetailArgs = {
 /** Root query type for all read operations. */
 export type QuerySessionGroupedFeedArgs = {
   input?: InputMaybe<ActivityFeedInput>;
+};
+
+/** Root query type for all read operations. */
+export type QuerySessionHealthExportArgs = {
+  sessionId: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -4608,6 +4618,57 @@ export type SessionHardestClimb = {
   climbUuid: Scalars['String']['output'];
   /** Grade name */
   grade: Scalars['String']['output'];
+};
+
+/**
+ * Viewer-specific export payload for writing a finished session to Apple Health.
+ * It intentionally contains only the requesting user's ticks and saved workout id.
+ */
+export type SessionHealthExport = {
+  __typename?: 'SessionHealthExport';
+  /** Primary board type for this viewer's workout */
+  boardType: Scalars['String']['output'];
+  /** Duration in minutes */
+  durationMinutes?: Maybe<Scalars['Int']['output']>;
+  /** When the session ended */
+  endedAt?: Maybe<Scalars['String']['output']>;
+  /** Hardest climb the viewer sent during the session */
+  hardestClimb?: Maybe<SessionHardestClimb>;
+  /** Existing Apple Health workout id saved for this viewer/session */
+  healthKitWorkoutId?: Maybe<Scalars['String']['output']>;
+  /** Viewer-owned lap events */
+  laps: Array<SessionHealthExportLap>;
+  /** Session ID */
+  sessionId: Scalars['ID']['output'];
+  /** When the session started */
+  startedAt?: Maybe<Scalars['String']['output']>;
+  /** Viewer-owned attempts, including the successful attempt on sends */
+  totalAttempts: Scalars['Int']['output'];
+  /** Viewer-owned sends */
+  totalSends: Scalars['Int']['output'];
+};
+
+/** One viewer-owned lap/event included in an Apple Health workout export. */
+export type SessionHealthExportLap = {
+  __typename?: 'SessionHealthExportLap';
+  /** Climb angle */
+  angle?: Maybe<Scalars['Int']['output']>;
+  /** Number of attempts represented by this tick */
+  attemptCount: Scalars['Int']['output'];
+  /** Board type */
+  boardType: Scalars['String']['output'];
+  /** Climb name */
+  climbName?: Maybe<Scalars['String']['output']>;
+  /** Climb UUID */
+  climbUuid: Scalars['String']['output'];
+  /** When the lap was logged */
+  climbedAt: Scalars['String']['output'];
+  /** Grade name */
+  grade?: Maybe<Scalars['String']['output']>;
+  /** Tick status (flash, send, attempt) */
+  status: Scalars['String']['output'];
+  /** Tick UUID */
+  tickUuid: Scalars['ID']['output'];
 };
 
 /** Participant stats in a session summary. */
@@ -5901,6 +5962,8 @@ export type ResolversTypes = ResolversObject<{
   SessionGradeCount: ResolverTypeWrapper<SessionGradeCount>;
   SessionGradeDistributionItem: ResolverTypeWrapper<SessionGradeDistributionItem>;
   SessionHardestClimb: ResolverTypeWrapper<SessionHardestClimb>;
+  SessionHealthExport: ResolverTypeWrapper<SessionHealthExport>;
+  SessionHealthExportLap: ResolverTypeWrapper<SessionHealthExportLap>;
   SessionParticipant: ResolverTypeWrapper<SessionParticipant>;
   SessionStatsUpdated: ResolverTypeWrapper<SessionStatsUpdated>;
   SessionStatus: SessionStatus;
@@ -6165,6 +6228,8 @@ export type ResolversParentTypes = ResolversObject<{
   SessionGradeCount: SessionGradeCount;
   SessionGradeDistributionItem: SessionGradeDistributionItem;
   SessionHardestClimb: SessionHardestClimb;
+  SessionHealthExport: SessionHealthExport;
+  SessionHealthExportLap: SessionHealthExportLap;
   SessionParticipant: SessionParticipant;
   SessionStatsUpdated: SessionStatsUpdated;
   SessionSummary: SessionSummary;
@@ -8406,6 +8471,12 @@ export type QueryResolvers<
     ContextType,
     Partial<QuerySessionGroupedFeedArgs>
   >;
+  sessionHealthExport?: Resolver<
+    Maybe<ResolversTypes['SessionHealthExport']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySessionHealthExportArgs, 'sessionId'>
+  >;
   sessionStatus?: Resolver<
     Maybe<ResolversTypes['SessionStatus']>,
     ParentType,
@@ -8877,6 +8948,39 @@ export type SessionHardestClimbResolvers<
   climbName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   grade?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type SessionHealthExportResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['SessionHealthExport'] = ResolversParentTypes['SessionHealthExport'],
+> = ResolversObject<{
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  durationMinutes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  endedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hardestClimb?: Resolver<Maybe<ResolversTypes['SessionHardestClimb']>, ParentType, ContextType>;
+  healthKitWorkoutId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  laps?: Resolver<Array<ResolversTypes['SessionHealthExportLap']>, ParentType, ContextType>;
+  sessionId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  startedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  totalAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  totalSends?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type SessionHealthExportLapResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['SessionHealthExportLap'] = ResolversParentTypes['SessionHealthExportLap'],
+> = ResolversObject<{
+  angle?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  attemptCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  climbName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  climbedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  grade?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tickUuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -9446,6 +9550,8 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   SessionGradeCount?: SessionGradeCountResolvers<ContextType>;
   SessionGradeDistributionItem?: SessionGradeDistributionItemResolvers<ContextType>;
   SessionHardestClimb?: SessionHardestClimbResolvers<ContextType>;
+  SessionHealthExport?: SessionHealthExportResolvers<ContextType>;
+  SessionHealthExportLap?: SessionHealthExportLapResolvers<ContextType>;
   SessionParticipant?: SessionParticipantResolvers<ContextType>;
   SessionStatsUpdated?: SessionStatsUpdatedResolvers<ContextType>;
   SessionSummary?: SessionSummaryResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -34,6 +34,12 @@ export const queriesTypeDefs = /* GraphQL */ `
     sessionSummary(sessionId: ID!): SessionSummary
 
     """
+    Get viewer-specific session data for an Apple Health workout export.
+    Requires authentication and returns only the requesting user's ticks.
+    """
+    sessionHealthExport(sessionId: ID!): SessionHealthExport
+
+    """
     Lightweight, presence-independent lifecycle check for a session.
     Reads the durable session row (not live Redis presence), so it tells an
     ended session apart from one that is merely empty. Returns null when the

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -202,4 +202,55 @@ export const sessionTypeDefs = /* GraphQL */ `
     "Session goal text"
     goal: String
   }
+
+  """
+  One viewer-owned lap/event included in an Apple Health workout export.
+  """
+  type SessionHealthExportLap {
+    "Tick UUID"
+    tickUuid: ID!
+    "Climb UUID"
+    climbUuid: String!
+    "Climb name"
+    climbName: String
+    "Grade name"
+    grade: String
+    "Tick status (flash, send, attempt)"
+    status: String!
+    "Number of attempts represented by this tick"
+    attemptCount: Int!
+    "Board type"
+    boardType: String!
+    "Climb angle"
+    angle: Int
+    "When the lap was logged"
+    climbedAt: String!
+  }
+
+  """
+  Viewer-specific export payload for writing a finished session to Apple Health.
+  It intentionally contains only the requesting user's ticks and saved workout id.
+  """
+  type SessionHealthExport {
+    "Session ID"
+    sessionId: ID!
+    "When the session started"
+    startedAt: String
+    "When the session ended"
+    endedAt: String
+    "Duration in minutes"
+    durationMinutes: Int
+    "Primary board type for this viewer's workout"
+    boardType: String!
+    "Viewer-owned sends"
+    totalSends: Int!
+    "Viewer-owned attempts, including the successful attempt on sends"
+    totalAttempts: Int!
+    "Hardest climb the viewer sent during the session"
+    hardestClimb: SessionHardestClimb
+    "Viewer-owned lap events"
+    laps: [SessionHealthExportLap!]!
+    "Existing Apple Health workout id saved for this viewer/session"
+    healthKitWorkoutId: String
+  }
 `;

--- a/packages/shared-schema/src/types/session.ts
+++ b/packages/shared-schema/src/types/session.ts
@@ -44,6 +44,31 @@ export type SessionSummary = {
   goal?: string | null;
 };
 
+export type SessionHealthExportLap = {
+  tickUuid: string;
+  climbUuid: string;
+  climbName?: string | null;
+  grade?: string | null;
+  status: string;
+  attemptCount: number;
+  boardType: string;
+  angle?: number | null;
+  climbedAt: string;
+};
+
+export type SessionHealthExport = {
+  sessionId: string;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  durationMinutes?: number | null;
+  boardType: string;
+  totalSends: number;
+  totalAttempts: number;
+  hardestClimb?: SessionHardestClimb | null;
+  laps: SessionHealthExportLap[];
+  healthKitWorkoutId?: string | null;
+};
+
 /**
  * Durable session lifecycle status. Only 'active' and 'ended' are ever
  * written: live presence moved to Redis, so the abandoned 'inactive' value

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3477,6 +3477,11 @@ export type Query = {
    */
   sessionGroupedFeed: SessionFeedResult;
   /**
+   * Get viewer-specific session data for an Apple Health workout export.
+   * Requires authentication and returns only the requesting user's ticks.
+   */
+  sessionHealthExport?: Maybe<SessionHealthExport>;
+  /**
    * Lightweight, presence-independent lifecycle check for a session.
    * Reads the durable session row (not live Redis presence), so it tells an
    * ended session apart from one that is merely empty. Returns null when the
@@ -3917,6 +3922,11 @@ export type QuerySessionDetailArgs = {
 /** Root query type for all read operations. */
 export type QuerySessionGroupedFeedArgs = {
   input?: InputMaybe<ActivityFeedInput>;
+};
+
+/** Root query type for all read operations. */
+export type QuerySessionHealthExportArgs = {
+  sessionId: Scalars['ID']['input'];
 };
 
 /** Root query type for all read operations. */
@@ -4605,6 +4615,57 @@ export type SessionHardestClimb = {
   climbUuid: Scalars['String']['output'];
   /** Grade name */
   grade: Scalars['String']['output'];
+};
+
+/**
+ * Viewer-specific export payload for writing a finished session to Apple Health.
+ * It intentionally contains only the requesting user's ticks and saved workout id.
+ */
+export type SessionHealthExport = {
+  __typename?: 'SessionHealthExport';
+  /** Primary board type for this viewer's workout */
+  boardType: Scalars['String']['output'];
+  /** Duration in minutes */
+  durationMinutes?: Maybe<Scalars['Int']['output']>;
+  /** When the session ended */
+  endedAt?: Maybe<Scalars['String']['output']>;
+  /** Hardest climb the viewer sent during the session */
+  hardestClimb?: Maybe<SessionHardestClimb>;
+  /** Existing Apple Health workout id saved for this viewer/session */
+  healthKitWorkoutId?: Maybe<Scalars['String']['output']>;
+  /** Viewer-owned lap events */
+  laps: Array<SessionHealthExportLap>;
+  /** Session ID */
+  sessionId: Scalars['ID']['output'];
+  /** When the session started */
+  startedAt?: Maybe<Scalars['String']['output']>;
+  /** Viewer-owned attempts, including the successful attempt on sends */
+  totalAttempts: Scalars['Int']['output'];
+  /** Viewer-owned sends */
+  totalSends: Scalars['Int']['output'];
+};
+
+/** One viewer-owned lap/event included in an Apple Health workout export. */
+export type SessionHealthExportLap = {
+  __typename?: 'SessionHealthExportLap';
+  /** Climb angle */
+  angle?: Maybe<Scalars['Int']['output']>;
+  /** Number of attempts represented by this tick */
+  attemptCount: Scalars['Int']['output'];
+  /** Board type */
+  boardType: Scalars['String']['output'];
+  /** Climb name */
+  climbName?: Maybe<Scalars['String']['output']>;
+  /** Climb UUID */
+  climbUuid: Scalars['String']['output'];
+  /** When the lap was logged */
+  climbedAt: Scalars['String']['output'];
+  /** Grade name */
+  grade?: Maybe<Scalars['String']['output']>;
+  /** Tick status (flash, send, attempt) */
+  status: Scalars['String']['output'];
+  /** Tick UUID */
+  tickUuid: Scalars['ID']['output'];
 };
 
 /** Participant stats in a session summary. */

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -171,6 +171,7 @@
     "saveToAppleHealth": "Save to Apple Health",
     "savingToAppleHealth": "Saving to Apple Health…",
     "savedToAppleHealth": "Saved to Apple Health",
+    "savedToAppleHealthWithoutCalories": "Saved without calories",
     "saveToAppleHealthRetry": "Save to Apple Health (retry)",
     "loadErrorTitle": "Couldn't load your session",
     "loadErrorMessage": "Your climbs are saved — the recap just didn't load. Try again or head back.",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -171,6 +171,7 @@
     "saveToAppleHealth": "Guardar en Apple Health",
     "savingToAppleHealth": "Guardando en Apple Health…",
     "savedToAppleHealth": "Guardado en Apple Health",
+    "savedToAppleHealthWithoutCalories": "Guardado sin calorías",
     "saveToAppleHealthRetry": "Guardar en Apple Health (reintentar)",
     "loadErrorTitle": "No se pudo cargar tu sesión",
     "loadErrorMessage": "Tus vías están guardadas, solo falló el resumen. Inténtalo de nuevo o vuelve atrás.",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -171,6 +171,7 @@
     "saveToAppleHealth": "Enregistrer dans Apple Santé",
     "savingToAppleHealth": "Enregistrement dans Apple Santé…",
     "savedToAppleHealth": "Enregistré dans Apple Santé",
+    "savedToAppleHealthWithoutCalories": "Enregistré sans calories",
     "saveToAppleHealthRetry": "Enregistrer dans Apple Santé (réessayer)",
     "loadErrorTitle": "Impossible de charger ta session",
     "loadErrorMessage": "Tes voies sont enregistrées, seul le récap n'a pas chargé. Réessaie ou reviens en arrière.",


### PR DESCRIPTION
## Summary

- Add viewer-specific `sessionHealthExport(sessionId)` data for Apple Health exports so party sessions only write the current user's stats and laps.
- Update the React Native Apple Health flow to load that export for auto and manual saves, preserve lap data after app restart, and skip duplicate writes when a workout id already exists.
- Enrich the native HealthKit workout with indoor/brand metadata, typed lap metadata, existing-workout lookup by `HKMetadataKeyExternalUUID`, and a `savedWithoutEnergy` UI state when Active Energy is not writable.
- Align Health permission copy and update integration docs.

## Validation

- `vp run codegen`
- `vp test run packages/mobile/src/lib/integrations/__tests__/apple-health-auto-save.test.ts packages/mobile/src/lib/integrations/__tests__/registry.test.ts packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx packages/mobile/src/lib/__tests__/healthkit-config.test.ts packages/backend/src/__tests__/session-summary.test.ts`
- `vp run typecheck:backend`
- `vp run typecheck:db`
- `vp run typecheck:mobile`
- `vp run typecheck:shared`
- `vp run typecheck:graphql`
- `vp run check:mobile-patches`
- `git diff --check`

`vp check` was attempted. Formatting passed, but the repo-wide command is currently blocked by unrelated existing lint/type backlog, including `mobile/capacitor.config.ts` missing `@capacitor/cli` and pre-existing lint issues outside this change.