### PR TITLE
Mobile: Liquid Glass header review fixes (Android blur, Home inset, a11y)

### DIFF
--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -354,8 +354,14 @@ export default function HomeTab() {
         extraData={summaryMap}
         renderItem={renderItem}
         keyExtractor={(item) => item.sessionId}
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={{ paddingBottom: bottomChrome.scrollBottomPadding + spacing[5] }}
+        // The floating glass header owns the top inset on every platform (the
+        // iOS-only `automatic` behaviour left an Android gap), so pad manually.
+        contentInsetAdjustmentBehavior="never"
+        contentContainerStyle={{
+          paddingTop: insets.top + TOP_ISLAND_BAND,
+          paddingBottom: bottomChrome.scrollBottomPadding + spacing[5],
+        }}
+        scrollIndicatorInsets={{ top: insets.top + TOP_ISLAND_BAND }}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         ListHeaderComponent={header}
@@ -429,6 +435,7 @@ export default function HomeTab() {
               title={scopeMenu.title}
               actions={scopeMenu.actions}
               onSelectIndex={scopeMenu.onSelectIndex}
+              accessibilityHint={t('mobile.home.scope.hint')}
             />
           </View>
           {/* Balance the avatar so the scope menu reads centred. */}
@@ -703,9 +710,9 @@ const styles = StyleSheet.create({
     gap: spacing[2],
   },
   header: {
-    // Clear the floating header band so the feed starts just below it (content
-    // then scrolls up under the islands + blur).
-    paddingTop: TOP_ISLAND_BAND,
+    // A small gap below the floating header band (the list already insets by the
+    // band via contentContainerStyle).
+    paddingTop: spacing[2],
   },
   shelfSection: {
     paddingBottom: spacing[5],

--- a/packages/mobile/src/components/ProgressiveBlur.tsx
+++ b/packages/mobile/src/components/ProgressiveBlur.tsx
@@ -3,6 +3,7 @@ import MaskedView from '@react-native-masked-view/masked-view';
 import { BlurView } from '@react-native-community/blur';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../providers/theme-provider';
+import { useEffectiveSurfaceMode } from '../hooks/use-effective-surface-mode';
 
 // A black→transparent vertical mask: MaskedView shows where the mask is opaque and
 // hides where it's transparent, so each blur layer is full strength at the top and
@@ -21,6 +22,13 @@ const DEFAULT_LAYERS = 3;
 // touching the grey frost lower down.
 const DARK_SCRIM_COLORS = ['rgba(0,0,0,0.6)', 'rgba(0,0,0,0)'] as const;
 const DARK_SCRIM_LOCATIONS = [0, 0.7] as const;
+// No-live-blur paths (Android Material, or Reduce Transparency): fade the opaque
+// scene background in from the top so content still tucks away cleanly. Concrete
+// hexes (iOS systemBackground), not PlatformColor — expo-linear-gradient bakes a
+// PlatformColor against the OS trait, which is the dark-mode white-band bug.
+const SOLID_BG_DARK = '#000000';
+const SOLID_BG_LIGHT = '#FFFFFF';
+const SOLID_FADE_LOCATIONS = [0, 0.55, 1] as const;
 
 type ProgressiveBlurProps = {
   /** Absolute position/size of the blur region (set by the caller). */
@@ -39,14 +47,34 @@ type ProgressiveBlurProps = {
  * one). The thin material matches the native tab bar's heavier glass so the header
  * and tab bar read as the same surface. The blur tint follows the app's resolved
  * colour scheme, so it honours the in-app light/dark override.
+ *
+ * Only renders a live blur on the iOS glass / blur paths. On Material (Android) or
+ * with Reduce Transparency on, `@react-native-community/blur` can't honour the iOS
+ * material types and a11y wants no translucency, so it falls back to fading the
+ * opaque scene background in from the top instead.
  */
 export function ProgressiveBlur({ style, blurAmount = 16, layers = DEFAULT_LAYERS }: ProgressiveBlurProps) {
   const { colorScheme } = useTheme();
+  const mode = useEffectiveSurfaceMode();
   const isDark = colorScheme === 'dark';
+
+  // Android / Reduce Transparency: no live blur — fade the opaque scene background.
+  if (mode !== 'glass' && mode !== 'blur') {
+    return (
+      <View pointerEvents="none" style={style}>
+        <LinearGradient
+          colors={[isDark ? SOLID_BG_DARK : SOLID_BG_LIGHT, isDark ? SOLID_BG_DARK : SOLID_BG_LIGHT, 'transparent']}
+          locations={SOLID_FADE_LOCATIONS}
+          pointerEvents="none"
+          style={StyleSheet.absoluteFill}
+        />
+      </View>
+    );
+  }
+
   // Thin material: heavier than ultra-thin, so it reads like the native tab bar's
   // chrome glass rather than a light grey. Stacking accumulates it toward the top.
   const blurType = isDark ? 'thinMaterialDark' : 'thinMaterialLight';
-  const fallbackColor = isDark ? '#000000' : '#F2F2F2';
 
   return (
     <View pointerEvents="none" style={style}>
@@ -62,12 +90,7 @@ export function ProgressiveBlur({ style, blurAmount = 16, layers = DEFAULT_LAYER
               <LinearGradient colors={MASK_COLORS} locations={[0, fadeEnd]} style={StyleSheet.absoluteFill} />
             }
           >
-            <BlurView
-              blurType={blurType}
-              blurAmount={blurAmount}
-              reducedTransparencyFallbackColor={fallbackColor}
-              style={StyleSheet.absoluteFill}
-            />
+            <BlurView blurType={blurType} blurAmount={blurAmount} style={StyleSheet.absoluteFill} />
           </MaskedView>
         );
       })}

--- a/packages/mobile/src/components/__tests__/progressive-blur.test.tsx
+++ b/packages/mobile/src/components/__tests__/progressive-blur.test.tsx
@@ -5,6 +5,9 @@ import { createElement, type ReactNode } from 'react';
 
 // Mutable so each test can exercise a resolved colour scheme.
 const themeMock = vi.hoisted(() => ({ colorScheme: 'dark' as 'dark' | 'light' }));
+// Mutable surface mode: 'blur'/'glass' = live iOS blur; 'material'/'solid' = the
+// Android / Reduce-Transparency fade fallback.
+const surfaceMock = vi.hoisted(() => ({ mode: 'blur' as 'glass' | 'blur' | 'material' | 'solid' }));
 
 vi.mock('react-native', () => ({
   StyleSheet: { absoluteFill: {} },
@@ -32,12 +35,14 @@ vi.mock('expo-linear-gradient', () => ({
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({ colorScheme: themeMock.colorScheme }),
 }));
+vi.mock('../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => surfaceMock.mode }));
 
 import { ProgressiveBlur } from '../ProgressiveBlur';
 
 describe('ProgressiveBlur', () => {
   afterEach(() => {
     themeMock.colorScheme = 'dark';
+    surfaceMock.mode = 'blur';
   });
 
   it('masks a blur with a top→transparent gradient (full blur up top, clear at the bottom)', () => {
@@ -81,5 +86,17 @@ describe('ProgressiveBlur', () => {
     themeMock.colorScheme = 'light';
     const { container } = render(<ProgressiveBlur />);
     expect(hasDarkScrim(container)).toBe(false);
+  });
+
+  it('renders no live blur on the Material / Reduce-Transparency path — a scene-background fade instead', () => {
+    surfaceMock.mode = 'material';
+    const { container } = render(<ProgressiveBlur />);
+    // No BlurView at all; just a themed opaque→transparent gradient.
+    expect(container.querySelector('[data-testid="blur-view"]')).toBeNull();
+    expect(container.querySelector('[data-testid="masked-view"]')).toBeNull();
+    const gradient = container.querySelector('[data-testid="mask-gradient"]');
+    const colors = JSON.parse(gradient?.getAttribute('data-colors') ?? '[]') as string[];
+    expect(colors[0]).toBe('#000000'); // dark scene background (default colour scheme)
+    expect(colors[colors.length - 1]).toBe('transparent');
   });
 });

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-large-title-header.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-large-title-header.test.tsx
@@ -42,6 +42,9 @@ vi.mock('../../../providers/theme-provider', () => ({
   }),
 }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
+// ProgressiveBlur renders the iOS blur path under this mode (short-circuits the
+// native a11y / glass-capability hooks it would otherwise pull in).
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'blur' }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 4: 16 }, shadows: { sm: {} } }));
 vi.mock('../GlassActionToolbar', () => ({ TOP_ACTION_SIZE: 48 }));
 vi.mock('../../GlassSurface', () => ({ GlassSurface: () => createElement('div', { 'data-glass': 'true' }) }));

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
@@ -43,18 +43,6 @@ vi.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }: { children?: ReactNode }) =>
     createElement('div', { 'data-gradient': 'true' }, children),
 }));
