### PR TITLE
Session simplification (R1): wall-connection holder model

### DIFF
--- a/packages/backend/src/__tests__/build-session-payload.test.ts
+++ b/packages/backend/src/__tests__/build-session-payload.test.ts
@@ -40,6 +40,7 @@ const getQueueStateMock = vi.fn();
 const getSessionDriverParticipantIdMock = vi.fn();
 const getSessionBoardSerialMock = vi.fn();
 const getSessionLeaderConnectionIdMock = vi.fn();
+const getWallConnectionsMock = vi.fn();
 
 vi.mock('../services/room-manager', () => ({
   roomManager: {
@@ -49,6 +50,7 @@ vi.mock('../services/room-manager', () => ({
     getSessionDriverParticipantId: (...args: unknown[]) => getSessionDriverParticipantIdMock(...args),
     getSessionBoardSerial: (...args: unknown[]) => getSessionBoardSerialMock(...args),
     getSessionLeaderConnectionId: (...args: unknown[]) => getSessionLeaderConnectionIdMock(...args),
+    getWallConnections: (...args: unknown[]) => getWallConnectionsMock(...args),
   },
 }));
 
@@ -97,11 +99,12 @@ beforeEach(() => {
   getQueueStateMock.mockReset().mockResolvedValue(sampleQueueState);
   getSessionDriverParticipantIdMock.mockReset().mockResolvedValue('participant-2');
   getSessionBoardSerialMock.mockReset().mockResolvedValue('SERIAL-123');
+  getWallConnectionsMock.mockReset().mockResolvedValue(new Map([[7, 'participant-2']]));
   getSessionLeaderConnectionIdMock.mockReset().mockResolvedValue('conn-1');
 });
 
 describe('buildSessionPayload — defaults (no overrides)', () => {
-  it('returns the full 16-field Session shape with values from the room manager', async () => {
+  it('returns the full 17-field Session shape with values from the room manager', async () => {
     const payload = await buildSessionPayload('session-1', makeCtx());
 
     expect(payload).toEqual({
@@ -117,6 +120,7 @@ describe('buildSessionPayload — defaults (no overrides)', () => {
       },
       isLeader: true, // leaderConnectionId === ctx.connectionId
       driverParticipantId: 'participant-2',
+      wallConnections: [{ boardId: 7, holderParticipantId: 'participant-2' }],
       lastConnectedBoardSerial: 'SERIAL-123',
       clientId: 'conn-1',
       participantId: 'participant-1',
@@ -129,7 +133,7 @@ describe('buildSessionPayload — defaults (no overrides)', () => {
     });
   });
 
-  it('fires all six room-manager reads in parallel', async () => {
+  it('fires all seven room-manager reads in parallel', async () => {
     await buildSessionPayload('session-1', makeCtx());
 
     expect(getSessionUsersMock).toHaveBeenCalledWith('session-1');
@@ -138,6 +142,7 @@ describe('buildSessionPayload — defaults (no overrides)', () => {
     expect(getSessionDriverParticipantIdMock).toHaveBeenCalledWith('session-1');
     expect(getSessionBoardSerialMock).toHaveBeenCalledWith('session-1');
     expect(getSessionLeaderConnectionIdMock).toHaveBeenCalledWith('session-1');
+    expect(getWallConnectionsMock).toHaveBeenCalledWith('session-1');
   });
 });
 

--- a/packages/backend/src/__tests__/helpers/mock-redis.ts
+++ b/packages/backend/src/__tests__/helpers/mock-redis.ts
@@ -122,6 +122,29 @@ export const createMockRedis = (): MockRedis => {
       }
       return newCount;
     }),
+    hget: vi.fn(async (key: string, field: string) => {
+      const hash = hashes.get(key);
+      return hash ? (hash[field] ?? null) : null;
+    }),
+    hsetnx: vi.fn(async (key: string, field: string, value: string) => {
+      if (!hashes.has(key)) hashes.set(key, {});
+      const hash = hashes.get(key)!;
+      if (field in hash) return 0;
+      hash[field] = value;
+      return 1;
+    }),
+    hdel: vi.fn(async (key: string, ...fields: string[]) => {
+      const hash = hashes.get(key);
+      if (!hash) return 0;
+      let count = 0;
+      for (const field of fields) {
+        if (field in hash) {
+          delete hash[field];
+          count++;
+        }
+      }
+      return count;
+    }),
     setex: vi.fn(async (key: string, _seconds: number, value: string) => {
       store.set(key, value);
       return 'OK';
@@ -161,6 +184,10 @@ export const createMockRedis = (): MockRedis => {
         },
         zrem: (key: string, member: string) => {
           commands.push(() => mockRedis.zrem(key, member));
+          return chainable;
+        },
+        hdel: (key: string, ...fields: string[]) => {
+          commands.push(() => mockRedis.hdel(key, ...fields));
           return chainable;
         },
         exec: async () => {

--- a/packages/backend/src/__tests__/session-context.test.ts
+++ b/packages/backend/src/__tests__/session-context.test.ts
@@ -58,6 +58,7 @@ vi.mock('../services/room-manager', () => ({
     // peers which physical board is paired. Default to "no board" so this
     // existing test suite needn't model BLE pairing.
     getSessionBoardSerial: vi.fn().mockResolvedValue(null),
+    getWallConnections: vi.fn().mockResolvedValue(new Map()),
   },
 }));
 

--- a/packages/backend/src/__tests__/session-persistence.test.ts
+++ b/packages/backend/src/__tests__/session-persistence.test.ts
@@ -827,4 +827,60 @@ describe('Session Persistence - Hybrid Redis + Postgres', () => {
       );
     });
   });
+
+  describe('Wall-connection per-connection cleanup', () => {
+    const boardPath = '/kilter/1/10/1,2/40/list';
+    // Same authenticated user on two connections → one stable participantId (the
+    // multi-tab / second-device case the liveness gate used to mishandle).
+    // Authenticated joins persist the session with created_by_user_id, so the
+    // user must exist (FK).
+    const wallUserId = `wall-user-${uuidv4()}`;
+
+    beforeEach(async () => {
+      await db.execute(sql`
+        INSERT INTO users (id, email, name, created_at, updated_at)
+        VALUES (${wallUserId}, ${`${wallUserId}@wall.test`}, 'Wall Climber', now(), now())
+        ON CONFLICT (id) DO NOTHING
+      `);
+    });
+
+    it('frees a crashed BLE holder slot even when the participant keeps a sibling connection', async () => {
+      const sessionId = `wall-sibling-${uuidv4()}`;
+      await roomManager.registerClient('conn-A', 'Climber', wallUserId);
+      const joinedA = await roomManager.joinSession('conn-A', sessionId, boardPath, 'Climber');
+      await roomManager.registerClient('conn-B', 'Climber', wallUserId);
+      const joinedB = await roomManager.joinSession('conn-B', sessionId, boardPath, 'Climber');
+      expect(joinedB.participantId).toBe(joinedA.participantId);
+      const participantId = joinedA.participantId;
+
+      const boardId = 4242;
+      const claim = await roomManager.claimWallConnection(sessionId, boardId, participantId);
+      expect(claim.didClaim).toBe(true);
+      roomManager.recordWallLinkForConnection('conn-A', boardId);
+      expect((await roomManager.getWallConnections(sessionId)).get(boardId)).toBe(participantId);
+
+      // A's socket drops while B (same participant) stays live. The wall link is
+      // bound to A's connection, so the slot must free — the old participant-
+      // liveness gate would have left it stuck behind B.
+      await roomManager.disconnectClient('conn-A');
+      expect((await roomManager.getWallConnections(sessionId)).has(boardId)).toBe(false);
+    });
+
+    it('a non-holder connection dropping leaves the holder slot intact', async () => {
+      const sessionId = `wall-nonholder-${uuidv4()}`;
+      await roomManager.registerClient('hold-A', 'Climber', wallUserId);
+      const joinedA = await roomManager.joinSession('hold-A', sessionId, boardPath, 'Climber');
+      await roomManager.registerClient('view-B', 'Climber', wallUserId);
+      await roomManager.joinSession('view-B', sessionId, boardPath, 'Climber');
+      const participantId = joinedA.participantId;
+
+      const boardId = 5353;
+      await roomManager.claimWallConnection(sessionId, boardId, participantId);
+      roomManager.recordWallLinkForConnection('hold-A', boardId);
+
+      // B never announced a wall link, so its drop frees nothing.
+      await roomManager.disconnectClient('view-B');
+      expect((await roomManager.getWallConnections(sessionId)).get(boardId)).toBe(participantId);
+    });
+  });
 });

--- a/packages/backend/src/__tests__/take-control-mutation.test.ts
+++ b/packages/backend/src/__tests__/take-control-mutation.test.ts
@@ -55,6 +55,7 @@ vi.mock('../services/room-manager', () => ({
     // session payload, so this needs to resolve to a value (null is fine —
     // the test doesn't assert on it).
     getSessionBoardSerial: vi.fn().mockResolvedValue(null),
+    getWallConnections: vi.fn().mockResolvedValue(new Map()),
   },
 }));
 

--- a/packages/backend/src/__tests__/wall-confirm-and-board-serial.test.ts
+++ b/packages/backend/src/__tests__/wall-confirm-and-board-serial.test.ts
@@ -49,6 +49,7 @@ vi.mock('../services/room-manager', () => ({
     // Individual tests override per-call when they want a different
     // authoritative answer.
     getSessionBoardSerial: vi.fn().mockResolvedValue(null),
+    getWallConnections: vi.fn().mockResolvedValue(new Map()),
     // Used by the setSessionBoardPath mutation. Returns the previous
     // boardPath when the value changed; null on no-op writes.
     updateSessionBoardPathIfChanged: vi.fn(),

--- a/packages/backend/src/graphql/resolvers/sessions/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/helpers.ts
@@ -32,6 +32,7 @@ export type SessionPayloadInputs = {
   queueState?: SessionQueueState;
   sessionData?: SessionDbRow | null;
   driverParticipantId?: string | null;
+  wallConnections?: { boardId: number; holderParticipantId: string }[];
   lastConnectedBoardSerial?: string | null;
   leaderConnectionId?: string | null;
   name?: string | null;
@@ -53,7 +54,7 @@ function override<T>(value: T | undefined, fetch: () => Promise<T>): Promise<T> 
 }
 
 /**
- * Build the 16-field Session GraphQL payload, fanning the four-to-six
+ * Build the 17-field Session GraphQL payload, fanning the four-to-seven
  * independent Redis reads into a single `Promise.all`. Replaces the verbatim
  * `id`/`name`/`boardPath`/`users`/`queueState`/`isLeader`/...-shaped return
  * objects in every Session-returning resolver. Pass `inputs.X` to short-
@@ -74,15 +75,27 @@ export async function buildSessionPayload(
       ? Promise.resolve<string | null>(null)
       : override(inputs.leaderConnectionId, () => roomManager.getSessionLeaderConnectionId(sessionId));
 
-  const [users, queueState, sessionData, driverParticipantId, lastConnectedBoardSerial, leaderConnectionId] =
-    await Promise.all([
-      override(inputs.users, () => roomManager.getSessionUsers(sessionId)),
-      override(inputs.queueState, () => roomManager.getQueueState(sessionId)),
-      override(inputs.sessionData, () => roomManager.getSessionById(sessionId)),
-      override(inputs.driverParticipantId, () => roomManager.getSessionDriverParticipantId(sessionId)),
-      override(inputs.lastConnectedBoardSerial, () => roomManager.getSessionBoardSerial(sessionId)),
-      leaderFetch,
-    ]);
+  const [
+    users,
+    queueState,
+    sessionData,
+    driverParticipantId,
+    lastConnectedBoardSerial,
+    leaderConnectionId,
+    wallConnections,
+  ] = await Promise.all([
+    override(inputs.users, () => roomManager.getSessionUsers(sessionId)),
+    override(inputs.queueState, () => roomManager.getQueueState(sessionId)),
+    override(inputs.sessionData, () => roomManager.getSessionById(sessionId)),
+    override(inputs.driverParticipantId, () => roomManager.getSessionDriverParticipantId(sessionId)),
+    override(inputs.lastConnectedBoardSerial, () => roomManager.getSessionBoardSerial(sessionId)),
+    leaderFetch,
+    override(inputs.wallConnections, () =>
+      roomManager
+        .getWallConnections(sessionId)
+        .then((map) => Array.from(map, ([boardId, holderParticipantId]) => ({ boardId, holderParticipantId }))),
+    ),
+  ]);
 
   return {
     id: sessionId,
@@ -101,6 +114,7 @@ export async function buildSessionPayload(
     },
     isLeader: inputs.isLeader !== undefined ? inputs.isLeader : leaderConnectionId === ctx.connectionId,
     driverParticipantId,
+    wallConnections,
     lastConnectedBoardSerial,
     clientId: inputs.clientId !== undefined ? inputs.clientId : ctx.connectionId,
     participantId: inputs.participantId ?? ctx.participantId ?? ctx.connectionId ?? '',

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -687,6 +687,63 @@ export const sessionMutations = {
   },
 
   /**
+   * Announce a live BLE connection to a board: claim-if-free the per-board
+   * wall-connection slot (the holder is the single frame writer + lights the
+   * shared "wall connected" indicator). Publishes WallConnectionChanged only on
+   * an actual transition. The simplified replacement for take/release control —
+   * the physical connection is the writer token, so there's nothing to "claim"
+   * beyond having connected.
+   */
+  announceWallLink: async (_: unknown, { boardId }: { boardId: number }, ctx: ConnectionContext) => {
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
+    const sessionId = requireSession(ctx);
+    await requireSessionMember(ctx, sessionId);
+    if (!Number.isInteger(boardId) || boardId <= 0) {
+      throw new Error('announceWallLink requires a positive integer boardId.');
+    }
+    if (!ctx.participantId) {
+      throw new Error('announceWallLink requires ctx.participantId; refusing to fall back to connectionId.');
+    }
+    const participantId = ctx.participantId;
+    const { holderParticipantId, didClaim } = await roomManager.claimWallConnection(sessionId, boardId, participantId);
+    if (didClaim) {
+      pubsub.publishSessionEvent(sessionId, {
+        __typename: 'WallConnectionChanged',
+        boardId,
+        holderParticipantId,
+      });
+    }
+    return buildSessionPayload(sessionId, ctx, { participantId });
+  },
+
+  /**
+   * Revoke this client's BLE-connection claim for a board (manual disconnect).
+   * Frees the slot and broadcasts WallConnectionChanged(null) when this client
+   * was the holder. Returns whether the slot was actually freed.
+   */
+  revokeWallLink: async (_: unknown, { boardId }: { boardId: number }, ctx: ConnectionContext) => {
+    await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
+    const sessionId = requireSession(ctx);
+    await requireSessionMember(ctx, sessionId);
+    if (!Number.isInteger(boardId) || boardId <= 0) {
+      throw new Error('revokeWallLink requires a positive integer boardId.');
+    }
+    if (!ctx.participantId) {
+      throw new Error('revokeWallLink requires ctx.participantId; refusing to fall back to connectionId.');
+    }
+    const participantId = ctx.participantId;
+    const released = await roomManager.releaseWallConnection(sessionId, boardId, participantId);
+    if (released) {
+      pubsub.publishSessionEvent(sessionId, {
+        __typename: 'WallConnectionChanged',
+        boardId,
+        holderParticipantId: null,
+      });
+    }
+    return released;
+  },
+
+  /**
    * End a session explicitly.
    * Validates the caller is the creator or current leader.
    * Returns a session summary with stats, or null if no ticks.

--- a/packages/backend/src/graphql/resolvers/sessions/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/mutations.ts
@@ -707,6 +707,9 @@ export const sessionMutations = {
     const participantId = ctx.participantId;
     const { holderParticipantId, didClaim } = await roomManager.claimWallConnection(sessionId, boardId, participantId);
     if (didClaim) {
+      // Bind the claim to this connection so it's freed when this socket drops,
+      // even if the participant keeps a sibling connection alive.
+      roomManager.recordWallLinkForConnection(ctx.connectionId, boardId);
       pubsub.publishSessionEvent(sessionId, {
         __typename: 'WallConnectionChanged',
         boardId,
@@ -733,6 +736,7 @@ export const sessionMutations = {
     }
     const participantId = ctx.participantId;
     const released = await roomManager.releaseWallConnection(sessionId, boardId, participantId);
+    roomManager.forgetWallLinkForConnection(ctx.connectionId, boardId);
     if (released) {
       pubsub.publishSessionEvent(sessionId, {
         __typename: 'WallConnectionChanged',

--- a/packages/backend/src/services/distributed-state/constants.ts
+++ b/packages/backend/src/services/distributed-state/constants.ts
@@ -47,6 +47,11 @@ export const KEYS = {
   // pivot's lightbulb gesture. Empty / missing key means "no driver" — the
   // wall is unclaimed.
   sessionDriver: (sessionId: string) => `boardsesh:session:${sessionId}:driver`,
+  // Hash: sessionId -> { boardId -> participantId of the member holding the BLE
+  // connection to that board }. The connection IS the writer token, so it's a
+  // claim-if-free slot (HSETNX), not a yank like the driver. Drives the shared
+  // "wall is connected" indicator and elects the single frame-writer per board.
+  sessionWallConnections: (sessionId: string) => `boardsesh:session:${sessionId}:wallConnections`,
   // String: sessionId -> last-connected BLE board serial. Set by
   // `setSessionBoardSerial`; consumed by mobile clients on join so a second
   // phone can auto-pair with the same physical board as the first.

--- a/packages/backend/src/services/distributed-state/distributed-state.ts
+++ b/packages/backend/src/services/distributed-state/distributed-state.ts
@@ -17,6 +17,10 @@ import {
   getSessionDriver,
   setSessionDriverAndReturnPrevious,
   clearSessionDriverIf,
+  claimWallConnection,
+  releaseWallConnection,
+  getWallConnections,
+  releaseAllWallConnectionsForParticipant,
   getSessionBoardSerial,
   setSessionBoardSerialAndReturnPrevious,
   pushRecentClimb,
@@ -196,6 +200,30 @@ export class DistributedStateManager {
    */
   async clearSessionDriverIf(sessionId: string, expectedParticipantId: string): Promise<boolean> {
     return clearSessionDriverIf(this.redis, sessionId, expectedParticipantId);
+  }
+
+  /** Claim-if-free the wall-connection slot for a board; returns holder + whether this call claimed it. */
+  async claimWallConnection(
+    sessionId: string,
+    boardId: number,
+    participantId: string,
+  ): Promise<{ holderParticipantId: string; didClaim: boolean }> {
+    return claimWallConnection(this.redis, sessionId, boardId, participantId);
+  }
+
+  /** Release a board's wall-connection slot when the caller holds it. */
+  async releaseWallConnection(sessionId: string, boardId: number, expectedParticipantId: string): Promise<boolean> {
+    return releaseWallConnection(this.redis, sessionId, boardId, expectedParticipantId);
+  }
+
+  /** All current wall-connection holders for a session, keyed by boardId. */
+  async getWallConnections(sessionId: string): Promise<Map<number, string>> {
+    return getWallConnections(this.redis, sessionId);
+  }
+
+  /** Release every board this participant held (disconnect cleanup); returns freed boardIds. */
+  async releaseAllWallConnectionsForParticipant(sessionId: string, participantId: string): Promise<number[]> {
+    return releaseAllWallConnectionsForParticipant(this.redis, sessionId, participantId);
   }
 
   /** Get the session's last-connected BLE board serial, or null when unset. */

--- a/packages/backend/src/services/distributed-state/session-ops.ts
+++ b/packages/backend/src/services/distributed-state/session-ops.ts
@@ -588,6 +588,100 @@ export async function clearSessionDriverIf(
 }
 
 /**
+ * Claim the wall-connection slot for a board in a session. Claim-if-free
+ * (HSETNX): the first connector holds the slot; a later connector to the same
+ * board does NOT steal it. Returns the resulting holder and whether THIS call
+ * claimed it (so the resolver can gate the WallConnectionChanged broadcast).
+ */
+export async function claimWallConnection(
+  redis: Redis,
+  sessionId: string,
+  boardId: number,
+  participantId: string,
+): Promise<{ holderParticipantId: string; didClaim: boolean }> {
+  validateSessionId(sessionId);
+  validateParticipantId(participantId);
+  const key = KEYS.sessionWallConnections(sessionId);
+  const field = String(boardId);
+  const set = await redis.hsetnx(key, field, participantId);
+  await redis.expire(key, TTL.sessionMembership);
+  if (set === 1) {
+    return { holderParticipantId: participantId, didClaim: true };
+  }
+  const holder = (await redis.hget(key, field)) ?? participantId;
+  return { holderParticipantId: holder, didClaim: false };
+}
+
+/**
+ * Release a board's wall-connection slot, but only when the caller currently
+ * holds it. WATCH-guarded so a concurrent re-claim isn't clobbered. Returns
+ * true when the slot was actually freed.
+ */
+export async function releaseWallConnection(
+  redis: Redis,
+  sessionId: string,
+  boardId: number,
+  expectedParticipantId: string,
+): Promise<boolean> {
+  validateSessionId(sessionId);
+  validateParticipantId(expectedParticipantId);
+  const key = KEYS.sessionWallConnections(sessionId);
+  const field = String(boardId);
+  await redis.watch(key);
+  try {
+    const current = await redis.hget(key, field);
+    if (current !== expectedParticipantId) {
+      await redis.unwatch();
+      return false;
+    }
+    const result = await redis.multi().hdel(key, field).exec();
+    if (result === null) return false;
+    const [delErr, delCount] = result[0] as [Error | null, number];
+    if (delErr) throw delErr;
+    return delCount === 1;
+  } catch (err) {
+    await redis.unwatch().catch(() => undefined);
+    throw err;
+  }
+}
+
+/** All current wall-connection holders for a session, keyed by boardId. */
+export async function getWallConnections(redis: Redis, sessionId: string): Promise<Map<number, string>> {
+  validateSessionId(sessionId);
+  const raw = await redis.hgetall(KEYS.sessionWallConnections(sessionId));
+  const result = new Map<number, string>();
+  for (const [field, participantId] of Object.entries(raw)) {
+    const boardId = Number(field);
+    if (Number.isInteger(boardId) && participantId) {
+      result.set(boardId, participantId);
+    }
+  }
+  return result;
+}
+
+/**
+ * Release every board this participant held the wall connection for (used on
+ * disconnect). Returns the boardIds actually freed so the caller can broadcast
+ * a WallConnectionChanged(null) per board.
+ */
+export async function releaseAllWallConnectionsForParticipant(
+  redis: Redis,
+  sessionId: string,
+  participantId: string,
+): Promise<number[]> {
+  validateSessionId(sessionId);
+  validateParticipantId(participantId);
+  const held = await getWallConnections(redis, sessionId);
+  const released: number[] = [];
+  for (const [boardId, holder] of held) {
+    if (holder === participantId && (await releaseWallConnection(redis, sessionId, boardId, participantId))) {
+      released.push(boardId);
+    }
+  }
+  return released;
+}
+
+/**
  * Get the last-connected BLE board serial for a session, or null when unset.
  */
 export async function getSessionBoardSerial(redis: Redis, sessionId: string): Promise<string | null> {

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -243,6 +243,10 @@ class RoomManager {
   }
 
   async leaveSession(connectionId: string): Promise<SessionLeaveResult | null> {
+    // Free this connection's wall links before the leave drops it from the
+    // client map (per-connection, so a sibling connection doesn't keep the slot
+    // stuck).
+    await this.releaseWallLinksForConnection(connectionId);
     const result = await leaveSessionFn(
       connectionId,
       this.clients,
@@ -281,6 +285,13 @@ class RoomManager {
   }
 
   async disconnectClient(connectionId: string): Promise<SessionDisconnectResult | null> {
+    // The wall link is bound to the physical connection: free any board THIS
+    // connection held the moment its socket drops, before the (participant-
+    // level, grace-gated) driver cleanup runs. This is what frees a crashed BLE
+    // holder whose participant still has a sibling connection. On a transient
+    // reconnect the client re-announces (participantId resets on re-join), so
+    // the brief release is reclaimed.
+    await this.releaseWallLinksForConnection(connectionId);
     return disconnectClientFn(
       connectionId,
       this.clients,
@@ -566,6 +577,58 @@ class RoomManager {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Record that a connection successfully claimed a board's wall link, so the
+   * claim can be freed per-connection when that connection drops. Only the
+   * connection that actually claimed records it (the resolver calls this on
+   * `didClaim`), so it never frees a slot it doesn't hold.
+   */
+  recordWallLinkForConnection(connectionId: string, boardId: number): void {
+    const client = this.clients.get(connectionId);
+    if (!client) return;
+    (client.announcedWallBoards ??= new Set()).add(boardId);
+  }
+
+  /** Forget a connection's wall-link claim (explicit revoke). */
+  forgetWallLinkForConnection(connectionId: string, boardId: number): void {
+    this.clients.get(connectionId)?.announcedWallBoards?.delete(boardId);
+  }
+
+  /**
+   * Free every wall link this connection holds, broadcasting
+   * WallConnectionChanged(null) per board. Bound to the connection, not the
+   * participant: a crashed BLE-holder connection's slot frees immediately even
+   * when the same participant still has a sibling connection alive (the old
+   * participant-liveness gate left it stuck). `releaseWallConnection` is a no-op
+   * if someone else now holds the slot, so a non-holder connection frees
+   * nothing.
+   */
+  private async releaseWallLinksForConnection(connectionId: string): Promise<void> {
+    const client = this.clients.get(connectionId);
+    if (!client?.sessionId || !client.announcedWallBoards?.size) return;
+    const sessionId = client.sessionId;
+    const participantId = client.participantId ?? connectionId;
+    const boards = [...client.announcedWallBoards];
+    client.announcedWallBoards.clear();
+    for (const boardId of boards) {
+      try {
+        const released = await this.releaseWallConnection(sessionId, boardId, participantId);
+        if (released) {
+          pubsub.publishSessionEvent(sessionId, {
+            __typename: 'WallConnectionChanged',
+            boardId,
+            holderParticipantId: null,
+          });
+        }
+      } catch (error) {
+        logger.error(
+          `[RoomManager] Failed to release wall link for connection ${connectionId.slice(0, 8)} board ${boardId}:`,
+          error,
+        );
+      }
+    }
   }
 
   /** All current wall-connection holders for a session, keyed by boardId. */

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -54,6 +54,10 @@ class RoomManager {
   // of truth, and parallel-writing here just creates read-after-write
   // skew windows. Same rationale for the board-serial map below.
   private localDriverBySession = new Map<string, string>();
+  // Single-instance fallback for the wall-connection holders: sessionId ->
+  // { boardId -> holder participantId }. Mirrors localDriverBySession; only the
+  // no-Redis path touches it (Redis is the source of truth otherwise).
+  private localWallConnectionsBySession = new Map<string, Map<number, string>>();
   private localBoardSerialBySession = new Map<string, string>();
   // In-memory recent-climbs ring buffer (per session). Same rationale as the
   // other local shadows: tests and single-instance dev don't have Redis. The
@@ -83,6 +87,7 @@ class RoomManager {
     this.sessions.clear();
     this.sessionParticipants.clear();
     this.localDriverBySession.clear();
+    this.localWallConnectionsBySession.clear();
     this.localBoardSerialBySession.clear();
     this.localRecentClimbsBySession.clear();
     this.redisStore = null;
@@ -367,6 +372,18 @@ class RoomManager {
           previousDriverParticipantId: participantId,
         });
       }
+
+      // Same disconnect, same liveness gate: free any board the departing
+      // member held the BLE connection for, so the shared "wall connected"
+      // indicator clears and the next connector can claim the writer slot.
+      const releasedBoards = await this.releaseAllWallConnectionsForParticipant(sessionId, participantId);
+      for (const boardId of releasedBoards) {
+        pubsub.publishSessionEvent(sessionId, {
+          __typename: 'WallConnectionChanged',
+          boardId,
+          holderParticipantId: null,
+        });
+      }
     } catch (error) {
       logger.error(
         `[RoomManager] Failed to release driver for departing participant ${participantId.slice(0, 8)} in session ${sessionId.slice(0, 8)}:`,
@@ -508,6 +525,73 @@ class RoomManager {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Claim-if-free the wall-connection slot for a board: the first member with a
+   * live BLE link holds it and writes frames; later connectors to the same
+   * board don't steal it. Returns the resulting holder and whether THIS call
+   * claimed it (so `announceWallLink` only broadcasts on an actual transition).
+   */
+  async claimWallConnection(
+    sessionId: string,
+    boardId: number,
+    participantId: string,
+  ): Promise<{ holderParticipantId: string; didClaim: boolean }> {
+    if (this.distributedState) {
+      return this.distributedState.claimWallConnection(sessionId, boardId, participantId);
+    }
+    let board = this.localWallConnectionsBySession.get(sessionId);
+    if (!board) {
+      board = new Map();
+      this.localWallConnectionsBySession.set(sessionId, board);
+    }
+    const existing = board.get(boardId);
+    if (existing === undefined) {
+      board.set(boardId, participantId);
+      return { holderParticipantId: participantId, didClaim: true };
+    }
+    return { holderParticipantId: existing, didClaim: false };
+  }
+
+  /** Release a board's wall-connection slot when the caller holds it. */
+  async releaseWallConnection(sessionId: string, boardId: number, expectedParticipantId: string): Promise<boolean> {
+    if (this.distributedState) {
+      return this.distributedState.releaseWallConnection(sessionId, boardId, expectedParticipantId);
+    }
+    const board = this.localWallConnectionsBySession.get(sessionId);
+    if (board?.get(boardId) === expectedParticipantId) {
+      board.delete(boardId);
+      if (board.size === 0) this.localWallConnectionsBySession.delete(sessionId);
+      return true;
+    }
+    return false;
+  }
+
+  /** All current wall-connection holders for a session, keyed by boardId. */
+  async getWallConnections(sessionId: string): Promise<Map<number, string>> {
+    if (this.distributedState) {
+      return this.distributedState.getWallConnections(sessionId);
+    }
+    return new Map(this.localWallConnectionsBySession.get(sessionId) ?? []);
+  }
+
+  /** Release every board this participant held (disconnect cleanup); returns freed boardIds. */
+  async releaseAllWallConnectionsForParticipant(sessionId: string, participantId: string): Promise<number[]> {
+    if (this.distributedState) {
+      return this.distributedState.releaseAllWallConnectionsForParticipant(sessionId, participantId);
+    }
+    const board = this.localWallConnectionsBySession.get(sessionId);
+    if (!board) return [];
+    const released: number[] = [];
+    for (const [boardId, holder] of board) {
+      if (holder === participantId) {
+        board.delete(boardId);
+        released.push(boardId);
+      }
+    }
+    if (board.size === 0) this.localWallConnectionsBySession.delete(sessionId);
+    return released;
   }
 
   /**
@@ -718,6 +802,7 @@ class RoomManager {
     // `cleanupEmptySession` when the session set drains; this is the
     // single-instance / single-process equivalent.
     this.localDriverBySession.delete(sessionId);
+    this.localWallConnectionsBySession.delete(sessionId);
     this.localBoardSerialBySession.delete(sessionId);
     this.localRecentClimbsBySession.delete(sessionId);
     return endSessionFn(

--- a/packages/backend/src/services/room-manager/types.ts
+++ b/packages/backend/src/services/room-manager/types.ts
@@ -19,6 +19,11 @@ export type ConnectedClient = {
   avatarUrl?: string;
   isLeader: boolean;
   connectedAt: Date;
+  // Boards this specific connection holds a wall-connection (BLE writer) claim
+  // for. The wall link is bound to the physical connection, not the
+  // participant, so it's freed when *this* connection drops — even if the same
+  // participant still has a sibling connection alive.
+  announcedWallBoards?: Set<number>;
 };
 
 export type LocalSessionParticipant = {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -337,6 +337,17 @@ type SessionUser {
 }
 
 """
+A board's current BLE connection holder within a session. The holder is the
+single member whose phone writes frames to that board's LEDs.
+"""
+type WallConnection {
+  "The board this connection is for (userBoards.id)"
+  boardId: Int!
+  "Stable participant id holding the BLE connection to the board"
+  holderParticipantId: ID!
+}
+
+"""
 An active climbing session where users can collaborate on a queue.
 """
 type Session {
@@ -354,6 +365,8 @@ type Session {
   isLeader: Boolean!
   "Stable participant id of the user currently driving the wall. Set via takeControl, cleared via releaseControl or driver disconnect. Distinct from isLeader, which is presentation/legacy only."
   driverParticipantId: ID
+  "Per-board BLE connection holders. In the simplified model the holder is the single frame-writer for that board, and any entry means the shared 'wall connected' indicator is lit. Maintained via announceWallLink / revokeWallLink; empty when no member is connected."
+  wallConnections: [WallConnection!]!
   "Most recently observed BLE board serial for this session. Set when a participant pairs their phone to a physical board; broadcast as SessionBoardSerialChanged so late-joiners can auto-connect to the same board. Null when no board has been recorded."
   lastConnectedBoardSerial: String
   "Unique identifier for this client's connection"
@@ -4380,6 +4393,23 @@ type Mutation {
   releaseControl: Session!
 
   """
+  Announce that this client now holds a live BLE connection to `boardId` in the
+  current session. Claim-if-free: the first connector becomes the board's frame
+  writer; a later connector to the same board does not steal the slot. Lights the
+  shared "wall connected" indicator for the session. Publishes
+  `WallConnectionChanged` when the holder changes. Idempotent for the same holder.
+  Session identity comes from the WebSocket connection context.
+  """
+  announceWallLink(boardId: Int!): Session!
+
+  """
+  Revoke this client's BLE-connection claim for `boardId` (manual disconnect).
+  Frees the slot for the next connector and, when this client was the holder,
+  publishes `WallConnectionChanged { holderParticipantId: null }`. Idempotent.
+  """
+  revokeWallLink(boardId: Int!): Boolean!
+
+  """
   Confirm to all session participants that a climb was successfully relayed to the wall
   over BLE from this client's phone. Any session participant may call (no driver
   requirement) — the BLE-capable phone that handled the send is the source of truth for
@@ -4969,6 +4999,7 @@ union SessionEvent =
   | UserPresenceChanged
   | LeaderChanged
   | DriverChanged
+  | WallConnectionChanged
   | WallConfirmedClimb
   | SessionBoardSerialChanged
   | SessionBoardPathChanged
@@ -5017,6 +5048,19 @@ type DriverChanged {
   driverParticipantId: ID
   "Stable participant id of the previous driver, or null when there was none (e.g. the very first take of the session, or after a release). Lets clients render 'X took the wall from Y' toasts and populate the Phase 5 previousDriver analytics property without local bookkeeping."
   previousDriverParticipantId: ID
+}
+
+"""
+Event when the member holding the BLE connection to a board changes. In the
+simplified collaboration model the connection holder is the single frame
+writer, and any holder existing means the shared "wall is connected"
+indicator lights up for everyone in the session.
+"""
+type WallConnectionChanged {
+  "The board whose connection holder changed (userBoards.id)"
+  boardId: Int!
+  "Stable participant id now holding the BLE connection to the board, or null when nobody holds it"
+  holderParticipantId: ID
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1966,6 +1966,15 @@ export type Mutation = {
    */
   addQueueItem: ClimbQueueItem;
   /**
+   * Announce that this client now holds a live BLE connection to `boardId` in the
+   * current session. Claim-if-free: the first connector becomes the board's frame
+   * writer; a later connector to the same board does not steal the slot. Lights the
+   * shared "wall connected" indicator for the session. Publishes
+   * `WallConnectionChanged` when the holder changes. Idempotent for the same holder.
+   * Session identity comes from the WebSocket connection context.
+   */
+  announceWallLink: Session;
+  /**
    * Attach an Instagram post or reel as beta for a climb. Idempotent on
    * (boardType, climbUuid, link).
    */
@@ -2148,6 +2157,12 @@ export type Mutation = {
   /** Revoke a community role from a user (admin only). */
   revokeRole: Scalars['Boolean']['output'];
   /**
+   * Revoke this client's BLE-connection claim for `boardId` (manual disconnect).
+   * Frees the slot for the next connector and, when this client was the holder,
+   * publishes `WallConnectionChanged { holderParticipantId: null }`. Idempotent.
+   */
+  revokeWallLink: Scalars['Boolean']['output'];
+  /**
    * Save Aurora climbing credentials.
    * Validates with Aurora API before saving.
    */
@@ -2306,6 +2321,11 @@ export type MutationAddGymMemberArgs = {
 export type MutationAddQueueItemArgs = {
   item: ClimbQueueItemInput;
   position?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationAnnounceWallLinkArgs = {
+  boardId: Scalars['Int']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -2595,6 +2615,11 @@ export type MutationResolveProposalArgs = {
 /** Root mutation type for all write operations. */
 export type MutationRevokeRoleArgs = {
   input: RevokeRoleInput;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationRevokeWallLinkArgs = {
+  boardId: Scalars['Int']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -4439,6 +4464,8 @@ export type Session = {
   startedAt?: Maybe<Scalars['String']['output']>;
   /** Users currently in the session */
   users: Array<SessionUser>;
+  /** Per-board BLE connection holders. In the simplified model the holder is the single frame-writer for that board, and any entry means the shared 'wall connected' indicator is lit. Maintained via announceWallLink / revokeWallLink; empty when no member is connected. */
+  wallConnections: Array<WallConnection>;
 };
 
 /**
@@ -4547,7 +4574,8 @@ export type SessionEvent =
   | UserJoined
   | UserLeft
   | UserPresenceChanged
-  | WallConfirmedClimb;
+  | WallConfirmedClimb
+  | WallConnectionChanged;
 
 /** A session feed card representing a group of ticks from a climbing session. */
 export type SessionFeedItem = {
@@ -5629,6 +5657,32 @@ export type WallConfirmedClimb = {
 };
 
 /**
+ * A board's current BLE connection holder within a session. The holder is the
+ * single member whose phone writes frames to that board's LEDs.
+ */
+export type WallConnection = {
+  __typename?: 'WallConnection';
+  /** The board this connection is for (userBoards.id) */
+  boardId: Scalars['Int']['output'];
+  /** Stable participant id holding the BLE connection to the board */
+  holderParticipantId: Scalars['ID']['output'];
+};
+
+/**
+ * Event when the member holding the BLE connection to a board changes. In the
+ * simplified collaboration model the connection holder is the single frame
+ * writer, and any holder existing means the shared "wall is connected"
+ * indicator lights up for everyone in the session.
+ */
+export type WallConnectionChanged = {
+  __typename?: 'WallConnectionChanged';
+  /** The board whose connection holder changed (userBoards.id) */
+  boardId: Scalars['Int']['output'];
+  /** Stable participant id now holding the BLE connection to the board, or null when nobody holds it */
+  holderParticipantId?: Maybe<Scalars['ID']['output']>;
+};
+
+/**
  * Bounding box defining a board region for filtering climbs.
  * Coordinates are in the same grid space as board placements
  * (board_holes.x/y) and board_climbs edge columns.
@@ -5747,7 +5801,8 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = Reso
     | UserJoined
     | UserLeft
     | UserPresenceChanged
-    | WallConfirmedClimb;
+    | WallConfirmedClimb
+    | WallConnectionChanged;
 }>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -6022,6 +6077,8 @@ export type ResolversTypes = ResolversObject<{
   VoteOnProposalInput: VoteOnProposalInput;
   VoteSummary: ResolverTypeWrapper<VoteSummary>;
   WallConfirmedClimb: ResolverTypeWrapper<WallConfirmedClimb>;
+  WallConnection: ResolverTypeWrapper<WallConnection>;
+  WallConnectionChanged: ResolverTypeWrapper<WallConnectionChanged>;
   ZoneBoxInput: ZoneBoxInput;
   ZoneMatchMode: ZoneMatchMode;
 }>;
@@ -6282,6 +6339,8 @@ export type ResolversParentTypes = ResolversObject<{
   VoteOnProposalInput: VoteOnProposalInput;
   VoteSummary: VoteSummary;
   WallConfirmedClimb: WallConfirmedClimb;
+  WallConnection: WallConnection;
+  WallConnectionChanged: WallConnectionChanged;
   ZoneBoxInput: ZoneBoxInput;
 }>;
 
@@ -7297,6 +7356,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationAddQueueItemArgs, 'item'>
   >;
+  announceWallLink?: Resolver<
+    ResolversTypes['Session'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationAnnounceWallLinkArgs, 'boardId'>
+  >;
   attachBetaLink?: Resolver<
     ResolversTypes['Boolean'],
     ParentType,
@@ -7606,6 +7671,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationRevokeRoleArgs, 'input'>
+  >;
+  revokeWallLink?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationRevokeWallLinkArgs, 'boardId'>
   >;
   saveAuroraCredential?: Resolver<
     ResolversTypes['AuroraCredentialStatus'],
@@ -8766,6 +8837,7 @@ export type SessionResolvers<
   queueState?: Resolver<ResolversTypes['QueueState'], ParentType, ContextType>;
   startedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   users?: Resolver<Array<ResolversTypes['SessionUser']>, ParentType, ContextType>;
+  wallConnections?: Resolver<Array<ResolversTypes['WallConnection']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -8867,7 +8939,8 @@ export type SessionEventResolvers<
     | 'UserJoined'
     | 'UserLeft'
     | 'UserPresenceChanged'
-    | 'WallConfirmedClimb',
+    | 'WallConfirmedClimb'
+    | 'WallConnectionChanged',
     ParentType,
     ContextType
   >;
@@ -9429,6 +9502,24 @@ export type WallConfirmedClimbResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type WallConnectionResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['WallConnection'] = ResolversParentTypes['WallConnection'],
+> = ResolversObject<{
+  boardId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  holderParticipantId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type WallConnectionChangedResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['WallConnectionChanged'] = ResolversParentTypes['WallConnectionChanged'],
+> = ResolversObject<{
+  boardId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  holderParticipantId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   ActivityFeedItem?: ActivityFeedItemResolvers<ContextType>;
   ActivityFeedResult?: ActivityFeedResultResolvers<ContextType>;
@@ -9585,4 +9676,6 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   UserSearchResult?: UserSearchResultResolvers<ContextType>;
   VoteSummary?: VoteSummaryResolvers<ContextType>;
   WallConfirmedClimb?: WallConfirmedClimbResolvers<ContextType>;
+  WallConnection?: WallConnectionResolvers<ContextType>;
+  WallConnectionChanged?: WallConnectionChangedResolvers<ContextType>;
 }>;

--- a/packages/shared-schema/src/schema/events.ts
+++ b/packages/shared-schema/src/schema/events.ts
@@ -8,6 +8,7 @@ export const eventsTypeDefs = /* GraphQL */ `
     | UserPresenceChanged
     | LeaderChanged
     | DriverChanged
+    | WallConnectionChanged
     | WallConfirmedClimb
     | SessionBoardSerialChanged
     | SessionBoardPathChanged
@@ -56,6 +57,19 @@ export const eventsTypeDefs = /* GraphQL */ `
     driverParticipantId: ID
     "Stable participant id of the previous driver, or null when there was none (e.g. the very first take of the session, or after a release). Lets clients render 'X took the wall from Y' toasts and populate the Phase 5 previousDriver analytics property without local bookkeeping."
     previousDriverParticipantId: ID
+  }
+
+  """
+  Event when the member holding the BLE connection to a board changes. In the
+  simplified collaboration model the connection holder is the single frame
+  writer, and any holder existing means the shared "wall is connected"
+  indicator lights up for everyone in the session.
+  """
+  type WallConnectionChanged {
+    "The board whose connection holder changed (userBoards.id)"
+    boardId: Int!
+    "Stable participant id now holding the BLE connection to the board, or null when nobody holds it"
+    holderParticipantId: ID
   }
 
   """

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -99,6 +99,23 @@ export const mutationsTypeDefs = /* GraphQL */ `
     releaseControl: Session!
 
     """
+    Announce that this client now holds a live BLE connection to \`boardId\` in the
+    current session. Claim-if-free: the first connector becomes the board's frame
+    writer; a later connector to the same board does not steal the slot. Lights the
+    shared "wall connected" indicator for the session. Publishes
+    \`WallConnectionChanged\` when the holder changes. Idempotent for the same holder.
+    Session identity comes from the WebSocket connection context.
+    """
+    announceWallLink(boardId: Int!): Session!
+
+    """
+    Revoke this client's BLE-connection claim for \`boardId\` (manual disconnect).
+    Frees the slot for the next connector and, when this client was the holder,
+    publishes \`WallConnectionChanged { holderParticipantId: null }\`. Idempotent.
+    """
+    revokeWallLink(boardId: Int!): Boolean!
+
+    """
     Confirm to all session participants that a climb was successfully relayed to the wall
     over BLE from this client's phone. Any session participant may call (no driver
     requirement) — the BLE-capable phone that handled the send is the source of truth for

--- a/packages/shared-schema/src/schema/session.ts
+++ b/packages/shared-schema/src/schema/session.ts
@@ -26,6 +26,17 @@ export const sessionTypeDefs = /* GraphQL */ `
   }
 
   """
+  A board's current BLE connection holder within a session. The holder is the
+  single member whose phone writes frames to that board's LEDs.
+  """
+  type WallConnection {
+    "The board this connection is for (userBoards.id)"
+    boardId: Int!
+    "Stable participant id holding the BLE connection to the board"
+    holderParticipantId: ID!
+  }
+
+  """
   An active climbing session where users can collaborate on a queue.
   """
   type Session {
@@ -43,6 +54,8 @@ export const sessionTypeDefs = /* GraphQL */ `
     isLeader: Boolean!
     "Stable participant id of the user currently driving the wall. Set via takeControl, cleared via releaseControl or driver disconnect. Distinct from isLeader, which is presentation/legacy only."
     driverParticipantId: ID
+    "Per-board BLE connection holders. In the simplified model the holder is the single frame-writer for that board, and any entry means the shared 'wall connected' indicator is lit. Maintained via announceWallLink / revokeWallLink; empty when no member is connected."
+    wallConnections: [WallConnection!]!
     "Most recently observed BLE board serial for this session. Set when a participant pairs their phone to a physical board; broadcast as SessionBoardSerialChanged so late-joiners can auto-connect to the same board. Null when no board has been recorded."
     lastConnectedBoardSerial: String
     "Unique identifier for this client's connection"

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1963,6 +1963,15 @@ export type Mutation = {
    */
   addQueueItem: ClimbQueueItem;
   /**
+   * Announce that this client now holds a live BLE connection to `boardId` in the
+   * current session. Claim-if-free: the first connector becomes the board's frame
+   * writer; a later connector to the same board does not steal the slot. Lights the
+   * shared "wall connected" indicator for the session. Publishes
+   * `WallConnectionChanged` when the holder changes. Idempotent for the same holder.
+   * Session identity comes from the WebSocket connection context.
+   */
+  announceWallLink: Session;
+  /**
    * Attach an Instagram post or reel as beta for a climb. Idempotent on
    * (boardType, climbUuid, link).
    */
@@ -2145,6 +2154,12 @@ export type Mutation = {
   /** Revoke a community role from a user (admin only). */
   revokeRole: Scalars['Boolean']['output'];
   /**
+   * Revoke this client's BLE-connection claim for `boardId` (manual disconnect).
+   * Frees the slot for the next connector and, when this client was the holder,
+   * publishes `WallConnectionChanged { holderParticipantId: null }`. Idempotent.
+   */
+  revokeWallLink: Scalars['Boolean']['output'];
+  /**
    * Save Aurora climbing credentials.
    * Validates with Aurora API before saving.
    */
@@ -2303,6 +2318,11 @@ export type MutationAddGymMemberArgs = {
 export type MutationAddQueueItemArgs = {
   item: ClimbQueueItemInput;
   position?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationAnnounceWallLinkArgs = {
+  boardId: Scalars['Int']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -2592,6 +2612,11 @@ export type MutationResolveProposalArgs = {
 /** Root mutation type for all write operations. */
 export type MutationRevokeRoleArgs = {
   input: RevokeRoleInput;
+};
+
+/** Root mutation type for all write operations. */
+export type MutationRevokeWallLinkArgs = {
+  boardId: Scalars['Int']['input'];
 };
 
 /** Root mutation type for all write operations. */
@@ -4436,6 +4461,8 @@ export type Session = {
   startedAt?: Maybe<Scalars['String']['output']>;
   /** Users currently in the session */
   users: Array<SessionUser>;
+  /** Per-board BLE connection holders. In the simplified model the holder is the single frame-writer for that board, and any entry means the shared 'wall connected' indicator is lit. Maintained via announceWallLink / revokeWallLink; empty when no member is connected. */
+  wallConnections: Array<WallConnection>;
 };
 
 /**
@@ -4544,7 +4571,8 @@ export type SessionEvent =
   | UserJoined
   | UserLeft
   | UserPresenceChanged
-  | WallConfirmedClimb;
+  | WallConfirmedClimb
+  | WallConnectionChanged;
 
 /** A session feed card representing a group of ticks from a climbing session. */
 export type SessionFeedItem = {
@@ -5623,6 +5651,32 @@ export type WallConfirmedClimb = {
   confirmedByParticipantId: Scalars['ID']['output'];
   /** UUID of the queue item that triggered this send, or null when the BLE-capable phone reported only a climb UUID. Lets clients disambiguate when the same climb is queued twice — without this, both queue entries' pending lightbulbs would clear on a single confirmation. */
   queueItemUuid?: Maybe<Scalars['ID']['output']>;
+};
+
+/**
+ * A board's current BLE connection holder within a session. The holder is the
+ * single member whose phone writes frames to that board's LEDs.
+ */
+export type WallConnection = {
+  __typename?: 'WallConnection';
+  /** The board this connection is for (userBoards.id) */
+  boardId: Scalars['Int']['output'];
+  /** Stable participant id holding the BLE connection to the board */
+  holderParticipantId: Scalars['ID']['output'];
+};
+
+/**
+ * Event when the member holding the BLE connection to a board changes. In the
+ * simplified collaboration model the connection holder is the single frame
+ * writer, and any holder existing means the shared "wall is connected"
+ * indicator lights up for everyone in the session.
+ */
+export type WallConnectionChanged = {
+  __typename?: 'WallConnectionChanged';
+  /** The board whose connection holder changed (userBoards.id) */
+  boardId: Scalars['Int']['output'];
+  /** Stable participant id now holding the BLE connection to the board, or null when nobody holds it */
+  holderParticipantId?: Maybe<Scalars['ID']['output']>;
 };
 
 /**


### PR DESCRIPTION
## Why

Part of firming up the collaboration model. The driver / take-control machinery overloads the LED controller (every connected phone could write) and causes the session bugs flagged for the RN release. The fix: drop "who may drive" as a claimed role and make the **member holding the BLE connection the single frame writer**, with any holder lighting a shared "wall connected" indicator for the whole session.

This PR is **R1 — purely additive**. It introduces the connection-holder model *alongside* the existing driver machinery so nothing breaks. Driver/take-control removal and the client migration (lightbulb → session-connection indicator, AutoSender suppression for non-holders) come in follow-up steps.

## Model

**Claim-if-free, not yank.** The first connector to a board holds the slot (`HSETNX`); a later connector doesn't steal it. The physical BLE connection is already exclusive, so there's nothing to elect — the connection *is* the writer token.

## What changed (all additive)

- **distributed-state**: `sessionWallConnections` hash key + `claimWallConnection` / `releaseWallConnection` / `getWallConnections` / `releaseAllWallConnectionsForParticipant` ops, mirroring the driver ops (WATCH-guarded conditional release).
- **room-manager**: local-shadow map + the four methods + `reset`/`endSession` teardown. Disconnect cleanup folds into `releaseDriverIfMatches` (reusing the same multi-instance liveness gate) and publishes `WallConnectionChanged(null)` per freed board.
- **schema**: `announceWallLink(boardId)` / `revokeWallLink(boardId)` mutations, `WallConnectionChanged` event, `Session.wallConnections` + `WallConnection` type.
- **resolvers**: `announceWallLink` / `revokeWallLink` (claim/release + transition-gated broadcast); `buildSessionPayload` hydrates `wallConnections`.

## Tests
- `typecheck` + `vp check` clean.
- 61 session/payload/disconnect backend tests green (roomManager mocks updated for `getWallConnections`; `build-session-payload` asserts the Map→array mapping).

## Follow-ups (same pillar)
- **R1 cont.**: mobile (primary) — lightbulb becomes a session-connection indicator; call `announceWallLink`/`revokeWallLink` on BLE connect/disconnect; suppress the `BluetoothAutoSender` for non-holders. Web (minimal) — keep compiling.
- **R2**: remove `takeControl`/`releaseControl`/`driverParticipantId`/`DriverChanged` once OTA clients have migrated (the plan's staged deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)