### PR TITLE
feat(mobile): native in-app account registration (#2851)

### DIFF
--- a/packages/backend/src/__tests__/native-auth-register.test.ts
+++ b/packages/backend/src/__tests__/native-auth-register.test.ts
@@ -25,6 +25,10 @@ process.env.NEXTAUTH_SECRET = 'test-secret-for-native-auth-register-tests';
 
 const mockDbSelectQueue: unknown[][] = [];
 const insertCalls: { table: unknown; values: unknown }[] = [];
+// When set, the NEXT insert(...).values(...) rejects with this error (and then
+// clears) — lets tests drive the transaction's catch path (23505 race → 409,
+// any other throw → 500).
+let nextInsertError: unknown = null;
 
 function makeAwaitableInsert(): Promise<unknown[]> & { onConflictDoNothing: () => Promise<unknown[]> } {
   const promise = Promise.resolve([]) as Promise<unknown[]> & { onConflictDoNothing: () => Promise<unknown[]> };
@@ -51,6 +55,11 @@ function makeChain() {
       return {
         values(values: unknown) {
           insertCalls.push({ table, values });
+          if (nextInsertError) {
+            const error = nextInsertError;
+            nextInsertError = null;
+            return Promise.reject(error);
+          }
           return makeAwaitableInsert();
         },
       };
@@ -173,6 +182,7 @@ describe('handleNativeAuthRegister', () => {
     __resetNativeAuthStateForTests();
     mockDbSelectQueue.length = 0;
     insertCalls.length = 0;
+    nextInsertError = null;
   });
 
   it('creates the account and returns a JWT + refresh token (auto-login)', async () => {
@@ -284,6 +294,36 @@ describe('handleNativeAuthRegister', () => {
     );
     // No rows written when the email is taken.
     expect(insertsFor(users)).toHaveLength(0);
+  });
+
+  it('maps a 23505 unique-violation race to 409 (no token pair)', async () => {
+    queueSelect([]); // pre-check passes…
+    nextInsertError = { code: '23505' }; // …but the users insert loses the race
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'racer@example.com', password: 'longenough' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(409);
+    expect(parseBody(res).error).toBe('An account with this email already exists');
+    expect(parseBody(res).jwt).toBeUndefined();
+  });
+
+  it('rolls back and returns 500 when a transaction insert throws', async () => {
+    queueSelect([]);
+    nextInsertError = new Error('db exploded');
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'boom@example.com', password: 'longenough' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(parseBody(res).error).toBe('Internal server error');
+    expect(parseBody(res).jwt).toBeUndefined();
   });
 
   it('returns 400 for an invalid email', async () => {

--- a/packages/backend/src/__tests__/native-auth-register.test.ts
+++ b/packages/backend/src/__tests__/native-auth-register.test.ts
@@ -1,0 +1,408 @@
+// @ts-nocheck — __tests__ is excluded from tsconfig.json, so the type-aware
+// lint can't resolve node globals or `node:*` specifiers. Type-checking happens
+// at test-run time via vitest.
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { compare } from 'bcryptjs';
+import { users, userCredentials, userProfiles, mobileRefreshTokens } from '@boardsesh/db/schema/auth';
+
+// ---------------------------------------------------------------------------
+// Test secret — must match what generateTokenPair reads from env
+// ---------------------------------------------------------------------------
+
+process.env.NEXTAUTH_SECRET = 'test-secret-for-native-auth-register-tests';
+
+// ---------------------------------------------------------------------------
+// Mocks (hoisted before importing the handler)
+//
+// A queue of rows for each `.select()....limit()` await, plus an insert-call
+// recorder so tests can assert which tables were written. `db` and the
+// transaction's `tx` share one chain so the same queue drains across both and
+// generateTokenPair's mobileRefreshTokens insert (run with `tx`) is recorded.
+// ---------------------------------------------------------------------------
+
+const mockDbSelectQueue: unknown[][] = [];
+const insertCalls: { table: unknown; values: unknown }[] = [];
+
+function makeAwaitableInsert(): Promise<unknown[]> & { onConflictDoNothing: () => Promise<unknown[]> } {
+  const promise = Promise.resolve([]) as Promise<unknown[]> & { onConflictDoNothing: () => Promise<unknown[]> };
+  promise.onConflictDoNothing = () => Promise.resolve([]);
+  return promise;
+}
+
+function makeChain() {
+  const chain = {
+    select() {
+      return chain;
+    },
+    from() {
+      return chain;
+    },
+    where() {
+      return chain;
+    },
+    limit() {
+      const rows = mockDbSelectQueue.shift() ?? [];
+      return Promise.resolve(rows);
+    },
+    insert(table: unknown) {
+      return {
+        values(values: unknown) {
+          insertCalls.push({ table, values });
+          return makeAwaitableInsert();
+        },
+      };
+    },
+  };
+  return chain;
+}
+
+const chain = makeChain();
+
+vi.mock('../db/client', () => ({
+  db: {
+    select: (...args: unknown[]) => chain.select(...args),
+    insert: (...args: unknown[]) => chain.insert(...args),
+    transaction: async (callback: (tx: unknown) => unknown) => callback(chain),
+  },
+}));
+
+vi.mock('../handlers/cors', () => ({
+  applyCorsHeaders: vi.fn(() => true),
+}));
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: vi.fn(() => false),
+    isRedisConfigured: vi.fn(() => false),
+    getClients: vi.fn(() => ({ publisher: {} })),
+  },
+}));
+
+const { handleNativeAuthRegister, __resetNativeAuthStateForTests, __fillRateLimitMapForTests } =
+  await import('../handlers/native-auth');
+
+// ---------------------------------------------------------------------------
+// Request / response helpers (mirror native-auth-credentials.test.ts)
+// ---------------------------------------------------------------------------
+
+interface MockReq extends EventEmitter {
+  method?: string;
+  url?: string;
+  headers: Record<string, string | string[]>;
+  socket: Partial<Socket>;
+  destroy: () => void;
+}
+
+function makeRequest(opts: { method: string; body?: unknown; rawBody?: string; remoteAddress?: string }): MockReq {
+  const emitter = new EventEmitter() as MockReq;
+  emitter.method = opts.method;
+  emitter.url = '/auth/native/register';
+  emitter.headers = {};
+  emitter.socket = { remoteAddress: opts.remoteAddress ?? '127.0.0.1' };
+  emitter.destroy = vi.fn();
+
+  setImmediate(() => {
+    if (opts.rawBody !== undefined) {
+      emitter.emit('data', Buffer.from(opts.rawBody, 'utf8'));
+    } else if (opts.body !== undefined) {
+      emitter.emit('data', Buffer.from(JSON.stringify(opts.body), 'utf8'));
+    }
+    emitter.emit('end');
+  });
+
+  return emitter;
+}
+
+interface MockRes {
+  statusCode: number;
+  body: string;
+  headers: Record<string, unknown>;
+  headersSent: boolean;
+  writeHead: (status: number, headers?: Record<string, unknown>) => void;
+  end: (body?: string) => void;
+  setHeader: (name: string, value: unknown) => void;
+}
+
+function makeResponse(): MockRes {
+  const res: MockRes = {
+    statusCode: 0,
+    body: '',
+    headers: {},
+    headersSent: false,
+    writeHead(status, headers) {
+      this.statusCode = status;
+      this.headersSent = true;
+      if (headers) Object.assign(this.headers, headers);
+    },
+    end(body) {
+      if (body !== undefined) this.body = body;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+  };
+  return res;
+}
+
+function parseBody(res: MockRes): Record<string, unknown> {
+  return JSON.parse(res.body) as Record<string, unknown>;
+}
+
+function queueSelect(rows: unknown[]): void {
+  mockDbSelectQueue.push(rows);
+}
+
+function insertsFor(table: unknown): { table: unknown; values: unknown }[] {
+  return insertCalls.filter((call) => call.table === table);
+}
+
+async function callHandler(req: MockReq, res: MockRes): Promise<void> {
+  await handleNativeAuthRegister(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('handleNativeAuthRegister', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNativeAuthStateForTests();
+    mockDbSelectQueue.length = 0;
+    insertCalls.length = 0;
+  });
+
+  it('creates the account and returns a JWT + refresh token (auto-login)', async () => {
+    queueSelect([]); // no existing user
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'new@example.com', password: 'longenough', name: 'Crusher' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    const body = parseBody(res);
+    expect(typeof body.jwt).toBe('string');
+    expect(typeof body.refreshToken).toBe('string');
+    expect(body.expiresAt).toBeDefined();
+
+    // The three account rows + the refresh-token row from generateTokenPair.
+    expect(insertsFor(users)).toHaveLength(1);
+    expect(insertsFor(userCredentials)).toHaveLength(1);
+    expect(insertsFor(userProfiles)).toHaveLength(1);
+    expect(insertsFor(mobileRefreshTokens)).toHaveLength(1);
+
+    const userValues = insertsFor(users)[0].values as Record<string, unknown>;
+    expect(userValues.email).toBe('new@example.com');
+    expect(userValues.name).toBe('Crusher');
+    expect(userValues.emailVerified).toBeInstanceOf(Date);
+  });
+
+  it('stores a bcrypt hash, never the plaintext password', async () => {
+    queueSelect([]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'hash@example.com', password: 'super-secret-pw' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    const credValues = insertsFor(userCredentials)[0].values as Record<string, unknown>;
+    expect(credValues.passwordHash).not.toBe('super-secret-pw');
+    expect(await compare('super-secret-pw', credValues.passwordHash as string)).toBe(true);
+  });
+
+  it('normalizes the email (trim + lowercase) before storing', async () => {
+    queueSelect([]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: '  NEW@Example.COM  ', password: 'longenough' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    const userValues = insertsFor(users)[0].values as Record<string, unknown>;
+    expect(userValues.email).toBe('new@example.com');
+  });
+
+  it('creates an UNVERIFIED account when email verification is enabled', async () => {
+    process.env.EMAIL_VERIFICATION_ENABLED = 'true';
+    try {
+      queueSelect([]);
+      const req = makeRequest({
+        method: 'POST',
+        body: { email: 'verify@example.com', password: 'longenough' },
+      });
+      const res = makeResponse();
+      await callHandler(req, res);
+
+      expect(res.statusCode).toBe(201);
+      const userValues = insertsFor(users)[0].values as Record<string, unknown>;
+      expect(userValues.emailVerified).toBeNull();
+    } finally {
+      delete process.env.EMAIL_VERIFICATION_ENABLED;
+    }
+  });
+
+  it('falls back to the email local-part when no name is given', async () => {
+    queueSelect([]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'sloper@example.com', password: 'longenough' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(201);
+    const userValues = insertsFor(users)[0].values as Record<string, unknown>;
+    expect(userValues.name).toBe('sloper');
+  });
+
+  it('returns 409 when an account already exists for that email', async () => {
+    queueSelect([{ id: 'existing-user', email: 'taken@example.com' }]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'taken@example.com', password: 'longenough' },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+
+    expect(res.statusCode).toBe(409);
+    expect(parseBody(res).error).toBe(
+      'An account with this email already exists. Please sign in with your existing account.',
+    );
+    // No rows written when the email is taken.
+    expect(insertsFor(users)).toHaveLength(0);
+  });
+
+  it('returns 400 for an invalid email', async () => {
+    const req = makeRequest({ method: 'POST', body: { email: 'not-an-email', password: 'longenough' } });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Invalid email address');
+  });
+
+  it('returns 400 for a password shorter than 8 characters', async () => {
+    const req = makeRequest({ method: 'POST', body: { email: 'x@y.zz', password: 'short' } });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Password must be at least 8 characters');
+  });
+
+  it('returns 400 for a password longer than 128 characters', async () => {
+    const req = makeRequest({ method: 'POST', body: { email: 'x@y.zz', password: 'a'.repeat(129) } });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Password must be less than 128 characters');
+  });
+
+  it('returns 400 for a name longer than 100 characters', async () => {
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'x@y.zz', password: 'longenough', name: 'a'.repeat(101) },
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Name must be less than 100 characters');
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const req = makeRequest({ method: 'POST', body: { password: 'longenough' } });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('email and password are required');
+  });
+
+  it('returns 400 when password is missing', async () => {
+    const req = makeRequest({ method: 'POST', body: { email: 'x@y.zz' } });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('email and password are required');
+  });
+
+  it('returns 400 for a non-object body', async () => {
+    const req = makeRequest({ method: 'POST', body: 'not-an-object' });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for an invalid JSON body', async () => {
+    const req = makeRequest({ method: 'POST', rawBody: 'not valid json {{{' });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(parseBody(res).error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 for an oversized request body', async () => {
+    // readBody caps the body at 4096 bytes and rejects beyond it; the handler
+    // maps that to a 400 (same as a malformed body).
+    const req = makeRequest({ method: 'POST', rawBody: 'x'.repeat(5000) });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    const req = makeRequest({ method: 'GET' });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 429 when the per-IP rate limit is exceeded', async () => {
+    // 10 successful registrations fill the bucket (limit is 10/min/IP).
+    for (let i = 0; i < 10; i++) {
+      queueSelect([]); // duplicate pre-check miss
+      const req = makeRequest({
+        method: 'POST',
+        body: { email: `crew${i}@example.com`, password: 'longenough' },
+        remoteAddress: '10.0.0.77',
+      });
+      const res = makeResponse();
+      await callHandler(req, res);
+      expect(res.statusCode).toBe(201);
+    }
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'crew11@example.com', password: 'longenough' },
+      remoteAddress: '10.0.0.77',
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['Retry-After']).toBeDefined();
+  });
+
+  it('returns 503 when the rate limit map is full', async () => {
+    __fillRateLimitMapForTests(50_000);
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'x@y.zz', password: 'longenough' },
+      remoteAddress: '10.0.0.88',
+    });
+    const res = makeResponse();
+    await callHandler(req, res);
+    expect(res.statusCode).toBe(503);
+    expect(parseBody(res).error).toBe('Service temporarily overloaded');
+  });
+});

