### PR TITLE
Strip query params from Instagram beta-video URLs

### DIFF
--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -689,6 +689,23 @@ describe('betaLinkPreview resolver', () => {
     });
   });
 
+  it('strips the Instagram share-attribution param from the echoed link', async () => {
+    fetchInstagramMetaMock.mockResolvedValueOnce({
+      status: 'ok',
+      thumbnail: 'https://scontent.cdninstagram.com/raw.jpg',
+      username: 'climber',
+      caption: 'Sent it',
+    });
+
+    const result = await betaLinkQueries.betaLinkPreview(
+      undefined,
+      { link: 'https://www.instagram.com/reel/ABC123/?igsh=NHB5ZXljZjV3bzB3' },
+      ctx(true),
+    );
+
+    expect(result.link).toBe('https://www.instagram.com/reel/ABC123/');
+  });
+
   it('throws when unauthenticated and never calls out to Instagram', async () => {
     await expect(
       betaLinkQueries.betaLinkPreview(undefined, { link: 'https://www.instagram.com/reel/ABC123/' }, ctx(false)),

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -90,6 +90,7 @@ vi.mock('../lib/instagram-meta', async () => {
     fetchInstagramMeta: fetchInstagramMetaMock,
     isInstagramUrl: shared.isInstagramUrl,
     getInstagramMediaId: shared.getInstagramMediaId,
+    normalizeBetaVideoUrl: shared.normalizeBetaVideoUrl,
   };
 });
 
@@ -266,6 +267,15 @@ describe('betaLinks resolver', () => {
     expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
   });
 
+  it('strips the Instagram share-attribution param from the returned link', async () => {
+    selectMock.mockReturnValueOnce([
+      row({ link: 'https://www.instagram.com/reel/ABC/?igsh=NHB5ZXljZjV3bzB3', thumbnail: OUR_S3_THUMB }),
+    ]);
+
+    const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
+    expect(result[0]?.link).toBe('https://www.instagram.com/reel/ABC/');
+  });
+
   it('routes TikTok URLs through the TikTok enricher', async () => {
     const tikUrl = 'https://www.tiktok.com/@climber/video/9999999999';
     selectMock.mockReturnValueOnce([row({ link: tikUrl })]);
@@ -365,6 +375,14 @@ describe('recentBetaLinks resolver', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.climbName).toBe('Project');
+  });
+
+  it('strips the Instagram share-attribution param from the returned link', async () => {
+    executeMock.mockReturnValueOnce([cteRow({ link: 'https://www.instagram.com/reel/ABC/?igsh=x' }, 'Project')]);
+
+    const result = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(result[0]?.betaLink.link).toBe('https://www.instagram.com/reel/ABC/');
   });
 
   it('tolerates a null climbName (beta link arrived before the climb synced)', async () => {

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -267,13 +267,28 @@ describe('betaLinks resolver', () => {
     expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
   });
 
-  it('strips the Instagram share-attribution param from the returned link', async () => {
+  it('strips the Instagram share-attribution param on the cached-thumbnail (short-circuit) path', async () => {
     selectMock.mockReturnValueOnce([
       row({ link: 'https://www.instagram.com/reel/ABC/?igsh=NHB5ZXljZjV3bzB3', thumbnail: OUR_S3_THUMB }),
     ]);
 
     const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
     expect(result[0]?.link).toBe('https://www.instagram.com/reel/ABC/');
+    expect(fetchInstagramMetaMock).not.toHaveBeenCalled();
+  });
+
+  it('strips the Instagram share-attribution param on the fresh-fetch path', async () => {
+    selectMock.mockReturnValueOnce([row({ link: 'https://www.instagram.com/reel/ABC/?igsh=x', thumbnail: null })]);
+    fetchInstagramMetaMock.mockResolvedValueOnce({
+      status: 'ok',
+      thumbnail: 'https://scontent.cdninstagram.com/raw.jpg',
+      username: 'climber',
+    });
+    cacheInstagramMock.mockResolvedValueOnce(OUR_S3_THUMB);
+
+    const result = await betaLinkQueries.betaLinks(undefined, { boardType: 'kilter', climbUuid: 'climb-1' });
+    expect(result[0]?.link).toBe('https://www.instagram.com/reel/ABC/');
+    expect(fetchInstagramMetaMock).toHaveBeenCalled();
   });
 
   it('routes TikTok URLs through the TikTok enricher', async () => {

--- a/packages/backend/src/__tests__/beta-link-save-normalization.test.ts
+++ b/packages/backend/src/__tests__/beta-link-save-normalization.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Captures the values passed to the boardBetaLinks insert so we can assert the
+// save-side normalization stores the canonical (param-free) Instagram URL.
+const { insertedValues, selectMock } = vi.hoisted(() => ({
+  insertedValues: { current: null as Record<string, unknown> | null },
+  // Dedup probe (findInstagramShortcodeConflict) — return no conflict.
+  selectMock: vi.fn(() => ({
+    from: () => ({ innerJoin: () => ({ where: () => Promise.resolve([]) }) }),
+  })),
+}));
+
+vi.mock('../db/client', () => ({
+  db: {
+    select: selectMock,
+    insert: () => ({
+      values: (values: Record<string, unknown>) => {
+        insertedValues.current = values;
+        return { onConflictDoNothing: () => Promise.resolve() };
+      },
+    }),
+  },
+}));
+
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn() }));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+
+vi.mock('../utils/instagram-beta-validation', async () => {
+  const actual = await vi.importActual<typeof import('../utils/instagram-beta-validation')>(
+    '../utils/instagram-beta-validation',
+  );
+  return {
+    ...actual,
+    validateInstagramBetaLink: vi.fn(async () => ({ mediaId: 'DZlVfVhxKJZ', username: 'climber', imageUrl: null })),
+  };
+});
+
+vi.mock('../lib/beta-link-thumbnails', async () => {
+  const actual = await vi.importActual<typeof import('../lib/beta-link-thumbnails')>('../lib/beta-link-thumbnails');
+  return { ...actual, cacheInstagramThumbnail: vi.fn(), isS3Configured: vi.fn(() => false) };
+});
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: () => false,
+    getClients: () => ({ publisher: { get: vi.fn(), set: vi.fn(), del: vi.fn() } }),
+  },
+}));
+
+vi.mock('../graphql/resolvers/shared/helpers', async () => {
+  const actual = await vi.importActual<typeof import('../graphql/resolvers/shared/helpers')>(
+    '../graphql/resolvers/shared/helpers',
+  );
+  return { ...actual, applyRateLimit: vi.fn(async () => {}) };
+});
+
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
+
+const ctx = { userId: 'user-1', isAuthenticated: true } as unknown as Parameters<
+  typeof tickMutations.attachBetaLink
+>[2];
+
+describe('attachBetaLink save-side normalization', () => {
+  beforeEach(() => {
+    insertedValues.current = null;
+    selectMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('stores the link and shortcode stripped of the igsh share-attribution param', async () => {
+    const result = await tickMutations.attachBetaLink(
+      undefined,
+      {
+        input: {
+          boardType: 'kilter',
+          climbUuid: '00000000-0000-0000-0000-000000000000',
+          link: 'https://www.instagram.com/reel/DZlVfVhxKJZ/?igsh=NHB5ZXljZjV3bzB3',
+        },
+      },
+      ctx,
+    );
+
+    expect(result).toBe(true);
+    expect(insertedValues.current).toMatchObject({
+      link: 'https://www.instagram.com/reel/DZlVfVhxKJZ/',
+      shortcode: 'DZlVfVhxKJZ',
+    });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -452,15 +452,18 @@ export const betaLinkQueries = {
     requireAuthenticated(ctx);
     await applyRateLimit(ctx, 30, 'beta-link-preview');
 
+    // Strip Instagram share-attribution params so the preview echoes the same
+    // clean URL we'd store, and the meta fetch keys off the canonical form.
+    const normalizedLink = normalizeBetaVideoUrl(link);
     const preview: BetaLinkPreviewResult = {
-      link: normalizeBetaVideoUrl(link),
+      link: normalizedLink,
       thumbnail: null,
       username: null,
       caption: null,
     };
 
-    if (isInstagramUrl(link)) {
-      const meta = await fetchInstagramMeta(link);
+    if (isInstagramUrl(normalizedLink)) {
+      const meta = await fetchInstagramMeta(normalizedLink);
       if (meta.status === 'ok') {
         preview.thumbnail = meta.thumbnail;
         preview.username = meta.username;
@@ -469,8 +472,8 @@ export const betaLinkQueries = {
       return preview;
     }
 
-    if (isTikTokUrl(link)) {
-      const meta = await fetchTikTokMeta(link);
+    if (isTikTokUrl(normalizedLink)) {
+      const meta = await fetchTikTokMeta(normalizedLink);
       if (meta.status === 'ok') {
         preview.thumbnail = meta.thumbnail;
         preview.username = meta.username;

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -2,7 +2,12 @@ import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { eq, and, desc, isNotNull, like, or, sql } from 'drizzle-orm';
 import { rowsFromResult } from '@boardsesh/db/client';
-import { fetchInstagramMeta, getInstagramMediaId, isInstagramUrl } from '../../../lib/instagram-meta';
+import {
+  fetchInstagramMeta,
+  getInstagramMediaId,
+  isInstagramUrl,
+  normalizeBetaVideoUrl,
+} from '../../../lib/instagram-meta';
 import { fetchTikTokMeta, getTikTokCacheId, isTikTokUrl } from '../../../lib/tiktok-meta';
 import {
   cacheInstagramThumbnail,
@@ -124,7 +129,7 @@ const ENRICH_CONCURRENCY = 5;
 function passthroughResult(row: Row): BetaLinkResult {
   return {
     climbUuid: row.climbUuid,
-    link: row.link,
+    link: normalizeBetaVideoUrl(row.link),
     foreignUsername: row.foreignUsername,
     angle: row.angle,
     thumbnail: isOurS3Url(row.thumbnail) ? row.thumbnail : null,
@@ -181,7 +186,7 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
   if (haveCachedThumbnail) {
     return {
       climbUuid: row.climbUuid,
-      link: row.link,
+      link: normalizeBetaVideoUrl(row.link),
       foreignUsername: row.foreignUsername,
       angle: row.angle,
       thumbnail: row.thumbnail,
@@ -221,7 +226,7 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
 
   return {
     climbUuid: row.climbUuid,
-    link: row.link,
+    link: normalizeBetaVideoUrl(row.link),
     foreignUsername: newUsername,
     angle: row.angle,
     thumbnail,
@@ -448,7 +453,7 @@ export const betaLinkQueries = {
     await applyRateLimit(ctx, 30, 'beta-link-preview');
 
     const preview: BetaLinkPreviewResult = {
-      link,
+      link: normalizeBetaVideoUrl(link),
       thumbnail: null,
       username: null,
       caption: null,
@@ -509,7 +514,7 @@ export const betaLinkQueries = {
       filtered.push({
         betaLink: {
           climbUuid: r.climb_uuid,
-          link: r.link,
+          link: normalizeBetaVideoUrl(r.link),
           foreignUsername: r.foreign_username,
           angle: r.angle,
           thumbnail: r.thumbnail,

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -14,7 +14,7 @@ import { queueBoardStatsPublish } from '../board-presence/stats';
 import { publishSocialEvent } from '../../../events';
 import { publishDebouncedSessionStats } from '../sessions/debounced-stats-publisher';
 import { queueClimbStatsRecompute } from './debounced-climb-stats-publisher';
-import { getInstagramMediaId, isInstagramUrl } from '../../../lib/instagram-meta';
+import { getInstagramMediaId, isInstagramUrl, normalizeBetaVideoUrl } from '../../../lib/instagram-meta';
 import {
   InstagramBetaValidationError,
   validateInstagramBetaLink,
@@ -391,7 +391,8 @@ export const tickMutations = {
     // to leave the video URL in the form. Cross-climb dup is still fatal:
     // the user explicitly chose this video URL and we want to surface the
     // friendly "post a separate reel" message.
-    const attachedVideoUrl = videoUrlForTickStatus(validatedInput.status, validatedInput.videoUrl);
+    const tickVideoUrl = videoUrlForTickStatus(validatedInput.status, validatedInput.videoUrl);
+    const attachedVideoUrl = tickVideoUrl ? normalizeBetaVideoUrl(tickVideoUrl) : tickVideoUrl;
     const betaPlan: BetaLinkInsertPlan = attachedVideoUrl
       ? await validateAndEnrichBetaLinkInsert(
           ctx,
@@ -542,6 +543,9 @@ export const tickMutations = {
     requireAuthenticated(ctx);
 
     const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
+    // Strip Instagram share-attribution params (`?igsh=...`) before the dedup
+    // probe and insert so the stored `link` opens straight to the reel.
+    validated.link = normalizeBetaVideoUrl(validated.link);
     const userId = ctx.userId!;
     const now = new Date().toISOString();
 

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -545,7 +545,7 @@ export const tickMutations = {
     const validated = validateInput(AttachBetaLinkInputSchema, input, 'input');
     // Strip Instagram share-attribution params (`?igsh=...`) before the dedup
     // probe and insert so the stored `link` opens straight to the reel.
-    validated.link = normalizeBetaVideoUrl(validated.link);
+    const normalizedLink = normalizeBetaVideoUrl(validated.link);
     const userId = ctx.userId!;
     const now = new Date().toISOString();
 
@@ -560,7 +560,7 @@ export const tickMutations = {
       ctx,
       validated.boardType,
       validated.climbUuid,
-      validated.link,
+      normalizedLink,
       { onSameClimbDup: 'throw' },
     );
     // With onSameClimbDup: 'throw' the helper either returns 'insert' or
@@ -577,8 +577,8 @@ export const tickMutations = {
         .values({
           boardType: validated.boardType,
           climbUuid: validated.climbUuid,
-          link: validated.link,
-          shortcode: getInstagramMediaId(validated.link),
+          link: normalizedLink,
+          shortcode: getInstagramMediaId(normalizedLink),
           angle: validated.angle ?? null,
           isListed: true,
           thumbnail: betaPlan.thumbnail,

--- a/packages/backend/src/lib/instagram-meta.ts
+++ b/packages/backend/src/lib/instagram-meta.ts
@@ -1,8 +1,13 @@
-import { getInstagramMediaId, INSTAGRAM_URL_REGEX, isInstagramUrl } from '@boardsesh/shared-schema';
+import {
+  getInstagramMediaId,
+  INSTAGRAM_URL_REGEX,
+  isInstagramUrl,
+  normalizeBetaVideoUrl,
+} from '@boardsesh/shared-schema';
 import { createCircuitBreaker } from './circuit-breaker';
 import { logger } from '../utils/logger';
 
-export { INSTAGRAM_URL_REGEX, isInstagramUrl, getInstagramMediaId };
+export { INSTAGRAM_URL_REGEX, isInstagramUrl, getInstagramMediaId, normalizeBetaVideoUrl };
 
 const FETCH_TIMEOUT_MS = 4000;
 const USER_AGENT =

--- a/packages/shared-schema/src/__tests__/beta-video-url.test.ts
+++ b/packages/shared-schema/src/__tests__/beta-video-url.test.ts
@@ -9,6 +9,7 @@ import {
   isBetaVideoUrl,
   isInstagramUrl,
   isTikTokUrl,
+  normalizeBetaVideoUrl,
   mapBetaLinkRow,
   mapBetaLinksResponse,
   type BetaLink,
@@ -113,6 +114,46 @@ describe('getTikTokVideoId', () => {
 
   it('returns null for non-tiktok url', () => {
     expect(getTikTokVideoId(IG_REEL)).toBeNull();
+  });
+});
+
+describe('normalizeBetaVideoUrl', () => {
+  it('strips the igsh share-attribution param from a reel url', () => {
+    expect(normalizeBetaVideoUrl('https://www.instagram.com/reel/DZlVfVhxKJZ/?igsh=NHB5ZXljZjV3bzB3')).toBe(
+      'https://www.instagram.com/reel/DZlVfVhxKJZ/',
+    );
+  });
+
+  it('strips any query string and fragment from Instagram urls', () => {
+    expect(normalizeBetaVideoUrl('https://instagram.com/p/Xyz123/?utm_source=share')).toBe(
+      'https://instagram.com/p/Xyz123/',
+    );
+    expect(normalizeBetaVideoUrl('https://www.instagram.com/tv/AbCdE12/#comments')).toBe(
+      'https://www.instagram.com/tv/AbCdE12/',
+    );
+  });
+
+  it('handles the instagr.am host and the no-trailing-slash form', () => {
+    expect(normalizeBetaVideoUrl('https://instagr.am/reel/abc/?igsh=x')).toBe('https://instagr.am/reel/abc/');
+    expect(normalizeBetaVideoUrl('https://www.instagram.com/reel/DZlVfVhxKJZ?igsh=x')).toBe(
+      'https://www.instagram.com/reel/DZlVfVhxKJZ',
+    );
+  });
+
+  it('leaves clean Instagram urls unchanged and is idempotent', () => {
+    expect(normalizeBetaVideoUrl(IG_REEL)).toBe(IG_REEL);
+    expect(normalizeBetaVideoUrl(normalizeBetaVideoUrl('https://instagram.com/p/Xyz123/?utm=a'))).toBe(
+      'https://instagram.com/p/Xyz123/',
+    );
+  });
+
+  it('leaves TikTok and unknown urls unchanged', () => {
+    expect(normalizeBetaVideoUrl(TIKTOK_LONG)).toBe(TIKTOK_LONG);
+    expect(normalizeBetaVideoUrl('https://www.tiktok.com/@u/video/123?is_from_webapp=1')).toBe(
+      'https://www.tiktok.com/@u/video/123?is_from_webapp=1',
+    );
+    expect(normalizeBetaVideoUrl('https://example.com/x?y=1')).toBe('https://example.com/x?y=1');
+    expect(normalizeBetaVideoUrl('')).toBe('');
   });
 });
 

--- a/packages/shared-schema/src/beta-video-url.ts
+++ b/packages/shared-schema/src/beta-video-url.ts
@@ -38,6 +38,17 @@ export function getInstagramMediaId(url: string): string | null {
 }
 
 /**
+ * Canonical storage/display form for a beta-video URL. Strips the query string
+ * and fragment from Instagram URLs so the `?igsh=...` share-attribution param
+ * doesn't trigger Instagram's "X shared this reel, follow them?" interstitial.
+ * Non-Instagram URLs (TikTok et al.) are returned unchanged. Idempotent.
+ */
+export function normalizeBetaVideoUrl(url: string): string {
+  if (!isInstagramUrl(url)) return url;
+  return url.replace(/[?#].*$/, '');
+}
+
+/**
  * Numeric video id for long-form `/@user/video/<id>` TikTok URLs. Short links
  * (`vm.tiktok.com/<short>`, `t.tiktok.com/<short>`) return null — we don't
  * unfold them.


### PR DESCRIPTION
## Problem

When a user shares an Instagram reel, the URL carries a share-attribution param:

```
https://www.instagram.com/reel/DZlVfVhxKJZ/?igsh=NHB5ZXljZjV3bzB3
```

We stored and returned that URL verbatim in `board_beta_links.link`. Opening a link with `?igsh=...` makes Instagram show its "X shared this reel, want to follow them?" interstitial instead of going straight to the reel.

## Fix

- Add `normalizeBetaVideoUrl()` to the shared beta-url helpers (`packages/shared-schema/src/beta-video-url.ts`). It strips the query string and fragment from Instagram URLs (preserving `/reel/`, `/p/`, `/tv/` and the host) and returns everything else (TikTok, unknown) unchanged. Idempotent.
- **Save side** (`ticks/mutations.ts`): normalize after Zod validation in `attachBetaLink` and `saveTick`, so the dedup probe, shortcode extraction, and the stored `link` all use the clean URL. The `(boardType, climbUuid, link)` primary key now also collapses param-only duplicates of the same reel.
- **Return side** (`beta-videos/queries.ts`): normalize the output `link` at each result-construction site (`betaLinks`, `recentBetaLinks`, `betaLinkPreview`), so already-stored legacy rows display clean too. The `row.link` used for DB writes/`persistEnriched` lookups stays raw so legacy rows keep matching.

No DB migration: read-time normalization handles existing rows for display, and `dedupeBetaLinks` already collapses any duplicate legacy rows in the UI by shortcode.

## Tests

- `normalizeBetaVideoUrl` unit tests (strips `?igsh=`/`#frag`, leaves clean IG / TikTok / unknown URLs unchanged, idempotent, handles `instagr.am` and no-trailing-slash).
- Backend resolver tests asserting `betaLinks` and `recentBetaLinks` return the stripped link.

## Validation

- `vp test run` — shared-schema (52) + backend beta-link suites (52) pass
- `vp run typecheck:backend`, `typecheck:shared` — clean
- `vp check` on changed files — no lint/format/type warnings

https://claude.ai/code/session_01TJELQRAzuxXchcXM5yooat

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJELQRAzuxXchcXM5yooat)_