### PR TITLE
Show a single grade name instead of V6–V6 for one selected grade

### DIFF
--- a/packages/mobile/src/lib/__tests__/filter-summary.test.ts
+++ b/packages/mobile/src/lib/__tests__/filter-summary.test.ts
@@ -51,6 +51,11 @@ describe('getFilterSummary', () => {
     expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('V2–V6');
   });
 
+  it('shows a single grade name when min and max are the same grade', () => {
+    const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 15, maxGrade: 15 };
+    expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('V6');
+  });
+
   it('shows min grade with plus sign', () => {
     const filters: ClimbFilters = { ...DEFAULT_FILTERS, minGrade: 10 };
     expect(getFilterSummary(filters, '', mockGrades, mockT)).toBe('V4+');

--- a/packages/mobile/src/lib/filter-tokens.ts
+++ b/packages/mobile/src/lib/filter-tokens.ts
@@ -71,7 +71,11 @@ export function getActiveFilterTokens({
       formatGradeByDifficultyId(difficultyId) ?? getGradeName(difficultyId, grades);
     let label: string;
     if (filters.minGrade != null && filters.maxGrade != null) {
-      label = labels.gradeRange(gradeName(filters.minGrade), gradeName(filters.maxGrade));
+      // A single selected grade (min == max) reads as the bare grade name, not a range.
+      label =
+        filters.minGrade === filters.maxGrade
+          ? gradeName(filters.minGrade)
+          : labels.gradeRange(gradeName(filters.minGrade), gradeName(filters.maxGrade));
     } else if (filters.minGrade != null) {
       label = labels.gradeMin(gradeName(filters.minGrade));
     } else {

--- a/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/filter-summary.test.ts
@@ -38,6 +38,11 @@ describe('getBaseFilterParts', () => {
     expect(getBaseFilterParts(filters, mockGrades, labels)).toEqual(['V2–V6']);
   });
 
+  it('shows a single grade name when min and max are the same grade', () => {
+    const filters: BaseFilters = { minGrade: 15, maxGrade: 15 };
+    expect(getBaseFilterParts(filters, mockGrades, labels)).toEqual(['V6']);
+  });
+
   it('shows min grade with plus', () => {
     expect(getBaseFilterParts({ minGrade: 10 }, mockGrades, labels)).toEqual(['V4+']);
   });

--- a/packages/shared/climb-filters/src/filter-summary.ts
+++ b/packages/shared/climb-filters/src/filter-summary.ts
@@ -58,7 +58,13 @@ export function getBaseFilterParts(
   }
 
   if (filters.minGrade != null && filters.maxGrade != null) {
-    parts.push(labels.gradeRange(getGradeName(filters.minGrade, grades), getGradeName(filters.maxGrade, grades)));
+    // A single selected grade (min == max) reads as the bare grade name ("V6"),
+    // not a "V6–V6" range. The grade name is scale text, so it needs no label.
+    if (filters.minGrade === filters.maxGrade) {
+      parts.push(getGradeName(filters.minGrade, grades));
+    } else {
+      parts.push(labels.gradeRange(getGradeName(filters.minGrade, grades), getGradeName(filters.maxGrade, grades)));
+    }
   } else if (filters.minGrade != null) {
     parts.push(labels.gradeMin(getGradeName(filters.minGrade, grades)));
   } else if (filters.maxGrade != null) {


### PR DESCRIPTION
## What

In the mobile app, selecting a single grade (so `minGrade === maxGrade`) rendered the climbs filter summary and the removable filter chip as a range — `V6–V6` — instead of just `V6`.

## Why

Both label builders unconditionally used the "range" label whenever a min **and** max grade were set, with no check for the two being equal.

## Changes

- `packages/shared/climb-filters/src/filter-summary.ts` — `getBaseFilterParts` now emits the bare grade name when `minGrade === maxGrade`. (This shared function is only consumed by mobile; web has its own separate `search-summary-utils.ts`.)
- `packages/mobile/src/lib/filter-tokens.ts` — `getActiveFilterTokens` mirrors the same check for the removable chip, reusing the existing single-scale `gradeName` helper.
- Added a single-grade test case to both `filter-summary` test files (alongside the existing range cases).

The grade name (e.g. `V6`) is scale text, not translatable, so no new i18n keys were needed.

## Validation

- `vp test run --project mobile` — 2009 tests pass
- `vp test run` for `packages/shared/climb-filters` filter-summary — 34 tests pass (includes new single-grade case)
- `vp run typecheck:mobile` — clean
- `vp check` on the four changed files — clean

https://claude.ai/code/session_01FFQGT8vUhdZUmqety7p6vt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFQGT8vUhdZUmqety7p6vt)_