--- a/packages/backend/src/handlers/native-auth.ts
+++ b/packages/backend/src/handlers/native-auth.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import crypto from 'crypto';
 import { SignJWT, createRemoteJWKSet, jwtVerify } from 'jose';
-import { compare } from 'bcryptjs';
+import { compare, hash } from 'bcryptjs';
 import { eq, and, isNull, lt, or, isNotNull } from 'drizzle-orm';
 import { mobileRefreshTokens, users, userCredentials, accounts, userProfiles } from '@boardsesh/db/schema/auth';
 import { db } from '../db/client';
@@ -19,6 +19,19 @@ const DUMMY_PASSWORD_HASH = '$2b$10$CwTycUXWue0Thq9StjUM0uJ8/oQbk1Ec7T0p/7K8nXfR
 
 /** Generic error returned for all credential validation failures. */
 const INVALID_CREDENTIALS_ERROR = 'Invalid email or password';
+
+/**
+ * Registration field bounds — mirror the web register route's Zod schema
+ * (packages/web/app/api/auth/register/route.ts) so both signup paths accept
+ * exactly the same inputs. The email regex is the same lax shape the web/mobile
+ * client validators use: it rejects nothing the server would otherwise accept.
+ */
+const REGISTER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 128;
+const NAME_MAX_LENGTH = 100;
+/** bcrypt cost factor — matches the web register route. */
+const BCRYPT_COST = 12;
 
 // Transfer tokens are short-lived (120s) and exchanged between our own
 // servers, so 5s tolerance is sufficient. Long-lived JWTs use 60s in
@@ -544,6 +557,152 @@ export async function handleNativeAuthCredentials(req: IncomingMessage, res: Ser
     sendJson(res, 200, tokenPair);
   } catch (error) {
     logger.error('[NativeAuth] Credentials sign-in failed:', error);
+    sendJson(res, 500, { error: 'Internal server error' });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /auth/native/register — create a Boardsesh account from the mobile app
+//
+// Mirrors the web register route (packages/web/app/api/auth/register/route.ts):
+// it creates the same users + userCredentials + userProfiles rows. The
+// difference is that on success we mint a mobile JWT pair and return it, so the
+// app logs the user straight in (no web browser, no email round-trip) — the same
+// auto-login behaviour the native OAuth and credentials handlers already have.
+//
+// Email verification: the backend can't send a verification email, and
+// handleNativeAuthCredentials never checks emailVerified, so the new user is
+// auto-logged-in on the device regardless. We still honour
+// EMAIL_VERIFICATION_ENABLED for the stored emailVerified value, mirroring the
+// web register route: when the flag is on, accounts are created UNVERIFIED
+// (emailVerified: null) so this native path can't mint verified accounts for
+// arbitrary emails and thereby bypass web's verification gate
+// (auth-options.ts blocks unverified credentials login when the flag is on).
+// When the flag is off (the default), accounts are created verified.
+// ---------------------------------------------------------------------------
+
+export async function handleNativeAuthRegister(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  // Rate limit by IP (shared limiter with the other native-auth endpoints)
+  const clientIp = getClientIp(req);
+  const retryAfter = checkAuthRateLimit(clientIp);
+  if (retryAfter === -1) {
+    sendJson(res, 503, { error: 'Service temporarily overloaded' });
+    return;
+  }
+  if (retryAfter !== null) {
+    res.setHeader('Retry-After', String(retryAfter));
+    sendJson(res, 429, { error: `Rate limit exceeded. Try again in ${retryAfter} seconds.` });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw);
+  } catch {
+    sendJson(res, 400, { error: 'Invalid JSON body' });
+    return;
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    sendJson(res, 400, { error: 'Request body must be a JSON object' });
+    return;
+  }
+
+  const { email, password, name } = body as Record<string, unknown>;
+
+  // Email: present, a string, and matching the lax client-side shape. Validate
+  // against the trimmed/lowercased form so a trailing space can't sneak past.
+  if (typeof email !== 'string' || email.trim().length === 0) {
+    sendJson(res, 400, { error: 'email and password are required' });
+    return;
+  }
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!REGISTER_EMAIL_REGEX.test(normalizedEmail)) {
+    sendJson(res, 400, { error: 'Invalid email address' });
+    return;
+  }
+
+  // Password: present, a string, within bounds (mirrors the web Zod schema).
+  if (typeof password !== 'string' || password.length === 0) {
+    sendJson(res, 400, { error: 'email and password are required' });
+    return;
+  }
+  if (password.length < PASSWORD_MIN_LENGTH) {
+    sendJson(res, 400, { error: 'Password must be at least 8 characters' });
+    return;
+  }
+  if (password.length > PASSWORD_MAX_LENGTH) {
+    sendJson(res, 400, { error: 'Password must be less than 128 characters' });
+    return;
+  }
+
+  // Name: optional. An empty/whitespace-only string is treated as absent; the
+  // display name then falls back to the email local-part (matches web).
+  let trimmedName: string | undefined;
+  if (name !== undefined && name !== null) {
+    if (typeof name !== 'string') {
+      sendJson(res, 400, { error: 'name must be a string' });
+      return;
+    }
+    const candidate = name.trim();
+    if (candidate.length > NAME_MAX_LENGTH) {
+      sendJson(res, 400, { error: 'Name must be less than 100 characters' });
+      return;
+    }
+    if (candidate.length > 0) trimmedName = candidate;
+  }
+
+  try {
+    // Pre-check keeps the clean 409 message without relying on a DB constraint
+    // (users.email currently has no unique index — see the catch below).
+    const existingRows = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
+    if (existingRows[0]) {
+      sendJson(res, 409, {
+        error: 'An account with this email already exists. Please sign in with your existing account.',
+      });
+      return;
+    }
+
+    const passwordHash = await hash(password, BCRYPT_COST);
+    // Mirror web: unverified when the verification gate is on, verified otherwise.
+    const emailVerificationEnabled = process.env.EMAIL_VERIFICATION_ENABLED === 'true';
+
+    const result = await db.transaction(async (tx) => {
+      const newUserId = crypto.randomUUID();
+      await tx.insert(users).values({
+        id: newUserId,
+        email: normalizedEmail,
+        name: trimmedName ?? normalizedEmail.split('@')[0],
+        emailVerified: emailVerificationEnabled ? null : new Date(),
+      });
+      await tx.insert(userCredentials).values({ userId: newUserId, passwordHash });
+      // Mirror the web createUser event: every user gets a profile row.
+      await tx.insert(userProfiles).values({ userId: newUserId }).onConflictDoNothing();
+      const tokenPair = await generateTokenPair(newUserId, tx);
+      return { userId: newUserId, tokenPair };
+    });
+
+    logger.info(`[NativeAuth] Registration successful for user ${result.userId}`);
+    sendJson(res, 201, result.tokenPair);
+  } catch (error) {
+    // Race: a concurrent request created this email between the pre-check and
+    // insert. PostgreSQL unique-violation code is '23505'. NOTE: users.email has
+    // no unique index today, so this won't fire from the email column yet — the
+    // pre-check above is the real guard. The handler stays correct once a
+    // uniqueIndex on lower-cased users.email is added (tracked as follow-up).
+    if (error && typeof error === 'object' && 'code' in error && error.code === '23505') {
+      sendJson(res, 409, { error: 'An account with this email already exists' });
+      return;
+    }
+    logger.error('[NativeAuth] Registration failed:', error);
     sendJson(res, 500, { error: 'Internal server error' });
   }
 }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -30,6 +30,7 @@ import {
   handleNativeAuthExchange,
   handleNativeAuthOAuth,
   handleNativeAuthRefresh,
+  handleNativeAuthRegister,
   handleNativeAuthRevoke,
   startRefreshTokenCleanup,
   stopRefreshTokenCleanup,
@@ -405,6 +406,11 @@ export async function startServer(): Promise<ServerResources> {
         return;
       }
 
+      if (pathname === '/auth/native/register' && (req.method === 'POST' || req.method === 'OPTIONS')) {
+        await handleNativeAuthRegister(req, res);
+        return;
+      }
+
       if (pathname === '/auth/native/oauth' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleNativeAuthOAuth(req, res);
         return;
@@ -510,6 +516,7 @@ export async function startServer(): Promise<ServerResources> {
     logger.info(`  Widget take-control: ${httpScheme}://0.0.0.0:${PORT}/api/widget/take-control`);
     logger.info(`  Native auth exchange: ${httpScheme}://0.0.0.0:${PORT}/auth/native/exchange`);
     logger.info(`  Native auth credentials: ${httpScheme}://0.0.0.0:${PORT}/auth/native/credentials`);
+    logger.info(`  Native auth register: ${httpScheme}://0.0.0.0:${PORT}/auth/native/register`);
     logger.info(`  Native auth oauth: ${httpScheme}://0.0.0.0:${PORT}/auth/native/oauth`);
     logger.info(`  Native auth refresh: ${httpScheme}://0.0.0.0:${PORT}/auth/native/refresh`);
     logger.info(`  Native auth revoke: ${httpScheme}://0.0.0.0:${PORT}/auth/native/revoke`);

--- a/packages/mobile/app/auth/_layout.tsx
+++ b/packages/mobile/app/auth/_layout.tsx
@@ -4,6 +4,8 @@ export default function AuthLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="login" />
+      {/* register.tsx sets its own header (title + back chevron) via Stack.Screen. */}
+      <Stack.Screen name="register" />
     </Stack>
   );
 }

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -306,7 +306,8 @@ export default function LoginScreen() {
               hapticLight();
               router.push('/auth/register');
             }}
