### PR TITLE
fix(mobile): address beta video sheet review feedback

### DIFF
--- a/packages/mobile/src/components/AddBetaVideoSheet.tsx
+++ b/packages/mobile/src/components/AddBetaVideoSheet.tsx
@@ -8,8 +8,8 @@
 // Driven by a `visible` prop (mirrors ClimbActionsSheet / LogAscentSheet) so it
 // can present above the play drawer's own modal via stackBehavior="push".
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { View, StyleSheet, TextInput, Pressable } from 'react-native';
-import type { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { View, StyleSheet, Pressable } from 'react-native';
+import { BottomSheetTextInput, type BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
@@ -28,6 +28,7 @@ import { useToast } from '../providers/toast-provider';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing, borderRadius } from '../theme/tokens';
+import { textStyles } from '../theme/typography';
 
 type AddBetaVideoSheetProps = {
   visible: boolean;
@@ -181,7 +182,11 @@ export function AddBetaVideoSheet({ visible, climb, boardName, layoutId, angle, 
           <View style={[styles.dividerLine, { backgroundColor: systemColors.separator }]} />
         </View>
 
-        <TextInput
+        {/* `BottomSheetTextInput` (vs the bare `TextInput`) is what makes the host
+            sheet stay above the keyboard — paired with ModalSheet's
+            keyboardBehavior="interactive" it lifts the input clear of the
+            software keyboard instead of letting it cover this bottom field. */}
+        <BottomSheetTextInput
           value={url}
           onChangeText={setUrl}
           placeholder={t('mobile.betaVideos.urlPlaceholder')}
@@ -298,7 +303,7 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.md,
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[3],
-    fontSize: 16,
+    fontSize: textStyles.callout.fontSize,
   },
   errorText: {
     marginTop: -spacing[2],

--- a/packages/mobile/src/components/__tests__/add-beta-video-sheet-analytics.test.tsx
+++ b/packages/mobile/src/components/__tests__/add-beta-video-sheet-analytics.test.tsx
@@ -31,13 +31,19 @@ vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
-  TextInput: ({ onChangeText }: { onChangeText?: (text: string) => void }) => {
-    captured.onChangeText = onChangeText ?? null;
-    return createElement('input');
-  },
   Pressable: ({ onPress, children }: { onPress?: () => void; children?: ReactNode }) => {
     captured.onPress = onPress ?? null;
     return createElement('button', null, typeof children === 'function' ? null : children);
+  },
+}));
+
+// The paste field is a gorhom `BottomSheetTextInput` (so the host sheet lifts it
+// above the keyboard). Mock it here to capture onChangeText and to keep the real
+// module — which pulls in reanimated — out of the jsdom run.
+vi.mock('@gorhom/bottom-sheet', () => ({
+  BottomSheetTextInput: ({ onChangeText }: { onChangeText?: (text: string) => void }) => {
+    captured.onChangeText = onChangeText ?? null;
+    return createElement('input');
   },
 }));
 

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -40,6 +40,10 @@ const playlistSheet = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
 }));
 
+const betaVideoSheet = vi.hoisted(() => ({
+  props: null as null | Record<string, unknown>,
+}));
+
 const boardSheet = vi.hoisted(() => ({
   props: null as null | Record<string, unknown>,
   present: vi.fn(),
@@ -153,7 +157,10 @@ vi.mock('../../components/AddToPlaylistSheet', () => ({
   },
 }));
 vi.mock('../../components/AddBetaVideoSheet', () => ({
-  AddBetaVideoSheet: () => createElement('div', { 'data-add-beta-video': 'true' }),
+  AddBetaVideoSheet: (props: Record<string, unknown>) => {
+    betaVideoSheet.props = props;
+    return createElement('div', { 'data-add-beta-video': 'true' });
+  },
 }));
 vi.mock('../../components/QueueAddedSnackbar', () => ({
   QueueAddedSnackbar: () => createElement('div', { 'data-queue-snackbar': 'true' }),
@@ -712,6 +719,7 @@ describe('DrawerHostProvider climb actions', () => {
     queueSheet.props = null;
     climbActions.props = null;
     playlistSheet.props = null;
+    betaVideoSheet.props = null;
     boardSheet.props = null;
     boardSheet.present.mockClear();
     boardSheet.dismiss.mockClear();
@@ -771,6 +779,36 @@ describe('DrawerHostProvider climb actions', () => {
       layoutId: 1,
       sizeId: 10,
       setIds: '1,2',
+      angle: 40,
+    });
+  });
+
+  it('opens add beta video from climb actions, snapshotting the climb even as the actions sheet closes', async () => {
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    const { container } = renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'climb-x').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openClimbActions(climb);
+    });
+    await waitFor(() => expect(climbActions.props).not.toBeNull());
+
+    // Mirror ClimbActionsSheet.handleAddBetaVideo: fire onAddBetaVideo, then
+    // onClose (which clears climbActions). The beta-video sheet must still receive
+    // the snapshotted climb + board config — the ordering must not be load-bearing.
+    act(() => {
+      (climbActions.props?.onAddBetaVideo as (() => void) | undefined)?.();
+      (climbActions.props?.onClose as (() => void) | undefined)?.();
+    });
+
+    await waitFor(() => expect(container.querySelector('[data-add-beta-video]')).not.toBeNull());
+    expect(container.querySelector('[data-climb-actions]')).toBeNull();
+    expect(betaVideoSheet.props).toMatchObject({
+      visible: true,
+      climb,
+      boardName: 'kilter',
+      layoutId: 1,
       angle: 40,
     });
   });

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -348,6 +348,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const handleClimbActionsAddBetaVideo = useCallback(() => {
     if (!climbActions) return;
+    // ClimbActionsSheet fires this then calls onClose (which clears climbActions).
+    // We snapshot climb + boardConfig into betaVideoClimb here, so the beta-video
+    // sheet holds its own copy and never reads from climbActions after it's null —
+    // the open-then-close ordering in ClimbActionsSheet stays incidental, not load-bearing.
     setBetaVideoClimb({
       climb: climbActions.climb,
       boardConfig: climbActions.boardConfig,

--- a/packages/shared/climb-actions/src/instagram-caption.ts
+++ b/packages/shared/climb-actions/src/instagram-caption.ts
@@ -35,7 +35,10 @@ type BoardCaptionConfig = SimpleBoardCaptionConfig | CustomBoardCaptionConfig;
 
 function findMoonBoardLayoutName(layoutId: number | null | undefined): string | null {
   if (layoutId == null) return null;
-  return getLayoutById(layoutId)?.[1]?.name ?? null;
+  // getLayoutById returns the matched Object.entries() pair [key, layout] (or
+  // undefined). Destructure the layout out of the tuple instead of indexing [1].
+  const [, layout] = getLayoutById(layoutId) ?? [];
+  return layout?.name ?? null;
 }
 
 function buildMoonBoardCaption({ climbName, angle, grade, setter, layoutId }: InstagramCaptionInput): string {


### PR DESCRIPTION
Addresses the review feedback on the `AddBetaVideoSheet` flow.

## Changes

1. **Keyboard avoidance regression** (`AddBetaVideoSheet.tsx`) — the paste-URL field at the bottom used a bare `TextInput`, so the software keyboard covered it on short screens (the deleted `BetaVideoAddSheet` had keyboard handling). Swapped to gorhom's `BottomSheetTextInput`, the repo's canonical pattern (see `QuickTickBar`, `CommentSheet`, etc.) that pairs with `ModalSheet`'s `keyboardBehavior="interactive"` to lift the input clear of the keyboard.

2. **Hardcoded fontSize** (`AddBetaVideoSheet.tsx`) — replaced the inline `fontSize: 16` with the `textStyles.callout.fontSize` typography token for consistency with the rest of the file.

3. **Fragile tuple index** (`instagram-caption.ts`) — `getLayoutById(layoutId)?.[1]?.name` now destructures the `Object.entries()` pair (`const [, layout] = getLayoutById(layoutId) ?? []`) so the layout is pulled off the tuple by name rather than a bare `[1]`.

4. **Implicit closure dependency** (`drawer-host-provider.tsx`) — `handleClimbActionsAddBetaVideo` reads `climbActions`, which `closeClimbActions` clears. Documented that the handler snapshots `climb` + `boardConfig` into `betaVideoClimb`, so the beta-video sheet holds its own copy and the `ClimbActionsSheet` open-then-close ordering is incidental, not load-bearing.

5. **Missing integration coverage** — `drawer-host-provider.test.tsx` stubbed the beta-video sheet out entirely. The stub now captures props, and a new test exercises the full path (open climb actions → fire `onAddBetaVideo` then `onClose` → verify the actions sheet unmounts and the beta-video sheet mounts with the snapshotted climb), guarding the ordering concern from point 4.

## Validation

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile drawer-host-provider` — 16 passed
- `vp test run instagram-caption` — 7 passed
- `vp check --fix` on changed files — clean

https://claude.ai/code/session_012J6v3PwKU9eLWHChPLqGKS

---
_Generated by [Claude Code](https://claude.ai/code/session_012J6v3PwKU9eLWHChPLqGKS)_