### PR TITLE
fix(mobile): keep the iOS 26 bottom accessory on the session detail screen

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -8,6 +8,10 @@ const cfg = vi.hoisted(() => ({
   sessionId: null as string | null,
   nativeAccessoryActive: true,
   hasCurrentClimb: false,
+  // Whether the focused route is inside the (tabs) group. The native bottom
+  // accessory only mounts on-tabs; a root-level push (session detail) or modal
+  // takes the tab bar off screen, so the host unmounts there.
+  insideTabs: true,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   // Whether the device can render real iOS 26 glass chrome. The native tab bar
   // mounts only for the Liquid Glass variant on a capable device; everything else
@@ -43,6 +47,13 @@ vi.mock('../../../src/providers/queue-provider', () => ({
 // use-has-accessory-climb, and the hold logic in use-sticky-accessory-presence.
 vi.mock('../../../src/hooks/use-sticky-accessory-presence', () => ({
   useStickyAccessoryPresence: () => cfg.hasCurrentClimb,
+}));
+
+// Route gate on the accessory mount: false once a root push/modal slides the tab
+// bar (and its accessory) off screen. Driven by useSegments() + isTabsRoute in the
+// real hook; the route-segment split is unit-tested in route-segments.test.
+vi.mock('../../../src/hooks/use-inside-tabs', () => ({
+  useInsideTabs: () => cfg.insideTabs,
 }));
 
 vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({
@@ -148,6 +159,7 @@ describe('TabLayout', () => {
     cfg.sessionId = null;
     cfg.nativeAccessoryActive = true;
     cfg.hasCurrentClimb = false;
+    cfg.insideTabs = true;
     cfg.variant = 'liquidGlass';
     cfg.glassCapable = true;
     cfg.platformOS = 'ios';
@@ -245,6 +257,19 @@ describe('TabLayout', () => {
   it('skips the empty native bottom accessory when no climb is current', () => {
     cfg.nativeAccessoryActive = true;
     cfg.hasCurrentClimb = false;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-bottom-accessory="true"]')).toBeNull();
+  });
+
+  it('skips the native bottom accessory when outside the tabs group', () => {
+    // A root push (session detail) or modal slides the tab bar off screen. Unmount
+    // the accessory host there so UIKit doesn't keep a stale glass-platter snapshot
+    // that re-presents doubled on return.
+    cfg.nativeAccessoryActive = true;
+    cfg.hasCurrentClimb = true;
+    cfg.insideTabs = false;
 
     const { container } = render(<TabLayout />);
 

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -12,6 +12,7 @@ import { MaterialTabBar } from '../../src/components/navigation/MaterialTabBar';
 import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
+import { useInsideTabs } from '../../src/hooks/use-inside-tabs';
 
 // Cold-start on Home: the leftmost tab carries the beta shelf and followed
 // activity feed, while Climbs remains the search surface one tab over. Drives
@@ -62,6 +63,15 @@ export default function TabLayout() {
   // wrapper additionally holds the mount across a brief presence blip (board
   // reconnect / queue rehydrate), so those don't churn the host either.
   const hasCurrentClimb = useStickyAccessoryPresence();
+  // Route term on the same mount gate: a root-level push (session detail) or modal
+  // slides the whole tab bar — and its bottom accessory — off screen. Without this,
+  // React leaves the accessory host mounted underneath, so UIKit keeps a stale glass
+  // platter that re-presents stacked under the fresh one on return (doubled, offset
+  // text). Unmounting on tab-group exit releases the host cleanly; bottom-chrome
+  // arbitration already assumes the native accessory is gone off-tabs, so this just
+  // makes the real mount match. `isTabsRoute` keys on segments[0] only, so intra-tab
+  // navigation doesn't toggle it.
+  const insideTabs = useInsideTabs();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
 
@@ -116,7 +126,7 @@ export default function TabLayout() {
       labelStyle={{ default: { color: systemColors.secondaryLabel }, selected: { color: systemColors.label } }}
       tintColor={systemColors.label}
     >
-      {nativeAccessoryActive && hasCurrentClimb ? (
+      {insideTabs && nativeAccessoryActive && hasCurrentClimb ? (
         <NativeTabs.BottomAccessory key="queue-bottom-accessory">
           <QueueBottomAccessory />
         </NativeTabs.BottomAccessory>

--- a/packages/mobile/app/(tabs)/home/_layout.tsx
+++ b/packages/mobile/app/(tabs)/home/_layout.tsx
@@ -1,0 +1,15 @@
+import { Stack } from 'expo-router';
+import { glassStackScreenOptions } from '../../../src/theme/navigation';
+
+export default function HomeLayout() {
+  return (
+    <Stack screenOptions={glassStackScreenOptions}>
+      {/* The Home feed owns its top via floating chrome (the avatar island + scope
+          title), like the other tabs — so the stack header is hidden here. */}
+      <Stack.Screen name="index" options={{ headerShown: false }} />
+      {/* Session detail keeps the native tab bar + bottom accessory by living in
+          this stack. It sets its own header title from the loaded session. */}
+      <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
+    </Stack>
+  );
+}

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -155,7 +155,7 @@ export default function HomeTab() {
   }, []);
 
   const handleSessionPress = useCallback(
-    (session: SessionFeedItem) => navigateToSessionFeedItem(router, session),
+    (session: SessionFeedItem) => navigateToSessionFeedItem(router, session, '/home/session/[sessionId]'),
     [router],
   );
 

--- a/packages/mobile/app/(tabs)/home/session/[sessionId].tsx
+++ b/packages/mobile/app/(tabs)/home/session/[sessionId].tsx
@@ -1,0 +1,4 @@
+// Session detail pushed inside the Home tab stack, so the native tab bar + Liquid
+// Glass bottom accessory stay on screen (matching the playlist detail view). Shares
+// the same screen component as the Profile tab's session route.
+export { default } from '../../../../src/components/session/SessionDetailScreen';

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -12,6 +12,9 @@ export default function ProfileLayout() {
           title collapsing into a glass capsule), like the Discover/Climbs tabs —
           so the stack header is hidden here. */}
       <Stack.Screen name="index" options={{ headerShown: false, title: t('mobile.nav.profile') }} />
+      {/* Session detail keeps the native tab bar + bottom accessory by living in
+          this stack. It sets its own header title from the loaded session. */}
+      <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
       <Stack.Screen name="more" options={{ title: t('mobile.more.title') }} />
       <Stack.Screen name="integrations" options={{ title: tSettings('integrations.title') }} />
       {/* i18n-ignore-next-line — preview-only screen */}

--- a/packages/mobile/app/(tabs)/profile/session/[sessionId].tsx
+++ b/packages/mobile/app/(tabs)/profile/session/[sessionId].tsx
@@ -1,0 +1,5 @@
+// Session detail pushed inside the Profile tab stack (reached from the Sessions
+// sub-tab), so the native tab bar + Liquid Glass bottom accessory stay on screen
+// (matching the playlist detail view). Shares the same screen component as the Home
+// tab's session route.
+export { default } from '../../../../src/components/session/SessionDetailScreen';

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -342,7 +342,6 @@ function RootLayout() {
                                                             name="auth"
                                                             options={{ headerShown: false, gestureEnabled: false }}
                                                           />
-                                                          <Stack.Screen name="session/[sessionId]" />
                                                           <Stack.Screen
                                                             name="join/[sessionId]"
                                                             options={{ presentation: 'modal', headerShown: false }}

--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -6,28 +6,35 @@ import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { SessionDetailTick, SessionFeedParticipant, SocialEntityType } from '@boardsesh/shared-schema';
 import { formatTickAbsoluteTime } from '@boardsesh/profile-stats';
-import { Text } from '../../src/components/Text';
-import { Icon } from '../../src/components/Icon';
-import { ActivityIndicator } from '../../src/components/ActivityIndicator';
-import { SectionHeader } from '../../src/components/SectionHeader';
-import { FeedSocialRow } from '../../src/components/you/FeedSocialRow';
-import { CommentSheet } from '../../src/components/you/CommentSheet';
-import { SessionDetailHero } from '../../src/components/session/SessionDetailHero';
-import { SessionStatTiles } from '../../src/components/session/SessionStatTiles';
-import { SessionAnalyticsSection } from '../../src/components/session/SessionAnalyticsSection';
-import { SessionBetaCarousel } from '../../src/components/session/SessionBetaCarousel';
-import { SessionParticipantBreakdown } from '../../src/components/session/SessionParticipantBreakdown';
-import { SessionTickRow } from '../../src/components/session/SessionTickRow';
-import { useSessionDetail } from '../../src/lib/graphql/hooks';
-import { openClimbInPlayDrawer } from '../../src/lib/open-climb-in-play-drawer';
-import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
-import { useDrawerHost } from '../../src/providers/drawer-host-provider';
-import { spacing } from '../../src/theme/tokens';
-import { useTheme } from '../../src/providers/theme-provider';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { SectionHeader } from '../SectionHeader';
+import { FeedSocialRow } from '../you/FeedSocialRow';
+import { CommentSheet } from '../you/CommentSheet';
+import { SessionDetailHero } from './SessionDetailHero';
+import { SessionStatTiles } from './SessionStatTiles';
+import { SessionAnalyticsSection } from './SessionAnalyticsSection';
+import { SessionBetaCarousel } from './SessionBetaCarousel';
+import { SessionParticipantBreakdown } from './SessionParticipantBreakdown';
+import { SessionTickRow } from './SessionTickRow';
+import { useSessionDetail } from '../../lib/graphql/hooks';
+import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
 
 // Hoisted so FlashList gets a stable reference across renders.
 const keyExtractor = (tick: SessionDetailTick) => tick.uuid;
 
+/**
+ * Session detail — hero + stats + ticks list. Mounted from a per-tab route
+ * (`home/session/[sessionId]`, `profile/session/[sessionId]`) so it pushes inside
+ * the tab stack and keeps the native tab bar + Liquid Glass bottom accessory on
+ * screen (matching the playlist detail view), rather than a root push that slides
+ * the tab bar away.
+ */
 export default function SessionDetailScreen() {
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
   const { t } = useTranslation('session');

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -163,7 +163,7 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
 
   const handleOpenSession = useCallback(
     (session: SessionFeedItem) => {
-      navigateToSessionFeedItem(router, session);
+      navigateToSessionFeedItem(router, session, '/profile/session/[sessionId]');
     },
     [router],
   );

--- a/packages/mobile/src/hooks/use-inside-tabs.ts
+++ b/packages/mobile/src/hooks/use-inside-tabs.ts
@@ -1,0 +1,18 @@
+import { useSegments } from 'expo-router';
+import { isTabsRoute } from '../lib/route-segments';
+
+/**
+ * True while the focused route is inside the (tabs) group — i.e. the native tab bar
+ * and its bottom accessory are on screen rather than slid away behind a pushed root
+ * screen (session detail) or a root modal.
+ *
+ * Gates the `NativeTabs.BottomAccessory` mount so leaving the tabs group fully
+ * unmounts the UIKit accessory host: a clean React unmount removes the
+ * `bottomAccessory` and releases its backing view, so on return there's no orphaned
+ * glass-platter snapshot to stack under the fresh one (the doubled, offset text).
+ * `isTabsRoute` only checks segments[0], so intra-tab navigation (e.g. climbs → a
+ * climb detail within the tab stack) doesn't toggle it and never churns the host.
+ */
+export function useInsideTabs(): boolean {
+  return isTabsRoute(useSegments());
+}

--- a/packages/mobile/src/lib/session-feed-navigation.ts
+++ b/packages/mobile/src/lib/session-feed-navigation.ts
@@ -3,6 +3,15 @@ import type { SessionFeedItem } from '@boardsesh/shared-schema';
 
 type Router = ReturnType<typeof useRouter>;
 
-export function navigateToSessionFeedItem(router: Router, session: SessionFeedItem): void {
-  router.push({ pathname: '/session/[sessionId]', params: { sessionId: session.sessionId } });
+// Session detail lives once per tab stack (Home, Profile) so the push stays inside
+// the tab and keeps the native tab bar + bottom accessory on screen. Each feed
+// passes the route for its own tab so the detail lands in that tab's back stack.
+export type SessionDetailPathname = '/home/session/[sessionId]' | '/profile/session/[sessionId]';
+
+export function navigateToSessionFeedItem(
+  router: Router,
+  session: SessionFeedItem,
+  pathname: SessionDetailPathname,
+): void {
+  router.push({ pathname, params: { sessionId: session.sessionId } });
 }


### PR DESCRIPTION
## Problem

On iOS 26 (Liquid Glass), opening a single session's detail and navigating back left the tab-bar **bottom accessory drawn doubled and slightly offset**, with overlapping unreadable text. On the way in, a differently-styled bar (the JS fallback capsule + floating tick) briefly showed.

Root cause: `session/[sessionId]` was a **root-level Stack screen outside `(tabs)`**. Pushing it slid the whole tab bar — and its `NativeTabs.BottomAccessory` — off screen, then re-presented on return, orphaning the glass platter's UIKit snapshot stacked under the fresh one. While off-tabs, the JS `PersistentQueueBar` (capsule + floating FAB) took over, which also read as a different-looking accessory than the in-tab native platter.

This is the same "stale UIKit snapshot" class fought in `b427f1d67` / `7b8af76d7` — but those only covered presence blips and climb changes, never the **navigation** trigger.

## Fix

Move the session detail **inside the tab stacks** so it never leaves `(tabs)`: the native tab bar + bottom accessory stay on screen the whole time, matching the playlist detail view (which already lives in the Discover tab stack).

- One shared `SessionDetailScreen` component (`src/components/session/SessionDetailScreen.tsx`), mounted from a per-tab route — `home/session/[sessionId]` and `profile/session/[sessionId]` — so a session opened from the Home feed lands in the Home stack and one from Profile → Sessions lands in the Profile stack. **No cross-tab navigation.**
- Home becomes a `Stack` (`app/(tabs)/home/_layout.tsx`) so it can push a child route (it was a bare screen); its index keeps `headerShown: false`.
- Removed the old root `app/session/[sessionId].tsx` + its `<Stack.Screen>` registration (nothing deep-linked to it; web's `/session/` route is separate).
- `navigateToSessionFeedItem` now takes the per-tab pathname; Home and Profile callers pass their own.

Also gate the native accessory mount on `insideTabs` (new `useInsideTabs` hook) so the genuinely-root screens (About, Licenses, board picker, modals) cleanly unmount the UIKit host instead of orphaning a snapshot on return — matching what `bottom-chrome-metrics` already assumed.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 2166 tests pass (added a tab-layout case for the off-tabs gate) ✅
- `vp run check:mobile-bundle` — OK ✅
- Device (iOS 26): session opens in-tab with the native platter accessory; back returns within the tab; **single accessory, no doubled/offset text.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)