-            hitSlop={8}
+            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+            style={styles.footerLinkHit}
             accessibilityRole="link"
           >
             <Text style={[styles.footerLink, { color: theme.systemColors.accent }]}>{t('login.submit.signUp')}</Text>
@@ -357,4 +358,6 @@ const styles = StyleSheet.create({
   },
   footerText: { fontSize: 15 },
   footerLink: { fontSize: 15, fontWeight: '600' },
+  // Keeps the tappable area at the 44pt/48dp minimum.
+  footerLinkHit: { minHeight: 44, justifyContent: 'center' },
 });

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -6,73 +6,31 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   View,
   type TextInput as RNTextInput,
 } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { Image } from 'expo-image';
+import { useRouter } from 'expo-router';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../../src/lib/native-auth-analytics';
 import { isGoogleSignInConfigured } from '../../src/lib/auth';
+import { EMAIL_REGEX } from '../../src/lib/auth-validation';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
+import { AuthTextInput } from '../../src/components/AuthTextInput';
+import { Button } from '../../src/components/Button';
 import { track } from '../../src/lib/analytics';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
-import { brandColors } from '../../src/theme/colors';
-import { iosSystemColors } from '../../src/theme/ios-colors';
-
-const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
-
-// Minimal email regex — same shape as the web validator, intentionally lax
-// so we don't reject anything the server would accept.
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function SignInButton({
-  title,
-  onPress,
-  disabled = false,
-}: {
-  title: string;
-  onPress: () => void;
-  disabled?: boolean;
-}) {
-  const scale = useSharedValue(1);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
-
-  return (
-    <AnimatedPressable
-      onPress={() => {
-        if (disabled) return;
-        hapticLight();
-        onPress();
-      }}
-      onPressIn={() => {
-        if (disabled) return;
-        scale.value = withSpring(0.97, { damping: 20, stiffness: 300, mass: 0.7 });
-      }}
-      onPressOut={() => {
-        if (disabled) return;
-        scale.value = withSpring(1, { damping: 20, stiffness: 300, mass: 0.7 });
-      }}
-      style={[animatedStyle, styles.button, disabled && styles.buttonDisabled]}
-    >
-      <Text style={styles.buttonText}>{title}</Text>
-    </AnimatedPressable>
-  );
-}
 
 export default function LoginScreen() {
   const { signInWithApple, signInWithGoogle, signInWithCredentials } = useAuth();
   const { t } = useTranslation('auth');
   const theme = useTheme();
+  const router = useRouter();
   const passwordRef = useRef<RNTextInput>(null);
 
   const [email, setEmail] = useState('');
@@ -211,17 +169,7 @@ export default function LoginScreen() {
     }
   }
 
-  // Input styling — dark-mode input fields are intentionally white (matches web).
   const isDark = theme.colorScheme === 'dark';
-  const inputBackground = isDark ? iosSystemColors.white : '#FFFFFF';
-  const inputBorder = isDark ? 'rgba(60, 60, 67, 0.36)' : 'rgba(60, 60, 67, 0.18)';
-  const inputTextColor = '#000000';
-  const inputPlaceholderColor = 'rgba(60, 60, 67, 0.6)';
-
-  const inputStyle = [
-    styles.input,
-    { backgroundColor: inputBackground, borderColor: inputBorder, color: inputTextColor },
-  ];
 
   // Sign in with Apple is iOS-only; Google only when the build shipped its
   // native config (an Apple-only / misconfigured build hides it rather than
@@ -246,33 +194,32 @@ export default function LoginScreen() {
             accessible={false}
           />
           <Text style={[styles.title, { color: theme.brandColors.primary }]}>Boardsesh</Text>
-          <Text style={styles.subtitle}>{t('nativeStart.tagline')}</Text>
+          <Text style={[styles.subtitle, { color: theme.systemColors.secondaryLabel }]}>
+            {t('nativeStart.tagline')}
+          </Text>
         </View>
 
         <View style={styles.form}>
-          <TextInput
-            style={inputStyle}
+          <AuthTextInput
+            label={t('login.fields.email')}
             value={email}
             onChangeText={setEmail}
             placeholder={t('login.placeholders.email')}
-            placeholderTextColor={inputPlaceholderColor}
+            keyboardType="email-address"
             autoCapitalize="none"
             autoCorrect={false}
-            keyboardType="email-address"
             textContentType="emailAddress"
             autoComplete="email"
             returnKeyType="next"
             onSubmitEditing={() => passwordRef.current?.focus()}
             editable={!submitting}
-            accessibilityLabel={t('login.fields.email')}
           />
-          <TextInput
+          <AuthTextInput
             ref={passwordRef}
-            style={inputStyle}
+            label={t('login.fields.password')}
             value={password}
             onChangeText={setPassword}
             placeholder={t('login.placeholders.password')}
-            placeholderTextColor={inputPlaceholderColor}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -283,14 +230,19 @@ export default function LoginScreen() {
               void onSubmit();
             }}
             editable={!submitting}
-            accessibilityLabel={t('login.fields.password')}
+            showLabel={t('login.a11y.showPassword')}
+            hideLabel={t('login.a11y.hidePassword')}
           />
-          <SignInButton
-            title={submitting ? t('nativeStart.signingIn') : t('nativeStart.signIn')}
+          <Button
+            title={t('nativeStart.signIn')}
             onPress={() => {
               void onSubmit();
             }}
+            variant="filled"
+            size="large"
+            loading={submitting}
             disabled={!canSubmit}
+            style={styles.submitButton}
           />
           {error ? (
             <Text style={styles.errorText} accessibilityLiveRegion="polite">
@@ -344,6 +296,22 @@ export default function LoginScreen() {
             </View>
           </>
         )}
+
+        <View style={styles.footer}>
+          <Text style={[styles.footerText, { color: theme.systemColors.secondaryLabel }]}>
+            {t('login.links.noAccount')}{' '}
+          </Text>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              router.push('/auth/register');
+            }}
+            hitSlop={8}
+            accessibilityRole="link"
+          >
+            <Text style={[styles.footerLink, { color: theme.systemColors.accent }]}>{t('login.submit.signUp')}</Text>
+          </Pressable>
+        </View>
       </ScrollView>
     </KeyboardAvoidingView>
   );
@@ -354,15 +322,9 @@ const styles = StyleSheet.create({
   header: { alignItems: 'center', marginBottom: 32 },
   logo: { width: 96, height: 96, marginBottom: 16 },
   title: { fontSize: 34, fontWeight: '700', marginBottom: 8 },
-  subtitle: { fontSize: 17, opacity: 0.7 },
+  subtitle: { fontSize: 17 },
   form: { gap: 12 },
-  input: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 14,
-    fontSize: 17,
-  },
+  submitButton: { alignSelf: 'stretch', marginTop: 4 },
   errorText: {
     color: '#FF3B30',
     fontSize: 15,
@@ -387,18 +349,12 @@ const styles = StyleSheet.create({
   // Apple's native button needs explicit height + width or it renders nothing.
   appleButton: { width: '100%', height: 50 },
   googleButton: { width: '100%', height: 50 },
-  button: {
-    backgroundColor: brandColors.primary,
-    paddingVertical: 16,
-    borderRadius: 12,
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
     alignItems: 'center',
+    marginTop: 24,
   },
-  buttonDisabled: {
-    opacity: 0.5,
-  },
-  buttonText: {
-    color: iosSystemColors.white,
-    fontSize: 17,
-    fontWeight: '600',
-  },
+  footerText: { fontSize: 15 },
+  footerLink: { fontSize: 15, fontWeight: '600' },
 });

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -15,11 +15,12 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../../src/lib/native-auth-analytics';
+import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
 import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { EMAIL_REGEX } from '../../src/lib/auth-validation';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
+import { useNativeOAuthSignIn } from '../../src/hooks/use-native-oauth-sign-in';
 import { AuthTextInput } from '../../src/components/AuthTextInput';
 import { Button } from '../../src/components/Button';
 import { track } from '../../src/lib/analytics';
@@ -27,7 +28,7 @@ import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
 
 export default function LoginScreen() {
-  const { signInWithApple, signInWithGoogle, signInWithCredentials } = useAuth();
+  const { signInWithCredentials } = useAuth();
   const { t } = useTranslation('auth');
   const theme = useTheme();
   const router = useRouter();
@@ -37,7 +38,8 @@ export default function LoginScreen() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [oauthInProgress, setOauthInProgress] = useState(false);
+  // Shared Apple/Google flow; errors land in the same region as credentials sign-in.
+  const { signIn: handleOAuthSignIn, inProgress: oauthInProgress } = useNativeOAuthSignIn({ setError });
 
   const trimmedEmail = email.trim();
   const canSubmit = !submitting && trimmedEmail.length > 0 && password.length > 0;
@@ -93,79 +95,6 @@ export default function LoginScreen() {
       throw signInError;
     } finally {
       setSubmitting(false);
-    }
-  }
-
-  async function handleOAuthSignIn(provider: 'apple' | 'google') {
-    // A rapid double-tap would open two concurrent native sheets.
-    if (oauthInProgress) return;
-    setOauthInProgress(true);
-    setError(null);
-    track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native' });
-    // duration_ms separates a human dismissing the system sheet (seconds) from
-    // the flow dying programmatically (sub-second).
-    const attemptStartedAt = Date.now();
-    try {
-      const result = provider === 'apple' ? await signInWithApple() : await signInWithGoogle();
-      if (result.success) {
-        track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: 'native' });
-        // AuthProvider flips isAuthenticated and the redirect handles navigation.
-        return;
-      }
-      if ('cancelled' in result) {
-        // The user dismissed the provider sheet — not an error, no message shown.
-        track(SHARED_EVENTS.LoginFailed, {
-          auth_method: provider,
-          flow: 'native',
-          failure_reason: 'cancel',
-          duration_ms: Date.now() - attemptStartedAt,
-        });
-        return;
-      }
-      // A real backend/token failure carrying the server's status + error.
-      const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
-      track(SHARED_EVENTS.LoginFailed, {
-        auth_method: provider,
-        flow: 'native',
-        failure_reason: oauthFailureReason,
-        failure_detail: result.error,
-        duration_ms: Date.now() - attemptStartedAt,
-      });
-      // Surface to error tracking too: an OAuth 401 / no_id_token is a config
-      // bug (client-id audience mismatch, unconfigured backend) rather than a
-      // user typo, so it's worth a $exception carrying the status + server
-      // message. Network blips downgrade to a warning (handled by report level).
-      reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
-        level: result.error === 'network' ? 'warning' : 'error',
-        tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
-        extra: { status: result.status, server_error: result.error },
-      });
-      setError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
-    } catch (oauthError) {
-      // The native module threw (Play Services missing, no presenter,
-      // DEVELOPER_ERROR for a signing/client-id mismatch, …). The native `.code`
-      // (e.g. DEVELOPER_ERROR) is far more actionable than the opaque message, so
-      // prefer it for failure_detail and tag it for filtering.
-      const nativeErrorCode = nativeSignInErrorCode(oauthError);
-      track(SHARED_EVENTS.LoginFailed, {
-        auth_method: provider,
-        flow: 'native',
-        failure_reason: 'exception',
-        failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
-        duration_ms: Date.now() - attemptStartedAt,
-      });
-      reportError(oauthError, {
-        tags: {
-          source: 'native-auth',
-          provider,
-          flow: 'native',
-          mechanism: 'exception',
-          native_error_code: nativeErrorCode,
-        },
-      });
-      setError(t('nativeStart.oauthError'));
-    } finally {
-      setOauthInProgress(false);
     }
   }
 
