### PR TITLE
Upload React Native source maps to PostHog for readable stack traces

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -61,6 +61,19 @@ jobs:
       # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
       # false, so every track() silently no-ops (the app shipped zero events before).
       EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      # PostHog source-map upload. The posthog-react-native/expo plugin adds a
+      # Gradle task that runs @posthog/cli during assemble/bundleRelease to upload
+      # the Hermes bundle + source map, so the app's $exception stack traces are
+      # readable in PostHog. Not the same as EXPO_PUBLIC_POSTHOG_KEY (public ingest
+      # token) — this is a personal API key + project id for the CLI. Gated in
+      # app.config.ts on POSTHOG_CLI_API_KEY: unset (forks, or before provisioning)
+      # → the plugin is omitted at prebuild, so no Gradle upload task is added and
+      # the release stays green. Unlike the @sentry/react-native Gradle task noted
+      # above (which broke on a removed exec() API), PostHog's posthog.gradle uses
+      # the modern injected ExecOperations API, so it isn't expected to hit that
+      # incompatibility — but the gate means a missing key can never break a release.
+      POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+      POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -60,6 +60,17 @@ jobs:
       # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
       # false, so every track() silently no-ops (the app shipped zero events before).
       EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      # PostHog source-map upload. The posthog-react-native/expo plugin adds an
+      # Xcode build phase that runs @posthog/cli during `xcodebuild archive` to
+      # upload the Hermes bundle + source map, so the app's $exception stack traces
+      # are readable in PostHog. These are NOT the same as EXPO_PUBLIC_POSTHOG_KEY
+      # (that's the public ingest token; this is a personal API key + project id for
+      # the CLI). The upload phase is gated in app.config.ts on POSTHOG_CLI_API_KEY:
+      # when the secret is unset (forks, or before it's provisioned) the plugin is
+      # omitted at prebuild, so the archive has no upload phase and still succeeds.
+      # POSTHOG_CLI_HOST omitted (US cloud).
+      POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+      POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -117,10 +117,12 @@ jobs:
         # here. Re-export with the same .env written above: the debug IDs injected
         # by getPostHogExpoConfig are content-derived, so this dist carries the same
         # IDs as the bundle `eas update` just shipped, and PostHog can match traces.
-        # Gated on the API key so fork PRs / missing-secret runs still publish OTA.
+        # Gated on BOTH CLI credentials (matching mobile-publish.ts): if only one
+        # is set the step cleanly skips instead of running and failing silently
+        # under continue-on-error. Fork PRs / missing-secret runs still publish OTA.
         # continue-on-error: the OTA already shipped in the step above, so a flaky
         # upload must neither fail the run nor skip the PR-comment step below.
-        if: env.POSTHOG_CLI_API_KEY != ''
+        if: env.POSTHOG_CLI_API_KEY != '' && env.POSTHOG_CLI_PROJECT_ID != ''
         continue-on-error: true
         working-directory: packages/mobile
         run: |

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -51,6 +51,14 @@ jobs:
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
       EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
       EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      # @posthog/cli reads these to upload OTA source maps so mobile $exception
+      # stack traces are readable in PostHog. The native build workflows do this
+      # via the Xcode/Gradle build phases; OTA updates aren't covered by those, so
+      # the upload step below runs the CLI explicitly. Absent (forks / missing
+      # secret) the upload step skips and the OTA still ships. POSTHOG_CLI_HOST is
+      # omitted — this project is on PostHog US (the CLI defaults to US).
+      POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+      POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
 
     steps:
       - name: Checkout repository
@@ -103,6 +111,21 @@ jobs:
             --non-interactive
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.name }}
+
+      - name: Upload source maps to PostHog
+        # OTA updates aren't covered by the native (Xcode/Gradle) upload, so do it
+        # here. Re-export with the same .env written above: the debug IDs injected
+        # by getPostHogExpoConfig are content-derived, so this dist carries the same
+        # IDs as the bundle `eas update` just shipped, and PostHog can match traces.
+        # Gated on the API key so fork PRs / missing-secret runs still publish OTA.
+        # continue-on-error: the OTA already shipped in the step above, so a flaky
+        # upload must neither fail the run nor skip the PR-comment step below.
+        if: env.POSTHOG_CLI_API_KEY != ''
+        continue-on-error: true
+        working-directory: packages/mobile
+        run: |
+          bunx expo export --dump-sourcemap --platform "$INPUT_PLATFORM"
+          bunx posthog-cli hermes upload --directory dist
 
       - name: Post update link to PR
         if: github.event_name == 'push'

