### PR TITLE
Prettier session detail page (mobile)

### DIFF
--- a/packages/backend/src/__tests__/live-session-stats.test.ts
+++ b/packages/backend/src/__tests__/live-session-stats.test.ts
@@ -62,6 +62,7 @@ function makeSessionDetail(overrides: Partial<SessionDetail> = {}): SessionDetai
         climbedAt: '2024-01-15T10:10:00.000Z',
         upvotes: 2,
         totalAttempts: 2,
+        betaLinks: [],
       },
     ],
     upvotes: 0,
@@ -132,6 +133,7 @@ describe('buildSessionStatsUpdatedEvent', () => {
       climbedAt: `2024-01-15T10:${String(i).padStart(2, '0')}:00.000Z`,
       upvotes: 0,
       totalAttempts: 1,
+      betaLinks: [],
     }));
     const detail = makeSessionDetail({ ticks });
     sessionDetailMock.mockResolvedValue(detail);

--- a/packages/backend/src/__tests__/session-detail-beta-links.test.ts
+++ b/packages/backend/src/__tests__/session-detail-beta-links.test.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import * as dbSchema from '@boardsesh/db/schema';
+
+// ---------------------------------------------------------------------------
+// Mock harness
+// ---------------------------------------------------------------------------
+// `sessionDetail` drives several differently-shaped Drizzle fluent chains plus
+// two raw `dbRead.execute(sql)` calls. Rather than emulate one rigid chain (as
+// session-feed-query.test.ts does for the single sessionGroupedFeed query), we
+// install a dispatching `dbRead` that branches on the table passed to
+// `.from(...)`. Every chain resolves to a row array; the beta-links branch is
+// counted so we can assert the per-session batch is a single query (no N+1
+// per tick) and that the resolver groups the returned rows back onto each tick
+// by climb.
+//
+// The is_listed = true / KayaClimb exclusion are SQL predicates evaluated by
+// Postgres, so a pure mock cannot exercise the DB filter itself. We therefore
+// (a) assert the resolver builds those predicates into the beta-links WHERE
+// clause, and (b) have the mock return only the rows the real query would
+// (the listed, non-Kaya link), proving the resolver surfaces exactly that row
+// per tick.
+
+const betaLinkTestState = vi.hoisted(() => {
+  // Rows the *real* board_beta_links query would return after Postgres applies
+  // `is_listed = true AND link !~* kayaclimb`. The unlisted row and the Kaya
+  // row are intentionally absent — the DB drops them — so the resolver should
+  // only ever see / surface the listed Instagram link.
+  const betaLinkRowsByQuery: Array<Record<string, unknown>[]> = [];
+
+  const executeMock = vi.fn();
+  const betaLinkWhereClauses: unknown[] = [];
+  const betaLinkSelectCallCount = { value: 0 };
+  // Tick rows the big sessionDetail select resolves to. Mutated per-test; the
+  // mock reads it live so each case controls its own session shape.
+  const state: {
+    betaLinkRowsByQuery: Array<Record<string, unknown>[]>;
+    executeMock: typeof executeMock;
+    betaLinkWhereClauses: unknown[];
+    betaLinkSelectCallCount: { value: number };
+    tickRows: Record<string, unknown>[];
+  } = {
+    betaLinkRowsByQuery,
+    executeMock,
+    betaLinkWhereClauses,
+    betaLinkSelectCallCount,
+    tickRows: [],
+  };
+  return state;
+});
+
+// Resolve a fluent select chain to a row array. Drizzle's builder is then-able
+// (awaiting it runs the query), and also chains .from/.leftJoin/.where/.orderBy
+// /.limit. We model that with a thenable proxy that ignores every intermediate
+// call and resolves to `rows` when awaited.
+function makeChain(rows: Record<string, unknown>[], onWhere?: (clause: unknown) => void) {
+  const chain: Record<string, unknown> = {};
+  const passthrough = () => chain;
+  chain.leftJoin = passthrough;
+  chain.innerJoin = passthrough;
+  chain.orderBy = passthrough;
+  chain.limit = passthrough;
+  chain.groupBy = passthrough;
+  chain.where = (clause: unknown) => {
+    onWhere?.(clause);
+    return chain;
+  };
+  // Make the chain awaitable -> resolves to the row array.
+  chain.then = (resolve: (value: Record<string, unknown>[]) => unknown) => resolve(rows);
+  return chain;
+}
+
+vi.mock('../db/client', () => {
+  const select = vi.fn(() => ({
+    from: (table: unknown) => {
+      if (table === dbSchema.boardBetaLinks) {
+        betaLinkTestState.betaLinkSelectCallCount.value += 1;
+        const callIndex = betaLinkTestState.betaLinkSelectCallCount.value - 1;
+        const rows = betaLinkTestState.betaLinkRowsByQuery[callIndex] ?? [];
+        return makeChain(rows, (clause) => betaLinkTestState.betaLinkWhereClauses.push(clause));
+      }
+      if (table === dbSchema.boardSessions) {
+        return makeChain([
+          {
+            id: 'party-1',
+            name: 'Lunch Laps',
+            goal: 'Finish the set',
+            createdByUserId: 'user-1',
+          },
+        ]);
+      }
+      if (table === dbSchema.boardseshTicks) {
+        return makeChain(betaLinkTestState.tickRows);
+      }
+      if (table === dbSchema.voteCounts) {
+        // Both the per-tick batch (entityType='tick') and the session-level
+        // count resolve through here; an empty array is a valid result for
+        // both (no votes recorded).
+        return makeChain([]);
+      }
+      if (table === dbSchema.comments) {
+        return makeChain([{ count: 0 }]);
+      }
+      if (table === dbSchema.sessionHealthKitWorkouts) {
+        return makeChain([]);
+      }
+      return makeChain([]);
+    },
+  }));
+
+  const fakeDb = {
+    select,
+    // totalAttempts CTE + fetchParticipants both call dbRead.execute(sql).
+    // rowsFromResult requires an array; returning [] keeps both happy.
+    execute: betaLinkTestState.executeMock,
+  };
+  return { db: fakeDb, dbRead: fakeDb };
+});
+
+// Serialize a captured WHERE condition to real Postgres text using drizzle's
+// own compiler — the same path the resolver uses to emit SQL. Far less brittle
+// than hand-walking queryChunks: column names render as their snake_case
+// identifiers (e.g. "is_listed") and inline `sql` fragments (the kayaclimb
+// regex) render verbatim, so we can assert both predicates are present.
+const pgDialect = new PgDialect();
+function conditionToText(node: unknown): string {
+  try {
+    return pgDialect.sqlToQuery(node as SQL).sql;
+  } catch {
+    return '';
+  }
+}
+
+const { sessionDetail } = await import('../graphql/resolvers/social/session-feed').then(
+  (module) => module.sessionFeedQueries,
+);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+function makeTickRow(overrides: {
+  uuid: string;
+  climbUuid: string;
+  climbName: string;
+  boardType?: string;
+  angle?: number;
+  status?: string;
+}) {
+  const boardType = overrides.boardType ?? 'kilter';
+  const angle = overrides.angle ?? 40;
+  return {
+    tick: {
+      uuid: overrides.uuid,
+      userId: 'user-1',
+      climbUuid: overrides.climbUuid,
+      boardType,
+      angle,
+      status: overrides.status ?? 'send',
+      attemptCount: 1,
+      difficulty: 10,
+      quality: 3,
+      isMirror: false,
+      isBenchmark: false,
+      comment: null,
+      climbedAt: '2024-01-15T10:00:00.000Z',
+    },
+    climbName: overrides.climbName,
+    climbDescription: '',
+    setterUsername: 'setter',
+    layoutId: 1,
+    frames: 'p1r1',
+    difficultyName: 'V10',
+    consensusDifficulty: 10,
+  };
+}
+
+const LISTED_INSTAGRAM_LINK = 'https://www.instagram.com/p/LISTED/';
+const LISTED_TIKTOK_LINK = 'https://www.tiktok.com/@climber/video/123';
+
+describe('sessionDetail per-tick betaLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    betaLinkTestState.betaLinkRowsByQuery.length = 0;
+    betaLinkTestState.betaLinkWhereClauses.length = 0;
+    betaLinkTestState.betaLinkSelectCallCount.value = 0;
+    // execute() backs the totalAttempts CTE and fetchParticipants; both go
+    // through rowsFromResult, which requires an array.
+    betaLinkTestState.executeMock.mockResolvedValue([]);
+  });
+
+  it('attaches a betaLinks array to every tick', async () => {
+    betaLinkTestState.tickRows = [makeTickRow({ uuid: 'tick-1', climbUuid: 'climb-a', climbName: 'Crimpathon' })];
+    // Real DB already dropped unlisted + Kaya rows; only the listed IG link
+    // survives to the resolver.
+    betaLinkTestState.betaLinkRowsByQuery.push([
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-a',
+        link: LISTED_INSTAGRAM_LINK,
+        foreignUsername: 'marco',
+        angle: 40,
+        thumbnail: 'https://cdn.example/thumb.jpg',
+        isListed: true,
+        createdAt: '2024-01-10T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await sessionDetail(undefined, { sessionId: 'party-1' });
+
+    expect(result).not.toBeNull();
+    expect(result?.ticks).toHaveLength(1);
+    for (const tick of result?.ticks ?? []) {
+      expect(Array.isArray(tick.betaLinks)).toBe(true);
+    }
+    expect(result?.ticks[0]?.betaLinks).toEqual([
+      {
+        climbUuid: 'climb-a',
+        link: LISTED_INSTAGRAM_LINK,
+        foreignUsername: 'marco',
+        angle: 40,
+        thumbnail: 'https://cdn.example/thumb.jpg',
+        isListed: true,
+        createdAt: '2024-01-10T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('only includes is_listed links and excludes KayaClimb URLs', async () => {
+    betaLinkTestState.tickRows = [makeTickRow({ uuid: 'tick-1', climbUuid: 'climb-a', climbName: 'Crimpathon' })];
+    // The mock returns what Postgres would after applying the is_listed/Kaya
+    // predicates: only the listed, non-Kaya Instagram link. (The unlisted link
+    // and the kayaclimb.com link the test "seeds" below never come back.)
+    betaLinkTestState.betaLinkRowsByQuery.push([
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-a',
+        link: LISTED_INSTAGRAM_LINK,
+        foreignUsername: 'marco',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-10T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await sessionDetail(undefined, { sessionId: 'party-1' });
+
+    const links = result?.ticks[0]?.betaLinks ?? [];
+    expect(links.map((betaLink) => betaLink.link)).toEqual([LISTED_INSTAGRAM_LINK]);
+    // No unlisted link leaked through.
+    expect(links.every((betaLink) => betaLink.isListed === true)).toBe(true);
+    // No kayaclimb.com URL leaked through.
+    expect(links.some((betaLink) => /kayaclimb\.com/i.test(betaLink.link))).toBe(false);
+
+    // The is_listed = true and KayaClimb-exclusion predicates must actually be
+    // in the WHERE clause the resolver sent to board_beta_links — that's what
+    // makes the DB drop the unlisted/Kaya rows. Assert on the serialized SQL so
+    // a future refactor that drops a predicate fails here.
+    const betaWhereText = betaLinkTestState.betaLinkWhereClauses.map(conditionToText).join(' | ');
+    expect(betaWhereText).toContain('is_listed');
+    expect(betaWhereText.toLowerCase()).toContain('kayaclimb');
+  });
+
+  it('batches all climbs into a single query and groups links by climb (no per-tick N+1)', async () => {
+    // Three ticks across two distinct climbs (climb-a twice, climb-b once).
+    betaLinkTestState.tickRows = [
+      makeTickRow({ uuid: 'tick-1', climbUuid: 'climb-a', climbName: 'Crimpathon' }),
+      makeTickRow({ uuid: 'tick-2', climbUuid: 'climb-a', climbName: 'Crimpathon' }),
+      makeTickRow({ uuid: 'tick-3', climbUuid: 'climb-b', climbName: 'Slopefest' }),
+    ];
+    // Single batched result for both climbs; climb-a has the IG link, climb-b
+    // has a TikTok link. climb-b's row arrives in the same query.
+    betaLinkTestState.betaLinkRowsByQuery.push([
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-a',
+        link: LISTED_INSTAGRAM_LINK,
+        foreignUsername: 'marco',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-10T00:00:00.000Z',
+      },
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-b',
+        link: LISTED_TIKTOK_LINK,
+        foreignUsername: 'sam',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-11T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await sessionDetail(undefined, { sessionId: 'party-1' });
+
+    // Exactly one query hit board_beta_links for the whole session, regardless
+    // of the three ticks / two climbs — the N+1 guard.
+    expect(betaLinkTestState.betaLinkSelectCallCount.value).toBe(1);
+
+    const ticks = result?.ticks ?? [];
+    const byUuid = new Map(ticks.map((tick) => [tick.uuid, tick] as const));
+
+    // Both ticks on climb-a get climb-a's link...
+    expect(byUuid.get('tick-1')?.betaLinks?.map((link) => link.link)).toEqual([LISTED_INSTAGRAM_LINK]);
+    expect(byUuid.get('tick-2')?.betaLinks?.map((link) => link.link)).toEqual([LISTED_INSTAGRAM_LINK]);
+    // ...and the climb-b tick gets climb-b's link — correct grouping by climb.
+    expect(byUuid.get('tick-3')?.betaLinks?.map((link) => link.link)).toEqual([LISTED_TIKTOK_LINK]);
+
+    // A climb's links never bleed onto another climb's ticks.
+    expect(byUuid.get('tick-3')?.betaLinks?.some((link) => link.link === LISTED_INSTAGRAM_LINK)).toBe(false);
+  });
+
+  it('returns an empty betaLinks array for climbs with no stored links', async () => {
+    betaLinkTestState.tickRows = [
+      makeTickRow({ uuid: 'tick-1', climbUuid: 'climb-a', climbName: 'Crimpathon' }),
+      makeTickRow({ uuid: 'tick-2', climbUuid: 'climb-z', climbName: 'No Beta Here' }),
+    ];
+    // Only climb-a has a link; climb-z returns nothing from the batch query.
+    betaLinkTestState.betaLinkRowsByQuery.push([
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-a',
+        link: LISTED_INSTAGRAM_LINK,
+        foreignUsername: 'marco',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-10T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await sessionDetail(undefined, { sessionId: 'party-1' });
+
+    const byUuid = new Map((result?.ticks ?? []).map((tick) => [tick.uuid, tick] as const));
+    expect(byUuid.get('tick-1')?.betaLinks?.map((link) => link.link)).toEqual([LISTED_INSTAGRAM_LINK]);
+    // Climb with no stored links surfaces an empty array, never undefined.
+    expect(byUuid.get('tick-2')?.betaLinks).toEqual([]);
+  });
+});

--- a/packages/backend/src/__tests__/session-detail-beta-links.test.ts
+++ b/packages/backend/src/__tests__/session-detail-beta-links.test.ts
@@ -131,6 +131,15 @@ function conditionToText(node: unknown): string {
     return '';
   }
 }
+// Bound parameter values (climb UUIDs render as params, not inline SQL), so the
+// canonical-vs-alias assertion checks params rather than the SQL text.
+function conditionToParams(node: unknown): unknown[] {
+  try {
+    return pgDialect.sqlToQuery(node as SQL).params;
+  } catch {
+    return [];
+  }
+}
 
 const { sessionDetail } = await import('../graphql/resolvers/social/session-feed').then(
   (module) => module.sessionFeedQueries,
@@ -143,6 +152,8 @@ function makeTickRow(overrides: {
   uuid: string;
   climbUuid: string;
   climbName: string;
+  /** Alias-resolved canonical UUID; defaults to climbUuid (no alias). */
+  canonicalClimbUuid?: string;
   boardType?: string;
   angle?: number;
   status?: string;
@@ -172,6 +183,7 @@ function makeTickRow(overrides: {
     frames: 'p1r1',
     difficultyName: 'V10',
     consensusDifficulty: 10,
+    canonicalClimbUuid: overrides.canonicalClimbUuid ?? overrides.climbUuid,
   };
 }
 
@@ -224,6 +236,40 @@ describe('sessionDetail per-tick betaLinks', () => {
         createdAt: '2024-01-10T00:00:00.000Z',
       },
     ]);
+  });
+
+  it('matches beta on the alias-resolved canonical climb UUID', async () => {
+    // Tick points at an alias UUID; its canonical ('climb-canonical') is where
+    // the listed beta lives.
+    betaLinkTestState.tickRows = [
+      makeTickRow({
+        uuid: 'tick-1',
+        climbUuid: 'climb-alias',
+        canonicalClimbUuid: 'climb-canonical',
+        climbName: 'Renamed',
+      }),
+    ];
+    betaLinkTestState.betaLinkRowsByQuery.push([
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-canonical',
+        link: LISTED_INSTAGRAM_LINK,
+        foreignUsername: 'marco',
+        angle: 40,
+        thumbnail: null,
+        isListed: true,
+        createdAt: '2024-01-10T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await sessionDetail(undefined, { sessionId: 'party-1' });
+
+    // The alias tick still surfaces the canonical climb's beta.
+    expect(result?.ticks[0]?.betaLinks?.map((beta) => beta.link)).toEqual([LISTED_INSTAGRAM_LINK]);
+    // The query bound the canonical UUID, not the alias.
+    const betaParams = betaLinkTestState.betaLinkWhereClauses.flatMap(conditionToParams);
+    expect(betaParams).toContain('climb-canonical');
+    expect(betaParams).not.toContain('climb-alias');
   });
 
   it('only includes is_listed links and excludes KayaClimb URLs', async () => {

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, sql, count as drizzleCount, isNull, inArray, type SQL } from 'drizzle-orm';
+import { eq, and, or, desc, sql, count as drizzleCount, isNull, inArray, type SQL } from 'drizzle-orm';
 import { dbRead } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { getGradeLabel } from '@boardsesh/db/queries';
@@ -14,6 +14,7 @@ import type {
   SessionFeedParticipant,
   SessionFeedTickHighlight,
   SessionDetailTick,
+  BetaLinksGqlRow,
   ConnectionContext,
 } from '@boardsesh/shared-schema';
 import { logger } from '../../../utils/logger';
@@ -561,6 +562,10 @@ export const sessionFeedQueries = {
         : [];
     const tickVoteMap = new Map(tickVoteCounts.map((v) => [v.entityId, Number(v.upvotes)]));
 
+    // Batch-fetch stored beta links for the session's climbs in one query.
+    // Keyed by `${boardType}:${climbUuid}` so each tick reads an O(1) Map entry.
+    const betaLinksByClimb = await fetchBetaLinksByClimb(tickRows);
+
     // Build ticks (totalAttempts added below)
     const ticks: SessionDetailTick[] = tickRows.map((row) => {
       const effectiveDifficulty =
@@ -589,6 +594,7 @@ export const sessionFeedQueries = {
         climbedAt: row.tick.climbedAt,
         upvotes: tickVoteMap.get(row.tick.uuid) ?? 0,
         totalAttempts: null,
+        betaLinks: betaLinksByClimb.get(`${row.tick.boardType}:${row.tick.climbUuid}`) ?? [],
       };
     });
 
@@ -1335,7 +1341,7 @@ async function fetchDailyGradeDistributionBatch(
   return map;
 }
 
-function mapBetaLinkRow(row: BetaLinkRow) {
+function mapBetaLinkRow(row: BetaLinkRow): BetaLinksGqlRow {
   return {
     climbUuid: row.climbUuid,
     link: row.link,
@@ -1345,6 +1351,83 @@ function mapBetaLinkRow(row: BetaLinkRow) {
     isListed: row.isListed,
     createdAt: row.createdAt,
   };
+}
+
+/**
+ * Batch-fetch stored beta links for the climbs ticked in a session, for the
+ * session-detail beta carousel.
+ *
+ * Runs ONE query against board_beta_links filtered to the unique
+ * (boardType, climbUuid) pairs from the session's ticks — the same direct
+ * climb-uuid lookup the per-climb `betaLinks` query (the play-drawer beta list)
+ * uses, so the carousel surfaces the same community beta a climber would see on
+ * each climb. It adds two gates appropriate to this aggregated public view:
+ * is_listed = true and the KayaClimb URL exclusion.
+ *
+ * This is deliberately NOT the featured-beta path (`betaCandidateJoinSql`),
+ * which additionally scopes to the ticking user's own beta, matches the tick
+ * angle, and resolves climb aliases to rank a single personal highlight — a
+ * different feature. Here we want every shareable clip for the climbs, not one.
+ *
+ * No live Instagram/TikTok enrichment — thumbnails are whatever is pre-cached.
+ * Returns a Map keyed `${boardType}:${climbUuid}`.
+ */
+async function fetchBetaLinksByClimb(
+  tickRows: Array<{ tick: { boardType: string; climbUuid: string } }>,
+): Promise<Map<string, BetaLinksGqlRow[]>> {
+  const map = new Map<string, BetaLinksGqlRow[]>();
+  if (tickRows.length === 0) return map;
+
+  // Unique (boardType, climbUuid) pairs so the IN-list stays bounded by the
+  // number of distinct climbs, not the number of ticks.
+  const pairSet = new Set<string>();
+  const pairPredicates: SQL[] = [];
+  for (const { tick } of tickRows) {
+    const key = `${tick.boardType}:${tick.climbUuid}`;
+    if (pairSet.has(key)) continue;
+    pairSet.add(key);
+    pairPredicates.push(
+      and(
+        eq(dbSchema.boardBetaLinks.boardType, tick.boardType),
+        eq(dbSchema.boardBetaLinks.climbUuid, tick.climbUuid),
+      ) as SQL,
+    );
+  }
+
+  const betaRows = await dbRead
+    .select({
+      boardType: dbSchema.boardBetaLinks.boardType,
+      climbUuid: dbSchema.boardBetaLinks.climbUuid,
+      link: dbSchema.boardBetaLinks.link,
+      foreignUsername: dbSchema.boardBetaLinks.foreignUsername,
+      angle: dbSchema.boardBetaLinks.angle,
+      thumbnail: dbSchema.boardBetaLinks.thumbnail,
+      isListed: dbSchema.boardBetaLinks.isListed,
+      createdAt: dbSchema.boardBetaLinks.createdAt,
+    })
+    .from(dbSchema.boardBetaLinks)
+    .where(
+      and(
+        or(...pairPredicates),
+        eq(dbSchema.boardBetaLinks.isListed, true),
+        // Match the featured-beta KayaClimb exclusion: drop links pointing at
+        // kayaclimb.com (and any subdomain), which aren't shareable video beta.
+        sql`${dbSchema.boardBetaLinks.link} !~* '^https?://([a-z0-9-]+\\.)*kayaclimb\\.com/'`,
+      ),
+    )
+    .orderBy(desc(dbSchema.boardBetaLinks.createdAt));
+
+  for (const row of betaRows) {
+    const key = `${row.boardType}:${row.climbUuid}`;
+    const existing = map.get(key);
+    const mapped = mapBetaLinkRow(row);
+    if (existing) {
+      existing.push(mapped);
+    } else {
+      map.set(key, [mapped]);
+    }
+  }
+  return map;
 }
 
 async function fetchFeaturedBetaBatch(

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -506,6 +506,9 @@ export const sessionFeedQueries = {
         frames: dbSchema.boardClimbs.frames,
         difficultyName: dbSchema.boardDifficultyGrades.boulderName,
         consensusDifficulty: dbSchema.boardClimbStats.displayDifficulty,
+        // Canonical climb UUID (alias-resolved) so beta links — which are stored
+        // against the canonical climb — resolve for ticks pointing at an alias.
+        canonicalClimbUuid: sql<string>`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid})`,
       })
       .from(dbSchema.boardseshTicks)
       // Resolve dedup-merged climbs to their canonical UUID before joining
@@ -594,7 +597,7 @@ export const sessionFeedQueries = {
         climbedAt: row.tick.climbedAt,
         upvotes: tickVoteMap.get(row.tick.uuid) ?? 0,
         totalAttempts: null,
-        betaLinks: betaLinksByClimb.get(`${row.tick.boardType}:${row.tick.climbUuid}`) ?? [],
+        betaLinks: betaLinksByClimb.get(`${row.tick.boardType}:${row.canonicalClimbUuid}`) ?? [],
       };
     });
 
@@ -1370,23 +1373,24 @@ function mapBetaLinkRow(row: BetaLinkRow): BetaLinksGqlRow {
  * different feature. Here we want every shareable clip for the climbs, not one.
  *
  * No live Instagram/TikTok enrichment — thumbnails are whatever is pre-cached.
- * Returns a Map keyed `${boardType}:${climbUuid}`.
+ * Matches on the alias-resolved canonical climb UUID (beta is stored against the
+ * canonical), and returns a Map keyed `${boardType}:${canonicalClimbUuid}`.
  */
 async function fetchBetaLinksByClimb(
-  tickRows: Array<{ tick: { boardType: string; climbUuid: string } }>,
+  tickRows: Array<{ tick: { boardType: string }; canonicalClimbUuid: string }>,
 ): Promise<Map<string, BetaLinksGqlRow[]>> {
   const map = new Map<string, BetaLinksGqlRow[]>();
   if (tickRows.length === 0) return map;
 
-  // Unique (boardType, climbUuid) pairs so the IN-list stays bounded by the
-  // number of distinct climbs, not the number of ticks.
+  // Unique (boardType, canonicalClimbUuid) pairs so the IN-list stays bounded by
+  // the number of distinct climbs, not the number of ticks.
   const pairSet = new Set<string>();
   const pairs: Array<{ boardType: string; climbUuid: string }> = [];
-  for (const { tick } of tickRows) {
-    const key = `${tick.boardType}:${tick.climbUuid}`;
+  for (const { tick, canonicalClimbUuid } of tickRows) {
+    const key = `${tick.boardType}:${canonicalClimbUuid}`;
     if (pairSet.has(key)) continue;
     pairSet.add(key);
-    pairs.push({ boardType: tick.boardType, climbUuid: tick.climbUuid });
+    pairs.push({ boardType: tick.boardType, climbUuid: canonicalClimbUuid });
   }
 
   const betaRows = await dbRead

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, desc, sql, count as drizzleCount, isNull, inArray, type SQL } from 'drizzle-orm';
+import { eq, and, desc, sql, count as drizzleCount, isNull, inArray, type SQL } from 'drizzle-orm';
 import { dbRead } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { getGradeLabel } from '@boardsesh/db/queries';
@@ -1381,17 +1381,12 @@ async function fetchBetaLinksByClimb(
   // Unique (boardType, climbUuid) pairs so the IN-list stays bounded by the
   // number of distinct climbs, not the number of ticks.
   const pairSet = new Set<string>();
-  const pairPredicates: SQL[] = [];
+  const pairs: Array<{ boardType: string; climbUuid: string }> = [];
   for (const { tick } of tickRows) {
     const key = `${tick.boardType}:${tick.climbUuid}`;
     if (pairSet.has(key)) continue;
     pairSet.add(key);
-    pairPredicates.push(
-      and(
-        eq(dbSchema.boardBetaLinks.boardType, tick.boardType),
-        eq(dbSchema.boardBetaLinks.climbUuid, tick.climbUuid),
-      ) as SQL,
-    );
+    pairs.push({ boardType: tick.boardType, climbUuid: tick.climbUuid });
   }
 
   const betaRows = await dbRead
@@ -1408,7 +1403,13 @@ async function fetchBetaLinksByClimb(
     .from(dbSchema.boardBetaLinks)
     .where(
       and(
-        or(...pairPredicates),
+        // Row-tuple IN-list over (board_type, climb_uuid): Postgres can probe the
+        // (board_type, climb_uuid, link) primary key per pair, which is friendlier
+        // than an OR-of-equality chain.
+        sql`(${dbSchema.boardBetaLinks.boardType}, ${dbSchema.boardBetaLinks.climbUuid}) in (${sql.join(
+          pairs.map((pair) => sql`(${pair.boardType}, ${pair.climbUuid})`),
+          sql`, `,
+        )})`,
         eq(dbSchema.boardBetaLinks.isListed, true),
         // Match the featured-beta KayaClimb exclusion: drop links pointing at
         // kayaclimb.com (and any subdomain), which aren't shareable video beta.

--- a/packages/mobile/app/session/[sessionId].tsx
+++ b/packages/mobile/app/session/[sessionId].tsx
@@ -15,6 +15,7 @@ import { CommentSheet } from '../../src/components/you/CommentSheet';
 import { SessionDetailHero } from '../../src/components/session/SessionDetailHero';
 import { SessionStatTiles } from '../../src/components/session/SessionStatTiles';
 import { SessionAnalyticsSection } from '../../src/components/session/SessionAnalyticsSection';
+import { SessionBetaCarousel } from '../../src/components/session/SessionBetaCarousel';
 import { SessionParticipantBreakdown } from '../../src/components/session/SessionParticipantBreakdown';
 import { SessionTickRow } from '../../src/components/session/SessionTickRow';
 import { useSessionDetail } from '../../src/lib/graphql/hooks';
@@ -22,6 +23,9 @@ import { navigateToSessionClimb } from '../../src/lib/session-tick-mapping';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { spacing } from '../../src/theme/tokens';
 import { useTheme } from '../../src/providers/theme-provider';
+
+// Hoisted so FlashList gets a stable reference across renders.
+const keyExtractor = (tick: SessionDetailTick) => tick.uuid;
 
 export default function SessionDetailScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
@@ -114,7 +118,9 @@ export default function SessionDetailScreen() {
         hardestGrade={session.hardestGrade}
       />
 
-      <SessionAnalyticsSection ticks={session.ticks} />
+      <SessionAnalyticsSection ticks={session.ticks} gradeDistribution={session.gradeDistribution} />
+
+      <SessionBetaCarousel ticks={session.ticks} />
 
       <SessionParticipantBreakdown participants={session.participants} />
 
@@ -133,11 +139,11 @@ export default function SessionDetailScreen() {
   );
 
   return (
-    <View style={styles.flex}>
+    <View style={[styles.flex, { backgroundColor: systemColors.groupedBackground }]}>
       <FlashList
         data={session.ticks}
         renderItem={renderItem}
-        keyExtractor={(tick) => tick.uuid}
+        keyExtractor={keyExtractor}
         ListHeaderComponent={header}
         contentContainerStyle={{ paddingBottom }}
       />

--- a/packages/mobile/app/session/[sessionId].tsx
+++ b/packages/mobile/app/session/[sessionId].tsx
@@ -118,7 +118,7 @@ export default function SessionDetailScreen() {
         hardestGrade={session.hardestGrade}
       />
 
-      <SessionAnalyticsSection ticks={session.ticks} gradeDistribution={session.gradeDistribution} />
+      <SessionAnalyticsSection gradeDistribution={session.gradeDistribution} />
 
       <SessionBetaCarousel ticks={session.ticks} />
 

--- a/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
+++ b/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
@@ -16,11 +16,7 @@ import { spacing } from '../../theme/tokens';
  * flash cap so a brighter top band reads as "flashed". A compact two-swatch
  * legend explains the shade split. Renders nothing when there's no data.
  */
-export function SessionAnalyticsSection({
-  gradeDistribution,
-}: {
-  gradeDistribution: SessionGradeDistributionItem[];
-}) {
+export function SessionAnalyticsSection({ gradeDistribution }: { gradeDistribution: SessionGradeDistributionItem[] }) {
   const { t } = useTranslation('profile');
   const { colorScheme } = useTheme();
   // Match the grade format the Progress tab / useYouProfileData uses so a

--- a/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
+++ b/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import type { SessionDetailTick, SessionGradeDistributionItem } from '@boardsesh/shared-schema';
+import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 import { Card } from '../Card';
 import { SectionHeader } from '../SectionHeader';
 import { StackedBarChart, type ChartLegendItem } from '../you/YouCharts';
@@ -17,14 +17,9 @@ import { spacing } from '../../theme/tokens';
  * legend explains the shade split. Renders nothing when there's no data.
  */
 export function SessionAnalyticsSection({
-  ticks,
-  gradeDistribution = [],
+  gradeDistribution,
 }: {
-  ticks: SessionDetailTick[];
-  // Optional until app/session/[sessionId].tsx is wired in a later phase to pass
-  // session.gradeDistribution; defaults to an empty distribution (renders the
-  // ticks-only empty path).
-  gradeDistribution?: SessionGradeDistributionItem[];
+  gradeDistribution: SessionGradeDistributionItem[];
 }) {
   const { t } = useTranslation('profile');
   const { colorScheme } = useTheme();
@@ -47,7 +42,9 @@ export function SessionAnalyticsSection({
     [t, colorScheme],
   );
 
-  if (!gradeBars && ticks.length === 0) return null;
+  // `buildSessionGradeBars` returns null for an empty or all-zero distribution,
+  // so this covers both the no-distribution and no-ascent cases.
+  if (!gradeBars) return null;
 
   return (
     <View>

--- a/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
+++ b/packages/mobile/src/components/session/SessionAnalyticsSection.tsx
@@ -1,82 +1,60 @@
 import { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { deriveProfileViewModel } from '@boardsesh/profile-stats';
-import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import type { SessionDetailTick, SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 import { Card } from '../Card';
 import { SectionHeader } from '../SectionHeader';
-import { StackedBarChart, GroupedBarChart, type ChartLegendItem } from '../you/YouCharts';
-import { layoutChartColor, flashRedpointColor } from '../you/profile-chart-colors';
-import { sessionTicksToLogbook } from '../../lib/session-tick-mapping';
+import { StackedBarChart, type ChartLegendItem } from '../you/YouCharts';
+import { buildSessionGradeBars, gradeBadgeColor, gradeChartColor } from '../you/profile-chart-colors';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
 
 /**
- * Rich per-session breakdown: maps the session's ticks into the shared
- * `deriveProfileViewModel` aggregation (timeframe 'all', all boards) and renders
- * the grade-distribution + flash-vs-redpoint charts, mirroring the Progress tab.
- * Renders nothing when there are no ticks.
+ * Per-session grade breakdown. Renders a grade-distribution chart where each bar
+ * is coloured by grade hue, split into a muted send (redpoint) base and a vivid
+ * flash cap so a brighter top band reads as "flashed". A compact two-swatch
+ * legend explains the shade split. Renders nothing when there's no data.
  */
-export function SessionAnalyticsSection({ ticks }: { ticks: SessionDetailTick[] }) {
+export function SessionAnalyticsSection({
+  ticks,
+  gradeDistribution = [],
+}: {
+  ticks: SessionDetailTick[];
+  // Optional until app/session/[sessionId].tsx is wired in a later phase to pass
+  // session.gradeDistribution; defaults to an empty distribution (renders the
+  // ticks-only empty path).
+  gradeDistribution?: SessionGradeDistributionItem[];
+}) {
   const { t } = useTranslation('profile');
   const { colorScheme } = useTheme();
   // Match the grade format the Progress tab / useYouProfileData uses so a
-  // session's charts read identically to the profile's.
-  const { gradeFormat } = useGradeFormat();
+  // session's chart reads identically to the profile's.
+  const { formatGrade } = useGradeFormat();
 
-  const viewModel = useMemo(() => {
-    if (ticks.length === 0) return null;
-    return deriveProfileViewModel({
-      allBoardsTicks: sessionTicksToLogbook(ticks),
-      selectedBoard: 'all',
-      timeframe: 'all',
-      fromDate: '',
-      toDate: '',
-      gradeFormat,
-      profileStats: null,
-    });
-  }, [ticks, gradeFormat]);
-
-  const gradeDistLegend = useMemo<ChartLegendItem[] | undefined>(
-    () =>
-      viewModel?.aggregatedStackedBars?.legend.map((entry) => ({
-        label: entry.label,
-        color: layoutChartColor(entry.key, colorScheme),
-      })),
-    [colorScheme, viewModel],
-  );
-  const flashRedpointLegend = useMemo<ChartLegendItem[] | undefined>(
-    () =>
-      viewModel?.aggregatedFlashRedpointBars?.[0]?.values.map((value) => ({
-        label: value.label,
-        color: flashRedpointColor(value.key, colorScheme),
-      })),
-    [viewModel, colorScheme],
+  const gradeBars = useMemo(
+    () => buildSessionGradeBars(gradeDistribution, formatGrade, { splitFlash: true, colorScheme }),
+    [gradeDistribution, formatGrade, colorScheme],
   );
 
-  if (!viewModel) return null;
+  // Representative vivid (flash) vs muted (redpoint) swatches so the user reads
+  // "brighter shade = flash" — V5 is a mid-palette grade that reads on both.
+  const shadeLegend = useMemo<ChartLegendItem[]>(
+    () => [
+      { label: t('stats.flash'), color: gradeBadgeColor('V5') },
+      { label: t('stats.redpoint'), color: gradeChartColor('V5', colorScheme) },
+    ],
+    [t, colorScheme],
+  );
+
+  if (!gradeBars && ticks.length === 0) return null;
 
   return (
     <View>
       <SectionHeader title={t('stats.gradeDistribution')} />
       <Card style={styles.chartCard}>
-        <StackedBarChart
-          bars={viewModel.aggregatedStackedBars?.bars ?? null}
-          colorBy="layout"
-          legend={gradeDistLegend}
-          fitYAxisToData
-        />
+        <StackedBarChart bars={gradeBars} colorBy="grade" legend={shadeLegend} fitYAxisToData />
       </Card>
-
-      {viewModel.aggregatedFlashRedpointBars && (
-        <>
-          <SectionHeader title={t('stats.flashVsRedpoint')} />
-          <Card style={styles.chartCard}>
-            <GroupedBarChart bars={viewModel.aggregatedFlashRedpointBars} legend={flashRedpointLegend} fitYAxisToData />
-          </Card>
-        </>
-      )}
     </View>
   );
 }

--- a/packages/mobile/src/components/session/SessionBetaCarousel.tsx
+++ b/packages/mobile/src/components/session/SessionBetaCarousel.tsx
@@ -33,7 +33,7 @@ export function SessionBetaCarousel({ ticks }: SessionBetaCarouselProps) {
 
   return (
     <View>
-      <SectionHeader title={t('betaVideos.title')} />
+      <SectionHeader title={t('mobile.betaVideos.title')} />
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/packages/mobile/src/components/session/SessionBetaCarousel.tsx
+++ b/packages/mobile/src/components/session/SessionBetaCarousel.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import { SectionHeader } from '../SectionHeader';
+import { betaLinkIdentity, dedupeBetaLinks, isBetaVideoUrl, mapBetaLinks } from '../../lib/beta-video-url';
+import { spacing } from '../../theme/tokens';
+import { BetaVideoCard, BETA_CARD_WIDTH } from '../play-drawer/BetaVideoCard';
+
+type SessionBetaCarouselProps = {
+  ticks: SessionDetailTick[];
+};
+
+const CARD_GAP = spacing[3];
+
+/**
+ * Beta-video shelf for the session detail screen. Aggregates every tick's beta
+ * links, keeps only valid Instagram/TikTok URLs, dedupes them across the
+ * session, and renders a horizontal snap carousel. The list is bounded (one
+ * deduped set per session), so a plain ScrollView matches BetaVideosSection.
+ * Self-hides when there's nothing to show.
+ */
+export function SessionBetaCarousel({ ticks }: SessionBetaCarouselProps) {
+  const { t } = useTranslation('session');
+
+  const betaLinks = useMemo(() => {
+    const mapped = mapBetaLinks(ticks.flatMap((tick) => tick.betaLinks ?? []));
+    const videos = mapped.filter((betaLink) => isBetaVideoUrl(betaLink.link));
+    return dedupeBetaLinks(videos);
+  }, [ticks]);
+
+  if (betaLinks.length === 0) return null;
+
+  return (
+    <View>
+      <SectionHeader title={t('betaVideos.title')} />
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+        snapToInterval={BETA_CARD_WIDTH + CARD_GAP}
+        decelerationRate="fast"
+        snapToAlignment="start"
+      >
+        {betaLinks.map((betaLink) => (
+          <BetaVideoCard key={betaLinkIdentity(betaLink.link)} link={betaLink} />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    gap: CARD_GAP,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/session/SessionDetailHero.tsx
+++ b/packages/mobile/src/components/session/SessionDetailHero.tsx
@@ -1,4 +1,5 @@
 import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import type { SessionDetail } from '@boardsesh/shared-schema';
 import { formatTickAbsoluteTime } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
@@ -6,6 +7,7 @@ import { Icon } from '../Icon';
 import { AvatarGroup } from '../you/AvatarGroup';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
 
 function formatDuration(minutes: number): string {
   if (minutes < 60) return `${minutes}m`;
@@ -20,38 +22,72 @@ type SessionDetailHeroProps = {
   title: string;
 };
 
-/** Hero block for the session-detail screen: avatars, name, date, board, duration, goal. */
+/** Hero block for the session-detail screen: avatars, name, summary, date, board · duration, goal. */
 export function SessionDetailHero({ session, title }: SessionDetailHeroProps) {
   const { systemColors } = useTheme();
+  const { t } = useTranslation('feed');
+  const { formatGrade } = useGradeFormat();
 
   const absoluteDate = formatTickAbsoluteTime(session.lastTickAt, 'MMM D, YYYY · h:mm A');
+
+  // One-line headline summary: "7 sends · 3 flashes" (falling back to the hardest
+  // grade when there are no flashes but a hardest grade is known). Built from the
+  // totals the hero already receives — no extra props needed.
+  const summaryParts: string[] = [];
+  if (session.totalSends > 0) {
+    summaryParts.push(t('sessionFeedCard.sendsCount', { count: session.totalSends }));
+  }
+  if (session.totalFlashes > 0) {
+    summaryParts.push(t('sessionFeedCard.flashesCount', { count: session.totalFlashes }));
+  } else if (session.hardestGrade) {
+    const displayGrade = formatGrade(session.hardestGrade) ?? session.hardestGrade;
+    summaryParts.push(t('sessionFeedCard.hardestGrade', { grade: displayGrade }));
+  }
+  const summary = summaryParts.join(' · ');
+
+  const board = session.boardTypes.join(' · ');
+  const duration =
+    session.durationMinutes != null && session.durationMinutes > 0 ? formatDuration(session.durationMinutes) : null;
 
   return (
     <View style={styles.container}>
       <AvatarGroup participants={session.participants} size={44} />
-      <Text variant="title2" style={styles.title}>
+      <Text variant="title1" style={styles.title}>
         {title}
       </Text>
+
+      {summary ? (
+        <Text variant="subheadline" color={systemColors.secondaryLabel}>
+          {summary}
+        </Text>
+      ) : null}
+
       <Text variant="subheadline" color={systemColors.secondaryLabel}>
         {absoluteDate}
       </Text>
 
-      {session.boardTypes.length > 0 && (
-        <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.boards}>
-          {session.boardTypes.join(' · ')}
-        </Text>
-      )}
-
-      <View style={styles.metaRow}>
-        {session.durationMinutes != null && session.durationMinutes > 0 && (
-          <View style={styles.metaItem}>
-            <Icon name="clock" size={14} color={systemColors.secondaryLabel} />
+      {board || duration ? (
+        <View style={styles.metaRow}>
+          {board ? (
             <Text variant="footnote" color={systemColors.secondaryLabel}>
-              {formatDuration(session.durationMinutes)}
+              {board}
             </Text>
-          </View>
-        )}
-      </View>
+          ) : null}
+          {board && duration ? (
+            <Text variant="footnote" color={systemColors.secondaryLabel}>
+              ·
+            </Text>
+          ) : null}
+          {duration ? (
+            <View style={styles.metaItem}>
+              <Icon name="clock" size={14} color={systemColors.secondaryLabel} />
+              <Text variant="footnote" color={systemColors.secondaryLabel}>
+                {duration}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+      ) : null}
 
       {session.goal ? (
         <View style={styles.goal}>
@@ -71,9 +107,8 @@ const styles = StyleSheet.create({
     paddingTop: spacing[4],
     gap: spacing[1],
   },
-  title: { fontWeight: '700', marginTop: spacing[2] },
-  boards: { marginTop: spacing[1] },
-  metaRow: { flexDirection: 'row', alignItems: 'center', gap: spacing[4], marginTop: spacing[2] },
+  title: { marginTop: spacing[2] },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: spacing[2], marginTop: spacing[1] },
   metaItem: { flexDirection: 'row', alignItems: 'center', gap: spacing[1] },
   goal: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing[2], marginTop: spacing[2] },
   goalText: { flex: 1 },

--- a/packages/mobile/src/components/session/SessionStatTiles.tsx
+++ b/packages/mobile/src/components/session/SessionStatTiles.tsx
@@ -47,7 +47,7 @@ function StatTile({ value, label, icon, tint }: { value: number; label: string; 
     <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
       <View style={styles.valueRow}>
         <Icon name={icon} size={14} color={tint} />
-        <Text variant="title3" color={tint}>
+        <Text variant="title2" color={systemColors.label}>
           {value}
         </Text>
       </View>
@@ -65,7 +65,7 @@ function GradeTile({ grade, label }: { grade: string; label: string }) {
   const displayGrade = formatGrade(grade) ?? grade;
   return (
     <View style={[styles.tile, { backgroundColor: background }]}>
-      <Text variant="title3" color={textColor}>
+      <Text variant="title2" color={textColor}>
         {displayGrade}
       </Text>
       <Text variant="caption1" color={textColor} style={styles.gradeLabel} numberOfLines={1}>

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -8,12 +8,18 @@ import { Icon } from '../Icon';
 import { type IconName } from '../icon-map';
 import { ListRow } from '../ListRow';
 import { Avatar } from '../Avatar';
+import { PressableSurface } from '../PressableSurface';
+import { ClimbListItemContent } from '../ClimbListItemContent';
 import { FeedSocialRow } from '../you/FeedSocialRow';
 import { gradeBadgeColor } from '../you/profile-chart-colors';
 import { useGradeFormat } from '../../hooks/use-grade-format';
-import { brandColors } from '../../theme/colors';
+import { useTheme } from '../../providers/theme-provider';
+import { brandColors, withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
+import { sessionTickToClimb } from '../../lib/session-tick-mapping';
+import { hapticSelection } from '../../lib/haptics';
 
 type TickStatusMeta = { icon: IconName; color: string };
 
@@ -81,12 +87,67 @@ export const SessionTickRow = memo(function SessionTickRow({
   onOpenComments,
 }: SessionTickRowProps) {
   const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
 
   const meta = statusMeta(tick.status);
   const attemptText = formatAttemptText(tick, t);
   const subtitleParts = [attemptText, tick.comment ?? null].filter((part): part is string => !!part);
   const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined;
+
+  const handlePress = () => {
+    hapticSelection();
+    onPress(tick);
+  };
+
+  const climb = sessionTickToClimb(tick);
+  const boardConfig = getBoardConfigForPlaylist(tick.boardType, tick.layoutId);
+
+  if (climb && boardConfig) {
+    return (
+      <View>
+        <PressableSurface
+          onPress={handlePress}
+          feedback="opacity"
+          opacityTo={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={tick.climbName ?? t('detail.unknownClimb')}
+          style={[styles.row, { backgroundColor: systemColors.secondaryBackground }]}
+        >
+          {isMultiUser ? (
+            <Avatar uri={participant?.avatarUrl} name={participant?.displayName} size={28} />
+          ) : (
+            <View style={styles.statusSlot}>
+              <View style={[styles.statusIcon, { backgroundColor: withAlpha(meta.color, 0.15) }]}>
+                <Icon name={meta.icon} size={14} color={meta.color} />
+              </View>
+            </View>
+          )}
+          <ClimbListItemContent
+            climb={climb}
+            boardName={boardConfig.boardName}
+            layoutId={boardConfig.layoutId}
+            sizeId={boardConfig.sizeId}
+            setIds={boardConfig.setIds.join(',')}
+            angle={tick.angle}
+            subtitleDetailParts={subtitleParts}
+            showAscentStatus={false}
+          />
+          <FeedSocialRow
+            entityId={tick.uuid}
+            entityType="tick"
+            upvotes={tick.upvotes}
+            userVote={null}
+            commentCount={0}
+            onOpenComments={onOpenComments}
+            compact
+          />
+        </PressableSurface>
+        <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
+      </View>
+    );
+  }
+
   const gradeLabel =
     formatGradeByDifficultyId(tick.difficulty) ?? formatGrade(tick.difficultyName) ?? tick.difficultyName;
   const gradeColor = gradeLabel ? gradeBadgeColor(tick.difficultyName ?? gradeLabel) : undefined;
@@ -95,7 +156,7 @@ export const SessionTickRow = memo(function SessionTickRow({
     <ListRow
       title={tick.climbName ?? t('detail.unknownClimb')}
       subtitle={subtitle}
-      onPress={() => onPress(tick)}
+      onPress={handlePress}
       leading={
         isMultiUser ? (
           <Avatar uri={participant?.avatarUrl} name={participant?.displayName} size={28} />
@@ -130,6 +191,29 @@ export const SessionTickRow = memo(function SessionTickRow({
 });
 
 const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing[3],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+  },
+  statusSlot: {
+    width: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  statusIcon: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: spacing[3] + 28 + spacing[3],
+  },
   badge: {
     width: 28,
     height: 28,

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -32,6 +32,10 @@ const STATUS_META: Record<string, TickStatusMeta> = {
 };
 const ATTEMPT_META: TickStatusMeta = { icon: 'circle', color: iosSystemColors.systemGray };
 
+// Leading status disc / avatar size. Shared by the styles and the separator
+// inset so the hairline always aligns past the disc + its two gutters.
+const STATUS_ICON_SIZE = 28;
+
 function statusMeta(status: string): TickStatusMeta {
   return STATUS_META[status] ?? ATTEMPT_META;
 }
@@ -95,6 +99,11 @@ export const SessionTickRow = memo(function SessionTickRow({
   const subtitleParts = [attemptText, tick.comment ?? null].filter((part): part is string => !!part);
   const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined;
 
+  // SessionDetail carries no per-tick comment count (only a session-level one),
+  // so the comment button opens the sheet without a count badge — FeedSocialRow
+  // hides the badge at 0. Real per-tick counts would be a separate backend add.
+  const tickCommentCount = 0;
+
   const handlePress = useCallback(() => {
     hapticSelection();
     onPress(tick);
@@ -138,7 +147,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             entityType="tick"
             upvotes={tick.upvotes}
             userVote={null}
-            commentCount={0}
+            commentCount={tickCommentCount}
             onOpenComments={onOpenComments}
             compact
           />
@@ -180,7 +189,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             entityType="tick"
             upvotes={tick.upvotes}
             userVote={null}
-            commentCount={0}
+            commentCount={tickCommentCount}
             onOpenComments={onOpenComments}
             compact
           />
@@ -199,25 +208,25 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[3],
   },
   statusSlot: {
-    width: 28,
+    width: STATUS_ICON_SIZE,
     alignItems: 'center',
     justifyContent: 'center',
   },
   statusIcon: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
+    width: STATUS_ICON_SIZE,
+    height: STATUS_ICON_SIZE,
+    borderRadius: STATUS_ICON_SIZE / 2,
     alignItems: 'center',
     justifyContent: 'center',
   },
   separator: {
     height: StyleSheet.hairlineWidth,
-    marginLeft: spacing[3] + 28 + spacing[3],
+    marginLeft: spacing[3] + STATUS_ICON_SIZE + spacing[3],
   },
   badge: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
+    width: STATUS_ICON_SIZE,
+    height: STATUS_ICON_SIZE,
+    borderRadius: STATUS_ICON_SIZE / 2,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
@@ -95,10 +95,10 @@ export const SessionTickRow = memo(function SessionTickRow({
   const subtitleParts = [attemptText, tick.comment ?? null].filter((part): part is string => !!part);
   const subtitle = subtitleParts.length > 0 ? subtitleParts.join(' · ') : undefined;
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     hapticSelection();
     onPress(tick);
-  };
+  }, [onPress, tick]);
 
   const climb = sessionTickToClimb(tick);
   const boardConfig = getBoardConfigForPlaylist(tick.boardType, tick.layoutId);

--- a/packages/mobile/src/components/session/__tests__/SessionAnalyticsSection.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionAnalyticsSection.test.tsx
@@ -2,7 +2,7 @@
 import { createElement, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SessionDetailTick, SessionGradeDistributionItem } from '@boardsesh/shared-schema';
+import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 
 type ChartBar = { key: string; label: string; segments: Array<{ value: number; key: string; color?: string }> };
 
@@ -44,34 +44,6 @@ vi.mock('../../../theme/tokens', () => ({ spacing: { 4: 16 } }));
 import { SessionAnalyticsSection } from '../SessionAnalyticsSection';
 import { gradeBadgeColor, gradeChartColor } from '../../you/profile-chart-colors';
 
-function tick(overrides: Partial<SessionDetailTick> = {}): SessionDetailTick {
-  return {
-    uuid: 'tick-1',
-    userId: 'user-1',
-    climbUuid: 'climb-1',
-    climbName: 'Test Climb',
-    boardType: 'kilter',
-    layoutId: 1,
-    angle: 40,
-    status: 'send',
-    attemptCount: 2,
-    difficulty: 12,
-    difficultyName: 'V4',
-    quality: null,
-    isMirror: false,
-    isBenchmark: false,
-    isNoMatch: false,
-    comment: null,
-    frames: 'p1',
-    setterUsername: null,
-    climbedAt: '2026-06-01T10:00:00.000Z',
-    upvotes: 0,
-    totalAttempts: 5,
-    betaLinks: [],
-    ...overrides,
-  };
-}
-
 const distribution: SessionGradeDistributionItem[] = [{ grade: 'V4', flash: 2, send: 3, attempt: 0 }];
 
 beforeEach(() => {
@@ -82,9 +54,7 @@ beforeEach(() => {
 
 describe('SessionAnalyticsSection', () => {
   it('renders exactly one grade-coloured chart (no second flash-vs-redpoint chart)', () => {
-    const { getAllByTestId } = render(
-      createElement(SessionAnalyticsSection, { ticks: [tick()], gradeDistribution: distribution }),
-    );
+    const { getAllByTestId } = render(createElement(SessionAnalyticsSection, { gradeDistribution: distribution }));
 
     expect(getAllByTestId('stacked-bar-chart')).toHaveLength(1);
     expect(chart.renderCount).toBe(1);
@@ -103,8 +73,18 @@ describe('SessionAnalyticsSection', () => {
     expect(chart.legendCount).toBe(2);
   });
 
-  it('renders nothing when the distribution is empty and there are no ticks', () => {
-    const { container } = render(createElement(SessionAnalyticsSection, { ticks: [], gradeDistribution: [] }));
+  it('renders nothing when the distribution is empty', () => {
+    const { container } = render(createElement(SessionAnalyticsSection, { gradeDistribution: [] }));
+    expect(container.querySelector('[data-testid="stacked-bar-chart"]')).toBeNull();
+    expect(chart.renderCount).toBe(0);
+  });
+
+  it('renders nothing when grades have only attempts (no sends or flashes to chart)', () => {
+    const { container } = render(
+      createElement(SessionAnalyticsSection, {
+        gradeDistribution: [{ grade: 'V4', flash: 0, send: 0, attempt: 3 }],
+      }),
+    );
     expect(container.querySelector('[data-testid="stacked-bar-chart"]')).toBeNull();
     expect(chart.renderCount).toBe(0);
   });

--- a/packages/mobile/src/components/session/__tests__/SessionAnalyticsSection.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionAnalyticsSection.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionDetailTick, SessionGradeDistributionItem } from '@boardsesh/shared-schema';
+
+type ChartBar = { key: string; label: string; segments: Array<{ value: number; key: string; color?: string }> };
+
+// Capture what SessionAnalyticsSection feeds the chart so we can assert the bars
+// are real grade-coloured bars and that there's exactly one chart (no second
+// flash-vs-redpoint chart). buildSessionGradeBars/gradeBadgeColor stay real so
+// the colours under test are the production ones.
+const chart = vi.hoisted(() => ({ renderCount: 0, bars: null as ChartBar[] | null, legendCount: 0 }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  // theme/colors (pulled in transitively by profile-chart-colors) reads these.
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-testid': 'chart-card' }, children),
+}));
+vi.mock('../../SectionHeader', () => ({
+  SectionHeader: ({ title }: { title: string }) => createElement('div', { 'data-testid': 'section-header' }, title),
+}));
+vi.mock('../../you/YouCharts', () => ({
+  StackedBarChart: ({ bars, legend }: { bars: ChartBar[] | null; legend?: unknown[] }) => {
+    chart.renderCount += 1;
+    chart.bars = bars;
+    chart.legendCount = legend?.length ?? 0;
+    return createElement('div', { 'data-testid': 'stacked-bar-chart' });
+  },
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ colorScheme: 'light' }) }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 4: 16 } }));
+
+import { SessionAnalyticsSection } from '../SessionAnalyticsSection';
+import { gradeBadgeColor, gradeChartColor } from '../../you/profile-chart-colors';
+
+function tick(overrides: Partial<SessionDetailTick> = {}): SessionDetailTick {
+  return {
+    uuid: 'tick-1',
+    userId: 'user-1',
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    status: 'send',
+    attemptCount: 2,
+    difficulty: 12,
+    difficultyName: 'V4',
+    quality: null,
+    isMirror: false,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: null,
+    frames: 'p1',
+    setterUsername: null,
+    climbedAt: '2026-06-01T10:00:00.000Z',
+    upvotes: 0,
+    totalAttempts: 5,
+    betaLinks: [],
+    ...overrides,
+  };
+}
+
+const distribution: SessionGradeDistributionItem[] = [{ grade: 'V4', flash: 2, send: 3, attempt: 0 }];
+
+beforeEach(() => {
+  chart.renderCount = 0;
+  chart.bars = null;
+  chart.legendCount = 0;
+});
+
+describe('SessionAnalyticsSection', () => {
+  it('renders exactly one grade-coloured chart (no second flash-vs-redpoint chart)', () => {
+    const { getAllByTestId } = render(
+      createElement(SessionAnalyticsSection, { ticks: [tick()], gradeDistribution: distribution }),
+    );
+
+    expect(getAllByTestId('stacked-bar-chart')).toHaveLength(1);
+    expect(chart.renderCount).toBe(1);
+
+    // The bars carry the split-flash grade colours: a muted send base + a vivid
+    // flash cap, both keyed by grade.
+    expect(chart.bars).not.toBeNull();
+    expect(chart.bars).toHaveLength(1);
+    const [bar] = chart.bars ?? [];
+    expect(bar.key).toBe('V4');
+    expect(bar.segments.map((segment) => segment.value)).toEqual([3, 2]);
+    expect(bar.segments[0].color).toBe(gradeChartColor('V4', 'light'));
+    expect(bar.segments[1].color).toBe(gradeBadgeColor('V4'));
+
+    // A two-swatch shade legend (flash vs redpoint), not a separate chart.
+    expect(chart.legendCount).toBe(2);
+  });
+
+  it('renders nothing when the distribution is empty and there are no ticks', () => {
+    const { container } = render(createElement(SessionAnalyticsSection, { ticks: [], gradeDistribution: [] }));
+    expect(container.querySelector('[data-testid="stacked-bar-chart"]')).toBeNull();
+    expect(chart.renderCount).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BetaLink, SessionDetailTick, BetaLinksGqlRow } from '@boardsesh/shared-schema';
+
+// Capture the link each (mocked) BetaVideoCard renders so we can assert exactly
+// one card per deduped video. The real beta-video-url helpers (filter + dedupe)
+// stay in play so the carousel's selection logic is what's under test.
+const cards = vi.hoisted(() => ({ links: [] as BetaLink[] }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-testid': 'beta-scroll' }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../SectionHeader', () => ({
+  SectionHeader: ({ title }: { title: string }) => createElement('div', { 'data-testid': 'section-header' }, title),
+}));
+vi.mock('../../play-drawer/BetaVideoCard', () => ({
+  BETA_CARD_WIDTH: 140,
+  BetaVideoCard: ({ link }: { link: BetaLink }) => {
+    cards.links.push(link);
+    return createElement('div', { 'data-testid': 'beta-card', 'data-link': link.link });
+  },
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 3: 12, 4: 16 } }));
+
+import { SessionBetaCarousel } from '../SessionBetaCarousel';
+
+function betaRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
+  return {
+    climbUuid: 'climb-1',
+    link: 'https://www.instagram.com/reel/aaa/',
+    foreignUsername: 'setter',
+    angle: 40,
+    thumbnail: null,
+    isListed: true,
+    createdAt: '2026-06-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function tick(betaLinks: BetaLinksGqlRow[]): SessionDetailTick {
+  return {
+    uuid: 'tick-1',
+    userId: 'user-1',
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    status: 'send',
+    attemptCount: 2,
+    difficulty: 12,
+    difficultyName: 'V4',
+    quality: null,
+    isMirror: false,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: null,
+    frames: null,
+    setterUsername: null,
+    climbedAt: '2026-06-01T10:00:00.000Z',
+    upvotes: 0,
+    totalAttempts: 5,
+    betaLinks,
+  };
+}
+
+beforeEach(() => {
+  cards.links = [];
+});
+
+describe('SessionBetaCarousel', () => {
+  it('renders one BetaVideoCard per deduped video link across ticks', () => {
+    const { getAllByTestId } = render(
+      createElement(SessionBetaCarousel, {
+        ticks: [
+          tick([betaRow({ link: 'https://www.instagram.com/reel/aaa/' })]),
+          tick([betaRow({ link: 'https://www.tiktok.com/@user/video/12345' })]),
+          // Same Instagram reel id as the first — deduped away.
+          tick([betaRow({ link: 'https://instagram.com/reel/aaa/?igsh=tracking' })]),
+        ],
+      }),
+    );
+
+    const renderedCards = getAllByTestId('beta-card');
+    expect(renderedCards).toHaveLength(2);
+    expect(cards.links.map((link) => link.link)).toEqual([
+      'https://www.instagram.com/reel/aaa/',
+      'https://www.tiktok.com/@user/video/12345',
+    ]);
+  });
+
+  it('filters out non-video links', () => {
+    const { getAllByTestId } = render(
+      createElement(SessionBetaCarousel, {
+        ticks: [
+          tick([
+            betaRow({ link: 'https://www.instagram.com/reel/bbb/' }),
+            betaRow({ link: 'https://www.youtube.com/watch?v=abcdefg' }),
+            betaRow({ link: 'https://example.com/beta' }),
+          ]),
+        ],
+      }),
+    );
+
+    expect(getAllByTestId('beta-card')).toHaveLength(1);
+    expect(cards.links.map((link) => link.link)).toEqual(['https://www.instagram.com/reel/bbb/']);
+  });
+
+  it('renders nothing when no tick has beta links', () => {
+    const { container } = render(createElement(SessionBetaCarousel, { ticks: [tick([]), tick([])] }));
+    expect(container.querySelector('[data-testid="beta-card"]')).toBeNull();
+    expect(container.querySelector('[data-testid="beta-scroll"]')).toBeNull();
+    expect(cards.links).toHaveLength(0);
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/profile-chart-colors.test.ts
+++ b/packages/mobile/src/components/you/__tests__/profile-chart-colors.test.ts
@@ -54,6 +54,7 @@ describe('buildSessionGradeBars with splitFlash', () => {
   it('emits a single send segment when there are no flashes', () => {
     const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 5, flash: 0 })], undefined, {
       splitFlash: true,
+      colorScheme: 'light',
     });
 
     expect(bars).toHaveLength(1);
@@ -65,6 +66,7 @@ describe('buildSessionGradeBars with splitFlash', () => {
   it('emits a single flash cap segment when there are no sends', () => {
     const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 0, flash: 4 })], undefined, {
       splitFlash: true,
+      colorScheme: 'light',
     });
 
     expect(bars).toHaveLength(1);
@@ -74,9 +76,12 @@ describe('buildSessionGradeBars with splitFlash', () => {
   });
 
   it('drops grades with no ascents and returns null for an entirely empty distribution', () => {
-    expect(buildSessionGradeBars([], undefined, { splitFlash: true })).toBeNull();
+    expect(buildSessionGradeBars([], undefined, { splitFlash: true, colorScheme: 'light' })).toBeNull();
     expect(
-      buildSessionGradeBars([gradeItem({ grade: 'V4', send: 0, flash: 0 })], undefined, { splitFlash: true }),
+      buildSessionGradeBars([gradeItem({ grade: 'V4', send: 0, flash: 0 })], undefined, {
+        splitFlash: true,
+        colorScheme: 'light',
+      }),
     ).toBeNull();
   });
 
@@ -84,7 +89,7 @@ describe('buildSessionGradeBars with splitFlash', () => {
     const bars = buildSessionGradeBars(
       [gradeItem({ grade: 'V6', send: 1 }), gradeItem({ grade: 'V2', send: 1 }), gradeItem({ grade: 'V4', send: 1 })],
       undefined,
-      { splitFlash: true },
+      { splitFlash: true, colorScheme: 'light' },
     );
 
     expect((bars ?? []).map((bar) => bar.key)).toEqual(['V2', 'V4', 'V6']);
@@ -93,6 +98,7 @@ describe('buildSessionGradeBars with splitFlash', () => {
   it('applies formatGrade to the segment label while keeping the grade key', () => {
     const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 1, flash: 1 })], (grade) => `Grade ${grade}`, {
       splitFlash: true,
+      colorScheme: 'light',
     });
 
     const [bar] = bars ?? [];

--- a/packages/mobile/src/components/you/__tests__/profile-chart-colors.test.ts
+++ b/packages/mobile/src/components/you/__tests__/profile-chart-colors.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { SessionGradeDistributionItem } from '@boardsesh/shared-schema';
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   PlatformColor: (name: string) => name,
 }));
 
-import { gradeChartColor, layoutChartColor } from '../profile-chart-colors';
+import { buildSessionGradeBars, gradeBadgeColor, gradeChartColor, layoutChartColor } from '../profile-chart-colors';
+
+function gradeItem(overrides: Partial<SessionGradeDistributionItem> = {}): SessionGradeDistributionItem {
+  return { grade: 'V4', flash: 0, send: 0, attempt: 0, ...overrides };
+}
 
 describe('profile chart colors', () => {
   it('uses opaque grade chart colors for light and dark schemes', () => {
@@ -21,5 +26,95 @@ describe('profile chart colors', () => {
     expect(layoutChartColor('unknown-layout', 'light')).toMatch(/^#/);
     expect(layoutChartColor('unknown-layout', 'dark')).toMatch(/^#/);
     expect(layoutChartColor('unknown-layout', 'light')).not.toBe(layoutChartColor('unknown-layout', 'dark'));
+  });
+});
+
+describe('buildSessionGradeBars with splitFlash', () => {
+  it('splits a grade with both sends and flashes into a muted send base and a vivid flash cap', () => {
+    const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 3, flash: 2 })], undefined, {
+      splitFlash: true,
+      colorScheme: 'light',
+    });
+
+    expect(bars).not.toBeNull();
+    expect(bars).toHaveLength(1);
+    const [bar] = bars ?? [];
+    expect(bar.segments).toHaveLength(2);
+
+    // segments[0] is the bottom of the stack — the muted send (redpoint) base.
+    expect(bar.segments[0]).toMatchObject({ value: 3, key: 'V4', color: gradeChartColor('V4', 'light') });
+    expect(bar.segments[0].color).toMatch(/^hsl\(/);
+
+    // segments[1] is pushed last so it caps the top of the stack — the vivid flash.
+    expect(bar.segments[1]).toMatchObject({ value: 2, key: 'V4', color: gradeBadgeColor('V4') });
+    // V4 resolves to its vivid badge hex (#FF5026), not the muted hsl().
+    expect(bar.segments[1].color).toBe('#FF5026');
+  });
+
+  it('emits a single send segment when there are no flashes', () => {
+    const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 5, flash: 0 })], undefined, {
+      splitFlash: true,
+    });
+
+    expect(bars).toHaveLength(1);
+    const [bar] = bars ?? [];
+    expect(bar.segments).toHaveLength(1);
+    expect(bar.segments[0]).toMatchObject({ value: 5, color: gradeChartColor('V4', 'light') });
+  });
+
+  it('emits a single flash cap segment when there are no sends', () => {
+    const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 0, flash: 4 })], undefined, {
+      splitFlash: true,
+    });
+
+    expect(bars).toHaveLength(1);
+    const [bar] = bars ?? [];
+    expect(bar.segments).toHaveLength(1);
+    expect(bar.segments[0]).toMatchObject({ value: 4, color: gradeBadgeColor('V4') });
+  });
+
+  it('drops grades with no ascents and returns null for an entirely empty distribution', () => {
+    expect(buildSessionGradeBars([], undefined, { splitFlash: true })).toBeNull();
+    expect(
+      buildSessionGradeBars([gradeItem({ grade: 'V4', send: 0, flash: 0 })], undefined, { splitFlash: true }),
+    ).toBeNull();
+  });
+
+  it('orders bars easy to hard regardless of input order', () => {
+    const bars = buildSessionGradeBars(
+      [gradeItem({ grade: 'V6', send: 1 }), gradeItem({ grade: 'V2', send: 1 }), gradeItem({ grade: 'V4', send: 1 })],
+      undefined,
+      { splitFlash: true },
+    );
+
+    expect((bars ?? []).map((bar) => bar.key)).toEqual(['V2', 'V4', 'V6']);
+  });
+
+  it('applies formatGrade to the segment label while keeping the grade key', () => {
+    const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 1, flash: 1 })], (grade) => `Grade ${grade}`, {
+      splitFlash: true,
+    });
+
+    const [bar] = bars ?? [];
+    expect(bar.label).toBe('Grade V4');
+    expect(bar.key).toBe('V4');
+    expect(bar.segments.every((segment) => segment.label === 'Grade V4')).toBe(true);
+  });
+});
+
+describe('buildSessionGradeBars default (no options) — regression guard', () => {
+  it('produces a single vivid total segment per grade (SessionGradeChart / SessionFeedCard shape)', () => {
+    const bars = buildSessionGradeBars([gradeItem({ grade: 'V4', send: 3, flash: 2 })]);
+
+    expect(bars).toHaveLength(1);
+    const [bar] = bars ?? [];
+    expect(bar.segments).toHaveLength(1);
+    // total = flash + send, drawn in the vivid grade colour.
+    expect(bar.segments[0]).toMatchObject({ value: 5, key: 'V4', color: gradeBadgeColor('V4') });
+    expect(bar.segments[0].color).toBe('#FF5026');
+  });
+
+  it('returns null for an empty distribution', () => {
+    expect(buildSessionGradeBars([])).toBeNull();
   });
 });

--- a/packages/mobile/src/components/you/profile-chart-colors.ts
+++ b/packages/mobile/src/components/you/profile-chart-colors.ts
@@ -131,15 +131,24 @@ export function gradeBadgeColor(gradeLabel: string | null | undefined): string {
   return getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR;
 }
 
-export type SessionGradeBarsOptions = {
-  /**
-   * Split each grade bar into a muted send (redpoint) base and a vivid flash
-   * cap, so a brighter top band reads as "flashed". When falsy (default) each
-   * bar is a single vivid segment of flash + send.
-   */
-  splitFlash?: boolean;
-  colorScheme?: ColorSchemeName;
-};
+export type SessionGradeBarsOptions =
+  | {
+      /**
+       * Split each grade bar into a muted send (redpoint) base and a vivid flash
+       * cap, so a brighter top band reads as "flashed".
+       */
+      splitFlash: true;
+      /**
+       * Required when splitting: the muted redpoint base is colour-scheme aware,
+       * so omitting it would silently force light-mode shades on dark-mode users.
+       */
+      colorScheme: ColorSchemeName;
+    }
+  | {
+      /** Each bar is a single vivid segment of flash + send (the default). */
+      splitFlash?: false;
+      colorScheme?: ColorSchemeName;
+    };
 
 /**
  * Build grade-distribution bars for a session view. By default each grade bar is

--- a/packages/mobile/src/components/you/profile-chart-colors.ts
+++ b/packages/mobile/src/components/you/profile-chart-colors.ts
@@ -131,17 +131,38 @@ export function gradeBadgeColor(gradeLabel: string | null | undefined): string {
   return getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR;
 }
 
+export type SessionGradeBarsOptions = {
+  /**
+   * Split each grade bar into a muted send (redpoint) base and a vivid flash
+   * cap, so a brighter top band reads as "flashed". When falsy (default) each
+   * bar is a single vivid segment of flash + send.
+   */
+  splitFlash?: boolean;
+  colorScheme?: ColorSchemeName;
+};
+
 /**
- * Build grade-distribution bars for a session view. Each grade bar is the total
- * ascents (flash + send) for that grade, drawn in the grade's own vivid colour —
- * a colourful grade pyramid. Grades with no ascents are dropped; returns null
- * when the whole distribution is empty. Pass straight to `StackedBarChart` (the
- * segment carries an explicit colour, so `colorBy` is ignored for these bars).
+ * Build grade-distribution bars for a session view. By default each grade bar is
+ * the total ascents (flash + send) for that grade, drawn in the grade's own vivid
+ * colour — a colourful grade pyramid.
+ *
+ * With `options.splitFlash`, each bar is split into two same-hue shades: a muted
+ * `gradeChartColor` send (redpoint) base and a vivid `gradeBadgeColor` flash cap.
+ * The flash segment is pushed last so it renders at the top of the stack
+ * (`StackedBarChart` maps `segments[0]` to the bottom of the bar). The same-hue
+ * two-shade split keeps grades distinguishable across the whole V0→V17 palette.
+ *
+ * Grades with no ascents are dropped; returns null when the whole distribution is
+ * empty. Pass straight to `StackedBarChart` (each segment carries an explicit
+ * colour, so `colorBy` is ignored for these bars).
  */
 export function buildSessionGradeBars(
   distribution: SessionGradeDistributionItem[],
   formatGrade?: FormatGrade,
+  options?: SessionGradeBarsOptions,
 ): ColoredBar[] | null {
+  const splitFlash = options?.splitFlash ?? false;
+  const colorScheme = options?.colorScheme ?? 'light';
   const bars: ColoredBar[] = [];
   // Order the X-axis easy→hard regardless of the order the backend returns.
   const ordered = [...distribution].sort((a, b) => gradeSortValue(a.grade) - gradeSortValue(b.grade));
@@ -149,11 +170,24 @@ export function buildSessionGradeBars(
     const total = item.flash + item.send;
     if (total <= 0) continue;
     const label = formatGrade?.(item.grade) ?? item.grade;
-    bars.push({
-      key: item.grade,
-      label,
-      segments: [{ value: total, key: item.grade, label, color: gradeBadgeColor(item.grade) }],
-    });
+    if (splitFlash) {
+      const segments: ColoredBarSegment[] = [];
+      // Send (redpoint) base — muted same-hue shade — sits at the bottom.
+      if (item.send > 0) {
+        segments.push({ value: item.send, key: item.grade, label, color: gradeChartColor(item.grade, colorScheme) });
+      }
+      // Flash cap — vivid same-hue shade — pushed last so it tops the stack.
+      if (item.flash > 0) {
+        segments.push({ value: item.flash, key: item.grade, label, color: gradeBadgeColor(item.grade) });
+      }
+      bars.push({ key: item.grade, label, segments });
+    } else {
+      bars.push({
+        key: item.grade,
+        label,
+        segments: [{ value: total, key: item.grade, label, color: gradeBadgeColor(item.grade) }],
+      });
+    }
   }
   return bars.length > 0 ? bars : null;
 }

--- a/packages/mobile/src/lib/__tests__/session-tick-mapping.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-tick-mapping.test.ts
@@ -6,7 +6,7 @@ vi.mock('../playlists/board-details-for-playlist', () => ({
 }));
 
 import { getBoardConfigForPlaylist } from '../playlists/board-details-for-playlist';
-import { sessionTicksToLogbook, navigateToSessionClimb } from '../session-tick-mapping';
+import { sessionTickToClimb, navigateToSessionClimb } from '../session-tick-mapping';
 
 const mockedGetBoardConfig = vi.mocked(getBoardConfigForPlaylist);
 
@@ -33,51 +33,63 @@ function makeTick(overrides: Partial<SessionDetailTick> = {}): SessionDetailTick
     climbedAt: '2026-06-01T10:00:00.000Z',
     upvotes: 0,
     totalAttempts: 5,
+    betaLinks: [],
     ...overrides,
   };
 }
 
-describe('sessionTicksToLogbook', () => {
-  it('buckets ticks by board type', () => {
-    const result = sessionTicksToLogbook([
-      makeTick({ uuid: 'a', boardType: 'kilter' }),
-      makeTick({ uuid: 'b', boardType: 'tension' }),
-      makeTick({ uuid: 'c', boardType: 'kilter' }),
-    ]);
-    expect(Object.keys(result).sort()).toEqual(['kilter', 'tension']);
-    expect(result.kilter).toHaveLength(2);
-    expect(result.tension).toHaveLength(1);
+describe('sessionTickToClimb', () => {
+  it('returns null without frames (falls back to the plain text row)', () => {
+    expect(sessionTickToClimb(makeTick({ frames: null }))).toBeNull();
   });
 
-  it('maps tick fields onto LogbookEntry, mirroring difficulty into effectiveDifficulty', () => {
-    const [entry] = sessionTicksToLogbook([makeTick({ difficulty: 12, attemptCount: 3, angle: 40 })]).kilter;
-    expect(entry).toMatchObject({
-      climbed_at: '2026-06-01T10:00:00.000Z',
-      difficulty: 12,
-      effectiveDifficulty: 12,
-      tries: 3,
-      angle: 40,
-      status: 'send',
-      layoutId: 1,
-      boardType: 'kilter',
-      climbUuid: 'climb-1',
+  it('maps a framed tick onto the ClimbListItemClimb shape', () => {
+    const climb = sessionTickToClimb(
+      makeTick({
+        climbUuid: 'climb-7',
+        climbName: 'Crimp City',
+        frames: 'p1145r15',
+        difficultyName: 'V6',
+        setterUsername: 'setter-bob',
+      }),
+    );
+
+    expect(climb).toMatchObject({
+      uuid: 'climb-7',
+      name: 'Crimp City',
+      frames: 'p1145r15',
+      difficulty: 'V6',
+      ascensionist_count: 0,
+      setter_username: 'setter-bob',
     });
   });
 
-  it('normalises unknown statuses to attempt and clamps tries to at least 1', () => {
-    const [entry] = sessionTicksToLogbook([makeTick({ status: 'repeat', attemptCount: 0 })]).kilter;
-    expect(entry.status).toBe('attempt');
-    expect(entry.tries).toBe(1);
+  it('sets benchmark_difficulty only when the tick is a benchmark', () => {
+    const benchmark = sessionTickToClimb(makeTick({ frames: 'p1', difficultyName: 'V5', isBenchmark: true }));
+    expect(benchmark?.benchmark_difficulty).toBe('V5');
+
+    const nonBenchmark = sessionTickToClimb(makeTick({ frames: 'p1', difficultyName: 'V5', isBenchmark: false }));
+    expect(nonBenchmark?.benchmark_difficulty).toBeNull();
   });
 
-  it('coalesces a null difficulty to null on both grade fields', () => {
-    const [entry] = sessionTicksToLogbook([makeTick({ difficulty: null })]).kilter;
-    expect(entry.difficulty).toBeNull();
-    expect(entry.effectiveDifficulty).toBeNull();
+  it('passes through mirrored and is_no_match flags', () => {
+    const climb = sessionTickToClimb(makeTick({ frames: 'p1', isMirror: true, isNoMatch: true }));
+    expect(climb?.mirrored).toBe(true);
+    expect(climb?.is_no_match).toBe(true);
   });
 
-  it('returns an empty object for no ticks', () => {
-    expect(sessionTicksToLogbook([])).toEqual({});
+  it('keeps the community star average hidden by defaulting quality_average to "0"', () => {
+    const climb = sessionTickToClimb(makeTick({ frames: 'p1', quality: 3 }));
+    expect(climb?.quality_average).toBe('0');
+  });
+
+  it('coalesces null name, difficultyName and setterUsername to empty strings', () => {
+    const climb = sessionTickToClimb(
+      makeTick({ frames: 'p1', climbName: null, difficultyName: null, setterUsername: null }),
+    );
+    expect(climb?.name).toBe('');
+    expect(climb?.difficulty).toBe('');
+    expect(climb?.setter_username).toBe('');
   });
 });
 

--- a/packages/mobile/src/lib/session-tick-mapping.ts
+++ b/packages/mobile/src/lib/session-tick-mapping.ts
@@ -1,45 +1,33 @@
 import { type useRouter } from 'expo-router';
-import type { LogbookEntry } from '@boardsesh/profile-stats';
 import type { SessionDetailTick } from '@boardsesh/shared-schema';
+import type { ClimbListItemClimb } from '../components/ClimbListItemContent';
 import { getBoardConfigForPlaylist } from './playlists/board-details-for-playlist';
 
 type Router = ReturnType<typeof useRouter>;
 
 /**
- * Normalise a session's per-climb ticks into the `LogbookEntry` shape the shared
- * `deriveProfileViewModel` aggregation consumes, bucketed by board type (the
- * derive step keys every chart off `Record<boardType, LogbookEntry[]>`).
+ * Adapt a session tick into the permissive `ClimbListItemClimb` shape the shared
+ * climb-list visual (thumbnail + name + colorized grade) consumes. Mirrors
+ * LogbookRow's `ascentToClimb`. Returns null without frames — the host then
+ * falls back to the plain text row (e.g. MoonBoard, which has no bundled art).
  *
- * `SessionDetailTick.status` is a free-form string off the GraphQL record, so we
- * narrow it to the three statuses the stats layer understands; anything else
- * (shouldn't happen in practice) falls through as an attempt.
+ * The logger's personal `quality` is deliberately NOT surfaced as the community
+ * star average, so `quality_average` stays '0' (the row hides the star when 0).
  */
-export function sessionTicksToLogbook(ticks: SessionDetailTick[]): Record<string, LogbookEntry[]> {
-  const byBoard: Record<string, LogbookEntry[]> = {};
-  for (const tick of ticks) {
-    const boardType = tick.boardType;
-    const entry: LogbookEntry = {
-      climbed_at: tick.climbedAt,
-      difficulty: tick.difficulty ?? null,
-      // Session ticks carry no consensus override, so the user difficulty doubles
-      // as the effective grade for bucketing.
-      effectiveDifficulty: tick.difficulty ?? null,
-      tries: Math.max(1, tick.attemptCount),
-      angle: tick.angle,
-      status: normaliseStatus(tick.status),
-      layoutId: tick.layoutId ?? null,
-      boardType,
-      climbUuid: tick.climbUuid,
-    };
-    (byBoard[boardType] ??= []).push(entry);
-  }
-  return byBoard;
-}
-
-function normaliseStatus(status: string): LogbookEntry['status'] {
-  if (status === 'flash') return 'flash';
-  if (status === 'send') return 'send';
-  return 'attempt';
+export function sessionTickToClimb(tick: SessionDetailTick): ClimbListItemClimb | null {
+  if (!tick.frames) return null;
+  return {
+    uuid: tick.climbUuid,
+    name: tick.climbName ?? '',
+    frames: tick.frames,
+    difficulty: tick.difficultyName ?? '',
+    ascensionist_count: 0,
+    quality_average: '0',
+    setter_username: tick.setterUsername ?? '',
+    benchmark_difficulty: tick.isBenchmark ? (tick.difficultyName ?? null) : null,
+    mirrored: tick.isMirror,
+    is_no_match: tick.isNoMatch,
+  };
 }
 
 /**

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1393,6 +1393,8 @@ type SessionDetailTick {
   upvotes: Int!
   "Total attempts (sum of attemptCount) since last successful ascent by this user on this climb"
   totalAttempts: Int
+  "Stored beta videos attached to this climb, batched with the session detail (no live enrichment). Populated by the session-detail query; absent on other selections that reuse this type (e.g. the live SessionStatsUpdated subscription)."
+  betaLinks: [BetaLink!]
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4663,6 +4663,8 @@ export type SessionDetailTick = {
   __typename?: 'SessionDetailTick';
   angle: Scalars['Int']['output'];
   attemptCount: Scalars['Int']['output'];
+  /** Stored beta videos attached to this climb, batched with the session detail (no live enrichment). Populated by the session-detail query; absent on other selections that reuse this type (e.g. the live SessionStatsUpdated subscription). */
+  betaLinks?: Maybe<Array<BetaLink>>;
   boardType: Scalars['String']['output'];
   climbName?: Maybe<Scalars['String']['output']>;
   climbUuid: Scalars['String']['output'];
@@ -9112,6 +9114,7 @@ export type SessionDetailTickResolvers<
 > = ResolversObject<{
   angle?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   attemptCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  betaLinks?: Resolver<Maybe<Array<ResolversTypes['BetaLink']>>, ParentType, ContextType>;
   boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   climbName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -511,6 +511,8 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     upvotes: Int!
     "Total attempts (sum of attemptCount) since last successful ascent by this user on this climb"
     totalAttempts: Int
+    "Stored beta videos attached to this climb, batched with the session detail (no live enrichment). Populated by the session-detail query; absent on other selections that reuse this type (e.g. the live SessionStatsUpdated subscription)."
+    betaLinks: [BetaLink!]
   }
 
   """

--- a/packages/shared-schema/src/types/activity-feed.ts
+++ b/packages/shared-schema/src/types/activity-feed.ts
@@ -261,6 +261,10 @@ export type SessionDetailTick = {
   climbedAt: string;
   upvotes: number;
   totalAttempts?: number | null;
+  // Populated by the session-detail query (always an array there); absent on
+  // other selection sets that reuse this type, e.g. the live SessionStatsUpdated
+  // subscription. Consumers default to [] when reading it.
+  betaLinks?: BetaLinksGqlRow[] | null;
 };
 
 export type SessionDetail = {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4660,6 +4660,8 @@ export type SessionDetailTick = {
   __typename?: 'SessionDetailTick';
   angle: Scalars['Int']['output'];
   attemptCount: Scalars['Int']['output'];
+  /** Stored beta videos attached to this climb, batched with the session detail (no live enrichment). Populated by the session-detail query; absent on other selections that reuse this type (e.g. the live SessionStatsUpdated subscription). */
+  betaLinks?: Maybe<Array<BetaLink>>;
   boardType: Scalars['String']['output'];
   climbName?: Maybe<Scalars['String']['output']>;
   climbUuid: Scalars['String']['output'];

--- a/packages/shared/graphql/src/operations/activity-feed.ts
+++ b/packages/shared/graphql/src/operations/activity-feed.ts
@@ -181,6 +181,15 @@ export const GET_SESSION_DETAIL = gql`
         climbedAt
         upvotes
         totalAttempts
+        betaLinks {
+          climbUuid
+          link
+          foreignUsername
+          angle
+          thumbnail
+          isListed
+          createdAt
+        }
       }
     }
   }

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -51,6 +51,7 @@
     "problems": "problems",
     "send": "send",
     "flash": "flash",
+    "redpoint": "redpoint",
     "percentile": "Percentile",
     "topPercent": "Top {{value}}%",
     "moreSentThan": "More problems sent than {{value}}% of climbers",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -51,6 +51,7 @@
     "problems": "bloques",
     "send": "encadene",
     "flash": "flash",
+    "redpoint": "trabajado",
     "percentile": "Percentil",
     "topPercent": "Top {{value}}%",
     "moreSentThan": "Más bloques encadenados que el {{value}}% de los escaladores",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -51,6 +51,7 @@
     "problems": "blocs",
     "send": "enchaînement",
     "flash": "flash",
+    "redpoint": "après-travail",
     "percentile": "Percentile",
     "topPercent": "Top {{value}} %",
     "moreSentThan": "Plus de blocs enchaînés que {{value}} % des grimpeurs",

--- a/packages/web/app/components/onboarding/mock-session-detail.ts
+++ b/packages/web/app/components/onboarding/mock-session-detail.ts
@@ -249,6 +249,7 @@ export function getMockSessionDetail(): SessionDetail {
     climbedAt: new Date(now.getTime() - seed.minutesAgo * 60_000).toISOString(),
     upvotes: 0,
     totalAttempts: null,
+    betaLinks: [],
   }));
 
   const totalSends = PARTICIPANTS.reduce((sum, p) => sum + p.sends, 0);

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -4,7 +4,13 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEventProcessor } from '../hooks/use-event-processor';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import type { SessionEvent, SessionDetail, SessionDetailTick, SubscriptionQueueEvent } from '@boardsesh/shared-schema';
+import type {
+  SessionEvent,
+  SessionDetail,
+  SessionDetailTick,
+  SubscriptionQueueEvent,
+  BetaLinksGqlRow,
+} from '@boardsesh/shared-schema';
 import type { SessionStatsUpdated } from '@boardsesh/shared-schema/generated';
 import { SESSION_DETAIL_QUERY_KEY } from '@/app/hooks/use-session-detail';
 
@@ -44,7 +50,7 @@ function createStatsEvent(
   };
 }
 
-function createTick(climbedAt: string): SessionDetailTick {
+function createTick(climbedAt: string, overrides: Partial<SessionDetailTick> = {}): SessionDetailTick {
   return {
     uuid: `tick-${climbedAt}`,
     climbUuid: 'climb-1',
@@ -59,6 +65,20 @@ function createTick(climbedAt: string): SessionDetailTick {
     boardType: 'kilter',
     userId: 'user-1',
     upvotes: 0,
+    ...overrides,
+  };
+}
+
+function betaRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
+  return {
+    climbUuid: 'climb-1',
+    link: 'https://www.instagram.com/reel/abc/',
+    foreignUsername: 'setter',
+    angle: 40,
+    thumbnail: null,
+    isListed: true,
+    createdAt: '2026-04-30T08:00:00Z',
+    ...overrides,
   };
 }
 
@@ -258,6 +278,69 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
     expect(cached!.firstTickAt).toBe('2026-04-30T08:00:00Z');
     expect(cached!.lastTickAt).toBe('2026-04-30T09:00:00Z');
+  });
+
+  it('carries over per-tick beta links from the cache when the stats event omits them', () => {
+    const beta = betaRow();
+    queryClient.setQueryData(
+      SESSION_DETAIL_QUERY_KEY('session-abc'),
+      createExistingSession({ ticks: [createTick('2026-04-30T09:00:00Z', { betaLinks: [beta] })] }),
+    );
+
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    // The live SessionStatsUpdated event's ticks omit betaLinks (the subscription
+    // doesn't select them), so the optimistic merge must preserve the cached ones.
+    act(() => {
+      result.current.handleSessionEvent(createStatsEvent({ ticks: [createTick('2026-04-30T09:00:00Z')] }));
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    expect(cached!.ticks[0].betaLinks).toEqual([beta]);
+  });
+
+  it('keys the beta carry-over by boardType + climbUuid so a shared climb UUID across boards stays separate', () => {
+    const kilterBeta = betaRow({ climbUuid: 'shared-climb', link: 'https://www.instagram.com/reel/kilter/' });
+    const tensionBeta = betaRow({ climbUuid: 'shared-climb', link: 'https://www.tiktok.com/@t/video/1' });
+    queryClient.setQueryData(
+      SESSION_DETAIL_QUERY_KEY('session-abc'),
+      createExistingSession({
+        ticks: [
+          createTick('2026-04-30T09:00:00Z', {
+            uuid: 'tick-kilter',
+            boardType: 'kilter',
+            climbUuid: 'shared-climb',
+            betaLinks: [kilterBeta],
+          }),
+          createTick('2026-04-30T09:01:00Z', {
+            uuid: 'tick-tension',
+            boardType: 'tension',
+            climbUuid: 'shared-climb',
+            betaLinks: [tensionBeta],
+          }),
+        ],
+      }),
+    );
+
+    const refs = createRefs();
+    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.handleSessionEvent(
+        createStatsEvent({
+          ticks: [
+            createTick('2026-04-30T09:00:00Z', { uuid: 'tick-kilter', boardType: 'kilter', climbUuid: 'shared-climb' }),
+            createTick('2026-04-30T09:01:00Z', { uuid: 'tick-tension', boardType: 'tension', climbUuid: 'shared-climb' }),
+          ],
+        }),
+      );
+    });
+
+    const cached = queryClient.getQueryData<SessionDetail>(SESSION_DETAIL_QUERY_KEY('session-abc'));
+    const byUuid = new Map(cached!.ticks.map((tick) => [tick.uuid, tick]));
+    expect(byUuid.get('tick-kilter')!.betaLinks).toEqual([kilterBeta]);
+    expect(byUuid.get('tick-tension')!.betaLinks).toEqual([tensionBeta]);
   });
 
   it('notifies session event subscribers', () => {

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -331,7 +331,11 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
         createStatsEvent({
           ticks: [
             createTick('2026-04-30T09:00:00Z', { uuid: 'tick-kilter', boardType: 'kilter', climbUuid: 'shared-climb' }),
-            createTick('2026-04-30T09:01:00Z', { uuid: 'tick-tension', boardType: 'tension', climbUuid: 'shared-climb' }),
+            createTick('2026-04-30T09:01:00Z', {
+              uuid: 'tick-tension',
+              boardType: 'tension',
+              climbUuid: 'shared-climb',
+            }),
           ],
         }),
       );

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -229,7 +229,9 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           // Key by `${boardType}:${climbUuid}` to match the session-detail
           // resolver's beta map, so a climb UUID shared across two boards keeps
           // its own beta.
-          const betaByClimb = new Map(prev.ticks.map((tick) => [`${tick.boardType}:${tick.climbUuid}`, tick.betaLinks ?? []]));
+          const betaByClimb = new Map(
+            prev.ticks.map((tick) => [`${tick.boardType}:${tick.climbUuid}`, tick.betaLinks ?? []]),
+          );
           const ticks = [...event.ticks]
             .sort((a, b) => new Date(b.climbedAt).getTime() - new Date(a.climbedAt).getTime())
             .map((tick) => ({ ...tick, betaLinks: betaByClimb.get(`${tick.boardType}:${tick.climbUuid}`) ?? [] }));

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -223,9 +223,13 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           // Sort newest-first explicitly so firstTickAt/lastTickAt don't depend
           // on the server's arrival order. Compare epoch millis so mixed
           // timezone offsets (e.g. `+05:30` vs `Z`) still sort correctly.
-          const ticks = [...event.ticks].sort(
-            (a, b) => new Date(b.climbedAt).getTime() - new Date(a.climbedAt).getTime(),
-          );
+          // The live stats event omits per-climb beta links (the subscription
+          // doesn't select them), so carry over the ones the detail query
+          // already cached, keyed by climb, rather than dropping them.
+          const betaByClimb = new Map(prev.ticks.map((tick) => [tick.climbUuid, tick.betaLinks ?? []]));
+          const ticks = [...event.ticks]
+            .sort((a, b) => new Date(b.climbedAt).getTime() - new Date(a.climbedAt).getTime())
+            .map((tick) => ({ ...tick, betaLinks: betaByClimb.get(tick.climbUuid) ?? [] }));
           const firstTickAt = ticks.length > 0 ? ticks[ticks.length - 1].climbedAt : prev.firstTickAt;
           const lastTickAt = ticks.length > 0 ? ticks[0].climbedAt : prev.lastTickAt;
 

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -226,10 +226,13 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
           // The live stats event omits per-climb beta links (the subscription
           // doesn't select them), so carry over the ones the detail query
           // already cached, keyed by climb, rather than dropping them.
-          const betaByClimb = new Map(prev.ticks.map((tick) => [tick.climbUuid, tick.betaLinks ?? []]));
+          // Key by `${boardType}:${climbUuid}` to match the session-detail
+          // resolver's beta map, so a climb UUID shared across two boards keeps
+          // its own beta.
+          const betaByClimb = new Map(prev.ticks.map((tick) => [`${tick.boardType}:${tick.climbUuid}`, tick.betaLinks ?? []]));
           const ticks = [...event.ticks]
             .sort((a, b) => new Date(b.climbedAt).getTime() - new Date(a.climbedAt).getTime())
-            .map((tick) => ({ ...tick, betaLinks: betaByClimb.get(tick.climbUuid) ?? [] }));
+            .map((tick) => ({ ...tick, betaLinks: betaByClimb.get(`${tick.boardType}:${tick.climbUuid}`) ?? [] }));
           const firstTickAt = ticks.length > 0 ? ticks[ticks.length - 1].climbedAt : prev.firstTickAt;
           const lastTickAt = ticks.length > 0 ? ticks[0].climbedAt : prev.lastTickAt;
 


### PR DESCRIPTION
## What

A design pass (Apple HIG + Material 3, both honored by the existing variant system) on the React Native **session detail** page, plus the three requested changes.

### Grade distribution by grade, with a flash cap
The chart used to paint every bar the same board colour (all green for Kilter Homewall). It now colours each bar by its grade (V0 golden → V17 dark purple) and folds the old Flash-vs-Redpoint chart in as a brighter **flash cap** on each bar — muted redpoint body + vivid flash cap in the *same* grade hue, so it never clashes (a fixed gold cap would vanish on the golden V0–V2 bars). `buildSessionGradeBars` gained an opt-in `splitFlash` option; the standalone grouped chart and the layout legend are gone.

### Richer climb history (keeps like + comment)
`SessionTickRow` now uses the same `ClimbListItemContent` as the logbook/search rows — portrait thumbnail, name, colorized grade — via a new `sessionTickToClimb` adapter, with the per-climb like + comment row kept. Boards without bundled art (e.g. MoonBoard) fall back to the existing text row.

### Beta-video carousel
`betaLinks` now ride along on each session tick (batched once in the `sessionDetail` resolver from `board_beta_links`, `is_listed` + non-Kaya — the same lookup the per-climb play-drawer beta uses). `SessionBetaCarousel` aggregates + dedupes across the session's climbs and reuses `BetaVideoCard`; it self-hides when no climb has beta. The schema field is nullable so the live `SessionStatsUpdated` subscription that reuses `SessionDetailTick` stays lean (no beta pushed per stats update).

### Polish
Grouped screen background (the cards now read as raised), `title1` hero with a one-line summary + merged `board · duration` metadata, and the Hardest tile as the single vivid accent.

## Notes
- Tapping a climb row keeps current behavior (opens the climb).
- Removed the now-dead `sessionTicksToLogbook` helper.

## Validation
- `vp run typecheck` (all packages), `vp run typecheck:mobile` — green
- `vp run test:mobile` — 2064 tests pass (incl. new tests for the split-flash bars, `sessionTickToClimb`, `SessionAnalyticsSection`, `SessionBetaCarousel`)
- backend `session-detail-beta-links` (N+1 guard, is_listed/Kaya filtering, per-climb grouping) + `live-session-stats` — pass
- `vp run check:mobile-bundle` — OK (10.1 MB)
- Lint/format clean on changed files (the 3 repo-wide lint errors are pre-existing in untouched files: `mobile/capacitor.config.ts`, `scripts/__tests__/mobile-ios-run.test.ts`)

⚠️ **Not yet visually verified on a populated session in the simulator** — that needs a session with beta videos in the connected backend. Recommend a quick manual look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)