-vi.mock('react-native-reanimated', () => ({
-  default: {
-    View: ({ children, pointerEvents }: { children?: ReactNode; pointerEvents?: string }) =>
-      createElement('div', { 'data-pointer': pointerEvents ?? '' }, children),
-  },
-  Extrapolation: { CLAMP: 'clamp' },
-  interpolate: () => 0,
-  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
-  useAnimatedReaction: () => {},
-  useAnimatedStyle: () => ({}),
-  useDerivedValue: () => ({ value: 0 }),
-}));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 47, bottom: 0, left: 0, right: 0 }),
 }));
@@ -87,6 +75,9 @@ vi.mock('../../../providers/queue-provider', () => ({
 }));
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
+// ProgressiveBlur renders the iOS blur path under this mode (short-circuits the
+// native a11y / glass-capability hooks it would otherwise pull in).
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'blur' }));
 vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 4: 16 }, shadows: { sm: {} } }));
 vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 48, capsule: 44 } }));

--- a/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
@@ -43,18 +43,6 @@ vi.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }: { children?: ReactNode }) =>
     createElement('div', { 'data-gradient': 'true' }, children),
 }));
-vi.mock('react-native-reanimated', () => ({
-  default: {
-    View: ({ children, pointerEvents }: { children?: ReactNode; pointerEvents?: string }) =>
-      createElement('div', { 'data-pointer': pointerEvents ?? '' }, children),
-  },
-  Extrapolation: { CLAMP: 'clamp' },
-  interpolate: () => 0,
-  runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
-  useAnimatedReaction: () => {},
-  useAnimatedStyle: () => ({}),
-  useDerivedValue: () => ({ value: 0 }),
-}));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 47, bottom: 0, left: 0, right: 0 }),
 }));
