### PR TITLE
fix(web/ble): guard re-entrant connect() that breaks iOS board pairing

### DIFF
--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -875,4 +875,70 @@ describe('useBoardBluetooth', () => {
       expect(call).toBeUndefined();
     });
   });
+
+  describe('re-entrant connect guard', () => {
+    it('ignores a second connect() while the first is still in flight (picker open)', async () => {
+      // Hold the first attempt at the scan/picker stage: requestAndConnect never
+      // resolves until we say so, mirroring a user still choosing a board.
+      let resolveConnect: (value: { deviceId: string; deviceName: string }) => void;
+      const pending = new Promise<{ deviceId: string; deviceName: string }>((resolve) => {
+        resolveConnect = resolve;
+      });
+      mockAdapter.requestAndConnect.mockReturnValue(pending);
+
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      let firstPromise!: Promise<boolean>;
+      act(() => {
+        firstPromise = result.current.connect();
+      });
+
+      // A second tap — or the 2-second wall-confirm fallback firing while the
+      // picker is open — must NOT start a second native scan ("Already scanning.
+      // Stopping now." on iOS). It returns false and creates no extra adapter.
+      let secondResult: boolean | undefined;
+      await act(async () => {
+        secondResult = await result.current.connect();
+      });
+
+      expect(secondResult).toBe(false);
+      expect(mockCreateBluetoothAdapter).toHaveBeenCalledTimes(1);
+      expect(mockAdapter.requestAndConnect).toHaveBeenCalledTimes(1);
+
+      // Let the first attempt finish.
+      await act(async () => {
+        resolveConnect!({ deviceId: 'test', deviceName: 'Board' });
+        await firstPromise;
+      });
+      expect(result.current.isConnected).toBe(true);
+
+      // Guard released: a later deliberate connect runs normally.
+      mockAdapter.requestAndConnect.mockResolvedValue({ deviceId: 'test-2', deviceName: 'Board 2' });
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(mockCreateBluetoothAdapter).toHaveBeenCalledTimes(2);
+    });
+
+    it('releases the guard after a failed attempt so the next connect can run', async () => {
+      mockAdapter.requestAndConnect.mockRejectedValueOnce(new Error('GATT connect failed'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.isConnected).toBe(false);
+
+      // The failed attempt cleared the in-flight guard in `finally`, so a retry
+      // is not swallowed.
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.isConnected).toBe(true);
+      expect(mockCreateBluetoothAdapter).toHaveBeenCalledTimes(2);
+      errorSpy.mockRestore();
+    });
+  });
 });

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -920,6 +920,30 @@ describe('useBoardBluetooth', () => {
       expect(mockCreateBluetoothAdapter).toHaveBeenCalledTimes(2);
     });
 
