### PR TITLE
Reuse lightbulb hook's localConnected in PlayDrawer

### DIFF
--- a/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
@@ -73,6 +73,17 @@ describe('useLightbulbControl lit state', () => {
     expect(result.current.localConnected).toBe(true);
   });
 
+  it('stays lit and locally connected when this device holds the wall and is subscribed', () => {
+    // This device drives the wall (isConnected) AND is subscribed to the board
+    // feed (boardId bound). Local connection short-circuits lit before the
+    // holder/session checks, so both read true.
+    ctrl.bluetooth = makeBluetooth({ isConnected: true });
+    ctrl.boardId = 42;
+    const { result } = renderControl();
+    expect(result.current.lit).toBe(true);
+    expect(result.current.localConnected).toBe(true);
+  });
+
   it('lights from a session peer holding the wall, without claiming local connection', () => {
     // The headline behaviour: subscribed to the board feed (boardId bound), a
     // peer holds it, this device is not connected — the bulb reads lit but the

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -150,7 +150,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const { isAuthenticated } = useAuth();
 
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
-  const bluetoothConnected = bluetooth?.isConnected ?? false;
   const bluetoothArmUndoWallChangeToast = bluetooth?.armUndoWallChangeToast;
   const bluetoothReassertWall = bluetooth?.reassertWall;
   const bluetoothClearBoard = bluetooth?.clearBoard;
@@ -192,6 +191,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   // that to the action bar for the accessibility label.
   const {
     lit: lightbulbActive,
+    localConnected: bluetoothConnected,
     pending: lightbulbPending,
     onPress: handleLightbulb,
   } = useLightbulbControl({


### PR DESCRIPTION
## What

Small cleanup in the mobile play drawer's lightbulb wiring, from a code review.

`PlayDrawer.tsx` re-derived `bluetoothConnected` from `bluetooth?.isConnected ?? false`, even though `useLightbulbControl` already returns an identical `localConnected` (`use-lightbulb-control.ts`). The drawer ignored that return value and recomputed the same boolean. The two are identical, so this is a dedup, not a behaviour change.

## Changes

- Consume `localConnected` from `useLightbulbControl` (aliased to `bluetoothConnected`) and drop the duplicate derivation. The three downstream consumers (the close-BLE-sheet effect, `lightbulbConnected`, and `lightbulbLongPressEnabled`) are unchanged.
- Add a `deriveLightbulbLit` test for the previously-uncovered combination where `localConnected` and `isSubscribedToBoardFeed` are both true (this device holds the wall while subscribed to the board feed) — asserts both `lit` and `localConnected` read true.

The review's third note (press-action tests calling `onPress()` without `act()`) was flagged as fine as-is and is left unchanged.

## Verification

- `vp run typecheck:mobile` — passes
- `vp test run --project mobile` — 2066 passed; the lightbulb suite is 8/8 (7 existing + 1 new)

https://claude.ai/code/session_01U1Aq3uYkiQY4NHyMbjgUUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1Aq3uYkiQY4NHyMbjgUUx)_