@@ -254,9 +183,9 @@ export default function LoginScreen() {
         {showSocialSignIn && (
           <>
             <View style={styles.dividerRow}>
-              <View style={styles.dividerLine} />
+              <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
               <Text style={styles.dividerLabel}>{t('nativeStart.orContinueWith')}</Text>
-              <View style={styles.dividerLine} />
+              <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
             </View>
 
             <View style={styles.buttons}>
@@ -340,7 +269,6 @@ const styles = StyleSheet.create({
   dividerLine: {
     flex: 1,
     height: StyleSheet.hairlineWidth,
-    backgroundColor: 'rgba(60, 60, 67, 0.36)',
   },
   dividerLabel: {
     fontSize: 13,

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -1,0 +1,380 @@
+import { useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  type TextInput as RNTextInput,
+} from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import * as AppleAuthentication from 'expo-apple-authentication';
+import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
+import { useTranslation } from 'react-i18next';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
+import { isGoogleSignInConfigured } from '../../src/lib/auth';
+import { validateRegisterFields, isValid, type RegisterFieldErrors } from '../../src/lib/auth-validation';
+import { useAuth } from '../../src/providers/auth-provider';
+import { useTheme } from '../../src/providers/theme-provider';
+import { AuthTextInput } from '../../src/components/AuthTextInput';
+import { Button } from '../../src/components/Button';
+import { Text } from '../../src/components/Text';
+import { track } from '../../src/lib/analytics';
+import { reportError } from '../../src/lib/error-reporting';
+import { hapticLight } from '../../src/lib/haptics';
+
+type FieldKey = 'name' | 'email' | 'password' | 'confirmPassword';
+
+export default function RegisterScreen() {
+  const { register, signInWithApple, signInWithGoogle } = useAuth();
+  const { t } = useTranslation('auth');
+  const theme = useTheme();
+  const router = useRouter();
+  const passwordRef = useRef<RNTextInput>(null);
+  const confirmRef = useRef<RNTextInput>(null);
+  const nameRef = useRef<RNTextInput>(null);
+
+  const [values, setValues] = useState({ name: '', email: '', password: '', confirmPassword: '' });
+  const [fieldErrors, setFieldErrors] = useState<RegisterFieldErrors>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [oauthInProgress, setOauthInProgress] = useState(false);
+
+  // Editing a field clears its inline error so a fixed field stops shouting.
+  const setField = (key: FieldKey) => (text: string) => {
+    setValues((prev) => ({ ...prev, [key]: text }));
+    setFieldErrors((prev) => (prev[key] ? { ...prev, [key]: undefined } : prev));
+  };
+
+  const trimmedEmail = values.email.trim();
+  const canSubmit =
+    !submitting && trimmedEmail.length > 0 && values.password.length > 0 && values.confirmPassword.length > 0;
+
+  async function onSubmit() {
+    if (!canSubmit) return;
+
+    const errorKeys = validateRegisterFields(values);
+    if (!isValid(errorKeys)) {
+      // Map the validator's i18n keys to translated, per-field messages.
+      setFieldErrors({
+        name: errorKeys.name ? t(errorKeys.name) : undefined,
+        email: errorKeys.email ? t(errorKeys.email) : undefined,
+        password: errorKeys.password ? t(errorKeys.password) : undefined,
+        confirmPassword: errorKeys.confirmPassword ? t(errorKeys.confirmPassword) : undefined,
+      });
+      return;
+    }
+
+    setFieldErrors({});
+    setFormError(null);
+    setSubmitting(true);
+    track(SHARED_EVENTS.LoginAttempted, { auth_method: 'credentials', flow: 'native', is_registration: true });
+    try {
+      const result = await register(trimmedEmail, values.password, values.name.trim() || undefined);
+      if (result.success) {
+        track(SHARED_EVENTS.LoginSucceeded, { auth_method: 'credentials', flow: 'native', is_registration: true });
+        // AuthProvider flips isAuthenticated and the auth-group Redirect lands the
+        // new user in the app — same auto-login path as signInWithCredentials.
+        return;
+      }
+
+      const failureReason = classifyNativeAuthFailureReason(result, 'credentials');
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: 'credentials',
+        flow: 'native',
+        failure_reason: failureReason,
+        failure_detail: result.error,
+        is_registration: true,
+      });
+      if (result.error === 'network') {
+        setFormError(t('nativeStart.networkError'));
+      } else if (result.status === 409) {
+        // Email already has an account — a normal case, not telemetry-worthy.
+        // Point them at the email field and the "Sign in" footer link.
+        setFieldErrors({ email: t('login.toasts.accountExists') });
+      } else if (result.status === 400) {
+        // Client validation should have caught this; surface the server message.
+        setFormError(result.error);
+      } else {
+        // An unexpected backend failure (5xx, malformed response, …) — report it
+        // so a broken register endpoint is visible, not just a red line.
+        reportError(new Error(`Registration failed: ${result.error}`), {
+          tags: { source: 'native-auth', provider: 'credentials', flow: 'native', failure_reason: failureReason },
+          extra: { status: result.status, server_error: result.error },
+        });
+        setFormError(t('login.toasts.registrationFailedRetry'));
+      }
+    } catch (registerError) {
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: 'credentials',
+        flow: 'native',
+        failure_reason: 'exception',
+        is_registration: true,
+      });
+      throw registerError;
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Mirrors login.tsx's handleOAuthSignIn — Apple/Google "sign up" is the same
+  // find-or-create flow as sign-in, tagged is_registration so the funnel can
+  // tell signup OAuth from login OAuth. (Kept local rather than shared to leave
+  // login's working flow untouched; a shared hook is a sensible follow-up.)
+  async function handleOAuthSignIn(provider: 'apple' | 'google') {
+    if (oauthInProgress) return;
+    setOauthInProgress(true);
+    setFormError(null);
+    track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native', is_registration: true });
+    const attemptStartedAt = Date.now();
+    try {
+      const result = provider === 'apple' ? await signInWithApple() : await signInWithGoogle();
+      if (result.success) {
+        track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: 'native', is_registration: true });
+        return;
+      }
+      if ('cancelled' in result) {
+        track(SHARED_EVENTS.LoginFailed, {
+          auth_method: provider,
+          flow: 'native',
+          failure_reason: 'cancel',
+          duration_ms: Date.now() - attemptStartedAt,
+          is_registration: true,
+        });
+        return;
+      }
+      const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: provider,
+        flow: 'native',
+        failure_reason: oauthFailureReason,
+        failure_detail: result.error,
+        duration_ms: Date.now() - attemptStartedAt,
+        is_registration: true,
+      });
+      reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
+        level: result.error === 'network' ? 'warning' : 'error',
+        tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
+        extra: { status: result.status, server_error: result.error },
+      });
+      setFormError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
+    } catch (oauthError) {
+      track(SHARED_EVENTS.LoginFailed, {
+        auth_method: provider,
+        flow: 'native',
+        failure_reason: 'exception',
+        failure_detail: oauthError instanceof Error ? oauthError.message : undefined,
+        duration_ms: Date.now() - attemptStartedAt,
+        is_registration: true,
+      });
+      reportError(oauthError, {
+        tags: { source: 'native-auth', provider, flow: 'native', mechanism: 'exception' },
+      });
+      setFormError(t('nativeStart.oauthError'));
+    } finally {
+      setOauthInProgress(false);
+    }
+  }
+
+  const isDark = theme.colorScheme === 'dark';
+  const showAppleSignIn = Platform.OS === 'ios';
+  const showGoogleSignIn = isGoogleSignInConfigured();
+  const showSocialSignIn = showAppleSignIn || showGoogleSignIn;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: true, title: t('login.tabs.signUp'), headerLargeTitle: false }} />
+      <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <ScrollView
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+        >
+          <Text variant="subheadline" color={theme.systemColors.secondaryLabel} style={styles.intro}>
+            {t('login.signUp.subtitle')}
+          </Text>
+
+          {showSocialSignIn && (
+            <>
+              <View style={styles.socialButtons}>
+                {showAppleSignIn && (
+                  // SIGN_UP variant on the registration screen, per Apple HIG.
+                  <AppleAuthentication.AppleAuthenticationButton
+                    buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_UP}
+                    buttonStyle={
+                      isDark
+                        ? AppleAuthentication.AppleAuthenticationButtonStyle.WHITE
+                        : AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
+                    }
+                    cornerRadius={12}
+                    style={styles.appleButton}
+                    onPress={() => {
+                      hapticLight();
+                      void handleOAuthSignIn('apple');
+                    }}
+                  />
+                )}
+                {showGoogleSignIn && (
+                  <GoogleSigninButton
+                    size={GoogleSigninButton.Size.Wide}
+                    color={isDark ? GoogleSigninButton.Color.Dark : GoogleSigninButton.Color.Light}
+                    disabled={oauthInProgress}
+                    style={styles.googleButton}
+                    onPress={() => {
+                      hapticLight();
+                      void handleOAuthSignIn('google');
+                    }}
+                  />
+                )}
+              </View>
+
+              <View style={styles.dividerRow}>
+                <View style={styles.dividerLine} />
+                <Text variant="footnote" color={theme.systemColors.secondaryLabel}>
+                  {t('login.divider')}
+                </Text>
+                <View style={styles.dividerLine} />
+              </View>
+            </>
+          )}
+
+          <View style={styles.form}>
+            <AuthTextInput
+              label={t('login.fields.email')}
+              value={values.email}
+              onChangeText={setField('email')}
+              placeholder={t('login.placeholders.email')}
+              error={fieldErrors.email}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              // `username` (not emailAddress) lets iOS offer Strong Password + save
+              // the new credential to Keychain on a create-account screen.
+              textContentType="username"
+              autoComplete="email"
+              returnKeyType="next"
+              onSubmitEditing={() => passwordRef.current?.focus()}
+              editable={!submitting}
+            />
+            <AuthTextInput
+              ref={passwordRef}
+              label={t('login.fields.password')}
+              value={values.password}
+              onChangeText={setField('password')}
+              placeholder={t('login.placeholders.password')}
+              error={fieldErrors.password}
+              hint={t('login.signUp.passwordHint')}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              textContentType="newPassword"
+              autoComplete="new-password"
+              passwordRules="minlength: 8; maxlength: 128;"
+              returnKeyType="next"
+              onSubmitEditing={() => confirmRef.current?.focus()}
+              editable={!submitting}
+              showLabel={t('login.a11y.showPassword')}
+              hideLabel={t('login.a11y.hidePassword')}
+            />
+            <AuthTextInput
+              ref={confirmRef}
+              label={t('login.fields.confirmPassword')}
+              value={values.confirmPassword}
+              onChangeText={setField('confirmPassword')}
+              placeholder={t('login.placeholders.confirmPassword')}
+              error={fieldErrors.confirmPassword}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              textContentType="newPassword"
+              autoComplete="new-password"
+              returnKeyType="next"
+              onSubmitEditing={() => nameRef.current?.focus()}
+              editable={!submitting}
+              showLabel={t('login.a11y.showPassword')}
+              hideLabel={t('login.a11y.hidePassword')}
+            />
+            <AuthTextInput
+              ref={nameRef}
+              label={t('login.fields.name')}
+              value={values.name}
+              onChangeText={setField('name')}
+              placeholder={t('login.placeholders.name')}
+              error={fieldErrors.name}
+              autoCapitalize="words"
+              autoCorrect={false}
+              textContentType="name"
+              autoComplete="name"
+              returnKeyType="done"
+              onSubmitEditing={() => {
+                void onSubmit();
+              }}
+              editable={!submitting}
+            />
+            <Button
+              title={t('login.submit.signUp')}
+              onPress={() => {
+                void onSubmit();
+              }}
+              variant="filled"
+              size="large"
+              loading={submitting}
+              disabled={!canSubmit}
+              style={styles.submitButton}
+            />
+            {formError ? (
+              <Text variant="footnote" style={styles.errorText} accessibilityLiveRegion="polite">
+                {formError}
+              </Text>
+            ) : null}
+          </View>
+
+          <View style={styles.footer}>
+            <Text variant="subheadline" color={theme.systemColors.secondaryLabel}>
+              {t('login.links.haveAccount')}{' '}
+            </Text>
+            {/* replace (not back) so a deep-link straight to /auth/register still
+                lands on login rather than no-op'ing on an empty back stack. */}
+            <Pressable onPress={() => router.replace('/auth/login')} hitSlop={8} accessibilityRole="link">
+              <Text variant="subheadline" color={theme.systemColors.accent} style={styles.footerLink}>
+                {t('login.submit.signIn')}
+              </Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1, justifyContent: 'flex-start', padding: 24 },
+  intro: { marginBottom: 24 },
+  socialButtons: { gap: 12 },
+  // Apple's native button needs explicit height + width or it renders nothing.
+  appleButton: { width: '100%', height: 50 },
+  googleButton: { width: '100%', height: 50 },
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 24,
+    gap: 12,
+  },
+  dividerLine: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: 'rgba(60, 60, 67, 0.36)',
+  },
+  form: { gap: 12 },
+  submitButton: { alignSelf: 'stretch', marginTop: 4 },
+  errorText: { color: '#FF3B30', marginTop: 4 },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  footerLink: { fontWeight: '600' },
+});

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -13,11 +13,12 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../../src/lib/native-auth-analytics';
+import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
 import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { validateRegisterFields, isValid, type RegisterFieldErrors } from '../../src/lib/auth-validation';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useTheme } from '../../src/providers/theme-provider';
