### PR TITLE
Fix bulkVoteSummaries empty-array errors

### DIFF
--- a/packages/backend/src/__tests__/social-validation.test.ts
+++ b/packages/backend/src/__tests__/social-validation.test.ts
@@ -8,6 +8,7 @@ import {
   SetterProfileInputSchema,
   SetterClimbsInputSchema,
   SetterClimbsFullInputSchema,
+  BulkVoteSummaryInputSchema,
 } from '../validation/schemas';
 
 describe('Social Validation Schemas', () => {
@@ -303,6 +304,35 @@ describe('Social Validation Schemas', () => {
       if (result.success) {
         expect(result.data.boardType).toBe('kilter');
       }
+    });
+  });
+
+  describe('BulkVoteSummaryInputSchema', () => {
+    it('should accept a populated entityIds array', () => {
+      const result = BulkVoteSummaryInputSchema.safeParse({
+        entityType: 'tick',
+        entityIds: ['a', 'b'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept an empty entityIds array (no-op, resolver returns [])', () => {
+      const result = BulkVoteSummaryInputSchema.safeParse({
+        entityType: 'session',
+        entityIds: [],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.entityIds).toEqual([]);
+      }
+    });
+
+    it('should reject more than 100 entityIds', () => {
+      const result = BulkVoteSummaryInputSchema.safeParse({
+        entityType: 'tick',
+        entityIds: Array.from({ length: 101 }, (_unused, index) => `id-${index}`),
+      });
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/packages/backend/src/validation/schemas/comments.ts
+++ b/packages/backend/src/validation/schemas/comments.ts
@@ -74,5 +74,6 @@ export const CommentsInputSchema = z.object({
  */
 export const BulkVoteSummaryInputSchema = z.object({
   entityType: SocialEntityTypeSchema,
-  entityIds: z.array(z.string().min(1).max(200)).min(1).max(100),
+  // Empty arrays are a valid no-op: the resolver returns []. (No `.min(1)` here.)
+  entityIds: z.array(z.string().min(1).max(200)).max(100),
 });

--- a/packages/mobile/src/lib/graphql/hooks/use-social.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-social.ts
@@ -70,6 +70,9 @@ export function useBulkVoteSummaries(entityType: SocialEntityType, entityIds: st
   return useQuery({
     queryKey: ['bulkVoteSummaries', entityType, sortedIds],
     queryFn: async () => {
+      // `enabled` gates automatic fetches, but a manual `refetch()` (e.g. pull-to-refresh)
+      // bypasses it — short-circuit here so we never send the backend an empty list.
+      if (entityIds.length === 0) return [];
       const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
         input: { entityType, entityIds },
       });
@@ -88,6 +91,7 @@ export function useChunkedBulkVoteSummaries(entityType: SocialEntityType, entity
       return {
         queryKey: ['bulkVoteSummaries', entityType, sortedIds],
         queryFn: async () => {
+          if (chunk.length === 0) return [];
           const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
             input: { entityType, entityIds: chunk },
           });
@@ -110,6 +114,7 @@ export function useGroupedBulkVoteSummaries(entityType: SocialEntityType, entity
       return {
         queryKey: ['bulkVoteSummaries', entityType, sortedIds],
         queryFn: async () => {
+          if (chunk.length === 0) return [];
           const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
             input: { entityType, entityIds: chunk },
           });


### PR DESCRIPTION
## Problem

Error tracking shows a recurring GraphQL error from the React Native app, hitting many users:

```
Invalid input: Too small: expected array to have >=1 items
path: ["bulkVoteSummaries"]
variables: { input: { entityType: "tick" | "session", entityIds: [] } }
```

## Root cause

The mobile Home tab pull-to-refresh handler (`packages/mobile/app/(tabs)/home/index.tsx`) calls `sessionVoteSummaries.refetch()` / `tickVoteSummaries.refetch()`. Those come from `useBulkVoteSummaries`, which gates *automatic* fetches with `enabled: enabled && entityIds.length > 0`. But **React Query's `refetch()` bypasses `enabled`** — so when a user pull-to-refreshes with an empty feed (new user, or before the feed loads), the query fires with `entityIds: []`, and the backend's Zod `.min(1)` rule rejects it.

The backend resolver already had `if (entityIds.length === 0) return []` — dead code today, because the `.min(1)` validation threw first. Empty arrays were always meant to be a valid no-op.

## Changes

- **Mobile** (`use-social.ts`): short-circuit empty `entityIds` at the top of the `queryFn` in `useBulkVoteSummaries` and the chunked/grouped variants, so a forced `refetch()` never sends an empty list.
- **Backend** (`comments.ts`): drop `.min(1)` from `BulkVoteSummaryInputSchema.entityIds`. Empty arrays now return `[]` via the resolver's existing guard. This also covers web feed callers as defense in depth. The `.max(100)` chunk guard stays.
- **Tests**: add `BulkVoteSummaryInputSchema` regression tests (accepts empty array, accepts populated, rejects >100).

## Verification

- [x] `vp run typecheck:mobile`
- [x] `vp run typecheck:backend`
- [x] lint + format clean on changed files (the only `vp check` errors are pre-existing in unrelated files: `session-context.test.ts`, `mobile-ios-run.test.ts`, `generate-board-data.test.mjs`)
- [x] backend `social-validation` tests — 36 passed (incl. 3 new `BulkVoteSummaryInputSchema` cases)
- [x] mobile tests — 2050 passed
- [x] `vp run check:mobile-bundle` — OK (10.1 MB)
- [ ] Manual: pull-to-refresh the mobile Home tab with an empty feed; confirm no `bulkVoteSummaries` error (not run in this headless environment)

https://claude.ai/code/session_01Www2tu3nN2i83y46hpaStx