### PR TITLE
Make the Play Drawer a more opaque material on mobile

### DIFF
--- a/packages/mobile/src/components/GlassSheetBackground.tsx
+++ b/packages/mobile/src/components/GlassSheetBackground.tsx
@@ -3,6 +3,7 @@ import type { BottomSheetBackgroundProps } from '@gorhom/bottom-sheet';
 import { GlassSurface } from './GlassSurface';
 import { useTheme } from '../providers/theme-provider';
 import { sheetStyles } from '../theme/tokens';
+import { playDrawerMaterialTint } from '../theme/colors';
 
 /**
  * Shared frosted-glass background for bottom sheets — the same Liquid-Glass
@@ -22,14 +23,22 @@ type GlassSheetBackgroundProps = BottomSheetBackgroundProps & {
    * 28dp corners so the sheet reads as a screen, not a panel.
    */
   flatTop?: boolean;
+  /**
+   * Composite a scheme-aware tint over the material so the surface reads as a
+   * denser, more opaque takeover than the lighter glass the other sheets use.
+   * Used by the Play Drawer only; off by default so every other sheet keeps the
+   * original glass.
+   */
+  opaqueMaterial?: boolean;
 };
 
-export function GlassSheetBackground({ style, pointerEvents, flatTop }: GlassSheetBackgroundProps) {
-  const { systemColors, sheet } = useTheme();
+export function GlassSheetBackground({ style, pointerEvents, flatTop, opaqueMaterial }: GlassSheetBackgroundProps) {
+  const { systemColors, sheet, colorScheme } = useTheme();
   return (
     <GlassSurface
       glassEffectStyle="regular"
       fallbackColor={systemColors.secondaryBackground}
+      tintColor={opaqueMaterial ? playDrawerMaterialTint[colorScheme] : undefined}
       style={[style, sheetStyles.background, sheet.corners, flatTop && styles.flatTop, styles.clip]}
       pointerEvents={pointerEvents}
     />

--- a/packages/mobile/src/components/__tests__/glass-sheet-background.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-sheet-background.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../../providers/theme-provider', () => ({
     systemColors: { secondaryBackground: '#1C1C1E' },
     // Material variant corners; null on Liquid Glass — both are valid style entries.
     sheet: { corners: { borderTopLeftRadius: 28, borderTopRightRadius: 28 } },
+    colorScheme: 'dark',
   }),
 }));
 
@@ -32,10 +33,14 @@ vi.mock('../../theme/tokens', () => ({
   sheetStyles: { background: { borderTopLeftRadius: 16, borderTopRightRadius: 16 } },
 }));
 
+vi.mock('../../theme/colors', () => ({
+  playDrawerMaterialTint: { light: 'rgba(255, 255, 255, 0.6)', dark: 'rgba(15, 11, 22, 0.55)' },
+}));
+
 import { GlassSheetBackground } from '../GlassSheetBackground';
 
 // gorhom passes more than style/pointerEvents; the component only reads those.
