### PR TITLE
refactor(mobile): consolidate dual design-language (M3 / Liquid Glass) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,11 @@ jobs:
       # patched source is actually present on this cheap Linux runner.
       - name: Check native patches are applied
         run: vp run check:mobile-patches
+      # Cheap source guard: no raw theme-variant magic-string compares regrew in
+      # mobile components (they must route through the variant primitives/tokens —
+      # see packages/mobile/src/theme/variants/README.md).
+      - name: Check mobile variant usage
+        run: vp run check:mobile-variants
       - name: Download built packages
         uses: actions/download-artifact@v4
         with:

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -80,15 +80,26 @@ older iPhone is the variant with the chrome degraded, not Material.
   (iOS < 26 frosted) → `material`/`solid` (Android, Reduce Transparency). Buttons stay JS
   (`PressableSurface`) on every path, so any phone on Liquid Glass falls back to JS buttons safely.
 
-**Component routing rule.** Cross-variant components expose one public prop API and branch internally
-on `theme.variant`. Call sites never change. The canonical shape (`Button.tsx`, `Card.tsx`):
+**Component routing rule.** Cross-variant components expose one public prop API and route internally
+on `theme.variant`; call sites never change. Don't hand-write the `variant === '…'` branch — use the
+shared primitives in `packages/mobile/src/theme/variants/` (full decision tree + four-axis model in
+its `README.md`):
 
 ```tsx
-export function Button(props: ButtonProps) {
-  const { variant } = useTheme();
-  return variant === 'material' ? <ButtonMaterial {...props} /> : <ButtonGlass {...props} />;
-}
+// Whole subtree differs → createVariantComponent (renders the chosen impl as JSX,
+// so each gets its own fiber/hook list and a live variant flip can't crash).
+export const Button = createVariantComponent('Button', { liquidGlass: ButtonGlass, material: ButtonMaterial });
+
+// A single value differs → selectByVariant (a typed Record<UiVariant, T>; a new
+// variant is a compile error at the call site).
+const iconColor = selectByVariant(variant, { liquidGlass: systemColors.label, material: brandColors.primary });
 ```
+
+Three rungs, in order of preference: (1) a **token** resolved once in the provider when the value has a
+designer-facing name (`theme.actionColors`, `theme.chartColors`, `theme.sectionCaption`,
+`theme.radii`, `theme.textStyles`); (2) **`createVariantComponent`** for a whole-subtree swap;
+(3) **`selectByVariant`** for a local one-off. A CI guard (`vp run check:mobile-variants`) blocks raw
+`variant === 'material'` / `=== 'liquidGlass'` compares from regrowing in `src/components/`.
 
 ---
 

--- a/packages/mobile/src/components/AuthTextInput.tsx
+++ b/packages/mobile/src/components/AuthTextInput.tsx
@@ -10,6 +10,7 @@ import { TextInput as PaperTextInput, HelperText } from 'react-native-paper';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
 import { iosSystemColors } from '../theme/ios-colors';
 
 // iOS systemRed — matches login.tsx's error text and is correct on the Liquid
@@ -96,7 +97,8 @@ export const AuthTextInput = forwardRef<RNTextInput, AuthTextInputProps>(functio
     secureTextEntry: masked,
   } as const;
 
