### PR TITLE
Session simplification (R1 clients): wire connection-holder into mobile

### DIFF
--- a/packages/mobile/src/lib/__tests__/session-runtime-event.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-runtime-event.test.ts
@@ -41,9 +41,23 @@ describe('toMobileSessionRuntimeEvent', () => {
     });
   });
 
+  it('adapts WallConnectionChanged so the holder reaches wallConnectionsByBoard', () => {
+    expect(
+      toMobileSessionRuntimeEvent({ __typename: 'WallConnectionChanged', boardId: 42, holderParticipantId: 'p-1' }),
+    ).toEqual({ __typename: 'WallConnectionChanged', boardId: 42, holderParticipantId: 'p-1' });
+    // A freed slot (nobody holds it) maps the holder to null.
+    expect(toMobileSessionRuntimeEvent({ __typename: 'WallConnectionChanged', boardId: 42 })).toEqual({
+      __typename: 'WallConnectionChanged',
+      boardId: 42,
+      holderParticipantId: null,
+    });
+  });
+
   it('ignores stats and incomplete events', () => {
     expect(toMobileSessionRuntimeEvent({ __typename: 'SessionStatsUpdated', totalSends: 1 })).toBeNull();
     expect(toMobileSessionRuntimeEvent({ __typename: 'UserJoined' })).toBeNull();
     expect(toMobileSessionRuntimeEvent({ __typename: 'SessionBoardPathChanged' })).toBeNull();
+    // No boardId → can't key wallConnectionsByBoard, so it's dropped.
+    expect(toMobileSessionRuntimeEvent({ __typename: 'WallConnectionChanged' })).toBeNull();
   });
 });

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -949,6 +949,10 @@ export const SESSION_UPDATES_SUBSCRIPTION = `
         driverParticipantId
         previousDriverParticipantId
       }
+      ... on WallConnectionChanged {
+        boardId
+        holderParticipantId
+      }
       ... on WallConfirmedClimb {
         climbUuid
         confirmedAt
@@ -1035,6 +1039,9 @@ export type SessionUpdateEvent = {
   // DriverChanged
   driverParticipantId?: string | null;
   previousDriverParticipantId?: string | null;
+  // WallConnectionChanged
+  boardId?: number;
+  holderParticipantId?: string | null;
   // WallConfirmedClimb
   climbUuid?: string;
   confirmedAt?: string;

--- a/packages/mobile/src/lib/session-runtime-event.ts
+++ b/packages/mobile/src/lib/session-runtime-event.ts
@@ -23,6 +23,17 @@ export function toMobileSessionRuntimeEvent(event: SessionUpdateEvent): RuntimeS
         driverParticipantId: event.driverParticipantId ?? null,
         previousDriverParticipantId: event.previousDriverParticipantId ?? null,
       };
+    case 'WallConnectionChanged':
+      // Drives wallConnectionsByBoard in the shared runtime, which
+      // deriveIsWallWriter reads to suppress non-holders. Without this case the
+      // map stays empty and every connected member falls back to "writer".
+      return typeof event.boardId === 'number'
+        ? {
+            __typename: 'WallConnectionChanged',
+            boardId: event.boardId,
+            holderParticipantId: event.holderParticipantId ?? null,
+          }
+        : null;
     case 'SessionBoardSerialChanged':
       return {
         __typename: 'SessionBoardSerialChanged',

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -701,14 +701,18 @@ export function BluetoothProvider({
     onConnectSuccess: handleConnectSuccess,
   });
 
-  // The connect-success path announces the wall link only when a session is
-  // already active. If a climber connects solo and *then* joins/starts a session
-  // on the same board, announce the already-connected board now so peers see a
-  // holder instead of every connected member falling back to "writer". Leaving
-  // the session frees our slot backend-side, so reset the ref to allow a fresh
-  // announce on rejoin (and so a later disconnect doesn't revoke a freed slot).
+  // Announce the wall link whenever this phone is in a session (with a
+  // participant) and BLE-connected. Beyond the connect-success path this covers:
+  // connecting solo then joining a session, and — keyed on participantId, which
+  // resets null -> new on every (re)join including the re-join after a WS
+  // reconnect — re-announcing (idempotent) to reclaim the slot the backend frees
+  // per-connection when the old socket drops. Without the re-announce a transient
+  // reconnect would leave this phone demoted. Leaving the session
+  // (sessionId/participantId null) frees our slot backend-side, so reset the ref
+  // to allow a fresh announce on rejoin (and so a later disconnect doesn't revoke
+  // a freed slot).
   useEffect(() => {
-    if (sessionId == null) {
+    if (sessionId == null || participantId == null) {
       announcedWallBoardIdRef.current = null;
       return;
     }
@@ -717,7 +721,7 @@ export function BluetoothProvider({
     if (boardId == null || announcedWallBoardIdRef.current === boardId) return;
     announcedWallBoardIdRef.current = boardId;
     void announceWallLink(boardId);
-  }, [sessionId, isConnected, announceWallLink]);
+  }, [sessionId, participantId, isConnected, announceWallLink]);
 
   const resolvedPickerBoards = useResolvedBleDeviceBoards(pickerState?.devices ?? EMPTY_PICKER_DEVICES);
   const currentBoardConfig = useMemo(() => {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -701,6 +701,24 @@ export function BluetoothProvider({
     onConnectSuccess: handleConnectSuccess,
   });
 
+  // The connect-success path announces the wall link only when a session is
+  // already active. If a climber connects solo and *then* joins/starts a session
+  // on the same board, announce the already-connected board now so peers see a
+  // holder instead of every connected member falling back to "writer". Leaving
+  // the session frees our slot backend-side, so reset the ref to allow a fresh
+  // announce on rejoin (and so a later disconnect doesn't revoke a freed slot).
+  useEffect(() => {
+    if (sessionId == null) {
+      announcedWallBoardIdRef.current = null;
+      return;
+    }
+    if (!isConnected) return;
+    const boardId = resolvedPresenceBoardIdRef.current;
+    if (boardId == null || announcedWallBoardIdRef.current === boardId) return;
+    announcedWallBoardIdRef.current = boardId;
+    void announceWallLink(boardId);
+  }, [sessionId, isConnected, announceWallLink]);
+
   const resolvedPickerBoards = useResolvedBleDeviceBoards(pickerState?.devices ?? EMPTY_PICKER_DEVICES);
   const currentBoardConfig = useMemo(() => {
     if (!boardName || layoutId === undefined || sizeId === undefined || !setIds) return undefined;

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -23,6 +23,7 @@ import { GET_BOARD } from '../lib/graphql/operations';
 import type { GetBoardQueryResponse } from '../lib/graphql/operations';
 import { getBoardRenderData } from '../lib/board-details';
 import { registerBluetoothConnection } from '../lib/ble/bluetooth-status-store';
+import { deriveIsWallWriter } from '@boardsesh/queue-runtime';
 import { useIsPartyPreviewOnly, useQueue, useQueueSessionControls } from './queue-provider';
 import { useBoardPresenceControls } from './board-presence-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
@@ -315,7 +316,16 @@ export function BluetoothProvider({
   boardUuid,
   children,
 }: BluetoothProviderProps) {
-  const { sessionId, confirmClimbOnWall, setSessionBoardSerial, lastConnectedBoardSerial } = useQueueSessionControls();
+  const {
+    sessionId,
+    participantId,
+    confirmClimbOnWall,
+    setSessionBoardSerial,
+    lastConnectedBoardSerial,
+    announceWallLink,
+    revokeWallLink,
+    wallConnectionsByBoard,
+  } = useQueueSessionControls();
   const isPartyPreviewOnly = useIsPartyPreviewOnly();
   const { t } = useTranslation('settings');
   // Board presence ("now on the wall"). All of these are inert when the
@@ -329,6 +339,21 @@ export function BluetoothProvider({
     resolveAndBindBoardByConfig,
     reportClimbForBoard,
   } = useBoardPresenceControls();
+
+  // The BLE connection is the writer token: the member holding the connection to
+  // this board is the single frame writer. deriveIsWallWriter falls back to
+  // "writer" when solo, no board is resolved, or nobody holds the slot — so this
+  // only suppresses writes when a confirmed OTHER member holds the connection.
+  // Belt-and-suspenders with isPartyPreviewOnly while the driver model coexists.
+  const isWallWriter = deriveIsWallWriter({
+    isPersistentSessionActive: sessionId !== null,
+    participantId,
+    wallConnectionsByBoard,
+    boardId: presenceBoardId,
+  });
+  // The board this phone announced a wall link for, so disconnect can revoke it
+  // (the backend only frees the slot on session-leave, not on BLE drop).
+  const announcedWallBoardIdRef = useRef<number | null>(null);
   const { currentClimb: wallCurrentClimb } = useBoardPresenceCurrent();
   const { showUndoWallChangeSnackbar } = useQueueSnackbar();
   const { overrides: holdColorOverrides, signature: holdColorSignature } = useHoldColorOverrides();
@@ -596,6 +621,13 @@ export function BluetoothProvider({
             if (!resolved) return;
             resolvedPresenceBoardIdRef.current = resolved.boardId;
             replayPendingWallReport(resolved.boardId);
+            // Claim the wall-connection slot so this phone is the board's sole
+            // frame writer for the session (no-op solo). The backend gates the
+            // claim on session membership.
+            if (sessionIdRef.current) {
+              announcedWallBoardIdRef.current = resolved.boardId;
+              void announceWallLink(resolved.boardId);
+            }
           })
           .catch((error: unknown) => {
             console.warn('[board-presence] board resolve failed', error);
@@ -617,7 +649,14 @@ export function BluetoothProvider({
         boardId: resolvedPresenceBoardIdRef.current ?? presenceBoardIdRef.current ?? undefined,
       });
     },
-    [boardName, setSessionBoardSerial, resolveAndBindBoard, resolveAndBindBoardByConfig, replayPendingWallReport],
+    [
+      boardName,
+      setSessionBoardSerial,
+      resolveAndBindBoard,
+      resolveAndBindBoardByConfig,
+      replayPendingWallReport,
+      announceWallLink,
+    ],
   );
 
   // Hold placements for the active board, required by the hook's
@@ -908,6 +947,11 @@ export function BluetoothProvider({
   // Wrap disconnect to track user-initiated disconnects
   const wrappedDisconnect = useCallback(async () => {
     clearPendingWallReportAndUndoToastArm();
+    const heldBoardId = announcedWallBoardIdRef.current;
+    if (heldBoardId !== null) {
+      announcedWallBoardIdRef.current = null;
+      void revokeWallLink(heldBoardId);
+    }
     isUserDisconnectRef.current = true;
     track(SHARED_EVENTS.BluetoothDisconnected, { boardName, reason: 'user', inSession: sessionIdRef.current != null });
     try {
@@ -921,7 +965,7 @@ export function BluetoothProvider({
     } finally {
       isUserDisconnectRef.current = false;
     }
-  }, [clearPendingWallReportAndUndoToastArm, disconnect, boardName]);
+  }, [clearPendingWallReportAndUndoToastArm, disconnect, boardName, revokeWallLink]);
 
   // Register with the module-level status store so consumers rendered outside
   // this provider (e.g. the root tab bar, the long-press BLE controls sheet) can
@@ -944,6 +988,13 @@ export function BluetoothProvider({
   useEffect(() => {
     if (wasConnectedRef.current && !isConnected && !isUserDisconnectRef.current) {
       clearPendingWallReportAndUndoToastArm();
+      // Free the wall-connection slot on an unexpected drop too, so a peer can
+      // become the writer instead of being suppressed by a dead holder.
+      const heldBoardId = announcedWallBoardIdRef.current;
+      if (heldBoardId !== null) {
+        announcedWallBoardIdRef.current = null;
+        void revokeWallLink(heldBoardId);
+      }
       track(SHARED_EVENTS.BluetoothDisconnected, {
         boardName,
         reason: 'unexpected',
@@ -951,7 +1002,7 @@ export function BluetoothProvider({
       });
     }
     wasConnectedRef.current = isConnected;
-  }, [clearPendingWallReportAndUndoToastArm, isConnected, boardName]);
+  }, [clearPendingWallReportAndUndoToastArm, isConnected, boardName, revokeWallLink]);
 
   const value = useMemo<BluetoothContextValue>(
     () => ({
@@ -982,7 +1033,7 @@ export function BluetoothProvider({
 
   return (
     <BluetoothContext.Provider value={value}>
-      {isConnected && !isPartyPreviewOnly && (
+      {isConnected && !isPartyPreviewOnly && isWallWriter && (
         <BluetoothAutoSender
           sendFramesToBoard={sendFramesToBoard}
           onWallConfirmed={handleWallConfirmed}

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -174,6 +174,20 @@ type QueueContextValue = {
    */
   confirmClimbOnWall: (climbUuid: string) => Promise<void>;
   /**
+   * Announce this phone now holds the BLE connection to `boardId` in the active
+   * session — claim-if-free, so the holder is the board's sole frame writer.
+   * Best-effort no-op when no session is active.
+   */
+  announceWallLink: (boardId: number) => Promise<void>;
+  /** Revoke this phone's BLE-connection claim for `boardId` on disconnect. */
+  revokeWallLink: (boardId: number) => Promise<void>;
+  /**
+   * Per-board BLE connection holders (boardId -> stable participantId) for the
+   * active session. Used to decide which phone writes frames + to light the
+   * shared "wall connected" indicator. Empty when solo or nobody is connected.
+   */
+  wallConnectionsByBoard: Record<number, string>;
+  /**
    * Store the connected board serial on the active session so native peers can
    * reconnect to the same physical wall without showing the picker.
    */
@@ -214,6 +228,9 @@ type QueueSessionControlContextValue = Pick<
   | 'lastConnectedBoardSerial'
   | 'takeControl'
   | 'releaseControl'
+  | 'announceWallLink'
+  | 'revokeWallLink'
+  | 'wallConnectionsByBoard'
   | 'confirmClimbOnWall'
   | 'setSessionBoardSerial'
 >;
@@ -297,6 +314,7 @@ type QueueActionsContextValue = Omit<
   | 'driverParticipantId'
   | 'lastConnectedBoardSerial'
   | 'participantId'
+  | 'wallConnectionsByBoard'
 >;
 
 const QueueActionsContext = createContext<QueueActionsContextValue | null>(null);
@@ -1280,6 +1298,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     }
   }, [mutations, showToast, t]);
   const confirmClimbOnWall = useCallback((climbUuid: string) => mutations.confirmClimbOnWall(climbUuid), [mutations]);
+  const announceWallLink = useCallback((boardId: number) => mutations.announceWallLink(boardId), [mutations]);
+  const revokeWallLink = useCallback((boardId: number) => mutations.revokeWallLink(boardId), [mutations]);
+  const wallConnectionsByBoard = useMemo(
+    () => sessionRuntimeState.wallConnectionsByBoard ?? {},
+    [sessionRuntimeState.wallConnectionsByBoard],
+  );
   const setSessionBoardSerial = useCallback((serial: string) => mutations.setSessionBoardSerial(serial), [mutations]);
 
   // Self-healing re-grade: a climb's difficulty/quality/sends are angle-specific
@@ -1725,6 +1749,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setSessionBoardPath,
       takeControl,
       releaseControl,
+      announceWallLink,
+      revokeWallLink,
       confirmClimbOnWall,
       setSessionBoardSerial,
       subscribeToQueueEvents,
@@ -1748,6 +1774,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setSessionBoardPath,
       takeControl,
       releaseControl,
+      announceWallLink,
+      revokeWallLink,
       confirmClimbOnWall,
       setSessionBoardSerial,
       subscribeToQueueEvents,
@@ -1764,9 +1792,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       driverParticipantId,
       lastConnectedBoardSerial,
       participantId,
+      wallConnectionsByBoard,
       ...actionsValue,
     }),
-    [state, sessionId, driverParticipantId, lastConnectedBoardSerial, participantId, actionsValue],
+    [
+      state,
+      sessionId,
+      driverParticipantId,
+      lastConnectedBoardSerial,
+      participantId,
+      wallConnectionsByBoard,
+      actionsValue,
+    ],
   );
 
   // Active-climb selector: identity changes ONLY when the active climb uuid
@@ -1822,6 +1859,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       lastConnectedBoardSerial,
       takeControl,
       releaseControl,
+      announceWallLink,
+      revokeWallLink,
+      wallConnectionsByBoard,
       confirmClimbOnWall,
       setSessionBoardSerial,
     }),
@@ -1832,6 +1872,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       lastConnectedBoardSerial,
       takeControl,
       releaseControl,
+      announceWallLink,
+      revokeWallLink,
+      wallConnectionsByBoard,
       confirmClimbOnWall,
       setSessionBoardSerial,
     ],

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -214,6 +214,30 @@ export const CONFIRM_CLIMB_ON_WALL = `
   }
 `;
 
+// Wall-link mutations — the connection-holder model's simpler replacement for
+// take/release control. A client announces it now holds a live BLE connection
+// to a board (claim-if-free: the first connector becomes the sole frame writer);
+// it revokes on disconnect. announceWallLink returns the Session (with
+// wallConnections) so callers can learn immediately whether they hold the slot.
+export const ANNOUNCE_WALL_LINK = `
+  mutation AnnounceWallLink($boardId: Int!) {
+    announceWallLink(boardId: $boardId) {
+      id
+      participantId
+      wallConnections {
+        boardId
+        holderParticipantId
+      }
+    }
+  }
+`;
+
+export const REVOKE_WALL_LINK = `
+  mutation RevokeWallLink($boardId: Int!) {
+    revokeWallLink(boardId: $boardId)
+  }
+`;
+
 // Session board serial — when a phone pairs with a physical board over BLE,
 // it records the serial on the session so other (mobile) participants can
 // auto-connect without picking from a list. Returns Session! for optimistic-UI
@@ -332,6 +356,10 @@ export const SESSION_UPDATES = `
       ... on DriverChanged {
         driverParticipantId
         previousDriverParticipantId
+      }
+      ... on WallConnectionChanged {
+        boardId
+        holderParticipantId
       }
       ... on WallConfirmedClimb {
         climbUuid

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -37,6 +37,8 @@ import {
   REPLACE_QUEUE_ITEM,
   TAKE_CONTROL,
   RELEASE_CONTROL,
+  ANNOUNCE_WALL_LINK,
+  REVOKE_WALL_LINK,
   CONFIRM_CLIMB_ON_WALL,
   SET_SESSION_BOARD_SERIAL,
   SET_SESSION_BOARD_PATH,
@@ -110,6 +112,17 @@ export type QueueMutationsActions<TItem> = {
    * isn't the driver. Backend no-op in solo.
    */
   releaseControl: () => Promise<void>;
+  /**
+   * Announce this client now holds a live BLE connection to `boardId`, making it
+   * the board's sole frame writer (claim-if-free). Lights the shared "wall
+   * connected" indicator. Best-effort; no-op in solo.
+   */
+  announceWallLink: (boardId: number) => Promise<void>;
+  /**
+   * Revoke this client's BLE-connection claim for `boardId` (disconnect).
+   * Best-effort; no-op in solo.
+   */
+  revokeWallLink: (boardId: number) => Promise<void>;
   /**
    * Tell the backend this client just relayed `climbUuid` to the wall over BLE
    * so it can broadcast `WallConfirmedClimb` to the other party members.
@@ -310,6 +323,26 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
       const ready = await resolveCurrent();
       if (!ready) return;
       await execute(ready.client, { query: RELEASE_CONTROL, variables: {} });
+    },
+
+    announceWallLink: async (boardId) => {
+      const ready = await resolveCurrent();
+      if (!ready) return;
+      try {
+        await execute(ready.client, { query: ANNOUNCE_WALL_LINK, variables: { boardId } });
+      } catch (error) {
+        onBestEffortError?.('announceWallLink', error);
+      }
+    },
+
+    revokeWallLink: async (boardId) => {
+      const ready = await resolveCurrent();
+      if (!ready) return;
+      try {
+        await execute(ready.client, { query: REVOKE_WALL_LINK, variables: { boardId } });
+      } catch (error) {
+        onBestEffortError?.('revokeWallLink', error);
+      }
     },
 
     confirmClimbOnWall: async (climbUuid) => {

--- a/packages/shared/queue-runtime/src/driver-state.ts
+++ b/packages/shared/queue-runtime/src/driver-state.ts
@@ -43,3 +43,37 @@ export function derivePreviewOnly(args: {
     driverParticipantId: args.driverParticipantId,
   });
 }
+
+/**
+ * Whether the session currently has a live BLE connection to a board — drives
+ * the shared "wall connected" indicator. False when solo, no board is resolved,
+ * or nobody holds the connection.
+ */
+export function deriveSessionWallConnected(args: {
+  isPersistentSessionActive: boolean;
+  wallConnectionsByBoard: Record<number, string> | null | undefined;
+  boardId: number | null;
+}): boolean {
+  if (!args.isPersistentSessionActive || args.boardId === null) return false;
+  return Boolean(args.wallConnectionsByBoard?.[args.boardId]);
+}
+
+/**
+ * Whether THIS client should physically write frames to the board. The BLE
+ * connection is the writer token, so:
+ *  - solo (no session) or no resolved board → always write (no election);
+ *  - in a session with a resolved board, write only when this client holds the
+ *    connection slot. Until a holder is recorded, fall back to "write" so a
+ *    session whose holder hasn't propagated yet never goes write-less.
+ */
+export function deriveIsWallWriter(args: {
+  isPersistentSessionActive: boolean;
+  participantId: string | null;
+  wallConnectionsByBoard: Record<number, string> | null | undefined;
+  boardId: number | null;
+}): boolean {
+  if (!args.isPersistentSessionActive || args.boardId === null) return true;
+  const holder = args.wallConnectionsByBoard?.[args.boardId];
+  if (!holder) return true;
+  return args.participantId !== null && holder === args.participantId;
+}

--- a/packages/shared/queue-runtime/src/index.ts
+++ b/packages/shared/queue-runtime/src/index.ts
@@ -16,7 +16,7 @@ export type {
 export { createJoinSessionTracker } from './ensure-joined';
 export type { JoinSessionTracker, JoinSessionTrackerOptions } from './ensure-joined';
 
-export { deriveIsDriver, derivePreviewOnly } from './driver-state';
+export { deriveIsDriver, derivePreviewOnly, deriveSessionWallConnected, deriveIsWallWriter } from './driver-state';
 
 export { applySessionRuntimeEvent, upsertRuntimeSessionUser } from './session-events';
 export type {

--- a/packages/shared/queue-runtime/src/session-events.ts
+++ b/packages/shared/queue-runtime/src/session-events.ts
@@ -12,6 +12,14 @@ export type RuntimeSessionState<TUser extends RuntimeSessionUser = RuntimeSessio
   isLeader: boolean;
   clientId: string;
   driverParticipantId: string | null;
+  /**
+   * Per-board BLE connection holders: boardId -> stable participantId. The
+   * holder is the single member whose phone writes frames to that board, and
+   * any entry means the shared "wall connected" indicator is lit. Optional so
+   * existing session constructors that predate the connection-holder model
+   * don't have to set it (treated as empty).
+   */
+  wallConnectionsByBoard?: Record<number, string>;
   lastConnectedBoardSerial: string | null;
   boardPath: string;
 };
@@ -22,6 +30,7 @@ export type RuntimeSessionEvent<TUser extends RuntimeSessionUser = RuntimeSessio
   | { __typename: 'UserLeft'; userId: string }
   | { __typename: 'LeaderChanged'; leaderId: string; leaderConnectionId?: string | null }
   | { __typename: 'DriverChanged'; driverParticipantId?: string | null; previousDriverParticipantId?: string | null }
+  | { __typename: 'WallConnectionChanged'; boardId: number; holderParticipantId?: string | null }
   | { __typename: 'SessionBoardSerialChanged'; lastConnectedBoardSerial?: string | null }
   | { __typename: 'SessionBoardPathChanged'; boardPath: string; changedByParticipantId?: string | null }
   | { __typename: 'SessionEnded'; reason?: string | null; newPath?: string | null };
@@ -65,6 +74,15 @@ export function applySessionRuntimeEvent<
     }
     case 'DriverChanged':
       return { ...prev, driverParticipantId: event.driverParticipantId ?? null };
+    case 'WallConnectionChanged': {
+      const next = { ...prev.wallConnectionsByBoard };
+      if (event.holderParticipantId) {
+        next[event.boardId] = event.holderParticipantId;
+      } else {
+        delete next[event.boardId];
+      }
+      return { ...prev, wallConnectionsByBoard: next };
+    }
     case 'SessionBoardSerialChanged':
       return { ...prev, lastConnectedBoardSerial: event.lastConnectedBoardSerial ?? null };
     case 'SessionBoardPathChanged':


### PR DESCRIPTION
**Stacked on #2842** (base: `feat/session-simplification`). Merge that first.

## Why
Makes the connection-holder model from #2842 actually drive behaviour on **mobile** (the primary session surface). The key fix: only the member holding the BLE connection writes frames, so several connected phones can't all hammer the LEDs ("lightbulb overload"). Additive — driver/take-control still works, so nothing breaks mid-migration. Web stays on the driver path (de-driver happens in the R2 PR).

## Shared (additive)
- **queue-runtime**: `RuntimeSessionState.wallConnectionsByBoard` + `WallConnectionChanged` handling in `applySessionRuntimeEvent`; new `deriveSessionWallConnected` / `deriveIsWallWriter` selectors.
- **graphql**: `ANNOUNCE_WALL_LINK` / `REVOKE_WALL_LINK` ops + `... on WallConnectionChanged` subscription fragment.
- **queue-react**: `announceWallLink` / `revokeWallLink` mutation methods.

## Mobile
- `queue-provider` exposes the new mutations + `wallConnectionsByBoard`.
- `bluetooth-provider` announces the wall link on BLE connect (resolved `boardId`) and revokes on disconnect — both user-initiated and unexpected-drop, so a dead holder can't suppress peers.
- **`BluetoothAutoSender` gates on `deriveIsWallWriter`** → only the connection holder writes frames. The selector falls back to "writer" when solo, no board is resolved, or nobody holds the slot, so there's **no behaviour change** when board-presence is off or you're the holder; the fix activates when board-presence is on and another phone holds the connection.

## Validation
Full `typecheck` (web+mobile+shared) clean · `vp check` clean · **1997 mobile + 58 shared runtime tests** green · Metro bundle OK.

## Follow-up (R2)
Remove `takeControl`/`releaseControl`/`driverParticipantId`/`DriverChanged`, flip the lightbulb to the shared connection indicator, minimal web de-driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)