### PR TITLE
Fix review findings on PR #2880 (direct beta-tick links)

### DIFF
--- a/docs/ascents-and-attempts.md
+++ b/docs/ascents-and-attempts.md
@@ -160,7 +160,14 @@ There are exactly three production code paths that insert into `boardsesh_ticks`
 - `quality: validatedInput.quality ?? null`
 - Aurora fields all set to `null`; they get populated later by the periodic sync daemon.
 - Publishes `ascent.logged` event for the feed (only for `flash`/`send`, not `attempt`).
-- If `videoUrl` was attached, also inserts a `board_beta_links` row.
+- If `videoUrl` was attached to a successful ascent, also inserts a
+  `board_beta_links` row tied directly to the new tick via `tick_uuid` and to
+  the resolved wall via `board_id` when one is known. Attempts ignore
+  `videoUrl`.
+- Beta-link inserts store a `video_identity` canonicalized from the platform
+  media id when possible. That keeps one canonical beta row per video and one
+  beta row per tick; a same-climb duplicate on `saveTick` skips only the beta
+  side effect and still saves the tick.
 - Calls `queueClimbStatsRecompute(boardType, climbUuid, angle)`. The debounced job
   (2 s window, `packages/backend/src/graphql/resolvers/ticks/debounced-climb-stats-publisher.ts`)
   recomputes `board_climb_stats.boardsesh_ascensionist_count` from the
@@ -247,7 +254,8 @@ Ticks only belong to a session when they were logged inside an explicitly-create
 3. **Always join `board_climb_stats` and COALESCE** when grouping ticks by grade. Reuse `consensusDifficultyExpr` from `packages/backend/src/graphql/resolvers/shared/sql-expressions.ts`.
 4. **Status is the source of truth, not `attempt_count`.** New code must check `status === 'flash'` / `'send'` / `'attempt'`, not infer from attempt counts. The attempt-count heuristic in `buildFlashRedpointBars` is a legacy fallback for pre-status rows only.
 5. **All inserts go through `saveTick` or the Aurora sync.** Don't write ad-hoc inserts elsewhere; you'll skip the `ascent.logged` event, beta-link attach, and the IndexedDB draft cleanup.
-6. **Aurora fields are owned by the sync daemon.** Don't set `aurora_id`, `aurora_type`, or `aurora_synced_at` from a write path other than the sync job.
-7. **Attempts never carry a `quality` or `difficulty`.** If you add an "attempt with grade override" UX, document it here first — every aggregation in this doc assumes the convention.
+6. **Tick-specific beta links belong on `board_beta_links.tick_uuid`.** The legacy climb-level lookup still exists for old rows, but new successful tick attachments should carry `tick_uuid`, `board_id` when known, and `video_identity`. A tick can have at most one beta link, and a canonical video can belong to only one beta row.
+7. **Aurora fields are owned by the sync daemon.** Don't set `aurora_id`, `aurora_type`, or `aurora_synced_at` from a write path other than the sync job.
+8. **Attempts never carry a `quality` or `difficulty`.** If you add an "attempt with grade override" UX, document it here first — every aggregation in this doc assumes the convention.
 
 If you change any of these invariants, update this document in the same PR.

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -1786,9 +1786,9 @@ The 8-tokens-per-session cap is enforced under a Postgres advisory lock (`pg_adv
 
 `unregisterActivityPushToken(sessionId, token)` is the symmetric mutation. The delete is scoped to `(token, sessionId)` so an attacker holding a leaked token cannot wipe another session's registrations. Same auth + participant + rate-limit checks apply.
 
-## Widget Navigation REST Endpoint
+## Widget REST Endpoints
 
-Lock-screen widget extensions cannot reach the JS webapp or its WebSocket. Instead, the Next / Previous buttons hit a dedicated REST endpoint:
+Lock-screen widget extensions cannot reach the JS webapp or its WebSocket. Two dedicated REST endpoints cover the write paths:
 
 ```
 POST /api/widget/navigate
@@ -1796,34 +1796,60 @@ POST /api/widget/navigate
   Content-Type: application/json
 
   { "sessionId": "<id>", "action": "next" | "previous", "currentIndex": <int ≥ 0> }
+
+POST /api/widget/take-control
+  Authorization: Bearer <APNs Live Activity push token>
+  Content-Type: application/json
+
+  { "sessionId": "<id>" }
 ```
 
-### Auth
+### Auth Contract: Always-Live Sessions
 
-The Bearer credential is the device's APNs Live Activity push token — the same value the widget pulled from `SharedKeychain.livePushTokenKey`. The handler looks up `(token, sessionId)` in `activity_push_tokens`; an unknown token returns 401, while a known token bound to a different session returns 410 so the widget can re-register. Treating the push token as the credential keeps the widget extension out of the user-auth path entirely (it never sees the user's Bearer token) and is safe because the token is already a per-session, per-device secret.
+Widget sessions are **always-live**: there is no driver role for these endpoints. Any authenticated session participant may navigate the queue or re-assert the current climb. This is a deliberate departure from the older driver-ownership model (where only the elected leader could make writes).
+
+**Threat model rationale:** The widget endpoints run outside the main app process; they cannot participate in the in-process leader-election protocol. A driver gate would either (a) require an extra per-request Redis round-trip to resolve current leadership, or (b) silently deny any widget tap while the session has no leader — both unacceptable for a lock-screen control. Since the Live Activity push token is already scoped to `(device, session)` and only issued to authenticated participants, possession of a valid token already proves the device joined and was authorised to be in the session.
+
+Two-layer auth on every request:
+
+1. **Token auth** (`widget-auth.ts`): Bearer token must be registered in `activity_push_tokens` with matching `sessionId`. Unknown token → 401. Token bound to a different session → 410 (widget re-registers). This layer identifies the device+session.
+2. **Membership check** (`widget-session-guard.ts`): Confirms the session is still active and the token owner is still a participant (`board_session_participants` row exists). Session ended → 410. Not a participant → 403. This prevents stale tokens from mutating an ended session's persisted queue.
+
+The `userId` on the `activity_push_tokens` row is used for analytics attribution only — the token proves participation, not identity. A `null` userId (token row pre-dating the `user_id` column) authorises navigation but emits an attribution-gap metric instead of a normal analytics event.
+
+`/api/widget/take-control` additionally requires a non-null `userId` on the token row (403 if `userId: null`), since re-asserting the board's LED state is a board-write action that should always be attributed.
+
+The push token as the credential keeps the widget extension out of the user-auth path entirely — it never sees the user's Bearer JWT. The token is already a per-session, per-device secret issued by Apple.
 
 ### Validation
 
+**navigate**
 - `sessionId`: non-empty string
 - `action`: `"next"` or `"previous"`
 - `currentIndex`: integer, `>= 0`
+- Request body capped at 4 KB
+
+**take-control**
+- `sessionId`: non-empty string
 - Request body capped at 4 KB
 
 Anything else returns 400.
 
 ### Rate Limiting
 
-Per-session token bucket — capacity 2, refill 1 per 1.5s. Burst clicks are smoothed; sustained tapping caps at ~40 req/min per session. Returns 429 when the bucket is empty. The session-scoped bucket means one device can't deny service for another.
+Both endpoints share a **per-session** token bucket (capacity 2, refill 1 per 1.5s) defined in `widget-rate-limit.ts`. Burst clicks are smoothed; sustained tapping caps at ~40 req/min per session. Returns 429 when the bucket is empty. The session-scoped bucket means one device can't deny service for another on the same session. Rate limiting is applied after auth so an unauthenticated caller cannot poison a real participant's bucket.
 
 ### Server-Authoritative Navigation
 
-The handler does NOT trust the `currentIndex` from the widget — it fetches the server's queue state via `roomManager.getQueueState(sessionId)`, computes the target index from `action` (wrapping at boundaries for `next`, clamped to 0 for `previous`), and calls `navigateToQueueItem` (shared with the `setCurrentClimb` GraphQL mutation). That function does optimistic-lock retry against the room manager and publishes the resulting `CurrentClimbChanged` via `pubsub.publishQueueEvent`, which fans out to JS subscribers and triggers the APNs push hook described above.
+The navigate handler does NOT trust the `currentIndex` from the widget — it fetches the server's queue state via `roomManager.getQueueState(sessionId)`, computes the target index from `action` (wrapping at boundaries for `next`, clamped to 0 for `previous`), and calls `navigateToQueueItem` (shared with the `setCurrentClimb` GraphQL mutation). That function does optimistic-lock retry against the room manager and publishes the resulting `CurrentClimbChanged` via `pubsub.publishQueueEvent`, which fans out to JS subscribers and triggers the APNs push hook described above.
 
 The `currentIndex` field in the request is validated for shape only; the handler reads server state for the actual position.
 
+The take-control handler re-publishes the session's current climb (re-asserting the board's LED state) by calling `setCurrentClimbAndPublish`. If no current climb exists in the queue the handler succeeds (200) as a no-op — there is nothing to assert.
+
 ### Why HTTP and Not a GraphQL Mutation
 
-A GraphQL mutation would require either the JS GraphQL client (not available in the widget process) or hand-rolled GraphQL-over-HTTP in Swift. The REST handler is simpler, cheaper, and lets us keep the widget extension free of GraphQL tooling. The downside — a second endpoint surface to keep in sync — is small for one operation.
+A GraphQL mutation would require either the JS GraphQL client (not available in the widget process) or hand-rolled GraphQL-over-HTTP in Swift. The REST handlers are simpler, cheaper, and let us keep the widget extension free of GraphQL tooling. The downside — a second endpoint surface to keep in sync — is small for two operations.
 
 ## Related Files
 
@@ -1838,6 +1864,10 @@ A GraphQL mutation would require either the JS GraphQL client (not available in 
 - `packages/backend/src/services/queue-navigation.ts` - Shared queue-navigation logic (used by `setCurrentClimb` and `/api/widget/navigate`)
 - `packages/backend/src/services/apns/index.ts` - APNs HTTP/2 send + 5s debounce + Live Activity content state assembly
 - `packages/backend/src/handlers/widget-navigate.ts` - REST handler for `POST /api/widget/navigate`
+- `packages/backend/src/handlers/widget-take-control.ts` - REST handler for `POST /api/widget/take-control`
+- `packages/backend/src/handlers/widget-auth.ts` - Bearer-token auth for both widget endpoints
+- `packages/backend/src/handlers/widget-session-guard.ts` - Membership + session-liveness gate (applied after token auth, before queue mutation)
+- `packages/backend/src/handlers/widget-rate-limit.ts` - Per-session token bucket shared by both widget endpoints (`checkWidgetRateLimit`, `ensureWidgetRateLimitPruner`)
 - `packages/backend/src/graphql/resolvers/queue/` - Queue mutations & subscriptions
 - `packages/backend/src/graphql/resolvers/sessions/` - Session mutations & subscriptions
 - `packages/backend/src/graphql/resolvers/sessions/push-tokens.ts` - `registerActivityPushToken` / `unregisterActivityPushToken` resolvers with the per-session cap + advisory-lock TOCTOU fix

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -18,7 +18,7 @@ This document describes the WebSocket implementation used for real-time party se
 12. [iOS Live Activity Integration](#ios-live-activity-integration)
 13. [Live Activity Push Notifications (APNs)](#live-activity-push-notifications-apns)
 14. [Activity Push Token Lifecycle](#activity-push-token-lifecycle)
-15. [Widget Navigation REST Endpoint](#widget-navigation-rest-endpoint)
+15. [Widget REST Endpoints](#widget-rest-endpoints)
 
 ---
 
@@ -1669,7 +1669,7 @@ The helper lives in `mobile/ios/App/App/SharedKeychain.swift`. The `keychain-acc
 
 ### Widget Button Flow
 
-Lock-screen widget taps (next/prev climb) do NOT go through the native WebSocket. They hit the backend directly via `/api/widget/navigate` (see [Widget Navigation REST Endpoint](#widget-navigation-rest-endpoint)) because the widget extension can't talk to `SessionWebSocketManager` (different process). The backend updates the queue, publishes a `CurrentClimbChanged` event, and the APNs hook fans the change back out to every device's Live Activity.
+Lock-screen widget taps (next/prev climb) do NOT go through the native WebSocket. They hit the backend directly via `/api/widget/navigate` (see [Widget REST Endpoints](#widget-rest-endpoints)) because the widget extension can't talk to `SessionWebSocketManager` (different process). The backend updates the queue, publishes a `CurrentClimbChanged` event, and the APNs hook fans the change back out to every device's Live Activity.
 
 ### Lifecycle
 
@@ -1831,7 +1831,7 @@ The push token as the credential keeps the widget extension out of the user-auth
 
 **take-control**
 - `sessionId`: non-empty string
-- Request body capped at 4 KB
+- Request body capped at 2 KB
 
 Anything else returns 400.
 

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -143,6 +143,8 @@ type Row = {
   thumbnail: string | null;
   isListed: boolean | null;
   createdAt: string | null;
+  tickUuid: string | null;
+  boardId: number | null;
 };
 
 function row(overrides: Partial<Row>): Row {
@@ -155,6 +157,8 @@ function row(overrides: Partial<Row>): Row {
     thumbnail: null,
     isListed: true,
     createdAt: '2026-04-26T00:00:00Z',
+    tickUuid: null,
+    boardId: null,
     ...overrides,
   };
 }

--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDbSelect } = vi.hoisted(() => ({
-  mockDbSelect: vi.fn(() => {
-    throw new Error('db.select should not be called for non-Instagram URLs');
-  }),
+  mockDbSelect: vi.fn(() => ({
+    from: () => ({
+      innerJoin: () => ({ where: () => Promise.resolve([]) }),
+    }),
+  })),
 }));
 
 vi.mock('../db/client', () => ({
@@ -46,8 +48,8 @@ vi.mock('../redis/client', () => ({
   },
 }));
 
-// Stub the rate limiter; the gate test only cares about the early-return path
-// for non-Instagram URLs, where applyRateLimit shouldn't even be reached.
+// Stub the rate limiter; the gate tests care about validation ordering, not
+// the limiter implementation itself.
 const { mockApplyRateLimit } = vi.hoisted(() => ({
   mockApplyRateLimit: vi.fn(async () => {}),
 }));
@@ -81,7 +83,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
     vi.unstubAllGlobals();
   });
 
-  it('returns insert plan with null enrichment for TikTok URLs without hitting fetch or DB', async () => {
+  it('returns insert plan with null enrichment for TikTok URLs without hitting fetch', async () => {
     const result = await validateAndEnrichBetaLinkInsert(
       fakeCtx,
       'kilter',
@@ -92,7 +94,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
 
     expect(result).toEqual({ action: 'insert', thumbnail: null, foreignUsername: null });
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
   });
 
   it('returns insert plan for short-form TikTok URLs', async () => {
@@ -106,7 +108,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
 
     expect(result).toEqual({ action: 'insert', thumbnail: null, foreignUsername: null });
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
   });
 
   it('rate-limits non-Instagram URLs too so TikTok attachments share the per-user write budget', async () => {
@@ -210,18 +212,18 @@ describe('escapeLikePattern', () => {
   });
 });
 
-// findInstagramShortcodeConflict drives the dedup decisions for both call
-// sites. We test it by short-circuiting the drizzle chain mock so we can feed
-// the rows we want directly.
+// findInstagramShortcodeConflict is kept as a compatibility wrapper around the
+// canonical video identity dedup logic. We test it by short-circuiting the
+// drizzle chain mock so we can feed the rows we want directly.
 describe('findInstagramShortcodeConflict', () => {
-  const stubDbReturning = (rows: Array<{ climbName: string | null; climbUuid: string }>) => {
+  const stubDbReturning = (rows: Array<{ boardType?: string; climbName: string | null; climbUuid: string }>) => {
     // Drizzle's chained query builder is heavily typed; for unit tests we
     // only need the runtime shape. Cast through unknown to bypass the
     // void-returning signature `mockDbSelect` got from its initial setup.
     mockDbSelect.mockImplementation((() => ({
       from: () => ({
         innerJoin: () => ({
-          where: () => Promise.resolve(rows),
+          where: () => Promise.resolve(rows.map((row) => ({ boardType: 'kilter', ...row }))),
         }),
       }),
     })) as unknown as () => never);
@@ -283,6 +285,17 @@ describe('findInstagramShortcodeConflict', () => {
     expect(result).toEqual({ kind: 'cross-climb', climbName: 'Other Climb' });
   });
 
+  it('returns cross-climb for the same climb uuid on a different board type', async () => {
+    const { findInstagramShortcodeConflict } = await import('../graphql/resolvers/ticks/mutations');
+    stubDbReturning([{ boardType: 'tension', climbName: 'Same UUID Elsewhere', climbUuid: 'climb-1' }]);
+    const result = await findInstagramShortcodeConflict(
+      'kilter',
+      'climb-1',
+      'https://www.instagram.com/reel/ABC123xyz/',
+    );
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'Same UUID Elsewhere' });
+  });
+
   it('returns none when no rows match', async () => {
     const { findInstagramShortcodeConflict } = await import('../graphql/resolvers/ticks/mutations');
     stubDbReturning([]);
@@ -294,14 +307,18 @@ describe('findInstagramShortcodeConflict', () => {
     expect(result).toEqual({ kind: 'none' });
   });
 
-  it('returns none for non-Instagram URLs (no shortcode to look up)', async () => {
-    const { findInstagramShortcodeConflict } = await import('../graphql/resolvers/ticks/mutations');
-    const result = await findInstagramShortcodeConflict(
-      'kilter',
-      'climb-1',
-      'https://www.tiktok.com/@user/video/12345',
-    );
+  it('detects long-form TikTok conflicts through the same identity lookup', async () => {
+    const { findBetaLinkIdentityConflict } = await import('../graphql/resolvers/ticks/mutations');
+    stubDbReturning([{ climbName: 'The Project', climbUuid: 'climb-other' }]);
+    const result = await findBetaLinkIdentityConflict('kilter', 'climb-1', 'https://www.tiktok.com/@user/video/12345');
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'The Project' });
+  });
+
+  it('returns none for TikTok URLs when no identity rows match', async () => {
+    const { findBetaLinkIdentityConflict } = await import('../graphql/resolvers/ticks/mutations');
+    stubDbReturning([]);
+    const result = await findBetaLinkIdentityConflict('kilter', 'climb-1', 'https://www.tiktok.com/@user/video/12345');
     expect(result).toEqual({ kind: 'none' });
-    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -252,7 +252,7 @@ describe('findInstagramShortcodeConflict', () => {
       'climb-1',
       'https://www.instagram.com/reel/ABC123xyz/',
     );
-    expect(result).toEqual({ kind: 'cross-climb', climbName: 'The Project' });
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'The Project', existingBoardType: 'kilter' });
   });
 
   it('falls back to "another climb" if the conflicting row has a null climb name', async () => {
@@ -263,7 +263,7 @@ describe('findInstagramShortcodeConflict', () => {
       'climb-1',
       'https://www.instagram.com/reel/ABC123xyz/',
     );
-    expect(result).toEqual({ kind: 'cross-climb', climbName: 'another climb' });
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'another climb', existingBoardType: 'kilter' });
   });
 
   it('returns cross-climb when both same-climb and other-climb rows exist (order-independent)', async () => {
@@ -282,7 +282,7 @@ describe('findInstagramShortcodeConflict', () => {
       'climb-1',
       'https://www.instagram.com/reel/ABC123xyz/',
     );
-    expect(result).toEqual({ kind: 'cross-climb', climbName: 'Other Climb' });
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'Other Climb', existingBoardType: 'kilter' });
   });
 
   it('returns cross-climb for the same climb uuid on a different board type', async () => {
@@ -293,7 +293,7 @@ describe('findInstagramShortcodeConflict', () => {
       'climb-1',
       'https://www.instagram.com/reel/ABC123xyz/',
     );
-    expect(result).toEqual({ kind: 'cross-climb', climbName: 'Same UUID Elsewhere' });
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'Same UUID Elsewhere', existingBoardType: 'tension' });
   });
 
   it('returns none when no rows match', async () => {
@@ -311,7 +311,7 @@ describe('findInstagramShortcodeConflict', () => {
     const { findBetaLinkIdentityConflict } = await import('../graphql/resolvers/ticks/mutations');
     stubDbReturning([{ climbName: 'The Project', climbUuid: 'climb-other' }]);
     const result = await findBetaLinkIdentityConflict('kilter', 'climb-1', 'https://www.tiktok.com/@user/video/12345');
-    expect(result).toEqual({ kind: 'cross-climb', climbName: 'The Project' });
+    expect(result).toEqual({ kind: 'cross-climb', climbName: 'The Project', existingBoardType: 'kilter' });
   });
 
   it('returns none for TikTok URLs when no identity rows match', async () => {

--- a/packages/backend/src/__tests__/beta-link-write-gate.test.ts
+++ b/packages/backend/src/__tests__/beta-link-write-gate.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const { mockDbSelect } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(() => ({
     from: () => ({
-      innerJoin: () => ({ where: () => Promise.resolve([]) }),
+      // The conflict check uses LEFT JOIN (changed from INNER JOIN so beta links
+      // for unsynced climbs are not silently excluded from the dedup query).
+      leftJoin: () => ({ where: () => Promise.resolve([]) }),
     }),
   })),
 }));
@@ -155,7 +157,7 @@ describe('validateAndEnrichBetaLinkInsert (gate)', () => {
       order.push('db');
       return {
         from: () => ({
-          innerJoin: () => ({ where: () => Promise.resolve([]) }),
+          leftJoin: () => ({ where: () => Promise.resolve([]) }),
         }),
       };
     }) as unknown as () => never);
@@ -222,7 +224,7 @@ describe('findInstagramShortcodeConflict', () => {
     // void-returning signature `mockDbSelect` got from its initial setup.
     mockDbSelect.mockImplementation((() => ({
       from: () => ({
-        innerJoin: () => ({
+        leftJoin: () => ({
           where: () => Promise.resolve(rows.map((row) => ({ boardType: 'kilter', ...row }))),
         }),
       }),

--- a/packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts
+++ b/packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// db.select is called twice in resolveBetaLinkTickContext:
+//   1. tick + alias left-join query  → chain: .from().leftJoin().leftJoin().where().limit()
+//   2. existing beta-link check      → chain: .from().where().limit()
+// Each test stubs these calls with mockImplementationOnce in order.
+const { mockDbSelect } = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+}));
+
+vi.mock('../db/client', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn() }));
+
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+
+vi.mock('../lib/beta-link-thumbnails', async () => {
+  const actual = await vi.importActual<typeof import('../lib/beta-link-thumbnails')>('../lib/beta-link-thumbnails');
+  return { ...actual, cacheInstagramThumbnail: vi.fn(), isS3Configured: vi.fn(() => false) };
+});
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: () => false,
+    getClients: () => ({ publisher: { get: vi.fn(), set: vi.fn(), del: vi.fn() } }),
+  },
+}));
+
+vi.mock('../graphql/resolvers/shared/helpers', async () => {
+  const actual = await vi.importActual<typeof import('../graphql/resolvers/shared/helpers')>(
+    '../graphql/resolvers/shared/helpers',
+  );
+  return { ...actual, applyRateLimit: vi.fn(async () => {}) };
+});
+
+import { resolveBetaLinkTickContext } from '../graphql/resolvers/ticks/mutations';
+
+type TickRow = {
+  uuid: string;
+  userId: string;
+  boardType: string;
+  climbUuid: string;
+  canonicalClimbUuid: string | null;
+  inputCanonicalClimbUuid: string | null;
+  angle: number;
+  status: string;
+  boardId: number | null;
+};
+
+function stubTickQuery(row: TickRow | null) {
+  mockDbSelect.mockImplementationOnce((() => ({
+    from: () => ({
+      leftJoin: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(row ? [row] : []),
+          }),
+        }),
+      }),
+    }),
+  })) as unknown as () => never);
+}
+
+function stubBetaLinkCheck(existingLink: string | null) {
+  mockDbSelect.mockImplementationOnce((() => ({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve(existingLink ? [{ link: existingLink }] : []),
+      }),
+    }),
+  })) as unknown as () => never);
+}
+
+function makeTick(overrides: Partial<TickRow> = {}): TickRow {
+  return {
+    uuid: 'tick-uuid-1',
+    userId: 'user-1',
+    boardType: 'kilter',
+    climbUuid: 'climb-1',
+    canonicalClimbUuid: null,
+    inputCanonicalClimbUuid: null,
+    angle: 40,
+    status: 'send',
+    boardId: 42,
+    ...overrides,
+  };
+}
+
+describe('resolveBetaLinkTickContext', () => {
+  beforeEach(() => {
+    mockDbSelect.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null context immediately when tickUuid is absent, never hitting the DB', async () => {
+    const result = await resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', angle: 45 }, 'user-1');
+    expect(result).toEqual({ tickUuid: null, boardId: null, angle: 45 });
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('returns null context with null angle when neither angle nor tickUuid is provided', async () => {
+    const result = await resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1' }, 'user-1');
+    expect(result).toEqual({ tickUuid: null, boardId: null, angle: null });
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('throws TICK_NOT_FOUND when the tick UUID does not exist', async () => {
+    stubTickQuery(null);
+    await expect(
+      resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'nonexistent-uuid' }, 'user-1'),
+    ).rejects.toMatchObject({ extensions: { code: 'TICK_NOT_FOUND' } });
+  });
+
+  it('throws FORBIDDEN when the tick belongs to a different user', async () => {
+    stubTickQuery(makeTick({ userId: 'other-user' }));
+    await expect(
+      resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
+    ).rejects.toMatchObject({ extensions: { code: 'FORBIDDEN' } });
+  });
+
+  it('throws BETA_LINK_TICK_NOT_ASCENT when tick status is attempt', async () => {
+    stubTickQuery(makeTick({ status: 'attempt' }));
+    await expect(
+      resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
+    ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_NOT_ASCENT' } });
+  });
+
+  it('throws BETA_LINK_TICK_MISMATCH when tick is for a different board type', async () => {
+    stubTickQuery(makeTick({ boardType: 'tension' }));
+    await expect(
+      resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
+    ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_MISMATCH' } });
+  });
+
+  it('throws when tick climb UUID does not match the input climb UUID', async () => {
+    stubTickQuery(makeTick({ climbUuid: 'climb-other', canonicalClimbUuid: null, inputCanonicalClimbUuid: null }));
+    await expect(
+      resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
+    ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_MISMATCH' } });
+  });
+
+  it('throws BETA_LINK_TICK_MISMATCH when the provided angle differs from the tick angle', async () => {
+    stubTickQuery(makeTick({ angle: 40 }));
+    await expect(
+      resolveBetaLinkTickContext(
+        { boardType: 'kilter', climbUuid: 'climb-1', angle: 45, tickUuid: 'tick-uuid-1' },
+        'user-1',
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_MISMATCH' } });
+  });
+
+  it('does not throw for angle check when no input angle is provided', async () => {
+    stubTickQuery(makeTick({ angle: 40 }));
+    stubBetaLinkCheck(null);
+    const result = await resolveBetaLinkTickContext(
+      { boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' },
+      'user-1',
+    );
+    expect(result).toMatchObject({ tickUuid: 'tick-uuid-1', angle: 40 });
+  });
+
+  it('throws BETA_LINK_TICK_ALREADY_LINKED when the tick already has a beta video', async () => {
+    stubTickQuery(makeTick());
+    stubBetaLinkCheck('https://www.instagram.com/reel/EXISTING/');
+    await expect(
+      resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
+    ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_ALREADY_LINKED' } });
+  });
+
+  it('returns full tick context on the happy path', async () => {
+    stubTickQuery(makeTick());
+    stubBetaLinkCheck(null);
+    const result = await resolveBetaLinkTickContext(
+      { boardType: 'kilter', climbUuid: 'climb-1', angle: 40, tickUuid: 'tick-uuid-1' },
+      'user-1',
+    );
+    expect(result).toEqual({ tickUuid: 'tick-uuid-1', boardId: 42, angle: 40 });
+  });
+
+  it('accepts both flash and send status ticks', async () => {
+    for (const status of ['flash', 'send'] as const) {
+      mockDbSelect.mockReset();
+      stubTickQuery(makeTick({ status }));
+      stubBetaLinkCheck(null);
+      const result = await resolveBetaLinkTickContext(
+        { boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' },
+        'user-1',
+      );
+      expect(result.tickUuid).toBe('tick-uuid-1');
+    }
+  });
+
+  it('resolves correctly when both tick and input share the same canonical UUID via aliases', async () => {
+    // tick.climbUuid = 'alias-a' → canonical 'canonical-1'
+    // input.climbUuid = 'alias-b' → canonical 'canonical-1'
+    // Both resolve to the same canonical — should succeed.
+    stubTickQuery(
+      makeTick({ climbUuid: 'alias-a', canonicalClimbUuid: 'canonical-1', inputCanonicalClimbUuid: 'canonical-1' }),
+    );
+    stubBetaLinkCheck(null);
+    const result = await resolveBetaLinkTickContext(
+      { boardType: 'kilter', climbUuid: 'alias-b', tickUuid: 'tick-uuid-1' },
+      'user-1',
+    );
+    expect(result.tickUuid).toBe('tick-uuid-1');
+  });
+
+  it('returns angle from the tick, not from the input (tick is authoritative)', async () => {
+    stubTickQuery(makeTick({ angle: 30 }));
+    stubBetaLinkCheck(null);
+    const result = await resolveBetaLinkTickContext(
+      // Matching angle passed — stored angle comes from the tick
+      { boardType: 'kilter', climbUuid: 'climb-1', angle: 30, tickUuid: 'tick-uuid-1' },
+      'user-1',
+    );
+    expect(result.angle).toBe(30);
+  });
+});

--- a/packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts
+++ b/packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts
@@ -182,11 +182,38 @@ describe('resolveBetaLinkTickContext', () => {
     expect(result).toMatchObject({ tickUuid: 'tick-uuid-1', angle: 40 });
   });
 
-  it('throws BETA_LINK_TICK_ALREADY_LINKED when the tick already has a beta video', async () => {
+  it('throws BETA_LINK_TICK_ALREADY_LINKED when the tick already has a different beta video', async () => {
+    setupDbMocks(makeTick(), 'https://www.instagram.com/reel/EXISTING/');
+    await expect(
+      resolveBetaLinkTickContext(
+        { boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1', link: 'https://www.instagram.com/reel/DIFFERENT/' },
+        'user-1',
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_ALREADY_LINKED' } });
+  });
+
+  it('throws BETA_LINK_TICK_ALREADY_LINKED when no link is provided and the tick already has a video', async () => {
     setupDbMocks(makeTick(), 'https://www.instagram.com/reel/EXISTING/');
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_ALREADY_LINKED' } });
+  });
+
+  it('returns existing context (idempotent) when the same canonical video is re-submitted for the same tick', async () => {
+    // Simulates a mobile retry: the first call succeeded, the tick now has a beta
+    // link, and the client retries. Since the video identity matches, succeed silently.
+    setupDbMocks(makeTick(), 'https://www.instagram.com/reel/SameId/');
+    const result = await resolveBetaLinkTickContext(
+      {
+        boardType: 'kilter',
+        climbUuid: 'climb-1',
+        tickUuid: 'tick-uuid-1',
+        // Same reel, different tracking params — normalizes to the same identity.
+        link: 'https://www.instagram.com/reel/SameId/?igsh=tracking',
+      },
+      'user-1',
+    );
+    expect(result).toEqual({ tickUuid: 'tick-uuid-1', boardId: 42, angle: 40 });
   });
 
   it('returns full tick context on the happy path', async () => {

--- a/packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts
+++ b/packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // db.select is called twice in resolveBetaLinkTickContext:
-//   1. tick + alias left-join query  → chain: .from().leftJoin().leftJoin().where().limit()
-//   2. existing beta-link check      → chain: .from().where().limit()
-// Each test stubs these calls with mockImplementationOnce in order.
+//   1. Tick + alias left-join query (.from(boardseshTicks) ...)
+//   2. Existing beta-link check     (.from(boardBetaLinks) ...)
+//
+// The mock dispatches on the table passed to .from() so adding/removing joins
+// in the production query doesn't silently break these tests — only an actual
+// change in which table is queried would do that.
 const { mockDbSelect } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
 }));
@@ -43,6 +46,7 @@ vi.mock('../graphql/resolvers/shared/helpers', async () => {
   return { ...actual, applyRateLimit: vi.fn(async () => {}) };
 });
 
+import * as dbSchema from '@boardsesh/db/schema';
 import { resolveBetaLinkTickContext } from '../graphql/resolvers/ticks/mutations';
 
 type TickRow = {
@@ -57,30 +61,6 @@ type TickRow = {
   boardId: number | null;
 };
 
-function stubTickQuery(row: TickRow | null) {
-  mockDbSelect.mockImplementationOnce((() => ({
-    from: () => ({
-      leftJoin: () => ({
-        leftJoin: () => ({
-          where: () => ({
-            limit: () => Promise.resolve(row ? [row] : []),
-          }),
-        }),
-      }),
-    }),
-  })) as unknown as () => never);
-}
-
-function stubBetaLinkCheck(existingLink: string | null) {
-  mockDbSelect.mockImplementationOnce((() => ({
-    from: () => ({
-      where: () => ({
-        limit: () => Promise.resolve(existingLink ? [{ link: existingLink }] : []),
-      }),
-    }),
-  })) as unknown as () => never);
-}
-
 function makeTick(overrides: Partial<TickRow> = {}): TickRow {
   return {
     uuid: 'tick-uuid-1',
@@ -94,6 +74,37 @@ function makeTick(overrides: Partial<TickRow> = {}): TickRow {
     boardId: 42,
     ...overrides,
   };
+}
+
+/**
+ * Configure the db.select mock to dispatch on the table passed to .from():
+ *   boardseshTicks → resolves tickRow (or empty array if null)
+ *   boardBetaLinks → resolves [{ link }] if existingLink provided, else []
+ *
+ * The mock returns a chain stub for whichever table is hit. Any join methods
+ * on the tick query are forwarded so the chain terminates correctly regardless
+ * of how many joins the production query uses.
+ */
+function setupDbMocks(tickRow: TickRow | null, existingLink: string | null = null) {
+  mockDbSelect.mockImplementation(() => ({
+    from: (table: unknown) => {
+      if (table === dbSchema.boardseshTicks) {
+        const tickResults = tickRow ? [tickRow] : [];
+        const chain = {
+          leftJoin: () => chain,
+          where: () => ({ limit: () => Promise.resolve(tickResults) }),
+        };
+        return chain;
+      }
+      if (table === dbSchema.boardBetaLinks) {
+        const linkResults = existingLink ? [{ link: existingLink }] : [];
+        return {
+          where: () => ({ limit: () => Promise.resolve(linkResults) }),
+        };
+      }
+      return { where: () => ({ limit: () => Promise.resolve([]) }) };
+    },
+  }));
 }
 
 describe('resolveBetaLinkTickContext', () => {
@@ -118,42 +129,42 @@ describe('resolveBetaLinkTickContext', () => {
   });
 
   it('throws TICK_NOT_FOUND when the tick UUID does not exist', async () => {
-    stubTickQuery(null);
+    setupDbMocks(null);
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'nonexistent-uuid' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'TICK_NOT_FOUND' } });
   });
 
   it('throws FORBIDDEN when the tick belongs to a different user', async () => {
-    stubTickQuery(makeTick({ userId: 'other-user' }));
+    setupDbMocks(makeTick({ userId: 'other-user' }));
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'FORBIDDEN' } });
   });
 
   it('throws BETA_LINK_TICK_NOT_ASCENT when tick status is attempt', async () => {
-    stubTickQuery(makeTick({ status: 'attempt' }));
+    setupDbMocks(makeTick({ status: 'attempt' }));
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_NOT_ASCENT' } });
   });
 
   it('throws BETA_LINK_TICK_MISMATCH when tick is for a different board type', async () => {
-    stubTickQuery(makeTick({ boardType: 'tension' }));
+    setupDbMocks(makeTick({ boardType: 'tension' }));
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_MISMATCH' } });
   });
 
   it('throws when tick climb UUID does not match the input climb UUID', async () => {
-    stubTickQuery(makeTick({ climbUuid: 'climb-other', canonicalClimbUuid: null, inputCanonicalClimbUuid: null }));
+    setupDbMocks(makeTick({ climbUuid: 'climb-other', canonicalClimbUuid: null, inputCanonicalClimbUuid: null }));
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_MISMATCH' } });
   });
 
   it('throws BETA_LINK_TICK_MISMATCH when the provided angle differs from the tick angle', async () => {
-    stubTickQuery(makeTick({ angle: 40 }));
+    setupDbMocks(makeTick({ angle: 40 }));
     await expect(
       resolveBetaLinkTickContext(
         { boardType: 'kilter', climbUuid: 'climb-1', angle: 45, tickUuid: 'tick-uuid-1' },
@@ -163,8 +174,7 @@ describe('resolveBetaLinkTickContext', () => {
   });
 
   it('does not throw for angle check when no input angle is provided', async () => {
-    stubTickQuery(makeTick({ angle: 40 }));
-    stubBetaLinkCheck(null);
+    setupDbMocks(makeTick({ angle: 40 }));
     const result = await resolveBetaLinkTickContext(
       { boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' },
       'user-1',
@@ -173,16 +183,14 @@ describe('resolveBetaLinkTickContext', () => {
   });
 
   it('throws BETA_LINK_TICK_ALREADY_LINKED when the tick already has a beta video', async () => {
-    stubTickQuery(makeTick());
-    stubBetaLinkCheck('https://www.instagram.com/reel/EXISTING/');
+    setupDbMocks(makeTick(), 'https://www.instagram.com/reel/EXISTING/');
     await expect(
       resolveBetaLinkTickContext({ boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' }, 'user-1'),
     ).rejects.toMatchObject({ extensions: { code: 'BETA_LINK_TICK_ALREADY_LINKED' } });
   });
 
   it('returns full tick context on the happy path', async () => {
-    stubTickQuery(makeTick());
-    stubBetaLinkCheck(null);
+    setupDbMocks(makeTick());
     const result = await resolveBetaLinkTickContext(
       { boardType: 'kilter', climbUuid: 'climb-1', angle: 40, tickUuid: 'tick-uuid-1' },
       'user-1',
@@ -192,9 +200,7 @@ describe('resolveBetaLinkTickContext', () => {
 
   it('accepts both flash and send status ticks', async () => {
     for (const status of ['flash', 'send'] as const) {
-      mockDbSelect.mockReset();
-      stubTickQuery(makeTick({ status }));
-      stubBetaLinkCheck(null);
+      setupDbMocks(makeTick({ status }));
       const result = await resolveBetaLinkTickContext(
         { boardType: 'kilter', climbUuid: 'climb-1', tickUuid: 'tick-uuid-1' },
         'user-1',
@@ -207,10 +213,9 @@ describe('resolveBetaLinkTickContext', () => {
     // tick.climbUuid = 'alias-a' → canonical 'canonical-1'
     // input.climbUuid = 'alias-b' → canonical 'canonical-1'
     // Both resolve to the same canonical — should succeed.
-    stubTickQuery(
+    setupDbMocks(
       makeTick({ climbUuid: 'alias-a', canonicalClimbUuid: 'canonical-1', inputCanonicalClimbUuid: 'canonical-1' }),
     );
-    stubBetaLinkCheck(null);
     const result = await resolveBetaLinkTickContext(
       { boardType: 'kilter', climbUuid: 'alias-b', tickUuid: 'tick-uuid-1' },
       'user-1',
@@ -219,8 +224,7 @@ describe('resolveBetaLinkTickContext', () => {
   });
 
   it('returns angle from the tick, not from the input (tick is authoritative)', async () => {
-    stubTickQuery(makeTick({ angle: 30 }));
-    stubBetaLinkCheck(null);
+    setupDbMocks(makeTick({ angle: 30 }));
     const result = await resolveBetaLinkTickContext(
       // Matching angle passed — stored angle comes from the tick
       { boardType: 'kilter', climbUuid: 'climb-1', angle: 30, tickUuid: 'tick-uuid-1' },

--- a/packages/backend/src/__tests__/widget-rate-limit.test.ts
+++ b/packages/backend/src/__tests__/widget-rate-limit.test.ts
@@ -145,15 +145,12 @@ describe('pruner TTL cutoff', () => {
     // Now fire the prune interval.
     vi.advanceTimersByTime(60_000 + 1); // crosses 5-min boundary from original creation
 
-    // Bucket should still exist (lastRefillMs was reset < 5 min ago).
-    // Bucket had partial refill from the long gap; it may or may not be
-    // throttled — but either way it should NOT return true/true/false of a
-    // freshly-allocated bucket, which would indicate incorrect eviction+realloc.
-    // Instead we just confirm the prune didn't silently reset to full capacity
-    // when it shouldn't have: try to drain, then verify the throttle is in effect.
-    checkWidgetRateLimit('session-refreshed'); // may be allowed
-    checkWidgetRateLimit('session-refreshed'); // may be allowed
-    // After draining at least 2, the next one must be throttled (cap is 2).
+    // Bucket was touched at t≈299s; now at t≈360s, 61s have passed, so it
+    // refills to capacity 2. Both drain calls must succeed (bucket was not
+    // evicted — lastRefillMs was reset well within the 5-min TTL), and the
+    // third must be throttled (cap is 2).
+    expect(checkWidgetRateLimit('session-refreshed')).toBe(true);
+    expect(checkWidgetRateLimit('session-refreshed')).toBe(true);
     expect(checkWidgetRateLimit('session-refreshed')).toBe(false);
   });
 });

--- a/packages/backend/src/__tests__/widget-rate-limit.test.ts
+++ b/packages/backend/src/__tests__/widget-rate-limit.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  checkWidgetRateLimit,
+  ensureWidgetRateLimitPruner,
+  __resetWidgetRateLimitForTests,
+} from '../handlers/widget-rate-limit';
+
+beforeEach(() => {
+  __resetWidgetRateLimitForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  __resetWidgetRateLimitForTests();
+  vi.useRealTimers();
+});
+
+describe('checkWidgetRateLimit', () => {
+  it('allows the first request on a new session and initialises the bucket', () => {
+    expect(checkWidgetRateLimit('session-1')).toBe(true);
+  });
+
+  it('allows the second immediate request (bucket starts at capacity 2)', () => {
+    expect(checkWidgetRateLimit('session-1')).toBe(true);
+    expect(checkWidgetRateLimit('session-1')).toBe(true);
+  });
+
+  it('throttles the third rapid request (both tokens consumed)', () => {
+    checkWidgetRateLimit('session-1');
+    checkWidgetRateLimit('session-1');
+    expect(checkWidgetRateLimit('session-1')).toBe(false);
+  });
+
+  it('refills a token after the expected interval and allows another request', () => {
+    checkWidgetRateLimit('session-1');
+    checkWidgetRateLimit('session-1');
+    // Bucket empty. Advance 1.5 s — enough to refill 1 token (refill rate = 1/1.5 s).
+    vi.advanceTimersByTime(1500);
+    expect(checkWidgetRateLimit('session-1')).toBe(true);
+  });
+
+  it('does not allow a request before a full refill interval', () => {
+    checkWidgetRateLimit('session-1');
+    checkWidgetRateLimit('session-1');
+    // Only 1 s — not enough for even 1 token at 1/1.5 s.
+    vi.advanceTimersByTime(1000);
+    expect(checkWidgetRateLimit('session-1')).toBe(false);
+  });
+
+  it('caps the bucket at capacity 2 regardless of how much time has passed', () => {
+    // One token consumed; advance far beyond full refill.
+    checkWidgetRateLimit('session-1');
+    vi.advanceTimersByTime(60_000);
+    // Bucket should be capped at 2 — so exactly 2 requests are allowed.
+    expect(checkWidgetRateLimit('session-1')).toBe(true);
+    expect(checkWidgetRateLimit('session-1')).toBe(true);
+    expect(checkWidgetRateLimit('session-1')).toBe(false);
+  });
+
+  it('maintains separate buckets per session', () => {
+    checkWidgetRateLimit('session-1');
+    checkWidgetRateLimit('session-1');
+    // session-1 is empty; session-2 starts fresh.
+    expect(checkWidgetRateLimit('session-2')).toBe(true);
+    expect(checkWidgetRateLimit('session-2')).toBe(true);
+    // But session-1 is still throttled.
+    expect(checkWidgetRateLimit('session-1')).toBe(false);
+  });
+
+  it('a fresh session always gets 2 requests regardless of other sessions being throttled', () => {
+    for (let i = 0; i < 10; i++) {
+      checkWidgetRateLimit(`session-${i}`);
+      checkWidgetRateLimit(`session-${i}`);
+      expect(checkWidgetRateLimit(`session-${i}`)).toBe(false);
+    }
+    // Brand-new session is unaffected.
+    expect(checkWidgetRateLimit('session-new')).toBe(true);
+  });
+});
+
+describe('ensureWidgetRateLimitPruner', () => {
+  it('is idempotent — calling it multiple times does not register duplicate intervals', () => {
+    // If setInterval were called twice with the same 5-min period, advancing
+    // 5 min would fire the pruner callback twice. We verify the bucket count
+    // is still correct after the prune by observing behaviour, not internals.
+    ensureWidgetRateLimitPruner();
+    ensureWidgetRateLimitPruner();
+    ensureWidgetRateLimitPruner();
+
+    // Populate a bucket.
+    checkWidgetRateLimit('session-singleton');
+
+    // Advance past TTL (5 min).
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    // The bucket was pruned (session is gone); the next request allocates
+    // a fresh bucket at full capacity.
+    expect(checkWidgetRateLimit('session-singleton')).toBe(true);
+    expect(checkWidgetRateLimit('session-singleton')).toBe(true);
+    expect(checkWidgetRateLimit('session-singleton')).toBe(false);
+  });
+});
+
+describe('pruner TTL cutoff', () => {
+  it('evicts buckets not touched for 5 minutes', () => {
+    ensureWidgetRateLimitPruner();
+
+    checkWidgetRateLimit('session-stale');
+    checkWidgetRateLimit('session-stale');
+    // Bucket is empty.
+
+    // Advance past the TTL so the pruner evicts it.
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    // After eviction the session gets a fresh full-capacity bucket.
+    expect(checkWidgetRateLimit('session-stale')).toBe(true);
+    expect(checkWidgetRateLimit('session-stale')).toBe(true);
+    expect(checkWidgetRateLimit('session-stale')).toBe(false);
+  });
+
+  it('keeps buckets that were recently touched within the TTL', () => {
+    ensureWidgetRateLimitPruner();
+
+    checkWidgetRateLimit('session-active');
+    checkWidgetRateLimit('session-active');
+    // Bucket empty. Advance 4 min (under TTL).
+    vi.advanceTimersByTime(4 * 60 * 1000);
+    // Prune interval is 5 min — nothing pruned yet.
+    // Refill would have given back ~2.67 tokens; consuming all of them.
+    expect(checkWidgetRateLimit('session-active')).toBe(true);
+    expect(checkWidgetRateLimit('session-active')).toBe(true);
+    // 3rd still throttled (capacity = 2).
+    expect(checkWidgetRateLimit('session-active')).toBe(false);
+  });
+
+  it('does not evict a bucket that was touched just before the prune interval fires', () => {
+    ensureWidgetRateLimitPruner();
+
+    // Create bucket, advance to just before the prune fires, touch it.
+    checkWidgetRateLimit('session-refreshed');
+    vi.advanceTimersByTime(4 * 60 * 1000 + 59_000); // ~4m59s
+    // Touch the bucket — resets lastRefillMs.
+    checkWidgetRateLimit('session-refreshed');
+
+    // Now fire the prune interval.
+    vi.advanceTimersByTime(60_000 + 1); // crosses 5-min boundary from original creation
+
+    // Bucket should still exist (lastRefillMs was reset < 5 min ago).
+    // Bucket had partial refill from the long gap; it may or may not be
+    // throttled — but either way it should NOT return true/true/false of a
+    // freshly-allocated bucket, which would indicate incorrect eviction+realloc.
+    // Instead we just confirm the prune didn't silently reset to full capacity
+    // when it shouldn't have: try to drain, then verify the throttle is in effect.
+    checkWidgetRateLimit('session-refreshed'); // may be allowed
+    checkWidgetRateLimit('session-refreshed'); // may be allowed
+    // After draining at least 2, the next one must be throttled (cap is 2).
+    expect(checkWidgetRateLimit('session-refreshed')).toBe(false);
+  });
+});
+
+describe('__resetWidgetRateLimitForTests', () => {
+  it('clears all buckets so a previously throttled session is allowed again', () => {
+    checkWidgetRateLimit('session-reset');
+    checkWidgetRateLimit('session-reset');
+    expect(checkWidgetRateLimit('session-reset')).toBe(false);
+
+    __resetWidgetRateLimitForTests();
+
+    expect(checkWidgetRateLimit('session-reset')).toBe(true);
+  });
+
+  it('stops the pruner so tests can start it again cleanly', () => {
+    ensureWidgetRateLimitPruner();
+    __resetWidgetRateLimitForTests();
+    // If the pruner handle were not cleared, ensureWidgetRateLimitPruner would
+    // skip registering a new one, and the test below would have no pruner to
+    // advance. Verifying it works proves reset cleared the handle.
+    ensureWidgetRateLimitPruner();
+    checkWidgetRateLimit('session-after-reset');
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    // Pruner fires → bucket evicted → fresh allocation.
+    expect(checkWidgetRateLimit('session-after-reset')).toBe(true);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -30,6 +30,8 @@ type BetaLinkResult = {
   thumbnail: string | null;
   isListed: boolean | null;
   createdAt: string | null;
+  tickUuid: string | null;
+  boardId: number | null;
 };
 
 type RecentBetaLinkResult = {
@@ -135,6 +137,8 @@ function passthroughResult(row: Row): BetaLinkResult {
     thumbnail: isOurS3Url(row.thumbnail) ? row.thumbnail : null,
     isListed: row.isListed,
     createdAt: row.createdAt,
+    tickUuid: row.tickUuid,
+    boardId: row.boardId,
   };
 }
 
@@ -192,6 +196,8 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
       thumbnail: row.thumbnail,
       isListed: row.isListed,
       createdAt: row.createdAt,
+      tickUuid: row.tickUuid,
+      boardId: row.boardId,
     };
   }
 
@@ -232,6 +238,8 @@ async function enrichRow(row: Row, cfg: EnrichConfig): Promise<BetaLinkResult | 
     thumbnail,
     isListed: row.isListed,
     createdAt: row.createdAt,
+    tickUuid: row.tickUuid,
+    boardId: row.boardId,
   };
 }
 
@@ -289,6 +297,8 @@ type CachedRecentBetaLinkRow = {
   thumbnail: string | null;
   is_listed: boolean | null;
   created_at: string | null;
+  tick_uuid: string | null;
+  board_id: number | null;
   climb_name: string | null;
   layout_id: number | null;
 };
@@ -311,6 +321,8 @@ async function runRecentBetaLinksQuery(): Promise<CachedRecentBetaLinkRow[]> {
         bl.thumbnail,
         bl.is_listed,
         bl.created_at,
+        bl.tick_uuid,
+        bl.board_id,
         bc.name AS climb_name,
         bc.layout_id AS layout_id,
         ROW_NUMBER() OVER (
@@ -324,7 +336,7 @@ async function runRecentBetaLinksQuery(): Promise<CachedRecentBetaLinkRow[]> {
         AND bl.thumbnail IS NOT NULL
         AND bl.thumbnail LIKE ${`${STATIC_THUMBNAIL_PREFIX}%`}
     )
-    SELECT board_type, climb_uuid, link, foreign_username, angle, thumbnail, is_listed, created_at, climb_name, layout_id
+    SELECT board_type, climb_uuid, link, foreign_username, angle, thumbnail, is_listed, created_at, tick_uuid, board_id, climb_name, layout_id
     FROM ranked
     WHERE foreign_username IS NULL OR user_rank <= ${HOME_PER_USER_CAP}
     ORDER BY created_at DESC
@@ -523,6 +535,8 @@ export const betaLinkQueries = {
           thumbnail: r.thumbnail,
           isListed: r.is_listed,
           createdAt: r.created_at,
+          tickUuid: r.tick_uuid ?? null,
+          boardId: r.board_id ?? null,
         },
         climbName: r.climb_name,
         boardType: r.board_type,

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -64,6 +64,8 @@ type BetaLinkRow = {
   thumbnail: string | null;
   isListed: boolean | null;
   createdAt: string | null;
+  betaLinkTickUuid: string | null;
+  boardId: number | null;
 };
 
 type FeaturedBetaRow = BetaLinkRow & {
@@ -1294,6 +1296,8 @@ function mapBetaLinkRow(row: BetaLinkRow): BetaLinksGqlRow {
     thumbnail: row.thumbnail,
     isListed: row.isListed,
     createdAt: row.createdAt,
+    tickUuid: row.betaLinkTickUuid ?? null,
+    boardId: row.boardId ?? null,
   };
 }
 
@@ -1406,8 +1410,14 @@ function betaCandidateJoinSql() {
     INNER JOIN board_beta_links bl
       ON bl.board_type = t.board_type
       AND bl.climb_uuid = COALESCE(bca_video.canonical_uuid, t.climb_uuid)
-      AND bl.created_by_user_id = t.user_id
-      AND (bl.angle IS NULL OR bl.angle = t.angle)
+      AND (
+        bl.tick_uuid = t.uuid
+        OR (
+          bl.tick_uuid IS NULL
+          AND bl.created_by_user_id = t.user_id
+          AND (bl.angle IS NULL OR bl.angle = t.angle)
+        )
+      )
       AND bl.is_listed IS TRUE
       AND bl.link !~* '^https?://([a-z0-9-]+\\.)*kayaclimb\\.com/'
   `;
@@ -1418,6 +1428,7 @@ function betaCandidateRankSql(partitionExpression: SQL) {
     ROW_NUMBER() OVER (
       PARTITION BY ${partitionExpression}
       ORDER BY
+        (bl.tick_uuid = t.uuid) DESC,
         COALESCE(t.difficulty, ROUND(bcs_beta.display_difficulty)::int, -1) DESC,
         t.climbed_at DESC,
         t.id DESC,
@@ -1446,6 +1457,8 @@ async function fetchSessionFeaturedBetaRows(
         bl.thumbnail,
         bl.is_listed AS "isListed",
         bl.created_at AS "createdAt",
+        bl.tick_uuid AS "betaLinkTickUuid",
+        bl.board_id AS "boardId",
         ${betaCandidateRankSql(sql`t.session_id`)}
       FROM boardsesh_ticks t
       ${betaCandidateJoinSql()}
@@ -1496,6 +1509,8 @@ async function fetchDailyFeaturedBetaRows(
         bl.thumbnail,
         bl.is_listed AS "isListed",
         bl.created_at AS "createdAt",
+        bl.tick_uuid AS "betaLinkTickUuid",
+        bl.board_id AS "boardId",
         ${betaCandidateRankSql(sql`keys.session_id`)}
       FROM keys
       INNER JOIN boardsesh_ticks t

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -41,7 +41,10 @@ export function videoUrlForTickStatus(status: TickStatus, videoUrl: string | nul
   }
 }
 
-export type ShortcodeConflict = { kind: 'none' } | { kind: 'same-climb' } | { kind: 'cross-climb'; climbName: string };
+export type ShortcodeConflict =
+  | { kind: 'none' }
+  | { kind: 'same-climb' }
+  | { kind: 'cross-climb'; climbName: string; existingBoardType: string };
 
 // Looks up whether the same canonical video is already attached anywhere.
 // Returns a structured result so each caller can decide how to handle
@@ -98,15 +101,19 @@ export async function findBetaLinkIdentityConflict(
       sawSameClimb = true;
       continue;
     }
-    return { kind: 'cross-climb', climbName: entry.climbName ?? 'another climb' };
+    return { kind: 'cross-climb', climbName: entry.climbName ?? 'another climb', existingBoardType: entry.boardType };
   }
   if (sawSameClimb) return { kind: 'same-climb' };
   return { kind: 'none' };
 }
 
 const SAME_CLIMB_DUP_MESSAGE = 'We already have this video linked for this climb. Try a different post or reel.';
-const crossClimbDupMessage = (otherClimbName: string): string =>
-  `This video is already attached to "${otherClimbName}". Multi-climb videos are hard to navigate - please post a separate clip for this climb and share that one instead.`;
+const crossClimbDupMessage = (otherClimbName: string, existingBoardType: string, requestedBoardType: string): string => {
+  if (existingBoardType !== requestedBoardType) {
+    return `This video is already attached to "${otherClimbName}" on a different board. A video can only belong to one climb across all boards — please post a separate clip for this climb.`;
+  }
+  return `This video is already attached to "${otherClimbName}". Multi-climb videos are hard to navigate - please post a separate clip for this climb and share that one instead.`;
+};
 
 type EnrichedBetaInsert = {
   thumbnail: string | null;
@@ -194,7 +201,7 @@ export async function validateAndEnrichBetaLinkInsert(
 
   const conflict = await findBetaLinkIdentityConflict(boardType, climbUuid, url);
   if (conflict.kind === 'cross-climb') {
-    throw new InstagramBetaValidationError(crossClimbDupMessage(conflict.climbName));
+    throw new InstagramBetaValidationError(crossClimbDupMessage(conflict.climbName, conflict.existingBoardType, boardType));
   }
   if (conflict.kind === 'same-climb') {
     if (options.onSameClimbDup === 'throw') {
@@ -221,7 +228,7 @@ type BetaLinkTickContext = {
 const tickClimbAlias = aliasedTable(dbSchema.boardClimbAliases, 'beta_link_tick_climb_alias');
 const inputClimbAlias = aliasedTable(dbSchema.boardClimbAliases, 'beta_link_input_climb_alias');
 
-async function resolveBetaLinkTickContext(
+export async function resolveBetaLinkTickContext(
   input: { boardType: string; climbUuid: string; angle?: number | null; tickUuid?: string | null },
   userId: string,
 ): Promise<BetaLinkTickContext> {
@@ -642,6 +649,12 @@ export const tickMutations = {
     const normalizedLink = normalizeBetaVideoUrl(validated.link);
     const userId = ctx.userId!;
     const now = new Date().toISOString();
+
+    // Gate the tick-context DB probe with the write budget so an authenticated
+    // caller cannot enumerate tick UUIDs by watching error variants without
+    // consuming any budget. validateAndEnrichBetaLinkInsert also calls
+    // applyRateLimit (burning a second unit) — both burns are intentional.
+    await applyRateLimit(ctx, 30, 'beta-link-validation');
     const tickContext = await resolveBetaLinkTickContext(validated, userId);
 
     // Validation runs first — it's an outbound HTTP fetch we don't want to

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -650,10 +650,16 @@ export const tickMutations = {
     const userId = ctx.userId!;
     const now = new Date().toISOString();
 
-    // Gate the tick-context DB probe with the write budget so an authenticated
-    // caller cannot enumerate tick UUIDs by watching error variants without
-    // consuming any budget. validateAndEnrichBetaLinkInsert also calls
-    // applyRateLimit (burning a second unit) — both burns are intentional.
+    // Each attachBetaLink call burns 2 rate-limit tokens (effective ceiling:
+    // 15 link-attaches/min per user, not 30):
+    //   1. Here — gates the tick-context DB probe so an authenticated caller
+    //      cannot enumerate tick UUIDs for free by watching which error code
+    //      comes back (TICK_NOT_FOUND vs FORBIDDEN vs BETA_LINK_TICK_MISMATCH).
+    //   2. Inside validateAndEnrichBetaLinkInsert — gates the cross-climb dedup
+    //      probe and the outbound IG validation fetch.
+    // Both burns are intentional. 15 link-attaches/min is well above legitimate
+    // use; the two-token cost is a side effect of the gating architecture, not
+    // a deliberate rate ceiling, but 15/min is still the effective limit.
     await applyRateLimit(ctx, 30, 'beta-link-validation');
     const tickContext = await resolveBetaLinkTickContext(validated, userId);
 

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -81,7 +81,7 @@ export async function findBetaLinkIdentityConflict(
       climbUuid: dbSchema.boardBetaLinks.climbUuid,
     })
     .from(dbSchema.boardBetaLinks)
-    .innerJoin(
+    .leftJoin(
       dbSchema.boardClimbs,
       and(
         eq(dbSchema.boardClimbs.boardType, dbSchema.boardBetaLinks.boardType),
@@ -163,8 +163,16 @@ export type BetaLinkInsertPlan =
 
 export type ValidateAndEnrichOptions = {
   // Decides whether a same-climb video duplicate is fatal (attachBetaLink)
-  // or a silent skip (saveTick). Cross-climb dups are always fatal.
+  // or a silent skip (saveTick).
   onSameClimbDup: 'throw' | 'skip';
+  // Decides what happens when the same video is attached to a *different board
+  // type* (e.g. the video is on a Kilter climb and saveTick is for a Tension
+  // climb). video_identity is global, so a cross-board conflict can occur even
+  // when the user is legitimately attaching beta for a completely different
+  // climb. saveTick passes 'skip' because the video URL is incidental; the
+  // tick itself is still valid. attachBetaLink passes 'throw' (the default)
+  // because the user explicitly chose this URL.
+  onCrossBoardDup?: 'throw' | 'skip';
 };
 
 // Single gated entrypoint for write-time beta-link validation. Steps:
@@ -201,6 +209,10 @@ export async function validateAndEnrichBetaLinkInsert(
 
   const conflict = await findBetaLinkIdentityConflict(boardType, climbUuid, url);
   if (conflict.kind === 'cross-climb') {
+    const isCrossBoard = conflict.existingBoardType !== boardType;
+    if (isCrossBoard && (options.onCrossBoardDup ?? 'throw') === 'skip') {
+      return { action: 'skip-existing' };
+    }
     throw new InstagramBetaValidationError(crossClimbDupMessage(conflict.climbName, conflict.existingBoardType, boardType));
   }
   if (conflict.kind === 'same-climb') {
@@ -229,7 +241,7 @@ const tickClimbAlias = aliasedTable(dbSchema.boardClimbAliases, 'beta_link_tick_
 const inputClimbAlias = aliasedTable(dbSchema.boardClimbAliases, 'beta_link_input_climb_alias');
 
 export async function resolveBetaLinkTickContext(
-  input: { boardType: string; climbUuid: string; angle?: number | null; tickUuid?: string | null },
+  input: { boardType: string; climbUuid: string; angle?: number | null; tickUuid?: string | null; link?: string },
   userId: string,
 ): Promise<BetaLinkTickContext> {
   if (!input.tickUuid) {
@@ -299,6 +311,13 @@ export async function resolveBetaLinkTickContext(
     .where(eq(dbSchema.boardBetaLinks.tickUuid, tick.uuid))
     .limit(1);
   if (existingTickBetaLink) {
+    // Idempotency: if the same canonical video is being re-submitted for the
+    // same tick (e.g. mobile retry after a network blip), treat it as a
+    // no-op success. A different video URL on an already-linked tick is
+    // a genuine conflict and still throws.
+    if (input.link && betaLinkIdentity(input.link) === betaLinkIdentity(existingTickBetaLink.link)) {
+      return { tickUuid: tick.uuid, boardId: tick.boardId, angle: tick.angle };
+    }
     throw new GraphQLError('This tick already has a beta video linked', {
       extensions: { code: 'BETA_LINK_TICK_ALREADY_LINKED' },
     });
@@ -486,9 +505,18 @@ export const tickMutations = {
     // saveTick is treating beta-link attach as an *incidental* side effect of
     // logging a tick, so a same-climb video dup must NOT fail the tick —
     // we'd otherwise reject a perfectly valid tick because the user happened
-    // to leave the video URL in the form. Cross-climb dup is still fatal:
-    // the user explicitly chose this video URL and we want to surface the
-    // friendly "post a separate reel" message.
+    // to leave the video URL in the form.
+    //
+    // video_identity is global (not per board type), so a cross-board dup is
+    // also silently skipped: if the user previously attached this video to a
+    // Kilter climb, a new Tension tick with the same URL is still valid — we
+    // just don't link the beta a second time. Cross-board conflicts are only
+    // fatal for the explicit `attachBetaLink` mutation, where the user made a
+    // deliberate choice.
+    //
+    // Same-board cross-climb dups (same board type, different climb) remain
+    // fatal: the user explicitly chose this URL for this climb and should see
+    // the "post a separate reel" message.
     const tickVideoUrl = videoUrlForTickStatus(validatedInput.status, validatedInput.videoUrl);
     const attachedVideoUrl = tickVideoUrl ? normalizeBetaVideoUrl(tickVideoUrl) : tickVideoUrl;
     const betaPlan: BetaLinkInsertPlan = attachedVideoUrl
@@ -499,6 +527,7 @@ export const tickMutations = {
           attachedVideoUrl,
           {
             onSameClimbDup: 'skip',
+            onCrossBoardDup: 'skip',
           },
         )
       : { action: 'no-url' };
@@ -638,7 +667,10 @@ export const tickMutations = {
 
   /**
    * Attach an Instagram or TikTok video as beta for a climb.
-   * Idempotent on (boardType, climbUuid, link).
+   * Idempotent on (boardType, climbUuid, link) when tickUuid is absent.
+   * When tickUuid is supplied, re-submitting the same canonical video for the
+   * same tick is also idempotent. Submitting a *different* video for an
+   * already-linked tick throws BETA_LINK_TICK_ALREADY_LINKED.
    */
   attachBetaLink: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
@@ -661,7 +693,7 @@ export const tickMutations = {
     // use; the two-token cost is a side effect of the gating architecture, not
     // a deliberate rate ceiling, but 15/min is still the effective limit.
     await applyRateLimit(ctx, 30, 'beta-link-validation');
-    const tickContext = await resolveBetaLinkTickContext(validated, userId);
+    const tickContext = await resolveBetaLinkTickContext({ ...validated, link: normalizedLink }, userId);
 
     // Validation runs first — it's an outbound HTTP fetch we don't want to
     // hold a DB connection open for. attachBetaLink is a deliberate user

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -1,7 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
 import { eq, and, inArray, isNull } from 'drizzle-orm';
+import { aliasedTable } from 'drizzle-orm/alias';
 import { GraphQLError } from 'graphql';
-import type { ConnectionContext, TickStatus } from '@boardsesh/shared-schema';
+import { betaLinkIdentity, type ConnectionContext, type TickStatus } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { sessions } from '../../../db/schema';
@@ -42,18 +43,17 @@ export function videoUrlForTickStatus(status: TickStatus, videoUrl: string | nul
 
 export type ShortcodeConflict = { kind: 'none' } | { kind: 'same-climb' } | { kind: 'cross-climb'; climbName: string };
 
-// Looks up whether the same Instagram shortcode is already attached to any
-// climb on this board. Returns a structured result so each caller can decide
-// how to handle conflicts (attachBetaLink throws on both kinds; saveTick
-// treats same-climb as a silent skip since the user just wanted to log a
-// climb, not re-attach beta).
+// Looks up whether the same canonical video is already attached anywhere.
+// Returns a structured result so each caller can decide how to handle
+// conflicts (attachBetaLink throws on both kinds; saveTick treats same-climb as
+// a silent skip since the user just wanted to log a climb, not re-attach beta).
 //
-// Uses the indexed `shortcode` column added in 0089_renumber_dedup_index for
-// an exact-match lookup — no LIKE prefilter, no JS post-filter.
+// Uses the indexed `video_identity` column for an exact-match lookup — no LIKE
+// prefilter, no JS post-filter.
 //
-// Race: two concurrent attaches of the same shortcode can both pass this
-// check. The (boardType, climbUuid, link) PK + onConflictDoNothing makes
-// the loser a silent no-op rather than a duplicate row. The loser misses
+// Race: two concurrent attaches of the same canonical video can both pass this
+// check. The partial unique index on `video_identity` + onConflictDoNothing
+// makes the loser a silent no-op rather than a duplicate row. The loser misses
 // the friendly "already linked" toast — accepted trade-off, see PR #1727
 // review notes.
 export async function findInstagramShortcodeConflict(
@@ -61,11 +61,19 @@ export async function findInstagramShortcodeConflict(
   selectedClimbUuid: string,
   instagramUrl: string,
 ): Promise<ShortcodeConflict> {
-  const incomingShortcode = getInstagramMediaId(instagramUrl);
-  if (!incomingShortcode) return { kind: 'none' };
+  return findBetaLinkIdentityConflict(boardType, selectedClimbUuid, instagramUrl);
+}
+
+export async function findBetaLinkIdentityConflict(
+  boardType: string,
+  selectedClimbUuid: string,
+  videoUrl: string,
+): Promise<ShortcodeConflict> {
+  const incomingVideoIdentity = betaLinkIdentity(videoUrl);
 
   const existingLinks = await db
     .select({
+      boardType: dbSchema.boardBetaLinks.boardType,
       climbName: dbSchema.boardClimbs.name,
       climbUuid: dbSchema.boardBetaLinks.climbUuid,
     })
@@ -77,19 +85,16 @@ export async function findInstagramShortcodeConflict(
         eq(dbSchema.boardClimbs.uuid, dbSchema.boardBetaLinks.climbUuid),
       ),
     )
-    .where(
-      and(eq(dbSchema.boardBetaLinks.boardType, boardType), eq(dbSchema.boardBetaLinks.shortcode, incomingShortcode)),
-    );
+    .where(eq(dbSchema.boardBetaLinks.videoIdentity, incomingVideoIdentity));
 
-  // Scan every match before deciding. If the same shortcode is attached to
-  // *both* the selected climb and a different climb (from a prior race or
-  // data drift), the saveTick path's `onSameClimbDup: 'skip'` would
-  // otherwise silently no-op when a same-climb row happens to come back
-  // first — letting a known cross-climb dup pass through. Cross-climb
-  // conflicts must always win.
+  // Scan every match before deciding. If the same video is attached to *both*
+  // the selected climb and a different climb (from a prior race or data drift),
+  // the saveTick path's `onSameClimbDup: 'skip'` would otherwise silently no-op
+  // when a same-climb row happens to come back first — letting a known
+  // cross-climb dup pass through. Cross-climb conflicts must always win.
   let sawSameClimb = false;
   for (const entry of existingLinks) {
-    if (entry.climbUuid === selectedClimbUuid) {
+    if (entry.boardType === boardType && entry.climbUuid === selectedClimbUuid) {
       sawSameClimb = true;
       continue;
     }
@@ -99,10 +104,9 @@ export async function findInstagramShortcodeConflict(
   return { kind: 'none' };
 }
 
-const SAME_CLIMB_DUP_MESSAGE =
-  'We already have this Instagram video linked for this climb. Try a different post or reel.';
+const SAME_CLIMB_DUP_MESSAGE = 'We already have this video linked for this climb. Try a different post or reel.';
 const crossClimbDupMessage = (otherClimbName: string): string =>
-  `This Instagram post is already attached to "${otherClimbName}". Multi-climb slideshows are hard to navigate — please post a separate reel for this climb and share that one instead.`;
+  `This video is already attached to "${otherClimbName}". Multi-climb videos are hard to navigate - please post a separate clip for this climb and share that one instead.`;
 
 type EnrichedBetaInsert = {
   thumbnail: string | null;
@@ -137,7 +141,7 @@ export type BetaLinkInsertPlan =
   // Insert the row. For non-Instagram URLs (TikTok et al.) the enrichment
   // fields are null — the read-time resolver will fill them in lazily.
   | { action: 'insert'; thumbnail: string | null; foreignUsername: string | null }
-  // The shortcode is already attached to *this* climb. saveTick treats this
+  // The canonical video is already attached to *this* climb. saveTick treats this
   // as a silent skip (the user logged a climb; the video URL is incidental
   // and the existing row covers it). attachBetaLink should pass
   // `onSameClimbDup: 'throw'` and never observe this case.
@@ -151,7 +155,7 @@ export type BetaLinkInsertPlan =
   | { action: 'no-url' };
 
 export type ValidateAndEnrichOptions = {
-  // Decides whether a same-climb shortcode duplicate is fatal (attachBetaLink)
+  // Decides whether a same-climb video duplicate is fatal (attachBetaLink)
   // or a silent skip (saveTick). Cross-climb dups are always fatal.
   onSameClimbDup: 'throw' | 'skip';
 };
@@ -159,15 +163,15 @@ export type ValidateAndEnrichOptions = {
 // Single gated entrypoint for write-time beta-link validation. Steps:
 //   1. Apply the per-user rate limit on beta-link writes — 30/min, well above
 //      legitimate use, well below what would let a caller spam writes or
-//      probe IG shortcode existence at scale via the dedup query below.
+//      probe video existence at scale via the dedup query below.
 //      The limit gates the DB probe, the outbound IG fetch, AND non-IG
 //      (TikTok et al.) write paths so every beta-link attach burns budget.
-//   2. Non-Instagram URLs (TikTok, etc.) bypass the deep checks and return
-//      `action: 'insert'` with null enrichment — the read-time `betaLinks`
-//      resolver will enrich them lazily.
-//   3. Run the cross-climb dedup check. Cross-climb dup -> friendly error
+//   2. Run the cross-climb dedup check. Cross-climb dup -> friendly error
 //      via InstagramBetaValidationError. Same-climb dup -> branch on the
 //      caller's `onSameClimbDup`.
+//   3. Non-Instagram URLs (TikTok, etc.) return `action: 'insert'` with null
+//      enrichment after dedup — the read-time `betaLinks` resolver enriches
+//      them lazily.
 //   4. Fetch the canonical post page, validate it's public + the caption
 //      mentions the climb name.
 //   5. Eagerly cache the thumbnail to S3 if configured (best-effort; the
@@ -183,16 +187,12 @@ export async function validateAndEnrichBetaLinkInsert(
 ): Promise<BetaLinkInsertPlan> {
   // Rate limit BEFORE branching on platform so TikTok / future non-IG
   // platforms get the same write-budget as IG. Also runs before the dedup
-  // probe so an authenticated caller can't enumerate "is this IG shortcode
+  // probe so an authenticated caller can't enumerate "is this video
   // attached anywhere?" by watching the error variant (cross-climb vs
   // same-climb vs none) without consuming budget. See review of PR #1745.
   await applyRateLimit(ctx, 30, 'beta-link-validation');
 
-  if (!isInstagramUrl(url)) {
-    return { action: 'insert', thumbnail: null, foreignUsername: null };
-  }
-
-  const conflict = await findInstagramShortcodeConflict(boardType, climbUuid, url);
+  const conflict = await findBetaLinkIdentityConflict(boardType, climbUuid, url);
   if (conflict.kind === 'cross-climb') {
     throw new InstagramBetaValidationError(crossClimbDupMessage(conflict.climbName));
   }
@@ -203,9 +203,101 @@ export async function validateAndEnrichBetaLinkInsert(
     return { action: 'skip-existing' };
   }
 
+  if (!isInstagramUrl(url)) {
+    return { action: 'insert', thumbnail: null, foreignUsername: null };
+  }
+
   const metadata = await validateInstagramBetaLink(url);
   const enriched = await enrichInstagramBetaInsert(metadata);
   return { action: 'insert', thumbnail: enriched.thumbnail, foreignUsername: enriched.foreignUsername };
+}
+
+type BetaLinkTickContext = {
+  tickUuid: string | null;
+  boardId: number | null;
+  angle: number | null;
+};
+
+const tickClimbAlias = aliasedTable(dbSchema.boardClimbAliases, 'beta_link_tick_climb_alias');
+const inputClimbAlias = aliasedTable(dbSchema.boardClimbAliases, 'beta_link_input_climb_alias');
+
+async function resolveBetaLinkTickContext(
+  input: { boardType: string; climbUuid: string; angle?: number | null; tickUuid?: string | null },
+  userId: string,
+): Promise<BetaLinkTickContext> {
+  if (!input.tickUuid) {
+    return { tickUuid: null, boardId: null, angle: input.angle ?? null };
+  }
+
+  const [tick] = await db
+    .select({
+      uuid: dbSchema.boardseshTicks.uuid,
+      userId: dbSchema.boardseshTicks.userId,
+      boardType: dbSchema.boardseshTicks.boardType,
+      climbUuid: dbSchema.boardseshTicks.climbUuid,
+      canonicalClimbUuid: tickClimbAlias.canonicalUuid,
+      inputCanonicalClimbUuid: inputClimbAlias.canonicalUuid,
+      angle: dbSchema.boardseshTicks.angle,
+      status: dbSchema.boardseshTicks.status,
+      boardId: dbSchema.boardseshTicks.boardId,
+    })
+    .from(dbSchema.boardseshTicks)
+    .leftJoin(
+      tickClimbAlias,
+      and(
+        eq(tickClimbAlias.boardType, dbSchema.boardseshTicks.boardType),
+        eq(tickClimbAlias.aliasUuid, dbSchema.boardseshTicks.climbUuid),
+      ),
+    )
+    .leftJoin(
+      inputClimbAlias,
+      and(eq(inputClimbAlias.boardType, input.boardType), eq(inputClimbAlias.aliasUuid, input.climbUuid)),
+    )
+    .where(eq(dbSchema.boardseshTicks.uuid, input.tickUuid))
+    .limit(1);
+
+  if (!tick) {
+    throw new GraphQLError('Tick not found', { extensions: { code: 'TICK_NOT_FOUND' } });
+  }
+  if (tick.userId !== userId) {
+    throw new GraphQLError('You can only attach beta to your own ticks', { extensions: { code: 'FORBIDDEN' } });
+  }
+  if (tick.status === 'attempt') {
+    throw new GraphQLError('Beta videos can only be attached to sends or flashes', {
+      extensions: { code: 'BETA_LINK_TICK_NOT_ASCENT' },
+    });
+  }
+  if (tick.boardType !== input.boardType) {
+    throw new GraphQLError('The selected tick is for a different board type', {
+      extensions: { code: 'BETA_LINK_TICK_MISMATCH' },
+    });
+  }
+
+  const canonicalTickClimbUuid = tick.canonicalClimbUuid ?? tick.climbUuid;
+  const canonicalInputClimbUuid = tick.inputCanonicalClimbUuid ?? input.climbUuid;
+  if (canonicalTickClimbUuid !== canonicalInputClimbUuid) {
+    throw new GraphQLError('The selected tick is for a different climb', {
+      extensions: { code: 'BETA_LINK_TICK_MISMATCH' },
+    });
+  }
+  if (input.angle != null && input.angle !== tick.angle) {
+    throw new GraphQLError('The selected tick is for a different angle', {
+      extensions: { code: 'BETA_LINK_TICK_MISMATCH' },
+    });
+  }
+
+  const [existingTickBetaLink] = await db
+    .select({ link: dbSchema.boardBetaLinks.link })
+    .from(dbSchema.boardBetaLinks)
+    .where(eq(dbSchema.boardBetaLinks.tickUuid, tick.uuid))
+    .limit(1);
+  if (existingTickBetaLink) {
+    throw new GraphQLError('This tick already has a beta video linked', {
+      extensions: { code: 'BETA_LINK_TICK_ALREADY_LINKED' },
+    });
+  }
+
+  return { tickUuid: tick.uuid, boardId: tick.boardId, angle: tick.angle };
 }
 
 export const tickMutations = {
@@ -379,14 +471,13 @@ export const tickMutations = {
       );
     }
 
-    // Run write-time Instagram validation before opening the transaction so a
+    // Run write-time beta-link validation before opening the transaction so a
     // bad video URL doesn't leave a half-state. Zod already validated the
-    // surface shape; the helper confirms the post is actually public, mentions
-    // the climb name, and isn't already attached to another climb. TikTok and
-    // other supported platforms skip the deep validation.
+    // surface shape; Instagram gets deep public/caption validation, while
+    // TikTok and other supported platforms skip platform metadata validation.
     //
     // saveTick is treating beta-link attach as an *incidental* side effect of
-    // logging a tick, so a same-climb shortcode dup must NOT fail the tick —
+    // logging a tick, so a same-climb video dup must NOT fail the tick —
     // we'd otherwise reject a perfectly valid tick because the user happened
     // to leave the video URL in the form. Cross-climb dup is still fatal:
     // the user explicitly chose this video URL and we want to surface the
@@ -451,6 +542,9 @@ export const tickMutations = {
             climbUuid: validatedInput.climbUuid,
             link: attachedVideoUrl,
             shortcode: getInstagramMediaId(attachedVideoUrl),
+            videoIdentity: betaLinkIdentity(attachedVideoUrl),
+            tickUuid: createdTick.uuid,
+            boardId: createdTick.boardId,
             angle: validatedInput.angle,
             isListed: true,
             thumbnail: betaPlan.thumbnail,
@@ -536,7 +630,7 @@ export const tickMutations = {
   },
 
   /**
-   * Attach an Instagram post or reel as beta for a climb.
+   * Attach an Instagram or TikTok video as beta for a climb.
    * Idempotent on (boardType, climbUuid, link).
    */
   attachBetaLink: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext): Promise<boolean> => {
@@ -548,10 +642,11 @@ export const tickMutations = {
     const normalizedLink = normalizeBetaVideoUrl(validated.link);
     const userId = ctx.userId!;
     const now = new Date().toISOString();
+    const tickContext = await resolveBetaLinkTickContext(validated, userId);
 
     // Validation runs first — it's an outbound HTTP fetch we don't want to
     // hold a DB connection open for. attachBetaLink is a deliberate user
-    // action so a same-climb shortcode dup is fatal (the user gets the
+    // action so a same-climb video dup is fatal (the user gets the
     // friendly "already linked" message); cross-climb dup is also fatal.
     // The catch on the insert covers the rare case where validation passed
     // but the write fails (constraint, connection drop), surfacing an
@@ -579,7 +674,10 @@ export const tickMutations = {
           climbUuid: validated.climbUuid,
           link: normalizedLink,
           shortcode: getInstagramMediaId(normalizedLink),
-          angle: validated.angle ?? null,
+          videoIdentity: betaLinkIdentity(normalizedLink),
+          tickUuid: tickContext.tickUuid,
+          boardId: tickContext.boardId,
+          angle: tickContext.angle,
           isListed: true,
           thumbnail: betaPlan.thumbnail,
           foreignUsername: betaPlan.foreignUsername,

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -64,6 +64,7 @@ export const AttachBetaLinkInputSchema = z.object({
   climbUuid: ExternalUUIDSchema,
   link: z.string().max(500).regex(BETA_VIDEO_URL_REGEX, BETA_VIDEO_URL_VALIDATION_MESSAGE),
   angle: z.number().int().min(0).max(90).optional().nullable(),
+  tickUuid: UUIDSchema.optional().nullable(),
 });
 
 /**

--- a/packages/backend/src/validation/schemas/ticks.ts
+++ b/packages/backend/src/validation/schemas/ticks.ts
@@ -63,6 +63,9 @@ export const AttachBetaLinkInputSchema = z.object({
   boardType: BoardNameSchema,
   climbUuid: ExternalUUIDSchema,
   link: z.string().max(500).regex(BETA_VIDEO_URL_REGEX, BETA_VIDEO_URL_VALIDATION_MESSAGE),
+  // When tickUuid is provided the stored angle comes from the resolved tick,
+  // not from this field. Clients may omit angle in that case. If both are
+  // supplied and disagree, the resolver throws BETA_LINK_TICK_MISMATCH.
   angle: z.number().int().min(0).max(90).optional().nullable(),
   tickUuid: UUIDSchema.optional().nullable(),
 });

--- a/packages/db/drizzle/0128_direct_beta_tick_links.sql
+++ b/packages/db/drizzle/0128_direct_beta_tick_links.sql
@@ -1,0 +1,109 @@
+ALTER TABLE "board_beta_links" ADD COLUMN IF NOT EXISTS "tick_uuid" text;--> statement-breakpoint
+ALTER TABLE "board_beta_links" ADD COLUMN IF NOT EXISTS "board_id" bigint;--> statement-breakpoint
+ALTER TABLE "board_beta_links" ADD COLUMN IF NOT EXISTS "video_identity" text;--> statement-breakpoint
+
+WITH parsed_links AS (
+  SELECT
+    ctid AS row_id,
+    link,
+    regexp_match(link, '^https://(www\.)?(instagram\.com|instagr\.am)/(p|reel|tv)/([[:alnum:]_-]+)/?([?#].*)?$', 'i') AS instagram_match,
+    regexp_match(link, '^https://([a-z0-9-]+\.)*tiktok\.com/@[A-Za-z0-9_.-]+/video/([0-9]+)', 'i') AS tiktok_match
+  FROM board_beta_links
+),
+identity_candidates AS (
+  SELECT
+    row_id,
+    CASE
+      WHEN instagram_match IS NOT NULL THEN 'instagram:' || instagram_match[4]
+      WHEN tiktok_match IS NOT NULL THEN 'tiktok:' || tiktok_match[2]
+      ELSE 'raw:' || link
+    END AS video_identity
+  FROM parsed_links
+),
+ranked_identities AS (
+  SELECT
+    bl.ctid AS row_id,
+    identity_candidates.video_identity,
+    row_number() OVER (
+      PARTITION BY identity_candidates.video_identity
+      ORDER BY
+        (bl.created_by_user_id IS NOT NULL) DESC,
+        bl.created_at DESC NULLS LAST,
+        (bl.thumbnail IS NOT NULL) DESC,
+        bl.board_type,
+        bl.climb_uuid,
+        bl.link
+    ) AS identity_rank
+  FROM board_beta_links bl
+  INNER JOIN identity_candidates ON identity_candidates.row_id = bl.ctid
+)
+UPDATE board_beta_links bl
+SET video_identity = ranked_identities.video_identity
+FROM ranked_identities
+WHERE bl.ctid = ranked_identities.row_id
+  AND ranked_identities.identity_rank = 1;--> statement-breakpoint
+
+WITH beta_candidates AS (
+  SELECT
+    bl.ctid AS beta_row_id,
+    t.uuid AS tick_uuid,
+    t.board_id AS board_id,
+    count(*) OVER (PARTITION BY bl.ctid) AS beta_candidate_count,
+    count(*) OVER (PARTITION BY t.uuid) AS tick_candidate_count
+  FROM board_beta_links bl
+  INNER JOIN boardsesh_ticks t
+    ON t.user_id = bl.created_by_user_id
+    AND t.board_type = bl.board_type
+    AND t.status IN ('flash', 'send')
+    AND (bl.angle IS NULL OR bl.angle = t.angle)
+  LEFT JOIN board_climb_aliases bca_tick
+    ON bca_tick.board_type = t.board_type
+    AND bca_tick.alias_uuid = t.climb_uuid
+  WHERE bl.video_identity IS NOT NULL
+    AND bl.created_by_user_id IS NOT NULL
+    AND COALESCE(bca_tick.canonical_uuid, t.climb_uuid) = bl.climb_uuid
+),
+safe_matches AS (
+  SELECT beta_row_id, tick_uuid, board_id
+  FROM beta_candidates
+  WHERE beta_candidate_count = 1
+    AND tick_candidate_count = 1
+)
+UPDATE board_beta_links bl
+SET
+  tick_uuid = safe_matches.tick_uuid,
+  board_id = safe_matches.board_id
+FROM safe_matches
+WHERE bl.ctid = safe_matches.beta_row_id;--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'board_beta_links_tick_uuid_boardsesh_ticks_uuid_fk'
+      AND conrelid = '"board_beta_links"'::regclass
+  ) THEN
+    ALTER TABLE "board_beta_links"
+      ADD CONSTRAINT "board_beta_links_tick_uuid_boardsesh_ticks_uuid_fk"
+      FOREIGN KEY ("tick_uuid") REFERENCES "public"."boardsesh_ticks"("uuid") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'board_beta_links_board_id_user_boards_id_fk'
+      AND conrelid = '"board_beta_links"'::regclass
+  ) THEN
+    ALTER TABLE "board_beta_links"
+      ADD CONSTRAINT "board_beta_links_board_id_user_boards_id_fk"
+      FOREIGN KEY ("board_id") REFERENCES "public"."user_boards"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "board_beta_links_video_identity_unique" ON "board_beta_links" USING btree ("video_identity") WHERE "board_beta_links"."video_identity" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "board_beta_links_tick_uuid_unique" ON "board_beta_links" USING btree ("tick_uuid") WHERE "board_beta_links"."tick_uuid" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "board_beta_links_board_id_idx" ON "board_beta_links" USING btree ("board_id") WHERE "board_beta_links"."board_id" IS NOT NULL;

--- a/packages/db/drizzle/0128_direct_beta_tick_links.sql
+++ b/packages/db/drizzle/0128_direct_beta_tick_links.sql
@@ -41,7 +41,22 @@ UPDATE board_beta_links bl
 SET video_identity = ranked_identities.video_identity
 FROM ranked_identities
 WHERE bl.ctid = ranked_identities.row_id
-  AND ranked_identities.identity_rank = 1;--> statement-breakpoint
+  AND ranked_identities.identity_rank = 1;
+-- NOTE: only the rank-1 winner per video_identity gets backfilled above.
+-- Loser rows (duplicate links resolving to the same identity) are left with
+-- video_identity = NULL so they are invisible to the partial unique index.
+-- They do not cause constraint violations but are stale. A follow-up
+-- cleanup migration should delete them with:
+--   DELETE FROM board_beta_links loser
+--   WHERE loser.video_identity IS NULL
+--     AND EXISTS (
+--       SELECT 1 FROM board_beta_links winner
+--       WHERE winner.video_identity IS NOT NULL
+--         AND winner.video_identity = <computed identity for loser.link>
+--     );
+-- That migration requires re-running the same regexp_match logic from the
+-- identity_candidates CTE above, scoped to WHERE video_identity IS NULL.
+--> statement-breakpoint
 
 WITH beta_candidates AS (
   SELECT

--- a/packages/db/drizzle/meta/0128_snapshot.json
+++ b/packages/db/drizzle/meta/0128_snapshot.json
@@ -1,0 +1,9497 @@
+{
+  "id": "1b27710d-0d3b-4d2e-99c6-a4e8f395a073",
+  "prevId": "fc15f1a5-92c6-480b-b75f-e2d504a71bb2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.board_attempts": {
+      "name": "board_attempts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_attempts_board_type_id_pk": {
+          "name": "board_attempts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_beta_links": {
+      "name": "board_beta_links",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "foreign_username": {
+          "name": "foreign_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tick_uuid": {
+          "name": "tick_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_identity": {
+          "name": "video_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_beta_links_shortcode_idx": {
+          "name": "board_beta_links_shortcode_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shortcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_beta_links\".\"shortcode\" IS NOT NULL",
+          "concurrently": false
+        },
+        "board_beta_links_created_by_idx": {
+          "name": "board_beta_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_beta_links\".\"created_by_user_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "board_beta_links_video_identity_unique": {
+          "name": "board_beta_links_video_identity_unique",
+          "columns": [
+            {
+              "expression": "video_identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_beta_links\".\"video_identity\" IS NOT NULL",
+          "concurrently": false
+        },
+        "board_beta_links_tick_uuid_unique": {
+          "name": "board_beta_links_tick_uuid_unique",
+          "columns": [
+            {
+              "expression": "tick_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_beta_links\".\"tick_uuid\" IS NOT NULL",
+          "concurrently": false
+        },
+        "board_beta_links_board_id_idx": {
+          "name": "board_beta_links_board_id_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_beta_links\".\"board_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_beta_links_board_type_climb_uuid_link_pk": {
+          "name": "board_beta_links_board_type_climb_uuid_link_pk",
+          "columns": ["board_type", "climb_uuid", "link"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits": {
+      "name": "board_circuits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_user_fk": {
+          "name": "board_circuits_user_fk",
+          "tableFrom": "board_circuits",
+          "columnsFrom": ["board_type", "user_id"],
+          "tableTo": "board_users",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_board_type_uuid_pk": {
+          "name": "board_circuits_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_circuits_climbs": {
+      "name": "board_circuits_climbs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "circuit_uuid": {
+          "name": "circuit_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_circuits_climbs_circuit_fk": {
+          "name": "board_circuits_climbs_circuit_fk",
+          "tableFrom": "board_circuits_climbs",
+          "columnsFrom": ["board_type", "circuit_uuid"],
+          "tableTo": "board_circuits",
+          "columnsTo": ["board_type", "uuid"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_circuits_climbs_climb_fk": {
+          "name": "board_circuits_climbs_climb_fk",
+          "tableFrom": "board_circuits_climbs",
+          "columnsFrom": ["climb_uuid"],
+          "tableTo": "board_climbs",
+          "columnsTo": ["uuid"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk": {
+          "name": "board_circuits_climbs_board_type_circuit_uuid_climb_uuid_pk",
+          "columns": ["board_type", "circuit_uuid", "climb_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_aliases": {
+      "name": "board_climb_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_uuid": {
+          "name": "alias_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_uuid": {
+          "name": "canonical_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_aliases_canonical_idx": {
+          "name": "board_climb_aliases_canonical_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_climb_aliases_canonical_fk": {
+          "name": "board_climb_aliases_canonical_fk",
+          "tableFrom": "board_climb_aliases",
+          "columnsFrom": ["canonical_uuid"],
+          "tableTo": "board_climbs",
+          "columnsTo": ["uuid"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_aliases_board_type_alias_uuid_pk": {
+          "name": "board_climb_aliases_board_type_alias_uuid_pk",
+          "columns": ["board_type", "alias_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_aliases_uuids_non_empty": {
+          "name": "board_climb_aliases_uuids_non_empty",
+          "value": "\"board_climb_aliases\".\"alias_uuid\" <> '' AND \"board_climb_aliases\".\"canonical_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_holds": {
+      "name": "board_climb_holds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_number": {
+          "name": "frame_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_state": {
+          "name": "hold_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_holds_search_idx": {
+          "name": "board_climb_holds_search_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_climb_holds_climb_fk": {
+          "name": "board_climb_holds_climb_fk",
+          "tableFrom": "board_climb_holds",
+          "columnsFrom": ["climb_uuid"],
+          "tableTo": "board_climbs",
+          "columnsTo": ["uuid"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_climb_holds_board_type_climb_uuid_hold_id_pk": {
+          "name": "board_climb_holds_board_type_climb_uuid_hold_id_pk",
+          "columns": ["board_type", "climb_uuid", "hold_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_ratings": {
+      "name": "board_climb_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_grade_id": {
+          "name": "difficulty_grade_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_ratings_user_climb_angle_idx": {
+          "name": "board_climb_ratings_user_climb_angle_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climb_ratings_kilter_id_unique": {
+          "name": "board_climb_ratings_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "board_climb_ratings_aurora_id_unique": {
+          "name": "board_climb_ratings_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_climb_ratings\".\"aurora_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "board_climb_ratings_user_kilter_idx": {
+          "name": "board_climb_ratings_user_kilter_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_climb_ratings\".\"kilter_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_climb_ratings_user_id_users_id_fk": {
+          "name": "board_climb_ratings_user_id_users_id_fk",
+          "tableFrom": "board_climb_ratings",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_climb_ratings_rating_range": {
+          "name": "board_climb_ratings_rating_range",
+          "value": "\"board_climb_ratings\".\"rating\" IS NULL OR (\"board_climb_ratings\".\"rating\" >= 1 AND \"board_climb_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats": {
+      "name": "board_climb_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_ascensionist_count": {
+          "name": "aurora_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_ascensionist_count": {
+          "name": "kilter_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardsesh_ascensionist_count": {
+          "name": "boardsesh_ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_normalized": {
+          "name": "quality_normalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_stats_board_type_climb_uuid_angle_pk": {
+          "name": "board_climb_stats_board_type_climb_uuid_angle_pk",
+          "columns": ["board_type", "climb_uuid", "angle"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_stats_history": {
+      "name": "board_climb_stats_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_difficulty": {
+          "name": "display_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_difficulty": {
+          "name": "benchmark_difficulty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ascensionist_count": {
+          "name": "ascensionist_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty_average": {
+          "name": "difficulty_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_average": {
+          "name": "quality_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_username": {
+          "name": "fa_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fa_at": {
+          "name": "fa_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_stats_history_lookup_idx": {
+          "name": "board_climb_stats_history_lookup_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climbs": {
+      "name": "board_climbs",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_id": {
+          "name": "setter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_count": {
+          "name": "frames_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "frames_pace": {
+          "name": "frames_pace",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_set_ids": {
+          "name": "required_set_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compatible_size_ids": {
+          "name": "compatible_size_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_fingerprint": {
+          "name": "hold_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_climbs_board_type_idx": {
+          "name": "board_climbs_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climbs_hold_fingerprint_idx": {
+          "name": "board_climbs_hold_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climbs_search_filter_idx": {
+          "name": "board_climbs_search_filter_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_draft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "frames_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_left",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_right",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_bottom",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "edge_top",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climbs_setter_username_idx": {
+          "name": "board_climbs_setter_username_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climbs_user_id_idx": {
+          "name": "board_climbs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"board_climbs\".\"user_id\" IS NOT NULL AND \"board_climbs\".\"is_draft\" = false",
+          "concurrently": false
+        },
+        "board_climbs_name_idx": {
+          "name": "board_climbs_name_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_climbs_user_id_users_id_fk": {
+          "name": "board_climbs_user_id_users_id_fk",
+          "tableFrom": "board_climbs",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_difficulty_grades": {
+      "name": "board_difficulty_grades",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boulder_name": {
+          "name": "boulder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_name": {
+          "name": "route_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_difficulty_grades_board_type_difficulty_pk": {
+          "name": "board_difficulty_grades_board_type_difficulty_pk",
+          "columns": ["board_type", "difficulty"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_holes": {
+      "name": "board_holes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored_hole_id": {
+          "name": "mirrored_hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror_group": {
+          "name": "mirror_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_holes_product_fk": {
+          "name": "board_holes_product_fk",
+          "tableFrom": "board_holes",
+          "columnsFrom": ["board_type", "product_id"],
+          "tableTo": "board_products",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_holes_board_type_id_pk": {
+          "name": "board_holes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_kits": {
+      "name": "board_kits",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_autoconnect": {
+          "name": "is_autoconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_kits_board_type_serial_number_pk": {
+          "name": "board_kits_board_type_serial_number_pk",
+          "columns": ["board_type", "serial_number"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_layout_aliases": {
+      "name": "board_layout_aliases",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_uuid": {
+          "name": "layout_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_layout_aliases_layout_idx": {
+          "name": "board_layout_aliases_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_layout_aliases_layout_fk": {
+          "name": "board_layout_aliases_layout_fk",
+          "tableFrom": "board_layout_aliases",
+          "columnsFrom": ["board_type", "layout_id"],
+          "tableTo": "board_layouts",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layout_aliases_board_type_layout_uuid_pk": {
+          "name": "board_layout_aliases_board_type_layout_uuid_pk",
+          "columns": ["board_type", "layout_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "board_layout_aliases_uuid_non_empty": {
+          "name": "board_layout_aliases_uuid_non_empty",
+          "value": "\"board_layout_aliases\".\"layout_uuid\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.board_layouts": {
+      "name": "board_layouts",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_caption": {
+          "name": "instagram_caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mirrored": {
+          "name": "is_mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_layouts_product_fk": {
+          "name": "board_layouts_product_fk",
+          "tableFrom": "board_layouts",
+          "columnsFrom": ["board_type", "product_id"],
+          "tableTo": "board_products",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_layouts_board_type_id_pk": {
+          "name": "board_layouts_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_leds": {
+      "name": "board_leds",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_leds_product_size_fk": {
+          "name": "board_leds_product_size_fk",
+          "tableFrom": "board_leds",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "tableTo": "board_product_sizes",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_leds_hole_fk": {
+          "name": "board_leds_hole_fk",
+          "tableFrom": "board_leds",
+          "columnsFrom": ["board_type", "hole_id"],
+          "tableTo": "board_holes",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_leds_board_type_id_pk": {
+          "name": "board_leds_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placement_roles": {
+      "name": "board_placement_roles",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "led_color": {
+          "name": "led_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_color": {
+          "name": "screen_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_placement_roles_product_fk": {
+          "name": "board_placement_roles_product_fk",
+          "tableFrom": "board_placement_roles",
+          "columnsFrom": ["board_type", "product_id"],
+          "tableTo": "board_products",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placement_roles_board_type_id_pk": {
+          "name": "board_placement_roles_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_placements": {
+      "name": "board_placements",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hole_id": {
+          "name": "hole_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_placement_role_id": {
+          "name": "default_placement_role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_placements_board_type_layout_id_set_hole_idx": {
+          "name": "board_placements_board_type_layout_id_set_hole_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hole_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_placements_layout_fk": {
+          "name": "board_placements_layout_fk",
+          "tableFrom": "board_placements",
+          "columnsFrom": ["board_type", "layout_id"],
+          "tableTo": "board_layouts",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_placements_hole_fk": {
+          "name": "board_placements_hole_fk",
+          "tableFrom": "board_placements",
+          "columnsFrom": ["board_type", "hole_id"],
+          "tableTo": "board_holes",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_placements_set_fk": {
+          "name": "board_placements_set_fk",
+          "tableFrom": "board_placements",
+          "columnsFrom": ["board_type", "set_id"],
+          "tableTo": "board_sets",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_placements_role_fk": {
+          "name": "board_placements_role_fk",
+          "tableFrom": "board_placements",
+          "columnsFrom": ["board_type", "default_placement_role_id"],
+          "tableTo": "board_placement_roles",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_placements_board_type_id_pk": {
+          "name": "board_placements_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes": {
+      "name": "board_product_sizes",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_left": {
+          "name": "edge_left",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_right": {
+          "name": "edge_right",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_bottom": {
+          "name": "edge_bottom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_top": {
+          "name": "edge_top",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_product_sizes_product_fk": {
+          "name": "board_product_sizes_product_fk",
+          "tableFrom": "board_product_sizes",
+          "columnsFrom": ["board_type", "product_id"],
+          "tableTo": "board_products",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_board_type_id_pk": {
+          "name": "board_product_sizes_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_product_sizes_layouts_sets": {
+      "name": "board_product_sizes_layouts_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_id": {
+          "name": "set_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_filename": {
+          "name": "image_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_psls_product_size_fk": {
+          "name": "board_psls_product_size_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "tableTo": "board_product_sizes",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_psls_layout_fk": {
+          "name": "board_psls_layout_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "columnsFrom": ["board_type", "layout_id"],
+          "tableTo": "board_layouts",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_psls_set_fk": {
+          "name": "board_psls_set_fk",
+          "tableFrom": "board_product_sizes_layouts_sets",
+          "columnsFrom": ["board_type", "set_id"],
+          "tableTo": "board_sets",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_product_sizes_layouts_sets_board_type_id_pk": {
+          "name": "board_product_sizes_layouts_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_products": {
+      "name": "board_products",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_count_in_frame": {
+          "name": "min_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_count_in_frame": {
+          "name": "max_count_in_frame",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_products_board_type_id_pk": {
+          "name": "board_products_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sets": {
+      "name": "board_sets",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_sets_board_type_id_pk": {
+          "name": "board_sets_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_shared_syncs": {
+      "name": "board_shared_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_shared_syncs_board_type_table_name_pk": {
+          "name": "board_shared_syncs_board_type_table_name_pk",
+          "columns": ["board_type", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_tags": {
+      "name": "board_tags",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_uuid": {
+          "name": "entity_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_tags_board_type_entity_uuid_user_id_name_pk": {
+          "name": "board_tags_board_type_entity_uuid_user_id_name_pk",
+          "columns": ["board_type", "entity_uuid", "user_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_user_syncs": {
+      "name": "board_user_syncs",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "table_name": {
+          "name": "table_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synchronized_at": {
+          "name": "last_synchronized_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_user_syncs_user_fk": {
+          "name": "board_user_syncs_user_fk",
+          "tableFrom": "board_user_syncs",
+          "columnsFrom": ["board_type", "user_id"],
+          "tableTo": "board_users",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_user_syncs_board_type_user_id_table_name_pk": {
+          "name": "board_user_syncs_board_type_user_id_table_name_pk",
+          "columns": ["board_type", "user_id", "table_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_users": {
+      "name": "board_users",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_users_board_type_id_pk": {
+          "name": "board_users_board_type_id_pk",
+          "columns": ["board_type", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_walls": {
+      "name": "board_walls",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_adjustable": {
+          "name": "is_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_size_id": {
+          "name": "product_size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hsm": {
+          "name": "hsm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_walls_user_fk": {
+          "name": "board_walls_user_fk",
+          "tableFrom": "board_walls",
+          "columnsFrom": ["board_type", "user_id"],
+          "tableTo": "board_users",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "board_walls_product_fk": {
+          "name": "board_walls_product_fk",
+          "tableFrom": "board_walls",
+          "columnsFrom": ["board_type", "product_id"],
+          "tableTo": "board_products",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        },
+        "board_walls_layout_fk": {
+          "name": "board_walls_layout_fk",
+          "tableFrom": "board_walls",
+          "columnsFrom": ["board_type", "layout_id"],
+          "tableTo": "board_layouts",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        },
+        "board_walls_product_size_fk": {
+          "name": "board_walls_product_size_fk",
+          "tableFrom": "board_walls",
+          "columnsFrom": ["board_type", "product_size_id"],
+          "tableTo": "board_product_sizes",
+          "columnsTo": ["board_type", "id"],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_walls_board_type_uuid_pk": {
+          "name": "board_walls_board_type_uuid_pk",
+          "columns": ["board_type", "uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "columnsFrom": ["userId"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_providerAccountId_pk": {
+          "name": "accounts_provider_providerAccountId_pk",
+          "columns": ["provider", "providerAccountId"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": ["userId"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationTokens": {
+      "name": "verificationTokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationTokens_identifier_token_pk": {
+          "name": "verificationTokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credentials": {
+      "name": "user_credentials",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credentials_user_id_users_id_fk": {
+          "name": "user_credentials_user_id_users_id_fk",
+          "tableFrom": "user_credentials",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aurora_credentials": {
+      "name": "aurora_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_username": {
+          "name": "encrypted_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_user_id": {
+          "name": "aurora_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_token": {
+          "name": "aurora_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_credential": {
+          "name": "unique_user_board_credential",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aurora_credentials_user_idx": {
+          "name": "aurora_credentials_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aurora_credentials_sync_priority_idx": {
+          "name": "aurora_credentials_sync_priority_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"aurora_credentials\".\"sync_status\" IN ('pending', 'active', 'error')",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "aurora_credentials_user_id_users_id_fk": {
+          "name": "aurora_credentials_user_id_users_id_fk",
+          "tableFrom": "aurora_credentials",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_mappings": {
+      "name": "user_board_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_user_id": {
+          "name": "board_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_user_id_text": {
+          "name": "board_user_id_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_username": {
+          "name": "board_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_board_mapping": {
+          "name": "unique_user_board_mapping",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_user_mapping_idx": {
+          "name": "board_user_mapping_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_user_mapping_text_idx": {
+          "name": "board_user_mapping_text_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_user_id_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_board_mappings_user_id_users_id_fk": {
+          "name": "user_board_mappings_user_id_users_id_fk",
+          "tableFrom": "user_board_mappings",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mobile_refresh_tokens": {
+      "name": "mobile_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mobile_refresh_tokens_token_hash_idx": {
+          "name": "mobile_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mobile_refresh_tokens_user_id_idx": {
+          "name": "mobile_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mobile_refresh_tokens_expires_at_idx": {
+          "name": "mobile_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mobile_refresh_tokens_revoked_at_partial_idx": {
+          "name": "mobile_refresh_tokens_revoked_at_partial_idx",
+          "columns": [
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"revoked_at\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_refresh_tokens_user_id_users_id_fk": {
+          "name": "mobile_refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "mobile_refresh_tokens",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_credentials": {
+      "name": "integration_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_name": {
+          "name": "external_account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_integration": {
+          "name": "unique_user_integration",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "integration_credentials_user_id_users_id_fk": {
+          "name": "integration_credentials_user_id_users_id_fk",
+          "tableFrom": "integration_credentials",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_follows": {
+      "name": "gym_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_follows_unique_gym_user": {
+          "name": "gym_follows_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gym_follows_gym_id_gyms_id_fk": {
+          "name": "gym_follows_gym_id_gyms_id_fk",
+          "tableFrom": "gym_follows",
+          "columnsFrom": ["gym_id"],
+          "tableTo": "gyms",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gym_follows_user_id_users_id_fk": {
+          "name": "gym_follows_user_id_users_id_fk",
+          "tableFrom": "gym_follows",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gym_members": {
+      "name": "gym_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "gym_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gym_members_unique_gym_user": {
+          "name": "gym_members_unique_gym_user",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gym_members_gym_id_gyms_id_fk": {
+          "name": "gym_members_gym_id_gyms_id_fk",
+          "tableFrom": "gym_members",
+          "columnsFrom": ["gym_id"],
+          "tableTo": "gyms",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gym_members_user_id_users_id_fk": {
+          "name": "gym_members_user_id_users_id_fk",
+          "tableFrom": "gym_members",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gyms": {
+      "name": "gyms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gyms_unique_slug": {
+          "name": "gyms_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "gyms_uuid_idx": {
+          "name": "gyms_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "gyms_owner_idx": {
+          "name": "gyms_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "gyms_public_idx": {
+          "name": "gyms_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"gyms\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gyms_owner_id_users_id_fk": {
+          "name": "gyms_owner_id_users_id_fk",
+          "tableFrom": "gyms",
+          "columnsFrom": ["owner_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gyms_uuid_unique": {
+          "name": "gyms_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_follows": {
+      "name": "board_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_follows_unique_user_board": {
+          "name": "board_follows_unique_user_board",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_follows_user_idx": {
+          "name": "board_follows_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_follows_board_uuid_idx": {
+          "name": "board_follows_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_follows_user_id_users_id_fk": {
+          "name": "board_follows_user_id_users_id_fk",
+          "tableFrom": "board_follows",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "board_follows_board_uuid_user_boards_uuid_fk": {
+          "name": "board_follows_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "board_follows",
+          "columnsFrom": ["board_uuid"],
+          "tableTo": "user_boards",
+          "columnsTo": ["uuid"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_boards": {
+      "name": "user_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_unlisted": {
+          "name": "is_unlisted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_location": {
+          "name": "hide_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_owned": {
+          "name": "is_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 40
+        },
+        "is_angle_adjustable": {
+          "name": "is_angle_adjustable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gym_id": {
+          "name": "gym_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_boards_gym_idx": {
+          "name": "user_boards_gym_idx",
+          "columns": [
+            {
+              "expression": "gym_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_boards_unique_owner_config": {
+          "name": "user_boards_unique_owner_config",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "set_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_boards\".\"deleted_at\" IS NULL AND \"user_boards\".\"owner_id\" != '00000000-0000-0000-0000-000000000000'",
+          "concurrently": false
+        },
+        "user_boards_owner_owned_idx": {
+          "name": "user_boards_owner_owned_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_owned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "user_boards_public_idx": {
+          "name": "user_boards_public_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "user_boards_unique_slug": {
+          "name": "user_boards_unique_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "user_boards_uuid_idx": {
+          "name": "user_boards_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_boards_unique_owner_serial": {
+          "name": "user_boards_unique_owner_serial",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "user_boards_serial_idx": {
+          "name": "user_boards_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"user_boards\".\"serial_number\" IS NOT NULL AND \"user_boards\".\"serial_number\" <> '' AND \"user_boards\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_boards_owner_id_users_id_fk": {
+          "name": "user_boards_owner_id_users_id_fk",
+          "tableFrom": "user_boards",
+          "columnsFrom": ["owner_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_boards_gym_id_gyms_id_fk": {
+          "name": "user_boards_gym_id_gyms_id_fk",
+          "tableFrom": "user_boards",
+          "columnsFrom": ["gym_id"],
+          "tableTo": "gyms",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_boards_uuid_unique": {
+          "name": "user_boards_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_board_serials": {
+      "name": "user_board_serials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_level": {
+          "name": "api_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_serials_unique_user_serial": {
+          "name": "user_board_serials_unique_user_serial",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_board_serials_serial_idx": {
+          "name": "user_board_serials_serial_idx",
+          "columns": [
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_board_serials_board_uuid_idx": {
+          "name": "user_board_serials_board_uuid_idx",
+          "columns": [
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_board_serials_user_id_users_id_fk": {
+          "name": "user_board_serials_user_id_users_id_fk",
+          "tableFrom": "user_board_serials",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_board_serials_board_uuid_user_boards_uuid_fk": {
+          "name": "user_board_serials_board_uuid_user_boards_uuid_fk",
+          "tableFrom": "user_board_serials",
+          "columnsFrom": ["board_uuid"],
+          "tableTo": "user_boards",
+          "columnsTo": ["uuid"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_clients": {
+      "name": "board_session_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_leader": {
+          "name": "is_leader",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_clients_session_id_board_sessions_id_fk": {
+          "name": "board_session_clients_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_clients",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_queues": {
+      "name": "board_session_queues",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "current_climb_queue_item": {
+          "name": "current_climb_queue_item",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_session_queues_session_id_board_sessions_id_fk": {
+          "name": "board_session_queues_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_queues",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_sessions": {
+      "name": "board_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_path": {
+          "name": "board_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal": {
+          "name": "goal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_permanent": {
+          "name": "is_permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_sessions_location_idx": {
+          "name": "board_sessions_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_sessions_discoverable_idx": {
+          "name": "board_sessions_discoverable_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_sessions_user_idx": {
+          "name": "board_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_sessions_status_idx": {
+          "name": "board_sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_sessions_last_activity_idx": {
+          "name": "board_sessions_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_sessions_discovery_idx": {
+          "name": "board_sessions_discovery_idx",
+          "columns": [
+            {
+              "expression": "discoverable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_sessions_created_by_user_id_users_id_fk": {
+          "name": "board_sessions_created_by_user_id_users_id_fk",
+          "tableFrom": "board_sessions",
+          "columnsFrom": ["created_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "board_sessions_board_id_user_boards_id_fk": {
+          "name": "board_sessions_board_id_user_boards_id_fk",
+          "tableFrom": "board_sessions",
+          "columnsFrom": ["board_id"],
+          "tableTo": "user_boards",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_boards": {
+      "name": "session_boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_boards_session_board_idx": {
+          "name": "session_boards_session_board_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "session_boards_session_idx": {
+          "name": "session_boards_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "session_boards_board_idx": {
+          "name": "session_boards_board_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_boards_session_id_board_sessions_id_fk": {
+          "name": "session_boards_session_id_board_sessions_id_fk",
+          "tableFrom": "session_boards",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "session_boards_board_id_user_boards_id_fk": {
+          "name": "session_boards_board_id_user_boards_id_fk",
+          "tableFrom": "session_boards",
+          "columnsFrom": ["board_id"],
+          "tableTo": "user_boards",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_health_kit_workouts": {
+      "name": "session_health_kit_workouts",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_health_kit_workouts_session_idx": {
+          "name": "session_health_kit_workouts_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "session_health_kit_workouts_user_idx": {
+          "name": "session_health_kit_workouts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_health_kit_workouts_session_id_board_sessions_id_fk": {
+          "name": "session_health_kit_workouts_session_id_board_sessions_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "session_health_kit_workouts_user_id_users_id_fk": {
+          "name": "session_health_kit_workouts_user_id_users_id_fk",
+          "tableFrom": "session_health_kit_workouts",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_health_kit_workouts_session_id_user_id_pk": {
+          "name": "session_health_kit_workouts_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_favorite": {
+          "name": "unique_user_favorite",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_favorites_user_idx": {
+          "name": "user_favorites_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_favorites_climb_idx": {
+          "name": "user_favorites_climb_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.boardsesh_ticks": {
+      "name": "boardsesh_ticks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_mirror": {
+          "name": "is_mirror",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tick_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "climbed_at": {
+          "name": "climbed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "aurora_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_sync_error": {
+          "name": "aurora_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "kilter_table_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_sync_error": {
+          "name": "kilter_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "boardsesh_ticks_user_board_idx": {
+          "name": "boardsesh_ticks_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_climb_idx": {
+          "name": "boardsesh_ticks_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_aurora_id_unique": {
+          "name": "boardsesh_ticks_aurora_id_unique",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_sync_pending_idx": {
+          "name": "boardsesh_ticks_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_kilter_id_unique": {
+          "name": "boardsesh_ticks_kilter_id_unique",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_kilter_sync_pending_idx": {
+          "name": "boardsesh_ticks_kilter_sync_pending_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_session_idx": {
+          "name": "boardsesh_ticks_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_climbed_at_idx": {
+          "name": "boardsesh_ticks_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_user_climbed_at_idx": {
+          "name": "boardsesh_ticks_user_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_board_climbed_at_idx": {
+          "name": "boardsesh_ticks_board_climbed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climbed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_board_user_idx": {
+          "name": "boardsesh_ticks_board_user_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "boardsesh_ticks_user_climb_lookup_idx": {
+          "name": "boardsesh_ticks_user_climb_lookup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "boardsesh_ticks_user_id_users_id_fk": {
+          "name": "boardsesh_ticks_user_id_users_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "boardsesh_ticks_session_id_board_sessions_id_fk": {
+          "name": "boardsesh_ticks_session_id_board_sessions_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "boardsesh_ticks_board_id_user_boards_id_fk": {
+          "name": "boardsesh_ticks_board_id_user_boards_id_fk",
+          "tableFrom": "boardsesh_ticks",
+          "columnsFrom": ["board_id"],
+          "tableTo": "user_boards",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "boardsesh_ticks_uuid_unique": {
+          "name": "boardsesh_ticks_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_events": {
+      "name": "board_climb_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter": {
+          "name": "setter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_events_board_confirmed_at_idx": {
+          "name": "board_climb_events_board_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climb_events_board_seq_unique": {
+          "name": "board_climb_events_board_seq_unique",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climb_events_session_idx": {
+          "name": "board_climb_events_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_climb_events_board_climb_idx": {
+          "name": "board_climb_events_board_climb_idx",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_climb_events_board_id_user_boards_id_fk": {
+          "name": "board_climb_events_board_id_user_boards_id_fk",
+          "tableFrom": "board_climb_events",
+          "columnsFrom": ["board_id"],
+          "tableTo": "user_boards",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "board_climb_events_user_id_users_id_fk": {
+          "name": "board_climb_events_user_id_users_id_fk",
+          "tableFrom": "board_climb_events",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "board_climb_events_session_id_board_sessions_id_fk": {
+          "name": "board_climb_events_session_id_board_sessions_id_fk",
+          "tableFrom": "board_climb_events",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_climbs": {
+      "name": "playlist_climbs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_climb": {
+          "name": "unique_playlist_climb",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlist_climbs_climb_idx": {
+          "name": "playlist_climbs_climb_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlist_climbs_position_idx": {
+          "name": "playlist_climbs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "playlist_climbs_playlist_id_playlists_id_fk": {
+          "name": "playlist_climbs_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_climbs",
+          "columnsFrom": ["playlist_id"],
+          "tableTo": "playlists",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_ownership": {
+      "name": "playlist_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_ownership": {
+          "name": "unique_playlist_ownership",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlist_ownership_user_idx": {
+          "name": "playlist_ownership_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "playlist_ownership_playlist_id_playlists_id_fk": {
+          "name": "playlist_ownership_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_ownership",
+          "columnsFrom": ["playlist_id"],
+          "tableTo": "playlists",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "playlist_ownership_user_id_users_id_fk": {
+          "name": "playlist_ownership_user_id_users_id_fk",
+          "tableFrom": "playlist_ownership",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_type": {
+          "name": "aurora_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_id": {
+          "name": "aurora_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aurora_synced_at": {
+          "name": "aurora_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_type": {
+          "name": "kilter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_id": {
+          "name": "kilter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kilter_synced_at": {
+          "name": "kilter_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_recommendation": {
+          "name": "generated_recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "playlists_board_layout_idx": {
+          "name": "playlists_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlists_generated_recommendation_idx": {
+          "name": "playlists_generated_recommendation_idx",
+          "columns": [
+            {
+              "expression": "generated_recommendation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlists_uuid_idx": {
+          "name": "playlists_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlists_updated_at_idx": {
+          "name": "playlists_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlists_last_accessed_at_idx": {
+          "name": "playlists_last_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlists_aurora_id_idx": {
+          "name": "playlists_aurora_id_idx",
+          "columns": [
+            {
+              "expression": "aurora_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlists_kilter_id_idx": {
+          "name": "playlists_kilter_id_idx",
+          "columns": [
+            {
+              "expression": "kilter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlists_uuid_unique": {
+          "name": "playlists_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_pins": {
+      "name": "user_playlist_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_playlist_pin": {
+          "name": "unique_user_playlist_pin",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_playlist_pins_user_idx": {
+          "name": "user_playlist_pins_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_playlist_pins_playlist_idx": {
+          "name": "user_playlist_pins_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_playlist_pins_user_id_users_id_fk": {
+          "name": "user_playlist_pins_user_id_users_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_playlist_pins_playlist_id_playlists_id_fk": {
+          "name": "user_playlist_pins_playlist_id_playlists_id_fk",
+          "tableFrom": "user_playlist_pins",
+          "columnsFrom": ["playlist_id"],
+          "tableTo": "playlists",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hold_classifications": {
+      "name": "user_hold_classifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_type": {
+          "name": "hold_type",
+          "type": "hold_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_rating": {
+          "name": "hand_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foot_rating": {
+          "name": "foot_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_direction": {
+          "name": "pull_direction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hold_classifications_user_board_idx": {
+          "name": "user_hold_classifications_user_board_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_hold_classifications_unique_idx": {
+          "name": "user_hold_classifications_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "size_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_hold_classifications_hold_idx": {
+          "name": "user_hold_classifications_hold_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_hold_classifications_user_id_users_id_fk": {
+          "name": "user_hold_classifications_user_id_users_id_fk",
+          "tableFrom": "user_hold_classifications",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esp32_controllers": {
+      "name": "esp32_controllers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "esp32_controllers_user_idx": {
+          "name": "esp32_controllers_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "esp32_controllers_api_key_idx": {
+          "name": "esp32_controllers_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "esp32_controllers_session_idx": {
+          "name": "esp32_controllers_session_idx",
+          "columns": [
+            {
+              "expression": "authorized_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "esp32_controllers_user_id_users_id_fk": {
+          "name": "esp32_controllers_user_id_users_id_fk",
+          "tableFrom": "esp32_controllers",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "esp32_controllers_api_key_unique": {
+          "name": "esp32_controllers_api_key_unique",
+          "columns": ["api_key"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_follows": {
+      "name": "playlist_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_uuid": {
+          "name": "playlist_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_playlist_follow": {
+          "name": "unique_playlist_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlist_follows_follower_idx": {
+          "name": "playlist_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "playlist_follows_playlist_idx": {
+          "name": "playlist_follows_playlist_idx",
+          "columns": [
+            {
+              "expression": "playlist_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "playlist_follows_follower_id_users_id_fk": {
+          "name": "playlist_follows_follower_id_users_id_fk",
+          "tableFrom": "playlist_follows",
+          "columnsFrom": ["follower_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "playlist_follows_playlist_uuid_playlists_uuid_fk": {
+          "name": "playlist_follows_playlist_uuid_playlists_uuid_fk",
+          "tableFrom": "playlist_follows",
+          "columnsFrom": ["playlist_uuid"],
+          "tableTo": "playlists",
+          "columnsTo": ["uuid"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setter_follows": {
+      "name": "setter_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_setter_follow": {
+          "name": "unique_setter_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "setter_follows_follower_idx": {
+          "name": "setter_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "setter_follows_setter_idx": {
+          "name": "setter_follows_setter_idx",
+          "columns": [
+            {
+              "expression": "setter_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "setter_follows_follower_id_users_id_fk": {
+          "name": "setter_follows_follower_id_users_id_fk",
+          "tableFrom": "setter_follows",
+          "columnsFrom": ["follower_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_follow": {
+          "name": "unique_user_follow",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_follows_follower_idx": {
+          "name": "user_follows_follower_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_follows_following_idx": {
+          "name": "user_follows_following_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "columnsFrom": ["follower_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_follows_following_id_users_id_fk": {
+          "name": "user_follows_following_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "columnsFrom": ["following_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "no_self_follow": {
+          "name": "no_self_follow",
+          "value": "\"user_follows\".\"follower_id\" != \"user_follows\".\"following_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_entity_created_at_idx": {
+          "name": "comments_entity_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_user_created_at_idx": {
+          "name": "comments_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_parent_comment_idx": {
+          "name": "comments_parent_comment_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "comments_user_id_users_id_fk": {
+          "name": "comments_user_id_users_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_uuid_unique": {
+          "name": "comments_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_unique_user_entity": {
+          "name": "votes_unique_user_entity",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "votes_entity_idx": {
+          "name": "votes_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "votes_user_idx": {
+          "name": "votes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_users_id_fk": {
+          "name": "votes_user_id_users_id_fk",
+          "tableFrom": "votes",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vote_value_check": {
+          "name": "vote_value_check",
+          "value": "\"votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_recipient_created_at_idx": {
+          "name": "notifications_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_dedup_idx": {
+          "name": "notifications_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": ["recipient_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": ["actor_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "notifications_comment_id_comments_id_fk": {
+          "name": "notifications_comment_id_comments_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": ["comment_id"],
+          "tableTo": "comments",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_uuid_unique": {
+          "name": "notifications_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "feed_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_uuid": {
+          "name": "board_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_recipient_created_at_idx": {
+          "name": "feed_items_recipient_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feed_items_recipient_board_created_at_idx": {
+          "name": "feed_items_recipient_board_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feed_items_actor_created_at_idx": {
+          "name": "feed_items_actor_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feed_items_created_at_idx": {
+          "name": "feed_items_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "feed_items_entity_type_entity_id_idx": {
+          "name": "feed_items_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "feed_items_recipient_id_users_id_fk": {
+          "name": "feed_items_recipient_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "columnsFrom": ["recipient_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "feed_items_actor_id_users_id_fk": {
+          "name": "feed_items_actor_id_users_id_fk",
+          "tableFrom": "feed_items",
+          "columnsFrom": ["actor_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_classic_status": {
+      "name": "climb_classic_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_classic": {
+          "name": "is_classic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_classic_status_unique_idx": {
+          "name": "climb_classic_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "climb_classic_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_classic_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_classic_status",
+          "columnsFrom": ["last_proposal_id"],
+          "tableTo": "climb_proposals",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_community_status": {
+      "name": "climb_community_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_grade": {
+          "name": "community_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_benchmark": {
+          "name": "is_benchmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_proposal_id": {
+          "name": "last_proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "climb_community_status_unique_idx": {
+          "name": "climb_community_status_unique_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "climb_community_status_last_proposal_id_climb_proposals_id_fk": {
+          "name": "climb_community_status_last_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "climb_community_status",
+          "columnsFrom": ["last_proposal_id"],
+          "tableTo": "climb_proposals",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.climb_proposals": {
+      "name": "climb_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "climb_proposals_climb_angle_type_idx": {
+          "name": "climb_proposals_climb_angle_type_idx",
+          "columns": [
+            {
+              "expression": "climb_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "angle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "climb_proposals_status_idx": {
+          "name": "climb_proposals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "climb_proposals_proposer_idx": {
+          "name": "climb_proposals_proposer_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "climb_proposals_board_type_idx": {
+          "name": "climb_proposals_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "climb_proposals_created_at_idx": {
+          "name": "climb_proposals_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "climb_proposals_proposer_id_users_id_fk": {
+          "name": "climb_proposals_proposer_id_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "columnsFrom": ["proposer_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "climb_proposals_resolved_by_users_id_fk": {
+          "name": "climb_proposals_resolved_by_users_id_fk",
+          "tableFrom": "climb_proposals",
+          "columnsFrom": ["resolved_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "climb_proposals_uuid_unique": {
+          "name": "climb_proposals_uuid_unique",
+          "columns": ["uuid"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_roles": {
+      "name": "community_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_roles_board_type_idx": {
+          "name": "community_roles_board_type_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "community_roles_user_id_users_id_fk": {
+          "name": "community_roles_user_id_users_id_fk",
+          "tableFrom": "community_roles",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "community_roles_granted_by_users_id_fk": {
+          "name": "community_roles_granted_by_users_id_fk",
+          "tableFrom": "community_roles",
+          "columnsFrom": ["granted_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_roles_user_role_board_idx": {
+          "name": "community_roles_user_role_board_idx",
+          "columns": ["user_id", "role", "board_type"],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_settings": {
+      "name": "community_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "set_by": {
+          "name": "set_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_settings_scope_key_idx": {
+          "name": "community_settings_scope_key_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "community_settings_set_by_users_id_fk": {
+          "name": "community_settings_set_by_users_id_fk",
+          "tableFrom": "community_settings",
+          "columnsFrom": ["set_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proposal_votes": {
+      "name": "proposal_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proposal_votes_unique_user_proposal": {
+          "name": "proposal_votes_unique_user_proposal",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "proposal_votes_proposal_idx": {
+          "name": "proposal_votes_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "proposal_votes_proposal_id_climb_proposals_id_fk": {
+          "name": "proposal_votes_proposal_id_climb_proposals_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": ["proposal_id"],
+          "tableTo": "climb_proposals",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "proposal_votes_user_id_users_id_fk": {
+          "name": "proposal_votes_user_id_users_id_fk",
+          "tableFrom": "proposal_votes",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proposal_vote_value_check": {
+          "name": "proposal_vote_value_check",
+          "value": "\"proposal_votes\".\"value\" IN (1, -1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.new_climb_subscriptions": {
+      "name": "new_climb_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "new_climb_subscriptions_unique_user_board_layout": {
+          "name": "new_climb_subscriptions_unique_user_board_layout",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "new_climb_subscriptions_user_idx": {
+          "name": "new_climb_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "new_climb_subscriptions_board_layout_idx": {
+          "name": "new_climb_subscriptions_board_layout_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "new_climb_subscriptions_user_id_users_id_fk": {
+          "name": "new_climb_subscriptions_user_id_users_id_fk",
+          "tableFrom": "new_climb_subscriptions",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_counts": {
+      "name": "vote_counts",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "social_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hot_score": {
+          "name": "hot_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vote_counts_score_idx": {
+          "name": "vote_counts_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "vote_counts_hot_score_idx": {
+          "name": "vote_counts_hot_score_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hot_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "vote_counts_entity_type_entity_id_pk": {
+          "name": "vote_counts_entity_type_entity_id_pk",
+          "columns": ["entity_type", "entity_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_session_participants": {
+      "name": "board_session_participants",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_session_participants_session_idx": {
+          "name": "board_session_participants_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "board_session_participants_user_idx": {
+          "name": "board_session_participants_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "board_session_participants_session_id_board_sessions_id_fk": {
+          "name": "board_session_participants_session_id_board_sessions_id_fk",
+          "tableFrom": "board_session_participants",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "board_session_participants_user_id_users_id_fk": {
+          "name": "board_session_participants_user_id_users_id_fk",
+          "tableFrom": "board_session_participants",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "board_session_participants_session_id_user_id_pk": {
+          "name": "board_session_participants_session_id_user_id_pk",
+          "columns": ["session_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_feedback": {
+      "name": "app_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_name": {
+          "name": "board_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_id": {
+          "name": "size_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_ids": {
+          "name": "set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "angle": {
+          "name": "angle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_feedback_created_at_idx": {
+          "name": "app_feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "app_feedback_user_idx": {
+          "name": "app_feedback_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "app_feedback_board_idx": {
+          "name": "app_feedback_board_idx",
+          "columns": [
+            {
+              "expression": "board_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "app_feedback_user_id_users_id_fk": {
+          "name": "app_feedback_user_id_users_id_fk",
+          "tableFrom": "app_feedback",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_climb_percentiles": {
+      "name": "user_climb_percentiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_distinct_climbs": {
+          "name": "total_distinct_climbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_active_users": {
+          "name": "total_active_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_climb_percentiles_user_id_users_id_fk": {
+          "name": "user_climb_percentiles_user_id_users_id_fk",
+          "tableFrom": "user_climb_percentiles",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_push_tokens": {
+      "name": "activity_push_tokens",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_push_tokens_session_idx": {
+          "name": "activity_push_tokens_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "activity_push_tokens_user_idx": {
+          "name": "activity_push_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "activity_push_tokens_updated_at_idx": {
+          "name": "activity_push_tokens_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "activity_push_tokens_session_id_board_sessions_id_fk": {
+          "name": "activity_push_tokens_session_id_board_sessions_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "columnsFrom": ["session_id"],
+          "tableTo": "board_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "activity_push_tokens_user_id_users_id_fk": {
+          "name": "activity_push_tokens_user_id_users_id_fk",
+          "tableFrom": "activity_push_tokens",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_climb_send_stats": {
+      "name": "board_climb_send_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_uuid": {
+          "name": "climb_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_count_30d": {
+          "name": "send_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sender_count_30d": {
+          "name": "sender_count_30d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "send_count_90d": {
+          "name": "send_count_90d",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_climb_send_stats_trending_idx": {
+          "name": "board_climb_send_stats_trending_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "send_count_30d",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_climb_send_stats_board_type_climb_uuid_pk": {
+          "name": "board_climb_send_stats_board_type_climb_uuid_pk",
+          "columns": ["board_type", "climb_uuid"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.board_setter_stats": {
+      "name": "board_setter_stats",
+      "schema": "",
+      "columns": {
+        "board_type": {
+          "name": "board_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setter_username": {
+          "name": "setter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "climb_count": {
+          "name": "climb_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_ascents": {
+          "name": "total_ascents",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_ascents_per_climb": {
+          "name": "avg_ascents_per_climb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_quality": {
+          "name": "avg_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setter_score": {
+          "name": "setter_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "board_setter_stats_score_idx": {
+          "name": "board_setter_stats_score_idx",
+          "columns": [
+            {
+              "expression": "board_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "setter_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "board_setter_stats_board_type_setter_username_pk": {
+          "name": "board_setter_stats_board_type_setter_username_pk",
+          "columns": ["board_type", "setter_username"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_exports": {
+      "name": "integration_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_activity_id": {
+          "name": "external_activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_integration_export": {
+          "name": "unique_integration_export",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "integration_exports_user_provider_idx": {
+          "name": "integration_exports_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "integration_exports_session_idx": {
+          "name": "integration_exports_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "integration_exports_user_id_users_id_fk": {
+          "name": "integration_exports_user_id_users_id_fk",
+          "tableFrom": "integration_exports",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.gym_member_role": {
+      "name": "gym_member_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    },
+    "public.aurora_table_type": {
+      "name": "aurora_table_type",
+      "schema": "public",
+      "values": ["ascents", "bids"]
+    },
+    "public.kilter_table_type": {
+      "name": "kilter_table_type",
+      "schema": "public",
+      "values": ["logs", "attempts"]
+    },
+    "public.tick_status": {
+      "name": "tick_status",
+      "schema": "public",
+      "values": ["flash", "send", "attempt"]
+    },
+    "public.hold_type": {
+      "name": "hold_type",
+      "schema": "public",
+      "values": ["jug", "sloper", "pinch", "crimp", "pocket"]
+    },
+    "public.social_entity_type": {
+      "name": "social_entity_type",
+      "schema": "public",
+      "values": ["playlist_climb", "climb", "tick", "comment", "proposal", "board", "gym", "session"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "new_follower",
+        "comment_reply",
+        "comment_on_tick",
+        "comment_on_climb",
+        "vote_on_tick",
+        "vote_on_comment",
+        "new_climb",
+        "new_climb_global",
+        "proposal_approved",
+        "proposal_rejected",
+        "proposal_vote",
+        "proposal_created",
+        "new_climbs_synced"
+      ]
+    },
+    "public.feed_item_type": {
+      "name": "feed_item_type",
+      "schema": "public",
+      "values": ["ascent", "new_climb", "comment", "proposal_approved", "session_summary"]
+    },
+    "public.community_role_type": {
+      "name": "community_role_type",
+      "schema": "public",
+      "values": ["admin", "community_leader"]
+    },
+    "public.proposal_status": {
+      "name": "proposal_status",
+      "schema": "public",
+      "values": ["open", "approved", "rejected", "superseded"]
+    },
+    "public.proposal_type": {
+      "name": "proposal_type",
+      "schema": "public",
+      "values": ["grade", "classic", "benchmark"]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -897,6 +897,13 @@
       "when": 1781398035290,
       "tag": "0127_backfill_gym_location_trigger",
       "breakpoints": true
+    },
+    {
+      "idx": 128,
+      "version": "7",
+      "when": 1781481772000,
+      "tag": "0128_direct_beta_tick_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -646,11 +646,31 @@ export const boardBetaLinks = pgTable(
     thumbnail: text(),
     isListed: boolean('is_listed'),
     createdAt: text('created_at'),
+    // Optional direct ascent this beta was attached to. Legacy rows can stay
+    // null and are still matched by climb/angle/user heuristics on read.
+    //
+    // FK managed manually in migration `0128_direct_beta_tick_links.sql`:
+    // `board_beta_links_tick_uuid_boardsesh_ticks_uuid_fk` references
+    // `boardsesh_ticks(uuid) ON DELETE SET NULL`. It is not declared here
+    // because this boards schema avoids cross-package FKs to app tables.
+    tickUuid: text('tick_uuid'),
+    // Optional physical board this beta was recorded on. Set alongside
+    // tickUuid when the ascent has a resolved user_boards row.
+    //
+    // FK managed manually in migration `0128_direct_beta_tick_links.sql`:
+    // `board_beta_links_board_id_user_boards_id_fk` references
+    // `user_boards(id) ON DELETE SET NULL`.
+    boardId: bigint('board_id', { mode: 'number' }),
     // Platform-stable identifier extracted from `link` at write time.
     // Currently only populated for Instagram URLs (the post/reel shortcode);
     // null for TikTok and other platforms. Used as the indexed key for the
     // cross-climb dedup check so we don't have to LIKE-scan every row.
     shortcode: text('shortcode'),
+    // Canonical video identity across supported platforms. This lets the same
+    // video be tied to exactly one tick even when the URL text differs by host
+    // or tracking params. Populated at write time for new rows; legacy
+    // duplicates may remain null after migration.
+    videoIdentity: text('video_identity'),
     // Boardsesh user who attached this link. Populated by attachBetaLink and
     // by the saveTick beta-link insert path; NULL for legacy rows written
     // before this column existed and for any future write path that didn't
@@ -669,10 +689,9 @@ export const boardBetaLinks = pgTable(
   },
   (table) => ({
     pk: primaryKey({ columns: [table.boardType, table.climbUuid, table.link] }),
-    // Partial index: shortcode is null for TikTok and other non-IG platforms,
-    // and the dedup query is keyed on a non-null shortcode (see
-    // findInstagramShortcodeConflict). Excluding null rows keeps the index
-    // smaller and skips entries the dedup query can never match.
+    // Historical Instagram-only lookup. New duplicate checks use
+    // videoIdentityUnique below, but this index is kept for existing read and
+    // maintenance paths keyed by the Instagram shortcode.
     shortcodeIdx: index('board_beta_links_shortcode_idx')
       .on(table.boardType, table.shortcode)
       .where(sql`${table.shortcode} IS NOT NULL`),
@@ -681,6 +700,15 @@ export const boardBetaLinks = pgTable(
     createdByIdx: index('board_beta_links_created_by_idx')
       .on(table.createdByUserId, table.createdAt)
       .where(sql`${table.createdByUserId} IS NOT NULL`),
+    videoIdentityUnique: uniqueIndex('board_beta_links_video_identity_unique')
+      .on(table.videoIdentity)
+      .where(sql`${table.videoIdentity} IS NOT NULL`),
+    tickUuidUnique: uniqueIndex('board_beta_links_tick_uuid_unique')
+      .on(table.tickUuid)
+      .where(sql`${table.tickUuid} IS NOT NULL`),
+    boardIdx: index('board_beta_links_board_id_idx')
+      .on(table.boardId)
+      .where(sql`${table.boardId} IS NOT NULL`),
     // Note: No FK to board_climbs - beta links may arrive before their corresponding climbs during sync
   }),
 );

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -649,17 +649,28 @@ export const boardBetaLinks = pgTable(
     // Optional direct ascent this beta was attached to. Legacy rows can stay
     // null and are still matched by climb/angle/user heuristics on read.
     //
-    // FK managed manually in migration `0128_direct_beta_tick_links.sql`:
-    // `board_beta_links_tick_uuid_boardsesh_ticks_uuid_fk` references
-    // `boardsesh_ticks(uuid) ON DELETE SET NULL`. It is not declared here
-    // because this boards schema avoids cross-package FKs to app tables.
+    // ⚠️ FK managed manually — there's a foreign key
+    //   `board_beta_links_tick_uuid_boardsesh_ticks_uuid_fk`
+    //   referencing `boardsesh_ticks(uuid) ON DELETE SET NULL`, added in
+    //   migration `0128_direct_beta_tick_links.sql`. It is NOT declared via
+    //   `.references()` here because this schema avoids cross-package FKs.
+    //   Drizzle-kit's snapshot does NOT know about this FK. The next
+    //   `drizzle-kit generate` run against this table may emit SQL that
+    //   drops it — always review generated migrations for this column.
     tickUuid: text('tick_uuid'),
     // Optional physical board this beta was recorded on. Set alongside
     // tickUuid when the ascent has a resolved user_boards row.
+    // Stored as bigint in Postgres; exposed as GraphQL Int (safe for
+    // auto-increment IDs that fit in 32 bits, but not the general case).
     //
-    // FK managed manually in migration `0128_direct_beta_tick_links.sql`:
-    // `board_beta_links_board_id_user_boards_id_fk` references
-    // `user_boards(id) ON DELETE SET NULL`.
+    // ⚠️ FK managed manually — there's a foreign key
+    //   `board_beta_links_board_id_user_boards_id_fk`
+    //   referencing `user_boards(id) ON DELETE SET NULL`, added in
+    //   migration `0128_direct_beta_tick_links.sql`. It is NOT declared via
+    //   `.references()` here to avoid cross-package FKs.
+    //   Drizzle-kit's snapshot does NOT know about this FK. The next
+    //   `drizzle-kit generate` run may emit SQL that drops it — always
+    //   review generated migrations for this column.
     boardId: bigint('board_id', { mode: 'number' }),
     // Platform-stable identifier extracted from `link` at write time.
     // Currently only populated for Instagram URLs (the post/reel shortcode);

--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -83,7 +83,7 @@ export default function ShareBetaScreen() {
     (ascent: AscentFeedItem) => {
       if (!link || attach.isPending) return;
       attach.mutate(
-        { boardType: ascent.boardType, climbUuid: ascent.climbUuid, link, angle: ascent.angle },
+        { boardType: ascent.boardType, climbUuid: ascent.climbUuid, link, angle: ascent.angle, tickUuid: ascent.uuid },
         {
           onSuccess: () => {
             void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);

--- a/packages/mobile/src/components/you/__tests__/session-feed-card-chart.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/session-feed-card-chart.test.tsx
@@ -83,7 +83,27 @@ vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 vi.mock('../../../lib/beta-video-url', () => ({
   isInstagramUrl: (url: string) => url.includes('instagram.com'),
   isTikTokUrl: (url: string) => url.includes('tiktok.com'),
-  mapBetaLink: (row: { link: string }) => ({ link: row.link }),
+  mapBetaLink: (row: {
+    climbUuid: string;
+    link: string;
+    foreignUsername: string | null;
+    angle: number | null;
+    thumbnail: string | null;
+    isListed: boolean | null;
+    createdAt: string;
+    tickUuid?: string | null;
+    boardId?: number | null;
+  }) => ({
+    climb_uuid: row.climbUuid,
+    link: row.link,
+    foreign_username: row.foreignUsername,
+    angle: row.angle,
+    thumbnail: row.thumbnail,
+    is_listed: row.isListed ?? false,
+    created_at: row.createdAt,
+    tick_uuid: row.tickUuid ?? null,
+    board_id: row.boardId ?? null,
+  }),
 }));
 vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({ getBoardConfigForPlaylist: () => null }));
 
@@ -160,7 +180,23 @@ describe('SessionFeedCard chart', () => {
     const hardest = tick();
     const { getByLabelText } = render(
       createElement(SessionFeedCard, {
-        session: session({ hardestSend: hardest }),
+        session: session({
+          hardestSend: tick(),
+          featuredBeta: {
+            tick: tick({ uuid: 'tick-2', climbName: 'Beta Climb' }),
+            betaLink: {
+              climbUuid: 'climb-2',
+              link: 'https://www.instagram.com/reel/demo/',
+              foreignUsername: 'setter',
+              angle: 40,
+              thumbnail: null,
+              isListed: true,
+              createdAt: '2026-06-12T00:00:00.000Z',
+              tickUuid: 'tick-2',
+              boardId: null,
+            },
+          },
+        }),
         onOpenComments: vi.fn(),
         onPress: vi.fn(),
         onOpenClimb,

--- a/packages/mobile/src/lib/__tests__/beta-video-url.test.ts
+++ b/packages/mobile/src/lib/__tests__/beta-video-url.test.ts
@@ -21,6 +21,8 @@ function makeRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
     thumbnail: '/static/beta-link-thumbnails/abc.jpg',
     isListed: true,
     createdAt: '2026-01-01T00:00:00Z',
+    tickUuid: null,
+    boardId: null,
     ...overrides,
   };
 }
@@ -65,6 +67,8 @@ describe('mapBetaLink (mobile)', () => {
       thumbnail: 'https://ws.boardsesh.test/static/abc.jpg?size=280',
       is_listed: true,
       created_at: '2026-01-01T00:00:00Z',
+      tick_uuid: null,
+      board_id: null,
     });
   });
 

--- a/packages/shared-schema/src/__tests__/beta-video-url.test.ts
+++ b/packages/shared-schema/src/__tests__/beta-video-url.test.ts
@@ -191,6 +191,8 @@ function makeLink(overrides: Partial<BetaLink> = {}): BetaLink {
     thumbnail: '/static/beta-link-thumbnails/abc.jpg',
     is_listed: true,
     created_at: '2026-01-01T00:00:00Z',
+    tick_uuid: null,
+    board_id: null,
     ...overrides,
   };
 }
@@ -262,6 +264,8 @@ function makeRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
     thumbnail: '/static/beta-link-thumbnails/abc.jpg',
     isListed: true,
     createdAt: '2026-01-01T00:00:00Z',
+    tickUuid: null,
+    boardId: null,
     ...overrides,
   };
 }
@@ -277,6 +281,8 @@ describe('mapBetaLinkRow', () => {
       thumbnail: '/static/beta-link-thumbnails/abc.jpg',
       is_listed: true,
       created_at: '2026-01-01T00:00:00Z',
+      tick_uuid: null,
+      board_id: null,
     });
   });
 

--- a/packages/shared-schema/src/__tests__/beta-video-url.test.ts
+++ b/packages/shared-schema/src/__tests__/beta-video-url.test.ts
@@ -180,6 +180,38 @@ describe('betaLinkIdentity', () => {
     const b = 'https://instagram.com/reel/SameId/?utm_source=share';
     expect(betaLinkIdentity(a)).toBe(betaLinkIdentity(b));
   });
+
+  // Alignment contract with migration 0128_direct_beta_tick_links.sql:
+  //   SQL Instagram regex: (www\.)?(instagram\.com|instagr\.am)/(p|reel|tv)/([[:alnum:]_-]+)/...
+  //     → shortcode is captured in SQL group 4; stored as 'instagram:' || match[4]
+  //   TS: non-capturing (?:www\.)?(?:...\.com)\/(?:p|reel|tv)\/([\w-]+)
+  //     → shortcode is group 1; identity = 'instagram:' + match[1]
+  //   Both extract the same shortcode string, so identities match.
+  //
+  //   SQL TikTok regex: ([a-z0-9-]+\.)*tiktok\.com/@...\/video\/([0-9]+)
+  //     → video id is captured in SQL group 2; stored as 'tiktok:' || match[2]
+  //   TS: non-capturing (?:[a-z0-9-]+\.)*tiktok\.com\/@[\w.-]+\/video\/(\d+)
+  //     → video id is group 1; identity = 'tiktok:' + match[1]
+  //   Both extract the same video id string, so identities match.
+  describe('SQL migration alignment', () => {
+    it('Instagram identity matches what SQL backfill group 4 would produce', () => {
+      expect(betaLinkIdentity('https://www.instagram.com/reel/CAbCdEfGhIj/')).toBe('instagram:CAbCdEfGhIj');
+      expect(betaLinkIdentity('https://instagr.am/p/Xyz123/')).toBe('instagram:Xyz123');
+      expect(betaLinkIdentity('https://www.instagram.com/tv/AbCdE12/')).toBe('instagram:AbCdE12');
+    });
+
+    it('TikTok identity matches what SQL backfill group 2 would produce', () => {
+      expect(betaLinkIdentity('https://www.tiktok.com/@some.user/video/7359000000000000000')).toBe(
+        'tiktok:7359000000000000000',
+      );
+      expect(betaLinkIdentity('https://tiktok.com/@climber/video/1234567890')).toBe('tiktok:1234567890');
+    });
+
+    it('raw: prefix matches what the SQL ELSE branch would produce', () => {
+      const url = 'https://vm.tiktok.com/ZShortcode/';
+      expect(betaLinkIdentity(url)).toBe(`raw:${url}`);
+    });
+  });
 });
 
 function makeLink(overrides: Partial<BetaLink> = {}): BetaLink {

--- a/packages/shared-schema/src/beta-video-url.ts
+++ b/packages/shared-schema/src/beta-video-url.ts
@@ -72,6 +72,8 @@ export type BetaLink = {
   thumbnail: string | null;
   is_listed: boolean;
   created_at: string;
+  tick_uuid: string | null;
+  board_id: number | null;
 };
 
 /**
@@ -85,6 +87,8 @@ export type BetaLinksGqlRow = {
   thumbnail: string | null;
   isListed: boolean | null;
   createdAt: string | null;
+  tickUuid: string | null;
+  boardId: number | null;
 };
 
 /**
@@ -121,6 +125,8 @@ export function dedupeBetaLinks(betaLinks: BetaLink[]): BetaLink[] {
       angle: existing.angle ?? betaLink.angle,
       thumbnail: existing.thumbnail ?? betaLink.thumbnail,
       created_at: existing.created_at || betaLink.created_at,
+      tick_uuid: existing.tick_uuid ?? betaLink.tick_uuid,
+      board_id: existing.board_id ?? betaLink.board_id,
     };
   }
 
@@ -142,6 +148,8 @@ export function mapBetaLinkRow(
     thumbnail: absolutizeThumbnail(row.thumbnail),
     is_listed: row.isListed ?? false,
     created_at: row.createdAt ?? '',
+    tick_uuid: row.tickUuid,
+    board_id: row.boardId,
   };
 }
 

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -834,7 +834,7 @@ input SaveTickInput {
   boardUuid: String
   "Resolved shared board id (from resolveBoardForSerial) for the BLE-connected wall everyone is logging to. Used when no boardUuid is given; falls back to board-config resolution if it doesn't match the payload."
   boardId: Int
-  "Optional Instagram post or reel URL to attach as beta for the climb"
+  "Optional Instagram or TikTok video URL to attach as beta for the climb"
   videoUrl: String
 }
 
@@ -870,17 +870,19 @@ input GetTicksInput {
 }
 
 """
-Input for attaching an Instagram video as beta for a climb.
+Input for attaching an Instagram or TikTok video as beta for a climb.
 """
 input AttachBetaLinkInput {
   "Board type"
   boardType: String!
   "Climb UUID"
   climbUuid: String!
-  "Instagram post or reel URL"
+  "Instagram or TikTok video URL"
   link: String!
   "Optional angle the video was climbed at"
   angle: Int
+  "Optional tick UUID this beta video belongs to"
+  tickUuid: ID
 }
 
 # ============================================
@@ -3624,6 +3626,8 @@ type BetaLink {
   thumbnail: String
   isListed: Boolean
   createdAt: String
+  tickUuid: ID
+  boardId: Int
 }
 
 """
@@ -4636,7 +4640,7 @@ type Mutation {
   updateTick(uuid: ID!, input: UpdateTickInput!): Tick!
 
   """
-  Attach an Instagram post or reel as beta for a climb. Idempotent on
+  Attach an Instagram or TikTok video as beta for a climb. Idempotent on
   (boardType, climbUuid, link).
   """
   attachBetaLink(input: AttachBetaLinkInput!): Boolean!

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -269,7 +269,7 @@ export type AscentFeedResult = {
   totalCount: Scalars['Int']['output'];
 };
 
-/** Input for attaching an Instagram video as beta for a climb. */
+/** Input for attaching an Instagram or TikTok video as beta for a climb. */
 export type AttachBetaLinkInput = {
   /** Optional angle the video was climbed at */
   angle?: InputMaybe<Scalars['Int']['input']>;
@@ -277,8 +277,10 @@ export type AttachBetaLinkInput = {
   boardType: Scalars['String']['input'];
   /** Climb UUID */
   climbUuid: Scalars['String']['input'];
-  /** Instagram post or reel URL */
+  /** Instagram or TikTok video URL */
   link: Scalars['String']['input'];
+  /** Optional tick UUID this beta video belongs to */
+  tickUuid?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Stored credentials for an Aurora Climbing board account. */
@@ -318,12 +320,14 @@ export type AuroraCredentialStatus = {
 export type BetaLink = {
   __typename?: 'BetaLink';
   angle?: Maybe<Scalars['Int']['output']>;
+  boardId?: Maybe<Scalars['Int']['output']>;
   climbUuid: Scalars['String']['output'];
   createdAt?: Maybe<Scalars['String']['output']>;
   foreignUsername?: Maybe<Scalars['String']['output']>;
   isListed?: Maybe<Scalars['Boolean']['output']>;
   link: Scalars['String']['output'];
   thumbnail?: Maybe<Scalars['String']['output']>;
+  tickUuid?: Maybe<Scalars['ID']['output']>;
 };
 
 /**
@@ -2039,7 +2043,7 @@ export type Mutation = {
    */
   addQueueItem: ClimbQueueItem;
   /**
-   * Attach an Instagram post or reel as beta for a climb. Idempotent on
+   * Attach an Instagram or TikTok video as beta for a climb. Idempotent on
    * (boardType, climbUuid, link).
    */
   attachBetaLink: Scalars['Boolean']['output'];
@@ -4495,7 +4499,7 @@ export type SaveTickInput = {
   sizeId?: InputMaybe<Scalars['Int']['input']>;
   /** Result of the attempt */
   status: TickStatus;
-  /** Optional Instagram post or reel URL to attach as beta for the climb */
+  /** Optional Instagram or TikTok video URL to attach as beta for the climb */
   videoUrl?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -6659,12 +6663,14 @@ export type BetaLinkResolvers<
   ParentType extends ResolversParentTypes['BetaLink'] = ResolversParentTypes['BetaLink'],
 > = ResolversObject<{
   angle?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  boardId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   climbUuid?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   foreignUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isListed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   link?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   thumbnail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tickUuid?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/packages/shared-schema/src/schema/beta-links.ts
+++ b/packages/shared-schema/src/schema/beta-links.ts
@@ -11,6 +11,8 @@ export const betaLinksTypeDefs = /* GraphQL */ `
     thumbnail: String
     isListed: Boolean
     createdAt: String
+    tickUuid: ID
+    boardId: Int
   }
 
   """

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -290,7 +290,7 @@ export const mutationsTypeDefs = /* GraphQL */ `
     updateTick(uuid: ID!, input: UpdateTickInput!): Tick!
 
     """
-    Attach an Instagram post or reel as beta for a climb. Idempotent on
+    Attach an Instagram or TikTok video as beta for a climb. Idempotent on
     (boardType, climbUuid, link).
     """
     attachBetaLink(input: AttachBetaLinkInput!): Boolean!

--- a/packages/shared-schema/src/schema/ticks.ts
+++ b/packages/shared-schema/src/schema/ticks.ts
@@ -113,7 +113,7 @@ export const ticksTypeDefs = /* GraphQL */ `
     boardUuid: String
     "Resolved shared board id (from resolveBoardForSerial) for the BLE-connected wall everyone is logging to. Used when no boardUuid is given; falls back to board-config resolution if it doesn't match the payload."
     boardId: Int
-    "Optional Instagram post or reel URL to attach as beta for the climb"
+    "Optional Instagram or TikTok video URL to attach as beta for the climb"
     videoUrl: String
   }
 
@@ -149,16 +149,18 @@ export const ticksTypeDefs = /* GraphQL */ `
   }
 
   """
-  Input for attaching an Instagram video as beta for a climb.
+  Input for attaching an Instagram or TikTok video as beta for a climb.
   """
   input AttachBetaLinkInput {
     "Board type"
     boardType: String!
     "Climb UUID"
     climbUuid: String!
-    "Instagram post or reel URL"
+    "Instagram or TikTok video URL"
     link: String!
     "Optional angle the video was climbed at"
     angle: Int
+    "Optional tick UUID this beta video belongs to"
+    tickUuid: ID
   }
 `;

--- a/packages/shared-schema/src/types/ticks.ts
+++ b/packages/shared-schema/src/types/ticks.ts
@@ -80,4 +80,5 @@ export type AttachBetaLinkInput = {
   climbUuid: string;
   link: string;
   angle?: number | null;
+  tickUuid?: string | null;
 };

--- a/packages/shared/graphql/src/generated/gql.ts
+++ b/packages/shared/graphql/src/generated/gql.ts
@@ -16,10 +16,10 @@ import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/
 type Documents = {
   '\n  query GetDeleteAccountInfo {\n    deleteAccountInfo {\n      publishedClimbCount\n    }\n  }\n': typeof types.GetDeleteAccountInfoDocument;
   '\n  mutation DeleteAccount($input: DeleteAccountInput!) {\n    deleteAccount(input: $input)\n  }\n': typeof types.DeleteAccountDocument;
-  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n': typeof types.GetBetaLinksDocument;
+  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      tickUuid\n      boardId\n    }\n  }\n': typeof types.GetBetaLinksDocument;
   '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n': typeof types.AttachBetaLinkDocument;
-  '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetRecentBetaLinksDocument;
-  '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n': typeof types.GetUserBetaLinksDocument;
+  '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n': typeof types.GetRecentBetaLinksDocument;
+  '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n': typeof types.GetUserBetaLinksDocument;
   '\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n': typeof types.BetaLinkPreviewDocument;
   '\n  query ClimbStatsHistory($boardName: String!, $climbUuid: ID!) {\n    climbStatsHistory(boardName: $boardName, climbUuid: $climbUuid) {\n      angle\n      ascensionistCount\n      qualityAverage\n      difficultyAverage\n      displayDifficulty\n      createdAt\n    }\n  }\n': typeof types.ClimbStatsHistoryDocument;
   '\n  query GetGlobalCommentFeed($input: GlobalCommentFeedInput) {\n    globalCommentFeed(input: $input) {\n      comments {\n        uuid\n        userId\n        userDisplayName\n        userAvatarUrl\n        entityType\n        entityId\n        parentCommentUuid\n        body\n        isDeleted\n        replyCount\n        upvotes\n        downvotes\n        voteScore\n        userVote\n        createdAt\n        updatedAt\n      }\n      totalCount\n      hasMore\n      cursor\n    }\n  }\n': typeof types.GetGlobalCommentFeedDocument;
@@ -129,13 +129,13 @@ const documents: Documents = {
     types.GetDeleteAccountInfoDocument,
   '\n  mutation DeleteAccount($input: DeleteAccountInput!) {\n    deleteAccount(input: $input)\n  }\n':
     types.DeleteAccountDocument,
-  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n':
+  '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      tickUuid\n      boardId\n    }\n  }\n':
     types.GetBetaLinksDocument,
   '\n  mutation AttachBetaLink($input: AttachBetaLinkInput!) {\n    attachBetaLink(input: $input)\n  }\n':
     types.AttachBetaLinkDocument,
-  '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n':
+  '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n':
     types.GetRecentBetaLinksDocument,
-  '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n':
+  '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n':
     types.GetUserBetaLinksDocument,
   '\n  query BetaLinkPreview($link: String!) {\n    betaLinkPreview(link: $link) {\n      link\n      thumbnail\n      username\n      caption\n    }\n  }\n':
     types.BetaLinkPreviewDocument,
@@ -370,8 +370,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n',
-): (typeof documents)['\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n    }\n  }\n'];
+  source: '\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      tickUuid\n      boardId\n    }\n  }\n',
+): (typeof documents)['\n  query GetBetaLinks($boardType: String!, $climbUuid: String!) {\n    betaLinks(boardType: $boardType, climbUuid: $climbUuid) {\n      climbUuid\n      link\n      foreignUsername\n      angle\n      thumbnail\n      isListed\n      createdAt\n      tickUuid\n      boardId\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -382,14 +382,14 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n',
-): (typeof documents)['\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n'];
+  source: '\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query GetRecentBetaLinks($limit: Int, $boardType: String) {\n    recentBetaLinks(limit: $limit, boardType: $boardType) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n',
-): (typeof documents)['\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n      }\n    }\n  }\n'];
+  source: '\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query GetUserBetaLinks($userId: String!, $limit: Int) {\n    userBetaLinks(userId: $userId, limit: $limit) {\n      climbName\n      boardType\n      layoutId\n      betaLink {\n        climbUuid\n        link\n        foreignUsername\n        angle\n        thumbnail\n        isListed\n        createdAt\n        tickUuid\n        boardId\n      }\n    }\n  }\n'];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -266,7 +266,7 @@ export type AscentFeedResult = {
   totalCount: Scalars['Int']['output'];
 };
 
-/** Input for attaching an Instagram video as beta for a climb. */
+/** Input for attaching an Instagram or TikTok video as beta for a climb. */
 export type AttachBetaLinkInput = {
   /** Optional angle the video was climbed at */
   angle?: InputMaybe<Scalars['Int']['input']>;
@@ -274,8 +274,10 @@ export type AttachBetaLinkInput = {
   boardType: Scalars['String']['input'];
   /** Climb UUID */
   climbUuid: Scalars['String']['input'];
-  /** Instagram post or reel URL */
+  /** Instagram or TikTok video URL */
   link: Scalars['String']['input'];
+  /** Optional tick UUID this beta video belongs to */
+  tickUuid?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Stored credentials for an Aurora Climbing board account. */
@@ -315,12 +317,14 @@ export type AuroraCredentialStatus = {
 export type BetaLink = {
   __typename?: 'BetaLink';
   angle?: Maybe<Scalars['Int']['output']>;
+  boardId?: Maybe<Scalars['Int']['output']>;
   climbUuid: Scalars['String']['output'];
   createdAt?: Maybe<Scalars['String']['output']>;
   foreignUsername?: Maybe<Scalars['String']['output']>;
   isListed?: Maybe<Scalars['Boolean']['output']>;
   link: Scalars['String']['output'];
   thumbnail?: Maybe<Scalars['String']['output']>;
+  tickUuid?: Maybe<Scalars['ID']['output']>;
 };
 
 /**
@@ -2036,7 +2040,7 @@ export type Mutation = {
    */
   addQueueItem: ClimbQueueItem;
   /**
-   * Attach an Instagram post or reel as beta for a climb. Idempotent on
+   * Attach an Instagram or TikTok video as beta for a climb. Idempotent on
    * (boardType, climbUuid, link).
    */
   attachBetaLink: Scalars['Boolean']['output'];
@@ -4492,7 +4496,7 @@ export type SaveTickInput = {
   sizeId?: InputMaybe<Scalars['Int']['input']>;
   /** Result of the attempt */
   status: TickStatus;
-  /** Optional Instagram post or reel URL to attach as beta for the climb */
+  /** Optional Instagram or TikTok video URL to attach as beta for the climb */
   videoUrl?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -5903,6 +5907,8 @@ export type GetBetaLinksQuery = {
     thumbnail?: string | null;
     isListed?: boolean | null;
     createdAt?: string | null;
+    tickUuid?: string | null;
+    boardId?: number | null;
   }>;
 };
 
@@ -5933,6 +5939,8 @@ export type GetRecentBetaLinksQuery = {
       thumbnail?: string | null;
       isListed?: boolean | null;
       createdAt?: string | null;
+      tickUuid?: string | null;
+      boardId?: number | null;
     };
   }>;
 };
@@ -5958,6 +5966,8 @@ export type GetUserBetaLinksQuery = {
       thumbnail?: string | null;
       isListed?: boolean | null;
       createdAt?: string | null;
+      tickUuid?: string | null;
+      boardId?: number | null;
     };
   }>;
 };
@@ -8181,6 +8191,8 @@ export const GetBetaLinksDocument = {
                 { kind: 'Field', name: { kind: 'Name', value: 'thumbnail' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'isListed' } },
                 { kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'tickUuid' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'boardId' } },
               ],
             },
           },
@@ -8281,6 +8293,8 @@ export const GetRecentBetaLinksDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'thumbnail' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'isListed' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'tickUuid' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'boardId' } },
                     ],
                   },
                 },
@@ -8348,6 +8362,8 @@ export const GetUserBetaLinksDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'thumbnail' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'isListed' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'createdAt' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'tickUuid' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'boardId' } },
                     ],
                   },
                 },

--- a/packages/shared/graphql/src/operations/activity-feed.ts
+++ b/packages/shared/graphql/src/operations/activity-feed.ts
@@ -136,6 +136,8 @@ const SESSION_FEED_ITEM_FIELDS = `
       thumbnail
       isListed
       createdAt
+      tickUuid
+      boardId
     }
   }
   socialEntityType

--- a/packages/shared/graphql/src/operations/beta-links.ts
+++ b/packages/shared/graphql/src/operations/beta-links.ts
@@ -18,6 +18,8 @@ export const GET_BETA_LINKS = gql`
       thumbnail
       isListed
       createdAt
+      tickUuid
+      boardId
     }
   }
 `;
@@ -48,6 +50,8 @@ export const GET_RECENT_BETA_LINKS = gql`
         thumbnail
         isListed
         createdAt
+        tickUuid
+        boardId
       }
     }
   }
@@ -76,6 +80,8 @@ export const GET_USER_BETA_LINKS = gql`
         thumbnail
         isListed
         createdAt
+        tickUuid
+        boardId
       }
     }
   }

--- a/packages/web/app/components/beta-videos/__tests__/home-recent-beta-section.test.tsx
+++ b/packages/web/app/components/beta-videos/__tests__/home-recent-beta-section.test.tsx
@@ -77,6 +77,8 @@ function makeRow(overrides: {
       thumbnail: null,
       isListed: true,
       createdAt: null,
+      tickUuid: null,
+      boardId: null,
     },
   };
 }

--- a/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-dialog.tsx
@@ -14,6 +14,7 @@ type AttachBetaLinkDialogProps = {
   climbUuid: string;
   climbName?: string;
   angle?: number | null;
+  tickUuid?: string | null;
   grade?: string | null;
   setter?: string | null;
   layoutId?: number | null;
@@ -27,6 +28,7 @@ const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
   climbUuid,
   climbName,
   angle,
+  tickUuid,
   grade,
   setter,
   layoutId,
@@ -44,6 +46,7 @@ const AttachBetaLinkDialog: React.FC<AttachBetaLinkDialogProps> = ({
           climbUuid={climbUuid}
           climbName={climbName}
           angle={angle}
+          tickUuid={tickUuid}
           grade={grade}
           setter={setter}
           layoutId={layoutId}

--- a/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
+++ b/packages/web/app/components/beta-videos/attach-beta-link-form.tsx
@@ -34,6 +34,7 @@ type AttachBetaLinkFormProps = {
   climbUuid: string;
   climbName?: string;
   angle?: number | null;
+  tickUuid?: string | null;
   grade?: string | null;
   setter?: string | null;
   layoutId?: number | null;
@@ -54,6 +55,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
   climbUuid,
   climbName,
   angle,
+  tickUuid,
   grade,
   setter,
   layoutId,
@@ -105,6 +107,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
           climbUuid,
           link: trimmed,
           angle: angle ?? undefined,
+          tickUuid: tickUuid ?? undefined,
         },
       };
       await client.request<AttachBetaLinkMutationResponse>(ATTACH_BETA_LINK, variables);
@@ -117,7 +120,7 @@ const AttachBetaLinkForm: React.FC<AttachBetaLinkFormProps> = ({
       } else if (isInstagramUrl(trimmed)) {
         platform = 'Instagram';
       }
-      track('Beta Video Added', { boardType, climbUuid, platform });
+      track('Beta Video Added', { boardType, climbUuid, tickUuid, platform });
       showMessage(t('betaVideos.addedToast'), 'success');
       setUrl('');
       onSuccess?.();

--- a/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
+++ b/packages/web/app/components/climb-detail/__tests__/build-climb-detail-sections.test.tsx
@@ -57,6 +57,8 @@ let mockBetaLinks: Array<{
   thumbnail: string | null;
   isListed: boolean;
   createdAt: string;
+  tickUuid: string | null;
+  boardId: number | null;
 }> = [];
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({
@@ -216,6 +218,8 @@ describe('useBuildClimbDetailSections', () => {
         thumbnail: null,
         isListed: true,
         createdAt: '2024-01-01',
+        tickUuid: null,
+        boardId: null,
       },
       {
         climbUuid: MOCK_CLIMB.uuid,
@@ -225,6 +229,8 @@ describe('useBuildClimbDetailSections', () => {
         thumbnail: null,
         isListed: true,
         createdAt: '2024-01-02',
+        tickUuid: null,
+        boardId: null,
       },
       {
         climbUuid: MOCK_CLIMB.uuid,
@@ -234,6 +240,8 @@ describe('useBuildClimbDetailSections', () => {
         thumbnail: null,
         isListed: true,
         createdAt: '2024-01-03',
+        tickUuid: null,
+        boardId: null,
       },
     ];
 
@@ -257,6 +265,8 @@ describe('useBuildClimbDetailSections', () => {
         thumbnail: null,
         isListed: true,
         createdAt: '2024-01-01',
+        tickUuid: null,
+        boardId: null,
       },
     ];
 

--- a/packages/web/app/components/library/logbook-feed-item.tsx
+++ b/packages/web/app/components/library/logbook-feed-item.tsx
@@ -928,6 +928,7 @@ const LogbookFeedItem: React.FC<LogbookFeedItemProps> = React.memo(
             climbUuid={item.climbUuid}
             climbName={item.climbName}
             angle={item.angle}
+            tickUuid={item.uuid}
             grade={item.difficultyName}
             setter={item.setterUsername}
             layoutId={item.layoutId}

--- a/packages/web/app/lib/__tests__/beta-video-url.test.ts
+++ b/packages/web/app/lib/__tests__/beta-video-url.test.ts
@@ -21,6 +21,8 @@ describe('mapBetaLinksResponse — thumbnail absolutization', () => {
       thumbnail,
       isListed: true,
       createdAt: '2026-04-26T00:00:00Z',
+      tickUuid: null,
+      boardId: null,
     };
   }
 

--- a/packages/web/app/lib/__tests__/instagram-url.test.ts
+++ b/packages/web/app/lib/__tests__/instagram-url.test.ts
@@ -12,6 +12,8 @@ function makeBetaLink(overrides: Partial<BetaLink>): BetaLink {
     thumbnail: null,
     is_listed: true,
     created_at: '2026-04-16T00:00:00.000Z',
+    tick_uuid: null,
+    board_id: null,
     ...overrides,
   };
 }

--- a/packages/web/app/profile/[user_id]/components/__tests__/profile-beta-section.test.tsx
+++ b/packages/web/app/profile/[user_id]/components/__tests__/profile-beta-section.test.tsx
@@ -77,6 +77,8 @@ function makeRow(overrides: {
       thumbnail: null,
       isListed: true,
       createdAt: null,
+      tickUuid: null,
+      boardId: null,
     },
   };
 }


### PR DESCRIPTION
$(cat <<'EOF'
Addresses all findings from the code review of #2880.

## Bug fixes

- **`attachBetaLink` stored `validated.link` (with `?igsh=` tracking params) instead of `normalizedLink`.** The dedup check ran on the normalized URL but the insert used the raw URL — defeating the purpose of normalization. Now consistently uses `normalizedLink` for `link`, `shortcode`, and `videoIdentity`.

## Security

- **Rate limit now runs before `resolveBetaLinkTickContext`.** Previously an authenticated caller could probe whether a UUID was a valid tick belonging to them without consuming any write budget. Added an explicit `applyRateLimit` call before the tick context DB query. `validateAndEnrichBetaLinkInsert` still calls it a second time (intentional double-burn; 30/min budget is well above legitimate use).

## API / type fixes

- **`ShortcodeConflict.cross-climb` now includes `existingBoardType`** so callers can distinguish same-board vs cross-board conflicts.
- **`crossClimbDupMessage` now emits a clearer message for cross-board conflicts:** `"This video is already attached to "X" on a different board. A video can only belong to one climb across all boards — please post a separate clip for this climb."` This explains the silent global-dedup behavior change that was flagged in review.
- **Comment added to `AttachBetaLinkInputSchema.angle`** clarifying it is overridden by the resolved tick's angle when `tickUuid` is provided, and that supplying both with a mismatch throws `BETA_LINK_TICK_MISMATCH`.

## New tests

- **`resolve-beta-link-tick-context.test.ts`** — 13 unit tests covering all authorization branches in `resolveBetaLinkTickContext` (the highest-priority gap from review):
  - Returns null context + no DB call when `tickUuid` absent
  - `TICK_NOT_FOUND` for unknown UUID
  - `FORBIDDEN` for another user's tick
  - `BETA_LINK_TICK_NOT_ASCENT` for attempt-status ticks
  - `BETA_LINK_TICK_MISMATCH` for wrong board type
  - `BETA_LINK_TICK_MISMATCH` for climb UUID mismatch
  - `BETA_LINK_TICK_MISMATCH` for angle mismatch (and no-throw when angle omitted)
  - `BETA_LINK_TICK_ALREADY_LINKED` when tick already has beta
  - Happy path returns `{ tickUuid, boardId, angle }`
  - Accepts both `flash` and `send` status
  - Resolves correctly via canonical alias (different alias UUIDs, same canonical)
  - Angle returned is from tick, not input

- **`beta-link-write-gate.test.ts`** — Updated all `cross-climb` `toEqual` assertions to include `existingBoardType`.

- **`beta-video-url.test.ts`** — Added `SQL migration alignment` describe block that locks the contract between TypeScript's `betaLinkIdentity()` and the `regexp_match` capture groups used in migration 0128's backfill CTEs. Verifies Instagram group 4 → TS group 1 and TikTok group 2 → TS group 1 produce the same identity strings.

## Documentation

- **`unified.ts`** — Upgraded `tickUuid` and `boardId` FK comments to match the existing `createdByUserId` pattern: explicit ⚠️ warning that `drizzle-kit generate` does not know about these FKs and may emit SQL that drops them. Also documents the `bigint` → GraphQL `Int` precision trade-off on `boardId`.

## Test plan

- [ ] `vp test run packages/backend/src/__tests__/beta-link-write-gate.test.ts packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts --reporter=agent` — all pass
- [ ] `vp test run packages/shared-schema/src/__tests__/beta-video-url.test.ts --reporter=agent` — all pass
- [ ] `vp run typecheck:backend` — clean

https://claude.ai/code/session_01C5sQGhpJohtxuPwo5pRhqF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5sQGhpJohtxuPwo5pRhqF)_