### PR TITLE
fix(mobile): diagnose native Google Sign-In failures + document Android SHA-1 requirement

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -48,9 +48,12 @@ jobs:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
-      # Activates Sentry at runtime in the shipped build (src/lib/sentry.ts gates
-      # on this var). Same DSN/project as web + backend; not secret — already
-      # hardcoded in packages/web and packages/backend source.
+      # NOTE: currently inert at runtime — the mobile app has no
+      # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
+      # DSN is not read by the running app; client-side errors go to PostHog only
+      # (reportError → captureError). Kept so adding Sentry later needs no workflow
+      # change. Same DSN/project as web + backend; not secret — already hardcoded
+      # in packages/web and packages/backend source.
       EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
       # PostHog product analytics. Intentionally the SAME project token as web
       # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -47,9 +47,12 @@ jobs:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
-      # Activates Sentry at runtime in the shipped build (src/lib/sentry.ts gates
-      # on this var). Same DSN/project as web + backend; not secret — already
-      # hardcoded in packages/web and packages/backend source.
+      # NOTE: currently inert at runtime — the mobile app has no
+      # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
+      # DSN is not read by the running app; client-side errors go to PostHog only
+      # (reportError → captureError). Kept so adding Sentry later needs no workflow
+      # change. Same DSN/project as web + backend; not secret — already hardcoded
+      # in packages/web and packages/backend source.
       EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
       # PostHog product analytics. Intentionally the SAME project token as web
       # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity

--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -151,6 +151,45 @@ consequences:
   app doesn't yet declare `autoVerify` App Link intent filters — that needs
   deep-link route handling first; tracked separately.)
 