--- a/bun.lock
+++ b/bun.lock
@@ -286,6 +286,7 @@
       },
       "devDependencies": {
         "@bacons/apple-targets": "^4.0.7",
+        "@posthog/cli": "^0.7.23",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "jsdom": "^28.1.0",
@@ -1712,6 +1713,8 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
+
+    "@posthog/cli": ["@posthog/cli@0.7.23", "", { "dependencies": { "detect-libc": "^2.1.2" }, "bin": { "posthog-cli": "run-posthog-cli.js" } }, "sha512-+Wv1zGLOkgBj1+Vbn6WsNVgV1NSqfW8IXeVIafRu/7MU9ZslTA7vLl6Vb+ChSbEfQtAWBNg2RcJ7eOn9v9H4Bw=="],
 
     "@posthog/core": ["@posthog/core@1.30.3", "", { "dependencies": { "@posthog/types": "1.379.0" } }, "sha512-mGIN4Du1a8fKxV5WfnEtogq3VOQLa4PfWMUg5uMIMDD+fp5bhTA4QG4oYAea4vBTZ1ZOanQbjXcX4b5k2X93Qw=="],
 

--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -58,8 +58,47 @@ PostHog: `react-query`, `native-auth`, `queue-mutation`, `queue-sync`,
 - `__DEV__`-only diagnostics (keep the `console.warn`; report only if the failure
   is user-affecting in production too).
 
+## Source maps (readable stack traces)
+
+`$exception` events arrive from minified, Hermes-compiled release bundles, so the raw
+stack frames are unreadable (PostHog flags this as "stack traces aren't readable").
+PostHog symbolicates them by matching a **debug ID** baked into the bundle to a source
+map uploaded at build time. How it's wired:
+
+- **Metro** (`metro.config.js`) uses `getPostHogExpoConfig` instead of Expo's
+  `getDefaultConfig`, which injects the per-bundle debug ID into the bundle + its map.
+- **Native builds** upload automatically via the `posthog-react-native/expo` config
+  plugin (`app.config.ts`): an Xcode build phase on iOS, a Gradle task on Android,
+  running during `xcodebuild archive` / `assembleRelease` in
+  `.github/workflows/ios-testflight-rn.yml` and `android-apk-rn.yml`. The plugin is
+  applied only when `POSTHOG_CLI_API_KEY` is set — those build scripts call the CLI
+  without `--no-fail`, so a keyless build would otherwise fail; gating on the key
+  keeps local prebuilds and fork CI green.
+- **OTA updates** (EAS Update) are NOT covered by the native upload, so
+  `mobile-eas-update.yml` and `vp run mobile:publish` re-export with
+  `expo export --dump-sourcemap` and run `posthog-cli hermes upload --directory dist`
+  after publishing. Debug IDs are content-derived, so the re-export matches the
+  bundle `eas update` shipped.
+
+Credentials are CI-only; every path skips the upload when they're absent, so local
+builds and fork PRs are unaffected:
+
+- `POSTHOG_CLI_API_KEY` — PostHog personal API key (error-tracking scope). GitHub
+  secret in the **Production** environment (iOS/Android) **and** at repo level (the OTA
+  workflow isn't Production-scoped). Generate it with `bunx posthog-cli login`.
+- `POSTHOG_CLI_PROJECT_ID` — PostHog project id (a GitHub variable; not secret).
+- US cloud, so `POSTHOG_CLI_HOST` stays unset.
+
+For EAS cloud builds (`vp run mobile:preview-build` → `eas build`), set the same two as
+EAS secrets (`eas secret:create`) so the plugin's native upload runs there too. The
+production native binaries ship from GitHub Actions (the workflows above), not EAS, so
+this only matters for the preview shell.
+
 ## Verifying
 
 `isAnalyticsEnabled = !!apiKey && !__DEV__`, so **local Metro dev sends nothing**.
 Verify on a preview / TestFlight / production build: trigger the failure, then look
-for the `$exception` in PostHog filtered by `source`.
+for the `$exception` in PostHog filtered by `source`. To confirm source maps resolved,
+check the event's stack trace shows real `.ts` files and line numbers — frames like
+`index.android.bundle:1:12345` mean the map didn't match, so check the upload step
+logs (debug IDs must line up between the shipped bundle and the uploaded map).

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -291,6 +291,18 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
         },
       ],
       'expo-updates',