-function renderBackground(props: { style?: unknown; pointerEvents?: string }) {
+function renderBackground(props: { style?: unknown; pointerEvents?: string; opaqueMaterial?: boolean }) {
   return render(createElement(GlassSheetBackground, props as unknown as ComponentProps<typeof GlassSheetBackground>));
 }
 
@@ -46,6 +51,16 @@ describe('GlassSheetBackground', () => {
     expect(glass.props?.glassEffectStyle).toBe('regular');
     expect(glass.props?.fallbackColor).toBe('#1C1C1E');
     expect(glass.props?.pointerEvents).toBe('auto');
+  });
+
+  it('leaves the material untinted by default so sibling sheets keep the lighter glass', () => {
+    renderBackground({ style: { flex: 1 }, pointerEvents: 'auto' });
+    expect(glass.props?.tintColor).toBeUndefined();
+  });
+
+  it('tints the material with the scheme-aware play-drawer tint when opaqueMaterial is set', () => {
+    renderBackground({ style: { flex: 1 }, pointerEvents: 'auto', opaqueMaterial: true });
+    expect(glass.props?.tintColor).toBe('rgba(15, 11, 22, 0.55)'); // dark scheme from the theme mock
   });
 
   it("forwards gorhom's positioning style, rounds the top corners, and clips the blur fallback", () => {

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -514,9 +514,11 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   );
 
   // Glass background with squared-off top corners so the sheet reads as a
-  // full-screen takeover, not a rounded panel.
+  // full-screen takeover, not a rounded panel. `opaqueMaterial` makes the
+  // takeover a denser, more opaque surface than the lighter glass on the other
+  // sheets, while staying light in light mode.
   const renderBackground = useCallback(
-    (props: BottomSheetBackgroundProps) => <GlassSheetBackground {...props} flatTop />,
+    (props: BottomSheetBackgroundProps) => <GlassSheetBackground {...props} flatTop opaqueMaterial />,
     [],
   );
 

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -168,6 +168,19 @@ export type AndroidFallbackColors = typeof androidFallbackColors;
 export type MaterialSurfaces = typeof materialSurfaces;
 
 /**
+ * Translucent tint composited over the Play Drawer's frosted material so its
+ * full-screen "now playing" takeover reads as a denser, more opaque surface than
+ * the lighter glass the other sheets use — board art behind it is muted, not
+ * crisp. Kept translucent so the material still reads as frosted glass, just
+ * heavier. Scheme-keyed so the drawer stays light in light mode and dark in dark
+ * mode; only the opacity of the material changes.
+ */
+export const playDrawerMaterialTint = {
+  light: 'rgba(255, 255, 255, 0.6)',
+  dark: 'rgba(15, 11, 22, 0.55)',
+} as const;
+
+/**
  * Normalise a `#RGB`/`#RRGGBB` hex string to a 6-digit hex (no `#`), or return
  * `null` for any other format (already-`rgba()`, named colour, PlatformColor).
  * Shared by `withAlpha` and `parseHex` so the expansion/validation rule can't


### PR DESCRIPTION
## What

The mobile Play Drawer's full-screen "now playing" takeover shared the same lighter frosted glass as every other sheet, so board art behind it showed through heavily. This makes the takeover read as a **denser, more opaque material** while staying **light in light mode** (and dark in dark mode — only the opacity of the material changes, not its colour).

## How

- **`packages/mobile/src/theme/colors.ts`** — new scheme-keyed `playDrawerMaterialTint` token (`rgba(255,255,255,0.6)` light / `rgba(15,11,22,0.55)` dark). Translucent so the surface still reads as frosted glass, just heavier.
- **`packages/mobile/src/components/GlassSheetBackground.tsx`** — new optional `opaqueMaterial` prop. When set, it passes the scheme-aware tint to `GlassSurface`'s existing `tintColor`; off by default.
- **`packages/mobile/src/components/play-drawer/PlayDrawer.tsx`** — the drawer's `renderBackground` opts in with `opaqueMaterial`.

The tint rides `GlassSurface`'s existing `tintColor` composite path, so the glass (iOS 26), blur (iOS < 26), material (Android) and solid (Reduce Transparency) surface modes all get the denser surface with no extra branching.

## Scope

Scoped to the Play Drawer only. `opaqueMaterial` is off by default, so QueueSheet, AngleSelectorSheet, LogAscentSheet, BleControlSheet and the other sheets that share `GlassSheetBackground` keep the original lighter glass.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2140 tests pass (added coverage in `glass-sheet-background.test.tsx` for both the default-untinted and `opaqueMaterial` paths)
- `vp run check:mobile-bundle` — Android bundle OK

Manual simulator/device QA (macOS) still recommended to fine-tune the light-mode alpha (~0.55–0.65) so content behind the drawer is muted but the surface stays clearly light.

https://claude.ai/code/session_01S4sxYyY85Qe9iNFGowDgbp

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4sxYyY85Qe9iNFGowDgbp)_