### PR TITLE
fix(mobile): stop doubled text in the iOS 26 bottom accessory

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -37,11 +37,12 @@ vi.mock('../../../src/providers/queue-provider', () => ({
   useQueueSessionId: () => ({ sessionId: cfg.sessionId }),
 }));
 
-// Wall-aware presence gate: true for a local OR a live wall (board-presence)
-// climb. The layout only sees the combined boolean — the local-vs-wall split is
-// unit-tested in use-has-accessory-climb / board-presence-react.
-vi.mock('../../../src/hooks/use-has-accessory-climb', () => ({
-  useHasAccessoryClimb: () => cfg.hasCurrentClimb,
+// Wall-aware, snapshot-stable presence gate: true for a local OR a live wall
+// (board-presence) climb, held briefly across a presence blip. The layout only
+// sees the combined boolean — the local-vs-wall split is unit-tested in
+// use-has-accessory-climb, and the hold logic in use-sticky-accessory-presence.
+vi.mock('../../../src/hooks/use-sticky-accessory-presence', () => ({
+  useStickyAccessoryPresence: () => cfg.hasCurrentClimb,
 }));
 
 vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -6,7 +6,7 @@ import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useTranslation } from 'react-i18next';
 import { useBluetoothConnectedStatus } from '../../src/lib/ble/bluetooth-status-store';
 import { useQueueSessionId } from '../../src/providers/queue-provider';
-import { useHasAccessoryClimb } from '../../src/hooks/use-has-accessory-climb';
+import { useStickyAccessoryPresence } from '../../src/hooks/use-sticky-accessory-presence';
 import { QueueBottomAccessory } from '../../src/components/queue-control/QueueBottomAccessory';
 import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
@@ -58,8 +58,10 @@ export default function TabLayout() {
   // doesn't re-render the tab tree on every queue change. Wall-aware: stays true
   // across a board-level climb change (only the climb identity changes), so the
   // UIKit accessory host is never unmounted/remounted mid-change — which is what
-  // left a stale snapshot stacked under the new one (doubled text).
-  const hasCurrentClimb = useHasAccessoryClimb();
+  // left a stale snapshot stacked under the new one (doubled text). The sticky
+  // wrapper additionally holds the mount across a brief presence blip (board
+  // reconnect / queue rehydrate), so those don't churn the host either.
+  const hasCurrentClimb = useStickyAccessoryPresence();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
 
@@ -115,7 +117,7 @@ export default function TabLayout() {
       tintColor={systemColors.label}
     >
       {nativeAccessoryActive && hasCurrentClimb ? (
-        <NativeTabs.BottomAccessory>
+        <NativeTabs.BottomAccessory key="queue-bottom-accessory">
           <QueueBottomAccessory />
         </NativeTabs.BottomAccessory>
       ) : null}

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, View, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
-import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb } from '@boardsesh/queue';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
@@ -10,12 +10,12 @@ import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
-import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 
 type AccessoryPlacement = 'regular' | 'inline';
 
 type NativeAccessoryClimbRowProps = {
+  climb: Climb;
   placement: AccessoryPlacement;
   width: number;
 };
@@ -60,41 +60,33 @@ function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardCon
   );
 }
 
-function climbFromItem(item: ClimbQueueItem | null | undefined): Climb | null {
-  return item?.climb ?? null;
-}
-
 /**
  * Content for the iOS 26 tab-bar bottom accessory (Liquid Glass variant only).
- * UIKit supplies the glass platter, so this stays bare: current climb + tick.
- * Tap-to-open is shared with the floating capsule via useAccessoryClimbTap. Its
- * plain grade + board thumbnail are tuned for the platter, so they intentionally
- * differ from the floating capsule's colorized grade.
+ * UIKit supplies the glass platter, so this stays bare: current climb + tick. The
+ * displayed climb is resolved once by {@link QueueBottomAccessory} and passed in,
+ * so this component never re-gates (a second gate could blank the live platter for
+ * a frame, which UIKit snapshotted as doubled text). Tap-to-open is shared with
+ * the floating capsule via useAccessoryClimbTap. Its plain grade + board thumbnail
+ * are tuned for the platter, so they intentionally differ from the floating
+ * capsule's colorized grade.
  */
-export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryClimbRowProps) {
+export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAccessoryClimbRowProps) {
   const { boardConfig } = useDrawerHost();
   const { systemColors } = useTheme();
   const { formatGrade } = useGradeFormat();
-  const { openGesture, currentItem } = useAccessoryClimbTap();
+  const { openGesture } = useAccessoryClimbTap();
 
-  const queueCurrentClimb = climbFromItem(currentItem);
-  // Source-of-truth flip: when a board feed is live (and the flag is on) the
-  // accessory shows the wall's actual lit climb; otherwise the local queue head.
-  const currentClimb = useWallOrQueueCurrentClimb(queueCurrentClimb);
   const showThumbnail = placement === 'regular' && boardConfig !== null;
-
-  if (!currentClimb) return null;
-
   const rowHeight = placement === 'inline' ? glassSize.inline : glassSize.standard;
-  const currentFormattedGrade = formatGrade(currentClimb.difficulty);
+  const currentFormattedGrade = formatGrade(climb.difficulty);
 
   return (
     <View style={[styles.row, { width, height: rowHeight }]}>
       <GestureDetector gesture={openGesture}>
-        <View style={styles.tapClip} accessibilityRole="button" accessibilityLabel={currentClimb.name}>
+        <View style={styles.tapClip} accessibilityRole="button" accessibilityLabel={climb.name}>
           <View style={styles.labelSlot}>
             <ClimbLabel
-              climb={currentClimb}
+              climb={climb}
               labelColor={systemColors.label}
               formattedGrade={currentFormattedGrade}
               showThumbnail={showThumbnail}
@@ -104,7 +96,7 @@ export function NativeAccessoryClimbRow({ placement, width }: NativeAccessoryCli
         </View>
       </GestureDetector>
       <View style={[styles.tickSlot, { width: glassSize.inline, height: rowHeight }]}>
-        <LogAscentToolbarButton climb={currentClimb} size={glassSize.inline} iconSize={24} />
+        <LogAscentToolbarButton climb={climb} size={glassSize.inline} iconSize={24} />
       </View>
     </View>
   );

--- a/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
+++ b/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useQueue } from '../../providers/queue-provider';
 import {
@@ -14,14 +14,19 @@ import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
  * iOS 26 tab-bar bottom accessory content. UIKit supplies the outer Liquid Glass
  * platter and swaps this subtree between regular and inline placements as the
  * tab bar minimizes, so the content stays bare: current climb plus tick only.
+ *
+ * This is the single source of truth for the displayed climb and the single
+ * render gate. It renders {@link NativeAccessoryClimbRow} directly (no extra
+ * wrapper) so the platter holds exactly one placement-sized row — a second nested
+ * gate/wrapper used to let the content blank for a frame inside the live host,
+ * which UIKit snapshotted as doubled text.
  */
 export function QueueBottomAccessory() {
   const placement = NativeTabs.BottomAccessory.usePlacement();
   const { width: screenWidth } = useWindowDimensions();
   const { state } = useQueue();
   // Show the accessory when there's a local queue climb OR a live wall climb
-  // (the flag-gated source flip — see useWallOrQueueCurrentClimb). The row itself
-  // re-applies the same selector for what it renders + ticks.
+  // (the flag-gated source flip — see useWallOrQueueCurrentClimb).
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
 
   const accessoryWidth = useMemo(() => {
@@ -33,25 +38,5 @@ export function QueueBottomAccessory() {
 
   if (!currentClimb) return null;
 
-  return (
-    <View
-      style={[styles.row, placement === 'inline' ? styles.inlineRow : styles.regularRow, { width: accessoryWidth }]}
-    >
-      <NativeAccessoryClimbRow placement={placement} width={accessoryWidth} />
-    </View>
-  );
+  return <NativeAccessoryClimbRow climb={currentClimb} placement={placement} width={accessoryWidth} />;
 }
-
-const styles = StyleSheet.create({
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  regularRow: {
-    height: glassSize.standard,
-  },
-  inlineRow: {
-    height: glassSize.inline,
-  },
-});

--- a/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
+++ b/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useWindowDimensions } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
+import type { Climb } from '@boardsesh/queue';
 import { useQueue } from '../../providers/queue-provider';
 import {
   glassSize,
@@ -9,6 +10,23 @@ import {
 } from '../../theme/layout';
 import { NativeAccessoryClimbRow } from './NativeAccessoryClimbRow';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
+
+/**
+ * Hold the last shown climb while this component stays mounted. The mount itself
+ * is gated by the sticky presence boolean (see useStickyAccessoryPresence), which
+ * keeps the UIKit host alive across a brief presence blip — board-presence
+ * reconnect, queue rehydrate. Without retaining the climb, the raw selector below
+ * resolves null during that same blip and the row unmounts/remounts inside the
+ * live host: the exact empty→content transition (and a blank platter for the
+ * window) UIKit snapshots as doubled text. Tying retention to the mount lifecycle
+ * — rather than a second timer — keeps it consistent with the presence hold by
+ * construction: the host unmount is the single thing that finally clears it.
+ */
+function useRetainedAccessoryClimb(currentClimb: Climb | null): Climb | null {
+  const lastClimbRef = useRef<Climb | null>(currentClimb);
+  if (currentClimb) lastClimbRef.current = currentClimb;
+  return currentClimb ?? lastClimbRef.current;
+}
 
 /**
  * iOS 26 tab-bar bottom accessory content. UIKit supplies the outer Liquid Glass
@@ -26,8 +44,10 @@ export function QueueBottomAccessory() {
   const { width: screenWidth } = useWindowDimensions();
   const { state } = useQueue();
   // Show the accessory when there's a local queue climb OR a live wall climb
-  // (the flag-gated source flip — see useWallOrQueueCurrentClimb).
-  const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  // (the flag-gated source flip — see useWallOrQueueCurrentClimb), retained across
+  // a presence blip so the live platter never blanks while the host is held open.
+  const resolvedClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  const currentClimb = useRetainedAccessoryClimb(resolvedClimb);
 
   const accessoryWidth = useMemo(() => {
     return Math.max(

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -284,6 +284,13 @@ function makeBoardConfig(): BoardConfig {
   return { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
 }
 
+// The displayed climb is now passed in by QueueBottomAccessory; default to the
+// queue head the test set up so the existing assertions keep reading it.
+function renderRow(placement: 'regular' | 'inline', width = 344) {
+  const climb = queue.state.currentClimbQueueItem?.climb as Climb;
+  return render(<NativeAccessoryClimbRow climb={climb} placement={placement} width={width} />);
+}
+
 function getCurrentThumbnail(container: HTMLElement): HTMLElement {
   const thumbnail = container.querySelector('[data-thumbnail="p1r12"]');
   expect(thumbnail).not.toBeNull();
@@ -308,7 +315,7 @@ describe('NativeAccessoryClimbRow', () => {
   });
 
   it('renders a regular now-climbing row with thumbnail, grade, and integrated tick', () => {
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
 
     expect(container.textContent).toContain("Alvin's Nuts");
     expect(container.textContent).toContain('V6');
@@ -354,7 +361,7 @@ describe('NativeAccessoryClimbRow', () => {
     queue.state.currentClimbQueueItem = mirroredItem;
     queue.state.queue = [mirroredItem];
 
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
 
     const thumbnail = getCurrentThumbnail(container);
     expect(thumbnail.getAttribute('data-mirrored')).toBe('true');
@@ -365,7 +372,7 @@ describe('NativeAccessoryClimbRow', () => {
   it('uses the full silhouette for very tall board thumbnails', () => {
     boardRender.boardWidth = 1080;
     boardRender.boardHeight = 2498;
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
     const thumbnail = getCurrentThumbnail(container);
 
     expectNumericAttribute(thumbnail, 'data-board-width', 17.293835);
@@ -375,7 +382,7 @@ describe('NativeAccessoryClimbRow', () => {
   it('keeps near-square Kilter Homewall thumbnails off the accessory edges', () => {
     boardRender.boardWidth = 1080;
     boardRender.boardHeight = 1157;
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
     const thumbnail = getCurrentThumbnail(container);
 
     expect(container.querySelector('[data-height="48"]')).not.toBeNull();
@@ -387,7 +394,7 @@ describe('NativeAccessoryClimbRow', () => {
   it('uses the full silhouette for wide board thumbnails', () => {
     boardRender.boardWidth = 1200;
     boardRender.boardHeight = 663;
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
     const thumbnail = getCurrentThumbnail(container);
 
     expectNumericAttribute(thumbnail, 'data-board-width', 40);
@@ -395,7 +402,7 @@ describe('NativeAccessoryClimbRow', () => {
   });
 
   it('keeps the thumbnail out of inline placement', () => {
-    const { container } = render(<NativeAccessoryClimbRow placement="inline" width={344} />);
+    const { container } = renderRow('inline');
 
     expect(container.textContent).toContain("Alvin's Nuts");
     expect(container.querySelector('[data-thumbnail]')).toBeNull();
@@ -405,7 +412,7 @@ describe('NativeAccessoryClimbRow', () => {
 
   it('omits the thumbnail when board config is unavailable', () => {
     drawer.boardConfig = null;
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
 
     expect(container.textContent).toContain("Alvin's Nuts");
     expect(container.querySelector('[data-thumbnail]')).toBeNull();
@@ -413,7 +420,7 @@ describe('NativeAccessoryClimbRow', () => {
   });
 
   it('keeps the tick outside the climb gesture target', () => {
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
     const tick = container.querySelector('[data-tick="true"]');
 
     expect(tick).not.toBeNull();
@@ -428,7 +435,7 @@ describe('NativeAccessoryClimbRow', () => {
     queue.state.currentClimbQueueItem = currentItem;
     queue.state.queue = [currentItem];
 
-    const { container } = render(<NativeAccessoryClimbRow placement="regular" width={344} />);
+    const { container } = renderRow('regular');
 
     const nameNodes = Array.from(container.querySelectorAll('[data-text]')).filter(
       (textNode) => textNode.textContent === 'Current Climb',
@@ -437,5 +444,24 @@ describe('NativeAccessoryClimbRow', () => {
 
     const tapTarget = container.querySelector('[data-role="button"]');
     expect(tapTarget?.getAttribute('data-actions')).toBe('');
+  });
+
+  it('renders the passed climb even when the local queue head is empty', () => {
+    // QueueBottomAccessory owns the single render gate; the row must not re-gate on
+    // its own queue read (an empty-vs-content flip inside the live platter is what
+    // UIKit snapshotted as doubled text). With no queue head, the prop still draws.
+    queue.state.currentClimbQueueItem = null;
+    queue.state.queue = [];
+
+    const { container } = render(
+      <NativeAccessoryClimbRow
+        climb={makeClimb({ uuid: 'wall', name: 'On The Wall' })}
+        placement="regular"
+        width={344}
+      />,
+    );
+
+    expect(container.textContent).toContain('On The Wall');
+    expect(container.querySelector('[data-tick="true"]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
-import type { ClimbQueueItem } from '@boardsesh/queue';
+import { createElement } from 'react';
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 
 const cfg = vi.hoisted(() => ({
   placement: 'regular' as 'regular' | 'inline',
-  currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
+  currentClimbQueueItem: { climb: { uuid: 'c1', name: 'Tea Magic', angle: 40 } } as unknown as ClimbQueueItem | null,
 }));
 
 vi.mock('expo-router/unstable-native-tabs', () => ({
@@ -14,18 +14,6 @@ vi.mock('expo-router/unstable-native-tabs', () => ({
 }));
 
 vi.mock('react-native', () => ({
-  View: ({ children, style }: { children?: ReactNode; style?: unknown }) => {
-    const styles = Array.isArray(style) ? style : [style];
-    const width = styles.reduce<unknown>((foundWidth, styleEntry) => {
-      if (foundWidth != null) return foundWidth;
-      return styleEntry != null && typeof styleEntry === 'object' && 'width' in styleEntry
-        ? (styleEntry as { width?: unknown }).width
-        : null;
-    }, null);
-    const dataWidth = typeof width === 'number' || typeof width === 'string' ? String(width) : '';
-    return createElement('div', { 'data-width': dataWidth }, children);
-  },
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
   useWindowDimensions: () => ({ width: 402, height: 874, scale: 3, fontScale: 1 }),
 }));
 
@@ -37,10 +25,21 @@ vi.mock('../../../theme/layout', () => ({
   NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH: 344,
   NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER: 32,
 }));
+// Stub the row so the test sees exactly what QueueBottomAccessory hands down, and
+// so the row stub is the only node under the accessory (no extra wrapper).
 vi.mock('../NativeAccessoryClimbRow', () => ({
-  NativeAccessoryClimbRow: ({ placement, width }: { placement: 'regular' | 'inline'; width: number }) =>
+  NativeAccessoryClimbRow: ({
+    climb,
+    placement,
+    width,
+  }: {
+    climb: Climb;
+    placement: 'regular' | 'inline';
+    width: number;
+  }) =>
     createElement('div', {
       'data-native-row': 'true',
+      'data-climb-name': climb.name,
       'data-placement': placement,
       'data-row-width': String(width),
     }),
@@ -57,43 +56,44 @@ import { QueueBottomAccessory } from '../QueueBottomAccessory';
 describe('QueueBottomAccessory', () => {
   beforeEach(() => {
     cfg.placement = 'regular';
-    cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
+    cfg.currentClimbQueueItem = { climb: { uuid: 'c1', name: 'Tea Magic', angle: 40 } } as unknown as ClimbQueueItem;
   });
 
-  it('renders the native accessory row in regular placement', () => {
+  it('renders the native accessory row with the resolved climb in regular placement', () => {
     const { container } = render(<QueueBottomAccessory />);
-    expect(container.querySelector('[data-native-row="true"]')).not.toBeNull();
-    expect(container.querySelector('[data-placement="regular"]')).not.toBeNull();
-    expect(container.querySelector('[data-icon="search"]')).toBeNull();
+    const row = container.querySelector('[data-native-row="true"]');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('data-climb-name')).toBe('Tea Magic');
+    expect(row?.getAttribute('data-placement')).toBe('regular');
   });
 
-  it('renders the native accessory row in inline placement', () => {
-    cfg.placement = 'inline';
+  it('hands the row straight to the platter with no extra wrapper node', () => {
+    // A single top-level node keeps UIKit from relayouting a redundant nested box —
+    // the doubled-text snapshot fed on the old double placement-height wrapper.
     const { container } = render(<QueueBottomAccessory />);
-    expect(container.querySelector('[data-native-row="true"]')).not.toBeNull();
-    expect(container.querySelector('[data-placement="inline"]')).not.toBeNull();
+    expect(container.childNodes).toHaveLength(1);
+    expect((container.firstChild as HTMLElement).getAttribute('data-native-row')).toBe('true');
   });
 
-  it('keeps inline placement the same width as regular placement', () => {
+  it('passes the inline placement through at the same width as regular', () => {
+    // max(56*2=112, min(344, 402-32=370)) = 344, independent of placement.
     const regular = render(<QueueBottomAccessory />);
-    const regularWidth = regular.container.querySelector('[data-width]')?.getAttribute('data-width');
     const regularRowWidth = regular.container.querySelector('[data-native-row]')?.getAttribute('data-row-width');
     regular.unmount();
 
     cfg.placement = 'inline';
     const inline = render(<QueueBottomAccessory />);
-    const inlineWidth = inline.container.querySelector('[data-width]')?.getAttribute('data-width');
-    const inlineRowWidth = inline.container.querySelector('[data-native-row]')?.getAttribute('data-row-width');
+    const inlineRow = inline.container.querySelector('[data-native-row]');
 
-    expect(inlineWidth).toBe(regularWidth);
-    expect(inlineWidth).toBe('344');
-    expect(inlineRowWidth).toBe(regularRowWidth);
-    expect(inlineRowWidth).toBe('344');
+    expect(inlineRow?.getAttribute('data-placement')).toBe('inline');
+    expect(inlineRow?.getAttribute('data-row-width')).toBe(regularRowWidth);
+    expect(inlineRow?.getAttribute('data-row-width')).toBe('344');
   });
 
   it('renders nothing without a current climb', () => {
     cfg.currentClimbQueueItem = null;
     const { container } = render(<QueueBottomAccessory />);
     expect(container.querySelector('[data-native-row]')).toBeNull();
+    expect(container.childNodes).toHaveLength(0);
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
@@ -96,4 +96,20 @@ describe('QueueBottomAccessory', () => {
     expect(container.querySelector('[data-native-row]')).toBeNull();
     expect(container.childNodes).toHaveLength(0);
   });
+
+  it('retains the displayed climb across a presence blip while mounted', () => {
+    // While the host stays mounted (sticky presence boolean), a blip resolves the
+    // raw selector to null for a frame — board reconnect / queue rehydrate. The row
+    // must keep showing the last climb, not blank: an empty→content flip inside the
+    // live platter is exactly what UIKit snapshots as doubled text.
+    const { container, rerender } = render(<QueueBottomAccessory />);
+    expect(container.querySelector('[data-native-row]')?.getAttribute('data-climb-name')).toBe('Tea Magic');
+
+    cfg.currentClimbQueueItem = null;
+    rerender(<QueueBottomAccessory />);
+
+    const row = container.querySelector('[data-native-row]');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('data-climb-name')).toBe('Tea Magic');
+  });
 });

--- a/packages/mobile/src/hooks/__tests__/use-sticky-accessory-presence.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-sticky-accessory-presence.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const cfg = vi.hoisted(() => ({ hasClimb: false }));
+
+vi.mock('../use-has-accessory-climb', () => ({
+  useHasAccessoryClimb: () => cfg.hasClimb,
+}));
+
+import { useStickyAccessoryPresence } from '../use-sticky-accessory-presence';
+
+const GRACE_MS = 500;
+
+describe('useStickyAccessoryPresence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    cfg.hasClimb = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports true immediately when a climb is present', () => {
+    cfg.hasClimb = true;
+    const { result } = renderHook(() => useStickyAccessoryPresence(GRACE_MS));
+    expect(result.current).toBe(true);
+  });
+
+  it('holds true across a brief presence dip shorter than the grace window', () => {
+    cfg.hasClimb = true;
+    const { result, rerender } = renderHook(() => useStickyAccessoryPresence(GRACE_MS));
+    expect(result.current).toBe(true);
+
+    // Presence blips off (e.g. board reconnect / queue rehydrate)...
+    cfg.hasClimb = false;
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(GRACE_MS - 100);
+    });
+    expect(result.current).toBe(true);
+
+    // ...and comes back before the grace window elapses.
+    cfg.hasClimb = true;
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(GRACE_MS);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('drops to false after presence stays gone past the grace window', () => {
+    cfg.hasClimb = true;
+    const { result, rerender } = renderHook(() => useStickyAccessoryPresence(GRACE_MS));
+
+    cfg.hasClimb = false;
+    rerender();
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(GRACE_MS);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('cancels the pending drop when presence returns before the window', () => {
+    cfg.hasClimb = true;
+    const { result, rerender } = renderHook(() => useStickyAccessoryPresence(GRACE_MS));
+
+    cfg.hasClimb = false;
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(GRACE_MS - 1);
+    });
+    cfg.hasClimb = true;
+    rerender();
+
+    // The earlier drop timer must not fire after presence is back.
+    act(() => {
+      vi.advanceTimersByTime(GRACE_MS * 2);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('does not fire the drop timer after unmount', () => {
+    cfg.hasClimb = true;
+    const { rerender, unmount } = renderHook(() => useStickyAccessoryPresence(GRACE_MS));
+
+    cfg.hasClimb = false;
+    rerender();
+    unmount();
+
+    // No state update should be scheduled on the unmounted hook.
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(GRACE_MS * 2);
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -3,7 +3,7 @@ import { useSegments } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../providers/theme-provider';
 import { isTabsRoute } from '../lib/route-segments';
-import { useHasAccessoryClimb } from './use-has-accessory-climb';
+import { useStickyAccessoryPresence } from './use-sticky-accessory-presence';
 import { useNativeAccessoryActive, useNativeTabBar } from './use-bottom-accessory';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 
@@ -19,9 +19,10 @@ export function useBottomChromeMetrics() {
   // presence-only selector, which flips solely when a climb appears/disappears.
   // This keeps bottom chrome from re-rendering on queue mutations OR on
   // climb-to-climb navigation across every screen that floats it. Wall-aware so a
-  // board-presence ("on the wall") climb counts too, keeping the JS-vs-native
-  // arbitration consistent with what the accessory actually renders.
-  const hasCurrentClimb = useHasAccessoryClimb();
+  // board-presence ("on the wall") climb counts too. Use the same sticky wrapper
+  // as the accessory mount gate so the JS-vs-native arbitration tracks what the
+  // accessory host actually shows (incl. its brief presence-blip hold).
+  const hasCurrentClimb = useStickyAccessoryPresence();
   const { variant } = useTheme();
   const insideTabs = isTabsRoute(segments);
   const nativeAccessoryActive = useNativeAccessoryActive();

--- a/packages/mobile/src/hooks/use-sticky-accessory-presence.ts
+++ b/packages/mobile/src/hooks/use-sticky-accessory-presence.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react';
+import { useHasAccessoryClimb } from './use-has-accessory-climb';
+
+// Hold the native bottom accessory mounted for this long after a climb's presence
+// drops. Board-presence reconnects and queue rehydration can blip presence
+// false→true within a frame or two; the grace window swallows that blip.
+const PRESENCE_DROP_GRACE_MS = 500;
+
+/**
+ * Sticky wrapper over {@link useHasAccessoryClimb} for the iOS 26 bottom-accessory
+ * mount gate. Returns `true` immediately when a climb is present; when presence
+ * drops it holds the previous `true` for a short grace window and only reports
+ * `false` if presence stays gone past it.
+ *
+ * Why: the native `NativeTabs.BottomAccessory` host is gated on presence. A
+ * board-presence reconnect (socket drop → `boardId`/feed gap) or a cold-restore
+ * queue rehydrate can flip the underlying presence false→true within a frame.
+ * Without this hold the host unmounts and remounts on that blip, and UIKit leaves
+ * a stale snapshot of the glass platter stacked under the new one — the doubled
+ * climb name. Collapsing the blip into a continuous `true` keeps the host's
+ * identity stable so no snapshot is orphaned. The grace window's exact length is a
+ * heuristic; the hold logic itself is what matters.
+ */
+export function useStickyAccessoryPresence(graceMs: number = PRESENCE_DROP_GRACE_MS): boolean {
+  const hasClimb = useHasAccessoryClimb();
+  const [sticky, setSticky] = useState(hasClimb);
+  // Mirror the latest sticky value so the cleanup-less true branch can no-op
+  // without listing `sticky` as an effect dependency.
+  const stickyRef = useRef(sticky);
+  stickyRef.current = sticky;
+
+  useEffect(() => {
+    if (hasClimb) {
+      if (!stickyRef.current) setSticky(true);
+      return;
+    }
+    const dropHandle = setTimeout(() => setSticky(false), graceMs);
+    return () => clearTimeout(dropHandle);
+  }, [hasClimb, graceMs]);
+
+  return sticky;
+}


### PR DESCRIPTION
## What

On iOS 26 the Liquid Glass tab-bar bottom accessory (current climb name + grade + tick, e.g. "Tea Magic V2 ✓") sometimes renders its **text doubled** — the same climb name drawn twice, offset diagonally, inside the one glass platter.

It is **not** a second accessory bar. There's a single mount point; the doubled image is a **stale UIKit snapshot** of `NativeTabs.BottomAccessory` that UIKit/react-native-screens fails to tear down. A prior fix (`98ea349b`, already in `main`) removed the *climb-to-climb remount* trigger by gating the mount on a presence-only signal. This PR addresses the **residual triggers** the reporter still hit: **navigating between screens** and "just appears at rest."

## Changes

**1. One stable accessory subtree** (`QueueBottomAccessory.tsx`, `NativeAccessoryClimbRow.tsx`)
- `QueueBottomAccessory` now resolves the displayed climb **once**, gates **once**, and renders `NativeAccessoryClimbRow` directly with the climb passed as a prop.
- Removes the row's **second independent** `useWallOrQueueCurrentClimb` resolution + **second `return null`** gate, and the redundant **outer placement-height wrapper `View`**. The live platter can no longer blank for a frame (an empty→content flip UIKit snapshotted as doubled text), and UIKit relayouts a single box instead of two.
- `useAccessoryClimbTap` still owns the tap/open target independently — unchanged.

**2. Sticky presence to stop remount-on-blip** (`use-sticky-accessory-presence.ts`, `use-bottom-chrome-metrics.ts`, `(tabs)/_layout.tsx`)
- New `useStickyAccessoryPresence` holds `useHasAccessoryClimb` true for a short window when presence briefly drops. A board-presence reconnect or a cold-restore queue rehydrate can flip presence false→true within a frame; without the hold the `NativeTabs.BottomAccessory` host unmounts/remounts on that blip and orphans a snapshot.
- Both the mount gate and `useBottomChromeMetrics` use it, so the JS-vs-native arbitration tracks what the host actually shows.
- Pinned the host's React identity with a stable `key`.

## Tests
- `native-accessory-climb-row.test.tsx`: row renders from the `climb` prop even when the local queue head is empty (proves the second gate is gone).
- `queue-bottom-accessory.test.tsx`: single top-level subtree (no extra wrapper), climb/placement/width passed down, returns null with no climb.
- `use-sticky-accessory-presence.test.ts`: true-immediate, hold across a brief dip, drop after a sustained gap, cancel-on-return, no timer leak on unmount.

## Validation
- `vp run typecheck:mobile` ✅
- full mobile test suite (2056 tests) ✅
- `vp run check:mobile-bundle` ✅
- lint + format clean on changed files ✅

## Not covered
This is an iOS 26 **native** snapshot artifact. The changes remove the JS-side triggers (double gate, double View, presence-flicker remount) and are proven by unit tests, but **visual confirmation that the ghost is gone needs an iOS 26 device** — deferred, as agreed (no device in this environment). A deeper react-native-screens patch to force-clear the snapshot on re-attach is a possible follow-up if the ghost survives on-device.

https://claude.ai/code/session_011z9cdKCZgWKE2AutCFSZXj

---
_Generated by [Claude Code](https://claude.ai/code/session_011z9cdKCZgWKE2AutCFSZXj)_