### PR TITLE
Address code-review findings for mobile error telemetry

### DIFF
--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -37,7 +37,10 @@ PostHog: `react-query`, `native-auth`, `queue-mutation`, `queue-sync`,
 - **React Query** (`providers/query-provider.tsx`) — `QueryCache` / `MutationCache`
   `onError` report every query/mutation failure once `retry` is exhausted. This is
   the chokepoint for API / GraphQL-HTTP / REST failures; don't re-report at
-  individual `useQuery`/`useMutation` call sites.
+  individual `useQuery`/`useMutation` call sites. Known gap: a query that keeps
+  failing for a non-network reason re-reports on each refetch (focus / remount /
+  reconnect) — same `queryHash`, so it groups, but watch event volume in PostHog
+  after rollout; add short-TTL dedup keyed on `queryHash` if it's noisy.
 - Direct **GraphQL-WS** ops (`@boardsesh/queue-react`, `@boardsesh/playlists-react`)
   bypass React Query, so their catch sites report explicitly.
 
@@ -45,8 +48,12 @@ PostHog: `react-query`, `native-auth`, `queue-mutation`, `queue-sync`,
 
 - Cancellations and expected-empty paths (e.g. a parser returning `null` for a URL
   that isn't a deep link).
-- Best-effort key/value store reads/writes that fall back to a default
-  (`last-search-store`, `recent-filter-store`, `session-store`, image cache, …).
+- Best-effort key/value store reads/writes whose failure is invisible and
+  self-recovering — search filters, recents, image cache, preferences
+  (`last-search-store`, `recent-filter-store`, `session-store`, …). Exception: a
+  store write that loses a **pending user action** is reported — the deep-link /
+  share-target stashes, where a dropped `AsyncStorage.setItem` silently loses a
+  tapped invite link or a shared video after login.
 - Rate-limit responses — that's expected user pacing, not a bug.
 - `__DEV__`-only diagnostics (keep the `console.warn`; report only if the failure
   is user-affecting in production too).

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -29,7 +29,6 @@ import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { BleControlSheet } from '../ble/BleControlSheet';
 import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
-import { reportHandledError } from '../../lib/error-reporting';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Icon } from '../Icon';
 import { useIsPartyPreviewOnly, usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
@@ -523,8 +522,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           });
         })
         .catch((error: unknown) => {
+          // takeControl/releaseControl already report via the queue-provider
+          // chokepoint (showQueueMutationErrorToast) before rethrowing, so don't
+          // report again here — it would double-count and leak rate-limited ops.
           console.error('[playDrawer] failed to release wall control:', error);
-          reportHandledError(error, { tags: { source: 'wall-control', op: 'release' } });
         });
       return;
     }
@@ -610,7 +611,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
         const shouldHandleFailure = wallControlPressOperationRef.current === operationId;
         if (!shouldHandleFailure) return;
         console.error('[playDrawer] failed to take wall control:', error);
-        reportHandledError(error, { tags: { source: 'wall-control', op: 'take' } });
         cancelWallConfirmWatcher();
         setPendingClimbUuid((currentClimbUuid) => (currentClimbUuid === displayedClimb.uuid ? null : currentClimbUuid));
         if (

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -42,7 +42,7 @@ import { springs } from '../../../theme/animations';
 import { borderRadius, spacing } from '../../../theme/tokens';
 import { gradeBadgeColor } from '../../you/profile-chart-colors';
 import { hapticSelection } from '../../../lib/haptics';
-import { reportError } from '../../../lib/error-reporting';
+import { reportHandledError } from '../../../lib/error-reporting';
 import { RecordTopChrome } from '../RecordTopChrome';
 import { SessionAnalytics } from './SessionAnalytics';
 import { SessionLeaderboard } from './SessionLeaderboard';
@@ -506,7 +506,7 @@ export function InSessionView({
     } catch (error) {
       // Surface the failure (the sheet stays open so the user can retry) rather than
       // leaving a thrown endSession() as a silent unhandled rejection.
-      reportError(error, { tags: { source: 'endSession' } });
+      reportHandledError(error, { tags: { source: 'endSession' } });
     } finally {
       // Always clear the spinner — without this a thrown endSession() would leave the
       // confirm button spinning forever and the sheet undismissable.

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -102,7 +102,7 @@ vi.mock('../../../EndSessionSheet', () => ({
     return null;
   },
 }));
-vi.mock('../../../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../../../lib/error-reporting', () => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
 vi.mock('../../../Icon', () => ({ Icon: () => null }));
 vi.mock('../../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -40,6 +40,15 @@ describe('reportHandledError', () => {
     });
   });
 
