### PR TITLE
fix(mobile): session-scope the lightbulb lit state, keep the holder avatar

### DIFF
--- a/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
@@ -18,6 +18,8 @@ const ctrl = vi.hoisted(() => ({
   boardId: null as number | null,
   isSessionWallLit: false,
   sessionId: null as string | null,
+  // The session roster's logged-in member userIds, for id-matching the holder.
+  sessionMemberUserIds: new Set<string>(),
   // Holder rides the per-climb BoardPresenceCurrentContext; null = wall free.
   presence: undefined as BoardPresenceCurrentState | undefined,
 }));
@@ -28,7 +30,11 @@ vi.mock('../../../providers/board-presence-provider', () => ({
   useBoardPresenceControls: () => ({ boardId: ctrl.boardId }),
 }));
 vi.mock('../../../providers/queue-provider', () => ({
-  useQueueSessionControls: () => ({ isSessionWallLit: ctrl.isSessionWallLit, sessionId: ctrl.sessionId }),
+  useQueueSessionControls: () => ({
+    isSessionWallLit: ctrl.isSessionWallLit,
+    sessionId: ctrl.sessionId,
+    sessionMemberUserIds: ctrl.sessionMemberUserIds,
+  }),
 }));
 vi.mock('../../../lib/analytics', () => ({ track: trackMock }));
 
@@ -47,7 +53,9 @@ function makeBluetooth(over: Partial<NonNullable<BluetoothCtx>> = {}): NonNullab
 }
 
 // Minimal holder — every BoardConnectionHolder field is optional (anonymous).
-const presenceWithHolder = { holder: {}, currentClimb: null } as unknown as BoardPresenceCurrentState;
+const anonymousHolderPresence = { holder: {}, currentClimb: null } as unknown as BoardPresenceCurrentState;
+const holderPresenceFor = (userId: string): BoardPresenceCurrentState =>
+  ({ holder: { userId }, currentClimb: null }) as unknown as BoardPresenceCurrentState;
 
 const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(BoardPresenceCurrentContext.Provider, { value: ctrl.presence }, children);
@@ -61,6 +69,7 @@ beforeEach(() => {
   ctrl.boardId = null;
   ctrl.isSessionWallLit = false;
   ctrl.sessionId = null;
+  ctrl.sessionMemberUserIds = new Set();
   ctrl.presence = undefined;
   trackMock.mockClear();
 });