-  if (theme.variant === 'material') {
+  const isMaterial = selectByVariant(theme.variant, { material: true, liquidGlass: false });
+  if (isMaterial) {
     return (
       <View>
         <PaperTextInput

--- a/packages/mobile/src/components/Badge.tsx
+++ b/packages/mobile/src/components/Badge.tsx
@@ -1,9 +1,9 @@
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { Badge as PaperBadge } from 'react-native-paper';
 import { Text } from './Text';
 import { iosSystemColors } from '../theme/ios-colors';
-import { useTheme } from '../providers/theme-provider';
+import { createVariantComponent } from '../theme/variants';
 
 type BadgeProps = {
   count?: number;
@@ -17,10 +17,7 @@ type BadgeProps = {
  * existing animated Liquid-Glass dot/count badge on the Liquid Glass variant.
  * The public prop API is identical for both, so call sites never change.
  */
-export function Badge(props: BadgeProps) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? <BadgeMaterial {...props} /> : <BadgeGlass {...props} />;
-}
+export const Badge = createVariantComponent('Badge', { liquidGlass: BadgeGlass, material: BadgeMaterial });
 
 function BadgeMaterial({ count, visible = true, color = iosSystemColors.systemRed, size = 'medium' }: BadgeProps) {
   const isDot = count === undefined || count === 0;

--- a/packages/mobile/src/components/Button.tsx
+++ b/packages/mobile/src/components/Button.tsx
@@ -6,6 +6,7 @@ import { PressableSurface } from './PressableSurface';
 import { iconMap, type IconName } from './icon-map';
 import { hapticLight } from '../lib/haptics';
 import { useTheme } from '../providers/theme-provider';
+import { createVariantComponent } from '../theme/variants';
 
 type ButtonVariant = 'filled' | 'outlined' | 'text';
 type ButtonSize = 'small' | 'medium' | 'large';
@@ -34,10 +35,7 @@ const sizeConfig = {
  * the existing Liquid-Glass/HIG button on the Liquid Glass variant. The public
  * prop API is identical for both, so call sites never change.
  */
-export function Button(props: ButtonProps) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? <ButtonMaterial {...props} /> : <ButtonGlass {...props} />;
-}
+export const Button = createVariantComponent('Button', { liquidGlass: ButtonGlass, material: ButtonMaterial });
 
 const PAPER_MODE = { filled: 'contained', outlined: 'outlined', text: 'text' } as const;
 

--- a/packages/mobile/src/components/Card.tsx
+++ b/packages/mobile/src/components/Card.tsx
@@ -14,6 +14,7 @@ import { PressableSurface } from './PressableSurface';
 import { hapticLight } from '../lib/haptics';
 import { borderRadius } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
+import { createVariantComponent } from '../theme/variants';
 
 type CardProps = {
   children: ReactNode;
@@ -32,10 +33,7 @@ type CardProps = {
  * Liquid Glass surface on the Liquid Glass variant. The public prop API is
  * identical for both, so call sites never change.
  */
-export function Card(props: CardProps) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? <CardMaterial {...props} /> : <CardGlass {...props} />;
-}
+export const Card = createVariantComponent('Card', { liquidGlass: CardGlass, material: CardMaterial });
 
 function CardMaterial({
   children,

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -15,7 +15,6 @@ import { ListRow } from './ListRow';
 import { Icon } from './Icon';
 import { useToast } from '../providers/toast-provider';
 import { useTheme } from '../providers/theme-provider';
-import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { WEB_BASE_URL } from '../lib/env';
 import { track } from '../lib/analytics';
@@ -192,10 +191,12 @@ function ClimbActionsSheet({
   // Sized for the climb preview row plus the action list (a couple more rows show
   // for owners / Aurora-app climbs); the modal pans down to close.
   const snapPoints = useMemo(() => ['55%'], []);
-  const neutralActionIconColor = theme.systemColors.label;
-  const successActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : theme.brandColors.success;
-  const favoriteActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : iosSystemColors.systemRed;
-  const accentActionIconColor = theme.variant === 'liquidGlass' ? neutralActionIconColor : theme.systemColors.accent;
+  // Monochrome on Liquid Glass, semantic on Material — resolved once as a token.
+  const {
+    success: successActionIconColor,
+    favorite: favoriteActionIconColor,
+    accent: accentActionIconColor,
+  } = theme.actionColors;
 
   return (
     <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose>

--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -15,7 +15,7 @@ import { PressableSurface } from './PressableSurface';
 import { Icon } from './Icon';
 import { Text } from './Text';
 import { iconMap, type IconName } from './icon-map';
-import { useTheme } from '../providers/theme-provider';
+import { createVariantComponent } from '../theme/variants';
 import { brandColors } from '../theme/colors';
 import { iosSystemColors } from '../theme/ios-colors';
 import { timing } from '../theme/animations';
@@ -69,10 +69,10 @@ function formatBadgeCount(badgeCount: number | undefined): string | null {
  * variant and to the original Liquid Glass circle on the Liquid Glass variant.
  * The public prop API is identical for both, so call sites never change.
  */
-export function GlassIconButton(props: GlassIconButtonProps) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? <GlassIconButtonMaterial {...props} /> : <GlassIconButtonGlass {...props} />;
-}
+export const GlassIconButton = createVariantComponent('GlassIconButton', {
+  liquidGlass: GlassIconButtonGlass,
+  material: GlassIconButtonMaterial,
+});
 
 /**
  * Material 3 icon button. Paper resolves the MDI glyph through our icon settings

--- a/packages/mobile/src/components/QueueAddedSnackbar.tsx
+++ b/packages/mobile/src/components/QueueAddedSnackbar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Text } from './Text';
 import { borderRadius, spacing, shadowColor } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
+import { createVariantComponent } from '../theme/variants';
 import { useBottomChromeMetrics } from '../hooks/use-bottom-chrome-metrics';
 
 const DEFAULT_DURATION = 4000;
@@ -27,10 +28,10 @@ type QueueAddedSnackbarProps = {
  * variant and to the existing Liquid-Glass pill on the Liquid Glass variant; the
  * public prop API is identical for both.
  */
-export function QueueAddedSnackbar(props: QueueAddedSnackbarProps) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? <QueueAddedSnackbarMaterial {...props} /> : <QueueAddedSnackbarGlass {...props} />;
-}
+export const QueueAddedSnackbar = createVariantComponent('QueueAddedSnackbar', {
+  liquidGlass: QueueAddedSnackbarGlass,
+  material: QueueAddedSnackbarMaterial,
+});
 
 function QueueAddedSnackbarMaterial({
   visible,

--- a/packages/mobile/src/components/ScreenTitle.tsx
+++ b/packages/mobile/src/components/ScreenTitle.tsx
@@ -1,0 +1,27 @@
+import { type ReactNode } from 'react';
+import { type StyleProp, type TextStyle } from 'react-native';
+import { Text } from './Text';
+import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
+
+type ScreenTitleProps = {
+  children: ReactNode;
+  style?: StyleProp<TextStyle>;
+};
+
+/**
+ * The in-body large screen title that sits under the floating chrome and collapses
+ * into the header capsule on scroll. Renders `null` on Material, where the M3 app
+ * bar owns the title — so the profile tabs and session screens write
+ * `<ScreenTitle>{title}</ScreenTitle>` unconditionally instead of repeating a
+ * Material-only null gate (the old inline largeTitle suppression) at each site.
+ */
+export function ScreenTitle({ children, style }: ScreenTitleProps) {
+  const { variant } = useTheme();
+  if (!selectByVariant(variant, { liquidGlass: true, material: false })) return null;
+  return (
+    <Text variant="largeTitle" style={style}>
+      {children}
+    </Text>
+  );
+}

--- a/packages/mobile/src/components/SearchHeader.tsx
+++ b/packages/mobile/src/components/SearchHeader.tsx
@@ -4,6 +4,7 @@ import { Searchbar } from 'react-native-paper';
 import { Icon } from './Icon';
 import { GlassSurface } from './GlassSurface';
 import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
 import { iosSystemColors } from '../theme/ios-colors';
 
 export type SearchHeaderHandle = {
@@ -81,7 +82,8 @@ export const SearchHeader = forwardRef<SearchHeaderHandle, SearchHeaderProps>(fu
   // Material variant: an authentic MD3 search bar. The imperative handle still
   // works because Paper's Searchbar forwards its ref to the inner TextInput
   // (blur/focus) and getText/setText stay backed by our own `text` state.
-  if (uiVariant === 'material') {
+  const isMaterial = selectByVariant(uiVariant, { material: true, liquidGlass: false });
+  if (isMaterial) {
     return (
       <View style={[styles.materialFrame, { height, borderRadius: radius }]}>
         <Searchbar

--- a/packages/mobile/src/components/SectionHeader.tsx
+++ b/packages/mobile/src/components/SectionHeader.tsx
@@ -1,8 +1,10 @@
-import { View, Platform, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
 import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
+import { applySectionCaption } from '../theme/variants/variant-tokens';
 import { spacing } from '../theme/tokens';
 
 type SectionHeaderProps = {
@@ -14,22 +16,22 @@ type SectionHeaderProps = {
 };
 
 export function SectionHeader({ title, actionLabel, onActionPress }: SectionHeaderProps) {
-  const { brandColors, variant, m3 } = useTheme();
-  const isMaterial = variant === 'material';
+  const { brandColors, variant, m3, sectionCaption } = useTheme();
   // M3 list/section headers are sentence-case titleSmall in onSurfaceVariant — not
-  // the iOS group-caption (uppercased, dimmed, tracked-out footnote). So Material
-  // drops the uppercasing + 0.6 opacity + letter-spacing and lifts to titleSmall.
-  const displayTitle = isMaterial ? title : Platform.OS === 'ios' ? title.toUpperCase() : title;
+  // the iOS group caption (uppercased, dimmed, tracked-out footnote). The uppercase
+  // + 0.6 opacity + letter-spacing come from `sectionCaption` (keyed on variant, not
+  // Platform.OS — a Liquid-Glass user on Android must still get the HIG caption); the
+  // Text scale, colour, and weight stay per-variant here.
+  const caption = applySectionCaption(title, sectionCaption);
+  const textVariant = selectByVariant(variant, { liquidGlass: 'footnote', material: 'subheadline' } as const);
+  const textColor = selectByVariant(variant, { liquidGlass: undefined, material: m3.onSurfaceVariant });
+  const weightStyle = selectByVariant(variant, { liquidGlass: undefined, material: styles.materialText });
   const showAction = !!actionLabel && !!onActionPress;
 
   return (
     <View style={[styles.container, showAction && styles.containerWithAction]}>
-      <Text
-        variant={isMaterial ? 'subheadline' : 'footnote'}
-        color={isMaterial ? m3.onSurfaceVariant : undefined}
-        style={isMaterial ? styles.materialText : styles.text}
-      >
-        {displayTitle}
+      <Text variant={textVariant} color={textColor} style={[caption.style, weightStyle]}>
+        {caption.text}
       </Text>
       {showAction ? (
         <PressableSurface
@@ -61,12 +63,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  text: {
-    opacity: 0.6,
-    letterSpacing: 0.5,
-  },
   // M3 titleSmall weight (the `subheadline` material scale is 14/400; titleSmall
-  // is 14/500). No opacity/letter-spacing — onSurfaceVariant carries the hierarchy.
+  // is 14/500). Opacity / letter-spacing come from `caption.style` per variant;
+  // onSurfaceVariant carries the hierarchy on Material.
   materialText: {
     fontWeight: '500',
   },

--- a/packages/mobile/src/components/SegmentedControl.tsx
+++ b/packages/mobile/src/components/SegmentedControl.tsx
@@ -5,6 +5,7 @@ import { PressableSurface } from './PressableSurface';
 import { hapticSelection } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
 
 type SegmentOption<K extends string> = {
   key: K;
@@ -102,8 +103,14 @@ function Segment({
  * change.
  */
 export function SegmentedControl<K extends string = string>(props: SegmentedControlProps<K>) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? <SegmentedControlMaterial {...props} /> : <SegmentedControlGlass {...props} />;
+  // Generic over the option key, so it stays an explicit wrapper (the variant factory
+  // fixes the prop type); selectByVariant keeps the swap declarative — no raw
+  // `variant ===` — and renders the chosen impl as JSX (its own fiber/hooks).
+  const Impl = selectByVariant(useTheme().variant, {
+    liquidGlass: SegmentedControlGlass,
+    material: SegmentedControlMaterial,
+  });
+  return <Impl {...props} />;
 }
 
 function SegmentedControlMaterial<K extends string = string>({

--- a/packages/mobile/src/components/Stepper.tsx
+++ b/packages/mobile/src/components/Stepper.tsx
@@ -3,6 +3,7 @@ import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
 import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
 import { spacing, borderRadius } from '../theme/tokens';
 
 type StepperProps = {
@@ -26,7 +27,7 @@ function clampStepperValue(value: number, min: number, max: number): number {
  */
 export function Stepper({ label, value, min, max, onChange, decreaseLabel, increaseLabel }: StepperProps) {
   const { systemColors, brandColors, opacity: themeOpacity, variant, m3 } = useTheme();
-  const isMaterial = variant === 'material';
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   const decrementDisabled = value <= min;
   const incrementDisabled = value >= max;
 

--- a/packages/mobile/src/components/SwitchRow.tsx
+++ b/packages/mobile/src/components/SwitchRow.tsx
@@ -5,6 +5,7 @@ import { hapticSelection } from '../lib/haptics';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
+import { selectByVariant } from '../theme/variants';
 
 type SwitchRowProps = {
   label: string;
@@ -42,29 +43,32 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
           </Text>
         ) : null}
       </View>
-      {uiVariant === 'material' ? (
+      {selectByVariant(uiVariant, {
         // The outer Pressable owns the toggle for the whole row. Paper's Switch is
         // a non-interactive visual indicator here (pointerEvents none, no
         // onValueChange) so a tap on the switch passes through to the row instead
         // of double-firing the toggle (Paper's Switch wraps its own Pressable,
         // which doesn't reliably absorb the touch the way the native RN Switch
         // does on the Liquid Glass path). It picks up M3 colours from PaperProvider.
-        <View pointerEvents="none" accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
-          <PaperSwitch value={value} disabled={disabled} />
-        </View>
-      ) : (
-        <RNSwitch
-          value={value}
-          onValueChange={handleToggle}
-          disabled={disabled}
-          // Filled track behind a white thumb — use the scheme-aware brand FILL so
-          // dark mode gets the brighter #7C3AED (white thumb 5.70:1). The lighter
-          // track also reduces the contrast of iOS's native track-edge highlight,
-          // which is what reads as a "white rim" on a dark, saturated switch.
-          trackColor={{ false: undefined, true: brandColors.primaryFill }}
-          ios_backgroundColor={iosSystemColors.systemGray4 as string}
-        />
-      )}
+        material: (
+          <View pointerEvents="none" accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+            <PaperSwitch value={value} disabled={disabled} />
+          </View>
+        ),
+        liquidGlass: (
+          <RNSwitch
+            value={value}
+            onValueChange={handleToggle}
+            disabled={disabled}
+            // Filled track behind a white thumb — use the scheme-aware brand FILL so
+            // dark mode gets the brighter #7C3AED (white thumb 5.70:1). The lighter
+            // track also reduces the contrast of iOS's native track-edge highlight,
+            // which is what reads as a "white rim" on a dark, saturated switch.
+            trackColor={{ false: undefined, true: brandColors.primaryFill }}
+            ios_backgroundColor={iosSystemColors.systemGray4 as string}
+          />
+        ),
+      })}
     </Pressable>
   );
 }

--- a/packages/mobile/src/components/Toast.tsx
+++ b/packages/mobile/src/components/Toast.tsx
@@ -18,6 +18,7 @@ import {
 import type { UiVariant } from '../theme/resolve-ui-variant';
 import { isTabsRoute } from '../lib/route-segments';
 import { useTheme } from '../providers/theme-provider';
+import { createVariantComponent, selectByVariant } from '../theme/variants';
 
 export type ToastVariant = 'success' | 'error' | 'info' | 'warning';
 
@@ -49,14 +50,7 @@ const VARIANT_CONFIG: Record<ToastVariant, { icon: IconName; colorKey: 'success'
  * existing Liquid-Glass/HIG pill on the Liquid Glass variant. The public prop API
  * is identical for both, so ToastProvider never changes.
  */
-export function Toast({ toast, onDismiss }: ToastProps) {
-  const { variant: uiVariant } = useTheme();
-  return uiVariant === 'material' ? (
-    <ToastMaterial toast={toast} onDismiss={onDismiss} />
-  ) : (
-    <ToastGlass toast={toast} onDismiss={onDismiss} />
-  );
-}
+export const Toast = createVariantComponent('Toast', { liquidGlass: ToastGlass, material: ToastMaterial });
 
 /**
  * Reserve the worst-case queue toolbar height on tab screens so a toast never
@@ -67,12 +61,15 @@ export function Toast({ toast, onDismiss }: ToastProps) {
 function useToastBottomOffset(uiVariant: UiVariant) {
   const insets = useSafeAreaInsets();
   const segments = useSegments();
-  const toolbarReserve = uiVariant === 'material' ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : TOOLBAR_RESERVE;
+  const toolbarReserve = selectByVariant(uiVariant, {
+    material: MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+    liquidGlass: TOOLBAR_RESERVE,
+  });
   // The Material variant's JS nav bar is the taller M3 80dp bar; Liquid Glass uses
   // the 49pt iOS tab bar. This is an independent recomputation (it sits above
   // QueueProvider, so it can't use computeBottomChromeMetrics) — keep the tab-bar
   // term variant-aware to match, or the Material snackbar tucks under the nav bar.
-  const tabBarHeight = uiVariant === 'material' ? MATERIAL_TAB_BAR_HEIGHT : TAB_BAR_HEIGHT;
+  const tabBarHeight = selectByVariant(uiVariant, { material: MATERIAL_TAB_BAR_HEIGHT, liquidGlass: TAB_BAR_HEIGHT });
   return isTabsRoute(segments)
     ? insets.bottom + tabBarHeight + toolbarReserve + spacing[2]
     : insets.bottom + spacing[3];

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -53,11 +53,19 @@ vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => ctrl.c
 vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({
-    variant: ctrl.variant,
-    brandColors: { success: '#0a0' },
-    systemColors: { accent: '#00f', label: '#fff' },
-  }),
+  useTheme: () => {
+    const label = '#fff';
+    return {
+      variant: ctrl.variant,
+      brandColors: { success: '#0a0' },
+      systemColors: { accent: '#00f', label },
+      // Resolved action-icon colours: monochrome on Liquid Glass, semantic on Material.
+      actionColors:
+        ctrl.variant === 'material'
+          ? { neutral: label, success: '#0a0', favorite: '#f00', accent: '#00f', pin: '#6D28D9' }
+          : { neutral: label, success: label, favorite: label, accent: label, pin: label },
+    };
+  },
 }));
 vi.mock('../../theme/ios-colors', () => ({ iosSystemColors: { systemRed: '#f00', systemOrange: '#f80' } }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8 } }));

--- a/packages/mobile/src/components/__tests__/section-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/section-header.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// The resolved variant SectionHeader's caption treatment keys on. The bug being
+// guarded: uppercasing used to key on Platform.OS, so a Liquid-Glass user on
+// Android lost the HIG caps. It now keys on `theme.sectionCaption` (variant).
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+
+// react-native isn't satisfiable under jsdom; stub the surface SectionHeader and
+// the colour modules touch. Platform.OS is deliberately 'android' to prove the
+// casing no longer depends on the platform.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'android' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../PressableSurface', () => ({
+  PressableSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    brandColors: { primary: '#6D28D9' },
+    m3: { onSurfaceVariant: '#49454F' },
+    sectionCaption:
+      ctrl.variant === 'liquidGlass'
+        ? { uppercase: true, opacity: 0.6, letterSpacing: 0.5 }
+        : { uppercase: false, opacity: 1, letterSpacing: 0 },
+  }),
+}));
+
+import { SectionHeader } from '../SectionHeader';
+
+describe('SectionHeader caption casing', () => {
+  it('uppercases on Liquid Glass even on Android (was Platform.OS-gated)', () => {
+    ctrl.variant = 'liquidGlass';
+    const { getByText } = render(createElement(SectionHeader, { title: 'stats summary' }));
+    expect(getByText('STATS SUMMARY')).toBeTruthy();
+  });
+
+  it('keeps sentence case on Material', () => {
+    ctrl.variant = 'material';
+    const { getByText } = render(createElement(SectionHeader, { title: 'stats summary' }));
+    expect(getByText('stats summary')).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/components/__tests__/stepper.test.tsx
+++ b/packages/mobile/src/components/__tests__/stepper.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../providers/theme-provider', () => ({
     systemColors: { label: '#000', separator: '#ccc', tertiaryBackground: '#eee', tertiaryLabel: '#aaa' },
     brandColors: { primary: '#6D28D9' },
     opacity: { disabled: 0.5 },
+    variant: 'liquidGlass',
   }),
 }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16 }, borderRadius: { md: 10 } }));

--- a/packages/mobile/src/components/board-presence/UndoWallChangeSnackbar.tsx
+++ b/packages/mobile/src/components/board-presence/UndoWallChangeSnackbar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { borderRadius, spacing, shadowColor } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 
 // Held longer than the queue-added snackbar (someone may be mid-route on the
@@ -36,11 +37,10 @@ export function UndoWallChangeSnackbar(props: UndoWallChangeSnackbarProps) {
   const bottom = bottomChrome.floatingControlBottom + spacing[2];
   return (
     <Portal>
-      {uiVariant === 'material' ? (
-        <UndoWallChangeSnackbarMaterial {...props} bottom={bottom} />
-      ) : (
-        <UndoWallChangeSnackbarGlass {...props} bottom={bottom} />
-      )}
+      {selectByVariant(uiVariant, {
+        material: <UndoWallChangeSnackbarMaterial {...props} bottom={bottom} />,
+        liquidGlass: <UndoWallChangeSnackbarGlass {...props} bottom={bottom} />,
+      })}
     </Portal>
   );
 }

--- a/packages/mobile/src/components/onboarding/OnboardingCarousel.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingCarousel.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../lib/onboarding/onboarding-analytics';
 import { hapticSelection } from '../../lib/haptics';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { spacing } from '../../theme/tokens';
 
@@ -219,7 +220,7 @@ export function OnboardingCarousel({
               onPress={handleNext}
               variant="filled"
               size="large"
-              tintColor={variant === 'material' ? undefined : accentColor}
+              tintColor={selectByVariant(variant, { material: undefined, liquidGlass: accentColor })}
               haptic={false}
               style={styles.cta}
             />

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -34,7 +34,7 @@ export function PlaylistActionsMenu({
   onClose,
 }: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors, brandColors, variant } = useTheme();
+  const { actionColors } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
   // Track presented state so we never call dismiss() on a not-presented modal
   // (which leaves gorhom in a state where the next present() is a no-op — the
@@ -57,9 +57,8 @@ export function PlaylistActionsMenu({
     isPresentedRef.current = false;
     onClose();
   }, [onClose]);
-  const neutralActionIconColor = systemColors.label;
-  const accentActionIconColor = variant === 'liquidGlass' ? neutralActionIconColor : systemColors.accent;
-  const pinActionIconColor = variant === 'liquidGlass' ? neutralActionIconColor : brandColors.primary;
+  // Monochrome on Liquid Glass, semantic on Material — resolved once as a token.
+  const { accent: accentActionIconColor, pin: pinActionIconColor } = actionColors;
 
   return (
     <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss}>

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -43,6 +43,7 @@ import { withAlpha } from '../../theme/colors';
 import { toQueueClimb, toSchemaClimb } from '../../lib/climb-types';
 import type { PlaylistRenderBoard, PlaylistBoardBanner } from '../../lib/playlists/use-playlist-render-board';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { glassSize } from '../../theme/layout';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -176,7 +177,7 @@ export function PlaylistDetailView({
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const listPaddingBottom = bottomChrome.scrollBottomPadding;
-  const isMaterial = variant === 'material';
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   const heroEmojiIcon = resolvePlaylistEmojiIcon(hero.icon);
 
   // Scroll offset + measured hero-banner height drive the collapsed colour header

--- a/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistEditDoneButton.tsx
@@ -29,10 +29,12 @@ type PlaylistEditDoneButtonProps = {
  */
 export function PlaylistEditDoneButton({ onPress, collapsed }: PlaylistEditDoneButtonProps) {
   const { t } = useTranslation('playlists');
-  const { systemColors, brandColors, variant } = useTheme();
+  const { systemColors, actionColors } = useTheme();
   const nativeGlass = useNativeGlass();
   const label = t('editClimbs.done');
-  const actionColor = variant === 'liquidGlass' ? systemColors.label : brandColors.primary;
+  // Done glyph/label: monochrome on Liquid Glass, brand on Material (the `pin`
+  // action policy — both share "glass → label, material → brand primary").
+  const actionColor = actionColors.pin;
 
   if (collapsed) {
     return (

--- a/packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx
@@ -30,11 +30,19 @@ vi.mock('../../Icon', () => ({
     createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
 }));
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({
-    variant: ctrl.variant,
-    systemColors: { label: '#000', accent: '#007AFF' },
-    brandColors: { primary: '#6D28D9' },
-  }),
+  useTheme: () => {
+    const label = '#000';
+    return {
+      variant: ctrl.variant,
+      systemColors: { label, accent: '#007AFF' },
+      brandColors: { primary: '#6D28D9' },
+      // Resolved action-icon colours: monochrome on Liquid Glass, semantic on Material.
+      actionColors:
+        ctrl.variant === 'material'
+          ? { neutral: label, success: label, favorite: '#FF3B30', accent: '#007AFF', pin: '#6D28D9' }
+          : { neutral: label, success: label, favorite: label, accent: label, pin: label },
+    };
+  },
 }));
 vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemRed: '#FF3B30' } }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8 } }));

--- a/packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-edit-done-button.test.tsx
@@ -11,11 +11,19 @@ vi.mock('react-native', () => ({
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({
-    variant: ctrl.variant,
-    systemColors: { label: '#000', fill: '#eee', separator: '#ccc' },
-    brandColors: { primary: '#6D28D9' },
-  }),
+  useTheme: () => {
+    const label = '#000';
+    return {
+      variant: ctrl.variant,
+      systemColors: { label, fill: '#eee', separator: '#ccc' },
+      brandColors: { primary: '#6D28D9' },
+      // Done glyph uses the `pin` action colour: label on Liquid Glass, brand on Material.
+      actionColors:
+        ctrl.variant === 'material'
+          ? { neutral: label, success: label, favorite: '#FF3B30', accent: label, pin: '#6D28D9' }
+          : { neutral: label, success: label, favorite: label, accent: label, pin: label },
+    };
+  },
 }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 vi.mock('../../../theme/tokens', () => ({ shadows: { sm: {} } }));

--- a/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
@@ -57,8 +57,9 @@ export function AccessoryBarSurface({
     );
   }
 
-  // Material is already opaque, so keep it on the Material surface path even
-  // when Reduce Transparency resolves translucent surfaces to solid.
+  // Material is already opaque, so keep it on the Material surface path even when
+  // Reduce Transparency resolves translucent surfaces to solid. Genuine dual-axis
+  // check (surface capability OR aesthetic variant) — see theme/variants/README.md.
   if (mode === 'material' || variant === 'material') {
     // Docked: neutral M3 surface that reads one elevation step above the tab bar
     // (hairline separator + elevation shadow). Floating: the same surface as a

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -19,6 +19,7 @@
 import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
@@ -40,7 +41,8 @@ export function PersistentQueueBar() {
   if (!currentClimb) return null;
   if (!bottomChrome.jsQueueToolbarVisible && bottomChrome.nativeAccessoryMounted) return null;
 
-  if (variant === 'material') {
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  if (isMaterial) {
     return (
       <ActiveContextBar
         fillPrimary

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -16,6 +16,7 @@ import { Appbar, Chip } from 'react-native-paper';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { spacing } from '../../theme/tokens';
 import { hapticLight } from '../../lib/haptics';
@@ -119,7 +120,8 @@ export function ClimbTopChrome({
     onSearchBlur();
   }, [onSearchBlur]);
 
-  if (variant === 'material') {
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  if (isMaterial) {
     const hasGradeFilter = gradeChip?.active === true;
     const nonGradeFilterCount = Math.max(0, activeFilterCount - (hasGradeFilter ? 1 : 0));
     const hasNonGradeFilters = nonGradeFilterCount > 0;

--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -5,6 +5,7 @@
 import { useTranslation } from 'react-i18next';
 import { GlassIconButton } from '../GlassIconButton';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { glassSize } from '../../theme/layout';
@@ -25,9 +26,7 @@ export function FilterButton({ activeFilterCount, onPress, onLongPress }: Filter
   // glyph is low-contrast — use white there. Material has no tint behind the
   // glyph, so it keeps the violet (white would vanish on the bare surface).
   const iconColor = active
-    ? variant === 'material'
-      ? brandColors.primary
-      : iosSystemColors.white
+    ? selectByVariant(variant, { liquidGlass: iosSystemColors.white, material: brandColors.primary })
     : systemColors.secondaryLabel;
 
   return (

--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -10,6 +10,7 @@ import { PressableSurface } from '../PressableSurface';
 import { iconMap } from '../icon-map';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { spacing } from '../../theme/tokens';
 
 // Record's defining action is the Start/End footer button, so the chrome's
@@ -66,7 +67,8 @@ export function RecordTopChrome({
     [onHeightChange],
   );
 
-  if (variant === 'material') {
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  if (isMaterial) {
     return (
       <View
         pointerEvents="box-none"

--- a/packages/mobile/src/components/session-screen/SessionStartFab.tsx
+++ b/packages/mobile/src/components/session-screen/SessionStartFab.tsx
@@ -7,6 +7,7 @@ import { Icon } from '../Icon';
 import { Text } from '../Text';
 import { iconMap, type IconName } from '../icon-map';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { hapticLight } from '../../lib/haptics';
 import { spacing, shadows } from '../../theme/tokens';
@@ -77,19 +78,22 @@ export function SessionStartFab({
       onLayout={onHeightChange ? handleLayout : undefined}
       style={[styles.container, { bottom: bottomOffset }]}
     >
-      {variant === 'material' ? (
-        <FAB
-          icon={iconMap[icon].android}
-          label={label}
-          onPress={onPress}
-          disabled={disabled}
-          loading={loading}
-          variant="primary"
-          mode="elevated"
-        />
-      ) : (
-        <StartGlassCapsule label={label} icon={icon} onPress={onPress} disabled={disabled} loading={loading} />
-      )}
+      {selectByVariant(variant, {
+        material: (
+          <FAB
+            icon={iconMap[icon].android}
+            label={label}
+            onPress={onPress}
+            disabled={disabled}
+            loading={loading}
+            variant="primary"
+            mode="elevated"
+          />
+        ),
+        liquidGlass: (
+          <StartGlassCapsule label={label} icon={icon} onPress={onPress} disabled={disabled} loading={loading} />
+        ),
+      })}
     </View>
   );
 }

--- a/packages/mobile/src/components/session-screen/__tests__/session-start-fab.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/session-start-fab.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-const ctrl = vi.hoisted(() => ({ variant: 'glass' as 'glass' | 'material', nativeGlass: true }));
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material', nativeGlass: true }));
 // Captures the props the Material FAB and the glass capsule's surface/pressable
 // receive so the test can assert variant routing + the tinted-glass contract.
 const fab = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
@@ -99,7 +99,7 @@ function makeProps(over: Partial<Parameters<typeof SessionStartFab>[0]> = {}) {
 }
 
 beforeEach(() => {
-  ctrl.variant = 'glass';
+  ctrl.variant = 'liquidGlass';
   ctrl.nativeGlass = true;
   fab.props = null;
   glass.props = null;

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -19,6 +19,7 @@ import { Icon } from '../../Icon';
 import { PressableSurface } from '../../PressableSurface';
 import { SectionHeader } from '../../SectionHeader';
 import { Text } from '../../Text';
+import { ScreenTitle } from '../../ScreenTitle';
 import { type IconName } from '../../icon-map';
 import { useTheme } from '../../../providers/theme-provider';
 import { useQueueSessionControls, useQueueActions, useQueueLiveStats } from '../../../providers/queue-provider';
@@ -230,7 +231,7 @@ export function InSessionView({
   screenHeight,
 }: InSessionViewProps) {
   const { t } = useTranslation('session');
-  const { systemColors, brandColors, variant } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const bottomChrome = useBottomChromeMetrics();
   const router = useRouter();
@@ -416,13 +417,10 @@ export function InSessionView({
 
   const [isEnding, setIsEnding] = useState(false);
   // End moved to the top chrome's trailing slot, so the bottom edge keeps only the
-  // global current-climb chrome + tab bar (no third glass band). NativeTabs/Liquid
-  // Glass anchors to the raw UIKit safe-area inset (on iOS 26 it already includes
-  // the tab bar + native accessory — see the on-device evidence in PreSessionView).
-  // When the native accessory is unavailable, the JS queue capsule still floats
-  // above that inset, so add only its reserve and avoid double-counting the tab bar.
-  const listBottomPadding =
-    variant === 'material' ? bottomChrome.fixedFooterBottom : insets.bottom + bottomChrome.jsQueueReserve;
+  // global current-climb chrome + tab bar (no third glass band). The Material-vs-glass
+  // arbitration — and the tab-bar double-count it avoids — lives in
+  // computeBottomChromeMetrics (see `inSessionListBottom`).
+  const listBottomPadding = bottomChrome.inSessionListBottom;
 
   const handleConfirmEnd = useCallback(async () => {
     setIsEnding(true);
@@ -487,11 +485,7 @@ export function InSessionView({
           overlay header strip already names the screen, so it's hidden there. On
           Material the app bar owns the title, so the in-body large title is gated
           off there too. */}
-      {showChrome && variant !== 'material' ? (
-        <Text variant="largeTitle" style={styles.screenTitle}>
-          {t('mobile.session.headerActive')}
-        </Text>
-      ) : null}
+      {showChrome ? <ScreenTitle style={styles.screenTitle}>{t('mobile.session.headerActive')}</ScreenTitle> : null}
 
       <SessionPresenceRow users={sessionUsers} />
 

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -19,6 +19,9 @@ const bottomChrome = vi.hoisted(() => ({
     fixedFooterBottom: 88,
     jsQueueReserve: 0,
     tabBarBottom: 50,
+    // The Material-vs-glass arbitration now lives in computeBottomChromeMetrics
+    // (unit-tested there); InSessionView just wires this resolved field.
+    inSessionListBottom: 130,
   },
 }));
 
@@ -162,7 +165,7 @@ import { InSessionView } from '../InSessionView';
 describe('InSessionView footer', () => {
   beforeEach(() => {
     list.contentContainerStyle = null;
-    bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 0, tabBarBottom: 50 };
+    bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 0, tabBarBottom: 50, inSessionListBottom: 130 };
     theme.variant = 'liquidGlass';
     queue.endSession.mockReset();
     queue.endSession.mockResolvedValue(null);
@@ -181,7 +184,7 @@ describe('InSessionView footer', () => {
   });
 
   it('adds the JS queue capsule reserve on Liquid Glass fallback devices', () => {
-    bottomChrome.metrics = { fixedFooterBottom: 196, jsQueueReserve: 66, tabBarBottom: 50 };
+    bottomChrome.metrics = { fixedFooterBottom: 196, jsQueueReserve: 66, tabBarBottom: 50, inSessionListBottom: 196 };
 
     render(createElement(InSessionView));
 
@@ -192,7 +195,7 @@ describe('InSessionView footer', () => {
 
   it('uses the fixed-footer reserve for the Material active-context bar', () => {
     theme.variant = 'material';
-    bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 48, tabBarBottom: 50 };
+    bottomChrome.metrics = { fixedFooterBottom: 88, jsQueueReserve: 48, tabBarBottom: 50, inSessionListBottom: 88 };
 
     render(createElement(InSessionView));
 

--- a/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/GeneratorPickerCard.tsx
@@ -40,6 +40,7 @@ import { Text } from '../../Text';
 import { GradeSingleSelectRail } from '../../grade';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
 import { useTheme } from '../../../providers/theme-provider';
+import { createVariantComponent, selectByVariant } from '../../../theme/variants';
 import { hapticSelection } from '../../../lib/haptics';
 import { spacing, borderRadius } from '../../../theme/tokens';
 import { springs } from '../../../theme/animations';
@@ -154,10 +155,7 @@ type ChipProps = {
 // selected) so it reads as a native M3 filter chip rather than an iOS pill.
 // Split into two sub-components (rather than an early return) so the glass
 // branch's reanimated hooks stay unconditional across a runtime variant flip.
-function Chip(props: ChipProps) {
-  const { variant } = useTheme();
-  return variant === 'material' ? <ChipMaterial {...props} /> : <ChipGlass {...props} />;
-}
+const Chip = createVariantComponent('Chip', { liquidGlass: ChipGlass, material: ChipMaterial });
 
 function ChipMaterial({ label, selected, onPress, accessibilityLabel }: ChipProps) {
   return (
@@ -217,7 +215,7 @@ type StepperRow = { key: string; node: ReactNode };
 // pattern. Rows carry stable keys (the option field name), so no index keys.
 function GroupedSteppers({ rows }: { rows: StepperRow[] }) {
   const { systemColors, variant, m3 } = useTheme();
-  const isMaterial = variant === 'material';
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   // Material: a filled tonal card (surfaceVariant) with outlineVariant dividers,
   // instead of the iOS `${systemGray}14` inset-table look.
   return (
@@ -271,7 +269,7 @@ export function GeneratorPickerCard({
   const { t } = useTranslation('session');
   const { systemColors, variant, m3 } = useTheme();
   const { formatGradeByDifficultyId } = useGradeFormat();
-  const isMaterial = variant === 'material';
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
 
   const isKilterHomewall = boardName === 'kilter' && layoutId === KILTER_HOMEWALL_LAYOUT_ID;
   const showTallClimbsFilter = isKilterHomewall && sizeId != null && isKilterHomewallTallSizeId(sizeId);

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -13,6 +13,7 @@ import { track } from '../../../lib/analytics';
 import { Card } from '../../Card';
 import { SectionHeader } from '../../SectionHeader';
 import { Text } from '../../Text';
+import { ScreenTitle } from '../../ScreenTitle';
 import type { QueueItemRowBoard } from '../../QueueItemRow';
 import { useTheme } from '../../../providers/theme-provider';
 import { spacing } from '../../../theme/tokens';
@@ -191,15 +192,10 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
   const canStart = activeBoard != null && !isStarting && generatorPreviewReady;
   // The single source of the Start capsule's bottom offset: passed to SessionStartFab
   // AND used for the list reservation, so the FAB position and the last-row clearance
-  // can't drift. Liquid Glass anchors to the raw safe-area inset; Material uses the
-  // fixed-footer reserve.
-  //
-  // Verified on-device (iPhone 17 Pro / iOS 26): with the native tab bar + climb
-  // accessory present, `useSafeAreaInsets().bottom` is 139 = home indicator (34) +
-  // tab bar (49) + accessory (56) — i.e. the glass tab bar DOES extend the UIKit safe
-  // area. `bottomChrome.fixedFooterBottom` adds the tab bar + accessory a second time
-  // (246), which strands the control ~110px up the screen — hence the raw inset here.
-  const footerBottom = variant === 'material' ? bottomChrome.fixedFooterBottom : insets.bottom;
+  // can't drift. The Material-vs-glass arbitration — with the on-device iPhone 17 Pro
+  // evidence for why glass uses the raw inset — lives in computeBottomChromeMetrics
+  // (see `preSessionFooterBottom`).
+  const footerBottom = bottomChrome.preSessionFooterBottom;
 
   // Inline status copy shown above an empty preview (loading / no results /
   // error). When rows are already present a rebuild keeps them mounted, so these
@@ -220,13 +216,9 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
     () => (
       <View style={styles.header}>
         {/* The screen's identity in-body under the floating chrome, collapsing
-            into the centred header capsule as it scrolls up. On Material the
-            app bar owns the title, so the in-body large title is gated off. */}
-        {variant === 'material' ? null : (
-          <Text variant="largeTitle" style={styles.screenTitle}>
-            {t('mobile.session.headerStart')}
-          </Text>
-        )}
+            into the centred header capsule as it scrolls up. ScreenTitle hides
+            itself on Material (the M3 app bar owns the title). */}
+        <ScreenTitle style={styles.screenTitle}>{t('mobile.session.headerStart')}</ScreenTitle>
 
         {/* The chrome pill owns board identity but collapses on scroll, so this
             keeps the full config (name · size · angle) persistently visible when a

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/generator-picker-card-analytics.test.tsx
@@ -185,7 +185,12 @@ vi.mock('../../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGradeByDifficultyId: (difficultyId: number) => `V${difficultyId}` }),
 }));
 vi.mock('../../../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { fill: '#eee' }, brandColors: {}, opacity: { disabled: 0.5 } }),
+  useTheme: () => ({
+    systemColors: { fill: '#eee' },
+    brandColors: {},
+    opacity: { disabled: 0.5 },
+    variant: 'liquidGlass',
+  }),
 }));
 vi.mock('../../../../lib/haptics', () => ({ hapticSelection: haptics.hapticSelection }));
 vi.mock('../../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
@@ -51,6 +51,9 @@ const bottomChrome = vi.hoisted(() => ({
     tabBarBottom: 120,
     tabBarHeight: 49,
     fixedFooterBottom: 120,
+    // Liquid Glass anchors to the raw safe-area inset (100); the Material-vs-glass
+    // arbitration lives in computeBottomChromeMetrics. PreSessionView wires this field.
+    preSessionFooterBottom: 100,
   },
 }));
 
@@ -195,6 +198,7 @@ beforeEach(() => {
     tabBarBottom: 120,
     tabBarHeight: 49,
     fixedFooterBottom: 120,
+    preSessionFooterBottom: 100,
   };
   preview.result.items = [makeRow('a'), makeRow('b')] as unknown[];
   preview.result.refreshingUuids = new Set<string>();

--- a/packages/mobile/src/components/you/FeedSectionLabel.tsx
+++ b/packages/mobile/src/components/you/FeedSectionLabel.tsx
@@ -1,18 +1,22 @@
-import { View, Platform, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { applySectionCaption } from '../../theme/variants/variant-tokens';
 import { spacing } from '../../theme/tokens';
 
 /**
  * Sticky-style section label for the grouped sessions feed (Today / This week /
- * Earlier). Mirrors `SectionHeader`'s uppercase iOS treatment but with the
+ * Earlier). Mirrors `SectionHeader`'s variant-keyed caption treatment (Liquid
+ * Glass uppercases + dims + tracks; Material keeps sentence case) but with the
  * card-aligned horizontal inset the feed uses.
  */
 export function FeedSectionLabel({ label }: { label: string }) {
-  const displayLabel = Platform.OS === 'ios' ? label.toUpperCase() : label;
+  const { sectionCaption } = useTheme();
+  const caption = applySectionCaption(label, sectionCaption);
   return (
     <View style={styles.container}>
-      <Text variant="footnote" style={styles.text}>
-        {displayLabel}
+      <Text variant="footnote" style={[styles.text, caption.style]}>
+        {caption.text}
       </Text>
     </View>
   );
@@ -24,9 +28,8 @@ const styles = StyleSheet.create({
     paddingTop: spacing[5],
     paddingBottom: spacing[1],
   },
+  // Opacity + letter-spacing come from `caption.style` per variant.
   text: {
-    opacity: 0.6,
-    letterSpacing: 0.5,
     fontWeight: '600',
   },
 });

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -7,6 +7,7 @@ import type { AscentFeedItem } from '@boardsesh/graphql/operations';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../lib/analytics';
 import { Text } from '../Text';
+import { ScreenTitle } from '../ScreenTitle';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { LogbookRow } from './LogbookRow';
@@ -25,7 +26,7 @@ type LogbookTabProps = {
 
 export function LogbookTab({ userId, topInset = 0 }: LogbookTabProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors, variant } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
 
@@ -57,17 +58,11 @@ export function LogbookTab({ userId, topInset = 0 }: LogbookTabProps) {
 
   // The screen's identity, in-body under the floating chrome. Memoized so
   // FlashList doesn't re-render the header on every LogbookTab render. Always
-  // present so it sits above the empty state too.
+  // present so it sits above the empty state too. ScreenTitle hides itself on
+  // Material (the M3 app bar owns the title).
   const listHeader = useMemo(
-    // On Material the M3 app bar owns the title, so the in-body large title is
-    // gated off there to avoid a doubled title.
-    () =>
-      variant === 'material' ? null : (
-        <Text variant="largeTitle" style={styles.screenTitle}>
-          {t('metadata.dashboard.title')}
-        </Text>
-      ),
-    [t, variant],
+    () => <ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>,
+    [t],
   );
 
   if (!userId || feed.isPending) {

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { Appbar } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../providers/theme-provider';
+import { createVariantComponent } from '../../theme/variants';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { spacing, shadows } from '../../theme/tokens';
 import { Icon } from '../Icon';
@@ -35,7 +36,7 @@ const SEGMENT_TRACK_RADIUS = 10;
 
 export type ProfileTabKey = 'progress' | 'sessions' | 'logbook';
 
-type ProfileTopChromeProps = {
+export type ProfileTopChromeProps = {
   /** Selected sub-tab; drives the segmented control's pill / the active tab. */
   activeTab: ProfileTabKey;
   onSelectTab: (key: ProfileTabKey) => void;
@@ -47,10 +48,10 @@ type ProfileTopChromeProps = {
   onHeightChange: (height: number) => void;
 };
 
-export function ProfileTopChrome(props: ProfileTopChromeProps) {
-  const { variant } = useTheme();
-  return variant === 'material' ? <ProfileTopChromeMaterial {...props} /> : <ProfileTopChromeGlass {...props} />;
-}
+export const ProfileTopChrome = createVariantComponent('ProfileTopChrome', {
+  liquidGlass: ProfileTopChromeGlass,
+  material: ProfileTopChromeMaterial,
+});
 
 function useSegmentOptions() {
   const { t } = useTranslation('you');

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -3,6 +3,7 @@ import { View, RefreshControl, ScrollView, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { useYouProfileData } from '../../lib/graphql/hooks';
 import { Text } from '../Text';
+import { ScreenTitle } from '../ScreenTitle';
 import { Icon } from '../Icon';
 import { Card } from '../Card';
 import { SectionHeader } from '../SectionHeader';
@@ -26,7 +27,7 @@ type ProgressTabProps = {
 export const ProgressTab = memo(function ProgressTab({ data, topInset }: ProgressTabProps) {
   const { t } = useTranslation('profile');
   const { t: tYou } = useTranslation('you');
-  const { systemColors, colorScheme, brandColors, variant } = useTheme();
+  const { systemColors, colorScheme, brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[6];
 
@@ -72,13 +73,9 @@ export const ProgressTab = memo(function ProgressTab({ data, topInset }: Progres
       }
     >
       {/* The screen's identity, in-body under the floating chrome — collapses into
-          the header capsule as it scrolls up behind the glass. On Material the M3
-          app bar owns the title, so it's gated off there to avoid a doubled title. */}
-      {variant === 'material' ? null : (
-        <Text variant="largeTitle" style={styles.screenTitle}>
-          {dashboardTitle}
-        </Text>
-      )}
+          the header capsule as it scrolls up behind the glass. ScreenTitle hides
+          itself on Material (the M3 app bar owns the title). */}
+      <ScreenTitle style={styles.screenTitle}>{dashboardTitle}</ScreenTitle>
 
       {totalAscents === 0 ? (
         <View style={styles.empty}>

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { SessionFeedItem, SocialEntityType } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
+import { ScreenTitle } from '../ScreenTitle';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { Card } from '../Card';
@@ -88,7 +89,7 @@ function SessionCardSkeleton() {
 
 export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors, variant } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const router = useRouter();
   const { openPlayDrawer } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
@@ -198,17 +199,12 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
   const listHeader = useMemo(
     () => (
       <>
-        {/* On Material the M3 app bar owns the title, so the in-body large title is
-            gated off there to avoid a doubled title. */}
-        {variant === 'material' ? null : (
-          <Text variant="largeTitle" style={styles.screenTitle}>
-            {t('metadata.dashboard.title')}
-          </Text>
-        )}
+        {/* ScreenTitle hides itself on Material (the M3 app bar owns the title). */}
+        <ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>
         {sessions.length > 0 ? <SessionsFeedHeader sessions={sessions} now={now} /> : null}
       </>
     ),
-    [t, sessions, now, variant],
+    [t, sessions, now],
   );
 
   if (!userId) {

--- a/packages/mobile/src/components/you/StatsSummaryCard.tsx
+++ b/packages/mobile/src/components/you/StatsSummaryCard.tsx
@@ -10,6 +10,7 @@ import { LayoutPercentageBar } from './LayoutPercentageBar';
 import { gradeBadgeColor } from './profile-chart-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 
 type Percentile = { percentile: number; totalActiveUsers: number } | null;
 
@@ -23,7 +24,7 @@ type StatsSummaryCardProps = {
 export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash, percentile }: StatsSummaryCardProps) {
   const { t } = useTranslation('profile');
   const { systemColors, brandColors, variant, m3 } = useTheme();
-  const isMaterial = variant === 'material';
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
 
   const showPercentile = percentile != null && percentile.percentile > 0;
   // "Top X%" — invert the percentile, clamped so a 100th-percentile climber

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -7,7 +7,6 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { useTheme } from '../../providers/theme-provider';
-import { androidFallbackColors, materialSurfaces } from '../../theme/colors';
 import { hapticSelection } from '../../lib/haptics';
 import { gradeChartColor, layoutChartColor, flashRedpointColor, type ColoredBar } from './profile-chart-colors';
 import {
@@ -267,16 +266,12 @@ export const StackedBarChart = memo(function StackedBarChart({
   showYAxisScale,
   minBarWidth = 4,
 }: StackedBarsProps) {
-  const { colorScheme, variant } = useTheme();
+  // gifted-charts colour props require plain strings (not PlatformColor); `chartColors`
+  // is the matching string table per variant+scheme, resolved once by the provider.
+  const { colorScheme, chartColors } = useTheme();
   const { t } = useTranslation('profile');
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const isEmpty = !bars || bars.length === 0;
-  // gifted-charts color props require plain strings (not PlatformColor). On the
-  // Material variant resolveSystemColors pulls from materialSurfaces; on glass/
-  // native iOS it uses PlatformColor — neither is safe to pass directly to the
-  // chart library. Pick the matching string table so the axis color is consistent
-  // with systemColors on every platform and variant.
-  const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
 
   // Color resolution is width-independent, so memoize it off the data.
   const tooltipModels = useMemo(
@@ -421,11 +416,10 @@ export const GroupedBarChart = memo(function GroupedBarChart({
   zoomable = true,
   fitYAxisToData,
 }: GroupedBarsProps) {
-  const { colorScheme, variant } = useTheme();
+  const { colorScheme, chartColors } = useTheme();
   const { t } = useTranslation('profile');
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const isEmpty = !bars || bars.length === 0;
-  const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
   const groupGap = 14;
   const innerGap = 2;
   const tooltipModels = useMemo(
@@ -536,8 +530,7 @@ export const TotalAreaChart = memo(function TotalAreaChart({
   interactive = true,
   zoomable = true,
 }: AreaProps) {
-  const { colorScheme, variant } = useTheme();
-  const chartColors = variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme];
+  const { chartColors } = useTheme();
   const isEmpty = !timeline || timeline.series.length === 0;
 
   // Data + axis labels are width-independent — memoize off the timeline.

--- a/packages/mobile/src/components/you/__tests__/feed-section-label.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/feed-section-label.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// FeedSectionLabel used to ignore the variant entirely and uppercase on Platform.OS
+// === 'ios'. The two visible bugs this guards: Material-on-iOS wrongly uppercased,
+// and Liquid-Glass-on-Android wrongly didn't. Both now key on `theme.sectionCaption`.
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'android' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    sectionCaption:
+      ctrl.variant === 'liquidGlass'
+        ? { uppercase: true, opacity: 0.6, letterSpacing: 0.5 }
+        : { uppercase: false, opacity: 1, letterSpacing: 0 },
+  }),
+}));
+
+import { FeedSectionLabel } from '../FeedSectionLabel';
+
+describe('FeedSectionLabel caption casing', () => {
+  it('uppercases on Liquid Glass even on Android', () => {
+    ctrl.variant = 'liquidGlass';
+    const { getByText } = render(createElement(FeedSectionLabel, { label: 'Today' }));
+    expect(getByText('TODAY')).toBeTruthy();
+  });
+
+  it('keeps sentence case on Material (was wrongly uppercased on iOS)', () => {
+    ctrl.variant = 'material';
+    const { getByText } = render(createElement(FeedSectionLabel, { label: 'Today' }));
+    expect(getByText('Today')).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
@@ -2,10 +2,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
-import type { ProfileTabKey } from '../ProfileTopChrome';
+import type { ProfileTabKey, ProfileTopChromeProps } from '../ProfileTopChrome';
 
 const ctrl = vi.hoisted(() => ({
-  variant: 'glass' as 'glass' | 'material',
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 // Captures the props the SegmentedControl receives so the test can assert its
 // option set / selected key / which variant branch rendered it.
@@ -147,7 +147,7 @@ vi.mock('../../chrome', () => ({
 
 import { ProfileTopChrome } from '../ProfileTopChrome';
 
-function makeProps(over: Partial<Parameters<typeof ProfileTopChrome>[0]> = {}) {
+function makeProps(over: Partial<ProfileTopChromeProps> = {}) {
   return {
     activeTab: 'progress' as ProfileTabKey,
     onSelectTab: vi.fn(),
@@ -166,7 +166,7 @@ const filterIcon = (root: HTMLElement) => root.querySelector('[data-icon="filter
 
 describe('ProfileTopChrome', () => {
   beforeEach(() => {
-    ctrl.variant = 'glass';
+    ctrl.variant = 'liquidGlass';
     segments.entries = [];
     materialTabs.entries = [];
   });

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -183,4 +183,50 @@ describe('computeBottomChromeMetrics', () => {
       }
     }
   });
+
+  describe('session list/footer bottoms (folded from InSessionView / PreSessionView)', () => {
+    it('docks both to the fixed-footer reserve on Material', () => {
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'material',
+        usesNativeTabBar: false,
+        insetsBottom: 24,
+        insideTabs: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: false,
+      });
+      expect(metrics.inSessionListBottom).toBe(metrics.fixedFooterBottom);
+      expect(metrics.preSessionFooterBottom).toBe(metrics.fixedFooterBottom);
+    });
+
+    it('anchors Liquid Glass to the raw inset and never double-counts the tab bar', () => {
+      // iPhone 17 Pro / iOS 26: the glass tab bar already extends the inset, so the
+      // footer is the raw inset — NOT fixedFooterBottom, which would add the bar again.
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: 139,
+        insideTabs: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+      });
+      expect(metrics.preSessionFooterBottom).toBe(139);
+      expect(metrics.preSessionFooterBottom).toBeLessThan(metrics.fixedFooterBottom);
+      // Native accessory mounted → no JS queue reserve, so the list also rides the raw inset.
+      expect(metrics.jsQueueReserve).toBe(0);
+      expect(metrics.inSessionListBottom).toBe(139);
+    });
+
+    it('adds only the JS queue reserve to the Liquid Glass in-session list when the accessory is unavailable', () => {
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: false,
+        insetsBottom: 34,
+        insideTabs: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: false,
+      });
+      expect(metrics.inSessionListBottom).toBe(34 + TOOLBAR_RESERVE);
+      expect(metrics.preSessionFooterBottom).toBe(34);
+    });
+  });
 });

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -1,4 +1,8 @@
 import type { UiVariant } from '../theme/resolve-ui-variant';
+// Import the leaf module (not the ./variants barrel): the barrel re-exports
+// createVariantComponent, which pulls the provider + react-native and would break
+// this module's pure, react-native-free unit test. select-by-variant is type-only.
+import { selectByVariant } from '../theme/variants/select-by-variant';
 import {
   MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
   MATERIAL_TAB_BAR_HEIGHT,
@@ -136,7 +140,12 @@ export function computeBottomChromeMetrics({
     scrollBottomPadding: insetsBottom + tabBarHeight + jsQueueReserve,
     floatingControlBottom: insetsBottom + tabBarHeight + Math.max(jsQueueReserve, nativeAccessoryReserve),
     fixedFooterBottom,
-    inSessionListBottom: uiVariant === 'material' ? fixedFooterBottom : insetsBottom + jsQueueReserve,
-    preSessionFooterBottom: uiVariant === 'material' ? fixedFooterBottom : insetsBottom,
+    // selectByVariant (vs a raw ternary) keeps these exhaustive: a new UiVariant is
+    // a compile error here, since this file is outside the components/ guard scope.
+    inSessionListBottom: selectByVariant(uiVariant, {
+      material: fixedFooterBottom,
+      liquidGlass: insetsBottom + jsQueueReserve,
+    }),
+    preSessionFooterBottom: selectByVariant(uiVariant, { material: fixedFooterBottom, liquidGlass: insetsBottom }),
   };
 }

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -58,6 +58,25 @@ export type BottomChromeMetrics = {
    * footers clear only active queue/accessory chrome.
    */
   fixedFooterBottom: number;
+  /**
+   * Bottom padding for the in-session climb list. Material docks a fixed footer
+   * (clears active queue/accessory chrome via `fixedFooterBottom`); Liquid Glass
+   * floats, so the list clears the raw safe-area inset plus only the JS queue
+   * reserve — the glass tab bar already extends the UIKit inset, so adding the
+   * tab bar height again would double-count it.
+   */
+  inSessionListBottom: number;
+  /**
+   * Bottom offset for the pre-session Start capsule / footer. Material uses the
+   * fixed-footer reserve; Liquid Glass anchors to the raw safe-area inset.
+   *
+   * Verified on-device (iPhone 17 Pro / iOS 26): with the native tab bar + climb
+   * accessory present, the safe-area bottom inset is 139 = home indicator (34) +
+   * tab bar (49) + accessory (56) — the glass tab bar extends the UIKit safe area.
+   * `fixedFooterBottom` would add the tab bar + accessory a second time (246),
+   * stranding the control ~110px up the screen — hence the raw inset on glass.
+   */
+  preSessionFooterBottom: number;
 };
 
 /**
@@ -117,5 +136,7 @@ export function computeBottomChromeMetrics({
     scrollBottomPadding: insetsBottom + tabBarHeight + jsQueueReserve,
     floatingControlBottom: insetsBottom + tabBarHeight + Math.max(jsQueueReserve, nativeAccessoryReserve),
     fixedFooterBottom,
+    inSessionListBottom: uiVariant === 'material' ? fixedFooterBottom : insetsBottom + jsQueueReserve,
+    preSessionFooterBottom: uiVariant === 'material' ? fixedFooterBottom : insetsBottom,
   };
 }

--- a/packages/mobile/src/hooks/use-effective-surface-mode.ts
+++ b/packages/mobile/src/hooks/use-effective-surface-mode.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
 import { useReduceTransparency } from './use-reduce-transparency';
 import { useGlassCapability } from './use-glass-capability';
+import { assertNever } from '../lib/assert-never';
 
 /**
  * How a translucent surface should actually render on this device, for this
@@ -22,9 +23,17 @@ export function useEffectiveSurfaceMode(): SurfaceMode {
   const reduceTransparency = useReduceTransparency();
   const glassCapable = useGlassCapability();
 
+  // a11y wins regardless of variant.
   if (reduceTransparency) return 'solid';
-  if (variant === 'material') return 'material';
-  if (glassCapable) return 'glass';
-  if (Platform.OS === 'ios') return 'blur';
-  return 'solid';
+  switch (variant) {
+    case 'material':
+      return 'material';
+    case 'liquidGlass':
+      if (glassCapable) return 'glass';
+      if (Platform.OS === 'ios') return 'blur';
+      return 'solid';
+    // A new UiVariant must declare its surface mode.
+    default:
+      return assertNever(variant);
+  }
 }

--- a/packages/mobile/src/lib/assert-never.ts
+++ b/packages/mobile/src/lib/assert-never.ts
@@ -1,0 +1,10 @@
+/**
+ * Exhaustiveness guard. Call it in the `default` of a `switch (variant)` (or
+ * after an if-chain that handles every `UiVariant`) so adding a variant becomes
+ * a compile error here: TypeScript only allows passing `never`, and an unhandled
+ * case widens the argument to a real type, breaking the build at exactly the
+ * spot that needs a decision.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled variant: ${String(value)}`);
+}

--- a/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/toast-provider.test.tsx
@@ -39,6 +39,9 @@ vi.mock('../../lib/haptics', () => ({
 
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
+    // createVariantComponent indexes impls[variant]; the old ternary tolerated an
+    // absent variant (fell through to the glass path), so pin it explicitly.
+    variant: 'liquidGlass',
     colorScheme: 'light',
     brandColors: { success: '#047857', error: '#C81E1E', primary: '#6D28D9', warning: '#B45309' },
     systemColors: { secondaryBackground: '#fff' },

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -30,7 +30,16 @@ import {
 } from '../theme/tokens';
 import { springs, timing } from '../theme/animations';
 import { resolveUiVariant, type UiVariant } from '../theme/resolve-ui-variant';
+import {
+  resolveActionColors,
+  resolveChartColors,
+  sectionCaptionByVariant,
+  type ActionColors,
+  type ChartColors,
+  type SectionCaption,
+} from '../theme/variants/variant-tokens';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
+import { assertNever } from '../lib/assert-never';
 
 type ColorScheme = 'light' | 'dark';
 
@@ -103,6 +112,18 @@ type Theme = {
    * roles, so use the `elevation.levelN` ladder for surface-container surfaces.
    */
   m3: MD3Theme['colors'];
+  /**
+   * Semantic foregrounds for action rows / action FABs, resolved per variant:
+   * monochrome (`systemColors.label`) on Liquid Glass, tinted by role on Material.
+   */
+  actionColors: ActionColors;
+  /**
+   * Plain-string colour palette for chart libraries (gifted-charts) that reject
+   * PlatformColor. Mirrors `systemColors` but is always hex/rgba.
+   */
+  chartColors: ChartColors;
+  /** Section-caption treatment (uppercase / opacity / letter-spacing), per variant. */
+  sectionCaption: SectionCaption;
 };
 
 const ThemeContext = createContext<Theme | null>(null);
@@ -117,34 +138,37 @@ const ThemeContext = createContext<Theme | null>(null);
  * androidFallbackColors light/dark map.
  */
 function resolveSystemColors(colorScheme: ColorScheme, variant: UiVariant): ResolvedSystemColors {
-  // Material variant: M3 tonal surfaces on every platform — including iOS 26
-  // hardware when the user explicitly chose Material. Drawn opaque (no glass),
-  // so we don't use PlatformColor here.
-  if (variant === 'material') {
-    return { ...materialSurfaces[colorScheme] };
+  switch (variant) {
+    // Material variant: M3 tonal surfaces on every platform — including iOS 26
+    // hardware when the user explicitly chose Material. Drawn opaque (no glass),
+    // so we don't use PlatformColor here.
+    case 'material':
+      return { ...materialSurfaces[colorScheme] };
+    case 'liquidGlass': {
+      if (Platform.OS === 'ios' && iosSystemColors) {
+        // PlatformColor values adapt automatically on iOS — return as-is.
+        return iosSystemColors as ResolvedSystemColors;
+      }
+      // Android: resolve from the single source of truth for fallback colors.
+      const fallback = colorScheme === 'dark' ? androidFallbackColors.dark : androidFallbackColors.light;
+      return {
+        background: fallback.background,
+        secondaryBackground: fallback.secondaryBackground,
+        tertiaryBackground: fallback.tertiaryBackground,
+        groupedBackground: fallback.groupedBackground,
+        elevatedSurface: fallback.elevatedSurface,
+        label: fallback.label,
+        secondaryLabel: fallback.secondaryLabel,
+        tertiaryLabel: fallback.tertiaryLabel,
+        separator: fallback.separator,
+        fill: fallback.fill,
+        accent: fallback.accent,
+      };
+    }
+    // A new UiVariant must declare how its system colours resolve.
+    default:
+      return assertNever(variant);
   }
-
-  if (Platform.OS === 'ios' && iosSystemColors) {
-    // PlatformColor values adapt automatically on iOS — return as-is.
-    return iosSystemColors as ResolvedSystemColors;
-  }
-
-  // Android: resolve from the single source of truth for fallback colors.
-  const fallback = colorScheme === 'dark' ? androidFallbackColors.dark : androidFallbackColors.light;
-
-  return {
-    background: fallback.background,
-    secondaryBackground: fallback.secondaryBackground,
-    tertiaryBackground: fallback.tertiaryBackground,
-    groupedBackground: fallback.groupedBackground,
-    elevatedSurface: fallback.elevatedSurface,
-    label: fallback.label,
-    secondaryLabel: fallback.secondaryLabel,
-    tertiaryLabel: fallback.tertiaryLabel,
-    separator: fallback.separator,
-    fill: fallback.fill,
-    accent: fallback.accent,
-  };
 }
 
 /**
@@ -265,11 +289,12 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   const theme = useMemo<Theme>(() => {
     const resolvedSystemColors = resolveSystemColors(colorScheme, variant);
+    const resolvedBrandColors = resolveBrandColors(colorScheme);
 
     return {
       colorScheme,
       systemColors: resolvedSystemColors,
-      brandColors: resolveBrandColors(colorScheme),
+      brandColors: resolvedBrandColors,
       textStyles: textStylesByVariant[variant],
       spacing,
       borderRadius,
@@ -285,6 +310,14 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       radii: radiiByVariant[variant],
       sheet: sheetChromeByVariant[variant],
       m3: m3Colors,
+      actionColors: resolveActionColors(variant, {
+        label: resolvedSystemColors.label,
+        accent: resolvedSystemColors.accent,
+        brandSuccess: resolvedBrandColors.success,
+        brandPrimary: resolvedBrandColors.primary,
+      }),
+      chartColors: resolveChartColors(variant, colorScheme),
+      sectionCaption: sectionCaptionByVariant[variant],
     };
   }, [colorScheme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant, m3Colors]);
 

--- a/packages/mobile/src/test/theme-mock.ts
+++ b/packages/mobile/src/test/theme-mock.ts
@@ -1,0 +1,59 @@
+import type { Theme } from '../providers/theme-provider';
+import { spacing, borderRadius, shadows, opacity, radiiByVariant, sheetChromeByVariant } from '../theme/tokens';
+import { springs, timing } from '../theme/animations';
+import { textStylesByVariant } from '../theme/typography';
+import { brandColors, brandColorsDark, materialSurfaces, androidFallbackColors } from '../theme/colors';
+import { buildPaperTheme } from '../theme/paper-theme';
+import { resolveActionColors, resolveChartColors, sectionCaptionByVariant } from '../theme/variants/variant-tokens';
+
+/**
+ * Build a complete `Theme` for unit tests. One factory so every test gets the
+ * full shape — including the variant-resolved fields (`actionColors`,
+ * `chartColors`, `sectionCaption`) — and a migration that relocates a colour
+ * into a new token only updates this file, not the ~25 inline `vi.mock`s that
+ * otherwise each hand-roll a partial theme.
+ *
+ * Pass `{ variant }` / `{ colorScheme }` to resolve everything for that
+ * combination the way the provider does, or override any field directly. Uses
+ * plain-string colour palettes (Android fallback / Material surfaces) so colour
+ * assertions read real hex, not `PlatformColor`.
+ */
+export function makeThemeMock(overrides: Partial<Theme> = {}): Theme {
+  const variant = overrides.variant ?? 'liquidGlass';
+  const colorScheme = overrides.colorScheme ?? 'light';
+  const brand = colorScheme === 'dark' ? brandColorsDark : brandColors;
+  const systemColors =
+    overrides.systemColors ??
+    (variant === 'material' ? materialSurfaces[colorScheme] : androidFallbackColors[colorScheme]);
+
+  const base: Theme = {
+    colorScheme,
+    systemColors,
+    brandColors: brand,
+    textStyles: textStylesByVariant[variant],
+    spacing,
+    borderRadius,
+    shadows,
+    opacity,
+    springs,
+    timing,
+    themeOverride: 'system',
+    setThemeOverride: () => Promise.resolve(),
+    variant,
+    uiVariantPreference: 'auto',
+    setUiVariant: () => Promise.resolve(),
+    radii: radiiByVariant[variant],
+    sheet: sheetChromeByVariant[variant],
+    m3: buildPaperTheme(colorScheme).colors,
+    actionColors: resolveActionColors(variant, {
+      label: systemColors.label,
+      accent: systemColors.accent,
+      brandSuccess: brand.success,
+      brandPrimary: brand.primary,
+    }),
+    chartColors: resolveChartColors(variant, colorScheme),
+    sectionCaption: sectionCaptionByVariant[variant],
+  };
+
+  return { ...base, ...overrides };
+}

--- a/packages/mobile/src/theme/variants/README.md
+++ b/packages/mobile/src/theme/variants/README.md
@@ -1,0 +1,76 @@
+# UI variants (Material 3 ↔ Apple HIG / Liquid Glass)
+
+The mobile app renders in two design languages and keeps both: `liquidGlass`
+(Apple HIG / iOS 26 Liquid Glass) and `material` (Material 3 / Android). The user
+can force either in Settings, so **variant is a runtime choice, not the platform**.
+
+This directory is the home for the small set of building blocks that keep variant
+differences out of render bodies. The goal: every variant difference is **data in
+a typed map resolved once by the provider**; the only `variant === '…'` left is in
+the provider, swap routers, and `selectByVariant` maps.
+
+## Four orthogonal axes — never conflate them
+
+| Axis                                  | Question                           | Read from                                                                                                                                                                                     |
+| ------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Aesthetic variant**              | Which design language?             | `theme.variant` (`'liquidGlass' \| 'material'`) — user can force it                                                                                                                           |
+| **B. Colour scheme**                  | Light or dark?                     | `theme.colorScheme`                                                                                                                                                                           |
+| **C. Effective rendering capability** | What can this device render _now_? | `useEffectiveSurfaceMode()` (glass/blur/material/solid), `useNativeTabBar()` — "which impl is actually on screen", e.g. an iOS < 26 Liquid-Glass device degrades to `blur` and the JS tab bar |
+| **D. Raw platform**                   | A literal OS / native-API fact?    | `Platform.OS`                                                                                                                                                                                 |
+
+**Governing rule for `Platform.OS`:** allowed **only** when the truth it expresses
+stays true if the user force-switches variants (HealthKit, BLE permissions, native
+Maps, Share payloads, gorhom containers, `KeyboardAvoidingView`). If flipping the
+variant toggle _should_ change the behaviour, it is **axis A** — read `theme.variant`
+or a token, never `Platform.OS`. (This is the bug class fixed in `SectionHeader` /
+`FeedSectionLabel`: `Platform.OS === 'ios'` stood in for "is this the HIG look".)
+
+**Axis C is not axis A.** `AccessoryBarSurface` correctly consults both
+(`mode === 'material' || variant === 'material'`) — leave it. Do not back any
+variant primitive with surface mode.
+
+## Decision tree — what to reach for
+
+1. Capability/rendering difference (glass vs blur; native vs JS tab bar)? → **axis C** hooks. Never key on `variant`.
+2. A whole component subtree differs (different RN/Paper elements)? → **component swap** (`createVariantComponent` for small twins; an explicit `index.tsx` router for large folder-split twins).
+3. A single value differs and has a **stable, designer-facing name** (action-icon colour policy, chart palette, caption style)? → **token**: add a `…ByVariant` map / resolver in `variant-tokens.ts`, resolve in the provider, read `theme.X`.
+4. A layout metric tied to chrome arbitration (reserves, insets, footer padding)? → push into `computeBottomChromeMetrics` and read a named field.
+5. Whether a feature/section shows at all? → a named component that returns `null` (e.g. `ScreenTitle`) — never a bare `variant === 'material' ? null`.
+6. A genuinely local, positional one-off? → `selectByVariant(variant, { liquidGlass, material })`.
+
+## The primitives
+
+- **`selectByVariant(variant, { liquidGlass, material })`** — declarative value pick. Maps are `Record<UiVariant, T>`, so a new variant is a compile error at every call site. Prefer a token (step 3) for anything with a name.
+- **`createVariantComponent(name, { liquidGlass, material })`** — one public component from two impls with an identical prop API. Renders the chosen impl as JSX so each gets its own fiber/hook list (a live variant flip unmounts one and mounts the other). React 19 `ref` forwards through `{...props}`.
+- **`variant-tokens.ts`** — the per-variant token resolvers (`resolveActionColors`, `resolveChartColors`, `sectionCaptionByVariant`, `applySectionCaption`). Shared by the provider and the test mock (`src/test/theme-mock.ts`) so they can't drift.
+- **`assertNever`** (`src/lib/assert-never.ts`) — exhaustiveness guard for the few `switch (variant)` sites in the provider.
+
+## Rules that keep it working
+
+- **Component swaps:** only wrap components whose two impls are already fully-distinct subtrees. A router flips the element _type_ on a variant change, so any `useState` / shared value / scroll / focus held **above** the variant split is lost on flip. Keep those as in-body `selectByVariant`. Never wrap an open-state sheet. Reanimated shared values / gestures must live **inside** each impl.
+- **a11y parity:** both impls of a swapped component must keep identical accessibility semantics (role/label/live-region). The shared `*.types.ts` contract won't catch a11y drift — check it by hand.
+- **Memoisation:** never pass an inline object literal to `selectByVariant`/`useVariantValue` when the result feeds a `React.memo` child or a `useMemo`/gesture dep — define the map as a module-scope `const`.
+- **Synchronous first paint:** every provider-resolved token must derive purely from already-resolved `variant`/`colorScheme`/`systemColors`/`brandColors` inside the single `theme` `useMemo` — never an async/effect path.
+
+## Adding a third variant — the punch-list
+
+Widen `UiVariant` in `../resolve-ui-variant.ts` and the compiler enumerates the work:
+every `…ByVariant` map, every `selectByVariant`/`createVariantComponent` call, and every
+swap router fails to compile until handled. A **manual** checklist covers the capability
+sites the type system can't reach: `resolveSystemColors` and `useEffectiveSurfaceMode`
+(guarded by `assertNever`), `theme.m3` (a Paper palette only meaningful on Material), and
+axis-D `Platform.OS` sites.
+
+## Scope
+
+Variant is **mobile-only** — no `packages/shared/*-react` package and nothing on web reads
+it, so there's nothing to extract per the monorepo's "extract don't duplicate" rule. There is
+no visual-regression harness, so the non-default variant (Material-on-iOS, Glass-on-Android) is
+covered by manual screenshots, not snapshots.
+
+## Enforcement
+
+A grep/lint gate keeps `variant === '…'` out of `src/components/**` render bodies (allowed only
+in `*/index.tsx` routers, `*.glass.tsx`/`*.material.tsx` impls, and `theme/`/`providers/`, plus
+the annotated `AccessoryBarSurface` dual-axis exception). It lands as a warning and flips to an
+error once the migration reaches zero offenders.

--- a/packages/mobile/src/theme/variants/__tests__/create-variant-component.test.tsx
+++ b/packages/mobile/src/theme/variants/__tests__/create-variant-component.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, useEffect, useState } from 'react';
+
+// Controls the resolved variant the factory routes on. createVariantComponent
+// reads it through useTheme(); the mock keeps this a pure object (no real hooks),
+// so the wrapper's own hook count is constant.
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: ctrl.variant }) }));
+
+import { createVariantComponent } from '../create-variant-component';
+
+type DemoProps = { label: string };
+
+// The glass impl runs TWO hooks; the material impl runs ZERO. If the factory called
+// the chosen impl as a plain function (instead of rendering it as JSX), a live
+// variant flip would change the hook count *within the wrapper's fiber* and crash
+// with "rendered fewer hooks than during the previous render". Rendering as JSX
+// gives each impl its own fiber, so a flip is a clean unmount + mount.
+function GlassImpl({ label }: DemoProps) {
+  const [n] = useState(0);
+  useEffect(() => {}, []);
+  return createElement('div', { 'data-variant': 'glass', 'data-n': n }, label);
+}
+function MaterialImpl({ label }: DemoProps) {
+  return createElement('div', { 'data-variant': 'material' }, label);
+}
+
+const Demo = createVariantComponent<DemoProps>('Demo', { liquidGlass: GlassImpl, material: MaterialImpl });
+
+describe('createVariantComponent', () => {
+  it('renders the implementation for the active variant (and passes props through)', () => {
+    ctrl.variant = 'liquidGlass';
+    const glass = render(createElement(Demo, { label: 'hi' }));
+    expect(glass.container.querySelector('[data-variant="glass"]')?.textContent).toBe('hi');
+    expect(glass.container.querySelector('[data-variant="material"]')).toBeNull();
+    glass.unmount();
+
+    ctrl.variant = 'material';
+    const material = render(createElement(Demo, { label: 'hi' }));
+    expect(material.container.querySelector('[data-variant="material"]')?.textContent).toBe('hi');
+    expect(material.container.querySelector('[data-variant="glass"]')).toBeNull();
+  });
+
+  it('sets displayName for DevTools / error overlays', () => {
+    expect(Demo.displayName).toBe('Demo');
+  });
+
+  it('survives a live variant flip when the two impls have different hook counts', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container, rerender } = render(createElement(Demo, { label: 'x' }));
+    expect(container.querySelector('[data-variant="glass"]')).toBeTruthy();
+
+    // Flip to the zero-hook impl and re-render the SAME element. Because the impl is
+    // rendered as JSX (its own fiber), this is an unmount of the 2-hook impl and a
+    // mount of the 0-hook impl — it must NOT throw a Rules-of-Hooks error.
+    ctrl.variant = 'material';
+    expect(() => rerender(createElement(Demo, { label: 'x' }))).not.toThrow();
+    expect(container.querySelector('[data-variant="material"]')).toBeTruthy();
+    expect(container.querySelector('[data-variant="glass"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/theme/variants/__tests__/variant-tokens.test.ts
+++ b/packages/mobile/src/theme/variants/__tests__/variant-tokens.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// variant-tokens pulls in the theme colour modules (colors.ts / ios-colors.ts),
+// which read Platform/PlatformColor at import. jsdom can't satisfy react-native,
+// so stub the surface they touch — Platform.OS='android' takes colors.ts down its
+// non-PlatformColor fallback path. Mirrors theme-provider.test.tsx.
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  PlatformColor: (name: string) => name,
+}));
+
+import { selectByVariant } from '../select-by-variant';
+import {
+  resolveActionColors,
+  resolveChartColors,
+  sectionCaptionByVariant,
+  applySectionCaption,
+} from '../variant-tokens';
+
+describe('selectByVariant', () => {
+  it('returns the value for the active variant', () => {
+    expect(selectByVariant('liquidGlass', { liquidGlass: 'a', material: 'b' })).toBe('a');
+    expect(selectByVariant('material', { liquidGlass: 'a', material: 'b' })).toBe('b');
+  });
+});
+
+describe('resolveActionColors', () => {
+  const inputs = { label: '#LABEL', accent: '#ACCENT', brandSuccess: '#SUCCESS', brandPrimary: '#PRIMARY' };
+
+  it('renders every role monochrome (label) on Liquid Glass', () => {
+    const colors = resolveActionColors('liquidGlass', inputs);
+    expect([colors.neutral, colors.success, colors.favorite, colors.accent, colors.pin]).toEqual([
+      '#LABEL',
+      '#LABEL',
+      '#LABEL',
+      '#LABEL',
+      '#LABEL',
+    ]);
+  });
+
+  it('tints each role by semantic meaning on Material', () => {
+    const colors = resolveActionColors('material', inputs);
+    expect(colors.neutral).toBe('#LABEL');
+    expect(colors.success).toBe('#SUCCESS');
+    expect(colors.accent).toBe('#ACCENT');
+    expect(colors.pin).toBe('#PRIMARY');
+    expect(colors.favorite).toBe('#FF3B30'); // static iOS systemRed
+  });
+});
+
+describe('resolveChartColors', () => {
+  it('returns plain-string palettes for every variant + scheme', () => {
+    expect(typeof resolveChartColors('material', 'light').separator).toBe('string');
+    expect(typeof resolveChartColors('material', 'dark').secondaryLabel).toBe('string');
+    expect(typeof resolveChartColors('liquidGlass', 'light').tertiaryLabel).toBe('string');
+    expect(typeof resolveChartColors('liquidGlass', 'dark').separator).toBe('string');
+  });
+});
+
+describe('sectionCaptionByVariant / applySectionCaption', () => {
+  it('uppercases on Liquid Glass and leaves sentence case on Material', () => {
+    expect(applySectionCaption('Today', sectionCaptionByVariant.liquidGlass).text).toBe('TODAY');
+    expect(applySectionCaption('Today', sectionCaptionByVariant.material).text).toBe('Today');
+  });
+
+  it('carries the dim/tracked treatment on Liquid Glass only', () => {
+    expect(applySectionCaption('x', sectionCaptionByVariant.liquidGlass).style).toEqual({
+      opacity: 0.6,
+      letterSpacing: 0.5,
+    });
+    expect(applySectionCaption('x', sectionCaptionByVariant.material).style).toEqual({ opacity: 1, letterSpacing: 0 });
+  });
+
+  it('declares every variant (exhaustive map)', () => {
+    expect(Object.keys(sectionCaptionByVariant).sort()).toEqual(['liquidGlass', 'material']);
+  });
+});

--- a/packages/mobile/src/theme/variants/create-variant-component.tsx
+++ b/packages/mobile/src/theme/variants/create-variant-component.tsx
@@ -1,0 +1,37 @@
+import { type ComponentType } from 'react';
+import { useTheme } from '../../providers/theme-provider';
+import type { UiVariant } from '../resolve-ui-variant';
+
+/**
+ * Build a single public component from one implementation per UI variant, with
+ * an identical prop API. Replaces the hand-written
+ * `variant === 'material' ? <XMaterial/> : <XGlass/>` router so every swap site
+ * is uniform and exhaustive (`Record<UiVariant, …>` — a new variant can't
+ * compile until each component supplies an implementation).
+ *
+ * The chosen implementation is rendered as JSX (`<Impl {...props} />`), NOT
+ * called as a function. This is load-bearing: rendering gives each variant its
+ * OWN fiber and hook list, so a live variant flip (the user toggling the setting)
+ * unmounts one subtree and mounts the other. Calling `Impl(props)` instead would
+ * run the impl's hooks in this wrapper's slot list — and the two impls routinely
+ * have different hook counts (e.g. the glass impl runs an extra animation effect),
+ * which crashes with "rendered fewer/more hooks than during the previous render".
+ *
+ * In React 19 `ref` is a normal prop, so it forwards through `{...props}` for any
+ * impl whose props type includes it — no `forwardRef` needed. Only wrap
+ * components whose two impls are already fully-distinct subtrees: a router flips
+ * the element TYPE on a variant change, so any `useState` / shared value / scroll
+ * / focus held ABOVE the variant split is lost on flip. Keep those as in-body
+ * `selectByVariant` so the stateful shell stays mounted. See ./README.md.
+ */
+export function createVariantComponent<P extends object>(
+  name: string,
+  impls: Record<UiVariant, ComponentType<P>>,
+): ComponentType<P> {
+  function VariantComponent(props: P) {
+    const Impl = impls[useTheme().variant];
+    return <Impl {...props} />;
+  }
+  VariantComponent.displayName = name;
+  return VariantComponent;
+}

--- a/packages/mobile/src/theme/variants/index.ts
+++ b/packages/mobile/src/theme/variants/index.ts
@@ -1,0 +1,2 @@
+export { selectByVariant } from './select-by-variant';
+export { createVariantComponent } from './create-variant-component';

--- a/packages/mobile/src/theme/variants/select-by-variant.ts
+++ b/packages/mobile/src/theme/variants/select-by-variant.ts
@@ -1,0 +1,24 @@
+import type { UiVariant } from '../resolve-ui-variant';
+
+/**
+ * Pick a value by the resolved UI variant from an exhaustive map.
+ *
+ * The map is typed `Record<UiVariant, T>`, so adding a third variant becomes a
+ * compile error at every call site until each one supplies a value —
+ * exhaustiveness by construction. This is the declarative replacement for
+ * `variant === 'material' ? a : b` ternaries in component render bodies.
+ *
+ * Reach for this only for a genuinely LOCAL, positional one-off. If the value
+ * has a stable, designer-facing name (an action-icon colour policy, a chart
+ * palette, a caption style) it belongs in a token resolved by the provider and
+ * read as `theme.X` — not here. See ./README.md for the decision tree.
+ *
+ * Performance: when `T` is an object handed to a `React.memo` child or used as a
+ * `useMemo`/gesture dependency, define the per-variant map as a module-scope
+ * `const` and pass it in — never an inline object literal built per render
+ * (that defeats memoisation, the same hazard `jsx-no-constructed-context-values`
+ * guards one level up).
+ */
+export function selectByVariant<T>(variant: UiVariant, byVariant: Record<UiVariant, T>): T {
+  return byVariant[variant];
+}

--- a/packages/mobile/src/theme/variants/variant-tokens.ts
+++ b/packages/mobile/src/theme/variants/variant-tokens.ts
@@ -1,0 +1,117 @@
+import { type OpaqueColorValue } from 'react-native';
+import type { UiVariant } from '../resolve-ui-variant';
+import { iosSystemColors } from '../ios-colors';
+import { materialSurfaces, androidFallbackColors, type SystemColorKey } from '../colors';
+
+/**
+ * Variant-resolved design tokens. These live in ONE place so the provider and
+ * the test theme mock (`src/test/theme-mock.ts`) resolve them identically and
+ * can't drift. The provider exposes each as `theme.actionColors` /
+ * `theme.chartColors` / `theme.sectionCaption`; components read the resolved
+ * value and never branch on `variant`. See ./README.md for the decision tree.
+ */
+
+type ColorValue = string | OpaqueColorValue;
+
+/**
+ * Semantic foregrounds for action rows / action FABs. Liquid Glass renders them
+ * monochrome (the row's meaning carried by the SF Symbol + copy, the HIG way);
+ * Material tints each by its semantic role per M3. One decision, resolved once.
+ */
+export type ActionColors = {
+  /** Default / non-semantic action glyph. */
+  neutral: ColorValue;
+  /** Add-to-queue, confirm. */
+  success: ColorValue;
+  /** Favourite / heart. */
+  favorite: ColorValue;
+  /** Edit · copy · open (interactive accent). */
+  accent: ColorValue;
+  /** Pin / feature. */
+  pin: ColorValue;
+};
+
+/**
+ * The colours `resolveActionColors` reads, passed in already resolved for the
+ * current scheme so this stays decoupled from the provider's `Theme` type
+ * (avoids an import cycle).
+ */
+export type ActionColorInputs = {
+  /** `systemColors.label` — the monochrome foreground. */
+  label: ColorValue;
+  /** `systemColors.accent` — the interactive-accent foreground. */
+  accent: ColorValue;
+  /** `brandColors.success`. */
+  brandSuccess: ColorValue;
+  /** `brandColors.primary`. */
+  brandPrimary: ColorValue;
+};
+
+export function resolveActionColors(variant: UiVariant, inputs: ActionColorInputs): ActionColors {
+  if (variant === 'liquidGlass') {
+    return {
+      neutral: inputs.label,
+      success: inputs.label,
+      favorite: inputs.label,
+      accent: inputs.label,
+      pin: inputs.label,
+    };
+  }
+  return {
+    neutral: inputs.label,
+    success: inputs.brandSuccess,
+    // Static iOS red (gifted-charts / animated styles can't take PlatformColor);
+    // reads fine on Android too.
+    favorite: iosSystemColors.systemRed,
+    accent: inputs.accent,
+    pin: inputs.brandPrimary,
+  };
+}
+
+/**
+ * Plain-string colour palette for chart libraries (react-native-gifted-charts)
+ * that reject `PlatformColor`/`OpaqueColorValue`. Mirrors `systemColors` but is
+ * always hex/rgba on every platform+variant. Liquid Glass borrows the Android
+ * fallback strings (iOS `systemColors` are PlatformColor and can't reach a chart);
+ * Material uses its M3 tonal strings.
+ */
+export type ChartColors = Record<SystemColorKey, string>;
+
+export function resolveChartColors(variant: UiVariant, colorScheme: 'light' | 'dark'): ChartColors {
+  return (variant === 'material' ? materialSurfaces : androidFallbackColors)[colorScheme];
+}
+
+/**
+ * Section-caption treatment. Liquid Glass uses the HIG group caption (uppercased,
+ * dimmed, tracked-out); Material uses sentence case (the M3 app bar / onSurfaceVariant
+ * carries the hierarchy instead). Keyed on VARIANT, not `Platform.OS` — fixing the
+ * `SectionHeader` / `FeedSectionLabel` bug where a Liquid-Glass user on Android lost
+ * the uppercasing and a Material user on iOS wrongly gained it.
+ */
+export type SectionCaption = {
+  uppercase: boolean;
+  opacity: number;
+  letterSpacing: number;
+};
+
+export const sectionCaptionByVariant = {
+  liquidGlass: { uppercase: true, opacity: 0.6, letterSpacing: 0.5 },
+  material: { uppercase: false, opacity: 1, letterSpacing: 0 },
+} as const satisfies Record<UiVariant, SectionCaption>;
+
+/**
+ * Apply a section-caption treatment to a label: returns the (possibly uppercased)
+ * text plus the style fragment, so `SectionHeader` and `FeedSectionLabel` stay
+ * branch-free and identical. JS `.toUpperCase()` (not RN `textTransform`) matches
+ * the existing behaviour; captions are non-user-generated UI strings, so the
+ * locale-sensitivity of `.toUpperCase()` is not a concern here.
+ */
+export function applySectionCaption(
+  text: string,
+  caption: SectionCaption,
+): { text: string; style: { opacity: number; letterSpacing: number } } {
+  return {
+    text: caption.uppercase ? text.toUpperCase() : text,
+    style: { opacity: caption.opacity, letterSpacing: caption.letterSpacing },
+  };
+}

--- a/scripts/mobile-variant-guard.sh
+++ b/scripts/mobile-variant-guard.sh
@@ -6,10 +6,12 @@
 # — never an inline `variant === 'material'` / `=== 'liquidGlass'` comparison that
 # can silently regrow. See packages/mobile/src/theme/variants/README.md.
 #
-# Deliberately scoped to the theme variant: it matches a `variant`/`uiVariant`
-# identifier compared to a UiVariant literal, so it does NOT flag the orthogonal
-# surface-capability axis (`mode === 'material'`, `surfaceMode === 'material'`) or
-# unrelated props (`variant === 'filled'`, `=== 'scroll'`).
+# Deliberately scoped to the theme variant: the `[vV]ariant` token matches a
+# `variant`, `uiVariant`, or `theme.variant` identifier (grep substring-matches, so
+# the `.` in `theme.variant` is fine) compared to a UiVariant literal. It does NOT
+# flag the orthogonal surface-capability axis (`mode === 'material'`,
+# `surfaceMode === 'material'`) or unrelated props (`variant === 'filled'`,
+# `=== 'scroll'`).
 #
 # Two escape hatches for genuine exceptions:
 #   1. A trailing `// variant-ok` comment on the offending line (per-line opt-out).
@@ -29,7 +31,7 @@ cd "$(dirname "$0")/.."
 ALLOWLIST='queue-control/AccessoryBarSurface\.tsx|user-drawer/UserAvatarToolbarAction\.tsx'
 
 matches=$(
-  grep -rnE "(ui)?[vV]ariant[[:space:]]*[!=]==[[:space:]]*'(material|liquidGlass)'" \
+  grep -rnE "[vV]ariant[[:space:]]*[!=]==[[:space:]]*'(material|liquidGlass)'" \
     packages/mobile/src/components \
     --include='*.tsx' --include='*.ts' \
     | grep -v '__tests__' \

--- a/scripts/mobile-variant-guard.sh
+++ b/scripts/mobile-variant-guard.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Guards against raw UI-variant magic-string compares in mobile component render
+# bodies. The aesthetic variant (Material 3 vs Liquid Glass) must be routed through
+# `selectByVariant` / `createVariantComponent` / a provider-resolved `theme.*` token
+# — never an inline `variant === 'material'` / `=== 'liquidGlass'` comparison that
+# can silently regrow. See packages/mobile/src/theme/variants/README.md.
+#
+# Deliberately scoped to the theme variant: it matches a `variant`/`uiVariant`
+# identifier compared to a UiVariant literal, so it does NOT flag the orthogonal
+# surface-capability axis (`mode === 'material'`, `surfaceMode === 'material'`) or
+# unrelated props (`variant === 'filled'`, `=== 'scroll'`).
+#
+# Two escape hatches for genuine exceptions:
+#   1. A trailing `// variant-ok` comment on the offending line (per-line opt-out).
+#   2. The ALLOWLIST below (whole-file opt-out, for files whose `variant` is not the
+#      theme variant or is an irreducible dual-axis check).
+#
+# Exit 1 (CI failure) on any unexpected match; 0 when clean.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Files whose flagged `variant === '…'` is NOT a routable theme-variant swap:
+#  - AccessoryBarSurface: `mode === 'material' || variant === 'material'` is a genuine
+#    dual-axis check (surface capability OR aesthetic) — see the four-axis model.
+#  - UserAvatarToolbarAction: `variant` is the component's OWN `'glass' | 'material'`
+#    prop, not `theme.variant`.
+ALLOWLIST='queue-control/AccessoryBarSurface\.tsx|user-drawer/UserAvatarToolbarAction\.tsx'
+
+matches=$(
+  grep -rnE "(ui)?[vV]ariant[[:space:]]*[!=]==[[:space:]]*'(material|liquidGlass)'" \
+    packages/mobile/src/components \
+    --include='*.tsx' --include='*.ts' \
+    | grep -v '__tests__' \
+    | grep -v 'variant-ok' \
+    | grep -vE "$ALLOWLIST" \
+    || true
+)
+
+if [ -n "$matches" ]; then
+  echo "✖ Raw theme-variant compares found in mobile components:"
+  echo "$matches"
+  echo
+  echo "  Route the aesthetic variant through selectByVariant / createVariantComponent"
+  echo "  / a theme.* token (see packages/mobile/src/theme/variants/README.md)."
+  echo "  For a genuine exception, add a trailing  // variant-ok  comment, or extend"
+  echo "  the ALLOWLIST in scripts/mobile-variant-guard.sh with a documented reason."
+  exit 1
+fi
+
+echo "✓ No raw theme-variant compares in mobile components."

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -482,6 +482,13 @@ export default defineConfig({
         command: 'tsx scripts/mobile-patches-check.ts',
         cache: false,
       },
+      'check:mobile-variants': {
+        // Guards against raw theme-variant magic-string compares regrowing in
+        // mobile components — they must route through selectByVariant /
+        // createVariantComponent / a theme.* token (see theme/variants/README.md).
+        command: 'bash scripts/mobile-variant-guard.sh',
+        cache: false,
+      },
       'check:mobile-bundle': {
         command: 'bash scripts/mobile-bundle-check.sh',
         cache: false,


### PR DESCRIPTION
## What & why

The mobile app intentionally supports two design languages — `liquidGlass` (Apple HIG / iOS 26 Liquid Glass) and `material` (Material 3 / Android) — but the support was added as an afterthought, so it leaked into render bodies as ad-hoc `variant === 'material'` ternaries and `Platform.OS` checks (~87 branch points across ~50 files). This consolidates every variant difference behind a small, typed, exhaustive primitive set and adds a CI gate so the inline branching can't regrow.

The foundation already existed (a single `theme.variant`, some variant-keyed tokens, a `Button`/`Card` swap convention); this **completes** that model rather than replacing it.

## How

**Primitives** (`packages/mobile/src/theme/variants/`, documented in `README.md` with a four-axis model + decision tree):
- `selectByVariant(variant, { liquidGlass, material })` — declarative value pick; `Record<UiVariant, T>` makes a new variant a compile error at every call site.
- `createVariantComponent(name, { liquidGlass, material })` — one public component from two impls, rendered as JSX so each keeps its own fiber/hook list across a live variant flip.
- `assertNever` — exhaustiveness guard.

**Tokens resolved once in the provider** (shared with a `makeThemeMock` test factory so they can't drift): `theme.actionColors`, `theme.chartColors`, `theme.sectionCaption`.

**Two latent bugs fixed:** `SectionHeader` and `FeedSectionLabel` keyed section-caption uppercasing on `Platform.OS === 'ios'` instead of the aesthetic variant, so a Liquid-Glass user on Android lost the HIG caps and a forced-Material user on iOS wrongly got them. Now keyed on the variant via `theme.sectionCaption`, with new tests covering all four `variant × platform` cells.

**Other consolidations:**
- Action-icon colors, chart palette → tokens (ClimbActionsSheet, playlist menus, FilterButton, YouCharts).
- In-session / pre-session bottom-reserve math folded into the pure `computeBottomChromeMetrics` (load-bearing on-device rationale comment moved with it; metrics test extended).
- A single `ScreenTitle` replaces 5 duplicated large-title suppression gates.
- ~20 component swaps formalized: clean two-impl routers (`Button`, `Card`, `Badge`, `Toast`, `QueueAddedSnackbar`, `GlassIconButton`, `ProfileTopChrome`, the `GeneratorPickerCard` chip) → `createVariantComponent`; the generic `SegmentedControl`, early-return chromes, and value-selects → `selectByVariant`.
- `resolveSystemColors` and `useEffectiveSurfaceMode` → exhaustive `switch` + `assertNever` (a third variant becomes a compile error).

**Enforcement:** `scripts/mobile-variant-guard.sh` (wired as `vp run check:mobile-variants` and a CI step) fails the build on any raw theme-variant magic-string compare in mobile components. It is scoped to the *aesthetic* variant, so it deliberately ignores the orthogonal surface-capability axis (`mode === 'material'`, `surfaceMode === 'material'`). Two documented exceptions are allowlisted: `AccessoryBarSurface` (a genuine dual-axis check) and `UserAvatarToolbarAction` (its `variant` is the component's own `'glass' | 'material'` prop, not `theme.variant`).

## Validation

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — **2071 passing** (+14 new: variant-tokens, caption casing across 4 cells, layout-reserve metrics)
- `vp run check:mobile-variants` — pass (zero raw theme-variant compares)
- `vp run check:mobile-bundle` — pass (10.1 MB)
- `vp check` — clean on all changed files
- A paired adversarial QA review confirmed behavior preservation across all swap conversions.

## Notes for review

- **Folder-split deviation:** the plan suggested folder-splitting the "large twins," but only `ProfileTopChrome` is cleanly two-impl. The others (`ClimbTopChrome`, `RecordTopChrome`, `persistent-queue-bar`) are early-return-with-shared-hooks, where splitting would force shared hooks into each impl — real risk for organizational gain. They use the factory / `selectByVariant` in place instead (same enforcement-clean result, no file-move risk).
- **Manual QA suggestion:** the caption casing change is the one user-visible delta. It's unit-tested across all four cells; a visual confirmation on Glass-on-Android (caps) and Material-on-iOS (sentence case) is recommended before release.

## Test plan

- [x] `typecheck:mobile`, `test:mobile`, `check:mobile-variants`, `check:mobile-bundle`, `vp check`
- [ ] Manual: toggle the UI-variant setting and exercise action sheets, the You tabs (titles + charts), session pre/in-session footers, swapped components, and section captions — especially Android-with-Liquid-Glass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