+import { useNativeOAuthSignIn } from '../../src/hooks/use-native-oauth-sign-in';
 import { AuthTextInput } from '../../src/components/AuthTextInput';
 import { Button } from '../../src/components/Button';
 import { Text } from '../../src/components/Text';
@@ -28,7 +29,7 @@ import { hapticLight } from '../../src/lib/haptics';
 type FieldKey = 'name' | 'email' | 'password' | 'confirmPassword';
 
 export default function RegisterScreen() {
-  const { register, signInWithApple, signInWithGoogle } = useAuth();
+  const { register } = useAuth();
   const { t } = useTranslation('auth');
   const theme = useTheme();
   const router = useRouter();
@@ -40,7 +41,11 @@ export default function RegisterScreen() {
   const [fieldErrors, setFieldErrors] = useState<RegisterFieldErrors>({});
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [oauthInProgress, setOauthInProgress] = useState(false);
+  // Shared Apple/Google flow; OAuth errors land in the same region as the form.
+  const { signIn: handleOAuthSignIn, inProgress: oauthInProgress } = useNativeOAuthSignIn({
+    isRegistration: true,
+    setError: setFormError,
+  });
 
   // Editing a field clears its inline error so a fixed field stops shouting.
   const setField = (key: FieldKey) => (text: string) => {
@@ -119,74 +124,6 @@ export default function RegisterScreen() {
     }
   }
 
-  // Mirrors login.tsx's handleOAuthSignIn — Apple/Google "sign up" is the same
-  // find-or-create flow as sign-in, tagged is_registration so the funnel can
-  // tell signup OAuth from login OAuth. (Kept local rather than shared to leave
-  // login's working flow untouched; a shared hook is a sensible follow-up.)
-  async function handleOAuthSignIn(provider: 'apple' | 'google') {
-    if (oauthInProgress) return;
-    setOauthInProgress(true);
-    setFormError(null);
-    track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native', is_registration: true });
-    const attemptStartedAt = Date.now();
-    try {
-      const result = provider === 'apple' ? await signInWithApple() : await signInWithGoogle();
-      if (result.success) {
-        track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: 'native', is_registration: true });
-        return;
-      }
-      if ('cancelled' in result) {
-        track(SHARED_EVENTS.LoginFailed, {
-          auth_method: provider,
-          flow: 'native',
-          failure_reason: 'cancel',
-          duration_ms: Date.now() - attemptStartedAt,
-          is_registration: true,
-        });
-        return;
-      }
-      const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
-      track(SHARED_EVENTS.LoginFailed, {
-        auth_method: provider,
-        flow: 'native',
-        failure_reason: oauthFailureReason,
-        failure_detail: result.error,
-        duration_ms: Date.now() - attemptStartedAt,
-        is_registration: true,
-      });
-      reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
-        level: result.error === 'network' ? 'warning' : 'error',
-        tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
-        extra: { status: result.status, server_error: result.error },
-      });
-      setFormError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
-    } catch (oauthError) {
-      // Prefer the native `.code` (e.g. an Android signing/client-id mismatch)
-      // over the opaque message — far more actionable in telemetry. Mirrors login.
-      const nativeErrorCode = nativeSignInErrorCode(oauthError);
-      track(SHARED_EVENTS.LoginFailed, {
-        auth_method: provider,
-        flow: 'native',
-        failure_reason: 'exception',
-        failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
-        duration_ms: Date.now() - attemptStartedAt,
-        is_registration: true,
-      });
-      reportError(oauthError, {
-        tags: {
-          source: 'native-auth',
-          provider,
-          flow: 'native',
-          mechanism: 'exception',
-          native_error_code: nativeErrorCode,
-        },
-      });
-      setFormError(t('nativeStart.oauthError'));
-    } finally {
-      setOauthInProgress(false);
-    }
-  }
-
   const isDark = theme.colorScheme === 'dark';
   const showAppleSignIn = Platform.OS === 'ios';
   const showGoogleSignIn = isGoogleSignInConfigured();
@@ -240,11 +177,11 @@ export default function RegisterScreen() {
               </View>
 
               <View style={styles.dividerRow}>
-                <View style={styles.dividerLine} />
+                <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
                 <Text variant="footnote" color={theme.systemColors.secondaryLabel}>
                   {t('login.divider')}
                 </Text>
-                <View style={styles.dividerLine} />
+                <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
               </View>
             </>
           )}
