### PR TITLE
Fix unreachable delete button in logbook edit sheet

### DIFF
--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -266,7 +266,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
   return (
     <Sheet
       ref={sheetRef}
-      snapPoints={['75%']}
+      snapPoints={['75%', '92%']}
       scrollable
       fullWindowOverlay
       onClose={onClose}


### PR DESCRIPTION
## Problem

On the mobile **You** page, tapping a logged ascent opens the logbook edit sheet (status / date / grade / stars / tries / comment, plus a **Delete** action at the bottom). The sheet couldn't be dragged bigger, so the delete button was unreachable.

## Root cause

`LogbookEditSheet` configured the sheet with a single snap point (`snapPoints={['75%']}`). With only one snap point, the drag-to-resize gesture has nowhere to go — the handle drag is a no-op and the sheet is locked at 75% of the screen. The form content is taller than that, so the delete row at the bottom stays below the fold.

Every other tall form sheet in the app uses a two-point config so it can be enlarged: `LogAscentSheet` (`['60%', '92%']`), `CreateDrawer` (`[peekHeight, '100%']`), and the `Sheet` wrapper default (`['50%', '90%']`). This sheet was the only outlier on a single point.

## Fix

Add a larger second snap point:

```diff
- snapPoints={['75%']}
+ snapPoints={['75%', '92%']}
```

- The sheet still opens at its 75% resting height, so nothing changes for the common case.
- Dragging the handle up now snaps to 92%, revealing the rest of the form including the delete row.
- The sheet is already `scrollable`, so any content still below the fold at 92% can be scrolled to — the larger max height + scroll together guarantee the delete button is reachable.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2008 tests pass
- `vp check` on the changed file — formatting + lint clean
- `vp run check:mobile-bundle` — bundle OK

Manual check (`vp run dev:mobile`): You page → tap a logged ascent → drag the sheet handle up (now expands to ~92%) → Delete button reachable at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)