### PR TITLE
Fix floating header: drop fallback drop-shadow + dark-toggle scrim band

### DIFF
--- a/packages/mobile/app/(tabs)/record/index.tsx
+++ b/packages/mobile/app/(tabs)/record/index.tsx
@@ -1,18 +1,18 @@
 import { StyleSheet, View } from 'react-native';
-import { GlassSurface } from '../../../src/components/GlassSurface';
 import { SessionScreen } from '../../../src/components/session-screen/SessionScreen';
 
 /**
  * The real Record tab screen. Renders the session screen inline — pre-session
  * config when there's no active session, the in-session live view once one is
- * running. A GlassSurface fills the background so the Liquid-Glass language from
- * the rest of the chrome carries through. No overlay props: there's no
- * drag/pull-to-dismiss here — switching tabs is the minimize.
+ * running. The screen sits on the navigation scene background (like the
+ * Discover/Climbs/Profile tabs); the floating chrome carries the Liquid-Glass
+ * language. A full-bleed glass base here only dimmed the scene to grey, which
+ * clashed with the header scrim's white fade in light mode. No overlay props:
+ * there's no drag/pull-to-dismiss here — switching tabs is the minimize.
  */
 export default function RecordIndex() {
   return (
     <View style={styles.root}>
-      <GlassSurface glassEffectStyle="regular" style={StyleSheet.absoluteFill} />
       <SessionScreen />
     </View>
   );

--- a/packages/mobile/src/components/chrome/BoardPill.tsx
+++ b/packages/mobile/src/components/chrome/BoardPill.tsx
@@ -5,7 +5,6 @@ import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { formatActiveBoardLabel } from '../../lib/boards/active-board-label';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { hapticLight } from '../../lib/haptics';
-import { shadows } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { GlassSurface } from '../GlassSurface';
 import { PressableSurface } from '../PressableSurface';
@@ -56,7 +55,6 @@ export function BoardPill({ onPress, accessibilityHint }: BoardPillProps) {
       <View
         style={[
           styles.capsule,
-          !nativeGlass && shadows.sm,
           !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
         ]}
       >

--- a/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
@@ -27,13 +27,19 @@ const TITLE_PILL_RADIUS = TITLE_PILL_HEIGHT / 2;
 export const COLLAPSE_START = 6;
 export const COLLAPSE_END = 48;
 
-// The scrim mirrors iOS systemBackground (pure white in light, pure black in
-// dark) as explicit hex rather than `systemColors.background`'s PlatformColor:
-// expo-linear-gradient resolves a PlatformColor once and never re-resolves it on
-// an in-app light↔dark toggle, so a PlatformColor scrim stays light-mode white
-// over the now-dark page (a white band at the top). Keying off the resolved
-// colorScheme makes the gradient prop actually change, so the native view repaints.
-const SCRIM_BACKGROUND = { light: '#FFFFFF', dark: '#000000' } as const;
+// The scrim fades the screen background to clear behind the floating islands, so
+// it must match the colour the screen content actually sits on: the React
+// Navigation scene background (app/_layout.tsx `ThemedNavigation`) — DefaultTheme
+// grey #F2F2F2 in light, `iosDarkColors.background` #000000 in dark. Using white
+// here (as `systemColors.background` resolves to) painted a white block over the
+// grey scene — a visible band wherever empty scene shows below the islands (the
+// Record tab). These are explicit hex, not `systemColors.background`'s
+// PlatformColor, for two reasons: (1) the scene background is the nav theme's, not
+// systemBackground; (2) expo-linear-gradient resolves a PlatformColor only once and
+// never re-resolves it on an in-app light↔dark toggle, so a PlatformColor scrim got
+// stuck light-mode-coloured over the now-dark page (the Climbs white band). Keying
+// off the resolved colorScheme makes the gradient prop change so the native view repaints.
+const SCRIM_BACKGROUND = { light: '#F2F2F2', dark: '#000000' } as const;
 
 /**
  * Shared collapse math for the floating large-title chrome. Returns the 0→1

--- a/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
@@ -27,6 +27,14 @@ const TITLE_PILL_RADIUS = TITLE_PILL_HEIGHT / 2;
 export const COLLAPSE_START = 6;
 export const COLLAPSE_END = 48;
 
+// The scrim mirrors iOS systemBackground (pure white in light, pure black in
+// dark) as explicit hex rather than `systemColors.background`'s PlatformColor:
+// expo-linear-gradient resolves a PlatformColor once and never re-resolves it on
+// an in-app light↔dark toggle, so a PlatformColor scrim stays light-mode white
+// over the now-dark page (a white band at the top). Keying off the resolved
+// colorScheme makes the gradient prop actually change, so the native view repaints.
+const SCRIM_BACKGROUND = { light: '#FFFFFF', dark: '#000000' } as const;
+
 /**
  * Shared collapse math for the floating large-title chrome. Returns the 0→1
  * `progress` derived value plus a `collapsed` boolean that flips once past the
@@ -96,10 +104,15 @@ export function CollapsingLargeTitleHeader({
   centerContent,
   children,
 }: CollapsingLargeTitleHeaderProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, colorScheme } = useTheme();
   const nativeGlass = useNativeGlass();
   const insets = useSafeAreaInsets();
   const { progress, collapsed } = useCollapseProgress(scrollY);
+
+  // Scrim colour resolved from the active scheme (see SCRIM_BACKGROUND) so it
+  // flips on an in-app light↔dark toggle instead of sticking on the mount-time
+  // PlatformColor.
+  const scrimColor = SCRIM_BACKGROUND[colorScheme];
 
   // Only the centre content (which is leaving) fades — flattening its glass
   // mid-fade is invisible because it's disappearing. The capsule that *stays*
@@ -125,7 +138,7 @@ export function CollapsingLargeTitleHeader({
           doesn't bleed through the gaps between the islands. */}
       <LinearGradient
         pointerEvents="none"
-        colors={[systemColors.background, systemColors.background, 'transparent'] as const}
+        colors={[scrimColor, scrimColor, 'transparent'] as const}
         locations={[0, 0.7, 1]}
         style={StyleSheet.absoluteFill}
       />

--- a/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
@@ -13,7 +13,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../providers/theme-provider';
 import { useNativeGlass } from '../../hooks/use-native-glass';
-import { spacing, shadows } from '../../theme/tokens';
+import { spacing } from '../../theme/tokens';
 import { Text } from '../Text';
 import { GlassSurface } from '../GlassSurface';
 import { PressableSurface } from '../PressableSurface';
@@ -178,7 +178,6 @@ export function CollapsingLargeTitleHeader({
               <View
                 style={[
                   styles.titlePill,
-                  !nativeGlass && shadows.sm,
                   !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
                 ]}
               >

--- a/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
@@ -5,7 +5,6 @@ import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useNativeGlass } from '../../hooks/use-native-glass';
-import { shadows } from '../../theme/tokens';
 import { Icon } from '../Icon';
 import { GlassSurface } from '../GlassSurface';
 import { BoardPill } from './BoardPill';
@@ -149,7 +148,6 @@ export function CollapsingTopChrome({
         style={[
           styles.rightToolbar,
           rightToolbarStyle,
-          !nativeGlass && shadows.sm,
           !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
         ]}
       >

--- a/packages/mobile/src/components/chrome/GlassActionToolbar.tsx
+++ b/packages/mobile/src/components/chrome/GlassActionToolbar.tsx
@@ -2,7 +2,6 @@ import { type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTheme } from '../../providers/theme-provider';
 import { useNativeGlass } from '../../hooks/use-native-glass';
-import { shadows } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { GlassSurface } from '../GlassSurface';
 import { PressableSurface } from '../PressableSurface';
@@ -15,8 +14,8 @@ const TOP_TOOLBAR_RADIUS = TOP_ACTION_SIZE / 2;
  * A floating glass "island" that hosts one or more toolbar actions, sized to a
  * whole number of `TOP_ACTION_SIZE` slots. Lifted out of ClimbTopChrome so the
  * Climbs and Discover chromes render the same island vocabulary. The glass /
- * blur / solid material plus the shadow + hairline fallback (when there is no
- * native glass) live here; callers supply only the actions and the count.
+ * blur / solid material plus the hairline fallback (when there is no native
+ * glass) live here; callers supply only the actions and the count.
  */
 export function GlassActionToolbar({ actionCount, children }: { actionCount: number; children: ReactNode }) {
   const { systemColors } = useTheme();
@@ -26,7 +25,6 @@ export function GlassActionToolbar({ actionCount, children }: { actionCount: num
       style={[
         styles.toolbar,
         { width: TOP_ACTION_SIZE * actionCount },
-        !nativeGlass && shadows.sm,
         !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
       ]}
     >


### PR DESCRIPTION
Two issues with the floating header chrome (`CollapsingLargeTitleHeader` / `CollapsingTopChrome`), pinned down on-device.

## 1. "Band/shadow" under the header islands (light mode, all tabs)

Each glass island (left toolbar, board pill, right toolbar, collapsed title pill) carried a `!nativeGlass && shadows.sm` drop shadow for the non-glass fallback path. The device drops off native glass more than expected — **Reduce Transparency flips the chrome into `solid` mode, and Low Power Mode forces Reduce Transparency on** — so those drop shadows render, and lined up across the header they read as a full-width band/shadow.

**Fix:** remove the drop shadow from all four islands; keep the hairline border, which is enough to separate the pills from the background in the solid/blur fallback. Native glass still renders its own edge. Verified on-device (real iPhone, iOS 26): shadow gone in both glass and fallback modes.

## 2. Header band stuck light-coloured after a light→dark toggle (Climbs)

The scrim faded from `systemColors.background` — a single `PlatformColor` reference shared across both schemes. `expo-linear-gradient` resolves a PlatformColor **once** and never re-resolves it on an in-app light↔dark toggle, so the scrim stayed light-coloured over the now-dark page.

**Fix:** drive the scrim from the resolved `colorScheme` via explicit hex so the gradient prop actually changes and the native view repaints. The colours match the React Navigation scene background the content sits on (`#F2F2F2` light / `#000000` dark), so the scrim is invisible against the page.

Also removed a vestigial full-bleed `regular` `GlassSurface` that the Record tab uniquely laid as its page background, so its scene is the flat nav grey the scrim matches (it was a leftover from when the session screen was an overlay/sheet).

## Validation

- `vp run typecheck:mobile` — passed
- `vp run test:mobile` — 2055 tests passed (chrome suite green)
- `vp run check:mobile-bundle` — OK
- `vp check` — lint + format clean
- **On-device:** confirmed via a temporary red-scrim probe that the bundle was live, then confirmed the shadow is gone with the real colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)