### PR TITLE
Fix iOS archive failure: missing return in lap-event compactMap

### DIFF
--- a/packages/mobile/modules/health-workouts/ios/HealthWorkoutsModule.swift
+++ b/packages/mobile/modules/health-workouts/ios/HealthWorkoutsModule.swift
@@ -249,7 +249,7 @@ public class HealthWorkoutsModule: Module {
                         if let angle = lap.angle {
                             lapMetadata["BoardseshAngle"] = angle
                         }
-                        HKWorkoutEvent(
+                        return HKWorkoutEvent(
                             type: .lap,
                             dateInterval: DateInterval(start: lapDate, duration: 0),
                             metadata: lapMetadata


### PR DESCRIPTION
## Problem

The **iOS TestFlight Deploy (React Native)** workflow is failing on `main` ([run 27486044347](https://github.com/boardsesh/boardsesh/actions/runs/27486044347/job/81242287055)):

```
packages/mobile/modules/health-workouts/ios/HealthWorkoutsModule.swift:257:21: error: missing return in closure expected to return 'HKWorkoutEvent?'
** ARCHIVE FAILED **
```

## Cause

In `saveWorkout`, the `laps.compactMap { lap -> HKWorkoutEvent? in ... }` closure builds an `HKWorkoutEvent(.lap, ...)` on its final line but never returns it. The `guard ... else { return nil }` paths return, but the success path falls off the end of the closure with no value, which Swift rejects (it also emitted `result of 'HKWorkoutEvent' initializer is unused` for the same line). Introduced in `4639a4b70` ("Improve Apple Health exports").

## Fix

Add the missing `return` so the constructed lap event is collected and handed to `builder.addWorkoutEvents(lapEvents)` as intended. One-line change.

## Validation

This is a native Swift compile error that the TS-side mobile checks (`typecheck:mobile`, Metro bundle) can't catch — it only surfaces in the Xcode Release archive. The change matches exactly the compiler diagnostic; the archive's only blocking error was this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)