@@ -379,7 +316,6 @@ const styles = StyleSheet.create({
   dividerLine: {
     flex: 1,
     height: StyleSheet.hairlineWidth,
-    backgroundColor: 'rgba(60, 60, 67, 0.36)',
   },
   form: { gap: 12 },
   submitButton: { alignSelf: 'stretch', marginTop: 4 },

--- a/packages/mobile/app/auth/register.tsx
+++ b/packages/mobile/app/auth/register.tsx
@@ -13,7 +13,7 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
+import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../../src/lib/native-auth-analytics';
 import { isGoogleSignInConfigured } from '../../src/lib/auth';
 import { validateRegisterFields, isValid, type RegisterFieldErrors } from '../../src/lib/auth-validation';
 import { useAuth } from '../../src/providers/auth-provider';
@@ -161,16 +161,25 @@ export default function RegisterScreen() {
       });
       setFormError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
     } catch (oauthError) {
+      // Prefer the native `.code` (e.g. an Android signing/client-id mismatch)
+      // over the opaque message — far more actionable in telemetry. Mirrors login.
+      const nativeErrorCode = nativeSignInErrorCode(oauthError);
       track(SHARED_EVENTS.LoginFailed, {
         auth_method: provider,
         flow: 'native',
         failure_reason: 'exception',
-        failure_detail: oauthError instanceof Error ? oauthError.message : undefined,
+        failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
         duration_ms: Date.now() - attemptStartedAt,
         is_registration: true,
       });
       reportError(oauthError, {
-        tags: { source: 'native-auth', provider, flow: 'native', mechanism: 'exception' },
+        tags: {
+          source: 'native-auth',
+          provider,
+          flow: 'native',
+          mechanism: 'exception',
+          native_error_code: nativeErrorCode,
+        },
       });
       setFormError(t('nativeStart.oauthError'));
     } finally {
@@ -337,7 +346,12 @@ export default function RegisterScreen() {
             </Text>
             {/* replace (not back) so a deep-link straight to /auth/register still
                 lands on login rather than no-op'ing on an empty back stack. */}
-            <Pressable onPress={() => router.replace('/auth/login')} hitSlop={8} accessibilityRole="link">
+            <Pressable
+              onPress={() => router.replace('/auth/login')}
+              hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+              style={styles.footerLinkHit}
+              accessibilityRole="link"
+            >
               <Text variant="subheadline" color={theme.systemColors.accent} style={styles.footerLink}>
                 {t('login.submit.signIn')}
               </Text>
@@ -377,4 +391,6 @@ const styles = StyleSheet.create({
     marginTop: 24,
   },
   footerLink: { fontWeight: '600' },
+  // Keeps the tappable area at the 44pt/48dp minimum.
+  footerLinkHit: { minHeight: 44, justifyContent: 'center' },
 });

--- a/packages/mobile/src/components/AuthTextInput.tsx
+++ b/packages/mobile/src/components/AuthTextInput.tsx
@@ -148,6 +148,8 @@ export const AuthTextInput = forwardRef<RNTextInput, AuthTextInputProps>(functio
           style={[
             styles.glassInput,
             secureTextEntry && styles.glassInputWithToggle,
+            // A hairline red is a weak error signal; thicken the errored border.
+            error ? styles.glassInputErrored : null,
             { backgroundColor: inputBackground, borderColor: inputBorder, color: inputTextColor },
           ]}
           placeholder={placeholder}
@@ -162,7 +164,7 @@ export const AuthTextInput = forwardRef<RNTextInput, AuthTextInputProps>(functio
             style={styles.glassToggle}
             accessibilityRole="button"
             accessibilityLabel={revealed ? hideLabel : showLabel}
-            accessibilityState={{ expanded: revealed }}
+            accessibilityState={{ selected: revealed }}
           >
             <Icon name={revealed ? 'visibility.off' : 'visibility'} size={20} color={inputPlaceholderColor} />
           </Pressable>
@@ -196,6 +198,7 @@ const styles = StyleSheet.create({
   },
   // Leave room for the eye toggle so long values don't run under it.
   glassInputWithToggle: { paddingRight: 48 },
+  glassInputErrored: { borderWidth: 1 },
   glassToggle: {
     position: 'absolute',
     right: 12,

--- a/packages/mobile/src/components/AuthTextInput.tsx
+++ b/packages/mobile/src/components/AuthTextInput.tsx
@@ -1,0 +1,209 @@
+import { forwardRef, useState, type ComponentProps } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  TextInput as RNTextInput,
+  View,
+  type TextInputProps as RNTextInputProps,
+} from 'react-native';
+import { TextInput as PaperTextInput, HelperText } from 'react-native-paper';
+import { Text } from './Text';
+import { Icon } from './Icon';
+import { useTheme } from '../providers/theme-provider';
+import { iosSystemColors } from '../theme/ios-colors';
+
+// iOS systemRed — matches login.tsx's error text and is correct on the Liquid
+// Glass branch (which only ever resolves on iOS hardware).
+const GLASS_ERROR_COLOR = '#FF3B30';
+
+type AuthTextInputProps = {
+  label: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  /** Visible placeholder on the glass branch (Material uses the floating label). */
+  placeholder?: string;
+  /** Translated error message — renders inline and flips the field to its error state. */
+  error?: string;
+  /** Translated helper text shown when there's no error (e.g. a password rule). */
+  hint?: string;
+  /** When true, the field is a password: it masks input and shows a show/hide toggle. */
+  secureTextEntry?: boolean;
+  editable?: boolean;
+  keyboardType?: RNTextInputProps['keyboardType'];
+  autoCapitalize?: RNTextInputProps['autoCapitalize'];
+  autoCorrect?: boolean;
+  autoComplete?: RNTextInputProps['autoComplete'];
+  textContentType?: RNTextInputProps['textContentType'];
+  returnKeyType?: RNTextInputProps['returnKeyType'];
+  passwordRules?: string;
+  onSubmitEditing?: () => void;
+  /** Defaults to `label` so VoiceOver/TalkBack always have a name. */
+  accessibilityLabel?: string;
+  /** Show-password / hide-password labels for the toggle (already translated). */
+  showLabel?: string;
+  hideLabel?: string;
+};
+
+/**
+ * A single auth field that renders the Apple-HIG white input on the Liquid Glass
+ * variant and a Material 3 outlined Paper field on the Material variant — the
+ * same internal branch-on-`theme.variant` pattern `Button` uses, so call sites
+ * (login, register) stay identical across platforms. Password fields get a
+ * show/hide toggle; errors/hints render inline per field.
+ */
+export const AuthTextInput = forwardRef<RNTextInput, AuthTextInputProps>(function AuthTextInput(
+  {
+    label,
+    value,
+    onChangeText,
+    placeholder,
+    error,
+    hint,
+    secureTextEntry = false,
+    editable = true,
+    keyboardType,
+    autoCapitalize,
+    autoCorrect,
+    autoComplete,
+    textContentType,
+    returnKeyType,
+    passwordRules,
+    onSubmitEditing,
+    accessibilityLabel,
+    showLabel = 'Show password',
+    hideLabel = 'Hide password',
+  },
+  ref,
+) {
+  const theme = useTheme();
+  const [revealed, setRevealed] = useState(false);
+  const masked = secureTextEntry && !revealed;
+  const a11yLabel = accessibilityLabel ?? label;
+
+  // Shared native-input props so the two branches stay in lockstep.
+  const sharedInputProps = {
+    value,
+    onChangeText,
+    editable,
+    keyboardType,
+    autoCapitalize,
+    autoCorrect,
+    autoComplete,
+    textContentType,
+    returnKeyType,
+    passwordRules,
+    onSubmitEditing,
+    secureTextEntry: masked,
+  } as const;
+
+  if (theme.variant === 'material') {
+    return (
+      <View>
+        <PaperTextInput
+          // Paper forwards focus()/blur() to the native input; the ref shapes
+          // differ structurally, so cast to the prop type Paper expects.
+          ref={ref as unknown as ComponentProps<typeof PaperTextInput>['ref']}
+          mode="outlined"
+          label={label}
+          placeholder={placeholder}
+          error={Boolean(error)}
+          accessibilityLabel={a11yLabel}
+          right={
+            secureTextEntry ? (
+              <PaperTextInput.Icon
+                icon={revealed ? 'eye-off-outline' : 'eye-outline'}
+                onPress={() => setRevealed((prev) => !prev)}
+                accessibilityLabel={revealed ? hideLabel : showLabel}
+                forceTextInputFocus={false}
+              />
+            ) : undefined
+          }
+          {...sharedInputProps}
+        />
+        {error ? (
+          <HelperText type="error" visible accessibilityLiveRegion="polite">
+            {error}
+          </HelperText>
+        ) : hint ? (
+          <HelperText type="info" visible>
+            {hint}
+          </HelperText>
+        ) : null}
+      </View>
+    );
+  }
+
+  // Liquid Glass / iOS branch — login.tsx's white-in-dark-mode field, verbatim.
+  const isDark = theme.colorScheme === 'dark';
+  const inputBackground = isDark ? iosSystemColors.white : '#FFFFFF';
+  const inputBorder = error ? GLASS_ERROR_COLOR : isDark ? 'rgba(60, 60, 67, 0.36)' : 'rgba(60, 60, 67, 0.18)';
+  const inputTextColor = '#000000';
+  const inputPlaceholderColor = 'rgba(60, 60, 67, 0.6)';
+
+  return (
+    <View>
+      <View style={styles.glassInputWrap}>
+        <RNTextInput
+          ref={ref}
+          style={[
+            styles.glassInput,
+            secureTextEntry && styles.glassInputWithToggle,
+            { backgroundColor: inputBackground, borderColor: inputBorder, color: inputTextColor },
+          ]}
+          placeholder={placeholder}
+          placeholderTextColor={inputPlaceholderColor}
+          accessibilityLabel={a11yLabel}
+          {...sharedInputProps}
+        />
+        {secureTextEntry ? (
+          <Pressable
+            onPress={() => setRevealed((prev) => !prev)}
+            hitSlop={12}
+            style={styles.glassToggle}
+            accessibilityRole="button"
+            accessibilityLabel={revealed ? hideLabel : showLabel}
+            accessibilityState={{ expanded: revealed }}
+          >
+            <Icon name={revealed ? 'visibility.off' : 'visibility'} size={20} color={inputPlaceholderColor} />
+          </Pressable>
+        ) : null}
+      </View>
+      {error ? (
+        <Text
+          variant="footnote"
+          style={[styles.glassError, { color: GLASS_ERROR_COLOR }]}
+          accessibilityLiveRegion="polite"
+        >
+          {error}
+        </Text>
+      ) : hint ? (
+        <Text variant="footnote" color={theme.systemColors.secondaryLabel} style={styles.glassHint}>
+          {hint}
+        </Text>
+      ) : null}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  glassInputWrap: { position: 'relative', justifyContent: 'center' },
+  glassInput: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    fontSize: 17,
+  },
+  // Leave room for the eye toggle so long values don't run under it.
+  glassInputWithToggle: { paddingRight: 48 },
+  glassToggle: {
+    position: 'absolute',
+    right: 12,
+    height: 44,
+    width: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  glassError: { marginTop: 4 },
+  glassHint: { marginTop: 4 },
+});

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -79,6 +79,8 @@ export const iconMap = {
   // Create climb
   flame: { ios: 'flame', android: 'fire' },
   lock: { ios: 'lock', android: 'lock-outline' },
+  visibility: { ios: 'eye', android: 'eye-outline' },
+  'visibility.off': { ios: 'eye.slash', android: 'eye-off-outline' },
   'play.circle': { ios: 'play.circle', android: 'play-circle-outline' },
   'square.and.arrow.up.on.square': { ios: 'square.and.arrow.up.on.square', android: 'tray-arrow-up' },
   eraser: { ios: 'eraser', android: 'eraser' },

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -1,0 +1,110 @@
+import { useCallback, useState } from 'react';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { useAuth } from '../providers/auth-provider';
+import { track } from '../lib/analytics';
+import { reportError } from '../lib/error-reporting';
+import { classifyNativeAuthFailureReason, nativeSignInErrorCode } from '../lib/native-auth-analytics';
+import { useTranslation } from 'react-i18next';
+
+type Provider = 'apple' | 'google';
+
+type Options = {
+  /** Tags the analytics funnel so signup OAuth is distinguishable from login OAuth. */
+  isRegistration?: boolean;
+  /** Where the caller surfaces a translated failure message (and `null` to clear it). */
+  setError: (message: string | null) => void;
+};
+
+/**
+ * The native Apple/Google sign-in flow, shared by the login and register screens
+ * so the two can't drift (telemetry, error classification, Sentry tags, and the
+ * double-tap guard all live here once). Apple/Google "sign up" is the same
+ * find-or-create flow as sign-in, so the only difference between the two callers
+ * is the `is_registration` analytics tag. `setError` is injected because login
+ * shares one error region with credentials sign-in while register has its own.
+ */
+export function useNativeOAuthSignIn({ isRegistration = false, setError }: Options) {
+  const { signInWithApple, signInWithGoogle } = useAuth();
+  const { t } = useTranslation('auth');
+  const [inProgress, setInProgress] = useState(false);
+
+  const signIn = useCallback(
+    async (provider: Provider) => {
+      // A rapid double-tap would open two concurrent native sheets.
+      if (inProgress) return;
+      setInProgress(true);
+      setError(null);
+      const registrationProps = isRegistration ? { is_registration: true } : {};
+      track(SHARED_EVENTS.LoginAttempted, { auth_method: provider, flow: 'native', ...registrationProps });
+      // duration_ms separates a human dismissing the system sheet (seconds) from
+      // the flow dying programmatically (sub-second).
+      const attemptStartedAt = Date.now();
+      try {
+        const result = provider === 'apple' ? await signInWithApple() : await signInWithGoogle();
+        if (result.success) {
+          track(SHARED_EVENTS.LoginSucceeded, { auth_method: provider, flow: 'native', ...registrationProps });
+          // AuthProvider flips isAuthenticated and the redirect handles navigation.
+          return;
+        }
+        if ('cancelled' in result) {
+          // The user dismissed the provider sheet — not an error, no message shown.
+          track(SHARED_EVENTS.LoginFailed, {
+            auth_method: provider,
+            flow: 'native',
+            failure_reason: 'cancel',
+            duration_ms: Date.now() - attemptStartedAt,
+            ...registrationProps,
+          });
+          return;
+        }
+        // A real backend/token failure carrying the server's status + error.
+        const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
+        track(SHARED_EVENTS.LoginFailed, {
+          auth_method: provider,
+          flow: 'native',
+          failure_reason: oauthFailureReason,
+          failure_detail: result.error,
+          duration_ms: Date.now() - attemptStartedAt,
+          ...registrationProps,
+        });
+        // Surface to error tracking too: an OAuth 401 / no_id_token is a config
+        // bug (client-id audience mismatch, unconfigured backend) rather than a
+        // user typo. Network blips downgrade to a warning.
+        reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
+          level: result.error === 'network' ? 'warning' : 'error',
+          tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
+          extra: { status: result.status, server_error: result.error },
+        });
+        setError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
+      } catch (oauthError) {
+        // The native module threw (Play Services missing, no presenter, a
+        // signing/client-id mismatch, …). Prefer the native `.code` for
+        // failure_detail — far more actionable than the opaque message.
+        const nativeErrorCode = nativeSignInErrorCode(oauthError);
+        track(SHARED_EVENTS.LoginFailed, {
+          auth_method: provider,
+          flow: 'native',
+          failure_reason: 'exception',
+          failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
+          duration_ms: Date.now() - attemptStartedAt,
+          ...registrationProps,
+        });
+        reportError(oauthError, {
+          tags: {
+            source: 'native-auth',
+            provider,
+            flow: 'native',
+            mechanism: 'exception',
+            native_error_code: nativeErrorCode,
+          },
+        });
+        setError(t('nativeStart.oauthError'));
+      } finally {
+        setInProgress(false);
+      }
+    },
+    [inProgress, isRegistration, setError, signInWithApple, signInWithGoogle, t],
+  );
+
+  return { signIn, inProgress };
+}

--- a/packages/mobile/src/lib/__tests__/auth-validation.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-validation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMAIL_REGEX,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_MAX_LENGTH,
+  NAME_MAX_LENGTH,
+  validateLoginFields,
+  validateRegisterFields,
+  isValid,
+} from '../auth-validation';
+
+// A valid base for register cases — override one field per test so each
+// assertion isolates a single rule.
+function register(overrides: Partial<{ name: string; email: string; password: string; confirmPassword: string }> = {}) {
+  return validateRegisterFields({
+    name: '',
+    email: 'climber@example.com',
+    password: 'longenough',
+    confirmPassword: 'longenough',
+    ...overrides,
+  });
+}
+
+describe('EMAIL_REGEX', () => {
+  it.each(['a@b.co', 'first.last@sub.domain.io', 'x+tag@y.dev'])('accepts %s', (email) => {
+    expect(EMAIL_REGEX.test(email)).toBe(true);
+  });
+
+  it.each(['', 'no-at', 'no@dot', 'a@b.', '@b.co', 'a b@c.co', 'a@b c.co'])('rejects %s', (email) => {
+    expect(EMAIL_REGEX.test(email)).toBe(false);
+  });
+});
+
+describe('validateLoginFields', () => {
+  it('passes for a valid email + password', () => {
+    const errors = validateLoginFields({ email: 'a@b.co', password: 'pw' });
+    expect(isValid(errors)).toBe(true);
+  });
+
+  it('requires the email', () => {
+    expect(validateLoginFields({ email: '', password: 'pw' }).email).toBe('login.validation.emailRequired');
+  });
+
+  it('rejects a malformed email', () => {
+    expect(validateLoginFields({ email: 'nope', password: 'pw' }).email).toBe('login.validation.emailInvalid');
+  });
+
+  it('requires the password', () => {
+    expect(validateLoginFields({ email: 'a@b.co', password: '' }).password).toBe('login.validation.passwordRequired');
+  });
+
+  it('trims surrounding whitespace before validating the email', () => {
+    expect(isValid(validateLoginFields({ email: '  a@b.co  ', password: 'pw' }))).toBe(true);
+  });
+});
+
+describe('validateRegisterFields', () => {
+  it('passes when every field is valid (name optional)', () => {
+    expect(isValid(register())).toBe(true);
+  });
+
+  it('requires the email and rejects a malformed one', () => {
+    expect(register({ email: '' }).email).toBe('login.validation.emailRequired');
+    expect(register({ email: 'bad' }).email).toBe('login.validation.emailInvalid');
+  });
+
+  it('requires a password and enforces the min length', () => {
+    expect(register({ password: '', confirmPassword: '' }).password).toBe('login.validation.passwordRequiredCreate');
+    const tooShort = 'a'.repeat(PASSWORD_MIN_LENGTH - 1);
+    expect(register({ password: tooShort, confirmPassword: tooShort }).password).toBe(
+      'login.validation.passwordTooShort',
+    );
+  });
+
+  it('enforces the max length (matches the backend 128-char bound)', () => {
+    const atMax = 'a'.repeat(PASSWORD_MAX_LENGTH);
+    expect(register({ password: atMax, confirmPassword: atMax }).password).toBeUndefined();
+    const tooLong = 'a'.repeat(PASSWORD_MAX_LENGTH + 1);
+    expect(register({ password: tooLong, confirmPassword: tooLong }).password).toBe('login.validation.passwordTooLong');
+  });
+
+  it('accepts the exact min length', () => {
+    const atMin = 'a'.repeat(PASSWORD_MIN_LENGTH);
+    expect(register({ password: atMin, confirmPassword: atMin }).password).toBeUndefined();
+  });
+
+  it('requires confirmation and flags a mismatch', () => {
+    expect(register({ confirmPassword: '' }).confirmPassword).toBe('login.validation.confirmPasswordRequired');
+    expect(register({ password: 'longenough', confirmPassword: 'different1' }).confirmPassword).toBe(
+      'login.validation.passwordsMismatch',
+    );
+  });
+
+  it('allows a name up to the boundary and flags one past it', () => {
+    expect(register({ name: 'a'.repeat(NAME_MAX_LENGTH) }).name).toBeUndefined();
+    expect(register({ name: 'a'.repeat(NAME_MAX_LENGTH + 1) }).name).toBe('login.validation.nameTooLong');
+  });
+
+  it('trims a name before measuring it (whitespace-padded max passes)', () => {
+    expect(register({ name: `  ${'a'.repeat(NAME_MAX_LENGTH)}  ` }).name).toBeUndefined();
+  });
+});
+
+describe('isValid', () => {
+  it('is true for no errors and false when any field has an error', () => {
+    expect(isValid({})).toBe(true);
+    expect(isValid({ email: 'login.validation.emailRequired' })).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/auth-validation.ts
+++ b/packages/mobile/src/lib/auth-validation.ts
@@ -8,6 +8,7 @@
 
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MAX_LENGTH = 128;
 export const NAME_MAX_LENGTH = 100;
 
 export type LoginFieldErrors = { email?: string; password?: string };
@@ -54,6 +55,8 @@ export function validateRegisterFields(values: {
     errors.password = 'login.validation.passwordRequiredCreate';
   } else if (values.password.length < PASSWORD_MIN_LENGTH) {
     errors.password = 'login.validation.passwordTooShort';
+  } else if (values.password.length > PASSWORD_MAX_LENGTH) {
+    errors.password = 'login.validation.passwordTooLong';
   }
   if (!values.confirmPassword) {
     errors.confirmPassword = 'login.validation.confirmPasswordRequired';

--- a/packages/mobile/src/lib/auth-validation.ts
+++ b/packages/mobile/src/lib/auth-validation.ts
@@ -1,0 +1,69 @@
+// Pure, framework-free auth field validation shared by the mobile login and
+// register screens so the two can't drift. Each validator returns the i18n KEY
+// of the first failing rule per field (or leaves the field undefined), which the
+// screen passes to its `t('auth')` translator. Rules mirror the web validator
+// (packages/web/app/components/auth/validate-fields.ts) and the backend
+// /auth/native/register bounds, so the client never blocks an input the server
+// would accept, nor submits one the server will reject.
+
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const PASSWORD_MIN_LENGTH = 8;
+export const NAME_MAX_LENGTH = 100;
+
+export type LoginFieldErrors = { email?: string; password?: string };
+export type RegisterFieldErrors = {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+};
+
+export function validateLoginFields(values: { email: string; password: string }): LoginFieldErrors {
+  const errors: LoginFieldErrors = {};
+  const email = values.email.trim();
+  if (!email) {
+    errors.email = 'login.validation.emailRequired';
+  } else if (!EMAIL_REGEX.test(email)) {
+    errors.email = 'login.validation.emailInvalid';
+  }
+  if (!values.password) {
+    errors.password = 'login.validation.passwordRequired';
+  }
+  return errors;
+}
+
+export function validateRegisterFields(values: {
+  name?: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}): RegisterFieldErrors {
+  const errors: RegisterFieldErrors = {};
+  const email = values.email.trim();
+  const name = values.name?.trim() ?? '';
+
+  if (name.length > NAME_MAX_LENGTH) {
+    errors.name = 'login.validation.nameTooLong';
+  }
+  if (!email) {
+    errors.email = 'login.validation.emailRequired';
+  } else if (!EMAIL_REGEX.test(email)) {
+    errors.email = 'login.validation.emailInvalid';
+  }
+  if (!values.password) {
+    errors.password = 'login.validation.passwordRequiredCreate';
+  } else if (values.password.length < PASSWORD_MIN_LENGTH) {
+    errors.password = 'login.validation.passwordTooShort';
+  }
+  if (!values.confirmPassword) {
+    errors.confirmPassword = 'login.validation.confirmPasswordRequired';
+  } else if (values.confirmPassword !== values.password) {
+    errors.confirmPassword = 'login.validation.passwordsMismatch';
+  }
+  return errors;
+}
+
+/** True when no field has an error. */
+export function isValid(errors: LoginFieldErrors | RegisterFieldErrors): boolean {
+  return Object.keys(errors).length === 0;
+}

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -227,6 +227,49 @@ export async function signInWithCredentials(email: string, password: string): Pr
   return { success: true };
 }
 
+/**
+ * Create a Boardsesh account and sign the new user straight in. Mirrors
+ * signInWithCredentials: the backend's /auth/native/register returns the same
+ * JWT pair, so a 2xx response means the account exists AND the device is
+ * authenticated. A 409 (preserved in `status`) is how the UI tells "this email
+ * already has an account" apart from a real failure. `name` is optional.
+ */
+export async function registerWithCredentials(
+  email: string,
+  password: string,
+  name?: string,
+): Promise<CredentialsSignInResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${BACKEND_URL}/auth/native/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, ...(name ? { name } : {}) }),
+      signal: createTimeoutSignal(15_000),
+    });
+  } catch {
+    // Network failure / timeout. The caller maps this to a translated message.
+    return { success: false, status: null, error: 'network' };
+  }
+
+  if (!response.ok) {
+    let serverError = `HTTP ${response.status}`;
+    try {
+      const parsed = (await response.json()) as { error?: unknown };
+      if (typeof parsed.error === 'string' && parsed.error.length > 0) {
+        serverError = parsed.error;
+      }
+    } catch {
+      // Body wasn't JSON; fall back to the HTTP status string above.
+    }
+    return { success: false, status: response.status, error: serverError };
+  }
+
+  const data = (await response.json()) as { jwt: string; refreshToken: string; expiresAt: string };
+  await storeTokens(data.jwt, data.refreshToken, data.expiresAt);
+  return { success: true };
+}
+
 export async function signOut(): Promise<void> {
   const refreshToken = await getRefreshToken();
   if (refreshToken) {

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -86,6 +86,7 @@ function signedIn() {
     signInWithApple: vi.fn(),
     signInWithGoogle: vi.fn(),
     signInWithCredentials: vi.fn(),
+    register: vi.fn(),
     signOut: vi.fn(),
     refreshAuthState: vi.fn(),
   });
@@ -98,6 +99,7 @@ function signedOut() {
     signInWithApple: vi.fn(),
     signInWithGoogle: vi.fn(),
     signInWithCredentials: vi.fn(),
+    register: vi.fn(),
     signOut: vi.fn(),
     refreshAuthState: vi.fn(),
   });

--- a/packages/mobile/src/providers/__tests__/party-profile-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/party-profile-provider.test.tsx
@@ -67,6 +67,7 @@ describe('PartyProfileProvider', () => {
       signInWithApple: vi.fn(),
       signInWithGoogle: vi.fn(),
       signInWithCredentials: vi.fn(),
+      register: vi.fn(),
       signOut: vi.fn(),
       refreshAuthState: vi.fn(),
     });
@@ -110,6 +111,7 @@ describe('PartyProfileProvider', () => {
       signInWithApple: vi.fn(),
       signInWithGoogle: vi.fn(),
       signInWithCredentials: vi.fn(),
+      register: vi.fn(),
       signOut: vi.fn(),
       refreshAuthState: vi.fn(),
     });
@@ -137,6 +139,7 @@ describe('PartyProfileProvider', () => {
       signInWithApple: vi.fn(),
       signInWithGoogle: vi.fn(),
       signInWithCredentials: vi.fn(),
+      register: vi.fn(),
       signOut: vi.fn(),
       refreshAuthState: vi.fn(),
     });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -9,6 +9,7 @@ import {
   signInWithGoogle as authSignInWithGoogle,
   signOut as authSignOut,
   signInWithCredentials as authSignInWithCredentials,
+  registerWithCredentials as authRegisterWithCredentials,
   type CredentialsSignInResult,
   type OAuthSignInResult,
 } from '../lib/auth';
@@ -27,6 +28,7 @@ type AuthState = {
   signInWithApple: () => Promise<OAuthSignInResult>;
   signInWithGoogle: () => Promise<OAuthSignInResult>;
   signInWithCredentials: (email: string, password: string) => Promise<CredentialsSignInResult>;
+  register: (email: string, password: string, name?: string) => Promise<CredentialsSignInResult>;
   signOut: (method?: 'manual' | 'account_deleted') => Promise<void>;
   refreshAuthState: () => Promise<void>;
 };
@@ -187,6 +189,20 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     [checkAuth],
   );
 
+  // Registration auto-logs-in: the backend returns a JWT pair, so on success we
+  // re-run checkAuth — which flips isAuthenticated and lets the auth-group
+  // Redirect carry the user into the app, exactly like signInWithCredentials.
+  const register = useCallback(
+    async (email: string, password: string, name?: string): Promise<CredentialsSignInResult> => {
+      const result = await authRegisterWithCredentials(email, password, name);
+      if (result.success) {
+        await checkAuth();
+      }
+      return result;
+    },
+    [checkAuth],
+  );
+
   // `method` distinguishes a plain Sign Out ('manual') from an account deletion
   // ('account_deleted') in analytics, matching web. The cleanup is identical:
   // authSignOut()'s revoke is best-effort (src/lib/auth.ts), so revoking a token
@@ -236,10 +252,20 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       signInWithApple,
       signInWithGoogle,
       signInWithCredentials,
+      register,
       signOut,
       refreshAuthState: checkAuth,
     }),