@@ -87,6 +75,9 @@ vi.mock('../../../providers/queue-provider', () => ({
 }));
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
+// ProgressiveBlur renders the iOS blur path under this mode (short-circuits the
+// native a11y / glass-capability hooks it would otherwise pull in).
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'blur' }));
 vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.light }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 4: 16 }, shadows: { sm: {} } }));
 vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 48, capsule: 44 } }));

--- a/packages/mobile/src/components/feed/FeedScopeTitle.tsx
+++ b/packages/mobile/src/components/feed/FeedScopeTitle.tsx
@@ -26,9 +26,11 @@ type FeedScopeTitleProps = {
   /** Menu items, in render order; `onSelectIndex` is called with the tapped index. */
   actions: ContextMenuAction[];
   onSelectIndex: (index: number) => void;
+  /** VoiceOver hint — the pill is a menu, so cue what activating it does. */
+  accessibilityHint?: string;
 };
 
-export function FeedScopeTitle({ title, actions, onSelectIndex }: FeedScopeTitleProps) {
+export function FeedScopeTitle({ title, actions, onSelectIndex, accessibilityHint }: FeedScopeTitleProps) {
   const { systemColors } = useTheme();
   const nativeGlass = useNativeGlass();
   // `selected` (the checkmark) and `systemIcon` only render on iOS; on Android
@@ -49,6 +51,7 @@ export function FeedScopeTitle({ title, actions, onSelectIndex }: FeedScopeTitle
       <View
         accessibilityRole="button"
         accessibilityLabel={title}
+        accessibilityHint={accessibilityHint}
         style={[
           styles.pill,
           !nativeGlass && shadows.sm,

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -120,6 +120,9 @@ vi.mock('../../../providers/drawer-host-provider', () => ({
 vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
   useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
 }));
+// The collapsed-bar ProgressiveBlur reads the surface mode; 'blur' renders its iOS
+// blur path and short-circuits the native a11y / glass-capability hooks.
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'blur' }));
 
 vi.mock('../../../theme/layout', () => ({ glassSize: { standard: 48, capsule: 36, hero: 56 } }));
 vi.mock('../../../theme/tokens', () => ({

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -190,6 +190,9 @@ vi.mock('../../../theme/colors', () => ({
 vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { white: '#fff' } }));
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => true }));
+// ProgressiveBlur renders the iOS blur path under this mode (short-circuits the
+// native a11y / glass-capability hooks it would otherwise pull in).
+vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'blur' }));
 vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
 }));

