### PR TITLE
fix(mobile): memoize per-row board config + clarify beta carousel test name

### DIFF
--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
@@ -110,7 +110,14 @@ export const SessionTickRow = memo(function SessionTickRow({
   }, [onPress, tick]);
 
   const climb = sessionTickToClimb(tick);
-  const boardConfig = getBoardConfigForPlaylist(tick.boardType, tick.layoutId);
+  // Per-row in a virtualised list: getBoardConfigForPlaylist runs a sizes scan
+  // (getSizesForLayoutId filter + reduce), so memoise on the board identity.
+  // Ticks in a session share one (boardType, layoutId), so this collapses to
+  // ~one compute per board. Mirrors PlaylistBoardBackdrop.
+  const boardConfig = useMemo(
+    () => getBoardConfigForPlaylist(tick.boardType, tick.layoutId),
+    [tick.boardType, tick.layoutId],
+  );
 
   if (climb && boardConfig) {
     return (

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
@@ -110,14 +110,9 @@ export const SessionTickRow = memo(function SessionTickRow({
   }, [onPress, tick]);
 
   const climb = sessionTickToClimb(tick);
-  // Per-row in a virtualised list: getBoardConfigForPlaylist runs a sizes scan
-  // (getSizesForLayoutId filter + reduce), so memoise on the board identity.
-  // Ticks in a session share one (boardType, layoutId), so this collapses to
-  // ~one compute per board. Mirrors PlaylistBoardBackdrop.
-  const boardConfig = useMemo(
-    () => getBoardConfigForPlaylist(tick.boardType, tick.layoutId),
-    [tick.boardType, tick.layoutId],
-  );
+  // getBoardConfigForPlaylist memoises internally (static board metadata), so
+  // this per-row call is O(1) after the first lookup for the board.
+  const boardConfig = getBoardConfigForPlaylist(tick.boardType, tick.layoutId);
 
   if (climb && boardConfig) {
     return (

--- a/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionBetaCarousel.test.tsx
@@ -96,7 +96,7 @@ describe('SessionBetaCarousel', () => {
     ]);
   });
 
-  it('filters out non-video links', () => {
+  it('filters out unsupported platforms (e.g. YouTube)', () => {
     const { getAllByTestId } = render(
       createElement(SessionBetaCarousel, {
         ticks: [

--- a/packages/mobile/src/lib/playlists/board-details-for-playlist.ts
+++ b/packages/mobile/src/lib/playlists/board-details-for-playlist.ts
@@ -13,15 +13,41 @@ function getDefaultLayoutId(boardName: BoardName): number | null {
   return layouts.length > 0 ? layouts[0].id : null;
 }
 
+// The board metadata behind a (boardType, layoutId) key is static, so the
+// resolved config never changes — memoise it. Callers hit this per row in
+// virtualised lists (session ticks, logbook) and the compute runs a sizes
+// filter + largest-area reduce, so the cache keeps repeat lookups O(1). The
+// FIFO cap just bounds memory; the real key space (every board × layout) sits
+// well under the limit, so it effectively never evicts.
+const BOARD_CONFIG_CACHE_LIMIT = 64;
+const boardConfigCache = new Map<string, PlaylistBoardConfig | null>();
+
 /**
  * Resolve a renderable board config (largest size + all its sets) for a
  * playlist that only carries `boardType` + `layoutId`. Mobile mirror of web's
  * `getBoardDetailsForPlaylist`, returning the minimal config the bundled
  * background cache needs. Returns null when the board/layout can't resolve
  * (e.g. moonboard, which the bundled-asset path doesn't cover) so the caller
- * falls back cleanly to the plain colour tile.
+ * falls back cleanly to the plain colour tile. Memoised by board key.
  */
 export function getBoardConfigForPlaylist(
+  boardType: string,
+  layoutId: number | null | undefined,
+): PlaylistBoardConfig | null {
+  const cacheKey = `${boardType}-${layoutId ?? ''}`;
+  const cached = boardConfigCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const result = computeBoardConfigForPlaylist(boardType, layoutId);
+  if (boardConfigCache.size >= BOARD_CONFIG_CACHE_LIMIT) {
+    const oldestKey = boardConfigCache.keys().next().value;
+    if (oldestKey !== undefined) boardConfigCache.delete(oldestKey);
+  }
+  boardConfigCache.set(cacheKey, result);
+  return result;
+}
+
+function computeBoardConfigForPlaylist(
   boardType: string,
   layoutId: number | null | undefined,
 ): PlaylistBoardConfig | null {


### PR DESCRIPTION
Addresses review feedback on the mobile session-detail redesign.

## Changes

**1. Perf — memoize `getBoardConfigForPlaylist` at the source**
`SessionTickRow` called `getBoardConfigForPlaylist` per row. That helper isn't O(1): it runs `getSizesForLayoutId` (an `Object.values().filter()`) then a largest-area `reduce`. A per-component `useMemo` would only dedupe re-renders — on a cold cache it still runs the scan — so the memoization instead lives in the helper itself: a module-level `Map` keyed by `${boardType}-${layoutId}`, mirroring `getBoardRenderData` in `board-details.ts` (FIFO-capped; board metadata is static, so the result never changes). This makes the lookup O(1) per board for *every* caller — `SessionTickRow`, `LogbookRow`, `SessionFeedCard`, `InSessionView` — and returns a stable reference, so the row just calls it directly.

**2. Test quality — rename misleading test**
`SessionBetaCarousel.test.tsx` had `it('filters out non-video links', …)`, but the test feeds a YouTube URL — a video — and asserts it's dropped. The real behaviour is "keep only Instagram/TikTok" (`isBetaVideoUrl = isInstagramUrl || isTikTokUrl`). Renamed to `'filters out unsupported platforms (e.g. YouTube)'`. Test body unchanged.

## Validation (Linux container)
- `vp run typecheck:mobile` — clean
- `vp test run --project mobile` — 281 files / 2055 tests pass (incl. the real-data `board-details-for-playlist` test); the renamed test runs green
- `vp check` — touched files clean (one unrelated pre-existing `docs/` formatting nit left untouched)
- `vp run check:mobile-bundle` — Android bundle builds OK (10.1 MB)

## Not done here
- **Visual pass:** the carousel + hero still need one manual look on a populated session in the iOS simulator. That's macOS-only and this run was on Linux, so it's left for a local pass. To populate the carousel the beta links must be Instagram/TikTok URLs — the current `seed:beta-links` fixtures use `dev-seed.example` URLs, which `isBetaVideoUrl` filters out.

https://claude.ai/code/session_01U17AMj9Es58MZgA5gNQTCv