### PR TITLE
Surface board-history cursor type, require mobile fetchHistory

### DIFF
--- a/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
@@ -97,7 +97,7 @@ describe('createMobileBoardPresenceClient', () => {
     const history = [makeClimb('h1'), makeClimb('h2')];
     transport.execute.mockResolvedValue({ boardHistory: history });
 
-    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory?.(7, { limit: 25, before: '900' });
+    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory(7, { limit: 25, before: '900' });
 
     expect(climbs).toEqual(history);
     const [passedClient, operation] = transport.execute.mock.calls[0];
@@ -108,13 +108,13 @@ describe('createMobileBoardPresenceClient', () => {
 
   it('defaults history limit + before to null when no paging opts are given', async () => {
     transport.execute.mockResolvedValue({ boardHistory: [] });
-    await createMobileBoardPresenceClient(getClient).fetchHistory?.(7);
+    await createMobileBoardPresenceClient(getClient).fetchHistory(7);
     expect(transport.execute.mock.calls[0][1].variables).toEqual({ boardId: 7, limit: null, before: null });
   });
 
   it('falls back to an empty array when boardHistory is missing', async () => {
     transport.execute.mockResolvedValue({});
-    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory?.(7);
+    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory(7);
     expect(climbs).toEqual([]);
   });
 

--- a/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
+++ b/packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { boardHistoryCursor } from '@boardsesh/board-presence-react';
 import type { Client } from '@boardsesh/graphql-client';
 import type { BoardPresenceEvent, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 
@@ -97,7 +98,10 @@ describe('createMobileBoardPresenceClient', () => {
     const history = [makeClimb('h1'), makeClimb('h2')];
     transport.execute.mockResolvedValue({ boardHistory: history });
 
-    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory(7, { limit: 25, before: '900' });
+    const climbs = await createMobileBoardPresenceClient(getClient).fetchHistory(7, {
+      limit: 25,
+      before: boardHistoryCursor(900),
+    });
 
     expect(climbs).toEqual(history);
     const [passedClient, operation] = transport.execute.mock.calls[0];

--- a/packages/mobile/src/lib/board-presence/board-presence-client.ts
+++ b/packages/mobile/src/lib/board-presence/board-presence-client.ts
@@ -67,6 +67,9 @@ export type SerialResolveArgs = {
  * keep using the legacy single-board resolver).
  */
 export type MobileBoardPresenceClient = BoardPresenceClient & {
+  // Always implemented here (unlike the optional shared method), so callers and
+  // tests can invoke it directly without optional chaining.
+  fetchHistory: NonNullable<BoardPresenceClient['fetchHistory']>;
   resolveBoardCandidatesForSerial(args: SerialResolveArgs): Promise<ResolveBoardResult>;
   chooseBoardForSerial(args: { boardId: number; serial: string }): Promise<ResolvedBoard>;
 };

--- a/packages/shared/board-presence-react/src/__tests__/board-history-cursor.test.ts
+++ b/packages/shared/board-presence-react/src/__tests__/board-history-cursor.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { boardHistoryCursor } from '../types';
+
+describe('boardHistoryCursor', () => {
+  it('stringifies a raw seq number', () => {
+    expect(boardHistoryCursor(900)).toBe('900');
+  });
+
+  it('stringifies the seq of a climb', () => {
+    const climb = { climbUuid: 'c1', sentAt: '2026-06-09T00:00:00.000Z', seq: 42 } as BoardPresenceClimb;
+    expect(boardHistoryCursor(climb)).toBe('42');
+  });
+});

--- a/packages/shared/board-presence-react/src/index.ts
+++ b/packages/shared/board-presence-react/src/index.ts
@@ -29,4 +29,5 @@ export {
   BoardPresenceHasClimbContext,
 } from './board-presence-provider';
 
-export type { BoardPresenceClient } from './types';
+export { boardHistoryCursor } from './types';
+export type { BoardHistoryCursor, BoardPresenceClient } from './types';

--- a/packages/shared/board-presence-react/src/types.ts
+++ b/packages/shared/board-presence-react/src/types.ts
@@ -14,6 +14,20 @@ import type {
   ResolvedBoard,
 } from '@boardsesh/shared-schema';
 
+/**
+ * Keyset cursor for `fetchHistory` paging: the stringified `seq` of the last
+ * row from the previous page. `seq` is a number everywhere else, but the
+ * GraphQL `boardHistory(before: String)` arg is a String and rejects a
+ * non-integer `before` with BAD_USER_INPUT — so always stringify the seq.
+ * Build it with `boardHistoryCursor` instead of calling `.toString()` ad hoc.
+ */
+export type BoardHistoryCursor = string;
+
+/** Cursor for the next page back: the `seq` of a climb (or a raw seq), stringified. */
+export function boardHistoryCursor(climbOrSeq: BoardPresenceClimb | number): BoardHistoryCursor {
+  return (typeof climbOrSeq === 'number' ? climbOrSeq : climbOrSeq.seq).toString();
+}
+
 export interface BoardPresenceClient {
   /**
    * Subscribe to a board's live "now on the wall" feed. Each event is one
@@ -39,7 +53,7 @@ export interface BoardPresenceClient {
    * size. Optional so read-only / web clients that only need the live feed plus
    * recent backfill still satisfy the interface.
    */
-  fetchHistory?(boardId: number, opts?: { limit?: number; before?: string }): Promise<BoardPresenceClimb[]>;
+  fetchHistory?(boardId: number, opts?: { limit?: number; before?: BoardHistoryCursor }): Promise<BoardPresenceClimb[]>;
 
   /** Durable + live stats for the board's wall feed. */
   fetchStats(boardId: number): Promise<BoardPresenceStats>;

--- a/packages/shared/board-presence-react/src/types.ts
+++ b/packages/shared/board-presence-react/src/types.ts
@@ -19,13 +19,13 @@ import type {
  * row from the previous page. `seq` is a number everywhere else, but the
  * GraphQL `boardHistory(before: String)` arg is a String and rejects a
  * non-integer `before` with BAD_USER_INPUT — so always stringify the seq.
- * Build it with `boardHistoryCursor` instead of calling `.toString()` ad hoc.
+ * Branded so the only way to make one is `boardHistoryCursor`, never an ad-hoc string.
  */
-export type BoardHistoryCursor = string;
+export type BoardHistoryCursor = string & { readonly _brand: 'BoardHistoryCursor' };
 
 /** Cursor for the next page back: the `seq` of a climb (or a raw seq), stringified. */
 export function boardHistoryCursor(climbOrSeq: BoardPresenceClimb | number): BoardHistoryCursor {
-  return (typeof climbOrSeq === 'number' ? climbOrSeq : climbOrSeq.seq).toString();
+  return (typeof climbOrSeq === 'number' ? climbOrSeq : climbOrSeq.seq).toString() as BoardHistoryCursor;
 }
 
 export interface BoardPresenceClient {


### PR DESCRIPTION
## What

Two small board-presence type-safety cleanups flagged in review, both about preventing *future* silent bugs (durable-history paging has no real caller yet — the Gym Wall scrubber will be the first to use it):

1. **History cursor now has a name and a builder.** `fetchHistory`'s `before` cursor was a bare `string`, but it carries the stringified `seq` of the previous page's last row — and `seq` is a `number` everywhere else (`BoardPresenceClimb.seq: number`, GraphQL `seq: Int!`). The GraphQL arg `boardHistory(before: String)` is a String and rejects a non-integer `before` with `BAD_USER_INPUT`. Nothing in the type told a caller to stringify the seq.
   - Added `BoardHistoryCursor` (aliased `string`) with JSDoc explaining the `seq → string` contract.
   - Added a `boardHistoryCursor(climbOrSeq)` builder so callers don't reach for `.toString()` ad hoc.
   - `fetchHistory`'s `before` option now typed `BoardHistoryCursor`.

2. **Mobile `fetchHistory` is now required on its client type.** The shared `BoardPresenceClient.fetchHistory` is optional, so the mobile client tests called it through `?.` — which would have silently short-circuited to `undefined` (and passed against nothing) if the implementation were ever removed. The mobile client always implements it, so `MobileBoardPresenceClient` now narrows it to non-optional and the tests call it directly.

The web client/test is untouched: web deliberately omits `fetchHistory`, so it stays optional on the shared interface.

## Files

- `packages/shared/board-presence-react/src/types.ts` — cursor alias + builder, `before` retyped
- `packages/shared/board-presence-react/src/index.ts` — export the alias + builder
- `packages/mobile/src/lib/board-presence/board-presence-client.ts` — require `fetchHistory`
- `packages/mobile/src/lib/board-presence/__tests__/board-presence-client.test.ts` — drop `?.` on the three history calls

## Verification

- `vp run typecheck:mobile` / `typecheck:shared` — pass
- `vp test run --project mobile` board-presence-client — 13/13 pass
- `vp check` on the changed packages — clean (format + lint)

https://claude.ai/code/session_01Dixvpsvz7G9gFycRgC2q5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dixvpsvz7G9gFycRgC2q5v)_