### PR TITLE
Add saveTick save-side normalization test

### DIFF
--- a/packages/backend/src/__tests__/beta-link-save-normalization.test.ts
+++ b/packages/backend/src/__tests__/beta-link-save-normalization.test.ts
@@ -1,30 +1,55 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Captures the values passed to the boardBetaLinks insert so we can assert the
-// save-side normalization stores the canonical (param-free) Instagram URL.
-const { insertedValues, selectMock } = vi.hoisted(() => ({
-  insertedValues: { current: null as Record<string, unknown> | null },
+// Captures the values written to boardBetaLinks from both save entry points
+// (attachBetaLink via db.insert, saveTick via tx.insert inside the transaction)
+// so we can assert the stored link/shortcode drop the igsh share-attribution
+// param. `betaInsert` is set whenever an inserted row carries a `link` field.
+const { betaInsert, selectMock } = vi.hoisted(() => ({
+  betaInsert: { current: null as Record<string, unknown> | null },
   // Dedup probe (findInstagramShortcodeConflict) — return no conflict.
   selectMock: vi.fn(() => ({
     from: () => ({ innerJoin: () => ({ where: () => Promise.resolve([]) }) }),
   })),
 }));
 
+function captureBetaInsert(values: Record<string, unknown>): void {
+  if (values && typeof values === 'object' && 'link' in values) {
+    betaInsert.current = values;
+  }
+}
+
+const tx = {
+  insert: () => ({
+    values: (values: Record<string, unknown>) => {
+      captureBetaInsert(values);
+      return {
+        returning: () => Promise.resolve([values]),
+        onConflictDoNothing: () => Promise.resolve(),
+      };
+    },
+  }),
+  update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+};
+
 vi.mock('../db/client', () => ({
   db: {
     select: selectMock,
     insert: () => ({
       values: (values: Record<string, unknown>) => {
-        insertedValues.current = values;
+        captureBetaInsert(values);
         return { onConflictDoNothing: () => Promise.resolve() };
       },
     }),
+    transaction: (callback: (txArg: typeof tx) => unknown) => callback(tx),
   },
 }));
 
 vi.mock('../events', () => ({ publishSocialEvent: vi.fn() }));
 vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
   publishDebouncedSessionStats: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: vi.fn(),
 }));
 
 vi.mock('../utils/instagram-beta-validation', async () => {
@@ -62,9 +87,12 @@ const ctx = { userId: 'user-1', isAuthenticated: true } as unknown as Parameters
   typeof tickMutations.attachBetaLink
 >[2];
 
-describe('attachBetaLink save-side normalization', () => {
+const REEL_WITH_PARAM = 'https://www.instagram.com/reel/DZlVfVhxKJZ/?igsh=NHB5ZXljZjV3bzB3';
+const REEL_CLEAN = 'https://www.instagram.com/reel/DZlVfVhxKJZ/';
+
+describe('save-side Instagram URL normalization', () => {
   beforeEach(() => {
-    insertedValues.current = null;
+    betaInsert.current = null;
     selectMock.mockClear();
   });
 
@@ -72,23 +100,43 @@ describe('attachBetaLink save-side normalization', () => {
     vi.unstubAllGlobals();
   });
 
-  it('stores the link and shortcode stripped of the igsh share-attribution param', async () => {
+  it('attachBetaLink stores the link and shortcode stripped of the igsh param', async () => {
     const result = await tickMutations.attachBetaLink(
       undefined,
       {
         input: {
           boardType: 'kilter',
           climbUuid: '00000000-0000-0000-0000-000000000000',
-          link: 'https://www.instagram.com/reel/DZlVfVhxKJZ/?igsh=NHB5ZXljZjV3bzB3',
+          link: REEL_WITH_PARAM,
         },
       },
       ctx,
     );
 
     expect(result).toBe(true);
-    expect(insertedValues.current).toMatchObject({
-      link: 'https://www.instagram.com/reel/DZlVfVhxKJZ/',
-      shortcode: 'DZlVfVhxKJZ',
-    });
+    expect(betaInsert.current).toMatchObject({ link: REEL_CLEAN, shortcode: 'DZlVfVhxKJZ' });
+  });
+
+  it('saveTick attaches the beta link with the igsh param stripped on a successful ascent', async () => {
+    await tickMutations.saveTick(
+      undefined,
+      {
+        input: {
+          boardType: 'kilter',
+          climbUuid: '00000000-0000-0000-0000-000000000000',
+          angle: 40,
+          isMirror: false,
+          status: 'send',
+          attemptCount: 1,
+          isBenchmark: false,
+          comment: '',
+          climbedAt: new Date().toISOString(),
+          videoUrl: REEL_WITH_PARAM,
+        },
+      },
+      ctx,
+    );
+
+    expect(betaInsert.current).toMatchObject({ link: REEL_CLEAN, shortcode: 'DZlVfVhxKJZ' });
   });
 });


### PR DESCRIPTION
## Follow-up to #2866

#2866 added a save-side test asserting `attachBetaLink` stores the Instagram link/shortcode stripped of the `?igsh=` share-attribution param, but only covered that one save entry point. This adds the symmetric case for the **`saveTick`** write path, which normalizes the attached video URL independently (`mutations.ts` — `attachedVideoUrl = normalizeBetaVideoUrl(tickVideoUrl)`).

## Change

`beta-link-save-normalization.test.ts` now exercises both save paths:
- `attachBetaLink` (existing) — direct `db.insert`
- `saveTick` (new) — `tx.insert` inside the transaction, on a successful (`send`) ascent with a `videoUrl`

Both assert the stored `link` and `shortcode` drop the query param. The test shapes the `saveTick` input with no `boardUuid`/`boardId`/`layoutId`/`sizeId`/`setIds`, so board resolution is skipped and no extra DB mocking is needed; the transaction is mocked to capture the `boardBetaLinks` insert values.

## Validation

- `vp test run --project backend` (this file) — 2 tests pass
- `vp check` + `vp run typecheck:backend` — clean

https://claude.ai/code/session_01TJELQRAzuxXchcXM5yooat

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJELQRAzuxXchcXM5yooat)_