### PR TITLE
fix(play-view): pulse-only wall-confirm watcher after self-initiated connect (follow-up to #2893)

### DIFF
--- a/docs/ui/06-play-view.md
+++ b/docs/ui/06-play-view.md
@@ -230,9 +230,9 @@ Buttons from left to right:
    - **Pending** (`lightbulbPending=true`): Box-shadow pulse animation (`lightbulbPulse`, 1100ms ease-in-out infinite). Amber box-shadow expands to 6px and fades.
    - **Coachmark** (`lightbulbCoachmark=true`): Same pulse animation but single iteration (900ms). A MUI `Tooltip` with `placement="top"` and `arrow` shows coachmark text. The tooltip auto-dismisses on animation end via `onAnimationEnd`.
 
-   Tap behavior (send / re-assert the current climb — same solo or party):
-   - **Disconnected**: Opens the Bluetooth device picker (`bluetoothConnect()`), then sends the current climb.
-   - **Connected**: Re-asserts (re-sends) the current climb to the board. Arms the 2-second wall-confirm watcher (`armWallConfirmWatcher`) and sets `pendingClimbUuid`; `WallConfirmedClimb` lights the bulb. A `WallDisconnected` event (relaying BLE link dropped) turns it back off while the current climb is preserved.
+   Tap behavior (always-live — no driver role):
+   - **Disconnected**: Initiates the connect (`bluetoothConnect()` — silent reconnect to the last board's serial on native shells, otherwise the device picker), then arms the 2-second wall-confirm watcher (`armWallConfirmWatcher`) and sets `pendingClimbUuid`; `WallConfirmedClimb` lights the bulb. The watcher is armed **pulse-only** (`pulseOnly: true`): on timeout it only clears the pulse and never fires a connect fallback, because the tap already started a connect — a second connect while the picker is still open would start a duplicate scan ("Already scanning" on iOS). A `WallDisconnected` event (relaying BLE link dropped) turns the bulb back off while the current climb is preserved.
+   - **Connected**: Disconnects (turns the board off); the drop releases the session wall + board-presence holder so every member's lightbulb clears.
 
    Long-press (via `useLongPress` hook): Opens the `LightControlDrawer` (disco light shows, glyph animations, LED color palette customization, manual BLE disconnect). The `consumeLongPress()` method in the click handler swallows the synthesized click that follows a long-press, preventing both actions from firing.
 

--- a/docs/ui/11-party-mode.md
+++ b/docs/ui/11-party-mode.md
@@ -17,7 +17,7 @@ The lightbulb is a send / re-assert affordance. Lit means our session's climb is
 
 2. **Connected, unlit:** Tapping re-asserts (re-sends) the current climb to the board.
 
-3. **Pending:** After tapping the lightbulb, a 2-second watcher timer starts. If `confirmClimbOnWall` arrives within that window (via the `wall-confirm-bus`), the timer is dismissed and the lightbulb lights. If not, a fallback runs (auto-connect or device picker).
+3. **Pending:** After tapping the lightbulb, a 2-second watcher timer starts. If `confirmClimbOnWall` arrives within that window (via the `wall-confirm-bus`), the timer is dismissed and the lightbulb lights. If not, the timer just clears the pulse. The tap already initiated the connect above, so the watcher is armed **pulse-only** (`pulseOnly: true`) and never fires its own connect fallback — a second connect while the device picker is still open would start a duplicate scan (the iOS "Already scanning" failure). The controller's `auto_connect` / `picker` fallbacks remain for callers that arm without first connecting.
 
 4. **Lit:** Our session's climb is confirmed on the wall. A `WallDisconnected` event turns it back off for everyone when the relaying connection drops.
 
@@ -98,13 +98,13 @@ When any participant changes the board angle:
 
 ### Data Layer
 
-| Operation               | Type         | Purpose                                                                                           |
-| ----------------------- | ------------ | ------------------------------------------------------------------------------------------------- |
-| `confirmClimbOnWall`    | Mutation     | Confirms a climb was sent to the board via BLE (lights the lightbulb for all members)             |
-| `reportWallDisconnect`  | Mutation     | Reports the relaying BLE link dropped (unlights the lightbulb for all members)                    |
-| `setSessionBoardPath`   | Mutation     | Broadcasts angle/board path change to all members                                                 |
-| `setSessionBoardSerial` | Mutation     | Shares which physical board serial is connected                                                   |
-| `sessionUpdates`        | Subscription | Real-time session events (wall confirm/disconnect, path changes, serial changes, joins/leaves)    |
-| `queueUpdates`          | Subscription | Real-time queue state changes (add, remove, reorder, current climb)                               |
+| Operation               | Type         | Purpose                                                                                        |
+| ----------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| `confirmClimbOnWall`    | Mutation     | Confirms a climb was sent to the board via BLE (lights the lightbulb for all members)          |
+| `reportWallDisconnect`  | Mutation     | Reports the relaying BLE link dropped (unlights the lightbulb for all members)                 |
+| `setSessionBoardPath`   | Mutation     | Broadcasts angle/board path change to all members                                              |
+| `setSessionBoardSerial` | Mutation     | Shares which physical board serial is connected                                                |
+| `sessionUpdates`        | Subscription | Real-time session events (wall confirm/disconnect, path changes, serial changes, joins/leaves) |
+| `queueUpdates`          | Subscription | Real-time queue state changes (add, remove, reorder, current climb)                            |
 
 ---

--- a/packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts
+++ b/packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts
@@ -240,6 +240,55 @@ describe('createWallConfirmFallbackController', () => {
     expect(wallConfirmBus.listenerCount()).toBe(0);
   });
 
+  it('pulseOnly: never connects on timeout even when disconnected and supported', () => {
+    // The production lightbulb path: the caller already initiated a connect, so
+    // a second bluetoothConnect here would start a duplicate native scan
+    // ("Already scanning. Stopping now." on iOS). pulseOnly suppresses it while
+    // still recording the timeout.
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus, {
+      // The exact state that previously triggered the harmful picker re-connect.
+      isBluetoothConnected: () => false,
+      isBluetoothSupported: () => true,
+      lastConnectedBoardSerial: () => 'serial-42',
+      isNativeApp: () => true,
+    });
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, mode: 'party', pulseOnly: true });
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+    expect(callbacks.onTimeout).toHaveBeenCalledWith({ climbUuid: 'climb-1' });
+    expect(callbacks.onTrackTimeout).toHaveBeenCalledWith({
+      mode: 'party',
+      fallback: 'pulse_only',
+      boardLayout: 'Original',
+    });
+  });
+
+  it('pulseOnly: still confirms the climb and clears the pulse when WallConfirmedClimb arrives', () => {
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, pulseOnly: true });
+    vi.advanceTimersByTime(400);
+    wallConfirmBus.emit('climb-1');
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+
+    expect(callbacks.onConfirmed).toHaveBeenCalledWith({
+      climbUuid: 'climb-1',
+      latencyMs: 400,
+      confirmedByRole: 'other',
+    });
+    expect(callbacks.onTimeout).not.toHaveBeenCalled();
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+    expect(wallConfirmBus.listenerCount()).toBe(0);
+  });
+
   it('reads current dependency values when the timeout fires', () => {
     const wallConfirmBus = createLocalWallConfirmBus();
     const callbacks = createCallbacks();

--- a/packages/shared/play-view/src/wall-confirm-fallback.ts
+++ b/packages/shared/play-view/src/wall-confirm-fallback.ts
@@ -12,12 +12,23 @@
 export const WALL_CONFIRM_TIMEOUT_MS = 2000;
 
 export type WallConfirmMode = 'party' | 'solo';
-export type WallConfirmFallback = 'already_connected' | 'unsupported' | 'auto_connect' | 'picker';
+export type WallConfirmFallback = 'already_connected' | 'unsupported' | 'auto_connect' | 'picker' | 'pulse_only';
 
 export type WallConfirmArmArgs = {
   climbUuid: string;
   mode: WallConfirmMode;
   boardLayout: string;
+  /**
+   * Drive the pulse/confirm UI but never connect on timeout. Set this when the
+   * caller has *itself* just initiated a connect (the always-live lightbulb tap
+   * does this): re-connecting 2s later is at best redundant (a successful
+   * connect already short-circuits via `already_connected`) and at worst a
+   * second native scan started while the first picker is still open — which
+   * trips "Already scanning. Stopping now." on the iOS shell. The watcher still
+   * waits for `WallConfirmedClimb` and fires `onConfirmed` / `onTimeout` to
+   * clear the pulse; only the connect fallback is suppressed.
+   */
+  pulseOnly?: boolean;
 };
 
 type WallConfirmTimeoutId = ReturnType<typeof setTimeout>;
@@ -80,7 +91,7 @@ export function createWallConfirmFallbackController(
     }
   };
 
-  const armWatcher = ({ climbUuid, mode, boardLayout }: WallConfirmArmArgs) => {
+  const armWatcher = ({ climbUuid, mode, boardLayout, pulseOnly = false }: WallConfirmArmArgs) => {
     cancelWatcher();
 
     const armedAt = getNow();
@@ -91,6 +102,13 @@ export function createWallConfirmFallbackController(
 
       cancelWatcher();
       callbacks.onTimeout?.({ climbUuid });
+
+      // The caller already kicked off its own connect — never start another one
+      // (the second scan is what breaks iOS pairing). Just record the timeout.
+      if (pulseOnly) {
+        callbacks.onTrackTimeout?.({ mode, fallback: 'pulse_only', boardLayout });
+        return;
+      }
 
       if (deps.isBluetoothConnected()) {
         callbacks.onTrackTimeout?.({ mode, fallback: 'already_connected', boardLayout });

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -453,15 +453,18 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     } else {
       void bluetoothConnect();
     }
-    // Pulse the bulb until the climb is confirmed on the wall (the 2s watcher is
-    // a no-op once connected — see wall-confirm-fallback's already_connected
-    // path — and a picker cancel resolves via timeout).
+    // Pulse the bulb until the climb is confirmed on the wall. We just initiated
+    // the connect above, so arm pulse-only: the watcher must NOT fire its own
+    // connect fallback on timeout. Re-connecting 2s later is redundant once the
+    // first connect lands, and firing it while the device picker is still open
+    // starts a second scan that trips "Already scanning. Stopping now." on iOS.
     if (currentClimb) {
       setPendingClimbUuid(currentClimb.uuid);
       armWallConfirmWatcher({
         climbUuid: currentClimb.uuid,
         mode: isPersistentSessionActive ? 'party' : 'solo',
         boardLayout,
+        pulseOnly: true,
       });
     }
   }, [


### PR DESCRIPTION
Follow-up to #2893. That PR stopped the iOS "Already scanning. Stopping now." regression with an in-flight guard in `connect()`. Code review flagged that the guard was left **load-bearing for correctness** — this removes the underlying cause so the guard is only defense-in-depth.

## The structural problem

`handleLightbulbClick` (`play-view-drawer.tsx`), in the disconnected→connect branch, calls `bluetoothConnect()` and then arms the 2-second wall-confirm watcher. The watcher's connect-fallback is **never useful in that branch**:
- connect succeeded → fallback short-circuits on `already_connected`;
- connect still in flight (picker open) → fallback fires a *second* `bluetoothConnect()` = the duplicate native scan that breaks iOS pairing;
- connect failed → re-opening the picker 2s later is not a designed behavior.

So the watcher there should drive the pulse UI only, never connect.

## Change

- **`@boardsesh/play-view` `wall-confirm-fallback.ts`**: add an opt-in `pulseOnly` flag to `WallConfirmArmArgs` (default `false`, so the existing `auto_connect` / `picker` behavior is unchanged). When set, the timeout still fires `onTimeout` / `onTrackTimeout` (tracked as `fallback: 'pulse_only'`) but never calls `bluetoothConnect`. New `WallConfirmFallback` member `'pulse_only'`.
- **`play-view-drawer.tsx`**: arm with `pulseOnly: true`, since it only ever arms right after initiating its own connect.

The web play-drawer is the controller's **only** consumer (the RN app doesn't use it — verified), so this is safe and tightly scoped. The `connect()` in-flight guard from #2893 stays as a belt-and-suspenders net.

## Tests

`wall-confirm-fallback.test.ts`:
- `pulseOnly` never connects on timeout even when disconnected + supported + has a stored serial on native (the exact prior trigger), and records `fallback: 'pulse_only'`.
- `pulseOnly` still confirms the climb / clears the pulse when `WallConfirmedClimb` arrives.

Green: shared `wall-confirm-fallback` (11), web `play-view` suite (74), `typecheck:shared`, `typecheck:web`, `vp check` (changed files).

## Merge order

Independent of #2893 (different files), but logically lands after it. Either order is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)