+    it('releases the guard after the user cancels the picker so a re-tap connects', async () => {
+      // The most common real re-entry: the user dismisses the picker, then taps
+      // the lightbulb again. The cancel rejects requestAndConnect → connect()'s
+      // finally clears the guard, so the re-tap is not swallowed.
+      mockAdapter.requestAndConnect.mockRejectedValueOnce(new Error('Device selection cancelled'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.isConnected).toBe(false);
+      // Cancelling stays silent (not a failure toast).
+      expect(mockShowMessage).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.isConnected).toBe(true);
+      expect(mockCreateBluetoothAdapter).toHaveBeenCalledTimes(2);
+      errorSpy.mockRestore();
+    });
+
     it('releases the guard after a failed attempt so the next connect can run', async () => {
       mockAdapter.requestAndConnect.mockRejectedValueOnce(new Error('GATT connect failed'));
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -208,6 +208,13 @@ export function useBoardBluetooth({
   // connection can fire several disconnects in a row. Reset once we reconnect
   // (or the user explicitly disconnects) so the next genuine drop prompts again.
   const boardTakenPromptShownRef = useRef(false);
+  // True from the moment a connect attempt starts until it settles — and the
+  // device picker being open counts as in-flight. A second concurrent connect()
+  // would start a second native scan and trip "Already scanning. Stopping now."
+  // on iOS (e.g. the wall-confirm 2s fallback firing while the user is still
+  // choosing a board in the picker). A ref, not the `loading` state, because
+  // state updates are async: two rapid calls both read the stale `false`.
+  const connectInFlightRef = useRef(false);
   // Latest config-matched reconnect serial, mirrored from the derived value
   // below so handleDisconnection's "take it back" action can silently reconnect
   // to the same board without taking the derived value (or boardDetails) as a
@@ -533,6 +540,17 @@ export function useBoardBluetooth({
         return false;
       }
 
+      // A connect attempt (possibly with the device picker still open) is
+      // already running. Starting a second one here scans again while the first
+      // scan is live, which trips "Already scanning. Stopping now." on the
+      // native iOS shell. Ignore the re-entrant call; the in-flight attempt
+      // stands. Sequential connects (reconnect to a different board) still work
+      // — the flag clears in `finally` below.
+      if (connectInFlightRef.current) {
+        return false;
+      }
+      connectInFlightRef.current = true;
+
       setLoading(true);
 
       // Tracks which stage of the pairing flow we're in so the catch block
@@ -663,6 +681,9 @@ export function useBoardBluetooth({
         }
       } finally {
         setLoading(false);
+        // Release the re-entrancy guard so the next deliberate connect (or a
+        // take-back reconnect) can run.
+        connectInFlightRef.current = false;
         // Re-arm the take-back prompt once a connect attempt finishes, whether
         // it succeeded or failed. Resetting only on success would leave the
         // guard stuck true after a failed take-back, so a later genuine drop


### PR DESCRIPTION
## What

iOS (legacy Capacitor app) board-connect failures **doubled on 2026-06-15** — failure rate ~21% → ~50%, broad across 27 users and all climb-view routes. Web Bluetooth (Chrome desktop/Android) was unaffected; this is iOS-only.

PostHog signature (`Pairing Failed`, `$lib=js`, `$os=iOS`):
- `"Already scanning. Stopping now."` (stage `gatt_connect`): **2 → 8 → 62** over 06-13..06-15.
- `"Device selection cancelled"` (stage `user_cancelled`): 6 → 22 → **67**.
- `"Connection timeout"` stayed flat (~21–26).

## Root cause

The "always-live sessions" redesign (#2875, merged 06-15) turned the play-drawer lightbulb into a connect/disconnect toggle. When tapped while **disconnected**, `handleLightbulbClick`:
1. calls `bluetoothConnect()` → opens the native device picker and starts a BLE scan, then
2. immediately arms the 2-second wall-confirm watcher.

Picking a board from the list takes **>2s**, so the watcher times out while still disconnected and `runFallback` (`@boardsesh/play-view/wall-confirm-fallback`) calls `bluetoothConnect()` **again**. The native iOS adapter's `requestAndConnect` calls `plugin.startScan()` while the first scan is live → `BoardBleManager` throws **"Already scanning. Stopping now."** The duplicate picker also makes users cancel.

`connect()` in `use-board-bluetooth.ts` had **no in-flight guard** (`loading` is React state, read at render, not inside the closure), so the concurrent call went through. Pre-#2875 the lightbulb fired while already connected, so the fallback hit the `already_connected` short-circuit and never re-scanned.

The Capacitor app loads the live `boardsesh.com` (`server.url` in `mobile/capacitor.config.ts`), so this web fix reaches it on deploy — no App Store push, no native change.

## Fix

Add an idempotent in-flight `useRef` guard to `connect()`: a concurrent call (the open picker counts as in-flight) returns `false` instead of starting a second scan. The flag clears in `finally`, so sequential connects, the take-back reconnect, and the mismatch-switch flow are unaffected. This also neutralizes the wall-confirm fallback's duplicate connect (it no-ops instead of scanning).

## Tests

- New `re-entrant connect guard` tests in `use-board-bluetooth.test.ts`: a second `connect()` while the first is pending (picker open) starts no second adapter/scan and returns `false`; the guard releases after success and after failure.
- Full suite green: `use-board-bluetooth` (36), BLE + play-view suites (482), `typecheck:web`, `vp check` (changed files).

## Verification after merge

Watch PostHog: iOS `Pairing Failed` "Already scanning. Stopping now." + "Device selection cancelled" should fall to baseline within ~1h, and iOS connect success should return to ~80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)