+  it('forces warning for a network error even if the caller asked for a higher level', () => {
+    const offline = new TypeError('Network request failed');
+    reportHandledError(offline, { level: 'fatal', tags: { source: 'x' } });
+    expect(mockedCaptureError).toHaveBeenCalledWith(offline, {
+      level: 'warning',
+      tags: { source: 'x', network: true },
+    });
+  });
+
   it('reports a real server error (response with an HTTP status) at error level', () => {
     const serverError = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
     reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -494,13 +494,19 @@ export function useBoardBluetooth({
           if (combinedSignal.aborted || (error instanceof DOMException && error.name === 'AbortError')) {
             return;
           }
+          const bleFailureReason = classifyBleFailureReason(error);
           console.error('Error sending frames to board:', error);
           track(SHARED_EVENTS.ClimbSentToBoardFailure, {
             ...boardAnalyticsProperties,
-            failureReason: classifyBleFailureReason(error),
+            failureReason: bleFailureReason,
           });
+          // A dropped link is routine on these last-connection-wins boards
+          // (another climber grabbed it, or it disconnected mid-session), so keep
+          // it a filterable warning rather than a full error that drowns real
+          // write bugs. Already tracked above via ClimbSentToBoardFailure.
           reportHandledError(error, {
-            tags: { source: 'ble-send', failure_reason: classifyBleFailureReason(error) },
+            level: bleFailureReason === 'disconnected' ? 'warning' : 'error',
+            tags: { source: 'ble-send', failure_reason: bleFailureReason },
           });
           // A write that fails because the link is gone (the board dropped or
           // another device grabbed it — these boards are last-connection-wins) is

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -34,12 +34,14 @@ function isCancellation(error: unknown): boolean {
  * a ClientError that carries no HTTP `response.status`.
  */
 function isNetworkError(error: unknown): boolean {
-  if (error instanceof TypeError && /network request failed|fetch failed/i.test(error.message)) return true;
   if (typeof error !== 'object' || error === null) return false;
   const response = (error as { response?: { status?: unknown } }).response;
   // A ClientError with a `response` but no numeric `status` is a transport
   // failure; one with a status is a real server error (4xx/5xx) we want to see.
   if (response !== undefined && typeof (response as { status?: unknown }).status !== 'number') return true;
+  // RN's fetch rejects offline with `TypeError: Network request failed` — a
+  // TypeError is an object with a `.message`, so the message check covers it
+  // without a separate instanceof branch.
   const message = (error as { message?: unknown }).message;
   return typeof message === 'string' && /network request failed|fetch failed/i.test(message);
 }

--- a/packages/mobile/src/lib/integrations/apple-health.ts
+++ b/packages/mobile/src/lib/integrations/apple-health.ts
@@ -21,6 +21,7 @@ import { SET_SESSION_HEALTHKIT_WORKOUT_ID } from '@boardsesh/graphql/operations/
 // package needing a dependency entry.
 import { healthWorkoutsNative, type SaveWorkoutResult } from '../../../modules/health-workouts/src/index';
 import { track } from '../analytics';
+import { reportHandledError } from '../error-reporting';
 import { getHttpClient } from '../graphql/client';
 import {
   GET_SESSION_HEALTH_EXPORT,
@@ -417,6 +418,7 @@ export async function manualSaveToAppleHealth(
   } catch (error) {
     setSaveState(sessionId, 'failed');
     console.warn('[AppleHealth] Manual save failed:', error);
+    reportHandledError(error, { tags: { source: 'integration', op: 'apple-health-save' } });
     return 'failed';
   }
 }

--- a/packages/mobile/src/lib/integrations/strava.ts
+++ b/packages/mobile/src/lib/integrations/strava.ts
@@ -5,6 +5,7 @@ import {
   type CreateIntegrationOAuthHandoffResponse,
 } from '@boardsesh/graphql/operations/integrations';
 import { track } from '../analytics';
+import { reportHandledError } from '../error-reporting';
 import { parseDeepLinkQueryParams } from '../deep-link-query';
 import { BACKEND_URL } from '../env';
 import { getHttpClient } from '../graphql/client';
@@ -34,7 +35,8 @@ export async function connectStrava(): Promise<StravaConnectResult> {
       { provider: 'STRAVA' },
     );
     handoff = response.createIntegrationOAuthHandoff;
-  } catch {
+  } catch (error) {
+    reportHandledError(error, { tags: { source: 'integration', op: 'strava-connect', step: 'handoff' } });
     return 'error';
   }
   if (!handoff) return 'error';
@@ -44,7 +46,8 @@ export async function connectStrava(): Promise<StravaConnectResult> {
   let result: WebBrowser.WebBrowserAuthSessionResult;
   try {
     result = await WebBrowser.openAuthSessionAsync(startUrl, STRAVA_REDIRECT_URL);
-  } catch {
+  } catch (error) {
+    reportHandledError(error, { tags: { source: 'integration', op: 'strava-connect', step: 'auth-session' } });
     return 'error';
   }
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -90,6 +90,7 @@ const queueSnapshotStore = vi.hoisted(() => ({
 
 const errorReporter = vi.hoisted(() => ({
   reportError: vi.fn(),
+  reportHandledError: vi.fn(),
 }));
 
 const toast = vi.hoisted(() => ({
@@ -126,7 +127,10 @@ vi.mock('../../lib/graphql/use-active-board', () => ({
 }));
 vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request: http.request }) }));
 vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
-vi.mock('../../lib/error-reporting', () => ({ reportError: errorReporter.reportError }));
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: errorReporter.reportError,
+  reportHandledError: errorReporter.reportHandledError,
+}));
 vi.mock('../toast-provider', () => ({ useToast: () => ({ showToast: toast.showToast }) }));
 vi.mock('../queue-snackbar-provider', () => ({ useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }) }));
 

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -283,7 +283,9 @@ function BluetoothAutoSender({
           } catch (error) {
             if (signal?.aborted) return;
             console.error('Error sending climb to board:', error);
-            reportHandledError(error, { tags: { source: 'ble-send' } });
+            // Distinct from the manual lightbulb send (`ble-send`) so PostHog can
+            // tell auto-sender failures (climb-change drain loop) apart.
+            reportHandledError(error, { tags: { source: 'ble-auto-send' } });
           }
 
           toSend = pendingSendRef.current;

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -959,7 +959,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
               await clearStoredQueueSnapshot();
             } catch (seedError) {
               if (__DEV__) console.warn('[queue] session queue seed failed', seedError);
-              reportError(seedError, { tags: { source: 'startSessionSeed' } });
+              reportHandledError(seedError, { tags: { source: 'startSessionSeed' } });
             }
           }
           setSessionId(newId);


