### PR TITLE
Board history review fixes: tie-free pagination + cursor validation

### DIFF
--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } 
 import Redis from 'ioredis';
 import { v4 as uuidv4 } from 'uuid';
 import { sql } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
 import type {
   ConnectionContext,
   BoardPresenceEvent,
@@ -1342,10 +1343,32 @@ describe('board-presence durable history (board_climb_events)', () => {
     expect(new Set(seen).size).toBe(5);
   });
 
-  it('rejects a malformed history cursor with a clean error, not a leaked DB error', async () => {
+  it('rejects a malformed history cursor with a BAD_USER_INPUT GraphQLError, not a leaked DB error', async () => {
     const boardId = await resolveBoardId(`BADCUR-${Date.now()}`);
-    await expect(
-      boardPresenceQueries.boardHistory(undefined, { boardId, before: 'not-a-cursor' }, authCtx()),
-    ).rejects.toThrow(/Invalid history cursor/);
+    // Capture the throw so we can assert the *extension code* — that's what
+    // graphql-js serialises into errors[].extensions.code over the wire, so
+    // confirming it here confirms BAD_USER_INPUT (not a raw Postgres error)
+    // reaches the client.
+    const error = await boardPresenceQueries
+      .boardHistory(undefined, { boardId, before: 'not-a-cursor' }, authCtx())
+      .then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect((error as GraphQLError).extensions?.code).toBe('BAD_USER_INPUT');
+  });
+
+  it('treats a whitespace-only cursor as no cursor (first page), never a silently empty page', async () => {
+    const boardId = await resolveBoardId(`WS-${Date.now()}`);
+    for (const seq of [1, 2]) {
+      await db.execute(
+        sql`INSERT INTO board_climb_events (board_id, board_type, climb_uuid, angle, seq, confirmed_at)
+            VALUES (${boardId}, 'kilter', ${TEST_CLIMB_UUID}, 40, ${seq}, '2026-01-01 00:00:00')`,
+      );
+    }
+    // Number(' ') is 0, so without the trim guard this returned an empty page.
+    const page = await boardPresenceQueries.boardHistory(undefined, { boardId, before: '   ' }, authCtx());
+    expect(page.map((row) => row.seq)).toEqual([2, 1]);
   });
 });

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -1315,4 +1315,37 @@ describe('board-presence durable history (board_climb_events)', () => {
     expect(history[0].name).toBe('Real Catalog Climb');
     expect(history[0].sentAt).toBeTruthy();
   });
+
+  it('keyset-paginates by seq with no repeats or skips when sends share a confirmedAt', async () => {
+    const boardId = await resolveBoardId(`PAGE-${Date.now()}`);
+    // Five rows at the SAME confirmed_at second with distinct monotonic seq —
+    // exactly the case a confirmedAt-only cursor would repeat or skip across
+    // pages.
+    const sameTs = '2026-01-01 00:00:00';
+    for (const seq of [10, 11, 12, 13, 14]) {
+      await db.execute(
+        sql`INSERT INTO board_climb_events (board_id, board_type, climb_uuid, angle, seq, confirmed_at)
+            VALUES (${boardId}, 'kilter', ${TEST_CLIMB_UUID}, 40, ${seq}, ${sameTs})`,
+      );
+    }
+
+    const page1 = await boardPresenceQueries.boardHistory(undefined, { boardId, limit: 3 }, authCtx());
+    expect(page1.map((row) => row.seq)).toEqual([14, 13, 12]);
+
+    const cursor = String(page1[page1.length - 1].seq);
+    const page2 = await boardPresenceQueries.boardHistory(undefined, { boardId, limit: 3, before: cursor }, authCtx());
+    expect(page2.map((row) => row.seq)).toEqual([11, 10]);
+
+    // Every row appears exactly once across the two pages.
+    const seen = [...page1, ...page2].map((row) => row.seq);
+    expect(seen).toEqual([14, 13, 12, 11, 10]);
+    expect(new Set(seen).size).toBe(5);
+  });
+
+  it('rejects a malformed history cursor with a clean error, not a leaked DB error', async () => {
+    const boardId = await resolveBoardId(`BADCUR-${Date.now()}`);
+    await expect(
+      boardPresenceQueries.boardHistory(undefined, { boardId, before: 'not-a-cursor' }, authCtx()),
+    ).rejects.toThrow(/Invalid history cursor/);
+  });
 });

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -486,6 +486,10 @@ export const boardPresenceMutations = {
     // a failed durable insert never fails the accepted report.
     const DURABLE_DWELL_MS = 60_000;
     try {
+      // `sentAt` is the server-generated ISO timestamp from above, so
+      // `Date.parse(sentAt)` is always valid; `firstSeen` is already guarded to
+      // a plausible epoch-ms or null in getBoardMembershipFirstSeen. A null
+      // firstSeen correctly skips the insert (presence not yet proven for 60s).
       const firstSeen = await pubsub.getBoardMembershipFirstSeen(String(boardId), ctx.userId!);
       if (firstSeen !== null && Date.parse(sentAt) - firstSeen >= DURABLE_DWELL_MS) {
         await db
@@ -496,6 +500,9 @@ export const boardPresenceMutations = {
             climbUuid,
             angle: effectiveAngle,
             userId: ctx.userId!,
+            // Reserved for session recaps. reportBoardClimb has no sessionId arg
+            // yet, so every durable row is solo-attributed until the
+            // session-attribution follow-up threads the active session through.
             sessionId: null,
             seq,
             frames: catalogClimb.frames ?? null,

--- a/packages/backend/src/graphql/resolvers/board-presence/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/queries.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, lt } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
 import type { ConnectionContext, BoardPresenceClimb, BoardPresenceStats } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -27,9 +28,20 @@ export const boardPresenceQueries = {
 
   /**
    * Durable history of what was pushed to a board, from `board_climb_events`
-   * (survives past the 24h Redis window). Newest-first; keyset-paged via
-   * `before` (an ISO confirmedAt cursor). This is the lasting "what was on the
-   * wall" record; `boardRecentClimbs` is the hot 24h cache.
+   * (survives past the 24h Redis window). Newest-first, keyset-paged via
+   * `before`: an opaque cursor that is the `seq` of the last row of the
+   * previous page.
+   *
+   * Ordering and the cursor are both on `seq`, which is unique and monotonic
+   * per board (`board_climb_events_board_seq_unique`). That makes paging
+   * tie-free — ordering by the second-granular `confirmedAt` could put several
+   * rows at the same timestamp, where a `confirmedAt`-only cursor would repeat
+   * or skip rows across pages.
+   *
+   * Intentionally public: a board's send log is shared, leaderboard-style data,
+   * so any authenticated user may read any active board's history (no
+   * membership check). Proof-of-presence gates *writes* (see reportBoardClimb),
+   * not reads. `boardRecentClimbs` is the hot 24h cache for the same data.
    */
   boardHistory: async (
     _: unknown,
@@ -41,13 +53,24 @@ export const boardPresenceQueries = {
     await applyRateLimit(ctx, 60, 'boardHistory');
     await requireActiveBoardById(boardId);
 
+    // Parse + validate the cursor before it reaches SQL, so a malformed value
+    // returns a clean error instead of a leaked Postgres parse error.
+    let beforeSeq: number | null = null;
+    if (before != null && before !== '') {
+      const parsed = Number(before);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new GraphQLError('Invalid history cursor', { extensions: { code: 'BAD_USER_INPUT' } });
+      }
+      beforeSeq = parsed;
+    }
+
     const cappedLimit = Math.min(Math.max(limit ?? 50, 1), 100);
     const boardMatch = eq(dbSchema.boardClimbEvents.boardId, boardId);
     const rows = await db
       .select()
       .from(dbSchema.boardClimbEvents)
-      .where(before ? and(boardMatch, lt(dbSchema.boardClimbEvents.confirmedAt, before)) : boardMatch)
-      .orderBy(desc(dbSchema.boardClimbEvents.confirmedAt), desc(dbSchema.boardClimbEvents.seq))
+      .where(beforeSeq !== null ? and(boardMatch, lt(dbSchema.boardClimbEvents.seq, beforeSeq)) : boardMatch)
+      .orderBy(desc(dbSchema.boardClimbEvents.seq))
       .limit(cappedLimit);
 
     return rows.map((row) => ({

--- a/packages/backend/src/graphql/resolvers/board-presence/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/queries.ts
@@ -54,14 +54,17 @@ export const boardPresenceQueries = {
     await requireActiveBoardById(boardId);
 
     // Parse + validate the cursor before it reaches SQL, so a malformed value
-    // returns a clean error instead of a leaked Postgres parse error.
+    // returns a clean error instead of a leaked Postgres parse error. Trim
+    // first and require digits only: `Number()` coerces whitespace/odd inputs
+    // (" " -> 0, "1e3" -> 1000, "0x10" -> 16), which would silently return a
+    // wrong/empty page. A blank/whitespace cursor is treated as "no cursor".
     let beforeSeq: number | null = null;
-    if (before != null && before !== '') {
-      const parsed = Number(before);
-      if (!Number.isInteger(parsed) || parsed < 0) {
+    const trimmedCursor = before?.trim();
+    if (trimmedCursor) {
+      if (!/^\d+$/.test(trimmedCursor)) {
         throw new GraphQLError('Invalid history cursor', { extensions: { code: 'BAD_USER_INPUT' } });
       }
-      beforeSeq = parsed;
+      beforeSeq = Number(trimmedCursor);
     }
 
     const cappedLimit = Math.min(Math.max(limit ?? 50, 1), 100);

--- a/packages/db/src/schema/app/board-climb-events.ts
+++ b/packages/db/src/schema/app/board-climb-events.ts
@@ -31,7 +31,10 @@ export const boardClimbEvents = pgTable(
     // The member whose phone wrote the frames. Nullable so deleting a user
     // doesn't erase the board's history.
     userId: text('user_id').references(() => users.id, { onDelete: 'set null' }),
-    // Present for in-session pushes; null for solo. Powers session recaps.
+    // Reserved for session recaps: will hold the active session for in-session
+    // pushes. Not yet populated — reportBoardClimb writes null until the
+    // session-attribution follow-up threads the session through. Always null for
+    // solo pushes.
     sessionId: text('session_id').references(() => boardSessions.id, { onDelete: 'set null' }),
     // Per-board monotonic sequence (reused from the live Redis feed) — gives
     // cross-instance ordering and a natural idempotency key with boardId.

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4054,9 +4054,12 @@ type Query {
 
   """
   Durable history of what was pushed to a board (survives past the 24h Redis
-  window), newest-first. `before` is an ISO 8601 confirmedAt cursor for
-  keyset paging; `limit` is capped at 100. This is the lasting "what was on
-  the wall" record; `boardRecentClimbs` is the hot 24h cache.
+  window), newest-first by `seq`. For keyset paging pass the `seq` of the
+  last item from the previous page as `before` (not `sentAt`) — `seq` is
+  unique and monotonic per board, so paging never repeats or skips even when
+  several sends share a `sentAt` second. A non-integer `before` is rejected
+  with BAD_USER_INPUT. `limit` is capped at 100. This is the lasting "what
+  was on the wall" record; `boardRecentClimbs` is the hot 24h cache.
   """
   boardHistory(boardId: Int!, limit: Int, before: String): [BoardPresenceClimb!]!
 

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3318,9 +3318,12 @@ export type Query = {
   boardBySlug?: Maybe<UserBoard>;
   /**
    * Durable history of what was pushed to a board (survives past the 24h Redis
-   * window), newest-first. `before` is an ISO 8601 confirmedAt cursor for
-   * keyset paging; `limit` is capped at 100. This is the lasting "what was on
-   * the wall" record; `boardRecentClimbs` is the hot 24h cache.
+   * window), newest-first by `seq`. For keyset paging pass the `seq` of the
+   * last item from the previous page as `before` (not `sentAt`) — `seq` is
+   * unique and monotonic per board, so paging never repeats or skips even when
+   * several sends share a `sentAt` second. A non-integer `before` is rejected
+   * with BAD_USER_INPUT. `limit` is capped at 100. This is the lasting "what
+   * was on the wall" record; `boardRecentClimbs` is the hot 24h cache.
    */
   boardHistory: Array<BoardPresenceClimb>;
   /** Get leaderboard for a board. */

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -399,9 +399,12 @@ export const queriesTypeDefs = /* GraphQL */ `
 
     """
     Durable history of what was pushed to a board (survives past the 24h Redis
-    window), newest-first. \`before\` is an ISO 8601 confirmedAt cursor for
-    keyset paging; \`limit\` is capped at 100. This is the lasting "what was on
-    the wall" record; \`boardRecentClimbs\` is the hot 24h cache.
+    window), newest-first by \`seq\`. For keyset paging pass the \`seq\` of the
+    last item from the previous page as \`before\` (not \`sentAt\`) — \`seq\` is
+    unique and monotonic per board, so paging never repeats or skips even when
+    several sends share a \`sentAt\` second. A non-integer \`before\` is rejected
+    with BAD_USER_INPUT. \`limit\` is capped at 100. This is the lasting "what
+    was on the wall" record; \`boardRecentClimbs\` is the hot 24h cache.
     """
     boardHistory(boardId: Int!, limit: Int, before: String): [BoardPresenceClimb!]!
 

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3315,9 +3315,12 @@ export type Query = {
   boardBySlug?: Maybe<UserBoard>;
   /**
    * Durable history of what was pushed to a board (survives past the 24h Redis
-   * window), newest-first. `before` is an ISO 8601 confirmedAt cursor for
-   * keyset paging; `limit` is capped at 100. This is the lasting "what was on
-   * the wall" record; `boardRecentClimbs` is the hot 24h cache.
+   * window), newest-first by `seq`. For keyset paging pass the `seq` of the
+   * last item from the previous page as `before` (not `sentAt`) — `seq` is
+   * unique and monotonic per board, so paging never repeats or skips even when
+   * several sends share a `sentAt` second. A non-integer `before` is rejected
+   * with BAD_USER_INPUT. `limit` is capped at 100. This is the lasting "what
+   * was on the wall" record; `boardRecentClimbs` is the hot 24h cache.
    */
   boardHistory: Array<BoardPresenceClimb>;
   /** Get leaderboard for a board. */


### PR DESCRIPTION
Follow-up to the durable send-log PR (#2844), addressing the review feedback. Goes through each item.

## Fixed

**Broken pagination when rows share a timestamp** (`queries.ts`)
`boardHistory` paged with `lt(confirmedAt, before)` while ordering by `(confirmedAt DESC, seq DESC)`. Multiple sends in the same `confirmedAt` second could repeat or skip across pages. Now ordering **and** the cursor are on `seq`, which is unique + monotonic per board (`board_climb_events_board_seq_unique`) — a single-column keyset that's tie-free by construction (cleaner than a composite `(confirmedAt, seq)` cursor). `before` is now the last row's `seq`. No client consumes the cursor yet, so the semantics change is safe.

**Unvalidated `before` cursor** (`queries.ts`)
The raw string went straight to Drizzle's `lt()` against a timestamp column, so a non-numeric value leaked a Postgres parse error. Now validated as a non-negative integer up front → clean `BAD_USER_INPUT` GraphQLError.

## Documented (deliberate non-changes, recorded so they aren't re-flagged)

**`sessionId` always null** (`mutations.ts`, `board-climb-events.ts`)
Correct — it's a reserved foundation. `reportBoardClimb` has no `sessionId` arg yet, so rows are solo-attributed until the session-attribution follow-up wires it. Clarified in the resolver + the schema column comment (the old comment implied it was already populated for in-session pushes).

## Not bugs (with reasoning)

**IDOR / no membership check** — *intentional.* A board's send history is shared, leaderboard-style data; any authenticated user may read any active board's history. Proof-of-presence gates **writes** (`reportBoardClimb`), not reads. Documented in the resolver so it isn't re-raised.

**Silent data loss on NaN** — no NaN path exists. `sentAt` is the **server-generated** `new Date().toISOString()` (not a client value), so `Date.parse(sentAt)` is always valid; `firstSeen` is already guarded to a plausible epoch-ms or `null` in `getBoardMembershipFirstSeen`. A `null` firstSeen *correctly* skips the insert (presence not proven for 60s). Added a comment recording the invariant.

**Publisher client used for GET** — correct as-is. The Redis manager exposes `publisher` / `subscriber` / `streamConsumer`. `subscriber` is in ioredis subscribe-mode and can't run `GET`; `streamConsumer` is reserved for *blocking* reads so they don't starve the shared connection. `publisher` is the general command connection used everywhere (rate limiter, all presence ops). A non-blocking `GET` belongs there.

**Resolver registration** — confirmed wired: `boardPresenceResolvers.Query` is spread into the top-level Query map (`resolvers/index.ts`), and `boardHistory` lives on `boardPresenceQueries`.

## Tests
- Keyset paging across rows that share a `confirmedAt` → no repeat/skip, every row once.
- Malformed cursor → clean error, not a DB leak.

`typecheck:backend`, lint, and the durable-history suite (5) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)