### PR TITLE
fix(board-presence): play-view crash + session board control (regressions from #2862)

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -303,15 +303,17 @@ function RootLayout() {
                                     exist before the picker mounts or gorhom
                                     throws "BottomSheetModalInternalContext
                                     cannot be null". */}
-                                      <BottomSheetModalProvider>
-                                        {/* Board presence ("now on the wall") owns the
-                                    connected boardId + the wall feed. Mounted
-                                    OUTSIDE BluetoothProviderWrapper so the BLE
-                                    flow can resolve+report through it, and
-                                    OUTSIDE DrawerHostProvider so the Board sheet
-                                    can read the wall state. Inert (boardId null)
-                                    until the `board-presence` flag is on. */}
-                                        <MobileBoardPresenceProvider>
+                                      {/* Board presence ("now on the wall") owns the
+                                    connected boardId + the wall feed. Wraps
+                                    BottomSheetModalProvider so gorhom-portaled
+                                    sheets (PlayDrawer, BoardSheet) — which render
+                                    at the modal host, not their declaration site —
+                                    can still read the wall state through context.
+                                    Also OUTSIDE BluetoothProviderWrapper /
+                                    DrawerHostProvider so the BLE flow + Board sheet
+                                    can use it. */}
+                                      <MobileBoardPresenceProvider>
+                                        <BottomSheetModalProvider>
                                           <BluetoothProviderWrapper>
                                             <DrawerHostProvider>
                                               <DeepLinkProvider>
@@ -369,8 +371,8 @@ function RootLayout() {
                                               </DeepLinkProvider>
                                             </DrawerHostProvider>
                                           </BluetoothProviderWrapper>
-                                        </MobileBoardPresenceProvider>
-                                      </BottomSheetModalProvider>
+                                        </BottomSheetModalProvider>
+                                      </MobileBoardPresenceProvider>
                                     </BoardProviderWrapper>
                                   </PlaylistsAdapterWrapper>
                                 </BoardAdapterWrapper>

--- a/packages/mobile/src/components/play-drawer/BoardConnectionBadge.tsx
+++ b/packages/mobile/src/components/play-drawer/BoardConnectionBadge.tsx
@@ -12,9 +12,9 @@
 // The idle check is a single threshold re-evaluated about once a minute (no
 // per-second ticking), matching the product decision to avoid a live countdown.
 
-import { memo, useEffect, useState } from 'react';
+import { memo, useContext, useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
+import { BoardPresenceCurrentContext } from '@boardsesh/board-presence-react';
 import { Avatar } from '../Avatar';
 import { Text } from '../Text';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -25,7 +25,13 @@ const IDLE_THRESHOLD_MS = 15 * 60 * 1000;
 const IDLE_RECHECK_MS = 60 * 1000;
 
 function BoardConnectionBadgeComponent({ size = 24 }: { size?: number }) {
-  const { holder, currentClimb } = useBoardPresenceCurrent();
+  // Read the context directly rather than via useBoardPresenceCurrent(), which
+  // throws when no provider is in scope. gorhom portals the play drawer to a
+  // modal host, so a consumer can render outside the provider subtree — degrade
+  // to nothing instead of crashing the screen.
+  const current = useContext(BoardPresenceCurrentContext);
+  const holder = current?.holder ?? null;
+  const currentClimb = current?.currentClimb ?? null;
   const [now, setNow] = useState(() => Date.now());
 
   const held = holder !== null;

--- a/packages/mobile/src/components/play-drawer/__tests__/BoardConnectionBadge.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/BoardConnectionBadge.test.tsx
@@ -4,24 +4,17 @@ import { render, cleanup } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { BoardConnectionHolder, BoardPresenceClimb } from '@boardsesh/shared-schema';
 
-// useBoardPresenceCurrent is the only data source; drive it from a hoisted bag.
-const presence = vi.hoisted(() => ({
-  holder: null as BoardConnectionHolder | null,
-  currentClimb: null as BoardPresenceClimb | null,
-}));
+// The badge reads BoardPresenceCurrentContext directly (not useBoardPresenceCurrent,
+// which throws outside a provider) so it can never crash a screen. Mock the package
+// to expose a real context the tests drive via its Provider.
+vi.mock('@boardsesh/board-presence-react', async () => {
+  const react = await import('react');
+  return { BoardPresenceCurrentContext: react.createContext(undefined) };
+});
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
-}));
-vi.mock('@boardsesh/board-presence-react', () => ({
-  useBoardPresenceCurrent: () => ({
-    holder: presence.holder,
-    currentClimb: presence.currentClimb,
-    previousClimb: null,
-    undoTarget: null,
-    isLive: true,
-  }),
 }));
 // Avatar → expose the uri/name it was handed so we can assert identity selection.
 vi.mock('../../Avatar', () => ({
@@ -36,6 +29,7 @@ vi.mock('../../../theme/ios-colors', () => ({
 }));
 
 import { BoardConnectionBadge } from '../BoardConnectionBadge';
+import { BoardPresenceCurrentContext } from '@boardsesh/board-presence-react';
 
 function holder(overrides: Partial<BoardConnectionHolder> = {}): BoardConnectionHolder {
   return { userId: 'u1', displayName: 'Crusher Carla', avatarUrl: 'https://x/c.jpg', lastSentAt: null, ...overrides };
@@ -51,23 +45,33 @@ function climb(sentAt: string, overrides: Partial<BoardPresenceClimb> = {}): Boa
   };
 }
 
-describe('BoardConnectionBadge', () => {
-  beforeEach(() => {
-    presence.holder = null;
-    presence.currentClimb = null;
-    cleanup();
-  });
+function renderBadge(value: { holder: BoardConnectionHolder | null; currentClimb: BoardPresenceClimb | null }) {
+  return render(
+    createElement(
+      BoardPresenceCurrentContext.Provider,
+      { value: { ...value, previousClimb: null, undoTarget: null, isLive: true } },
+      createElement(BoardConnectionBadge),
+    ),
+  );
+}
 
-  it('renders nothing when the wall is free', () => {
+describe('BoardConnectionBadge', () => {
+  beforeEach(() => cleanup());
+
+  it('renders nothing (no crash) when rendered outside the board-presence provider', () => {
     const { container } = render(createElement(BoardConnectionBadge));
     expect(container.querySelector('[data-testid="avatar"]')).toBeNull();
     expect(container.textContent).toBe('');
   });
 
+  it('renders nothing when the wall is free', () => {
+    const { container } = renderBadge({ holder: null, currentClimb: null });
+    expect(container.querySelector('[data-testid="avatar"]')).toBeNull();
+    expect(container.textContent).toBe('');
+  });
+
   it('shows the holder avatar from the live climb identity when held and recent', () => {
-    presence.holder = holder();
-    presence.currentClimb = climb(new Date().toISOString());
-    const { container } = render(createElement(BoardConnectionBadge));
+    const { container } = renderBadge({ holder: holder(), currentClimb: climb(new Date().toISOString()) });
     const avatar = container.querySelector('[data-testid="avatar"]');
     expect(avatar).not.toBeNull();
     expect(avatar?.getAttribute('data-name')).toBe('Crusher Carla');
@@ -77,9 +81,10 @@ describe('BoardConnectionBadge', () => {
   });
 
   it('passes null identity through for an anonymous holder (Avatar renders "?")', () => {
-    presence.holder = holder({ userId: null, displayName: null, avatarUrl: null });
-    presence.currentClimb = null;
-    const { container } = render(createElement(BoardConnectionBadge));
+    const { container } = renderBadge({
+      holder: holder({ userId: null, displayName: null, avatarUrl: null }),
+      currentClimb: null,
+    });
     const avatar = container.querySelector('[data-testid="avatar"]');
     expect(avatar).not.toBeNull();
     expect(avatar?.getAttribute('data-name')).toBe('');
@@ -88,17 +93,16 @@ describe('BoardConnectionBadge', () => {
 
   it('adds the idle "?" overlay once the last send is older than 15 minutes', () => {
     const twentyMinAgo = new Date(Date.now() - 20 * 60 * 1000).toISOString();
-    presence.holder = holder();
-    presence.currentClimb = climb(twentyMinAgo);
-    const { container } = render(createElement(BoardConnectionBadge));
+    const { container } = renderBadge({ holder: holder(), currentClimb: climb(twentyMinAgo) });
     expect(container.querySelector('[data-testid="avatar"]')).not.toBeNull();
     expect(container.textContent).toContain('?');
   });
 
   it('falls back to the holder lastSentAt for idle when no current climb', () => {
-    presence.holder = holder({ lastSentAt: new Date(Date.now() - 20 * 60 * 1000).toISOString() });
-    presence.currentClimb = null;
-    const { container } = render(createElement(BoardConnectionBadge));
+    const { container } = renderBadge({
+      holder: holder({ lastSentAt: new Date(Date.now() - 20 * 60 * 1000).toISOString() }),
+      currentClimb: null,
+    });
     expect(container.textContent).toContain('?');
   });
 });


### PR DESCRIPTION
## Hotfix for a production crash from #2862

**Error:** `useBoardPresenceCurrent must be used within a BoardPresenceProvider` (play view crash on open).

### Root cause
`PlayDrawer` (and `BoardSheet`) render through gorhom's `BottomSheetModal`, which **portals** content to the modal host — so they only see context available *at the host*, not at their declaration site. `MobileBoardPresenceProvider` was mounted **below** `BottomSheetModalProvider` in `app/_layout.tsx`, so the portaled play drawer couldn't see it. #2862 added `BoardConnectionBadge` (the first `PlayDrawer` consumer of `useBoardPresenceCurrent`), which then threw and crashed the screen. (The Board/Queue providers were already placed *above* the modal host precisely for this reason — board-presence was the one that wasn't.)

### Fix
- **Move `MobileBoardPresenceProvider` to wrap `BottomSheetModalProvider`** so portaled sheets read the wall state through context. `BoardDisambiguationSheet` is a plain RN `Modal`, so it doesn't need the bottom-sheet host above it; the DevicePicker/modal-host ordering is preserved. This also fixes the same latent crash in `BoardSheet`.
- **Defense-in-depth:** `BoardConnectionBadge` now reads `BoardPresenceCurrentContext` directly (non-throwing) and renders nothing when no provider is in scope, so a stray portal can never crash a screen again.

### Validation
`vp run typecheck:mobile`, `vp run test:mobile` (2050 pass), badge/play-drawer suites, and `vp check` on the touched files — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)