@@ -86,19 +95,55 @@ describe('useLightbulbControl lit state', () => {
 
   it('lights from a session peer holding the wall, without claiming local connection', () => {
     // The headline behaviour: subscribed to the board feed (boardId bound), a
-    // peer holds it, this device is not connected — the bulb reads lit but the
-    // tap still connects/takes over (localConnected stays false).
+    // session member holds it (their userId is in my roster), this device is not
+    // connected — the bulb reads lit but the tap still connects/takes over.
     ctrl.boardId = 42;
-    ctrl.presence = presenceWithHolder;
+    ctrl.sessionId = 'session-1';
+    ctrl.sessionMemberUserIds = new Set(['peer-user']);
+    ctrl.presence = holderPresenceFor('peer-user');
     const { result } = renderControl();
     expect(result.current.lit).toBe(true);
     expect(result.current.localConnected).toBe(false);
   });
 
-  it('reads off once subscribed and the holder has cleared, even if the session flag is stuck', () => {
-    // The regression guard: holder authoritatively cleared, but the best-effort
-    // session flag is stuck true. Subscribed clients trust the holder → off.
+  it('stays off when a stranger holds the wall while solo', () => {
+    // The bug fix: subscribed and a holder exists, but I'm not in a session, so
+    // the holder isn't someone I'm climbing with — the bulb reads off (the avatar
+    // still shows separately via BoardConnectionBadge).
     ctrl.boardId = 42;
+    ctrl.sessionId = null;
+    ctrl.presence = holderPresenceFor('stranger-user');
+    const { result } = renderControl();
+    expect(result.current.lit).toBe(false);
+  });
+
+  it('stays off when an in-session holder is not a roster member', () => {
+    // In a session, but the board holder's userId isn't in my roster (a stranger
+    // on the same physical board) → off.
+    ctrl.boardId = 42;
+    ctrl.sessionId = 'session-1';
+    ctrl.sessionMemberUserIds = new Set(['peer-user']);
+    ctrl.presence = holderPresenceFor('stranger-user');
+    const { result } = renderControl();
+    expect(result.current.lit).toBe(false);
+  });
+
+  it('lights from an anonymous session peer via the session flag', () => {
+    // Anonymous holder (no userId to id-match) while in a session: fall back to
+    // the best-effort wall-lit flag.
+    ctrl.boardId = 42;
+    ctrl.sessionId = 'session-1';
+    ctrl.isSessionWallLit = true;
+    ctrl.presence = anonymousHolderPresence;
+    const { result } = renderControl();
+    expect(result.current.lit).toBe(true);
+  });
+
+  it('reads off once the holder has cleared, even if the session flag is stuck', () => {
+    // The regression guard: holder authoritatively cleared, but the best-effort
+    // session flag is stuck true. No holder → neither path fires → off.
+    ctrl.boardId = 42;
+    ctrl.sessionId = 'session-1';
     ctrl.presence = undefined; // holder cleared
     ctrl.isSessionWallLit = true;
     const { result } = renderControl();

--- a/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
+++ b/packages/mobile/src/components/ble/__tests__/use-lightbulb-control.test.ts
@@ -106,6 +106,20 @@ describe('useLightbulbControl lit state', () => {
     expect(result.current.localConnected).toBe(false);
   });
 
+  it('lights for a late-joiner from the seeded holder, without the session flag', () => {
+    // A late-joiner seeds the holder via the boardConnection query but never
+    // receives the WallConfirmedClimb that sets isSessionWallLit. The logged-in
+    // peer's userId match lights the bulb immediately, so the bulb is correct
+    // before (and even without) the fragile session flag.
+    ctrl.boardId = 42;
+    ctrl.sessionId = 'session-1';
+    ctrl.sessionMemberUserIds = new Set(['peer-user']);
+    ctrl.isSessionWallLit = false;
+    ctrl.presence = holderPresenceFor('peer-user');
+    const { result } = renderControl();
+    expect(result.current.lit).toBe(true);
+  });
+
   it('stays off when a stranger holds the wall while solo', () => {
     // The bug fix: subscribed and a holder exists, but I'm not in a session, so
     // the holder isn't someone I'm climbing with — the bulb reads off (the avatar

--- a/packages/mobile/src/components/ble/use-lightbulb-control.ts
+++ b/packages/mobile/src/components/ble/use-lightbulb-control.ts
@@ -56,15 +56,27 @@ export function useLightbulbControl(options: UseLightbulbControlOptions): Lightb
   // Raw context (non-throwing) so a bulb rendered outside the provider degrades
   // to "no peer holder" instead of crashing.
   const boardPresenceCurrent = useContext(BoardPresenceCurrentContext);
-  const { isSessionWallLit, sessionId } = useQueueSessionControls();
+  const { isSessionWallLit, sessionId, sessionMemberUserIds } = useQueueSessionControls();
 
   const localConnected = bluetooth?.isConnected ?? false;
   const pending = bluetooth?.loading ?? false;
 
+  // The board-presence holder is board-scoped (anyone on this board feed). Tie it
+  // to the session so the bulb only lights for someone I'm climbing with: a
+  // logged-in holder matches by userId; an anonymous holder falls back to the
+  // session wall-lit flag (in a session only). A holder who isn't in my session —
+  // or any holder while I'm solo — no longer lights the bulb, but its avatar still
+  // shows via BoardConnectionBadge.
+  const holder = boardPresenceCurrent?.holder ?? null;
+  const holderUserId = holder?.userId ?? null;
+  const sessionHolderPresent = sessionId !== null && holderUserId !== null && sessionMemberUserIds.has(holderUserId);
+  const holderIsAnonymous = holder !== null && holderUserId === null && sessionId !== null;
+
   const lit = deriveLightbulbLit({
     localConnected,
     isSubscribedToBoardFeed: boardId !== null,
-    peerHolderPresent: boardPresenceCurrent?.holder != null,
+    sessionHolderPresent,
+    holderIsAnonymous,
     isSessionWallLit,
   });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/lightbulb-control.test.ts
@@ -55,33 +55,74 @@ describe('deriveLightbulbLit', () => {
       deriveLightbulbLit({
         localConnected: true,
         isSubscribedToBoardFeed: false,
-        peerHolderPresent: false,
+        sessionHolderPresent: false,
+        holderIsAnonymous: false,
         isSessionWallLit: false,
       }),
     ).toBe(true);
   });
 
-  it('lights when subscribed and a peer holds the wall', () => {
+  it('lights when subscribed and a session member holds the wall', () => {
     expect(
       deriveLightbulbLit({
         localConnected: false,
         isSubscribedToBoardFeed: true,
-        peerHolderPresent: true,
+        sessionHolderPresent: true,
+        holderIsAnonymous: false,
         isSessionWallLit: false,
       }),
     ).toBe(true);
   });
 
-  it('ignores a stuck session flag once subscribed to the authoritative feed', () => {
-    // The regression: the holder has cleared (peer disconnected) but the
-    // best-effort session flag is stuck true. Subscribed clients trust the
-    // holder, so the bulb correctly reads off — the phone can take control back.
+  it('stays off when subscribed and the holder is not in my session (stranger / solo)', () => {
+    // A board holder exists but they aren't a member of my session (or I'm solo):
+    // session-scoped, so the bulb reads off even though the holder's avatar shows.
     expect(
       deriveLightbulbLit({
         localConnected: false,
         isSubscribedToBoardFeed: true,
-        peerHolderPresent: false,
+        sessionHolderPresent: false,
+        holderIsAnonymous: false,
+        isSessionWallLit: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores a stuck session flag once the holder has cleared', () => {
+    // The regression guard: the holder cleared (peer disconnected) but the
+    // best-effort session flag is stuck true. With no holder, neither the
+    // session-member nor the anonymous path can fire, so the bulb reads off.
+    expect(
+      deriveLightbulbLit({
+        localConnected: false,
+        isSubscribedToBoardFeed: true,
+        sessionHolderPresent: false,
+        holderIsAnonymous: false,
         isSessionWallLit: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('falls back to the session flag for an anonymous holder in a session', () => {
+    // An anonymous session peer can't be id-matched, so trust the session flag —
+    // but only while a holder actually exists.
+    expect(
+      deriveLightbulbLit({
+        localConnected: false,
+        isSubscribedToBoardFeed: true,
+        sessionHolderPresent: false,
+        holderIsAnonymous: true,
+        isSessionWallLit: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      deriveLightbulbLit({
+        localConnected: false,
+        isSubscribedToBoardFeed: true,
+        sessionHolderPresent: false,
+        holderIsAnonymous: true,
+        isSessionWallLit: false,
       }),
     ).toBe(false);
   });
@@ -91,7 +132,8 @@ describe('deriveLightbulbLit', () => {
       deriveLightbulbLit({
         localConnected: false,
         isSubscribedToBoardFeed: false,
-        peerHolderPresent: false,
+        sessionHolderPresent: false,
+        holderIsAnonymous: false,
         isSessionWallLit: true,
       }),
     ).toBe(true);
@@ -100,7 +142,8 @@ describe('deriveLightbulbLit', () => {
       deriveLightbulbLit({
         localConnected: false,
         isSubscribedToBoardFeed: false,
-        peerHolderPresent: false,
+        sessionHolderPresent: false,
+        holderIsAnonymous: false,
         isSessionWallLit: false,
       }),
     ).toBe(false);

--- a/packages/mobile/src/components/play-drawer/lightbulb-control.ts
+++ b/packages/mobile/src/components/play-drawer/lightbulb-control.ts
@@ -37,7 +37,11 @@ export function derivePlayDrawerLightbulbPressAction(args: {
 export function deriveLightbulbLit(args: {
   localConnected: boolean;
   isSubscribedToBoardFeed: boolean;
-  /** A board-presence holder whose userId matches a member of my session (incl. me). */
+  /**
+   * A board-presence holder whose userId matches a member of my session (incl.
+   * me). Mutually exclusive with `holderIsAnonymous`: a holder either has a
+   * matchable userId or is anonymous, never both.
+   */
   sessionHolderPresent: boolean;
   /** The current holder is anonymous (exists, userId == null) AND I'm in a session. */
   holderIsAnonymous: boolean;

--- a/packages/mobile/src/components/play-drawer/lightbulb-control.ts
+++ b/packages/mobile/src/components/play-drawer/lightbulb-control.ts
@@ -13,31 +13,46 @@ export function derivePlayDrawerLightbulbPressAction(args: {
 
 /**
  * Whether the lightbulb reads lit: this device is driving the wall, or someone
- * in the session is. Shared by the header toolbar bulb and the play-drawer bulb
- * so both light identically.
+ * *in this user's session* is. Shared by the header toolbar bulb and the
+ * play-drawer bulb so both light identically.
  *
- * The cross-phone "a peer holds the wall" signal has two possible sources, and
- * they are NOT equivalent:
- *  - `peerHolderPresent` (board-presence holder) is authoritative: server-owned,
+ * The lit signal is session-scoped, but the board-presence holder is board-scoped
+ * (anyone physically on the same board feed can be the holder — a stranger when
+ * you're solo, or a non-member when you're in a session). So we don't light from
+ * the bare holder; we light from a holder we can tie to the session:
+ *  - `sessionHolderPresent` — a board-presence holder whose userId matches a
+ *    member of my session (incl. me). Authoritative: the holder is server-owned,
  *    seq-gated, with a reliable compare-and-delete broadcast on disconnect and a
- *    WS-drop backstop, so it clears reliably.
+ *    WS-drop backstop, so it clears reliably. This is what stops the bulb getting
+ *    stuck lit on a phone that handed off control.
  *  - `isSessionWallLit` is a best-effort session UI flag toggled by
  *    WallConfirmedClimb / WallDisconnected with no reconciliation — a missed or
- *    late "disconnected" event leaves it stuck `true`.
+ *    late "disconnected" event leaves it stuck `true`. It's only consulted as a
+ *    fallback for an *anonymous* holder (no userId to id-match) while in a session,
+ *    or for a session member who never bound the board feed (no holder to read).
  *
- * So when this device is subscribed to the board feed (it has bound a board),
- * trust the holder and ignore the fragile session flag — this is what stops the
- * bulb getting stuck lit on a phone that handed off control. Fall back to the
- * session flag only for a member who never bound the board (no feed to read).
+ * Net effect: a board holder who isn't part of my session (or any holder while I'm
+ * solo) no longer lights my bulb, while the holder's avatar still shows separately.
  */
 export function deriveLightbulbLit(args: {
   localConnected: boolean;
   isSubscribedToBoardFeed: boolean;
-  peerHolderPresent: boolean;
+  /** A board-presence holder whose userId matches a member of my session (incl. me). */
+  sessionHolderPresent: boolean;
+  /** The current holder is anonymous (exists, userId == null) AND I'm in a session. */
+  holderIsAnonymous: boolean;
+  /** Best-effort session "a member lit a climb" flag. */
   isSessionWallLit: boolean;
 }): boolean {
   if (args.localConnected) return true;
-  return args.isSubscribedToBoardFeed ? args.peerHolderPresent : args.isSessionWallLit;
+  // No board feed bound: no holder to trust; fall back to the session flag
+  // (only ever true inside a session).
+  if (!args.isSubscribedToBoardFeed) return args.isSessionWallLit;
+  // Subscribed: trust the authoritative holder, but only a session member's.
+  if (args.sessionHolderPresent) return true;
+  // Anonymous holder can't be id-matched; fall back to the session flag, but only
+  // while a holder actually exists (a cleared holder + stuck flag still reads off).
+  return args.holderIsAnonymous && args.isSessionWallLit;
 }
 
 export function buildPlayDrawerBoardLayout(args: { boardName: string; layoutId: number; sizeId: number }): string {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1672,24 +1672,28 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [playlistSuggestionSource],
   );
 
-  // Stable join key of the session's logged-in member userIds (anonymous members
-  // have no userId to match, so they're filtered out). `sessionUsers` gets a new
-  // array identity on every ≤1/2s SessionStatsUpdated push; keying the Set on this
-  // sorted string means its identity only changes on a real roster delta, so the
-  // session-control value (and the lightbulbs that read it) don't churn on stats.
-  // userIds are DB UUIDs, so a comma join round-trips losslessly.
-  const sessionMemberUserIdKey = useMemo(
+  // Sorted, logged-in member userIds (anonymous members have no userId to match,
+  // so they're filtered out). `sessionUsers` gets a new array identity on every
+  // ≤1/2s SessionStatsUpdated push even when the roster is unchanged; sorting gives
+  // a stable order for the change-detector below.
+  const sessionMemberUserIdList = useMemo(
     () =>
       sessionUsers
         .map((user) => user.userId)
         .filter((userId): userId is string => userId != null)
-        .sort()
-        .join(','),
+        .sort(),
     [sessionUsers],
   );
+  // Gate the Set's identity on a content signature so a stats push with an
+  // unchanged roster doesn't churn the session-control value (and re-light the
+  // bulbs that read it). The Set is rebuilt from the list itself — never by
+  // splitting the signature back into ids — so it's robust to any userId shape.
+  const sessionMemberUserIdSignature = sessionMemberUserIdList.join(' ');
   const sessionMemberUserIds = useMemo<ReadonlySet<string>>(
-    () => new Set(sessionMemberUserIdKey ? sessionMemberUserIdKey.split(',') : []),
-    [sessionMemberUserIdKey],
+    // Depends on the signature, not the list: the list gets a fresh identity on
+    // each stats push, but the Set rebuilds only when its contents actually change.
+    () => new Set(sessionMemberUserIdList),
+    [sessionMemberUserIdSignature],
   );
 
   const sessionControlValue = useMemo<QueueSessionControlContextValue>(

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -382,6 +382,9 @@ const createEmptySessionRuntimeState = (): MobileSessionRuntimeState => ({
   boardPath: '',
 });
 
+// Stable empty Set so the no-session case never publishes a fresh identity.
+const EMPTY_USER_ID_SET: ReadonlySet<string> = new Set<string>();
+
 export function QueueProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(queueReducer, defaultSearchParams, initialState);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -1672,29 +1675,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [playlistSuggestionSource],
   );
 
-  // Sorted, logged-in member userIds (anonymous members have no userId to match,
-  // so they're filtered out). `sessionUsers` gets a new array identity on every
-  // ≤1/2s SessionStatsUpdated push even when the roster is unchanged; sorting gives
-  // a stable order for the change-detector below.
-  const sessionMemberUserIdList = useMemo(
-    () =>
-      sessionUsers
-        .map((user) => user.userId)
-        .filter((userId): userId is string => userId != null)
-        .sort(),
-    [sessionUsers],
-  );
-  // Gate the Set's identity on a content signature so a stats push with an
-  // unchanged roster doesn't churn the session-control value (and re-light the
-  // bulbs that read it). The Set is rebuilt from the list itself — never by
-  // splitting the signature back into ids — so it's robust to any userId shape.
-  const sessionMemberUserIdSignature = sessionMemberUserIdList.join(' ');
-  const sessionMemberUserIds = useMemo<ReadonlySet<string>>(
-    // Depends on the signature, not the list: the list gets a fresh identity on
-    // each stats push, but the Set rebuilds only when its contents actually change.
-    () => new Set(sessionMemberUserIdList),
-    [sessionMemberUserIdSignature],
-  );
+  // The logged-in member userIds (anonymous members have no userId to match, so
+  // they're filtered out), used to id-match the board-presence holder. `sessionUsers`
+  // gets a fresh array identity on every ≤1/2s SessionStatsUpdated push even when the
+  // roster is unchanged, so we hold the Set in a ref and keep its identity stable by
+  // content equality: a new Set is published only when the membership actually
+  // changes, so a stats-only push doesn't churn the session-control value (and
+  // re-light the bulbs that read it). Content equality also avoids any
+  // string-signature delimiter ambiguity.
+  const sessionMemberUserIdsRef = useRef<ReadonlySet<string>>(EMPTY_USER_ID_SET);
+  const sessionMemberUserIds = useMemo<ReadonlySet<string>>(() => {
+    const next = new Set(sessionUsers.map((user) => user.userId).filter((userId): userId is string => userId != null));
+    const prev = sessionMemberUserIdsRef.current;
+    const unchanged = prev.size === next.size && [...next].every((userId) => prev.has(userId));
+    if (unchanged) return prev;
+    sessionMemberUserIdsRef.current = next;
+    return next;
+  }, [sessionUsers]);
 
   const sessionControlValue = useMemo<QueueSessionControlContextValue>(
     () => ({

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -196,7 +196,7 @@ const QueueContext = createContext<QueueContextValue | null>(null);
  * - useQueue(): legacy/full reducer state plus actions; use only when state shape is required.
  * - useQueueActions(): stable command surface for enqueue/session/playback writes.
  * - useQueueSessionId(): rare session-id changes for structural chrome.
- * - useQueueSessionControls(): session id plus serial/wall controls for party surfaces.
+ * - useQueueSessionControls(): session id, serial/wall controls, and the member-userId set for party surfaces.
  * - useQueueLiveStats(): high-frequency live stats and roster updates.
  * - useActiveClimbUuid(): row-level active-climb highlighting.
  * - useHasActiveClimb(): presence-only bottom chrome metrics.
@@ -211,7 +211,16 @@ type QueueSessionControlContextValue = Pick<
   | 'confirmClimbOnWall'
   | 'reportWallDisconnect'
   | 'setSessionBoardSerial'
->;
+> & {
+  /**
+   * Stable DB user UUIDs of the current session's members (including me). Used to
+   * id-match the board-presence holder against "someone in my session" so the
+   * lightbulb lights only for a session member's BLE link, not any board holder.
+   * Empty when solo. Memoized by the sorted-id set so the ≤1/2s party push doesn't
+   * churn its identity.
+   */
+  sessionMemberUserIds: ReadonlySet<string>;
+};
 
 const QueueSessionControlContext = createContext<QueueSessionControlContextValue | null>(null);
 
@@ -1663,12 +1672,33 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [playlistSuggestionSource],
   );
 
+  // Stable join key of the session's logged-in member userIds (anonymous members
+  // have no userId to match, so they're filtered out). `sessionUsers` gets a new
+  // array identity on every ≤1/2s SessionStatsUpdated push; keying the Set on this
+  // sorted string means its identity only changes on a real roster delta, so the
+  // session-control value (and the lightbulbs that read it) don't churn on stats.
+  // userIds are DB UUIDs, so a comma join round-trips losslessly.
+  const sessionMemberUserIdKey = useMemo(
+    () =>
+      sessionUsers
+        .map((user) => user.userId)
+        .filter((userId): userId is string => userId != null)
+        .sort()
+        .join(','),
+    [sessionUsers],
+  );
+  const sessionMemberUserIds = useMemo<ReadonlySet<string>>(
+    () => new Set(sessionMemberUserIdKey ? sessionMemberUserIdKey.split(',') : []),
+    [sessionMemberUserIdKey],
+  );
+
   const sessionControlValue = useMemo<QueueSessionControlContextValue>(
     () => ({
       sessionId,
       participantId,
       lastConnectedBoardSerial,
       isSessionWallLit,
+      sessionMemberUserIds,
       confirmClimbOnWall,
       reportWallDisconnect,
       setSessionBoardSerial,
@@ -1678,6 +1708,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       participantId,
       lastConnectedBoardSerial,
       isSessionWallLit,
+      sessionMemberUserIds,
       confirmClimbOnWall,
       reportWallDisconnect,
       setSessionBoardSerial,


### PR DESCRIPTION
## What

The mobile play-view lightbulb showed as **lit** whenever a board feed was bound and a board-presence *holder* existed — but the holder is **board-scoped**, so a stranger physically on the same board (or *any* holder while you're solo) lit your bulb even though nobody you're climbing with had a Bluetooth link.

This makes the **lit** signal session-scoped while leaving the **avatar** board-scoped:

- Light from the holder only when its `userId` matches a member of your current session (server-stamped, so it can't be forged).
- For an **anonymous** holder (no `userId` to id-match) while in a session, fall back to the best-effort `isSessionWallLit` flag.
- A session member who never bound the board feed still falls back to `isSessionWallLit`.
- The holder's avatar still shows for any holder via `BoardConnectionBadge` — unchanged.

Result: solo + a stranger holds the wall ⇒ **off, but the avatar still shows**; a logged-in session peer holds ⇒ lit + their avatar; a holder who isn't in your session ⇒ off.

## Why

When the current user has no BLE and nobody in their session has BLE (or they're not in a session), the bulb should read off — while still showing who has control of the board.

## How

- `deriveLightbulbLit` now takes `sessionHolderPresent` + `holderIsAnonymous` instead of the board-scoped `peerHolderPresent`.
- `QueueProvider` exposes a memoized `sessionMemberUserIds` set via `useQueueSessionControls()`, keyed on a stable sorted-id string so the ≤1/2s party stats push doesn't churn its identity (and re-light the bulbs).
- `use-lightbulb-control.ts` id-matches the holder against the roster and derives the two booleans.

The prior "stuck lit on the other phone" fix is preserved: a cleared holder reads off even if the session flag is stuck (the authoritative holder still gates everything). Late-joiners light immediately via the seeded holder.

Web is left unchanged — it already gates its holder clause behind an active session and has no avatar on its bulb.

## Tests

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (2137 tests)
- `vp run check:mobile-bundle` ✅
- Updated the pure-function tests (`lightbulb-control.test.ts`) and the hook tests (`use-lightbulb-control.test.ts`), including the stuck-flag regression guard and new solo / stranger / anonymous-peer cases.

## Edge cases

- Solo + stranger holder ⇒ off (no session). **Primary fix.**
- In-session non-member holder ⇒ off (userId not in roster).
- Anonymous session peer ⇒ lit via the session-flag fallback (best-effort, as today).
- Holder cleared + `isSessionWallLit` stuck true ⇒ off (preserves prior regression fix).
- Late-joiner, logged-in peer ⇒ lit immediately via the seeded holder.

https://claude.ai/code/session_01BT4PQ5Z7cETFqwAXkR45HC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT4PQ5Z7cETFqwAXkR45HC)_