### PR TITLE
fix(session): board doesn't update in a session — retire driver/previ…

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { View, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
+import { BoardPresenceCurrentContext } from '@boardsesh/board-presence-react';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
@@ -200,6 +201,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       }),
     [bluetoothConnected, bluetoothLoading],
   );
+  // The lightbulb reads lit if *anyone* is connected to the board, not just this
+  // device: in a session every member shares the wall, so another member's
+  // connection (the board-presence holder) lights it too. Read the context
+  // directly (non-throwing) so the portaled drawer never crashes if it renders
+  // outside the provider. The press action still keys on THIS device's BLE.
+  const boardPresenceCurrent = useContext(BoardPresenceCurrentContext);
+  const lightbulbActive = lightbulbState.lightbulbActive || boardPresenceCurrent?.holder != null;
   // Queue-mutation gating comes from the provider's roster-aware selector (a
   // solo occupant keeps full control).
   const isPartyPreviewOnly = useIsPartyPreviewOnly();
@@ -681,7 +689,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                   supportsMirroring={supportsMirroring}
                   isFavorited={isFavorited}
                   remainingQueueCount={navigationState.remainingCount}
-                  lightbulbActive={lightbulbState.lightbulbActive}
+                  lightbulbActive={lightbulbActive}
                   lightbulbPending={lightbulbState.lightbulbPending}
                   lightbulbLongPressEnabled={bluetoothConnected}
                   ascentCount={ascentCount}

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1645,7 +1645,7 @@ describe('QueueProvider preview-only roster gating', () => {
     });
   });
 
-  it('never gates a solo occupant, gates party non-drivers, releases for the driver', async () => {
+  it('never gates queue control — every session participant controls the wall instantly (no driver mechanics)', async () => {
     const previewOnlyValues: boolean[] = [];
     render(
       createElement(
@@ -1655,9 +1655,6 @@ describe('QueueProvider preview-only roster gating', () => {
       ),
     );
 
-    // Restored solo session: roster is just us, no driver claimed — a solo
-    // occupant keeps full queue control (the bug this guards against: a
-    // driverless session bricking every activation tap).
     await waitFor(() => {
       expect(ws.getSessionUpdatesSink()).not.toBeNull();
     });
@@ -1666,8 +1663,10 @@ describe('QueueProvider preview-only roster gating', () => {
     const sessionUpdatesSink = ws.getSessionUpdatesSink();
     if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
 
-    // A second participant joins with no driver: everyone is preview-only
-    // until someone takes wall control.
+    // A second participant joins and wall control changes hands between members.
+    // None of it gates: the driver / preview-only mechanics were removed, so
+    // every participant keeps full control of the shared queue + wall at all
+    // times (the backend accepts queue mutations from any participant).
     act(() => {
       sessionUpdatesSink.next({
         data: {
@@ -1678,41 +1677,23 @@ describe('QueueProvider preview-only roster gating', () => {
         },
       });
     });
-    await waitFor(() => {
-      expect(previewOnlyValues.at(-1)).toBe(true);
-    });
-
-    // We take control: gate releases for us.
-    act(() => {
-      sessionUpdatesSink.next({
-        data: {
-          sessionUpdates: {
-            __typename: 'DriverChanged',
-            driverParticipantId: 'participant-self',
-            previousDriverParticipantId: null,
-          },
-        },
-      });
-    });
-    await waitFor(() => {
-      expect(previewOnlyValues.at(-1)).toBe(false);
-    });
-
-    // The peer takes control: we're preview-only again.
     act(() => {
       sessionUpdatesSink.next({
         data: {
           sessionUpdates: {
             __typename: 'DriverChanged',
             driverParticipantId: 'participant-2',
-            previousDriverParticipantId: 'participant-self',
+            previousDriverParticipantId: null,
           },
         },
       });
     });
+
     await waitFor(() => {
-      expect(previewOnlyValues.at(-1)).toBe(true);
+      expect(previewOnlyValues.length).toBeGreaterThan(0);
     });
+    // Preview-only is never true — no member is ever locked out of control.
+    expect(previewOnlyValues.every((value) => value === false)).toBe(true);
   });
 
   it('does not restore or clear the stored session when the status check fails with a server response', async () => {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -32,7 +32,6 @@ import {
   createJoinSessionTracker,
   createReleaseControlOptimisticPlan,
   createTakeControlOptimisticPlan,
-  derivePreviewOnly,
   mapSubscriptionEnvelopeToAction,
   shouldRollbackReleaseControlDriver,
   shouldRollbackTakeControlDriver,
@@ -1804,17 +1803,13 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [playlistSuggestionSource],
   );
 
-  // Preview-only selector — the single queue-mutation gate (play drawer, queue
-  // sheet, activation taps, widget nav all consume this hook). Roster-aware:
-  // a solo occupant of a session always keeps full control of the queue; with
-  // 2+ live participants, a released driver (driverParticipantId null) leaves
-  // everyone preview-only until someone takes wall control.
-  const isPartyPreviewOnly = derivePreviewOnly({
-    isSessionActive: sessionId !== null,
-    participantId,
-    driverParticipantId,
-    sessionUserCount: sessionUsers.length,
-  });
+  // No driver mechanics: every session participant controls the shared queue and
+  // wall instantly. The backend accepts queue/current-climb mutations from any
+  // participant (last write wins), so there is no preview-only gate — navigation,
+  // activation, and queue edits drive the shared wall for everyone, the same as
+  // solo. (Kept as a hook so the many consumers don't all need touching; retiring
+  // the driver/preview concept end-to-end is a follow-up.)
+  const isPartyPreviewOnly = false;
   const partyPreviewOnlyValue = useMemo<QueuePartyPreviewOnlyContextValue>(
     () => ({ isPartyPreviewOnly }),
     [isPartyPreviewOnly],


### PR DESCRIPTION
…ew-only

In a 2+ person session every member was preview-only until someone "took wall control" (the driver). Navigation by a preview-only member only set a local preview (drawerPreviewItem) and never changed state.currentClimbQueueItem — the only thing the BLE auto-sender watches — so connecting in a session never lit the wall. The old lightbulb's takeControl flipped you out of preview-only; the new connect/disconnect lightbulb doesn't, so everyone stayed preview-only. Solo was unaffected.

Per the new no-driver model (every session member controls the board instantly):
- queue-provider: isPartyPreviewOnly is now always false. The backend accepts queue/current-climb mutations from any participant (last write wins), so navigation/activation/queue edits drive the shared wall for everyone, like solo. (Hook kept; fully retiring the driver/preview concept is a follow-up.)
- PlayDrawer: the lightbulb reads lit if ANY member holds the board (the board-presence holder), not just this device — so a session shows the wall as connected when a peer is connected. The press still keys on this device's BLE. Read via the non-throwing context so the portaled drawer can't crash.
- Updated the preview-only session test to assert control is never gated.