### PR TITLE
feat(mobile): Liquid Glass fallback for older iPhones + any-phone opt-in

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -20,10 +20,11 @@ from the Boardsesh logo (built from the V11–V16 climbing-grade purples); the s
 each platform's own design system.
 
 - **Platform-native, not lowest-common-denominator.** The app renders in one of two variants —
-  **Liquid Glass** (Apple's iOS 26 look) or **Material 3** (everywhere else). The brand palette and
-  the component APIs are identical across both; the silhouettes, elevation, motion and type scale
-  follow whichever platform you're on. A control is the same product in both variants, drawn the way
-  that platform draws controls.
+  **Liquid Glass** (Apple's look) or **Material 3**. The variant is the _aesthetic_; it is distinct
+  from whether the device can render real iOS 26 glass _chrome_ (see "Aesthetic vs. capability"
+  below). The brand palette and the component APIs are identical across both; the silhouettes,
+  elevation, motion and type scale follow whichever variant you're in. A control is the same product
+  in both variants, drawn the way that platform draws controls.
 - **One violet across light and dark.** The brand reads violet in every scheme. Dark mode lifts the
   tint and brightens fills so the same identity stays legible on near-black — it is not a different
   palette.
@@ -42,25 +43,42 @@ Source: `packages/mobile/src/theme/resolve-ui-variant.ts`, `providers/theme-prov
 
 The whole app renders in one resolved `variant`:
 
-| Variant       | When                                                          | Look                                                                                     |
-| ------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `liquidGlass` | iOS 26 hardware (preferred, primary)                          | Apple Liquid Glass — floating glass capsules, soft corners, HIG type, reanimated springs |
-| `material`    | Everywhere else (Android, older iOS, or explicit user choice) | Material 3 — elevation, ripple, nav active-indicator pill, M3 type and corners           |
+| Variant       | When                                                  | Look                                                                                     |
+| ------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `liquidGlass` | Every iPhone by default; opt-in on Android            | Apple Liquid Glass — floating glass capsules, soft corners, HIG type, reanimated springs |
+| `material`    | Android by default; explicit user choice any platform | Material 3 — elevation, ripple, nav active-indicator pill, M3 type and corners           |
 
 The user's stored preference is `UiVariantPreference` = `'auto' | 'liquidGlass' | 'material'`.
-`'auto'` resolves against a synchronous native capability check (`useGlassCapability()` → iOS 26):
+`'auto'` resolves against the **platform**, not glass capability — Liquid Glass on every iPhone
+(including iOS < 26), Material on Android:
 
 ```ts
-export function resolveUiVariant(preference: UiVariantPreference, glassCapable: boolean): UiVariant {
+export function resolveUiVariant(preference: UiVariantPreference, autoPrefersGlass: boolean): UiVariant {
   if (preference === 'liquidGlass') return 'liquidGlass';
   if (preference === 'material') return 'material';
-  return glassCapable ? 'liquidGlass' : 'material'; // 'auto'
+  return autoPrefersGlass ? 'liquidGlass' : 'material'; // 'auto'; caller passes Platform.OS === 'ios'
 }
 ```
 
-Change it with `theme.setUiVariant(next)`. Material is drawn opaque (M3 tonal surfaces) on **every**
-platform when chosen — including iOS 26 hardware — so a user who picks Material gets a real M3 app,
-not a glass app with the blur turned off.
+Change it with `theme.setUiVariant(next)`. Every option is selectable on every platform — any phone
+can opt into Liquid Glass. Material is drawn opaque (M3 tonal surfaces) on **every** platform when
+chosen, so a user who picks Material gets a real M3 app, not a glass app with the blur turned off.
+
+### Aesthetic vs. capability
+
+The `variant` chooses the _aesthetic_; a separate, synchronous **capability** check decides whether
+real iOS 26 glass _chrome_ is used or a fallback stands in. Keep the two apart — Liquid Glass on an
+older iPhone is the variant with the chrome degraded, not Material.
+
+- `useGlassCapability()` → iOS 26 only (the native `GlassView` / `GlassContainer` API is present).
+- `useNativeTabBar()` (= `liquidGlass && useGlassCapability()`) gates the native `NativeTabs` glass
+  tab bar + `BottomAccessory`. When it's false — Material, **or** Liquid Glass on a non-capable
+  device — the JS `Tabs` + `MaterialTabBar` carry navigation and the floating `PersistentQueueBar`
+  carries the current climb. This is the canonical predicate; `useBottomChromeMetrics` keys tab-bar
+  geometry on it so the layout math matches the bar actually on screen.
+- Surfaces degrade in `GlassSurface` via `useEffectiveSurfaceMode()`: `glass` (iOS 26) → `blur`
+  (iOS < 26 frosted) → `material`/`solid` (Android, Reduce Transparency). Buttons stay JS
+  (`PressableSurface`) on every path, so any phone on Liquid Glass falls back to JS buttons safely.
 
 **Component routing rule.** Cross-variant components expose one public prop API and branch internally
 on `theme.variant`. Call sites never change. The canonical shape (`Button.tsx`, `Card.tsx`):

--- a/docs/ui/18-settings.md
+++ b/docs/ui/18-settings.md
@@ -63,10 +63,10 @@ The mobile More tab contains appearance and UI-style controls that have no direc
 
 - `SegmentedControl` with three options: Auto, Liquid Glass, Material.
 - Persisted as `UiVariantPreference` via `useTheme().setUiVariant`.
-- **Auto**: resolves to Liquid Glass on iOS 26+ hardware, Material everywhere else.
-- **Liquid Glass**: native iOS 26 `NativeTabs` tab bar + `GlassView` surfaces.
+- **Auto**: resolves to Liquid Glass on every iPhone (including iOS < 26, via the blur surface fallback) and Material on Android. `resolveUiVariant` keys this on `Platform.OS === 'ios'`, not glass capability.
+- **Liquid Glass**: the glass aesthetic. On a glass-capable device (iOS 26) it uses the native `NativeTabs` tab bar + `GlassView` surfaces; on iOS < 26 it falls back to the JS `MaterialTabBar` + frosted `BlurView` surfaces; on Android it falls back to the JS `MaterialTabBar` + solid surfaces. Whether the native tab bar mounts is gated by `useNativeTabBar()` (`liquidGlass && useGlassCapability()`).
 - **Material**: JS `MaterialTabBar` + opaque M3 surfaces.
-- The Liquid Glass option is shown **disabled** (not hidden) on devices that cannot render it (`useGlassCapability()` returns false — Android or iOS < 26). An explanatory footnote switches between `mobile.more.uiStyle.description` and `mobile.more.uiStyle.glassUnavailable` based on capability.
+- All three options are always **selectable** on every platform — any phone can opt into Liquid Glass, falling back to JS buttons where the native iOS 26 chrome can't render. An explanatory footnote switches between `mobile.more.uiStyle.description` (glass-capable), `mobile.more.uiStyle.glassFallback` (iOS < 26), and `mobile.more.uiStyle.glassFallbackAndroid` (Android) based on capability and platform.
 
 **Grade Format** (V-Grade / Font / Both):
 

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -9,6 +9,10 @@ const cfg = vi.hoisted(() => ({
   nativeAccessoryActive: true,
   hasCurrentClimb: false,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  // Whether the device can render real iOS 26 glass chrome. The native tab bar
+  // mounts only for the Liquid Glass variant on a capable device; everything else
+  // (Material, plus Liquid Glass on iOS < 26 / Android) takes the JS tab bar.
+  glassCapable: true,
   platformOS: 'ios' as 'ios' | 'android',
   materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean } }>,
 }));
@@ -54,6 +58,7 @@ vi.mock('../../../src/providers/theme-provider', () => ({
 
 vi.mock('../../../src/hooks/use-bottom-accessory', () => ({
   useNativeAccessoryActive: () => cfg.nativeAccessoryActive,
+  useNativeTabBar: () => cfg.variant === 'liquidGlass' && cfg.glassCapable,
 }));
 
 // Stub the Material-variant path so it doesn't pull in native modules.
@@ -137,6 +142,7 @@ describe('TabLayout', () => {
     cfg.nativeAccessoryActive = true;
     cfg.hasCurrentClimb = false;
     cfg.variant = 'liquidGlass';
+    cfg.glassCapable = true;
     cfg.platformOS = 'ios';
     cfg.materialScreens = [];
   });
@@ -159,6 +165,25 @@ describe('TabLayout', () => {
 
     render(<TabLayout />);
 
+    expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
+      'home',
+      'climbs',
+      'record',
+      'discover',
+      'profile',
+    ]);
+  });
+
+  it('falls back to the JS Material tab bar for Liquid Glass on a non-capable device', () => {
+    // Older iPhone / Android on the Liquid Glass variant: the native iOS 26 tab bar
+    // can't render, so the JS Tabs + MaterialTabBar carry the navigation instead.
+    cfg.variant = 'liquidGlass';
+    cfg.glassCapable = false;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs-material="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tabs="true"]')).toBeNull();
     expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
       'home',
       'climbs',

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -10,7 +10,7 @@ import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBo
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
-import { useNativeAccessoryActive } from '../../src/hooks/use-bottom-accessory';
+import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
 
 // Cold-start on Home: the leftmost tab carries the beta shelf and followed
 // activity feed, while Climbs remains the search surface one tab over. Drives
@@ -30,17 +30,19 @@ const materialTabIcon =
   );
 
 /**
- * Bottom tabs. The Liquid Glass variant uses the system Liquid Glass tab bar
- * (`expo-router/unstable-native-tabs`) with a native `BottomAccessory` platter
- * for the current climb + tick. The Material variant uses a JS `Tabs` navigator
- * with the Material 3 `MaterialTabBar`; its climb/tick chrome rides the floating
- * `PersistentQueueBar` (the native accessory is Liquid-Glass-only).
+ * Bottom tabs. The system Liquid Glass tab bar (`expo-router/unstable-native-tabs`)
+ * — with a native `BottomAccessory` platter for the current climb + tick — is used
+ * only on the Liquid Glass variant AND a glass-capable device (iOS 26). Everywhere
+ * else (Material, plus Liquid Glass on iOS < 26 / Android) falls back to a JS `Tabs`
+ * navigator with the Material 3 `MaterialTabBar`; its climb/tick chrome rides the
+ * floating `PersistentQueueBar` (the native accessory is iOS-26-only).
  */
 export default function TabLayout() {
   const { t } = useTranslation('common');
   const { t: tPlaylists } = useTranslation('playlists');
   const { t: tSession } = useTranslation('session');
-  const { variant, systemColors } = useTheme();
+  const { systemColors } = useTheme();
+  const nativeTabBar = useNativeTabBar();
   const nativeAccessoryActive = useNativeAccessoryActive();
 
   // Record-tab status cue: a badge when a board is connected over Bluetooth or a
@@ -57,7 +59,7 @@ export default function TabLayout() {
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
 
-  if (variant === 'material') {
+  if (!nativeTabBar) {
     return (
       <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
         <Tabs.Screen

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -59,9 +59,6 @@ export default function MoreScreen() {
     { key: 'liquidGlass', label: t('mobile.more.uiStyle.liquidGlass') },
     { key: 'material', label: t('mobile.more.uiStyle.material') },
   ];
-  // Liquid Glass can't render on Android / iOS < 26, so show it disabled there
-  // rather than hide it — more honest than a no-op control.
-  const disabledUiStyles = glassCapable ? undefined : new Set<UiVariantPreference>(['liquidGlass']);
 
   const gradeFormatOptions: { key: GradeDisplayFormat; label: string }[] = [
     { key: 'v-grade', label: t('mobile.more.gradeFormat.vGrade') },
@@ -142,12 +139,11 @@ export default function MoreScreen() {
             options={uiStyleOptions}
             selectedKey={uiVariantPreference}
             onSelect={(key) => void setUiVariant(key)}
-            disabledKeys={disabledUiStyles}
             trackColor={systemColors.fill}
             accessibilityLabel={t('mobile.more.uiStyle.title')}
           />
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
-            {glassCapable ? t('mobile.more.uiStyle.description') : t('mobile.more.uiStyle.glassUnavailable')}
+            {glassCapable ? t('mobile.more.uiStyle.description') : t('mobile.more.uiStyle.glassFallback')}
           </Text>
         </View>
       </View>

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,5 +1,5 @@
 import { router } from 'expo-router';
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import type { ThemeOverride, UiVariantPreference } from '@boardsesh/key-value-storage';
@@ -59,6 +59,14 @@ export default function MoreScreen() {
     { key: 'liquidGlass', label: t('mobile.more.uiStyle.liquidGlass') },
     { key: 'material', label: t('mobile.more.uiStyle.material') },
   ];
+  // Hint copy: capable iPhones explain the Auto behaviour; older iPhones get the
+  // iOS-26 upgrade note; Android gets a glass-fallback note without the (irrelevant)
+  // iOS-26 reference.
+  const uiStyleHint = glassCapable
+    ? t('mobile.more.uiStyle.description')
+    : Platform.OS === 'ios'
+      ? t('mobile.more.uiStyle.glassFallback')
+      : t('mobile.more.uiStyle.glassFallbackAndroid');
 
   const gradeFormatOptions: { key: GradeDisplayFormat; label: string }[] = [
     { key: 'v-grade', label: t('mobile.more.gradeFormat.vGrade') },
@@ -143,7 +151,7 @@ export default function MoreScreen() {
             accessibilityLabel={t('mobile.more.uiStyle.title')}
           />
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
-            {glassCapable ? t('mobile.more.uiStyle.description') : t('mobile.more.uiStyle.glassFallback')}
+            {uiStyleHint}
           </Text>
         </View>
       </View>

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -73,6 +73,9 @@ vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant
 vi.mock('../../../hooks/use-bottom-accessory', () => ({
   isBottomAccessoryAvailable: () => false,
   useNativeAccessoryActive: () => cfg.nativeAccessoryActive,
+  // Native tab bar and native accessory share the same capability gate (iOS 26 +
+  // Liquid Glass), so the accessory flag doubles as the tab-bar signal here.
+  useNativeTabBar: () => cfg.nativeAccessoryActive,
 }));
 vi.mock('../ClimbCapsule', () => ({
   ClimbCapsule: ({

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -13,6 +13,7 @@ const cfg = vi.hoisted(() => ({
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   measuredTabBarHeight: null as number | null,
   nativeAccessoryActive: false,
+  nativeTabBar: false,
 }));
 
 vi.mock('react-native', () => ({
@@ -72,10 +73,11 @@ vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant
 // reads now (variant-aware); the capability function stays for other callers.
 vi.mock('../../../hooks/use-bottom-accessory', () => ({
   isBottomAccessoryAvailable: () => false,
+  // Drive each hook from its own flag: the native tab bar and the native accessory
+  // can diverge (e.g. a capable device with no current climb mounts the bar but not
+  // the accessory), so the tests keep them independent.
   useNativeAccessoryActive: () => cfg.nativeAccessoryActive,
-  // Native tab bar and native accessory share the same capability gate (iOS 26 +
-  // Liquid Glass), so the accessory flag doubles as the tab-bar signal here.
-  useNativeTabBar: () => cfg.nativeAccessoryActive,
+  useNativeTabBar: () => cfg.nativeTabBar,
 }));
 vi.mock('../ClimbCapsule', () => ({
   ClimbCapsule: ({
@@ -124,6 +126,7 @@ describe('PersistentQueueBar', () => {
     cfg.variant = 'liquidGlass';
     cfg.measuredTabBarHeight = null;
     cfg.nativeAccessoryActive = false;
+    cfg.nativeTabBar = false;
   });
 
   it('renders nothing when no climb is current', () => {
@@ -140,6 +143,7 @@ describe('PersistentQueueBar', () => {
 
   it('does not render the JS toolbar when the native bottom accessory is active', () => {
     cfg.nativeAccessoryActive = true;
+    cfg.nativeTabBar = true;
     cfg.insideTabs = true;
 
     const { container } = render(<PersistentQueueBar />);
@@ -150,6 +154,7 @@ describe('PersistentQueueBar', () => {
 
   it('keeps the JS toolbar fallback outside tabs when the native accessory path is active', () => {
     cfg.nativeAccessoryActive = true;
+    cfg.nativeTabBar = true;
     cfg.insideTabs = false;
 
     const { container } = render(<PersistentQueueBar />);

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -17,6 +17,7 @@ describe('computeBottomChromeMetrics', () => {
   it('reserves nothing extra outside the tabs group', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
+      usesNativeTabBar: false,
       insetsBottom: 34,
       insideTabs: false,
       hasCurrentClimb: false,
@@ -34,6 +35,7 @@ describe('computeBottomChromeMetrics', () => {
   it('reserves the JS toolbar when a climb is set and the native accessory is unavailable', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
+      usesNativeTabBar: true,
       insetsBottom: 0,
       insideTabs: true,
       hasCurrentClimb: true,
@@ -46,9 +48,31 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.fixedFooterBottom).toBe(TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
   });
 
+  it('clears the JS Material tab bar for Liquid Glass on a non-capable device', () => {
+    // Older iPhone / Android on Liquid Glass: the variant is liquidGlass (floating
+    // island queue chrome → TOOLBAR_RESERVE) but the rendered bar is the 80dp JS
+    // MaterialTabBar, which sits in flow rather than overlaying content.
+    const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
+      usesNativeTabBar: false,
+      insetsBottom: 0,
+      insideTabs: true,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: false,
+    });
+    expect(metrics.jsQueueToolbarVisible).toBe(true);
+    expect(metrics.jsQueueReserve).toBe(TOOLBAR_RESERVE);
+    expect(metrics.tabBarHeight).toBe(MATERIAL_TAB_BAR_HEIGHT);
+    expect(metrics.scrollBottomPadding).toBe(MATERIAL_TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
+    expect(metrics.floatingControlBottom).toBe(MATERIAL_TAB_BAR_HEIGHT + TOOLBAR_RESERVE);
+    // JS bar is in flow, so a fixed footer clears only the queue chrome, not the bar.
+    expect(metrics.fixedFooterBottom).toBe(TOOLBAR_RESERVE);
+  });
+
   it('reserves the docked Material bar when the JS toolbar is visible', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'material',
+      usesNativeTabBar: false,
       insetsBottom: 0,
       insideTabs: true,
       hasCurrentClimb: true,
@@ -65,6 +89,7 @@ describe('computeBottomChromeMetrics', () => {
   it('does not pad scroll content for the UIKit-owned native accessory', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
+      usesNativeTabBar: true,
       insetsBottom: 0,
       insideTabs: true,
       hasCurrentClimb: true,
@@ -84,6 +109,7 @@ describe('computeBottomChromeMetrics', () => {
   it('reserves queue chrome for fixed footers outside the tabs group', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
+      usesNativeTabBar: false,
       insetsBottom: 34,
       insideTabs: false,
       hasCurrentClimb: true,
@@ -98,6 +124,7 @@ describe('computeBottomChromeMetrics', () => {
   it('keeps the tab bar but no toolbar reserve when no climb is set, even if the accessory is mounted', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'liquidGlass',
+      usesNativeTabBar: true,
       insetsBottom: 34,
       insideTabs: true,
       hasCurrentClimb: false,
@@ -113,6 +140,7 @@ describe('computeBottomChromeMetrics', () => {
   it('keeps scroll tab clearance but not fixed-footer tab clearance inside Material tabs', () => {
     const metrics = computeBottomChromeMetrics({
       uiVariant: 'material',
+      usesNativeTabBar: false,
       insetsBottom: 24,
       insideTabs: true,
       hasCurrentClimb: false,
@@ -129,6 +157,7 @@ describe('computeBottomChromeMetrics', () => {
       for (const nativeAccessoryMounted of [true, false]) {
         const metrics = computeBottomChromeMetrics({
           uiVariant: 'liquidGlass',
+          usesNativeTabBar: true,
           insetsBottom: 0,
           insideTabs: true,
           hasCurrentClimb,

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -25,6 +25,9 @@ vi.mock('react-native', () => ({
 
 vi.mock('expo-glass-effect', () => ({
   isLiquidGlassAvailable: () => cfg.liquidGlassAvailable,
+  // useGlassCapability (via useNativeTabBar) also checks the GlassView API; gate it
+  // on the same flag so a single switch models a fully (in)capable device.
+  isGlassEffectAPIAvailable: () => cfg.liquidGlassAvailable,
 }));
 
 vi.mock('expo-router/unstable-native-tabs', () => ({
@@ -43,7 +46,7 @@ vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({ variant: cfg.variant }),
 }));
 
-import { isBottomAccessoryAvailable, useNativeAccessoryActive } from '../use-bottom-accessory';
+import { isBottomAccessoryAvailable, useNativeAccessoryActive, useNativeTabBar } from '../use-bottom-accessory';
 
 describe('use-bottom-accessory', () => {
   beforeEach(() => {
@@ -118,5 +121,35 @@ describe('use-bottom-accessory', () => {
     const { result } = renderHook(() => useNativeAccessoryActive());
 
     expect(result.current).toBe(false);
+  });
+
+  describe('useNativeTabBar', () => {
+    it('is true only for the Liquid Glass variant on a glass-capable device', () => {
+      const { result, rerender } = renderHook(() => useNativeTabBar());
+
+      expect(result.current).toBe(true);
+
+      cfg.variant = 'material';
+      rerender();
+
+      expect(result.current).toBe(false);
+    });
+
+    it('is false on the Liquid Glass variant when the device is not glass-capable', () => {
+      // Older iPhone / Android on Liquid Glass: the JS MaterialTabBar renders instead.
+      cfg.liquidGlassAvailable = false;
+
+      const { result } = renderHook(() => useNativeTabBar());
+
+      expect(result.current).toBe(false);
+    });
+
+    it('is false off iOS even on the Liquid Glass variant', () => {
+      cfg.platformOS = 'android';
+
+      const { result } = renderHook(() => useNativeTabBar());
+
+      expect(result.current).toBe(false);
+    });
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -7,6 +7,9 @@ const cfg = vi.hoisted(() => ({
   platformOS: 'ios' as 'ios' | 'android',
   reactNativeMinor: 82 as number | undefined,
   liquidGlassAvailable: true,
+  // The two expo-glass-effect probes are tracked separately so a test can model
+  // them diverging (Liquid Glass available, GlassView API not).
+  glassEffectApiAvailable: true,
   nativeTabs: {} as unknown,
   bottomAccessory: {} as unknown,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
@@ -25,9 +28,7 @@ vi.mock('react-native', () => ({
 
 vi.mock('expo-glass-effect', () => ({
   isLiquidGlassAvailable: () => cfg.liquidGlassAvailable,
-  // useGlassCapability (via useNativeTabBar) also checks the GlassView API; gate it
-  // on the same flag so a single switch models a fully (in)capable device.
-  isGlassEffectAPIAvailable: () => cfg.liquidGlassAvailable,
+  isGlassEffectAPIAvailable: () => cfg.glassEffectApiAvailable,
 }));
 
 vi.mock('expo-router/unstable-native-tabs', () => ({
@@ -53,6 +54,7 @@ describe('use-bottom-accessory', () => {
     cfg.platformOS = 'ios';
     cfg.reactNativeMinor = 82;
     cfg.liquidGlassAvailable = true;
+    cfg.glassEffectApiAvailable = true;
     cfg.nativeTabs = {};
     cfg.bottomAccessory = {};
     cfg.variant = 'liquidGlass';
@@ -151,5 +153,19 @@ describe('use-bottom-accessory', () => {
 
       expect(result.current).toBe(false);
     });
+  });
+
+  it('keeps the accessory and the native tab bar consistent when the glass APIs diverge', () => {
+    // Liquid Glass reports available but the GlassView API does not: the native tab
+    // bar falls back to JS, and the accessory (which lives inside NativeTabs) must
+    // agree and stay inactive — otherwise the JS queue toolbar gets suppressed for an
+    // accessory that never mounts. Both predicates share useGlassCapability() now.
+    cfg.glassEffectApiAvailable = false;
+
+    const tabBar = renderHook(() => useNativeTabBar());
+    const accessory = renderHook(() => useNativeAccessoryActive());
+
+    expect(tabBar.result.current).toBe(false);
+    expect(accessory.result.current).toBe(false);
   });
 });

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -21,6 +21,13 @@ import {
 export type BottomChromeInputs = {
   /** Resolved UI variant; controls the JS toolbar shape/reserve. */
   uiVariant: UiVariant;
+  /**
+   * Whether the native iOS 26 tab bar (`NativeTabs`) is the one on screen, as
+   * opposed to the JS `MaterialTabBar`. This is the *rendered tab bar*, which can
+   * differ from `uiVariant`: Liquid Glass on iOS < 26 / Android falls back to the
+   * JS bar. Drives tab-bar height + whether the bar overlays content.
+   */
+  usesNativeTabBar: boolean;
   /** Bottom safe-area inset. */
   insetsBottom: number;
   /** Whether the current route is inside the (tabs) group (tab bar present). */
@@ -67,6 +74,7 @@ export type BottomChromeMetrics = {
  */
 export function computeBottomChromeMetrics({
   uiVariant,
+  usesNativeTabBar,
   insetsBottom,
   insideTabs,
   hasCurrentClimb,
@@ -74,12 +82,15 @@ export function computeBottomChromeMetrics({
 }: BottomChromeInputs): BottomChromeMetrics {
   const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
   const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
-  // The Material variant renders the taller M3 JS nav bar; Liquid Glass uses the
-  // native 49pt iOS tab bar. Floating overlays (FAB, snackbar) and scroll padding
-  // clear this height, so it has to track the real bar per variant.
-  const tabBarConstant = uiVariant === 'material' ? MATERIAL_TAB_BAR_HEIGHT : TAB_BAR_HEIGHT;
+  // The native iOS tab bar is 49pt; the JS M3 `MaterialTabBar` is taller. Key this
+  // on the *rendered* bar, not the variant — Liquid Glass on iOS < 26 / Android
+  // falls back to the JS bar. Floating overlays (FAB, snackbar) and scroll padding
+  // clear this height, so it has to track the real bar on screen.
+  const tabBarConstant = usesNativeTabBar ? TAB_BAR_HEIGHT : MATERIAL_TAB_BAR_HEIGHT;
   const tabBarHeight = insideTabs ? tabBarConstant : 0;
-  const tabBarOverlaysContent = insideTabs && uiVariant !== 'material';
+  // Only the native tab bar overlays content (UIKit draws it over the scroll view);
+  // the JS `MaterialTabBar` sits in flow.
+  const tabBarOverlaysContent = insideTabs && usesNativeTabBar;
   // The Material bar reserves its full height even though it's tucked ~2px into the
   // tab bar (MATERIAL_TABBAR_OVERLAP in persistent-queue-bar), so its visible height
   // above the tab bar is ~2px less. The resulting 2px of extra scroll padding is

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useTheme } from '../providers/theme-provider';
+import { useGlassCapability } from './use-glass-capability';
 
 /**
  * Whether the device *can* host `NativeTabs.BottomAccessory` — the pure
@@ -21,4 +22,18 @@ export function isBottomAccessoryAvailable(): boolean {
 export function useNativeAccessoryActive(): boolean {
   const { variant } = useTheme();
   return variant === 'liquidGlass' && isBottomAccessoryAvailable();
+}
+
+/**
+ * Whether the native iOS 26 Liquid Glass tab bar (`NativeTabs`) is in use right
+ * now: the Liquid Glass variant on a glass-capable device. The single canonical
+ * predicate for "the native tab bar renders" — everything else (Material, plus
+ * Liquid Glass on iOS < 26 / Android) falls back to the JS `Tabs` + `MaterialTabBar`.
+ * Drives the tab-bar choice in `_layout` and the tab-bar geometry in
+ * `useBottomChromeMetrics`, so the two never disagree about which bar is on screen.
+ */
+export function useNativeTabBar(): boolean {
+  const { variant } = useTheme();
+  const glassCapable = useGlassCapability();
+  return variant === 'liquidGlass' && glassCapable;
 }

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -14,17 +14,6 @@ export function isBottomAccessoryAvailable(): boolean {
 }
 
 /**
- * Whether the native bottom accessory is actually in use right now: the device
- * supports it AND the user is on the Liquid Glass variant. On the Material
- * variant the JS tab bar replaces `NativeTabs`, so the current climb + tick ride
- * the floating `PersistentQueueBar` instead and this returns false.
- */
-export function useNativeAccessoryActive(): boolean {
-  const { variant } = useTheme();
-  return variant === 'liquidGlass' && isBottomAccessoryAvailable();
-}
-
-/**
  * Whether the native iOS 26 Liquid Glass tab bar (`NativeTabs`) is in use right
  * now: the Liquid Glass variant on a glass-capable device. The single canonical
  * predicate for "the native tab bar renders" — everything else (Material, plus
@@ -36,4 +25,18 @@ export function useNativeTabBar(): boolean {
   const { variant } = useTheme();
   const glassCapable = useGlassCapability();
   return variant === 'liquidGlass' && glassCapable;
+}
+
+/**
+ * Whether the native bottom accessory is actually in use right now. The accessory
+ * lives *inside* `NativeTabs`, so it requires the native tab bar to be on screen —
+ * gating it on `useNativeTabBar()` (rather than re-deriving from the variant)
+ * guarantees the two share the same `useGlassCapability()` check. If they used
+ * different `expo-glass-effect` predicates and diverged, the metrics could suppress
+ * the JS queue toolbar for an accessory that never actually mounts. On the Material
+ * variant / non-capable devices the current climb + tick ride the floating
+ * `PersistentQueueBar` instead and this returns false.
+ */
+export function useNativeAccessoryActive(): boolean {
+  return useNativeTabBar() && isBottomAccessoryAvailable();
 }

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useHasActiveClimb } from '../providers/queue-provider';
 import { useTheme } from '../providers/theme-provider';
 import { isTabsRoute } from '../lib/route-segments';
-import { useNativeAccessoryActive } from './use-bottom-accessory';
+import { useNativeAccessoryActive, useNativeTabBar } from './use-bottom-accessory';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 
 /**
@@ -24,16 +24,19 @@ export function useBottomChromeMetrics() {
   const insideTabs = isTabsRoute(segments);
   const nativeAccessoryActive = useNativeAccessoryActive();
   const nativeAccessoryMounted = insideTabs && nativeAccessoryActive;
+  const nativeTabBar = useNativeTabBar();
+  const usesNativeTabBar = insideTabs && nativeTabBar;
 
   return useMemo(
     () =>
       computeBottomChromeMetrics({
         uiVariant: variant,
+        usesNativeTabBar,
         insetsBottom: insets.bottom,
         insideTabs,
         hasCurrentClimb,
         nativeAccessoryMounted,
       }),
-    [variant, insets.bottom, insideTabs, hasCurrentClimb, nativeAccessoryMounted],
+    [variant, usesNativeTabBar, insets.bottom, insideTabs, hasCurrentClimb, nativeAccessoryMounted],
   );
 }

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -32,8 +32,9 @@ vi.mock('react-native', () => ({
   Appearance: { setColorScheme: vi.fn() },
 }));
 
-// useGlassCapability imports these; under jsdom (Platform.OS='android') the
-// capability is false regardless, but the import must resolve.
+// The provider resolves 'auto' off Platform.OS ('android' here → Material), not
+// glass capability. Other modules in the import graph still pull expo-glass-effect,
+// so mock it defensively; the values don't affect the provider's variant choice.
 vi.mock('expo-glass-effect', () => ({
   isLiquidGlassAvailable: () => false,
   isGlassEffectAPIAvailable: () => false,
@@ -141,7 +142,7 @@ describe('ThemeProvider', () => {
   });
 
   describe('uiVariant', () => {
-    it("defaults to the Material variant on a non-glass device ('auto' → material)", async () => {
+    it("defaults to the Material variant on Android ('auto' → material)", async () => {
       const { result } = renderHook(() => useTheme(), { wrapper });
       await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
       expect(result.current.uiVariantPreference).toBe('auto');

--- a/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/theme-provider.test.tsx
@@ -23,8 +23,18 @@ vi.mock('../../lib/preferences/secure-store-adapter', () => ({
 // module doesn't blow up. PlatformColor is still mocked as a passthrough for
 // belt-and-braces in case some other module reaches for it.
 const useColorSchemeMock = vi.fn();
+// Platform.OS is a getter so a test can flip it to 'ios' and exercise the
+// platform-driven 'auto' → liquidGlass resolution. Default 'android' keeps the
+// colour assertions below on the Android fallback path; iosSystemColors is
+// computed at module import (null here), so the iOS path degrades to that
+// fallback rather than touching native PlatformColor.
+const platform = vi.hoisted(() => ({ os: 'android' as 'ios' | 'android' }));
 vi.mock('react-native', () => ({
-  Platform: { OS: 'android' },
+  Platform: {
+    get OS() {
+      return platform.os;
+    },
+  },
   useColorScheme: () => useColorSchemeMock(),
   PlatformColor: (name: string) => name,
   // The provider drives Appearance.setColorScheme so the override flips native
@@ -51,10 +61,11 @@ describe('ThemeProvider', () => {
     setMock.mockReset();
     removeMock.mockReset();
     useColorSchemeMock.mockReset();
-    // Defaults: no stored preference, OS in light mode.
+    // Defaults: no stored preference, OS in light mode, Android platform.
     getMock.mockResolvedValue(null);
     setMock.mockResolvedValue(undefined);
     useColorSchemeMock.mockReturnValue('light');
+    platform.os = 'android';
   });
 
   describe('resolved colorScheme (without persistence)', () => {
@@ -150,6 +161,18 @@ describe('ThemeProvider', () => {
       // Material maps M3 tonal surfaces + the 20dp button radius.
       expect(result.current.radii.button).toBe(20);
       expect(result.current.systemColors.background).toBe('#F3EFFA');
+    });
+
+    it("defaults to the Liquid Glass variant on iPhone ('auto' → liquidGlass), incl. iOS < 26", async () => {
+      // The provider keys 'auto' on Platform.OS, not glass capability — so every
+      // iPhone (older ones degrade their surfaces downstream) lands on liquidGlass.
+      platform.os = 'ios';
+      const { result } = renderHook(() => useTheme(), { wrapper });
+      await waitFor(() => expect(getMock).toHaveBeenCalledWith(UI_VARIANT_KEY));
+      expect(result.current.uiVariantPreference).toBe('auto');
+      expect(result.current.variant).toBe('liquidGlass');
+      // Liquid Glass keeps the soft 10dp button radius, not the Material 20dp.
+      expect(result.current.radii.button).toBe(10);
     });
 
     it('setUiVariant persists to SecureStore and flips the resolved variant + tokens', async () => {

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -30,7 +30,6 @@ import {
 } from '../theme/tokens';
 import { springs, timing } from '../theme/animations';
 import { resolveUiVariant, type UiVariant } from '../theme/resolve-ui-variant';
-import { useGlassCapability } from '../hooks/use-glass-capability';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
 
 type ColorScheme = 'light' | 'dark';
@@ -246,12 +245,15 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   }, []);
 
-  // Synchronous native check — lets the first paint resolve 'auto' to the right
-  // variant without waiting on the async SecureStore read.
-  const glassCapable = useGlassCapability();
+  // 'auto' follows the platform aesthetic: Liquid Glass on every iPhone (the blur
+  // fallback covers iOS < 26), Material on Android. This is a synchronous check, so
+  // the first paint resolves 'auto' without waiting on the async SecureStore read.
+  // Whether real iOS 26 glass chrome renders is a separate, downstream concern
+  // (useGlassCapability / useEffectiveSurfaceMode).
+  const autoPrefersGlass = Platform.OS === 'ios';
   const variant = useMemo<UiVariant>(
-    () => resolveUiVariant(uiVariantPreference, glassCapable),
-    [uiVariantPreference, glassCapable],
+    () => resolveUiVariant(uiVariantPreference, autoPrefersGlass),
+    [uiVariantPreference, autoPrefersGlass],
   );
 
   // MD3 colour roles for the current scheme, memoized so the Paper theme is built

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -246,14 +246,14 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   }, []);
 
   // 'auto' follows the platform aesthetic: Liquid Glass on every iPhone (the blur
-  // fallback covers iOS < 26), Material on Android. This is a synchronous check, so
-  // the first paint resolves 'auto' without waiting on the async SecureStore read.
-  // Whether real iOS 26 glass chrome renders is a separate, downstream concern
-  // (useGlassCapability / useEffectiveSurfaceMode).
-  const autoPrefersGlass = Platform.OS === 'ios';
+  // fallback covers iOS < 26), Material on Android. Read Platform.OS inside the memo
+  // — it's a process constant, so listing it as a dep would read as reactive when it
+  // never changes. The synchronous check lets the first paint resolve 'auto' without
+  // waiting on the async SecureStore read. Whether real iOS 26 glass chrome renders
+  // is a separate, downstream concern (useGlassCapability / useEffectiveSurfaceMode).
   const variant = useMemo<UiVariant>(
-    () => resolveUiVariant(uiVariantPreference, autoPrefersGlass),
-    [uiVariantPreference, autoPrefersGlass],
+    () => resolveUiVariant(uiVariantPreference, Platform.OS === 'ios'),
+    [uiVariantPreference],
   );
 
   // MD3 colour roles for the current scheme, memoized so the Paper theme is built

--- a/packages/mobile/src/theme/__tests__/resolve-ui-variant.test.ts
+++ b/packages/mobile/src/theme/__tests__/resolve-ui-variant.test.ts
@@ -2,22 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { resolveUiVariant } from '../resolve-ui-variant';
 
 describe('resolveUiVariant', () => {
-  it("follows capability on 'auto': glass when capable, Material otherwise", () => {
+  it("follows the platform on 'auto': glass on iPhone, Material on Android", () => {
+    // autoPrefersGlass = (Platform.OS === 'ios'), true on every iPhone including
+    // iOS < 26 (which degrades to the blur surface fallback downstream).
     expect(resolveUiVariant('auto', true)).toBe('liquidGlass');
     expect(resolveUiVariant('auto', false)).toBe('material');
   });
 
-  it('honours an explicit Liquid Glass choice even when capable', () => {
+  it('honours an explicit Liquid Glass choice on iPhone', () => {
     expect(resolveUiVariant('liquidGlass', true)).toBe('liquidGlass');
   });
 
-  it('honours an explicit Liquid Glass choice even on incapable hardware', () => {
-    // Forced glass on a non-capable device still resolves to the glass *variant*;
+  it('honours an explicit Liquid Glass choice on Android', () => {
+    // Forced glass on a non-glass platform still resolves to the glass *variant*;
     // GlassSurface degrades the actual rendering to solid.
     expect(resolveUiVariant('liquidGlass', false)).toBe('liquidGlass');
   });
 
-  it('honours an explicit Material choice even on iOS 26 hardware', () => {
+  it('honours an explicit Material choice on any platform', () => {
     expect(resolveUiVariant('material', true)).toBe('material');
     expect(resolveUiVariant('material', false)).toBe('material');
   });

--- a/packages/mobile/src/theme/resolve-ui-variant.ts
+++ b/packages/mobile/src/theme/resolve-ui-variant.ts
@@ -12,15 +12,20 @@ import type { UiVariantPreference } from '@boardsesh/key-value-storage';
 export type UiVariant = 'liquidGlass' | 'material';
 
 /**
- * Resolve the effective variant from the user's preference and whether the
- * device can render Liquid Glass. An explicit choice always wins; `'auto'`
- * follows capability (glass on iOS 26, Material everywhere else).
+ * Resolve the effective variant from the user's preference and whether this
+ * platform prefers the glass aesthetic by default. An explicit choice always
+ * wins; `'auto'` follows the platform — Liquid Glass on every iPhone (including
+ * iOS < 26, where it renders via the blur fallback) and Material on Android.
+ *
+ * Note this is the *aesthetic* decision, separate from whether the device can
+ * render real iOS 26 glass chrome (`useGlassCapability`): an older iPhone resolves
+ * to `liquidGlass` here and degrades its surfaces/tab bar downstream.
  *
  * Pure and synchronous so the first paint can pick the right variant without
- * waiting on async storage — `glassCapable` is a synchronous native check.
+ * waiting on async storage — `autoPrefersGlass` is a synchronous platform check.
  */
-export function resolveUiVariant(preference: UiVariantPreference, glassCapable: boolean): UiVariant {
+export function resolveUiVariant(preference: UiVariantPreference, autoPrefersGlass: boolean): UiVariant {
   if (preference === 'liquidGlass') return 'liquidGlass';
   if (preference === 'material') return 'material';
-  return glassCapable ? 'liquidGlass' : 'material';
+  return autoPrefersGlass ? 'liquidGlass' : 'material';
 }

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -73,7 +73,8 @@
         "liquidGlass": "Liquid Glass",
         "material": "Material",
         "description": "Auto uses Liquid Glass on iPhone and Material on Android. Pick one to override.",
-        "glassFallback": "Liquid Glass uses a simpler fallback here. The full glass effect needs iOS 26."
+        "glassFallback": "Liquid Glass uses a simpler fallback here. The full glass effect needs iOS 26.",
+        "glassFallbackAndroid": "Liquid Glass uses a simpler, solid-surface look on Android."
       },
       "gradeFormat": {
         "title": "Grade format",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -72,8 +72,8 @@
         "auto": "Auto",
         "liquidGlass": "Liquid Glass",
         "material": "Material",
-        "description": "Auto picks Liquid Glass where your device can render it, Material everywhere else.",
-        "glassUnavailable": "Liquid Glass needs iOS 26. Your device runs Material."
+        "description": "Auto uses Liquid Glass on iPhone and Material on Android. Pick one to override.",
+        "glassFallback": "Liquid Glass uses a simpler fallback here. The full glass effect needs iOS 26."
       },
       "gradeFormat": {
         "title": "Grade format",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -271,7 +271,8 @@
         "liquidGlass": "Liquid Glass",
         "material": "Material",
         "description": "Automático usa Liquid Glass en iPhone y Material en Android. Elige uno para anularlo.",
-        "glassFallback": "Liquid Glass usa una versión simplificada aquí. El efecto de vidrio completo requiere iOS 26."
+        "glassFallback": "Liquid Glass usa una versión simplificada aquí. El efecto de vidrio completo requiere iOS 26.",
+        "glassFallbackAndroid": "Liquid Glass usa un aspecto simplificado de superficies sólidas en Android."
       },
       "gradeFormat": {
         "title": "Formato de grado",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -270,8 +270,8 @@
         "auto": "Automático",
         "liquidGlass": "Liquid Glass",
         "material": "Material",
-        "description": "Automático usa Liquid Glass donde tu dispositivo puede mostrarlo y Material en el resto.",
-        "glassUnavailable": "Liquid Glass requiere iOS 26. Tu dispositivo usa Material."
+        "description": "Automático usa Liquid Glass en iPhone y Material en Android. Elige uno para anularlo.",
+        "glassFallback": "Liquid Glass usa una versión simplificada aquí. El efecto de vidrio completo requiere iOS 26."
       },
       "gradeFormat": {
         "title": "Formato de grado",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -73,7 +73,8 @@
         "liquidGlass": "Liquid Glass",
         "material": "Material",
         "description": "Automatique utilise Liquid Glass sur iPhone et Material sur Android. Choisis-en un pour passer outre.",
-        "glassFallback": "Liquid Glass utilise un rendu simplifié ici. L'effet de verre complet nécessite iOS 26."
+        "glassFallback": "Liquid Glass utilise un rendu simplifié ici. L'effet de verre complet nécessite iOS 26.",
+        "glassFallbackAndroid": "Liquid Glass utilise un rendu simplifié à surfaces pleines sur Android."
       },
       "gradeFormat": {
         "title": "Format de cotation",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -72,8 +72,8 @@
         "auto": "Automatique",
         "liquidGlass": "Liquid Glass",
         "material": "Material",
-        "description": "Automatique choisit Liquid Glass quand ton appareil peut l'afficher, Material partout ailleurs.",
-        "glassUnavailable": "Liquid Glass nécessite iOS 26. Ton appareil utilise Material."
+        "description": "Automatique utilise Liquid Glass sur iPhone et Material sur Android. Choisis-en un pour passer outre.",
+        "glassFallback": "Liquid Glass utilise un rendu simplifié ici. L'effet de verre complet nécessite iOS 26."
       },
       "gradeFormat": {
         "title": "Format de cotation",


### PR DESCRIPTION
## What

Older iPhones now default to the Liquid Glass aesthetic (rendered via the existing blur fallback), and any phone can opt into Liquid Glass from Settings — with the tab bar safely falling back to JS buttons where the native iOS 26 glass chrome can't render.

Previously the variant logic conflated two distinct signals:
- **`variant`** (`liquidGlass` | `material`) — the aesthetic.
- **`glassCapable`** (iOS 26 only) — whether native glass chrome (`NativeTabs` glass tab bar, `BottomAccessory`, `GlassView`) can render.

Because `auto` resolved to `liquidGlass` *only* when iOS-26-capable, every older iPhone fell back to Material and never saw the glass look. And `_layout.tsx` mounted the native `NativeTabs` tab bar for any non-Material variant, so naively forcing glass on an older iPhone would mount the iOS-26-only tab bar on a device that can't do it.

## Changes

- **Variant follows platform, not capability** — `resolveUiVariant('auto', …)` resolves to Liquid Glass on every iPhone (incl. iOS < 26) and Material on Android. `theme-provider` passes `Platform.OS === 'ios'`.
- **Native tab bar gates on capability** — new `useNativeTabBar()` (`liquidGlass && glassCapable`) is the single predicate. `_layout.tsx` renders the JS `Tabs` + `MaterialTabBar` ("JS buttons") whenever the device isn't capable, regardless of variant; the native glass tab bar + `BottomAccessory` mount only on iOS 26. The floating glass queue bar still rides on top.
- **Bottom-chrome geometry tracks the rendered bar** — `computeBottomChromeMetrics` takes `usesNativeTabBar` for tab-bar height/overlay, while the queue-bar shape stays keyed on `variant`. Keeps safe-area math correct when Liquid Glass uses the 80dp JS tab bar.
- **Settings opt-in for all** — removed the capability gate on the Liquid Glass option; non-capable devices get a fallback-aware hint (`glassUnavailable` → `glassFallback`, copy updated in en/es/fr).

Surfaces (`GlassSurface` → glass/blur/solid) and icon buttons (`GlassIconButton`) already degrade correctly, so they're unchanged.

## Accepted tradeoff

Liquid Glass on a non-capable device shows the **Material-styled JS tab bar** (the explicit "fall back to JS buttons" choice) while surfaces and the floating queue bar keep the glass/blur aesthetic. A bespoke glass-styled JS tab bar is a separate, larger effort.

## Testing

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (2021 passed) — updated `resolve-ui-variant`, `use-bottom-accessory`, `bottom-chrome-metrics`, `theme-provider`, `tab-layout`, and `persistent-queue-bar` tests; added Liquid-Glass-on-non-capable cases.
- `vp run check:mobile-bundle` ✅
- i18n catalog parity holds for the renamed key (pre-existing, unrelated `subtitleWithStrava` / `aurora.mobile.*` gaps remain).
- Not verified on-device: visual confirmation on a real iOS < 26 build is worth doing before release (`check:mobile-simulator` / `mobile:screenshot` are macOS-only).

https://claude.ai/code/session_01612JJFnWz3prjEwFJioTrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01612JJFnWz3prjEwFJioTrB)_