### PR TITLE
feat(board-presence): expose durable boardHistory (BOARD_HISTORY op + fetchHistory)

### DIFF
--- a/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
@@ -93,6 +93,31 @@ describe('createMobileBoardPresenceClient', () => {
     expect(climbs).toEqual([]);
   });
 
+  it('fetches durable history, forwarding limit + before and unwrapping boardHistory', async () => {
+    const history = [makeClimb('h1'), makeClimb('h2')];
+    transport.execute.mockResolvedValue({ boardHistory: history });
+
+    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory?.(7, { limit: 25, before: '900' });
+
+    expect(climbs).toEqual(history);
+    const [passedClient, operation] = transport.execute.mock.calls[0];
+    expect(passedClient).toBe(fakeClient);
+    expect(operation.variables).toEqual({ boardId: 7, limit: 25, before: '900' });
+    expect(operation.query).toContain('boardHistory');
+  });
+
+  it('defaults history limit + before to null when no paging opts are given', async () => {
+    transport.execute.mockResolvedValue({ boardHistory: [] });
+    await createMobileBoardPresenceClient(getClient).fetchHistory?.(7);
+    expect(transport.execute.mock.calls[0][1].variables).toEqual({ boardId: 7, limit: null, before: null });
+  });
+
+  it('falls back to an empty array when boardHistory is missing', async () => {
+    transport.execute.mockResolvedValue({});
+    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory?.(7);
+    expect(climbs).toEqual([]);
+  });
+
   it('fetches stats and unwraps the boardPresenceStats field', async () => {
     const stats = {
       climbsSentCount: 3,

--- a/packages/mobile/src/lib/board-presence/board-presence-client.ts
+++ b/packages/mobile/src/lib/board-presence/board-presence-client.ts
@@ -16,6 +16,7 @@
 import { type Client, execute, subscribe } from '@boardsesh/graphql-client';
 import {
   BOARD_CONNECTION,
+  BOARD_HISTORY,
   BOARD_NOW_PLAYING,
   BOARD_PRESENCE_STATS,
   BOARD_RECENT_CLIMBS,
@@ -40,6 +41,7 @@ import type {
 
 type BoardNowPlayingData = { boardNowPlaying: BoardPresenceEvent };
 type BoardRecentClimbsData = { boardRecentClimbs: BoardPresenceClimb[] };
+type BoardHistoryData = { boardHistory: BoardPresenceClimb[] };
 type BoardPresenceStatsData = { boardPresenceStats: BoardPresenceStats };
 type BoardConnectionData = { boardConnection: BoardConnectionHolder | null };
 type ReportBoardClimbData = { reportBoardClimb: boolean };
@@ -103,6 +105,14 @@ export function createMobileBoardPresenceClient(getClient: () => Client): Mobile
         variables: { boardId },
       });
       return data.boardRecentClimbs ?? [];
+    },
+
+    async fetchHistory(boardId, opts) {
+      const data = await execute<BoardHistoryData>(getClient(), {
+        query: BOARD_HISTORY,
+        variables: { boardId, limit: opts?.limit ?? null, before: opts?.before ?? null },
+      });
+      return data.boardHistory ?? [];
     },
 
     async fetchStats(boardId) {

--- a/packages/shared/board-presence-react/src/types.ts
+++ b/packages/shared/board-presence-react/src/types.ts
@@ -31,6 +31,16 @@ export interface BoardPresenceClient {
   /** Newest-first recent climbs, used to backfill history for a late joiner. */
   fetchRecentClimbs(boardId: number): Promise<BoardPresenceClimb[]>;
 
+  /**
+   * Durable, keyset-paged history of what was lit on the board, from the
+   * `board_climb_events` log — beyond the ~50 / 24h window `fetchRecentClimbs`
+   * covers. Newest-first; pass `before` (the `seq` of the previous page's last
+   * row) to page back, and `limit` (server-capped 1–100, default 50) for page
+   * size. Optional so read-only / web clients that only need the live feed plus
+   * recent backfill still satisfy the interface.
+   */
+  fetchHistory?(boardId: number, opts?: { limit?: number; before?: string }): Promise<BoardPresenceClimb[]>;
+
   /** Durable + live stats for the board's wall feed. */
   fetchStats(boardId: number): Promise<BoardPresenceStats>;
 

--- a/packages/shared/graphql/src/operations/board-presence.ts
+++ b/packages/shared/graphql/src/operations/board-presence.ts
@@ -233,6 +233,20 @@ export const BOARD_RECENT_CLIMBS = `
   }
 `;
 
+// Query — durable, keyset-paged history of what was lit on a board, from
+// `board_climb_events` (survives past the 24h Redis window that backs
+// BOARD_RECENT_CLIMBS). Newest-first; `before` is an opaque cursor equal to the
+// `seq` of the previous page's last row, and `limit` is server-capped 1–100
+// (default 50). Reuses the same climb fields as the live feed so every wall
+// surface decodes one shape.
+export const BOARD_HISTORY = `
+  query BoardHistory($boardId: Int!, $limit: Int, $before: String) {
+    boardHistory(boardId: $boardId, limit: $limit, before: $before) {
+      ${BOARD_PRESENCE_CLIMB_FIELDS}
+    }
+  }
+`;
+
 // Query — durable + live stats for a board's wall feed.
 export const BOARD_PRESENCE_STATS = `
   query BoardPresenceStats($boardId: Int!) {


### PR DESCRIPTION
## What

Wires the **client side** of the already-live `boardHistory` resolver so consumers can read a board's **durable, keyset-paged history** of what was lit — beyond the ~50 / 24h window that `boardRecentClimbs` covers.

- Export `BOARD_HISTORY` query in `@boardsesh/graphql` operations (`packages/shared/graphql/src/operations/board-presence.ts`), reusing the shared `BOARD_PRESENCE_CLIMB_FIELDS` so every wall surface decodes one shape.
- Add optional `fetchHistory(boardId, { limit, before })` to `BoardPresenceClient` (`packages/shared/board-presence-react/src/types.ts`). **Optional** (like `fetchConnection?`/`reportDisconnect?`) so the web / read-only clients satisfy the interface unchanged.
- Implement it in the mobile board-presence client, mirroring `fetchRecentClimbs`.
- Unit tests for the paging variables (`limit`/`before` → `null` defaults) and the empty-response fallback.

## Why

Groundwork for the upcoming **iPad "Gym Wall"** surface (time-travel scrubber of what was lit at time T). Landing the shared/client wiring **first, standalone**, so the deployed backend supports durable history before any iPad device QA. The resolver itself is **already live** (`packages/backend/src/graphql/resolvers/board-presence/queries.ts`, keyset-paged on `seq`); this PR only exposes it to clients.

## Notes

- **No resolver/SDL change, no native change** → rides OTA. `vp run codegen` produces no diff (these operations are plain-string constants with hand-written result types; the SDL field already existed).
- **Auth:** `boardHistory` calls `requireAuthenticated` (unlike the anonymous-readable `boardRecentClimbs`/`boardConnection`) — relevant for the Gym Wall's dedicated kiosk-account model.

## Validation

- `vp run typecheck` (full monorepo) — green (incl. web, which consumes the interface unchanged).
- `vp test run --project mobile` — 302 files / 2186 tests pass, including the new `fetchHistory` cases.
- `vp run check:mobile-bundle` — OK.
- `vp check --fix` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)