+      // PostHog source-map upload for readable $exception stack traces. Adds an
+      // Xcode build phase (iOS) + Gradle task (Android) that run @posthog/cli
+      // during `expo prebuild` → archive/assemble. Gated on POSTHOG_CLI_API_KEY:
+      // those scripts call the CLI WITHOUT --no-fail, so they hard-fail the build
+      // when the CLI can't authenticate — applying the plugin only when the key is
+      // present keeps local prebuilds, dev, and fork CI green (no key → no upload
+      // phase added). The debug IDs that make uploads matchable are injected by
+      // getPostHogExpoConfig in metro.config.js regardless of this gate, so OTA
+      // (EAS Update) uploads — handled in mobile-eas-update.yml — keep working.
+      // The plugin also disables Xcode User Script Sandboxing by default so the
+      // upload phase can run (same approach as Sentry's RN plugin).
+      ...(process.env.POSTHOG_CLI_API_KEY ? ['posthog-react-native/expo'] : []),
       'expo-web-browser',
       'react-native-ble-plx',
       // Makes Boardsesh a share target so a beta video link shared from

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -1,10 +1,17 @@
-const { getDefaultConfig } = require('expo/metro-config');
+// getPostHogExpoConfig wraps Expo's getDefaultConfig and adds a custom serializer
+// that injects a content-derived debug ID into the JS bundle + its source map. That
+// debug ID is what lets PostHog match a minified/Hermes `$exception` stack trace back
+// to the source map we upload (via @posthog/cli) — without it, every trace stays
+// unreadable. It returns the same config shape as getDefaultConfig, so all the
+// customizations below (watch folders, blockList, singleton resolver, dev middleware)
+// apply unchanged. See docs/mobile-error-telemetry.md.
+const { getPostHogExpoConfig } = require('posthog-react-native/metro');
 const path = require('path');
 
 const projectRoot = __dirname;
 const monorepoRoot = path.resolve(projectRoot, '../..');
 