-    [isAuthenticated, isLoading, signInWithApple, signInWithGoogle, signInWithCredentials, signOut, checkAuth],
+    [
+      isAuthenticated,
+      isLoading,
+      signInWithApple,
+      signInWithGoogle,
+      signInWithCredentials,
+      register,
+      signOut,
+      checkAuth,
+    ],
   );
 
   if (isLoading) {

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -25,6 +25,7 @@
       "passwordRequired": "Please enter your password",
       "passwordRequiredCreate": "Please enter a password",
       "passwordTooShort": "Password must be at least 8 characters",
+      "passwordTooLong": "Password must be less than 128 characters",
       "confirmPasswordRequired": "Please confirm your password",
       "passwordsMismatch": "Passwords do not match",
       "nameTooLong": "Name must be less than 100 characters"

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -48,7 +48,20 @@
       "registrationFailedRetry": "Registration failed. Please try again.",
       "checkEmail": "Please check your email to verify your account",
       "accountCreated": "Account created! Logging you in...",
-      "loginAfterCreate": "Please log in with your account"
+      "loginAfterCreate": "Please log in with your account",
+      "accountExists": "You've already got an account — sign in instead."
+    },
+    "signUp": {
+      "subtitle": "Your logbook, sends, and crew stay with you.",
+      "passwordHint": "At least 8 characters."
+    },
+    "links": {
+      "haveAccount": "Already have an account?",
+      "noAccount": "New here?"
+    },
+    "a11y": {
+      "showPassword": "Show password",
+      "hidePassword": "Hide password"
     }
   },
   "error": {

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -25,6 +25,7 @@
       "passwordRequired": "Escribe tu contraseña",
       "passwordRequiredCreate": "Escribe una contraseña",
       "passwordTooShort": "La contraseña debe tener al menos 8 caracteres",
+      "passwordTooLong": "La contraseña debe tener menos de 128 caracteres",
       "confirmPasswordRequired": "Confirma tu contraseña",
       "passwordsMismatch": "Las contraseñas no coinciden",
       "nameTooLong": "El nombre debe tener menos de 100 caracteres"

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -48,7 +48,20 @@
       "registrationFailedRetry": "No se pudo crear la cuenta. Inténtalo otra vez.",
       "checkEmail": "Revisa tu correo para verificar tu cuenta",
       "accountCreated": "¡Cuenta creada! Iniciando sesión...",
-      "loginAfterCreate": "Inicia sesión con tu cuenta"
+      "loginAfterCreate": "Inicia sesión con tu cuenta",
+      "accountExists": "Ya tienes una cuenta — inicia sesión."
+    },
+    "signUp": {
+      "subtitle": "Tu bitácora, tus encadenes y tu grupo se quedan contigo.",
+      "passwordHint": "Al menos 8 caracteres."
+    },
+    "links": {
+      "haveAccount": "¿Ya tienes una cuenta?",
+      "noAccount": "¿Nuevo por aquí?"
+    },
+    "a11y": {
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña"
     }
   },
   "error": {

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -25,6 +25,7 @@
       "passwordRequired": "Saisissez votre mot de passe",
       "passwordRequiredCreate": "Saisissez un mot de passe",
       "passwordTooShort": "Le mot de passe doit faire au moins 8 caractères",
+      "passwordTooLong": "Le mot de passe doit faire moins de 128 caractères",
       "confirmPasswordRequired": "Confirmez votre mot de passe",
       "passwordsMismatch": "Les mots de passe ne correspondent pas",
       "nameTooLong": "Le nom doit faire moins de 100 caractères"

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -48,7 +48,20 @@
       "registrationFailedRetry": "Impossible de créer le compte. Réessayez.",
       "checkEmail": "Consultez votre boîte mail pour vérifier votre compte",
       "accountCreated": "Compte créé ! Connexion en cours...",
-      "loginAfterCreate": "Connectez-vous avec votre compte"
+      "loginAfterCreate": "Connectez-vous avec votre compte",
+      "accountExists": "Vous avez déjà un compte — connectez-vous."
+    },
+    "signUp": {
+      "subtitle": "Votre carnet, vos croix et votre équipe restent avec vous.",
+      "passwordHint": "Au moins 8 caractères."
+    },
+    "links": {
+      "haveAccount": "Vous avez déjà un compte ?",
+      "noAccount": "Nouveau ici ?"
+    },
+    "a11y": {
+      "showPassword": "Afficher le mot de passe",
+      "hidePassword": "Masquer le mot de passe"
     }
   },
   "error": {


### PR DESCRIPTION
Closes #2851.

## What & why

The mobile app could only **sign in** — there was no way to create a Boardsesh account without leaving for the web UI (`rn:blocks` release blocker). This adds a native **Create account** screen reachable from the login screen that creates the account and **logs the user straight in** (no browser, no email round-trip). Aurora has no public signup API, so this is purely a Boardsesh account — the same `users` + `userCredentials` + `userProfiles` rows the web `/api/auth/register` route creates.

Two product decisions (confirmed with the requester):
1. **Platform-appropriate fields** — a new variant-aware `AuthTextInput` renders the HIG white input on Liquid Glass (iOS) and a Material 3 outlined Paper field on Android. `login.tsx` was refactored onto it too, so login and register match on each platform. (Designed with an Apple HIG + a Material 3 design pass.)
2. **Auto-login immediately** — registration returns a token pair, consistent with the existing native OAuth/credentials handlers (native login already ignores `emailVerified`).

## Backend
- New `POST /auth/native/register` (`packages/backend/src/handlers/native-auth.ts`) mirroring the web register route: hand-rolled validation matching the web Zod bounds, `email.trim().toLowerCase()` normalization (parity with native credentials login so the new account can log in afterward), duplicate pre-check → 409, then `users` + `userCredentials` (bcrypt cost 12) + `userProfiles` created in one `db.transaction` followed by `generateTokenPair` → returns `{ jwt, refreshToken, expiresAt }` (201). Reuses the existing rate-limit / CORS / `readBody` / `sendJson` helpers.
- `emailVerified` honours `EMAIL_VERIFICATION_ENABLED` (unverified when the gate is on) so this native path can't mint verified accounts that bypass web's verification gate (`auth-options.ts` blocks unverified credentials login when the flag is on). The backend has no email service and native login ignores `emailVerified`, so the user is still auto-logged-in on the device.
- Route wired in `server.ts`; new test suite `native-auth-register.test.ts` (18 cases: happy path, auto-login token shape, email normalization, verified/unverified by flag, duplicate 409, 400 variants, 405, 429, 503, oversized body).

## Mobile
- `registerWithCredentials` (`src/lib/auth.ts`) mirroring `signInWithCredentials`; `register()` added to `AuthProvider` — on success it runs `checkAuth()` and the existing auth-group `Redirect` lands the user in the app.
- New `app/auth/register.tsx`: Apple/Google above the form (Apple `SIGN_UP`), email → password → confirm → name (optional, last), per-field show/hide toggles, strong-password / Keychain hints (`textContentType`, `passwordRules`), inline per-field validation, 409 → "account exists" pointing at the Sign in link.
- New variant-aware `AuthTextInput` + shared `auth-validation.ts` (validators return i18n keys, rules mirror web's `validate-fields.ts`). `login.tsx` refactored onto both + a footer link to register; its submit button is now the themed `Button` (M3 on Android, glass on iOS).
- New `auth` i18n keys added to **all three** locales (en-US/es/fr).

## Validation
- `vp run typecheck:backend` ✓ · `vp run typecheck:mobile` ✓
- Backend native-auth suites: **103 passing** (register 18 + credentials/oauth/exchange) ✓
- Mobile project tests: **2010 passing** ✓
- i18n catalog parity: `auth.json` in parity across locales (the 2 failing `common.json` cases are pre-existing on `main`) ✓
- `vp run check:mobile-bundle` ✓ · `vp check` (lint+format) clean ✓
- Adversarial review pass: no critical issues; the items it raised (verification-flag handling, deep-link footer nav, dead i18n key) are fixed in this PR.

## Manual QA (do NOT test against prod)
The app defaults `BACKEND_URL` to prod, so registering against the default creates a real account. Test with a local backend + `EXPO_PUBLIC_BACKEND_URL=http://<LAN-ip>:<port> vp run dev:mobile`. Verify: new email → lands in-app; the same email/password then works on login (normalization parity); re-register → 409; short/mismatched password caught client-side; offline → network copy. Screenshot iOS + Android to confirm white/glass vs M3-outlined fields.

## Known follow-ups (out of scope)
- Add a `uniqueIndex` on lower-cased `users.email` (the duplicate guard is currently the pre-check, same latent gap the web route has). Risky against any existing prod duplicates, so deferred.
- Extract the native OAuth handler into a shared hook (currently duplicated between login and register to leave login's working flow untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)