### PR DESCRIPTION
Follow-up to #2845 (now merged), resolving the two code reviews I ran plus the listed nits.

## Correctness / signal quality

- **Double-report fixed.** `takeControl`/`releaseControl` already report (`source: queue-mutation`) via the queue-provider chokepoint (`showQueueMutationErrorToast`) before rethrowing, so `PlayDrawer` no longer reports `wall-control` again. This also stops a rate-limited wall-control op from leaking past the rate-limit suppression (the rethrow had defeated it).
- **BLE noise.** Routine `disconnected` send failures (expected on last-connection-wins boards when another climber grabs the wall or it drops) now report at `warning` instead of `error`, so they don't drown real write bugs. `classifyBleFailureReason` is computed once into a variable (was called twice).
- **Auto-sender tag.** `BluetoothAutoSender` failures tag `ble-auto-send`, distinct from the manual lightbulb `ble-send`, so PostHog can tell them apart.

## Coverage

- Report **Apple Health** manual-save and **Strava** connect failures — native / `WebBrowser` flows that bypass the React Query chokepoint and previously reported nothing.
- `endSession` / `startSessionSeed` use `reportHandledError` so an offline attempt downgrades to a `warning` rather than a full `error`.

## Cleanup

- Drop the redundant `TypeError` branch in `isNetworkError` (a `TypeError` is an object with a `.message`, so the message check already covers it).
- **Test:** assert a network error forces `level: 'warning'` even when the caller passes a higher level. Added `reportHandledError` to two test mocks (`in-session-view-footer`, `queue-provider-local-queue`) that the code now reaches.
- **Doc:** narrow the "don't report" store-write exclusion so it no longer contradicts the deep-link / share-target **pending-action** stashes, which we do report (a dropped invite link / shared video is user-affecting).

## Validation

- `vp run typecheck:mobile` ✓ · `vp run test:mobile` — **2008 passed** ✓ · `vp check` (12 files) ✓ · `vp run check:mobile-bundle` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)