+### Google Sign-In requires SHA-1 registration (per signing key)
+
+Native Google Sign-In (`@react-native-google-signin`, used by the login screen)
+resolves the Android OAuth client by **package name + signing-certificate
+SHA-1**, _not_ by the `androidClientId` string. So the `EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID`
+baked into the build is never consulted by the native flow (it exists only for
+backend-audience parity) — what matters is that the **SHA-1 of the key that
+signed the running APK** is registered as an Android OAuth client, in the same
+Google Cloud project as the `webClientId` the app ships
+(`401523882502-…`, project **401523882502**).
+
+If it isn't, `GoogleSignin.signIn()` fails **before any network call** — so the
+backend never logs anything, and the login screen shows the generic "Sign in
+didn't complete." (The classic Play Services flow reported this as
+`DEVELOPER_ERROR` / status 10; the Credential Manager flow in current
+`@react-native-google-signin` surfaces an unmapped error instead, which is why
+the code below keys off "not a known status code" rather than a specific code.)
+`login.tsx` forwards the native `.code` to PostHog as `failure_detail` /
+`native_error_code`, and a local dev build prints a hint — see
+`nativeSignInErrorCode` in `packages/mobile/src/lib/native-auth-analytics.ts`.
+
+`com.boardsesh.app` is signed by up to three different keys, each needing its own
+Android OAuth client (same package, different SHA-1 — they coexist):
+
+| Where it runs                                                        | Signing key                         | How to get the SHA-1                                                                                                                |
+| -------------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Sideload GitHub Release APK (this workflow)                          | upload key (`ANDROID_KEYSTORE_*`)   | `apksigner verify --print-certs <apk>` — currently `12:21:33:D0:1B:E4:B0:05:0C:62:6D:ED:27:74:46:AD:D4:EC:CC:B2`                    |
+| Play internal-track install                                          | Play app-signing key (Google holds) | Play Console → Setup → App signing → **App signing key certificate** → SHA-1                                                        |
+| Local `expo run:android` / debug-signed PR APK (`android-pr-rn.yml`) | Expo debug keystore                 | after a prebuild: `keytool -list -v -keystore packages/mobile/android/app/debug.keystore -alias androiddebugkey -storepass android` |
+
+To register: GCP Console → **APIs & Services → Credentials → Create credentials →
+OAuth client ID → Android**, package `com.boardsesh.app`, paste the SHA-1.
+Propagation takes a few minutes; no rebuild is needed — the registration is
+server-side, so an already-installed APK starts working once it lands.
+
+Use `apksigner verify --print-certs` to read an APK's signer — `keytool -printcert
+-jarfile` only understands the legacy v1/JAR signature and prints nothing for
+these v2/v3-signed release APKs.
+
 ### versionCode
 
 No separate version source: the app version is read from

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -171,6 +171,19 @@ EMAIL_FROM=your-email@fastmail.com
 
 7. Copy **Client ID** and **Client Secret** to environment variables
 
+> **Mobile (React Native) Google Sign-In is different.** The native flow
+> (`@react-native-google-signin`) resolves the OAuth client by **package name +
+> signing-certificate SHA-1**, not by a client-id string — so each signing key
+> that ships `com.boardsesh.app` needs its own **Android** OAuth client (same
+> package, different SHA-1) in the _same_ Google Cloud project as the web
+> `clientId` the app ships. A missing SHA-1 makes sign-in fail client-side
+> (classic flow: `DEVELOPER_ERROR`; Credential Manager: an unmapped error),
+> before it reaches the backend. The backend
+> (`GOOGLE_WEB_CLIENT_ID` / `GOOGLE_ANDROID_CLIENT_ID` / `GOOGLE_IOS_CLIENT_ID`,
+> any of which it accepts as the token audience) must include that web client id.
+> Full key-by-key setup and SHA-1 extraction commands:
+> [docs/android-sideload-build.md](./android-sideload-build.md#google-sign-in-requires-sha-1-registration-per-signing-key).
+
 ### 2. Apple Sign-In
 
 **Difficulty**: Hard | **Time**: ~30-60 minutes | **Requires**: Paid Apple Developer Account ($99/year)

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -16,7 +16,7 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
+import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../../src/lib/native-auth-analytics';
 import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
@@ -185,16 +185,25 @@ export default function LoginScreen() {
       setError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
     } catch (oauthError) {
       // The native module threw (Play Services missing, no presenter,
-      // DEVELOPER_ERROR for a signing/client-id mismatch, …).
+      // DEVELOPER_ERROR for a signing/client-id mismatch, …). The native `.code`
+      // (e.g. DEVELOPER_ERROR) is far more actionable than the opaque message, so
+      // prefer it for failure_detail and tag it for filtering.
+      const nativeErrorCode = nativeSignInErrorCode(oauthError);
       track(SHARED_EVENTS.LoginFailed, {
         auth_method: provider,
         flow: 'native',
         failure_reason: 'exception',
-        failure_detail: oauthError instanceof Error ? oauthError.message : undefined,
+        failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
         duration_ms: Date.now() - attemptStartedAt,
       });
       reportError(oauthError, {
-        tags: { source: 'native-auth', provider, flow: 'native', mechanism: 'exception' },
+        tags: {
+          source: 'native-auth',
+          provider,
+          flow: 'native',
+          mechanism: 'exception',
+          native_error_code: nativeErrorCode,
+        },
       });
       setError(t('nativeStart.oauthError'));
     } finally {

--- a/packages/mobile/src/lib/__tests__/auth.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classifyNativeAuthFailureReason } from '../native-auth-analytics';
+import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../native-auth-analytics';
 
 describe('classifyNativeAuthFailureReason', () => {
   it('maps native credential and OAuth failures to low-cardinality analytics reasons', () => {
@@ -52,5 +52,27 @@ describe('classifyNativeAuthFailureReason', () => {
     expect(classifyNativeAuthFailureReason({ success: false, status: 401, error: 'Unauthorized' }, 'oauth')).toBe(
       'invalid_oauth_token',
     );
+  });
+});
+
+describe('nativeSignInErrorCode', () => {
+  it('returns the string `.code` from a thrown native CodedError', () => {
+    // The most important one: a signing-SHA-1 / OAuth-client mismatch on Android.
+    expect(nativeSignInErrorCode({ code: 'DEVELOPER_ERROR', message: 'opaque' })).toBe('DEVELOPER_ERROR');
+    expect(nativeSignInErrorCode({ code: 'SIGN_IN_CANCELLED' })).toBe('SIGN_IN_CANCELLED');
+  });
+
+  it('stringifies a numeric `.code` (older google-signin uses numeric status codes)', () => {
+    expect(nativeSignInErrorCode({ code: 10 })).toBe('10');
+    expect(nativeSignInErrorCode({ code: 0 })).toBe('0');
+  });
+
+  it('returns undefined when there is no usable code, so the caller falls back to the message', () => {
+    expect(nativeSignInErrorCode(new Error('boom'))).toBeUndefined();
+    expect(nativeSignInErrorCode({ code: null })).toBeUndefined();
+    expect(nativeSignInErrorCode({ code: { nested: true } })).toBeUndefined();
+    expect(nativeSignInErrorCode(undefined)).toBeUndefined();
+    expect(nativeSignInErrorCode(null)).toBeUndefined();
+    expect(nativeSignInErrorCode('DEVELOPER_ERROR')).toBeUndefined();
   });
 });

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { getRandomBytes, digestStringAsync, CryptoDigestAlgorithm, CryptoEncodin
 import { GoogleSignin, statusCodes } from '@react-native-google-signin/google-signin';
 import { createTimeoutSignal } from './abort-timeout';
 import { storeTokens, clearTokens, getRefreshToken } from './auth-store';
+import { nativeSignInErrorCode } from './native-auth-analytics';
 import { BACKEND_URL } from './env';
 
 export type AuthProvider = 'google' | 'apple';
@@ -134,6 +135,13 @@ function configureGoogleSignin(): void {
   if (googleConfigured) return;
   // webClientId is required to receive an idToken; iosClientId scopes the
   // native flow on iOS. Both are inlined at build time (EXPO_PUBLIC_*).
+  //
+  // No androidClientId on purpose: @react-native-google-signin resolves the
+  // Android OAuth client by package name + signing-certificate SHA-1 (registered
+  // in the webClientId's Google Cloud project), not by an id string — passing one
+  // is ignored. EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID exists only for backend-
+  // audience parity. If Android sign-in fails before any network call, the
+  // running build's SHA-1 likely isn't registered (see docs/android-sideload-build.md).
   GoogleSignin.configure({
     webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
     iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
@@ -163,6 +171,24 @@ export async function signInWithGoogle(): Promise<OAuthSignInResult> {
     return oauthNativeSignIn('google', idToken);
   } catch (error) {
     if (isGoogleCancellation(error)) return { success: false, cancelled: true };
+    // An error that isn't one of the library's known status codes is, on Android,
+    // almost always a config problem: the running build's signing-cert SHA-1 isn't
+    // registered as an Android OAuth client for the package (the classic Play
+    // Services flow called this DEVELOPER_ERROR; the newer Credential Manager flow
+    // surfaces an unmapped error). It's a Google Cloud fix, not a code one — spell
+    // it out for local dev. Release builds carry the code into PostHog via
+    // login.tsx's failure_detail/tag.
+    if (__DEV__) {
+      const errorCode = nativeSignInErrorCode(error);
+      const isKnownStatus = errorCode !== undefined && Object.values(statusCodes).includes(errorCode);
+      if (!isKnownStatus)
+        console.warn(
+          `[auth] Google sign-in failed with an unmapped error (code: ${errorCode ?? 'none'}). On Android ` +
+            "this is typically a config issue — the build's signing-certificate SHA-1 isn't registered as an " +
+            "Android OAuth client for com.boardsesh.app in the webClientId's Google Cloud project. Get the " +
+            'SHA-1 via `apksigner verify --print-certs <apk>` (see docs/android-sideload-build.md).',
+        );
+    }
     throw error;
   }
 }

--- a/packages/mobile/src/lib/native-auth-analytics.ts
+++ b/packages/mobile/src/lib/native-auth-analytics.ts
@@ -32,3 +32,21 @@ export function classifyNativeAuthFailureReason(
   if (failure.status != null && failure.status >= 500) return 'server_error';
   return 'http_error';
 }
+
+/**
+ * Extract the status code from a thrown native sign-in error. The Google
+ * (@react-native-google-signin) and Apple (expo-apple-authentication) modules
+ * reject with a CodedError whose `.code` names the failure — most importantly
+ * `DEVELOPER_ERROR`, which on Android means the running build's signing-cert
+ * SHA-1 isn't registered as an Android OAuth client for this package in the
+ * webClientId's Google Cloud project (the #1 native-sign-in misconfig, and one
+ * that never reaches our backend). The message for these is usually opaque, so
+ * surfacing the code turns a generic "sign in failed" into an actionable
+ * telemetry property. Returns undefined for anything without a string/number
+ * `code` (the caller falls back to the error message).
+ */
+export function nativeSignInErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined;
+}


### PR DESCRIPTION
## What

Sideloaded Android builds failed Google Sign-In with the generic "Sign in didn't complete," and nothing showed in the backend or PostHog.

## Root cause

Native Google Sign-In (`@react-native-google-signin`) resolves the Android OAuth client by **package name + signing-certificate SHA-1**, not by the `androidClientId` string. The release APK's upload-key SHA-1 was never registered as an Android OAuth client in the `webClientId`'s Google Cloud project — the legacy Capacitor app, which shares the key, used a browser OAuth flow, so native sign-in's SHA-1 requirement was new. `signIn()` therefore failed **client-side, before any network call** (hence the silent backend). Mobile has no `@sentry/react-native` and the PR build ships no PostHog key, so the failure left no telemetry anywhere.

The unblock itself is a Google Cloud Console change (register the signing SHA-1 as an Android OAuth client) — done out of band, and confirmed to fix sign-in on the already-installed `rn-android-2.0.210` with no rebuild. This PR makes the failure **diagnosable** and **documents** the requirement so it doesn't recur.

## Changes

- **Diagnostics** — `nativeSignInErrorCode()` (pure, tested) extracts the thrown native `.code`; `login.tsx` forwards it to PostHog as `failure_detail` + a `native_error_code` tag; `auth.ts` prints a dev-console hint for unmapped sign-in errors. Note: this `@react-native-google-signin` v16 uses Credential Manager and has **no `DEVELOPER_ERROR`** in `statusCodes`, so the hint keys off "not a known status code" rather than a specific code.
- **Docs** — `docs/android-sideload-build.md` gains a "Google Sign-In requires SHA-1 registration" section (the three signing keys: upload / Play app-signing / Expo debug; SHA-1 extraction via `apksigner verify --print-certs`); `docs/oauth-setup.md` gains a mobile pointer.
- **Cleanup** — corrected the stale `src/lib/sentry.ts` comment in `android-apk-rn.yml` + `ios-testflight-rn.yml`; mobile has no Sentry runtime wiring, so client errors go to PostHog only.

## Verification

- `vp run typecheck:mobile` ✓
- `vp check` (changed files) ✓
- `vp test run --project mobile` — 2011 tests ✓ (3 new for `nativeSignInErrorCode`)
- `vp run check:mobile-bundle` ✓
- Manual: registering the upload-key SHA-1 fixed Google Sign-In on the installed release APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)