--- a/packages/shared/i18n/locales/en-US/feed.json
+++ b/packages/shared/i18n/locales/en-US/feed.json
@@ -37,7 +37,8 @@
       "scope": {
         "myCrew": "My crew",
         "everyone": "Everyone",
-        "findGym": "Find a gym near you"
+        "findGym": "Find a gym near you",
+        "hint": "Switches whose climbs you see"
       }
     }
   },

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -37,7 +37,8 @@
       "scope": {
         "myCrew": "Mi crew",
         "everyone": "Todos",
-        "findGym": "Busca un gimnasio cerca"
+        "findGym": "Busca un gimnasio cerca",
+        "hint": "Cambia de quién ves las vías"
       }
     }
   },

--- a/packages/shared/i18n/locales/fr/feed.json
+++ b/packages/shared/i18n/locales/fr/feed.json
@@ -37,7 +37,8 @@
       "scope": {
         "myCrew": "Mon crew",
         "everyone": "Tout le monde",
-        "findGym": "Trouver une salle près de toi"
+        "findGym": "Trouver une salle près de toi",
+        "hint": "Change les voies que vous voyez"
       }
     }
   },


### PR DESCRIPTION
## What

Follow-up to #2881 (merged). These are the code-review fixes that landed just after the squash, so they didn't make the merge. Three review passes flagged them.

## Changes

- **`ProgressiveBlur` is surface-mode-aware** (`useEffectiveSurfaceMode`). It only renders a live `@react-native-community/blur` on the iOS glass / blur paths. On Android (Material) or with **Reduce Transparency** on, it fades the opaque scene background in from the top instead.
  - Fixes an Android dark-overlay band: the iOS-only material blur types (`thinMaterialDark`/`Light`) fall through to a hardcoded dark wash on Android's BlurView, and Home/Discover render this chrome on every platform (no Material branch).
  - Fixes a Reduce-Transparency a11y regression on iOS (the header kept a live blur while everything else went solid).
  - Uses concrete hexes for the fade, not `PlatformColor` — avoids the trait-baking that caused the original dark-mode white band.
- **Home feed insets manually** — `contentInsetAdjustmentBehavior="never"` + `insets.top + band` instead of the iOS-only `"automatic"`, which left an Android top gap now that the header floats as a glass overlay on every platform.
- **Home scope title-menu pill gets an `accessibilityHint`** — it was the only menu control without one. New `feed…scope.hint` key in all three locales (en-US / es / fr).
- Dropped the now-dead `react-native-reanimated` test mocks from the two chrome suites; mocked `useEffectiveSurfaceMode` in the suites that render the real `ProgressiveBlur` (short-circuits the native a11y / glass-capability hooks).

## Verification

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 296 files / 2138 tests ✅ (added a Material/Reduce-Transparency-path test to `progressive-blur`)
- i18n catalog-completeness ✅
- `vp run check:mobile-bundle` ✅
- `vp check` (lint + format) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