-const config = getDefaultConfig(projectRoot);
+const config = getPostHogExpoConfig(projectRoot);
 
 config.watchFolders = [monorepoRoot];
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -97,6 +97,7 @@
   },
   "devDependencies": {
     "@bacons/apple-targets": "^4.0.7",
+    "@posthog/cli": "^0.7.23",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "jsdom": "^28.1.0",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -550,17 +550,7 @@
       }
     },
     "detail": {
-      "notFound": "Climb not found",
-      "addToQueue": "Add to Queue",
-      "logAscent": "Log Ascent",
-      "sent_one": "Sent {{count}} time",
-      "sent_other": "Sent {{count}} times",
-      "sentWithAttempts_one": "Sent {{count}} time in {{attempts}} {{attemptWord}}",
-      "sentWithAttempts_other": "Sent {{count}} times in {{attempts}} {{attemptWord}}",
-      "attempt_one": "attempt",
-      "attempt_other": "attempts",
-      "send_one": "send",
-      "send_other": "sends"
+      "notFound": "Climb not found"
     },
     "logAscent": {
       "attempt": "Attempt",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -175,7 +175,6 @@
       "home": "Home",
       "boards": "Boards",
       "climbs": "Climbs",
-      "climb": "Climb",
       "profile": "Profile",
       "holdFilter": "Hold types",
       "zoneFilter": "Board region"

--- a/packages/shared/i18n/locales/en-US/feed.json
+++ b/packages/shared/i18n/locales/en-US/feed.json
@@ -17,7 +17,6 @@
   },
   "mobile": {
     "home": {
-      "title": "Home",
       "betaTitle": "Fresh beta",
       "betaEmpty": "No beta videos yet",
       "betaError": "Couldn't load beta videos.",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -550,17 +550,7 @@
       }
     },
     "detail": {
-      "notFound": "Bloque no encontrado",
-      "addToQueue": "Agregar a la cola",
-      "logAscent": "Registrar encadene",
-      "sent_one": "Encadenado {{count}} vez",
-      "sent_other": "Encadenado {{count}} veces",
-      "sentWithAttempts_one": "Encadenado {{count}} vez en {{attempts}} {{attemptWord}}",
-      "sentWithAttempts_other": "Encadenado {{count}} veces en {{attempts}} {{attemptWord}}",
-      "attempt_one": "intento",
-      "attempt_other": "intentos",
-      "send_one": "encadene",
-      "send_other": "encadenes"
+      "notFound": "Bloque no encontrado"
     },
     "logAscent": {
       "attempt": "Intento",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -373,7 +373,6 @@
       "home": "Inicio",
       "boards": "Tablas",
       "climbs": "Bloques",
-      "climb": "Bloque",
       "profile": "Perfil",
       "holdFilter": "Tipos de presa",
       "zoneFilter": "Zona del muro"

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -17,7 +17,6 @@
   },
   "mobile": {
     "home": {
-      "title": "Inicio",
       "betaTitle": "Beta reciente",
       "betaEmpty": "Aún no hay vídeos de beta",
       "betaError": "No se pudieron cargar los vídeos de beta.",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -550,17 +550,7 @@
       }
     },
     "detail": {
-      "notFound": "Bloc introuvable",
-      "addToQueue": "Ajouter à la file",
-      "logAscent": "Enregistrer un enchaînement",
-      "sent_one": "Enchaîné {{count}} fois",
-      "sent_other": "Enchaîné {{count}} fois",
-      "sentWithAttempts_one": "Enchaîné {{count}} fois en {{attempts}} {{attemptWord}}",
-      "sentWithAttempts_other": "Enchaîné {{count}} fois en {{attempts}} {{attemptWord}}",
-      "attempt_one": "essai",
-      "attempt_other": "essais",
-      "send_one": "enchaînement",
-      "send_other": "enchaînements"
+      "notFound": "Bloc introuvable"
     },
     "logAscent": {
       "attempt": "Essai",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -175,7 +175,6 @@
       "home": "Accueil",
       "boards": "Boards",
       "climbs": "Blocs",
-      "climb": "Bloc",
       "profile": "Profil",
       "holdFilter": "Types de prise",
       "zoneFilter": "Zone du mur"

--- a/packages/shared/i18n/locales/fr/feed.json
+++ b/packages/shared/i18n/locales/fr/feed.json
@@ -17,7 +17,6 @@
   },
   "mobile": {
     "home": {
-      "title": "Accueil",
       "betaTitle": "Beta récente",
       "betaEmpty": "Aucune vidéo beta pour le moment",
       "betaError": "Impossible de charger les vidéos beta.",

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -152,6 +152,42 @@ if (result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
+// Upload source maps so this OTA update's $exception stack traces are readable in
+// PostHog error tracking. Native builds do this via the Xcode/Gradle build phases;
+// OTA isn't covered by those. Best-effort and gated on credentials: most local
+// publishes are unkeyed and skip it; CI (mobile-eas-update.yml) sets the env vars.
+// expo export re-bundles deterministically, so the debug IDs match the bundle eas
+// update just shipped.
+const posthogApiKey = process.env.POSTHOG_CLI_API_KEY;
+const posthogProjectId = process.env.POSTHOG_CLI_PROJECT_ID;
+if (posthogApiKey && posthogProjectId) {
+  console.log('');
+  console.log('[mobile:publish] Uploading source maps to PostHog...');
+  const exportResult = spawnSync('bunx', ['expo', 'export', '--dump-sourcemap', '--platform', platform], {
+    cwd: MOBILE_DIR,
+    stdio: 'inherit',
+    env: { ...process.env },
+  });
+  if (exportResult.status !== 0) {
+    console.warn('[mobile:publish] expo export failed — skipping PostHog source map upload (OTA already shipped).');
+  } else {
+    const uploadResult = spawnSync('bunx', ['posthog-cli', 'hermes', 'upload', '--directory', 'dist'], {
+      cwd: MOBILE_DIR,
+      stdio: 'inherit',
+      env: { ...process.env },
+    });
+    if (uploadResult.status !== 0) {
+      console.warn('[mobile:publish] PostHog source map upload failed (OTA already shipped).');
+    } else {
+      console.log('[mobile:publish] Source maps uploaded to PostHog.');
+    }
+  }
+} else {
+  console.log('');
+  console.log('[mobile:publish] POSTHOG_CLI_API_KEY / POSTHOG_CLI_PROJECT_ID not set — skipping source map upload.');
+  console.log('[mobile:publish] (CI uploads automatically; set both to upload from a local publish.)');
+}
+
 console.log('');
 console.log(`[mobile:publish] Published to branch "${sanitizedBranch}".`);
 console.log(`[mobile:publish] Testers on the "preview" build will receive this update.`);


### PR DESCRIPTION
## Problem

PostHog Error Tracking reports **"100% of your stack traces aren't readable — let the wizard set up automatic uploads."**

The source is the **mobile** app, not web. `packages/mobile` (`posthog-react-native`) has `errorTracking.autocapture` on and is the only app sending `$exception` events to PostHog — web (`posthog-js-lite`, `autocapture: false`) and the backend route errors to **Sentry**, which already uploads source maps. RN release bundles are minified and Hermes-compiled, so the frames in those events point at minified positions with no source maps uploaded.

## What changed (mobile-only)

Uses PostHog's official RN tooling — `@posthog/cli` + the `posthog-react-native` Metro/Expo integration — to upload source maps (with debug IDs) from every path that ships a JS bundle.

- **`metro.config.js`** — base factory swapped to `getPostHogExpoConfig` (injects per-bundle debug IDs); all existing watch/resolver/middleware customizations preserved.
- **`app.config.ts`** — adds the `posthog-react-native/expo` plugin (Xcode build phase + Gradle task), **gated on `POSTHOG_CLI_API_KEY`**. Its native scripts run `@posthog/cli` *without* `--no-fail`, so a keyless build would hard-fail — gating keeps local/dev/fork builds green (verified: plugin absent without the key, present with it).
- **OTA** (`mobile-eas-update.yml` + `scripts/mobile-publish.ts`) — after `eas update`, re-export with `expo export --dump-sourcemap` and run `posthog-cli hermes upload --directory dist`, gated on **both** CLI credentials, best-effort (`continue-on-error`) since the OTA already shipped.
- **iOS / Android native** (`ios-testflight-rn.yml`, `android-apk-rn.yml`) — wire the CLI env vars so upload runs during `xcodebuild archive` / `assembleRelease`. (Unlike Sentry's Gradle task, which broke on a removed `exec()` API, `posthog.gradle` uses the modern injected `ExecOperations` API.)
- **`package.json`** — adds `@posthog/cli`; **`docs/mobile-error-telemetry.md`** — new "Source maps" section.

## i18n cleanup (isolated in commit `7903564e`)

The orphaned-i18n-key check runs whenever a PR touches `packages/mobile/**`, and flagged 12 `mobile.*` keys that were **already dead on `main`** (zero references in web/mobile source). To keep this PR's required `i18n` job green, that commit deletes them from all three locales (en-US/es/fr): `climbs.json` `mobile.detail.{addToQueue, logAscent, sent_one/_other, sentWithAttempts_one/_other, attempt_one/_other, send_one/_other}`, `common.json` `mobile.nav.climb` (the app uses `nav.climbs`), `feed.json` `mobile.home.title`. Used siblings are kept; orphan check + catalog-completeness parity pass. Kept in its own commit for easy bisect/revert.

## ⚠️ Required before this works (cannot be provisioned from CI)

Generate with `bunx posthog-cli login`, then:

**GitHub:**
- `POSTHOG_CLI_API_KEY` — secret, in the **Production** environment (iOS/Android workflows) **and** at repo level (the OTA workflow isn't Production-scoped).
- `POSTHOG_CLI_PROJECT_ID` — variable.
- US cloud → `POSTHOG_CLI_HOST` unset.

**EAS (preview-only):** if you use `vp run mobile:preview-build` (`eas build` cloud), add the same two as **EAS secrets** (`eas secret:create`) — otherwise the preview shell's native upload silently skips. Production binaries ship from GitHub Actions, not EAS, so this is only for the preview shell.

Until these are set, every path safely skips the upload (no broken builds, no readable traces yet).

## Verification

- ✅ `vp run typecheck:mobile`, `vp run test:mobile` (2132 tests), `vp run check:mobile-bundle` (produced the Hermes `.hbc`), `vp check`.
- ✅ Plugin gating verified via `expo config` (absent without key, present with it).
- ✅ i18n orphan check + catalog parity pass after the cleanup.
- ✅ `posthog-cli` 0.7.23; `hermes upload --directory` confirmed.
- ⏳ **OTA debug-ID matching:** the upload re-exports with `expo export --dump-sourcemap` after `eas update`. Debug IDs are content-derived, so identical source → identical IDs — this is PostHog's documented flow and is deterministic on a clean CI runner (fresh checkout, cold Metro cache both times). The theoretical risk is divergent Metro resolution between the two exports; `continue-on-error` keeps the OTA live on failure and the step still shows **red in Actions** (so there is a signal). Confirm empirically: trigger an error on a preview build and check the `$exception` resolves to real file/line in PostHog.
- ⏳ Native iOS/Android upload phases need a real macOS/Android CI run (can't be exercised on Linux).

> Note: an unrelated, pre-existing web test (`error-boundary` retry-budget timer) flakes in CI (passes locally, 7/7); it's not touched by this PR and clears on re-run.

## Out of scope

- Web error tracking (Sentry already symbolicates; web sends no exceptions to PostHog).
- What `posthog-client.ts` captures — unchanged; this only makes existing captures readable.

https://claude.ai/code/session_01E1efvFgvBNUr3wHURx4KCi