### PR TITLE
Report handled user errors to PostHog (mobile)

### DIFF
--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -1,0 +1,58 @@
+# Mobile error telemetry (PostHog)
+
+The RN app (`packages/mobile`) has no Sentry — PostHog is the only error sink. So
+every error a user actually hits must be reported, or it's invisible. Two layers:
+
+## What's automatic
+
+`src/lib/posthog-client.ts` configures PostHog `errorTracking.autocapture` for
+**uncaught exceptions** and **unhandled promise rejections**, plus a global
+`ErrorUtils` handler (`global-error-capture.ts`) and the Expo Router
+`ErrorBoundary` (`app/_layout.tsx`). Crashes and render errors land in PostHog as
+`$exception` events with no extra work.
+
+## What you must do: report _handled_ errors
+
+The blind spot is errors the app **catches** and turns into a toast, inline
+message, degraded state, or silent `console.warn`. Those never reach autocapture.
+Rule of thumb: **every catch that handles a user-affecting failure reports it.**
+
+Use the helpers in `src/lib/error-reporting.ts`:
+
+- `reportHandledError(error, { tags: { source, ... }, extra })` — the default.
+  Drops cancellations (`AbortError` / TanStack `CancelledError`) and downgrades
+  offline/network failures to a `warning` tagged `network: true`, so error
+  tracking stays signal-rich. Use it in catch blocks, GraphQL-WS handlers, and the
+  React Query caches.
+- `reportError(error, { level, tags, extra })` — raw passthrough. Use only when
+  the caller already owns the severity (e.g. auth: a 401 is an `error`, a network
+  blip is a `warning`).
+
+Always pass a `tags.source` (and an `op` where it helps) so events group in
+PostHog: `react-query`, `native-auth`, `queue-mutation`, `queue-sync`,
+`auth-refresh`, `ble-send`, `ble-connect`, `playlist`, `wall-control`, etc.
+
+### Where it's already wired
+
+- **React Query** (`providers/query-provider.tsx`) — `QueryCache` / `MutationCache`
+  `onError` report every query/mutation failure once `retry` is exhausted. This is
+  the chokepoint for API / GraphQL-HTTP / REST failures; don't re-report at
+  individual `useQuery`/`useMutation` call sites.
+- Direct **GraphQL-WS** ops (`@boardsesh/queue-react`, `@boardsesh/playlists-react`)
+  bypass React Query, so their catch sites report explicitly.
+
+### What NOT to report (avoid noise)
+
+- Cancellations and expected-empty paths (e.g. a parser returning `null` for a URL
+  that isn't a deep link).
+- Best-effort key/value store reads/writes that fall back to a default
+  (`last-search-store`, `recent-filter-store`, `session-store`, image cache, …).
+- Rate-limit responses — that's expected user pacing, not a bug.
+- `__DEV__`-only diagnostics (keep the `console.warn`; report only if the failure
+  is user-affecting in production too).
+
+## Verifying
+
+`isAnalyticsEnabled = !!apiKey && !__DEV__`, so **local Metro dev sends nothing**.
+Verify on a preview / TestFlight / production build: trigger the failure, then look
+for the `$exception` in PostHog filtered by `source`.

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -33,6 +33,7 @@ import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-render-board';
 import { recordPlaylistOpen } from '../../../src/lib/playlists/recents-store';
+import { reportHandledError } from '../../../src/lib/error-reporting';
 import { toQueueClimbs } from '../../../src/lib/climb-types';
 import { hapticSelection } from '../../../src/lib/haptics';
 import { useAuth } from '../../../src/providers/auth-provider';
@@ -188,6 +189,7 @@ export default function PlaylistDetail() {
         await reorderPlaylistClimb({ playlistId: playlistUuid, climbUuid, newIndex: target });
       } catch (err) {
         console.error('Failed to reorder playlist climb:', err);
+        reportHandledError(err, { tags: { source: 'playlist', op: 'reorder-climb' } });
         // Only wholesale-restore the pre-move snapshot if no other edit landed in
         // the meantime; otherwise a concurrent op's optimistic state would be
         // clobbered, so reconcile from the server instead.
@@ -226,6 +228,7 @@ export default function PlaylistDetail() {
                 await removeClimbFromPlaylist({ playlistId: playlistUuid, climbUuid });
               } catch (err) {
                 console.error('Failed to remove playlist climb:', err);
+                reportHandledError(err, { tags: { source: 'playlist', op: 'remove-climb' } });
                 // Restore only if no concurrent edit landed since; otherwise
                 // reconcile from the server so we don't clobber it.
                 if (editClimbsRef.current === next) {
@@ -290,6 +293,7 @@ export default function PlaylistDetail() {
       else await unpinPlaylist(playlist.uuid);
     } catch (err) {
       console.error('Failed to toggle pin:', err);
+      reportHandledError(err, { tags: { source: 'playlist', op: 'toggle-pin' } });
       setIsPinned(!next);
       queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
         prev ? { ...prev, isPinnedByMe: !next } : prev,
@@ -315,6 +319,7 @@ export default function PlaylistDetail() {
       else await unfollowPlaylist(playlist.uuid);
     } catch (err) {
       console.error('Failed to toggle follow:', err);
+      reportHandledError(err, { tags: { source: 'playlist', op: 'toggle-follow' } });
       setIsFollowing(!next);
       setFollowerCount((count) => count - delta);
       queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
@@ -346,6 +351,7 @@ export default function PlaylistDetail() {
         showToast(t('edit.messages.updated'), 'success');
       } catch (err) {
         console.error('Failed to update playlist:', err);
+        reportHandledError(err, { tags: { source: 'playlist', op: 'update' } });
         showToast(t('edit.messages.updateFailed'), 'error');
       } finally {
         setSavingEdit(false);
@@ -369,6 +375,7 @@ export default function PlaylistDetail() {
             navigation.goBack();
           } catch (err) {
             console.error('Failed to delete playlist:', err);
+            reportHandledError(err, { tags: { source: 'playlist', op: 'delete' } });
             showToast(t('detail.deleteFailed'), 'error');
           }
         },

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -29,6 +29,7 @@ import { SMART_PLAYLISTS, type SmartPlaylistPresentation } from '../../../src/li
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useToast } from '../../../src/providers/toast-provider';
+import { reportHandledError } from '../../../src/lib/error-reporting';
 import { useAuthToken } from '../../../src/lib/graphql/use-auth-token';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
@@ -341,6 +342,7 @@ export default function DiscoverLibrary() {
         router.push(`/(tabs)/discover/${created.uuid}`);
       } catch (err) {
         console.error('Failed to create playlist:', err);
+        reportHandledError(err, { tags: { source: 'playlist', op: 'create' } });
         showToast(t('bottomTabBar.createPlaylistFailed'), 'error');
       } finally {
         setCreating(false);

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -21,6 +21,7 @@ import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
 import { track } from '../../src/lib/analytics';
+import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
 import { brandColors } from '../../src/theme/colors';
 import { iosSystemColors } from '../../src/theme/ios-colors';
@@ -97,15 +98,29 @@ export default function LoginScreen() {
     try {
       const result = await signInWithCredentials(trimmedEmail, password);
       if (!result.success) {
+        const credentialsFailureReason = classifyNativeAuthFailureReason(result, 'credentials');
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: 'credentials',
-          failure_reason: classifyNativeAuthFailureReason(result, 'credentials'),
+          failure_reason: credentialsFailureReason,
+          failure_detail: result.error,
         });
         if (result.error === 'network') {
           setError(t('nativeStart.networkError'));
         } else if (result.status === 401) {
+          // Wrong email/password is a normal user error, not telemetry-worthy.
           setError(t('login.toasts.invalidCredentials'));
         } else {
+          // An unexpected backend failure (5xx, malformed response, …) — report
+          // it so a broken credentials endpoint is visible, not just a red toast.
+          reportError(new Error(`Credentials sign-in failed: ${result.error}`), {
+            tags: {
+              source: 'native-auth',
+              provider: 'credentials',
+              flow: 'native',
+              failure_reason: credentialsFailureReason,
+            },
+            extra: { status: result.status, server_error: result.error },
+          });
           setError(result.error);
         }
       } else {
@@ -150,21 +165,36 @@ export default function LoginScreen() {
         return;
       }
       // A real backend/token failure carrying the server's status + error.
+      const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
       track(SHARED_EVENTS.LoginFailed, {
         auth_method: provider,
         flow: 'native',
-        failure_reason: classifyNativeAuthFailureReason(result, 'oauth'),
+        failure_reason: oauthFailureReason,
+        failure_detail: result.error,
         duration_ms: Date.now() - attemptStartedAt,
+      });
+      // Surface to error tracking too: an OAuth 401 / no_id_token is a config
+      // bug (client-id audience mismatch, unconfigured backend) rather than a
+      // user typo, so it's worth a $exception carrying the status + server
+      // message. Network blips downgrade to a warning (handled by report level).
+      reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
+        level: result.error === 'network' ? 'warning' : 'error',
+        tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
+        extra: { status: result.status, server_error: result.error },
       });
       setError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
     } catch (oauthError) {
-      // The native module threw (Play Services missing, no presenter, …).
+      // The native module threw (Play Services missing, no presenter,
+      // DEVELOPER_ERROR for a signing/client-id mismatch, …).
       track(SHARED_EVENTS.LoginFailed, {
         auth_method: provider,
         flow: 'native',
         failure_reason: 'exception',
         failure_detail: oauthError instanceof Error ? oauthError.message : undefined,
         duration_ms: Date.now() - attemptStartedAt,
+      });
+      reportError(oauthError, {
+        tags: { source: 'native-auth', provider, flow: 'native', mechanism: 'exception' },
       });
       setError(t('nativeStart.oauthError'));
     } finally {

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -29,6 +29,7 @@ import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { BleControlSheet } from '../ble/BleControlSheet';
 import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
+import { reportHandledError } from '../../lib/error-reporting';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Icon } from '../Icon';
 import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
@@ -523,6 +524,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         })
         .catch((error: unknown) => {
           console.error('[playDrawer] failed to release wall control:', error);
+          reportHandledError(error, { tags: { source: 'wall-control', op: 'release' } });
         });
       return;
     }
@@ -608,6 +610,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         const shouldHandleFailure = wallControlPressOperationRef.current === operationId;
         if (!shouldHandleFailure) return;
         console.error('[playDrawer] failed to take wall control:', error);
+        reportHandledError(error, { tags: { source: 'wall-control', op: 'take' } });
         cancelWallConfirmWatcher();
         setPendingClimbUuid((currentClimbUuid) => (currentClimbUuid === displayedClimb.uuid ? null : currentClimbUuid));
         if (

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { reportError, reportHandledError } from '../error-reporting';
+import { captureError } from '../posthog-client';
+
+// captureError is the only side-effecting dependency; mocking it keeps this a
+// pure test of the noise policy (and avoids posthog-client's import-time global
+// error-capture install).
+vi.mock('../posthog-client', () => ({
+  captureError: vi.fn(),
+}));
+
+const mockedCaptureError = vi.mocked(captureError);
+
+afterEach(() => {
+  mockedCaptureError.mockClear();
+});
+
+describe('reportHandledError', () => {
+  it('drops cancellations (user dismiss / unmount) without reporting', () => {
+    reportHandledError(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+    reportHandledError(Object.assign(new Error('cancelled'), { name: 'CancelledError' }));
+    expect(mockedCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('downgrades offline fetch failures to a warning and tags them network', () => {
+    const offline = new TypeError('Network request failed');
+    reportHandledError(offline, { tags: { source: 'react-query' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(offline, {
+      level: 'warning',
+      tags: { source: 'react-query', network: true },
+    });
+  });
+
+  it('treats a transport ClientError (response without a numeric status) as network', () => {
+    const transport = Object.assign(new Error('boom'), { response: { errors: [] } });
+    reportHandledError(transport, { tags: { source: 'queue-mutation' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(transport, {
+      level: 'warning',
+      tags: { source: 'queue-mutation', network: true },
+    });
+  });
+
+  it('reports a real server error (response with an HTTP status) at error level', () => {
+    const serverError = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
+    reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(serverError, {
+      level: 'error',
+      tags: { source: 'react-query', kind: 'mutation' },
+    });
+  });
+
+  it('defaults a plain error to error level', () => {
+    const error = new Error('boom');
+    reportHandledError(error, { tags: { source: 'ble-connect' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(error, {
+      level: 'error',
+      tags: { source: 'ble-connect' },
+    });
+  });
+
+  it('lets the caller keep a non-error severity for a non-network failure', () => {
+    const error = new Error('boom');
+    reportHandledError(error, { level: 'info', tags: { source: 'x' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(error, { level: 'info', tags: { source: 'x' } });
+  });
+});
+
+describe('reportError', () => {
+  it('forwards verbatim to captureError', () => {
+    const error = new Error('x');
+    reportError(error, { level: 'error', tags: { source: 's' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(error, { level: 'error', tags: { source: 's' } });
+  });
+});

--- a/packages/mobile/src/lib/auth-interceptor.ts
+++ b/packages/mobile/src/lib/auth-interceptor.ts
@@ -1,6 +1,7 @@
 import { getAuthToken, getRefreshToken, storeTokens, isTokenExpiringSoon } from './auth-store';
 import { signOut } from './auth';
 import { BACKEND_URL } from './env';
+import { reportError, reportHandledError } from './error-reporting';
 
 let refreshPromise: Promise<boolean> | null = null;
 
@@ -29,6 +30,15 @@ async function refreshTokens(): Promise<boolean> {
 
     if (!response.ok) {
       console.warn(`[Auth] Token refresh failed: HTTP ${response.status}`);
+      // A 401/403 is an expired/revoked refresh token — routine, the user just
+      // signs in again. A 5xx means our refresh endpoint is broken for everyone,
+      // which we do want to see.
+      if (response.status >= 500) {
+        reportError(new Error(`Token refresh failed: HTTP ${response.status}`), {
+          tags: { source: 'auth-refresh' },
+          extra: { status: response.status },
+        });
+      }
       return false;
     }
 
@@ -37,6 +47,8 @@ async function refreshTokens(): Promise<boolean> {
     return true;
   } catch (error) {
     console.warn('[Auth] Token refresh error:', error instanceof Error ? error.message : 'unknown');
+    // Offline/aborted refreshes downgrade to a warning; a real throw reports.
+    reportHandledError(error, { tags: { source: 'auth-refresh' } });
     return false;
   }
 }

--- a/packages/mobile/src/lib/ble/bluetooth-status-store.ts
+++ b/packages/mobile/src/lib/ble/bluetooth-status-store.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react';
+import { reportHandledError } from '../error-reporting';
 
 let connectedCount = 0;
 const listeners = new Set<() => void>();
@@ -42,6 +43,7 @@ export function disconnectAllBluetooth(): void {
       disconnect();
     } catch (error) {
       console.error('Failed to disconnect bluetooth:', error);
+      reportHandledError(error, { tags: { source: 'ble-disconnect' } });
     }
   }
 }

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -27,6 +27,7 @@ import { requestBleRuntimePermissions } from './use-ble-permissions';
 import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
+import { reportHandledError } from '../error-reporting';
 import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
@@ -498,6 +499,9 @@ export function useBoardBluetooth({
             ...boardAnalyticsProperties,
             failureReason: classifyBleFailureReason(error),
           });
+          reportHandledError(error, {
+            tags: { source: 'ble-send', failure_reason: classifyBleFailureReason(error) },
+          });
           // A write that fails because the link is gone (the board dropped or
           // another device grabbed it — these boards are last-connection-wins) is
           // often the only signal we get: the adapter's disconnect event may never
@@ -685,6 +689,7 @@ export function useBoardBluetooth({
         return true;
       } catch (error) {
         console.error('Error connecting to Bluetooth:', error);
+        reportHandledError(error, { tags: { source: 'ble-connect' } });
         setIsConnected(false);
 
         // Dismiss the picker sheet if it's still showing. When a reconnect-by-

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -14,3 +14,55 @@ export type ErrorReportContext = {
 export function reportError(error: unknown, context?: ErrorReportContext): void {
   captureError(error, context);
 }
+
+/**
+ * A request the user (or an unmounting screen) cancelled. Not a failure — the
+ * app did exactly what was asked — so it must never reach error tracking.
+ * Covers our own AbortController signals and TanStack Query's CancelledError.
+ */
+function isCancellation(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const name = (error as { name?: unknown }).name;
+  return name === 'AbortError' || name === 'CancelledError';
+}
+
+/**
+ * An offline / transport failure (no server response). Expected on flaky mobile
+ * networks, so we keep it filterable as a low-severity breadcrumb rather than a
+ * full `error` that drowns real bugs. RN's fetch rejects offline requests with
+ * `TypeError: Network request failed`; graphql-request wraps a fetch failure in
+ * a ClientError that carries no HTTP `response.status`.
+ */
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError && /network request failed|fetch failed/i.test(error.message)) return true;
+  if (typeof error !== 'object' || error === null) return false;
+  const response = (error as { response?: { status?: unknown } }).response;
+  // A ClientError with a `response` but no numeric `status` is a transport
+  // failure; one with a status is a real server error (4xx/5xx) we want to see.
+  if (response !== undefined && typeof (response as { status?: unknown }).status !== 'number') return true;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && /network request failed|fetch failed/i.test(message);
+}
+
+/**
+ * Report a *handled* error — one the app caught and surfaced as UX (a toast,
+ * inline message, or degraded state) rather than letting crash. Applies the
+ * noise policy so error tracking stays signal-rich:
+ *   - cancellations are dropped entirely,
+ *   - offline/network failures are downgraded to `warning` and tagged `network`,
+ *   - everything else reports at the caller's level (default `error`).
+ * Use this from React Query caches, GraphQL-WS, and catch blocks; use the raw
+ * `reportError` only when the caller already owns the severity decision.
+ */
+export function reportHandledError(error: unknown, context?: ErrorReportContext): void {
+  if (isCancellation(error)) return;
+  if (isNetworkError(error)) {
+    reportError(error, {
+      ...context,
+      level: 'warning',
+      tags: { ...context?.tags, network: true },
+    });
+    return;
+  }
+  reportError(error, { level: 'error', ...context });
+}

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -17,6 +17,7 @@ import { useIsPartyPreviewOnly, useQueueActions } from '../../providers/queue-pr
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
+import { reportHandledError } from '../error-reporting';
 import { toSchemaClimb } from '../climb-types';
 
 /** A single page of the suggestion-refresh fetch. */
@@ -182,6 +183,7 @@ export function usePlaylistActivation({
       openPlayDrawer(toSchemaClimb(climb), { setAsCurrent: false, previewQueueItem: item });
       return activate(climb).catch((error: unknown) => {
         console.error('Playlist climb activation failed:', error);
+        reportHandledError(error, { tags: { source: 'playlist', op: 'activate-climb' } });
       });
     },
     [activate, openPlayDrawer, isPartyPreviewOnly, resolveTarget, sourceId, allClimbs],

--- a/packages/mobile/src/providers/__tests__/query-provider.test.ts
+++ b/packages/mobile/src/providers/__tests__/query-provider.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { reportMutationFailure, reportQueryFailure } from '../query-provider';
+import { reportHandledError } from '../../lib/error-reporting';
+
+// The global caches are the whole point — a query/mutation failure anywhere in
+// the app must reach error tracking once retries are exhausted. The cache
+// onError handlers delegate to these reporters, so testing them covers the
+// key serialization + tags without running the fetch/retry loop.
+vi.mock('../../lib/error-reporting', () => ({
+  reportHandledError: vi.fn(),
+}));
+
+const mockedReport = vi.mocked(reportHandledError);
+
+afterEach(() => {
+  mockedReport.mockClear();
+});
+
+describe('reportQueryFailure', () => {
+  it('reports with the serialized queryKey and hash', () => {
+    const error = new Error('query boom');
+    reportQueryFailure(error, ['searchClimbs', { q: 'x' }], 'hash-1');
+    expect(mockedReport).toHaveBeenCalledWith(error, {
+      tags: { source: 'react-query', kind: 'query' },
+      extra: { queryKey: JSON.stringify(['searchClimbs', { q: 'x' }]), queryHash: 'hash-1' },
+    });
+  });
+});
+
+describe('reportMutationFailure', () => {
+  it('reports with the serialized mutationKey', () => {
+    const error = new Error('mutation boom');
+    reportMutationFailure(error, ['createPlaylist']);
+    expect(mockedReport).toHaveBeenCalledWith(error, {
+      tags: { source: 'react-query', kind: 'mutation' },
+      extra: { mutationKey: JSON.stringify(['createPlaylist']) },
+    });
+  });
+
+  it('reports a keyless mutation with a null mutationKey', () => {
+    const error = new Error('keyless');
+    reportMutationFailure(error, undefined);
+    expect(mockedReport).toHaveBeenCalledWith(error, {
+      tags: { source: 'react-query', kind: 'mutation' },
+      extra: { mutationKey: null },
+    });
+  });
+});

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -23,6 +23,7 @@ import { GET_BOARD } from '../lib/graphql/operations';
 import type { GetBoardQueryResponse } from '../lib/graphql/operations';
 import { getBoardRenderData } from '../lib/board-details';
 import { registerBluetoothConnection } from '../lib/ble/bluetooth-status-store';
+import { reportHandledError } from '../lib/error-reporting';
 import { useIsPartyPreviewOnly, useQueue, useQueueSessionControls } from './queue-provider';
 import { useBoardPresenceControls } from './board-presence-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
@@ -282,6 +283,7 @@ function BluetoothAutoSender({
           } catch (error) {
             if (signal?.aborted) return;
             console.error('Error sending climb to board:', error);
+            reportHandledError(error, { tags: { source: 'ble-send' } });
           }
 
           toSend = pendingSendRef.current;
@@ -798,6 +800,7 @@ export function BluetoothProvider({
         });
       } catch (error) {
         console.error('Failed to switch to correct board config:', error);
+        reportHandledError(error, { tags: { source: 'board-config', op: 'switch' } });
         Alert.alert(t('boardConfigMismatch.title'), t('boardConfigMismatch.mobileSwitchFailed'));
       }
     },

--- a/packages/mobile/src/providers/deep-link-provider.tsx
+++ b/packages/mobile/src/providers/deep-link-provider.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import * as Linking from 'expo-linking';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { reportHandledError } from '../lib/error-reporting';
 import { useAuth } from './auth-provider';
 
 // Stash for a join that arrived before the user was signed in. The auth gate
@@ -104,6 +105,7 @@ export function DeepLinkProvider({ children }: { children: ReactNode }) {
         await AsyncStorage.setItem(PENDING_JOIN_KEY, sessionId);
       } catch (error) {
         if (__DEV__) console.warn('[deep-link] failed to stash pending join', error);
+        reportHandledError(error, { tags: { source: 'deep-link', op: 'stash-pending-join' } });
       }
     },
     [navigateToJoin],
@@ -147,6 +149,7 @@ export function DeepLinkProvider({ children }: { children: ReactNode }) {
         }
       } catch (error) {
         if (__DEV__) console.warn('[deep-link] failed to consume pending join', error);
+        reportHandledError(error, { tags: { source: 'deep-link', op: 'consume-pending-join' } });
       }
     })();
     return () => {

--- a/packages/mobile/src/providers/query-provider.tsx
+++ b/packages/mobile/src/providers/query-provider.tsx
@@ -1,19 +1,60 @@
 import { useState, type ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryCache, QueryClient, QueryClientProvider, MutationCache } from '@tanstack/react-query';
+import { reportHandledError } from '../lib/error-reporting';
+
+// The serialized failing request, trimmed for triage. queryKey/mutationKey are
+// the React Query identity (e.g. ['searchClimbs', params]); pulling them into
+// PostHog lets us group `$exception`s by what failed without leaking payloads.
+function toReportableKey(key: unknown): string {
+  try {
+    return JSON.stringify(key);
+  } catch {
+    return String(key);
+  }
+}
+
+// Pure reporters (exported for tests). reportHandledError drops cancellations
+// and downgrades offline noise, so these stay signal-rich.
+export function reportQueryFailure(error: unknown, queryKey: unknown, queryHash: string): void {
+  reportHandledError(error, {
+    tags: { source: 'react-query', kind: 'query' },
+    extra: { queryKey: toReportableKey(queryKey), queryHash },
+  });
+}
+
+export function reportMutationFailure(error: unknown, mutationKey: unknown): void {
+  reportHandledError(error, {
+    tags: { source: 'react-query', kind: 'mutation' },
+    extra: { mutationKey: mutationKey === undefined ? null : toReportableKey(mutationKey) },
+  });
+}
+
+// Every query/mutation failure flows through the cache onError once retries (see
+// defaultOptions.retry) are exhausted — a single chokepoint so API / GraphQL /
+// REST errors land in PostHog without instrumenting each call site.
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => reportQueryFailure(error, query.queryKey, query.queryHash),
+    }),
+    mutationCache: new MutationCache({
+      // Signature is (error, variables, onMutateResult, mutation, context); the
+      // mutation is the 4th arg — that's all we need.
+      onError: (error, _variables, _onMutateResult, mutation) =>
+        reportMutationFailure(error, mutation.options.mutationKey),
+    }),
+    defaultOptions: {
+      queries: {
+        staleTime: 5 * 60 * 1000,
+        gcTime: 30 * 60 * 1000,
+        retry: 2,
+      },
+    },
+  });
+}
 
 export function QueryProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 5 * 60 * 1000,
-            gcTime: 30 * 60 * 1000,
-            retry: 2,
-          },
-        },
-      }),
-  );
+  const [queryClient] = useState(createQueryClient);
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -75,7 +75,7 @@ import { toClimbQueueItem, type SubscriptionQueueItem } from '../lib/queue-conve
 import { toMobileSessionRuntimeEvent } from '../lib/session-runtime-event';
 import { climbToQueueItem, toClimbInput } from '../lib/climb-to-queue-item';
 import { track } from '../lib/analytics';
-import { reportError } from '../lib/error-reporting';
+import { reportError, reportHandledError } from '../lib/error-reporting';
 import { extractGraphqlMessage, isGraphqlRateLimitedError } from '../lib/graphql/extract-error-message';
 import { useToast } from './toast-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
@@ -102,9 +102,13 @@ function showQueueMutationErrorToast(
   showToast: (message: string, variant: 'error') => void,
 ): void {
   if (error instanceof GraphQLOperationError && isRateLimitedExtension(error.extensions)) {
+    // Rate-limiting is expected user-pacing, not a bug — toast only, no report.
     showToast(t('mobile.queue.rateLimited'), 'error');
   } else {
     showToast(t('mobile.queue.actionFailed'), 'error');
+    // These mutations are direct GraphQL-WS ops (@boardsesh/queue-react), so the
+    // React Query MutationCache doesn't see them — report here instead.
+    reportHandledError(error, { tags: { source: 'queue-mutation' } });
   }
 }
 
@@ -631,6 +635,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         logJoinFailure(joinError);
         if (joinRetryCount === 0) {
           showToastRef.current(tRef.current('mobile.queue.syncError'), 'error');
+          reportHandledError(joinError, { tags: { source: 'queue-sync', op: 'join' } });
         }
         scheduleJoinRetry(currentStartToken);
         return;
@@ -1131,6 +1136,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       return true;
     } catch (error) {
       if (__DEV__) console.warn('[queue] resyncQueueFromServer failed', error);
+      reportHandledError(error, { tags: { source: 'queue-sync', op: 'resync' } });
       return false;
     } finally {
       resyncInFlightRef.current = false;

--- a/packages/mobile/src/providers/share-target-provider.tsx
+++ b/packages/mobile/src/providers/share-target-provider.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { reportHandledError } from '../lib/error-reporting';
 import { useShareIntent, type ShareIntent } from 'expo-share-intent';
 import { useTranslation } from 'react-i18next';
 import { isBetaVideoUrl } from '@boardsesh/shared-schema';
@@ -82,6 +83,7 @@ export function ShareTargetProvider({ children }: { children: ReactNode }) {
         await AsyncStorage.setItem(PENDING_SHARE_KEY, link);
       } catch (error) {
         if (__DEV__) console.warn('[share-target] failed to stash pending share', error);
+        reportHandledError(error, { tags: { source: 'share-target', op: 'stash-pending-share' } });
       }
     },
     [navigateToShare],
@@ -115,6 +117,7 @@ export function ShareTargetProvider({ children }: { children: ReactNode }) {
         if (isBetaVideoUrl(pendingLink)) navigateToShare(pendingLink);
       } catch (error) {
         if (__DEV__) console.warn('[share-target] failed to consume pending share', error);
+        reportHandledError(error, { tags: { source: 'share-target', op: 'consume-pending-share' } });
       }
     })();
     return () => {


### PR DESCRIPTION
## Why

The RN app has no Sentry (removed — it wasn't working), so PostHog is the only error sink. Crashes were covered (PostHog `errorTracking.autocapture` for uncaught exceptions + unhandled rejections, plus the Expo Router `ErrorBoundary`), but **handled** errors — failures the app catches and turns into a toast / inline message / silent `console.warn` — never reached telemetry. We were flying blind on exactly the errors users actually hit (e.g. the Google sign-in failure on the sideload build, which only emitted a detail-less `LoginFailed` event).

## What

Route handled errors into the existing `reportError` plumbing, tiered by coverage-per-change.

- **Shared policy** (`src/lib/error-reporting.ts`): new `reportHandledError(error, ctx)` — drops cancellations (`AbortError`/`CancelledError`), downgrades offline/transport failures to a `warning` tagged `network`, reports the rest at `error`. Keeps `reportError` for callers that own severity (auth).
- **React Query** (`query-provider.tsx`): `QueryCache`/`MutationCache` `onError` report every query/mutation failure once `retry` is exhausted — one chokepoint for API / GraphQL-HTTP / REST failures, tagged with `queryKey`/`mutationKey`.
- **Auth** (`login.tsx`): report OAuth + credentials failures with `status` + server error, and add `failure_detail` to `LoginFailed`. The Google failure now surfaces as a `$exception` (`source: native-auth, provider: google`) carrying `status: 401` (backend audience/env mismatch) or the `no_id_token`/`DEVELOPER_ERROR` detail — splitting the two root-cause hypotheses.
- **Direct GraphQL-WS + targeted catches**: `@boardsesh/queue-react`/`playlists-react` ops (not React Query), queue join/resync, token refresh (5xx + transport), BLE send/connect/disconnect, playlist mutations, wall-control, board-config switch, deep-link/share stash+consume.
- **Left quiet** (avoid noise): benign key/value store fallbacks, `__DEV__`-only logs, rate-limits, expected-empty parsers.

## Tests / docs

- `error-reporting.test.ts` (noise policy) + `query-provider.test.ts` (reporters) — 10 new tests.
- `docs/mobile-error-telemetry.md` records the convention.

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — **2007 passed** ✓
- `vp check` (17 files) — format + lint clean ✓
- `vp run check:mobile-bundle` ✓

## Verifying on device

`isAnalyticsEnabled = !!apiKey && !__DEV__`, so local Metro sends nothing — these `$exception`s appear only on preview/OTA/release builds. Reproduce the Google sign-in failure on a preview build and filter PostHog by `source: native-auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)