### PR TITLE
[codex] Fix mobile board id ticks

### DIFF
--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -755,7 +755,7 @@ describe('board-presence resolvers', () => {
       return row ? Number((row as { board_id: number | null }).board_id) : null;
     }
 
-    it('stamps a valid explicit presence boardId over the caller config board', async () => {
+    it('stamps a valid explicit boardId over the caller config board', async () => {
       const sharedBoardId = await createSecondUserSharedBoard();
       const ownBoardId = await createOwnConfigBoard();
 
@@ -781,7 +781,7 @@ describe('board-presence resolvers', () => {
       expect(await latestTickBoardId()).toBe(ownBoardId);
     });
 
-    it('ignores explicit boardId while board presence is disabled', async () => {
+    it('stamps explicit boardId while board presence is disabled', async () => {
       const sharedBoardId = await createSecondUserSharedBoard();
       const ownBoardId = await createOwnConfigBoard();
       process.env.BOARD_PRESENCE_ENABLED = 'false';
@@ -791,7 +791,8 @@ describe('board-presence resolvers', () => {
         process.env.BOARD_PRESENCE_ENABLED = 'true';
       }
 
-      expect(await latestTickBoardId()).toBe(ownBoardId);
+      expect(await latestTickBoardId()).toBe(sharedBoardId);
+      expect(await latestTickBoardId()).not.toBe(ownBoardId);
     });
 
     it('pushes a BoardStatsUpdated event that excludes attempts, resolves grades, and equals the cold fetch', async () => {

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -731,7 +731,18 @@ describe('board-presence resolvers', () => {
         { serial: `TICK-${Date.now()}`, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
         authCtx({ userId: SECOND_USER_ID }),
       );
+      await db.execute(sql`UPDATE user_boards SET is_public = false WHERE id = ${resolved.boardId}`);
       return resolved.boardId;
+    }
+
+    async function createSecondUserPublicBoard(): Promise<number> {
+      const slug = `public-config-${Date.now()}`;
+      const [row] = await db.execute(sql`
+        INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public)
+        VALUES (${`uuid-${slug}`}, ${slug}, ${SECOND_USER_ID}, 'kilter', 1, 10, '1,2', 'Public Config', true)
+        RETURNING id
+      `);
+      return Number((row as { id: number }).id);
     }
 
     async function createOwnConfigBoard(): Promise<number> {
@@ -755,9 +766,10 @@ describe('board-presence resolvers', () => {
       return row ? Number((row as { board_id: number | null }).board_id) : null;
     }
 
-    it('stamps a valid explicit boardId over the caller config board', async () => {
+    it('stamps a valid explicit boardId over the caller config board when caller has board membership', async () => {
       const sharedBoardId = await createSecondUserSharedBoard();
       const ownBoardId = await createOwnConfigBoard();
+      await pubsub.stampBoardMembership(String(sharedBoardId), TEST_USER_ID);
 
       await tickMutations.saveTick(undefined, { input: baseTickInput({ boardId: sharedBoardId }) }, authCtx());
 
@@ -781,22 +793,33 @@ describe('board-presence resolvers', () => {
       expect(await latestTickBoardId()).toBe(ownBoardId);
     });
 
-    it('stamps explicit boardId while board presence is disabled', async () => {
+    it('ignores private explicit boardId without ownership, visibility, or board membership', async () => {
       const sharedBoardId = await createSecondUserSharedBoard();
+      const ownBoardId = await createOwnConfigBoard();
+
+      await tickMutations.saveTick(undefined, { input: baseTickInput({ boardId: sharedBoardId }) }, authCtx());
+
+      expect(await latestTickBoardId()).toBe(ownBoardId);
+      expect(await latestTickBoardId()).not.toBe(sharedBoardId);
+    });
+
+    it('stamps reachable explicit boardId while board presence is disabled', async () => {
+      const publicBoardId = await createSecondUserPublicBoard();
       const ownBoardId = await createOwnConfigBoard();
       process.env.BOARD_PRESENCE_ENABLED = 'false';
       try {
-        await tickMutations.saveTick(undefined, { input: baseTickInput({ boardId: sharedBoardId }) }, authCtx());
+        await tickMutations.saveTick(undefined, { input: baseTickInput({ boardId: publicBoardId }) }, authCtx());
       } finally {
         process.env.BOARD_PRESENCE_ENABLED = 'true';
       }
 
-      expect(await latestTickBoardId()).toBe(sharedBoardId);
+      expect(await latestTickBoardId()).toBe(publicBoardId);
       expect(await latestTickBoardId()).not.toBe(ownBoardId);
     });
 
     it('pushes a BoardStatsUpdated event that excludes attempts, resolves grades, and equals the cold fetch', async () => {
       const sharedBoardId = await createSecondUserSharedBoard();
+      await pubsub.stampBoardMembership(String(sharedBoardId), TEST_USER_ID);
 
       // A second climber's ATTEMPT on a different (never-sent) climb, at a
       // HARDER difficulty. It must count toward distinctClimbersCount but must
@@ -862,6 +885,7 @@ describe('board-presence resolvers', () => {
       // recompute+publish (which could pair a stale snapshot with a higher seq
       // and regress the tiles). One trailing push per board, reflecting all.
       const sharedBoardId = await createSecondUserSharedBoard();
+      await pubsub.stampBoardMembership(String(sharedBoardId), TEST_USER_ID);
       const received: BoardPresenceEvent[] = [];
       const unsubscribe = await pubsub.subscribeBoardPresence(String(sharedBoardId), (event) => received.push(event));
       try {

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -40,7 +40,7 @@ const SYSTEM_BOARD_OWNER_EMAIL = 'system@boardsesh.com';
 
 export type ActivePresenceBoard = Pick<
   typeof dbSchema.userBoards.$inferSelect,
-  'id' | 'name' | 'boardType' | 'layoutId' | 'sizeId' | 'setIds' | 'serialNumber' | 'angle'
+  'id' | 'name' | 'ownerId' | 'boardType' | 'layoutId' | 'sizeId' | 'setIds' | 'serialNumber' | 'angle' | 'isPublic'
 >;
 
 export function toResolvedBoard(board: ActivePresenceBoard): ResolvedBoard {
@@ -59,12 +59,14 @@ export async function findActiveBoardBySerial(serial: string): Promise<ActivePre
     .select({
       id: dbSchema.userBoards.id,
       name: dbSchema.userBoards.name,
+      ownerId: dbSchema.userBoards.ownerId,
       boardType: dbSchema.userBoards.boardType,
       layoutId: dbSchema.userBoards.layoutId,
       sizeId: dbSchema.userBoards.sizeId,
       setIds: dbSchema.userBoards.setIds,
       serialNumber: dbSchema.userBoards.serialNumber,
       angle: dbSchema.userBoards.angle,
+      isPublic: dbSchema.userBoards.isPublic,
     })
     .from(dbSchema.userBoards)
     .where(and(eq(dbSchema.userBoards.serialNumber, serial), isNull(dbSchema.userBoards.deletedAt)))
@@ -77,12 +79,14 @@ export async function findActiveBoardById(boardId: number): Promise<ActivePresen
     .select({
       id: dbSchema.userBoards.id,
       name: dbSchema.userBoards.name,
+      ownerId: dbSchema.userBoards.ownerId,
       boardType: dbSchema.userBoards.boardType,
       layoutId: dbSchema.userBoards.layoutId,
       sizeId: dbSchema.userBoards.sizeId,
       setIds: dbSchema.userBoards.setIds,
       serialNumber: dbSchema.userBoards.serialNumber,
       angle: dbSchema.userBoards.angle,
+      isPublic: dbSchema.userBoards.isPublic,
     })
     .from(dbSchema.userBoards)
     .where(and(eq(dbSchema.userBoards.id, boardId), isNull(dbSchema.userBoards.deletedAt)))
@@ -98,12 +102,14 @@ export async function findReachableActiveBoardByUuid(
     .select({
       id: dbSchema.userBoards.id,
       name: dbSchema.userBoards.name,
+      ownerId: dbSchema.userBoards.ownerId,
       boardType: dbSchema.userBoards.boardType,
       layoutId: dbSchema.userBoards.layoutId,
       sizeId: dbSchema.userBoards.sizeId,
       setIds: dbSchema.userBoards.setIds,
       serialNumber: dbSchema.userBoards.serialNumber,
       angle: dbSchema.userBoards.angle,
+      isPublic: dbSchema.userBoards.isPublic,
     })
     .from(dbSchema.userBoards)
     .where(
@@ -157,12 +163,14 @@ export async function findOwnActiveBoardByConfig(
     .select({
       id: dbSchema.userBoards.id,
       name: dbSchema.userBoards.name,
+      ownerId: dbSchema.userBoards.ownerId,
       boardType: dbSchema.userBoards.boardType,
       layoutId: dbSchema.userBoards.layoutId,
       sizeId: dbSchema.userBoards.sizeId,
       setIds: dbSchema.userBoards.setIds,
       serialNumber: dbSchema.userBoards.serialNumber,
       angle: dbSchema.userBoards.angle,
+      isPublic: dbSchema.userBoards.isPublic,
     })
     .from(dbSchema.userBoards)
     .where(

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -196,6 +196,7 @@ async function enrichBoard(
   const gymInfo = (gymInfoResult as Array<{ uuid: string; name: string }>)[0];
 
   return {
+    id: Number(board.id),
     uuid: board.uuid,
     slug: board.slug,
     ownerId: board.ownerId,
@@ -342,6 +343,7 @@ async function enrichBoards(
     const gym = board.gymId ? gymMap.get(board.gymId) : undefined;
 
     return {
+      id: Number(board.id),
       uuid: board.uuid,
       slug: board.slug,
       ownerId: board.ownerId,
@@ -687,6 +689,7 @@ export const socialBoardQueries = {
     if (!ctx.isAuthenticated) {
       return boards.map((board) => {
         return {
+          id: Number(board.id),
           uuid: board.uuid,
           slug: board.slug,
           ownerId: '',

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -313,9 +313,9 @@ export const tickMutations = {
     //     seeded gym board owned by the system user). Best-effort: a deleted or
     //     stale uuid records the tick unassociated rather than rejecting it, and
     //     does NOT fall back to config resolution.
-    //  2. boardId — the board-presence connected wall (resolveBoardForSerial),
-    //     flag-gated. On a stale/mismatched id we warn and fall back to the
-    //     config lookup rather than surfacing a raw FK/type mismatch.
+    //  2. boardId — the selected/connected wall's user_boards.id. On a
+    //     stale/mismatched id we warn and fall back to the config lookup rather
+    //     than surfacing a raw FK/type mismatch.
     // Absent both, the legacy `/[board_name]/[layout_id]/...` config lookup runs.
     let boardId: number | null = null;
     if (validatedInput.boardUuid) {
@@ -337,7 +337,7 @@ export const tickMutations = {
       if (board) {
         boardId = board.id;
       }
-    } else if (validatedInput.boardId != null && isBoardPresenceEnabled()) {
+    } else if (validatedInput.boardId != null) {
       const explicitBoard = await findActiveBoardById(validatedInput.boardId);
       // Accept the explicit wall board only when its FULL config matches the
       // tick's target (type + layout + size + set). A stale presence boardId

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -12,6 +12,7 @@ import { resolveBoardFromPath } from '../social/boards';
 import { findActiveBoardById, isBoardPresenceEnabled, normalizeSetIds } from '../board-presence/shared';
 import { queueBoardStatsPublish } from '../board-presence/stats';
 import { publishSocialEvent } from '../../../events';
+import { pubsub } from '../../../pubsub/index';
 import { publishDebouncedSessionStats } from '../sessions/debounced-stats-publisher';
 import { queueClimbStatsRecompute } from './debounced-climb-stats-publisher';
 import { getInstagramMediaId, isInstagramUrl } from '../../../lib/instagram-meta';
@@ -350,11 +351,17 @@ export const tickMutations = {
         explicitBoard.layoutId === validatedInput.layoutId &&
         explicitBoard.sizeId === validatedInput.sizeId &&
         normalizeSetIds(explicitBoard.setIds) === normalizeSetIds(validatedInput.setIds);
-      if (configMatches) {
+      const canUseExplicitBoard =
+        explicitBoard != null &&
+        configMatches &&
+        (explicitBoard.ownerId === userId ||
+          explicitBoard.isPublic === true ||
+          (isBoardPresenceEnabled() && (await pubsub.hasBoardMembership(String(explicitBoard.id), userId))));
+      if (canUseExplicitBoard) {
         boardId = explicitBoard.id;
       } else {
         logger.warn(
-          `[board-presence] Ignoring tick boardId ${validatedInput.boardId} — config mismatch for ${validatedInput.boardType}`,
+          `[board-presence] Ignoring tick boardId ${validatedInput.boardId} — unavailable or invalid for ${validatedInput.boardType}`,
         );
       }
     }

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -28,6 +28,7 @@ type LogAscentSheetProps = {
   onDismiss: () => void;
   climbUuid: string;
   boardName: string;
+  boardId?: number;
   angle: number;
   isMirror: boolean;
   isBenchmark: boolean;
@@ -49,6 +50,7 @@ export function LogAscentSheet({
   onDismiss,
   climbUuid,
   boardName,
+  boardId,
   angle,
   isMirror,
   isBenchmark,
@@ -135,6 +137,7 @@ export function LogAscentSheet({
         <QuickTickBar
           climbUuid={climbUuid}
           boardName={boardName}
+          boardId={boardId}
           angle={angle}
           isMirror={isMirror}
           isBenchmark={isBenchmark}

--- a/packages/mobile/src/components/ble/__tests__/DeviceCard.test.tsx
+++ b/packages/mobile/src/components/ble/__tests__/DeviceCard.test.tsx
@@ -87,6 +87,7 @@ import { DeviceCard, describeSavedBoard, getPreviewImageStyle } from '../DeviceC
 
 function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
   return {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -85,6 +85,7 @@ function rowBoardForBoardConfig(boardConfig: BoardConfig): BoardSheetRowBoard {
 
 function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
   return [
+    boardConfig.boardId ?? 'none',
     boardConfig.boardName,
     boardConfig.layoutId,
     boardConfig.sizeId,
@@ -96,9 +97,14 @@ function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
 
 function boardConfigActionSignature(boardConfig: BoardConfig | null): string {
   if (!boardConfig) return 'none';
-  return [boardConfig.boardName, boardConfig.layoutId, boardConfig.sizeId, boardConfig.setIds, boardConfig.angle].join(
-    ':',
-  );
+  return [
+    boardConfig.boardId ?? 'none',
+    boardConfig.boardName,
+    boardConfig.layoutId,
+    boardConfig.sizeId,
+    boardConfig.setIds,
+    boardConfig.angle,
+  ].join(':');
 }
 
 function actionContextForPresenceClimb(

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -57,6 +57,7 @@ import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, sheetStyles } from '../../theme/tokens';
 
 type BoardConfig = {
+  boardId?: number;
   boardName: string;
   layoutId: number;
   sizeId: number;
@@ -971,6 +972,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           onDismiss={handleTickBarDismiss}
           climbUuid={displayedClimb.uuid}
           boardName={boardName}
+          boardId={boardConfig.boardId}
           angle={angle}
           isMirror={isMirrored}
           isBenchmark={displayedClimb.benchmark_difficulty != null}

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -36,6 +36,7 @@ import { spacing } from '../../theme/tokens';
 type QuickTickBarProps = {
   climbUuid: string;
   boardName: string;
+  boardId?: number;
   angle: number;
   isMirror: boolean;
   isBenchmark: boolean;
@@ -54,6 +55,7 @@ type QuickTickBarProps = {
 export const QuickTickBar = React.memo(function QuickTickBar({
   climbUuid,
   boardName,
+  boardId,
   angle,
   isMirror,
   isBenchmark,
@@ -121,8 +123,10 @@ export const QuickTickBar = React.memo(function QuickTickBar({
 
   const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
   const minAttempts = useMemo(() => getMinAttempts(ascentType), [ascentType]);
+  const capturedBoardIdForTick = typeof boardId === 'number' ? boardId : null;
   const activeBoardIdForTick = useMemo(() => {
     if (!activeBoard) return null;
+    if (typeof activeBoard.id !== 'number') return null;
     if (activeBoard.boardType !== boardName) return null;
     if (layoutId == null || sizeId == null || !setIds) return null;
     const activeSetIds = normalizeSetIdsForTick(activeBoard.setIds);
@@ -133,7 +137,9 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     return activeBoard.id;
   }, [activeBoard, boardName, layoutId, sizeId, setIds]);
   const tickBoardId =
-    boardPresenceEnabled && boardPresenceBoardId != null ? boardPresenceBoardId : activeBoardIdForTick;
+    capturedBoardIdForTick ??
+    activeBoardIdForTick ??
+    (boardPresenceEnabled && boardPresenceBoardId != null ? boardPresenceBoardId : null);
 
   // Reset form state when the climb context changes underneath an open
   // sheet (e.g. user swiped to next while the sheet was already open).
@@ -214,6 +220,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     [
       saveTick,
       climbUuid,
+      capturedBoardIdForTick,
       angle,
       isMirror,
       isBenchmark,

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -26,6 +26,7 @@ import { toBoardName } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useToast } from '../../providers/toast-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { track } from '../../lib/analytics';
 import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { brandColors } from '../../theme/colors';
@@ -70,6 +71,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   const insets = useSafeAreaInsets();
   const saveTick = useSaveTick(toBoardName(boardName));
   const { enabled: boardPresenceEnabled, boardId: boardPresenceBoardId } = useBoardPresenceControls();
+  const { data: activeBoard } = useActiveBoard();
   const { data: grades } = useGrades(boardName);
 
   // Mobile's `Climb.userAscents`/`userAttempts` GraphQL fields aren't
@@ -119,6 +121,19 @@ export const QuickTickBar = React.memo(function QuickTickBar({
 
   const ascentType = deriveAscentType(hasPriorHistory, tickState.attemptCount);
   const minAttempts = useMemo(() => getMinAttempts(ascentType), [ascentType]);
+  const activeBoardIdForTick = useMemo(() => {
+    if (!activeBoard) return null;
+    if (activeBoard.boardType !== boardName) return null;
+    if (layoutId == null || sizeId == null || !setIds) return null;
+    const activeSetIds = normalizeSetIdsForTick(activeBoard.setIds);
+    const tickSetIds = normalizeSetIdsForTick(setIds);
+    if (activeBoard.layoutId !== layoutId || activeBoard.sizeId !== sizeId || activeSetIds !== tickSetIds) {
+      return null;
+    }
+    return activeBoard.id;
+  }, [activeBoard, boardName, layoutId, sizeId, setIds]);
+  const tickBoardId =
+    boardPresenceEnabled && boardPresenceBoardId != null ? boardPresenceBoardId : activeBoardIdForTick;
 
   // Reset form state when the climb context changes underneath an open
   // sheet (e.g. user swiped to next while the sheet was already open).
@@ -164,7 +179,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
           ...(layoutId != null ? { layoutId } : {}),
           ...(sizeId != null ? { sizeId } : {}),
           ...(setIds ? { setIds } : {}),
-          ...(boardPresenceEnabled && boardPresenceBoardId != null ? { boardId: boardPresenceBoardId } : {}),
+          ...(tickBoardId != null ? { boardId: tickBoardId } : {}),
         },
         {
           onSuccess: () => {
@@ -206,8 +221,7 @@ export const QuickTickBar = React.memo(function QuickTickBar({
       layoutId,
       sizeId,
       setIds,
-      boardPresenceEnabled,
-      boardPresenceBoardId,
+      tickBoardId,
       tickState,
       comment,
       onDismiss,
@@ -343,6 +357,19 @@ export const QuickTickBar = React.memo(function QuickTickBar({
     </View>
   );
 });
+
+function normalizeSetIdsForTick(setIds: string): string {
+  return [
+    ...new Set(
+      setIds
+        .split(',')
+        .map((token) => token.trim())
+        .filter((token) => /^\d+$/.test(token)),
+    ),
+  ]
+    .sort((first, second) => Number(first) - Number(second))
+    .join(',');
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, type ComponentProps, type ReactNode } from 'react';
 import { logbookClimbAngleKey, type LogbookEntry } from '@boardsesh/board-react';
 
 // QuickTickBar's `hasPriorHistory` decides flash vs send (deriveAscentType).
@@ -16,11 +16,38 @@ const ANGLE = 40;
 const boardState = vi.hoisted(() => ({
   current: null as unknown,
 }));
+const saveTickState = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: false,
+}));
+const presenceState = vi.hoisted(() => ({
+  enabled: false,
+  boardId: null as number | null,
+}));
+const activeBoardState = vi.hoisted(() => ({
+  data: null as {
+    id: number;
+    uuid: string;
+    boardType: string;
+    layoutId: number;
+    sizeId: number;
+    setIds: string;
+  } | null,
+}));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  Pressable: ({ children, accessibilityLabel }: { children?: ReactNode; accessibilityLabel?: string }) =>
-    createElement('button', { 'data-label': accessibilityLabel }, children),
+  Pressable: ({
+    children,
+    accessibilityLabel,
+    disabled,
+    onPress,
+  }: {
+    children?: ReactNode;
+    accessibilityLabel?: string;
+    disabled?: boolean;
+    onPress?: () => void;
+  }) => createElement('button', { 'data-label': accessibilityLabel, disabled, onClick: onPress }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 vi.mock('@gorhom/bottom-sheet', () => ({ BottomSheetTextInput: () => null }));
@@ -44,7 +71,10 @@ vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToa
 // QuickTickBar reads board-presence flags; mock the provider so the test doesn't
 // pull in its ws-client → expo-secure-store chain (un-mockable native module).
 vi.mock('../../../providers/board-presence-provider', () => ({
-  useBoardPresenceControls: () => ({ enabled: false, boardId: null }),
+  useBoardPresenceControls: () => ({ enabled: presenceState.enabled, boardId: presenceState.boardId }),
+}));
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoardState.data }),
 }));
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../../../lib/haptics', () => ({ hapticSuccess: vi.fn(), hapticError: vi.fn() }));
@@ -59,13 +89,13 @@ vi.mock('@boardsesh/board-react', async (importOriginal) => {
   return {
     ...actual,
     useOptionalBoardProvider: () => boardState.current,
-    useSaveTick: () => ({ mutate: vi.fn(), isPending: false }),
+    useSaveTick: () => saveTickState,
   };
 });
 
 import { QuickTickBar } from '../QuickTickBar';
 
-function renderBar() {
+function renderBar(overrides: Partial<ComponentProps<typeof QuickTickBar>> = {}) {
   return render(
     createElement(QuickTickBar, {
       climbUuid: CLIMB_UUID,
@@ -74,11 +104,21 @@ function renderBar() {
       isMirror: false,
       isBenchmark: false,
       onDismiss: vi.fn(),
+      ...overrides,
     }),
   );
 }
 
 describe('QuickTickBar hasPriorHistory', () => {
+  beforeEach(() => {
+    boardState.current = null;
+    saveTickState.mutate.mockClear();
+    saveTickState.isPending = false;
+    presenceState.enabled = false;
+    presenceState.boardId = null;
+    activeBoardState.data = null;
+  });
+
   it('reads the logbookByClimbAngle index, not the raw logbook array', () => {
     const tick = { climb_uuid: CLIMB_UUID, angle: ANGLE } as unknown as LogbookEntry;
     boardState.current = {
@@ -113,5 +153,71 @@ describe('QuickTickBar hasPriorHistory', () => {
       (node) => node.textContent === 'playView.tickBar.flashSaveLabel',
     );
     expect(flashButton).toBeUndefined();
+  });
+
+  it('saves ticks against the selected active board id without Bluetooth', () => {
+    boardState.current = null;
+    activeBoardState.data = {
+      id: 77,
+      uuid: 'board-uuid-77',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '2,1',
+    };
+
+    const { container } = renderBar({ layoutId: 1, sizeId: 10, setIds: '1,2' });
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+
+    sendButton?.click();
+
+    expect(saveTickState.mutate).toHaveBeenCalledTimes(1);
+    expect(saveTickState.mutate.mock.calls[0][0]).toMatchObject({ boardId: 77 });
+  });
+
+  it('prefers the resolved presence board id when one is available', () => {
+    presenceState.enabled = true;
+    presenceState.boardId = 99;
+    activeBoardState.data = {
+      id: 77,
+      uuid: 'board-uuid-77',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+
+    const { container } = renderBar({ layoutId: 1, sizeId: 10, setIds: '1,2' });
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+
+    sendButton?.click();
+
+    expect(saveTickState.mutate).toHaveBeenCalledTimes(1);
+    expect(saveTickState.mutate.mock.calls[0][0]).toMatchObject({ boardId: 99 });
+  });
+
+  it('does not stamp a mismatched active board id', () => {
+    activeBoardState.data = {
+      id: 77,
+      uuid: 'board-uuid-77',
+      boardType: 'kilter',
+      layoutId: 2,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+
+    const { container } = renderBar({ layoutId: 1, sizeId: 10, setIds: '1,2' });
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+
+    sendButton?.click();
+
+    expect(saveTickState.mutate).toHaveBeenCalledTimes(1);
+    expect(saveTickState.mutate.mock.calls[0][0]).not.toHaveProperty('boardId');
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -177,7 +177,7 @@ describe('QuickTickBar hasPriorHistory', () => {
     expect(saveTickState.mutate.mock.calls[0][0]).toMatchObject({ boardId: 77 });
   });
 
-  it('prefers the resolved presence board id when one is available', () => {
+  it('prefers the selected active board id over a resolved presence board id', () => {
     presenceState.enabled = true;
     presenceState.boardId = 99;
     activeBoardState.data = {
@@ -197,7 +197,43 @@ describe('QuickTickBar hasPriorHistory', () => {
     sendButton?.click();
 
     expect(saveTickState.mutate).toHaveBeenCalledTimes(1);
+    expect(saveTickState.mutate.mock.calls[0][0]).toMatchObject({ boardId: 77 });
+  });
+
+  it('falls back to the resolved presence board id when no selected board id matches', () => {
+    presenceState.enabled = true;
+    presenceState.boardId = 99;
+
+    const { container } = renderBar({ layoutId: 1, sizeId: 10, setIds: '1,2' });
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+
+    sendButton?.click();
+
+    expect(saveTickState.mutate).toHaveBeenCalledTimes(1);
     expect(saveTickState.mutate.mock.calls[0][0]).toMatchObject({ boardId: 99 });
+  });
+
+  it('uses a captured board id from the sheet context before ambient state', () => {
+    activeBoardState.data = {
+      id: 77,
+      uuid: 'board-uuid-77',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+
+    const { container } = renderBar({ boardId: 55, layoutId: 1, sizeId: 10, setIds: '1,2' });
+    const sendButton = Array.from(container.querySelectorAll('button')).find(
+      (node) => node.textContent === 'playView.tickBar.sendSaveLabel',
+    );
+
+    sendButton?.click();
+
+    expect(saveTickState.mutate).toHaveBeenCalledTimes(1);
+    expect(saveTickState.mutate.mock.calls[0][0]).toMatchObject({ boardId: 55 });
   });
 
   it('does not stamp a mismatched active board id', () => {

--- a/packages/mobile/src/lib/__tests__/active-board-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/active-board-store.test.ts
@@ -22,6 +22,7 @@ vi.mock('@react-native-async-storage/async-storage', () => {
 // Minimal UserBoard stand-in — only the fields the active-board readers consume
 // plus uuid (used for the picker highlight). Cast covers the unused remainder.
 const board = {
+  id: 1,
   uuid: 'board-1',
   boardType: 'kilter',
   layoutId: 1,

--- a/packages/mobile/src/lib/active-board-store.ts
+++ b/packages/mobile/src/lib/active-board-store.ts
@@ -20,7 +20,7 @@
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getPreference, setPreference, removePreference } from './preference-store';
 
-const ACTIVE_BOARD_KEY = 'boardsesh_active_board_v2';
+const ACTIVE_BOARD_KEY = 'boardsesh_active_board_v3';
 
 export function getStoredActiveBoard(): Promise<UserBoard | null> {
   return getPreference<UserBoard>(ACTIVE_BOARD_KEY);

--- a/packages/mobile/src/lib/active-board-store.ts
+++ b/packages/mobile/src/lib/active-board-store.ts
@@ -13,14 +13,14 @@
 //
 // Schema migration note: `getPreference` silently returns null when JSON.parse
 // fails, but a stale value whose shape no longer matches `UserBoard` will parse
-// successfully and be cast to the wrong type. If `UserBoard` gains required
-// fields in a future migration, bump `ACTIVE_BOARD_KEY` so stale values are
-// ignored rather than misread.
+// successfully and be cast to the wrong type. `useActiveBoard()` hydrates old
+// v2 boards that predate `UserBoard.id` by UUID before board-id-dependent
+// ticking uses them.
 
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getPreference, setPreference, removePreference } from './preference-store';
 
-const ACTIVE_BOARD_KEY = 'boardsesh_active_board_v3';
+const ACTIVE_BOARD_KEY = 'boardsesh_active_board_v2';
 
 export function getStoredActiveBoard(): Promise<UserBoard | null> {
   return getPreference<UserBoard>(ACTIVE_BOARD_KEY);

--- a/packages/mobile/src/lib/ble/__tests__/board-config-match.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/board-config-match.test.ts
@@ -16,6 +16,7 @@ function makeCurrentConfig(overrides: Partial<BleBoardConfig> = {}): BleBoardCon
 
 function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
   return {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',

--- a/packages/mobile/src/lib/ble/__tests__/resolve-serials-hook.test.tsx
+++ b/packages/mobile/src/lib/ble/__tests__/resolve-serials-hook.test.tsx
@@ -31,6 +31,7 @@ import { useResolvedBleDeviceBoards } from '../resolve-serials';
 
 function makeBoard(serialNumber: string, overrides: Partial<UserBoard> = {}): UserBoard {
   return {
+    id: 1,
     uuid: `board-${serialNumber}`,
     slug: `board-${serialNumber}`,
     ownerId: 'owner-1',

--- a/packages/mobile/src/lib/ble/__tests__/resolve-serials.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/resolve-serials.test.ts
@@ -27,6 +27,7 @@ import { resolveBleSerialNumbers, serialsFromDiscoveredDevices } from '../resolv
 
 function makeBoard(serialNumber: string, overrides: Partial<UserBoard> = {}): UserBoard {
   return {
+    id: 1,
     uuid: `board-${serialNumber}`,
     slug: `board-${serialNumber}`,
     ownerId: 'owner-1',

--- a/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
+++ b/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
@@ -4,6 +4,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import { buildMobileFeedbackEnrichment, clipFeedbackString } from '../feedback-enrichment';
 
 const activeBoard: UserBoard = {
+  id: 1,
   uuid: 'board-uuid',
   slug: 'home-board',
   ownerId: 'user-1',

--- a/packages/mobile/src/lib/graphql/__tests__/use-active-board.test.tsx
+++ b/packages/mobile/src/lib/graphql/__tests__/use-active-board.test.tsx
@@ -4,6 +4,17 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import { GET_BOARD } from '../operations';
+
+const graphqlClientState = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+vi.mock('../client', () => ({
+  getHttpClient: () => ({
+    request: graphqlClientState.request,
+  }),
+}));
 
 // AsyncStorage-backed preference store (in-memory).
 vi.mock('@react-native-async-storage/async-storage', () => {
@@ -25,6 +36,7 @@ vi.mock('@react-native-async-storage/async-storage', () => {
 });
 
 const storedBoard = {
+  id: 1,
   uuid: 'stored-1',
   boardType: 'tension',
   layoutId: 9,
@@ -33,6 +45,7 @@ const storedBoard = {
   angle: 25,
 } as unknown as UserBoard;
 const otherBoard = {
+  id: 2,
   uuid: 'other-1',
   boardType: 'kilter',
   layoutId: 1,
@@ -58,6 +71,7 @@ async function resetAsyncStorage() {
 describe('useActiveBoard', () => {
   beforeEach(async () => {
     vi.resetModules();
+    graphqlClientState.request.mockReset();
     await resetAsyncStorage();
   });
 
@@ -69,6 +83,30 @@ describe('useActiveBoard', () => {
     const { result } = renderHook(() => useActiveBoard(), { wrapper: wrapper() });
 
     await waitFor(() => expect(result.current.data).toEqual(storedBoard));
+    expect(graphqlClientState.request).not.toHaveBeenCalled();
+  });
+
+  it('hydrates a stored v2 board without id by uuid and persists the full board', async () => {
+    const legacyStoredBoard = {
+      uuid: 'legacy-1',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 40,
+    } as unknown as UserBoard;
+    const resolvedBoard = { ...legacyStoredBoard, id: 42 } as UserBoard;
+    graphqlClientState.request.mockResolvedValueOnce({ board: resolvedBoard });
+
+    const { setStoredActiveBoard, getStoredActiveBoard } = await import('../../active-board-store');
+    await setStoredActiveBoard(legacyStoredBoard);
+
+    const { useActiveBoard } = await import('../use-active-board');
+    const { result } = renderHook(() => useActiveBoard(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.data).toEqual(resolvedBoard));
+    expect(graphqlClientState.request).toHaveBeenCalledWith(GET_BOARD, { boardUuid: 'legacy-1' });
+    await expect(getStoredActiveBoard()).resolves.toEqual(resolvedBoard);
   });
 
   it('returns null when nothing is stored — no server fallback', async () => {

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -31,6 +31,7 @@ import type { SubscriptionQueueItem } from '../queue-conversion';
 // ============================================
 
 const BOARD_FIELDS = `
+  id
   uuid
   slug
   ownerId

--- a/packages/mobile/src/lib/graphql/use-active-board.ts
+++ b/packages/mobile/src/lib/graphql/use-active-board.ts
@@ -14,8 +14,33 @@ import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getStoredActiveBoard, setStoredActiveBoard } from '../active-board-store';
+import { getHttpClient } from './client';
+import { GET_BOARD, type GetBoardQueryResponse } from './operations';
 
 export const ACTIVE_BOARD_QUERY_KEY = ['activeBoard'] as const;
+
+function hasNumericBoardId(board: UserBoard): boolean {
+  return typeof (board as { id?: unknown }).id === 'number';
+}
+
+async function hydrateStoredActiveBoard(): Promise<UserBoard | null> {
+  const storedBoard = await getStoredActiveBoard();
+  if (!storedBoard) return null;
+  if (hasNumericBoardId(storedBoard)) return storedBoard;
+
+  try {
+    const response = await getHttpClient().request<GetBoardQueryResponse>(GET_BOARD, { boardUuid: storedBoard.uuid });
+    if (response.board && hasNumericBoardId(response.board)) {
+      await setStoredActiveBoard(response.board);
+      return response.board;
+    }
+  } catch {
+    // Keep the existing v2 selection available for board config consumers. It
+    // just won't be used as a tick boardId until a network fetch hydrates it.
+  }
+
+  return storedBoard;
+}
 
 /**
  * Read the active board from storage. Returns `null` when the user hasn't
@@ -24,7 +49,7 @@ export const ACTIVE_BOARD_QUERY_KEY = ['activeBoard'] as const;
 export function useActiveBoard() {
   return useQuery({
     queryKey: ACTIVE_BOARD_QUERY_KEY,
-    queryFn: () => getStoredActiveBoard(),
+    queryFn: () => hydrateStoredActiveBoard(),
     // The stored board is authoritative until the user explicitly switches
     // (which calls setActiveBoard and updates the cache directly), so there's
     // no value in background refetching here.

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -219,6 +219,7 @@ function makePresenceClimb(overrides: Partial<BoardPresenceClimb> = {}): BoardPr
 
 function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
   return {
+    id: 1,
     uuid: 'board-tension',
     slug: 'garage-tension',
     ownerId: 'owner-1',

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -48,6 +48,7 @@ const boardSheet = vi.hoisted(() => ({
 
 const activeBoard = vi.hoisted(() => {
   const defaultStored = {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -21,6 +21,7 @@ const http = vi.hoisted(() => ({ request: vi.fn() }));
 
 const activeBoard = vi.hoisted(() => ({
   stored: {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -22,6 +22,7 @@ const http = vi.hoisted(() => ({ request: vi.fn() }));
 
 const activeBoard = vi.hoisted(() => ({
   stored: {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -20,6 +20,7 @@ const http = vi.hoisted(() => ({ request: vi.fn() }));
 
 const activeBoard = vi.hoisted(() => ({
   stored: {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -62,6 +62,7 @@ const queueSnapshotStore = vi.hoisted(() => ({
 
 const activeBoard = vi.hoisted(() => ({
   stored: {
+    id: 1,
     uuid: 'board-1',
     slug: 'board-1',
     ownerId: 'owner-1',
@@ -349,6 +350,7 @@ describe('QueueProvider session update subscription', () => {
     ws.client.on.mockClear();
     ws.client.subscribe.mockClear();
     activeBoard.stored = {
+      id: 1,
       uuid: 'board-1',
       slug: 'board-1',
       ownerId: 'owner-1',

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -39,6 +39,7 @@ import { useBoardPresenceControls, type ResolveBoardUuidArgs } from './board-pre
 import { useOptionalBluetoothContext } from './bluetooth-provider';
 
 export type BoardConfig = {
+  boardId?: number;
   boardName: string;
   layoutId: number;
   sizeId: number;
@@ -56,6 +57,7 @@ export type LogAscentInput = {
   sizeId?: number;
   setIds?: string;
   sessionId?: string | null;
+  boardId?: number;
   // Climb's consensus grade name (just `Climb.difficulty`). Forwarded to
   // GradeSingleSelectRail so the consensus chip is centered and outlined
   // without being preselected. Optional — callers that don't have a
@@ -67,6 +69,7 @@ function boardConfigsMatch(left: BoardConfig | null, right: BoardConfig | null):
   if (!left || !right) return false;
   return (
     left.boardName === right.boardName &&
+    left.boardId === right.boardId &&
     left.layoutId === right.layoutId &&
     left.sizeId === right.sizeId &&
     left.setIds === right.setIds &&
@@ -162,6 +165,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     if (boardConfigOverride) return boardConfigOverride;
     if (!activeBoard) return null;
     return {
+      boardId: typeof activeBoard.id === 'number' ? activeBoard.id : undefined,
       boardName: activeBoard.boardType,
       layoutId: activeBoard.layoutId,
       sizeId: activeBoard.sizeId,
@@ -321,6 +325,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     setLogAscentInput({
       climbUuid: climbActions.climb.uuid,
       boardName: climbActions.boardConfig.boardName,
+      boardId: climbActions.boardConfig.boardId,
       angle: climbActions.boardConfig.angle,
       isMirror: false,
       isBenchmark: !!climbActions.climb.benchmark_difficulty,
@@ -430,6 +435,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       setLogAscentInput({
         climbUuid: item.climb.uuid,
         boardName: boardConfig.boardName,
+        boardId: boardConfig.boardId,
         angle: boardConfig.angle,
         isMirror: item.climb.mirrored === true,
         isBenchmark: !!item.climb.benchmark_difficulty,
@@ -552,6 +558,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onDismiss={dismissLogAscent}
           climbUuid={logAscentInput.climbUuid}
           boardName={logAscentInput.boardName}
+          boardId={logAscentInput.boardId}
           angle={logAscentInput.angle}
           isMirror={logAscentInput.isMirror}
           isBenchmark={logAscentInput.isBenchmark}

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1942,6 +1942,8 @@ type SmartPlaylistCount {
 A named physical board installation (board type + layout + size + hold sets).
 """
 type UserBoard {
+  "Numeric database identifier used for board-scoped ticks and stats"
+  id: Int!
   "Unique identifier"
   uuid: ID!
   "URL slug for this board"

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -830,7 +830,7 @@ input SaveTickInput {
   setIds: String
   "Specific board entity this tick is on, by uuid. When provided, takes precedence over (layoutId, sizeId, setIds) resolution and lets ticks attach to a board the climber doesn't own (e.g. a seeded gym board)."
   boardUuid: String
-  "Resolved shared board id (from resolveBoardForSerial) for the BLE-connected wall everyone is logging to. Used when no boardUuid is given; falls back to board-config resolution if it doesn't match the payload."
+  "Numeric user_boards.id for the selected or connected board. Used when no boardUuid is given; accepted only when the board config matches and the climber owns, can see, or is connected to that board."
   boardId: Int
   "Optional Instagram post or reel URL to attach as beta for the climb"
   videoUrl: String

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -5434,6 +5434,8 @@ export type UserBoard = {
   gymUuid?: Maybe<Scalars['String']['output']>;
   /** Whether hidden from proximity/nearby search */
   hideLocation: Scalars['Boolean']['output'];
+  /** Numeric database identifier used for board-scoped ticks and stats */
+  id: Scalars['Int']['output'];
   /** Whether the board's angle is physically adjustable */
   isAngleAdjustable: Scalars['Boolean']['output'];
   /** Whether the current user follows this board */
@@ -9303,6 +9305,7 @@ export type UserBoardResolvers<
   gymName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   gymUuid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   hideLocation?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   isAngleAdjustable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isFollowedByMe?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isOwned?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4291,7 +4291,7 @@ export type SaveTickInput = {
   angle: Scalars['Int']['input'];
   /** Number of attempts */
   attemptCount: Scalars['Int']['input'];
-  /** Resolved shared board id (from resolveBoardForSerial) for the BLE-connected wall everyone is logging to. Used when no boardUuid is given; falls back to board-config resolution if it doesn't match the payload. */
+  /** Numeric user_boards.id for the selected or connected board. Used when no boardUuid is given; accepted only when the board config matches and the climber owns, can see, or is connected to that board. */
   boardId?: InputMaybe<Scalars['Int']['input']>;
   /** Board type */
   boardType: Scalars['String']['input'];

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -7,6 +7,8 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
   A named physical board installation (board type + layout + size + hold sets).
   """
   type UserBoard {
+    "Numeric database identifier used for board-scoped ticks and stats"
+    id: Int!
     "Unique identifier"
     uuid: ID!
     "URL slug for this board"

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -111,7 +111,7 @@ export const ticksTypeDefs = /* GraphQL */ `
     setIds: String
     "Specific board entity this tick is on, by uuid. When provided, takes precedence over (layoutId, sizeId, setIds) resolution and lets ticks attach to a board the climber doesn't own (e.g. a seeded gym board)."
     boardUuid: String
-    "Resolved shared board id (from resolveBoardForSerial) for the BLE-connected wall everyone is logging to. Used when no boardUuid is given; falls back to board-config resolution if it doesn't match the payload."
+    "Numeric user_boards.id for the selected or connected board. Used when no boardUuid is given; accepted only when the board config matches and the climber owns, can see, or is connected to that board."
     boardId: Int
     "Optional Instagram post or reel URL to attach as beta for the climb"
     videoUrl: String

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -1,6 +1,7 @@
 // Board entity types
 
 export type UserBoard = {
+  id: number;
   uuid: string;
   slug: string;
   ownerId: string;

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -63,9 +63,9 @@ export type SaveTickInput = {
    * attach to a board the climber doesn't own (e.g. a seeded gym board).
    */
   boardUuid?: string;
-  // Resolved shared board id (from resolveBoardForSerial) for the BLE-connected
-  // wall everyone is logging to. Used when no boardUuid is given; falls back to
-  // board-config resolution if it doesn't match the payload.
+  // Numeric user_boards.id for the selected or connected board. Used when no
+  // boardUuid is given; accepted only when the board config matches and the
+  // climber owns, can see, or is connected to that board.
   boardId?: number | null;
   videoUrl?: string | null;
 };

--- a/packages/shared/board-react/src/__tests__/use-save-tick.test.tsx
+++ b/packages/shared/board-react/src/__tests__/use-save-tick.test.tsx
@@ -147,6 +147,19 @@ describe('useSaveTick (shared)', () => {
     expect(executeHttp.mock.calls[0][1].input.boardId).toBe(4242);
   });
 
+  it('forwards a selected boardId when provided', async () => {
+    const executeHttp = vi.fn().mockResolvedValue({ saveTick: savedTick({ uuid: 'real-board' }) });
+    const { wrapper } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });
+    const { result } = renderHook(() => useSaveTick('kilter'), { wrapper });
+
+    await act(async () => {
+      result.current.mutate(tickOptions({ boardId: 77 }));
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(executeHttp.mock.calls[0][1].input.boardId).toBe(77);
+  });
+
   it('rolls back the optimistic entry on error', async () => {
     const executeHttp = vi.fn().mockRejectedValue(new Error('Server exploded'));
     const { wrapper, queryClient } = createWrapper({ executeHttp: executeHttp as unknown as ExecuteHttp });

--- a/packages/shared/board-react/src/tick-helpers.ts
+++ b/packages/shared/board-react/src/tick-helpers.ts
@@ -24,8 +24,8 @@ export type SaveTickOptions = {
    * attach to a board the climber doesn't own (e.g. a seeded gym board).
    */
   boardUuid?: string;
-  // Resolved shared board id (from resolveBoardForSerial) for the BLE-connected
-  // wall; used when no boardUuid is given.
+  // Numeric user_boards.id for the selected or connected board; used when no
+  // boardUuid is given.
   boardId?: number | null;
   videoUrl?: string;
 };

--- a/packages/shared/board-react/src/use-save-tick.ts
+++ b/packages/shared/board-react/src/use-save-tick.ts
@@ -119,6 +119,16 @@ export function useSaveTick(boardName: BoardName | null) {
       void queryClient.invalidateQueries({ queryKey: ['climb'] });
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
 
+      // Named-board sends can change board summary counts shown in board
+      // pickers/details. Bust those caches when the tick was associated with a
+      // concrete board row rather than only a board config.
+      if (options.boardId != null || options.boardUuid) {
+        void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+        void queryClient.invalidateQueries({ queryKey: ['board'] });
+        void queryClient.invalidateQueries({ queryKey: ['searchBoards'] });
+        void queryClient.invalidateQueries({ queryKey: ['boardsBySerialNumbers'] });
+      }
+
       // The You-page Logbook tab feed and the Sessions feed/detail are separate
       // cache families from the optimistically-updated accumulated logbook, so
       // a new tick won't appear there without busting them. Matches the

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -5431,6 +5431,8 @@ export type UserBoard = {
   gymUuid?: Maybe<Scalars['String']['output']>;
   /** Whether hidden from proximity/nearby search */
   hideLocation: Scalars['Boolean']['output'];
+  /** Numeric database identifier used for board-scoped ticks and stats */
+  id: Scalars['Int']['output'];
   /** Whether the board's angle is physically adjustable */
   isAngleAdjustable: Scalars['Boolean']['output'];
   /** Whether the current user follows this board */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4288,7 +4288,7 @@ export type SaveTickInput = {
   angle: Scalars['Int']['input'];
   /** Number of attempts */
   attemptCount: Scalars['Int']['input'];
-  /** Resolved shared board id (from resolveBoardForSerial) for the BLE-connected wall everyone is logging to. Used when no boardUuid is given; falls back to board-config resolution if it doesn't match the payload. */
+  /** Numeric user_boards.id for the selected or connected board. Used when no boardUuid is given; accepted only when the board config matches and the climber owns, can see, or is connected to that board. */
   boardId?: InputMaybe<Scalars['Int']['input']>;
   /** Board type */
   boardType: Scalars['String']['input'];

--- a/packages/shared/graphql/src/operations/boards.ts
+++ b/packages/shared/graphql/src/operations/boards.ts
@@ -18,6 +18,7 @@ import type {
 // ============================================
 
 const BOARD_FIELDS = `
+  id
   uuid
   slug
   ownerId

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -631,6 +631,7 @@ export function BluetoothProvider({
       overrides: Partial<UserBoard> &
         Pick<UserBoard, 'boardType' | 'layoutId' | 'sizeId' | 'setIds' | 'name' | 'serialNumber'>,
     ): UserBoard => ({
+      id: 1,
       uuid: `demo-${overrides.serialNumber}`,
       slug: `demo-${overrides.serialNumber}`,
       ownerId: 'demo-owner',

--- a/packages/web/app/components/board-scroll/__tests__/board-filter-strip.test.tsx
+++ b/packages/web/app/components/board-scroll/__tests__/board-filter-strip.test.tsx
@@ -54,6 +54,7 @@ vi.mock('../board-scroll.module.css', () => ({
 
 function makeBoard(overrides?: Partial<UserBoard>): UserBoard {
   return {
+    id: 1,
     uuid: 'board-1',
     slug: 'my-kilter',
     ownerId: 'user-1',

--- a/packages/web/app/components/board-scroll/__tests__/board-scroll-card.test.tsx
+++ b/packages/web/app/components/board-scroll/__tests__/board-scroll-card.test.tsx
@@ -67,6 +67,7 @@ function makeUserBoard(overrides?: Partial<UserBoard>): UserBoard {
     commentCount: 0,
     isFollowedByMe: false,
     ...overrides,
+    id: overrides?.id ?? 1,
   };
 }
 

--- a/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
+++ b/packages/web/app/components/board-search-drawer/__tests__/board-search-drawer.test.tsx
@@ -93,6 +93,7 @@ vi.mock('@boardsesh/graphql/operations', () => ({
 
 function makeBoard(uuid: string, overrides: Partial<UserBoard> = {}): UserBoard {
   return {
+    id: 1,
     uuid,
     name: `Board ${uuid}`,
     boardType: 'kilter',

--- a/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
+++ b/packages/web/app/components/climb-actions/__tests__/tick-action.test.tsx
@@ -83,6 +83,7 @@ function createMockUserBoard(overrides?: Partial<UserBoard>): UserBoard {
     sizeDescription: 'Full',
     setNames: ['Standard'],
     ...overrides,
+    id: overrides?.id ?? 1,
   };
 }
 

--- a/packages/web/app/components/library/logbook-feed.tsx
+++ b/packages/web/app/components/library/logbook-feed.tsx
@@ -119,9 +119,9 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
   // Build board list from layout stats (boards the user has ticks for)
   const logbookBoards: UserBoard[] = useMemo(
     () =>
-      layoutStats.map((ls) => {
-        const layoutId = ls.layoutId ?? 0;
-        const boardName = ls.boardType as BoardName;
+      layoutStats.map((layoutStat, layoutStatIndex) => {
+        const layoutId = layoutStat.layoutId ?? 0;
+        const boardName = layoutStat.boardType as BoardName;
 
         let sizeId = 0;
         let setIds = '';
@@ -132,14 +132,14 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
           if (layoutEntry) {
             const [layoutKey] = layoutEntry;
             const moonSets = MOONBOARD_SETS[layoutKey as MoonBoardLayoutKey] ?? [];
-            setIds = moonSets.map((s) => s.id).join(',');
+            setIds = moonSets.map((moonSet) => moonSet.id).join(',');
           }
         } else {
           const defaultSize = getDefaultSizeForLayout(boardName, layoutId);
           if (defaultSize !== null) {
             sizeId = defaultSize;
             const sets = getSetsForLayoutAndSize(boardName, layoutId, sizeId);
-            setIds = sets.map((s) => s.id).join(',');
+            setIds = sets.map((set) => set.id).join(',');
           } else {
             const fallback = boardName === 'kilter' ? ORPHANED_KILTER_LAYOUT_DEFAULTS[layoutId] : undefined;
             if (fallback) {
@@ -154,14 +154,15 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
         }
 
         return {
-          uuid: `logbook-${ls.boardType}-${layoutId}`,
+          id: -(layoutStatIndex + 1),
+          uuid: `logbook-${layoutStat.boardType}-${layoutId}`,
           slug: '',
           ownerId: '',
-          boardType: ls.boardType,
+          boardType: layoutStat.boardType,
           layoutId,
           sizeId,
           setIds,
-          name: getLayoutDisplayName(ls.boardType, ls.layoutId),
+          name: getLayoutDisplayName(layoutStat.boardType, layoutStat.layoutId),
           isPublic: false,
           isUnlisted: false,
           hideLocation: false,
@@ -169,7 +170,7 @@ export default function LogbookFeed({ layoutStats, loadingLayoutStats }: Logbook
           angle: 0,
           isAngleAdjustable: false,
           createdAt: '',
-          totalAscents: ls.distinctClimbCount,
+          totalAscents: layoutStat.distinctClimbCount,
           uniqueClimbers: 0,
           followerCount: 0,
           commentCount: 0,

--- a/packages/web/app/components/user-drawer/__tests__/user-drawer.test.tsx
+++ b/packages/web/app/components/user-drawer/__tests__/user-drawer.test.tsx
@@ -170,6 +170,7 @@ function makeUserBoard(overrides: Partial<UserBoard> = {}): UserBoard {
     commentCount: 0,
     isFollowedByMe: false,
     ...overrides,
+    id: overrides.id ?? 1,
   };
 }
 

--- a/packages/web/app/hooks/__tests__/use-discover-boards.test.ts
+++ b/packages/web/app/hooks/__tests__/use-discover-boards.test.ts
@@ -25,6 +25,7 @@ vi.mock('@boardsesh/graphql/operations', () => ({
 
 function makeBoard(uuid: string, totalAscents: number, overrides?: Partial<UserBoard>): UserBoard {
   return {
+    id: 1,
     uuid,
     name: `Board ${uuid}`,
     boardType: 'kilter',

--- a/packages/web/app/hooks/__tests__/use-search-boards-map.test.ts
+++ b/packages/web/app/hooks/__tests__/use-search-boards-map.test.ts
@@ -33,6 +33,7 @@ vi.mock('@boardsesh/graphql/operations', () => ({
 
 function makeBoard(uuid: string, overrides?: Partial<UserBoard>): UserBoard {
   return {
+    id: 1,
     uuid,
     name: `Board ${uuid}`,
     boardType: 'kilter',

--- a/packages/web/app/lib/__tests__/find-matching-board.test.ts
+++ b/packages/web/app/lib/__tests__/find-matching-board.test.ts
@@ -3,6 +3,7 @@ import { findMatchingBoard } from '../find-matching-board';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
 const makeBoard = (overrides: Partial<UserBoard> = {}): UserBoard => ({
+  id: 1,
   uuid: 'board-1',
   slug: 'my-kilter',
   ownerId: 'user-1',

--- a/packages/web/app/playlists/__tests__/library-page-content.test.tsx
+++ b/packages/web/app/playlists/__tests__/library-page-content.test.tsx
@@ -210,6 +210,7 @@ vi.mock('@/app/components/library/create-playlist-drawer', () => ({
 
 function makeBoard(uuid: string, overrides?: Partial<UserBoard>): UserBoard {
   return {
+    id: 1,
     uuid,
     slug: `slug-${uuid}`,
     ownerId: 'owner',


### PR DESCRIPTION
## Summary

Fixes mobile tick attribution for named boards when the app is not connected to the physical board over Bluetooth.

- Exposes the numeric `UserBoard.id` through GraphQL board fields so mobile can persist and reuse the board-scoped tick identifier.
- Sends the selected/captured active board's numeric `boardId` from `QuickTickBar` when it matches the tick target, with presence id as fallback only.
- Threads `boardId` through mobile board config/log-ascent sheet context so board-specific surfaces do not depend only on ambient active-board state.
- Hydrates existing stored active boards that predate `UserBoard.id` by resolving the stored board UUID, instead of dropping the user's selected board.
- Lets the backend honor explicit `boardId` while validating both config and authorization: owner, public visibility, or board-presence membership.
- Invalidates board query caches after board-scoped tick saves so board detail/list counts refresh.
- Updates typed fixtures, generated GraphQL artifacts, and schema/type docs for the now-required `UserBoard.id`.

## Root Cause

Mobile only attached `boardId` to save-tick requests when board presence had resolved a connected board id. If the user selected a named board but was not connected over Bluetooth, the tick could fall back to config-based board resolution instead of the selected board's `user_boards.id`, so board-sheet counts for that named board did not update as expected.

`boardPresenceBoardId` is not a separate identifier type; it is the same numeric `user_boards.id` surfaced by the presence provider after resolving a connected or selected board. The selected/captured board id is now authoritative when available.

## Review Follow-up

Ran four focused code-review subagents and fixed the findings:

- blocked arbitrary private-board attribution by adding backend owner/public/membership authorization for explicit `boardId`
- made selected/captured named board id win over stale/different presence id
- preserved and hydrated existing v2 active-board storage instead of dropping selected boards
- invalidated board list/detail/search caches after board-scoped ticks
- refreshed generated schema/type docs

## Validation

- `vp run codegen`
- `vp test run --project backend packages/backend/src/__tests__/board-presence.test.ts`
- `vp test run --project mobile packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx`
- `vp test run --project mobile packages/mobile/src/lib/graphql/__tests__/use-active-board.test.tsx`
- `vp test run --project mobile packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx`
- `vp test run --project board-react packages/shared/board-react/src/__tests__/use-save-tick.test.tsx`
- `vp run typecheck:mobile`
- `vp run typecheck:backend`
- `vp run typecheck:shared`
- `vp run typecheck:board-react`
- `vp run typecheck:graphql`
- `vp run typecheck:web`
- `vp fmt --check`
- `git diff --check`