### PR TITLE
feat(mobile): adaptive iPad shell — glass sidebar replaces the tab bar

### DIFF
--- a/.github/workflows/mobile-screenshots-ios.yml
+++ b/.github/workflows/mobile-screenshots-ios.yml
@@ -15,10 +15,14 @@ name: Mobile Screenshots (iOS)
 # This is a 3-stage fan-out so every locale captures in parallel and a single
 # overloaded runner never thrashes:
 #   ios-build    — build/restore the cached .app ONCE (no per-shard cold build).
-#   ios-capture  — matrix of locale (en-US, es, fr) on one device size (the 6.9"
-#                  iPhone 16 Pro Max; Apple scales it down to all other iPhones) =
-#                  3 shards, each its own runner: one Metro, one simulator, one
-#                  capture.
+#   ios-capture  — matrix of locale (en-US, es, fr) × device (the 6.9" iPhone 16
+#                  Pro Max — Apple scales it down to all other iPhones — plus the
+#                  iPad Pro 13-inch and 11-inch, a separate slot that doesn't
+#                  auto-scale) = 9 shards, each its own runner: one Metro, one
+#                  simulator, one capture. --shutdown is kept as belt-and-suspenders
+#                  (a shard only ever boots one sim, so there's nothing to accumulate
+#                  — several booted at once on one runner is what made the old job
+#                  thrash and time out at "iOS driver not ready in time").
 #   ios-finalize — merge the per-shard artifacts into one tree, run the dimension
 #                  gate (it needs all four App Store locales at once), and upload.
 #
@@ -135,7 +139,7 @@ jobs:
       # ios-capture shard restores the exact same bucket.
       - name: Compute app cache key
         id: appkey
-        run: echo "key=${{ runner.os }}-${{ runner.arch }}-screenshot-sim-app-v1-${{ hashFiles('packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'packages/mobile/package.json', 'patches/**', 'package.json') }}" >> "$GITHUB_OUTPUT"
+        run: echo "key=${{ runner.os }}-${{ runner.arch }}-screenshot-sim-app-v1-${{ hashFiles('packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'packages/mobile/package.json', 'patches/**', 'package.json', 'scripts/mobile-build-sim-app.ts', 'scripts/screenshot-sim.entitlements') }}" >> "$GITHUB_OUTPUT"
 
       # lookup-only: this job only needs to KNOW whether the .app is cached (the
       # shards do the actual restore), so on a hit we skip downloading a .app this
@@ -176,16 +180,19 @@ jobs:
       # One shard failing shouldn't abandon the rest — let them all finish so
       # ios-finalize can report exactly which (locale, device) is short.
       fail-fast: false
-      # One device size only: the 6.9" iPhone 16 Pro Max. App Store Connect auto-scales
-      # it down to every smaller iPhone, so extra sizes add no value, only macOS-runner
-      # time. Locale is the axis that matters, so it stays a full sweep. Matrix = 3
-      # shards (one per locale), still one simulator per shard.
+      # Devices: the 6.9" iPhone 16 Pro Max (App Store Connect auto-scales it down to
+      # every smaller iPhone, so no smaller iPhone is worth a shard) plus the iPad Pro
+      # 13-inch and 11-inch, a separate App Store slot that doesn't auto-scale from
+      # iPhone. Locale is the other axis, a full sweep. Matrix = 3 locales × 3 devices
+      # = 9 shards, one simulator per shard.
       matrix:
         # Locales come from the setup job: the full en-US,es,fr set by default, or
         # the narrowed `locales` input when one is given.
         locale: ${{ fromJSON(needs.setup.outputs.ios_locales) }}
         device:
           - { name: iPhone 16 Pro Max, slug: iphone-16-pro-max }
+          - { name: iPad Pro 13-inch (M5), slug: ipad-pro-13-inch-m5 }
+          - { name: iPad Pro 11-inch (M5), slug: ipad-pro-11-inch-m5 }
 
     env:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
@@ -252,9 +259,9 @@ jobs:
         # path. Always against prod (signed in as the test user); no
         # EXPO_PUBLIC_BACKEND_URL override, so the bundle uses the app's production
         # backend defaults. --locales is a single value: `es` expands to both es-ES
-        # and es-MX, so the 3 shards together produce all four App Store locales on
-        # the one device size. --shutdown is belt-and-suspenders (a shard only boots
-        # this one sim, so there's nothing to accumulate).
+        # and es-MX for this device, so the 9 shards together produce all four App
+        # Store locales × 3 devices. --shutdown is belt-and-suspenders (a shard only
+        # boots this one sim, so there's nothing to accumulate).
         run: |
           set -euo pipefail
           vp run mobile:screenshots -- \
@@ -315,7 +322,7 @@ jobs:
     env:
       # Marks an upload dispatch — gates the App Store Connect upload steps so the
       # nightly cron and capture-only runs never touch ASC.
-      UPLOAD_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.upload }}
+      UPLOAD_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.upload && inputs.flow == 'app-store' }}
 
     steps:
       - name: Checkout repository

--- a/app-stores/README.md
+++ b/app-stores/README.md
@@ -28,7 +28,10 @@ vp run mobile:screenshots -- --platform android --backend prod --theme dark --ap
 Apple screenshots are written to
 `app-stores/apple/screenshots/<app-store-locale>/<device>/`. `--locales all`
 captures the app locales `en-US`, `es`, and `fr`, then writes App Store Connect
-folders `en-US`, `es-ES`, `es-MX`, and `fr-FR`.
+folders `en-US`, `es-ES`, `es-MX`, and `fr-FR`. `--devices common` captures
+the full App Store matrix: the three iPhone portrait slots plus 13-inch and
+11-inch iPad landscape slots. Use `--devices phones` or `--devices ipads` for
+narrowed local capture.
 
 Google Play screenshots are written to `app-stores/google/screenshots/<device>/`.
 Dark is the default; pass `--theme light` for a light set. See

--- a/app-stores/apple/app-store-metadata.md
+++ b/app-stores/apple/app-store-metadata.md
@@ -43,7 +43,10 @@ Canonical: [`fastlane/metadata/en-US/release_notes.txt`](../../fastlane/metadata
 
 ## Screenshots
 
-iPhone 6.9" (1320×2868), captured + uploaded by `vp run mobile:screenshots` (Maestro → fastlane; see `packages/mobile/.maestro/README.md`). Ten slots, in store display order (the filename prefix sets the order):
+Generated iPhone portrait and iPad landscape screenshots, captured + uploaded by
+`vp run mobile:screenshots` (Maestro -> fastlane; see
+`packages/mobile/.maestro/README.md`). Ten slots, in store display order (the
+filename prefix sets the order):
 
 1. `00-home` — the global "Everyone" activity feed
 2. `01-climbs` — browse the board's climbs
@@ -56,7 +59,7 @@ iPhone 6.9" (1320×2868), captured + uploaded by `vp run mobile:screenshots` (Ma
 9. `08-logbook` — your logged sends and progression
 10. `09-profile` — your stats and progression
 
-Apple allows up to 10 and this set fills all 10; the board-switcher sheet shot was retired to make room. Google Play caps phones at 8, so its set drops party, playlist detail, and logbook (see the Play metadata).
+Apple allows up to 10; the current generated set uploads 10 screenshots. Google Play caps phones at 8, so its set drops playlist detail and logbook (see the Play metadata).
 
 ## Review Notes
 

--- a/app-stores/apple/app-store-submission-guide.md
+++ b/app-stores/apple/app-store-submission-guide.md
@@ -31,30 +31,33 @@ Automated native capture (the real RN app, dark theme) via Maestro:
 vp run mobile:screenshots -- --platform ios --backend prod --theme dark --devices common --locales all
 ```
 
-This drives the common iPhone simulator set against prod (signed in as the test
+This drives the common Apple simulator set against prod (signed in as the test
 user) and saves PNGs to `app-stores/apple/screenshots/<app-store-locale>/<device>/`
-— e.g. `app-stores/apple/screenshots/en-US/iphone-16-pro-max/`. See
+— e.g. `app-stores/apple/screenshots/en-US/iphone-16-pro-max/` and
+`app-stores/apple/screenshots/en-US/ipad-pro-13-inch-m5/`. See
 `packages/mobile/.maestro/README.md` for prerequisites (Maestro, the
 `SCREENSHOT_USER_PASSWORD` env, etc.).
 
 ### Required screenshot sizes
 
-| Device                          | Resolution | Required?                             |
-| ------------------------------- | ---------- | ------------------------------------- |
-| 6.9" iPhone (iPhone 16 Pro Max) | 1320x2868  | Yes — the only size the flow captures |
-| 13" iPad (iPad Pro)             | 2064x2752  | Not required while tablet is disabled |
+| Device                          | Resolution       | Required?                                    |
+| ------------------------------- | ---------------- | -------------------------------------------- |
+| 6.9" iPhone (iPhone 16 Pro Max) | 1320x2868        | Yes — the only iPhone size the flow captures |
+| 13" iPad (iPad Pro)             | 2752x2064        | Yes — captured in landscape for tablet app   |
+| 11" iPad (iPad Pro)             | 2420x1668 family | Yes — captured in landscape for tablet app   |
 
-We capture a single device size, the 6.9" iPhone 16 Pro Max. App Store Connect
-**auto-scales the largest screenshot down** to every smaller iPhone, so one 6.9"
-set covers the whole device range — extra device sizes are invisible to users and
-add no ranking value, only CI time. The axis that helps the listing is locale, so
-that stays a full sweep. (See
+For iPhone we capture a single size, the 6.9" iPhone 16 Pro Max. App Store Connect
+**auto-scales the largest iPhone screenshot down** to every smaller iPhone, so one
+6.9" set covers the whole iPhone range — extra iPhone sizes are invisible to users
+and add no ranking value, only CI time. iPad is a separate App Store slot that does
+**not** auto-scale from iPhone, so the 13" and 11" iPad Pro captures are their own
+set. The other axis that helps the listing is locale, so that stays a full sweep.
+(See
 <https://developer.apple.com/help/app-store-connect/manage-app-information/upload-app-previews-and-screenshots/>.)
 
-The app currently has `supportsTablet: false`, so iPad screenshots are not part
-of the automated set. `--locales all` captures `en-US`, `es`, and `fr`; the
-single Spanish app locale is uploaded to both App Store Connect Spanish locales:
-`es-ES` and `es-MX`.
+The app has `supportsTablet: true`, so the automated set includes iPad screenshots.
+`--locales all` captures `en-US`, `es`, and `fr`; the single Spanish app locale
+is uploaded to both App Store Connect Spanish locales: `es-ES` and `es-MX`.
 
 Dark is the canonical appearance; pass `--theme light` for a light set.
 
@@ -63,7 +66,7 @@ Dark is the canonical appearance; pass `--theme light` for a light set.
 If you need a specific screen the flow doesn't cover:
 
 1. Open Xcode > Window > Devices and Simulators
-2. Create or select an iPhone 16 Pro Max simulator
+2. Create or select an iPhone 16 Pro Max, iPad Pro 13-inch, or iPad Pro 11-inch simulator
 3. Run the app in the simulator
 4. Navigate to each key screen:
    - Board selection / home feed
@@ -97,17 +100,17 @@ Store Connect.
 
 What it does:
 
-1. Captures common iPhone screenshots on simulators, against **prod** (signed in
-   as the test user) for every supported app locale — the canonical store
-   recipe, with no local backend needed.
+1. Captures common iPhone portrait screenshots and iPad landscape screenshots on
+   simulators, against **prod** (signed in as the test user) for every supported
+   app locale — the canonical store recipe, with no local backend needed.
 2. Runs `vp run check:screenshot-dimensions`, which fails the run if any PNG
    isn't an Apple-accepted size for its slot (so Apple can't reject the upload
    for a bad resolution).
 3. Runs `fastlane ios screenshots` (`fastlane/Fastfile`), which uploads the PNGs
    with `skip_binary_upload`, `skip_metadata`, and `submit_for_review: false`.
    deliver routes each image to its display slot by pixel dimensions
-   (1320×2868 → the 6.9" iPhone slot); the `00-`/`01-` filename prefixes set the
-   display order inside each device slot.
+   (1320x2868 -> the 6.9" iPhone slot, 2752x2064 -> the 13" iPad slot); the
+   `00-`/`01-` filename prefixes set the display order inside each device slot.
 
 **Authentication** uses the App Store Connect API key already configured for the
 TestFlight workflows — no new secrets:
@@ -164,16 +167,10 @@ If a build fails:
 
 ## 4. Upload to App Store Connect
 
-1. In the Xcode Organizer (**Window > Organizer**), select the archive you just created.
-2. Click **Distribute App**.
-3. Select **App Store Connect** as the distribution method.
-4. Select **Upload** (not Export).
-5. Leave the default options (bitcode, symbols, etc.) and click **Next**.
-6. Select the signing profile **Boardsesh App Store Distribution** (should be auto-detected).
-7. Click **Upload**.
-8. Wait for the upload to complete. You will see a success message.
-
-The build will appear in App Store Connect within 5-30 minutes after upload. Apple runs automated processing (including a basic compliance check) before it becomes available.
+The React Native workflow uploads the archive during export, so there is no
+manual Xcode Organizer upload step in the normal release path. Use Organizer only
+for an emergency local archive after recreating the same `packages/mobile/ios`
+prebuild inputs.
 
 ---
 

--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -310,6 +310,73 @@ borderless)` builds a Pressable `android_ripple` config at that state-layer opac
 
 ---
 
+## iPad adaptive layout
+
+iPad (only — no Android tablets) gets a multi-column shell; every iPhone, and an iPad in a narrow
+split, falls through to the phone UI **verbatim**. The size class is pure and unit-tested in
+`theme/size-class.ts` (`resolveDeviceLayout`), fed window width by `hooks/use-device-layout.ts`:
+
+- **`compact`** — every iPhone, plus an iPad window narrower than `REGULAR_WIDTH_BREAKPOINT` (700pt:
+  Slide Over / a narrow Split View). Renders today's phone UI; no phase may regress it.
+- **`regular`** — an iPad window wide enough for the glass sidebar (`IpadSidebar`, replacing the bottom
+  tab bar) + a content column + a detail pane. `expanded` (≥1024pt) is a flag on top.
+
+**The right column is master-detail, not status.** At `regular` width the shell is
+`sidebar · active-tab content · detail pane` (`(tabs)/_layout.tsx`). The detail pane (`IpadPlayPane` →
+`PlayDrawer presentation="pane"`) follows the user's **selection** — tapping a list row updates it —
+mirroring Mail/Notes/Files. It is the SELECTION surface; do not repoint it at shared/live status (that
+was the original bug). A `setAsCurrent:false` open (feed / beta / climb view) previews in the pane
+without committing to the queue (`drawer-host-provider`'s `panePreviewItem`), so every climb-open entry
+point populates the pane.
+
+**The live wall is STATUS, with its own width-adaptive home** (`resolveWallSurface({ width, widthClass,
+sidebarWidth })` → `'none' | 'strip' | 'column'`):
+
+- Ambient `SidebarWallCell` in the rail footer (always, `regular`) — the glanceable cross-tab anchor.
+- A dedicated **`column`** on the trailing edge in landscape, when sidebar + browse list (≥
+  `WALL_COLUMN_CONTENT_FLOOR` 400pt) + detail pane (`DETAIL_PANE_WIDTH_WITH_WALL` 320pt) +
+  `WALL_COLUMN_WIDTH` (300pt) all fit (≈≥1116pt → both 11" and 13" landscape).
+- A compact **`strip`** docked atop the detail pane in portrait, where a 4th column would crush the
+  list (11" 834pt / 13" 1032pt).
+
+All three reuse `NowOnTheWallPanel` (extracted from `BoardSheet`, `variant: 'sheet' | 'column'`) and tap
+through to the full `BoardSheet`. Rules when adding layout-sensitive iPad components:
+
+- Decide column-vs-strip from the **computed width budget**, never a raw breakpoint — it stays correct
+  across rotation / Split View / Stage Manager.
+- Exactly **one wall surface per layout**: the shell passes `showWallCell={!showWallColumn}` to the
+  sidebar so the rail cell and the column never both show.
+- Inline columns/strips **own their safe-area insets** (`insets.top` for a top-of-shell column header,
+  `insets.bottom` for a full-height column footer); a gorhom sheet handles its own. When a strip is
+  docked above the pane, the shell sets `PlayDrawer paneTopInset={false}` so the inset isn't doubled.
+- Status may **annotate** selection (the pane shows an "On the wall" chip when the selected climb is the
+  lit one) — but never replace it.
+
+**The detail pane is width-budgeted, like the wall column** — not gated on a raw breakpoint. The
+persistent detail (play) pane mounts only when, after the sidebar and a minimum pane width, the browse
+list still clears the readable content floor (`WALL_COLUMN_CONTENT_FLOOR` 400pt) — via
+`resolveDetailPaneSurface` in `theme/size-class.ts`, mirroring `resolveWallSurface`. On the narrowest
+regular widths (iPad mini and 9.7–10.2" portrait, ~744–810pt) the pane would squeeze the list below the
+floor, so there it falls back to the compact bottom-sheet `PlayDrawer` and the list keeps the full
+content column. This applies the "compute from the width budget, never a raw breakpoint" rule above to
+the detail pane, closing the one place it wasn't followed.
+
+**The active sidebar row uses neutral system glyphs**, matching the bottom tab bars. The sidebar is the
+tab-bar analogue, so its active row follows the same chrome-glyph rule as `NativeTabs` and
+`MaterialTabBar`: `systemColors.label` selected / `secondaryLabel` inactive, with the `systemColors.fill`
+pill as the active affordance — not a brand-violet tint. Brand colour stays for genuine accents, per the
+chrome-glyph rule documented under Iconography.
+
+**The shell is width-adaptive, not idiom-adaptive.** Size class is driven by `Platform.isPad` (fixed at
+process launch) plus the live window width; only width is live. The guarantee is "the right layout for
+the current window width on iPad," not a layout that re-derives the device idiom across Stage Manager or
+an external display. Note also the deliberate choice of a bespoke 96pt icon-over-label rail instead of a
+`UISplitViewController` sidebar: a Phase-1 call that keeps the rail simple but means it won't inherit
+system sidebar behaviours (collapse control, pointer magnetism). Revisit in Phase 2+ whether to adopt a
+true wide text sidebar or the iPadOS 18 floating-tab-bar-to-sidebar pattern.
+
+---
+
 ## Motion & haptics
 
 **Springs** (`theme/animations.ts`, for reanimated `withSpring`):

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -30,7 +30,9 @@ The iOS lane uploads PNGs in
 `vp run mobile:screenshots -- --devices common --locales all`) as
 **screenshots only** — no binary, no text metadata, no review submission.
 deliver routes each image to its display slot by pixel dimensions; the `NN-`
-filename prefixes set the display order inside each slot.
+filename prefixes set the display order inside each slot. The common iOS matrix
+includes the three iPhone portrait slots plus 13-inch and 11-inch iPad landscape
+slots.
 
 The upload expects the generated Apple locale folders `en-US`, `es-ES`, `es-MX`,
 and `fr-FR`. The app has one Spanish locale (`es`), so the capture pipeline

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -28,11 +28,14 @@ orchestrator builds with the prod `EXPO_PUBLIC_BACKEND_URL` and resets the
 simulator keychain first so login authenticates cleanly against prod.
 `--backend local` (the default) points at the seeded dev DB instead.
 
-By default the orchestrator captures one device size (`--devices common`: the
-6.9" iPhone 16 Pro Max — App Store Connect scales it down to every smaller iPhone,
-so extra sizes add no value) across every app locale (`--locales all`: en-US, es,
-fr). Spanish is written to both App Store Connect Spanish folders (`es-ES` and
-`es-MX`).
+By default the orchestrator captures the store device set (`--devices common`: the
+6.9" iPhone 16 Pro Max, the iPad Pro 13-inch (M5), and the iPad Pro 11-inch (M5))
+across every app locale (`--locales all`: en-US, es, fr). App Store Connect scales
+the largest iPhone screenshot down to every smaller iPhone, so one 6.9" set covers
+the whole iPhone range; iPad is a separate slot that doesn't auto-scale from iPhone,
+so both iPad Pro sizes are captured in landscape. Use `--devices phones` or
+`--devices ipads` for narrowed local runs. Spanish is written to both App Store
+Connect Spanish folders (`es-ES` and `es-MX`).
 
 ## Flows
 
@@ -106,10 +109,15 @@ on boot. They live only in screenshot-only builds; the separate prod-stripping o
   tree only exposes native text inputs and system dialogs — plain Views, Text,
   reanimated pressables and gesture rows don't surface, so app buttons can't be
   matched by id/text. The iOS flow now has **no** `point:` taps (every screen is a
-  deep link, the board is active from boot). Android keeps just the board-switcher
-  tap (`78%,10%`) for its board-sheet shot; re-check it if the emulator layout
-  differs. There's no login step at all — the app auto-signs-in on boot and never
-  shows a login screen.
+  deep link, the board is active from boot). The orchestrator renders the iOS
+  flow's orientation placeholder per device before Maestro runs: phones capture in
+  `PORTRAIT`, iPads in `LANDSCAPE_LEFT` so the store shots show the adaptive
+  sidebar/pane layout. On iPad, Maestro can save the raw portrait framebuffer even
+  after the app rotates, so the orchestrator rotates those PNGs into upright
+  landscape before copying them to the store folders. Android keeps just the
+  board-switcher tap (`78%,10%`) for its board-sheet shot;
+  re-check it if the emulator layout differs. There's no login step at all —
+  the app auto-signs-in on boot and never shows a login screen.
 - Screenshot mode (the build-time `EXPO_PUBLIC_SCREENSHOT_MODE=1` flag) auto-signs-in
   on boot with the baked `SCREENSHOT_USER_*` credentials, locks the theme to dark, the
   locale to `EXPO_PUBLIC_SCREENSHOT_LOCALE`, and the platform variant, pre-selects the

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -19,8 +19,9 @@ name: app-store screenshots
 # board-pick / board-view / board-sheet coordinate taps are all gone — a missed pick used
 # to leave Climbs/Board View stuck on the "No board selected" empty state.
 #
-# This flow is captured once per (device, locale) pair: the orchestrator bakes
-# EXPO_PUBLIC_SCREENSHOT_LOCALE into the Metro bundle per locale and reruns it on each
+# This flow is captured once per (device, locale) pair: the orchestrator renders
+# MAESTRO_DEVICE_ORIENTATION below to the target device's concrete orientation, bakes
+# EXPO_PUBLIC_SCREENSHOT_LOCALE into the Metro bundle per locale, and reruns it on each
 # device in --devices, writing app-stores/apple/screenshots/<app-store-locale>/<device>/.
 #
 # Notes:
@@ -45,6 +46,8 @@ name: app-store screenshots
 # The screenshot build auto-signs-in on boot and lands straight on home (no login screen);
 # the orchestrator waits for home (the `$screen /home` log) before running Maestro, so the
 # flow opens right into the shots.
+
+- setOrientation: ${MAESTRO_DEVICE_ORIENTATION}
 
 # Prime the "Open in 'Boardsesh'?" dialog. simctl openurl of the custom scheme makes iOS
 # re-pop that confirmation on the first one or two in-session deep links (inconsistently —

--- a/packages/mobile/.maestro/onboarding.yaml
+++ b/packages/mobile/.maestro/onboarding.yaml
@@ -24,6 +24,8 @@ name: onboarding illustrations
 # (boots straight to home); the orchestrator gates on `$screen /home` before
 # running Maestro, so this flow opens right into the deep links below.
 
+- setOrientation: ${MAESTRO_DEVICE_ORIENTATION}
+
 # Prime the "Open in 'Boardsesh'?" confirmation away on throwaway /home
 # navigations before any capture (see app-store.yaml for the full rationale).
 - openLink: com.boardsesh.app://home

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -278,7 +278,10 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
       // App ID in the Apple Developer portal (manual, one-time). App Review
       // requires Apple sign-in whenever a third-party login (Google) is offered.
       usesAppleSignIn: true,
-      supportsTablet: false,
+      // iPad gets a first-class adaptive UI (sidebar + panes). `requireFullScreen`
+      // is intentionally left unset (false) so Slide Over / Split View work — a
+      // narrow split falls back to the phone UI verbatim (see `size-class.ts`).
+      supportsTablet: true,
       // Entitlements for the App Group (shared with the BoardseshWidgets target),
       // shared keychain (so SharedKeychain.swift can read auth + push tokens),
       // and APNs (so ActivityKit can register Live Activity push tokens).
@@ -290,6 +293,16 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
       },
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
+        // iPad rotates freely — landscape is the primary canvas for the sidebar +
+        // panes — while iPhone stays portrait-locked via the top-level
+        // `orientation: 'portrait'`. This `~ipad` key overrides the base
+        // UISupportedInterfaceOrientations for iPad only.
+        'UISupportedInterfaceOrientations~ipad': [
+          'UIInterfaceOrientationPortrait',
+          'UIInterfaceOrientationPortraitUpsideDown',
+          'UIInterfaceOrientationLandscapeLeft',
+          'UIInterfaceOrientationLandscapeRight',
+        ],
         NSHealthUpdateUsageDescription: HEALTH_UPDATE_USAGE_DESCRIPTION,
         NSHealthShareUsageDescription: HEALTH_SHARE_USAGE_DESCRIPTION,
         NSBluetoothAlwaysUsageDescription:

--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -18,6 +18,21 @@ const cfg = vi.hoisted(() => ({
   // (Material, plus Liquid Glass on iOS < 26 / Android) takes the JS tab bar.
   glassCapable: true,
   platformOS: 'ios' as 'ios' | 'android',
+  // 'regular' takes the iPad sidebar shell; 'compact' keeps the phone tab bars.
+  widthClass: 'compact' as 'compact' | 'regular',
+  // iPad in a narrow split: compact width but still an iPad, which the shell keeps on
+  // JS Tabs (never NativeTabs). Independent of widthClass; 'regular' always implies iPad.
+  isPad: false,
+  // Window width drives the wall surface in the regular shell: a dedicated column
+  // (landscape) vs a strip atop the pane (portrait) — see resolveWallSurface.
+  windowWidth: 1024,
+  // Board presence gates the wall column: no bound board → no column (the wall
+  // stays the sidebar cell instead).
+  boardPresenceEnabled: false,
+  boardPresenceBoardId: null as number | null,
+  // The column also needs a resolved active board (the panel renders its config);
+  // boardId can be set from BLE without one, so the layout gates on this too.
+  activeBoard: null as { uuid: string } | null,
   materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean } }>,
 }));
 
@@ -27,6 +42,14 @@ vi.mock('react-native', () => ({
       return cfg.platformOS;
     },
   },
+  // _layout.tsx wraps the iPad shell in Views + calls StyleSheet.create at module
+  // eval, so the strict RN mock must supply both.
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-style': style == null ? '' : JSON.stringify(style) }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  // The regular-width shell sizes the play pane + decides the wall surface off the
+  // window width.
+  useWindowDimensions: () => ({ width: cfg.windowWidth, height: 1366 }),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -54,6 +77,37 @@ vi.mock('../../../src/hooks/use-sticky-accessory-presence', () => ({
 // in the real hook; the route-segment split is unit-tested in route-segments.test.
 vi.mock('../../../src/hooks/use-on-accessory-surface', () => ({
   useOnAccessorySurface: () => cfg.onAccessorySurface,
+}));
+
+vi.mock('../../../src/hooks/use-device-layout', () => ({
+  // `regular` is only ever reached on an iPad (an iPhone is always compact), so it
+  // always implies isPad; cfg.isPad additionally models an iPad in a narrow split.
+  useDeviceLayout: () => ({
+    widthClass: cfg.widthClass,
+    expanded: false,
+    isPad: cfg.widthClass === 'regular' || cfg.isPad,
+  }),
+}));
+
+vi.mock('../../../src/components/navigation/IpadSidebar', () => ({
+  IpadSidebar: ({ showWallCell = true }: { showWallCell?: boolean }) =>
+    createElement('aside', { 'data-ipad-sidebar': 'true', 'data-show-wall-cell': String(showWallCell) }),
+}));
+
+vi.mock('../../../src/components/play-drawer/IpadPlayPane', () => ({
+  IpadPlayPane: () => createElement('aside', { 'data-ipad-play-pane': 'true' }),
+}));
+
+vi.mock('../../../src/components/board-presence/IpadWallColumn', () => ({
+  IpadWallColumn: () => createElement('aside', { 'data-ipad-wall-column': 'true' }),
+}));
+
+vi.mock('../../../src/providers/board-presence-provider', () => ({
+  useBoardPresenceControls: () => ({ enabled: cfg.boardPresenceEnabled, boardId: cfg.boardPresenceBoardId }),
+}));
+
+vi.mock('../../../src/lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: cfg.activeBoard }),
 }));
 
 vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({
@@ -153,6 +207,12 @@ vi.mock('expo-router/unstable-native-tabs', () => {
 
 import TabLayout, { unstable_settings } from '../_layout';
 
+function renderedViewStyles(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-style]')).map(
+    (element) => element.getAttribute('data-style') ?? '',
+  );
+}
+
 describe('TabLayout', () => {
   beforeEach(() => {
     cfg.bluetoothConnected = false;
@@ -163,6 +223,12 @@ describe('TabLayout', () => {
     cfg.variant = 'liquidGlass';
     cfg.glassCapable = true;
     cfg.platformOS = 'ios';
+    cfg.widthClass = 'compact';
+    cfg.isPad = false;
+    cfg.windowWidth = 1024;
+    cfg.boardPresenceEnabled = false;
+    cfg.boardPresenceBoardId = null;
+    cfg.activeBoard = null;
     cfg.materialScreens = [];
   });
 
@@ -210,6 +276,168 @@ describe('TabLayout', () => {
       'discover',
       'profile',
     ]);
+  });
+
+  it('keeps an iPad in a narrow split on the JS Material tab bar (never NativeTabs)', () => {
+    // Slide Over / Split View: compact width but still an iPad. The single-navigator
+    // shell routes it through JS Tabs + the Material bar so a resize across the 700pt
+    // boundary doesn't swap navigator types — NativeTabs never renders on iPad, and
+    // there's no rail at compact width.
+    cfg.isPad = true;
+    cfg.widthClass = 'compact';
+    cfg.variant = 'liquidGlass';
+    cfg.glassCapable = true;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs-material="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-tabs="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')).toBeNull();
+    expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
+      'home',
+      'climbs',
+      'record',
+      'discover',
+      'profile',
+    ]);
+  });
+
+  it('renders the iPad sidebar shell at regular width and registers all five tabs', () => {
+    // Regular-width iPad takes the sidebar branch before the native/Material tab
+    // bars: the glass sidebar carries navigation and the native iOS 26 tab bar is
+    // gone, but the Tabs navigator still registers every tab screen.
+    cfg.widthClass = 'regular';
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-sidebar="true"]')).not.toBeNull();
+    // The right column hosts the PlayDrawer pane (replaces the floating accessory bar).
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
+    // At narrow-regular width (1024) the wall has no room for a column, so it stays
+    // the sidebar cell — no dedicated column, rail cell shown.
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+    expect(container.querySelector('[data-tabs="true"]')).toBeNull();
+    expect(cfg.materialScreens.map((screen) => screen.name)).toEqual([
+      'home',
+      'climbs',
+      'record',
+      'discover',
+      'profile',
+    ]);
+  });
+
+  it('suppresses the detail pane on the tightest regular portraits, keeping the list full width', () => {
+    // iPad mini portrait (744): sidebar (96) + the pane's 320pt floor would leave the
+    // browse list ~328pt — below the 400pt readable floor — so resolveDetailPaneSurface
+    // drops the pane and the compact bottom-sheet PlayDrawer hosts the drawer instead.
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 744;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-sidebar="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).toBeNull();
+    // No room for a wall column at this width either — the wall stays the sidebar cell.
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+  });
+
+  it('shows the dedicated wall column in landscape with a bound board, hiding the rail cell', () => {
+    // Wide enough for sidebar + browse list + detail pane + wall column (1366), and
+    // a board is bound — so the wall graduates to its own column and the ambient
+    // sidebar cell steps aside (one wall surface per layout).
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1366;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = { uuid: 'board-1' };
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
+    expect(renderedViewStyles(container).some((style) => style.includes('"width":485'))).toBe(true);
+    expect(renderedViewStyles(container).some((style) => style.includes('"width":300'))).toBe(true);
+  });
+
+  it('hides the sidebar wall cell when the portrait play-pane strip owns the wall surface', () => {
+    // 13" portrait has room for the play pane but not the dedicated wall column.
+    // The wall therefore renders as the strip inside IpadPlayPane, so the sidebar
+    // cell steps aside just like it does for the landscape wall column.
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1032;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = { uuid: 'board-1' };
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('false');
+  });
+
+  it('keeps the sidebar wall cell when tight regular width suppresses the play pane', () => {
+    // iPad mini portrait has no play pane, so there is no strip host either. The
+    // sidebar cell remains the only wall affordance in that regular-width shell.
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 744;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = { uuid: 'board-1' };
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+  });
+
+  it('keeps the sidebar wall cell in portrait while the active board config is unresolved', () => {
+    // Presence can be bound from BLE before the active board query resolves. The
+    // strip cannot render a useful wall surface yet, so the sidebar cell remains.
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1032;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = null;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-play-pane="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+  });
+
+  it('keeps the wall as the sidebar cell (no column) when no board is bound', () => {
+    // Landscape width, but presence has no bound board — an empty column would be
+    // dead space, so the wall stays the ambient sidebar cell.
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1366;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = null;
+    cfg.activeBoard = { uuid: 'board-1' };
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
+  });
+
+  it('does not reserve a wall column when a board is BLE-bound but no active board is resolved', () => {
+    // boardId can be set from the BLE serial before/without an active board; the
+    // column renders its content from the active board config, so without one the
+    // layout must NOT reserve the 300pt column (it would be dead space).
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1366;
+    cfg.boardPresenceEnabled = true;
+    cfg.boardPresenceBoardId = 1;
+    cfg.activeBoard = null;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-ipad-wall-column="true"]')).toBeNull();
+    expect(container.querySelector('[data-ipad-sidebar="true"]')?.getAttribute('data-show-wall-cell')).toBe('true');
   });
 
   it('does not render the Record badge when no status is active', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'react';
-import { Platform, type ColorValue } from 'react-native';
+import { Platform, StyleSheet, View, useWindowDimensions, type ColorValue } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { Tabs } from 'expo-router';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
@@ -13,6 +13,19 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
 import { useOnAccessorySurface } from '../../src/hooks/use-on-accessory-surface';
+import { useDeviceLayout } from '../../src/hooks/use-device-layout';
+import { IpadSidebar } from '../../src/components/navigation/IpadSidebar';
+import { IpadPlayPane } from '../../src/components/play-drawer/IpadPlayPane';
+import { IpadWallColumn } from '../../src/components/board-presence/IpadWallColumn';
+import { useBoardPresenceControls } from '../../src/providers/board-presence-provider';
+import { useActiveBoard } from '../../src/lib/graphql/use-active-board';
+import {
+  resolveWallSurface,
+  resolveDetailPaneSurface,
+  resolveDetailPaneWidth,
+  WALL_COLUMN_WIDTH,
+} from '../../src/theme/size-class';
+import { SIDEBAR_WIDTH } from '../../src/theme/layout';
 
 // Cold-start on Home: the leftmost tab carries the beta shelf and followed
 // activity feed, while Climbs remains the search surface one tab over. Drives
@@ -30,6 +43,10 @@ const materialTabIcon =
   ({ focused, color, size }: TabIconProps) => (
     <MaterialCommunityIcons name={focused ? active : inactive} color={color} size={size} />
   );
+
+// The iPad shell hides the Tabs navigator's own bar (the glass sidebar carries
+// navigation), while the navigator still owns routing + per-tab state.
+const renderHiddenTabBar = () => null;
 
 /**
  * Bottom tabs. The system Liquid Glass tab bar (`expo-router/unstable-native-tabs`)
@@ -73,43 +90,159 @@ export default function TabLayout() {
   const onAccessorySurface = useOnAccessorySurface();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
+  // Regular-width iPad opts into the sidebar shell; compact width (every iPhone,
+  // a narrow iPad split) keeps the native / Material tab bars below verbatim.
+  // (deviceLayout.expanded is computed but intentionally unconsumed here — it's
+  // reserved for the Phase-3 master+detail Climbs browser; see size-class.ts.)
+  const deviceLayout = useDeviceLayout();
+  const { width: windowWidth } = useWindowDimensions();
+  // The live wall gets a dedicated column in landscape (room for sidebar + browse
+  // list + detail pane + wall) and falls back to a strip atop the pane in portrait
+  // (see resolveWallSurface). Gated on a bound board so an empty column never sits
+  // as dead space. The presence controls context only changes on bind/unbind, not
+  // on wall climb updates, so this doesn't re-render the shell per wall event.
+  const { enabled: boardPresenceEnabled, boardId: boardPresenceBoardId } = useBoardPresenceControls();
+  // The column only renders content when a board config is resolved (the wall
+  // panel reads it via the host). `boardPresenceBoardId` can be set from the BLE
+  // serial before/without an active board, so gate on the active board too — else
+  // the column View reserves 300pt while `IpadWallColumn` renders null (dead space).
+  const { data: activeBoard } = useActiveBoard();
+  const wallSurface = resolveWallSurface({
+    width: windowWidth,
+    widthClass: deviceLayout.widthClass,
+    sidebarWidth: SIDEBAR_WIDTH,
+  });
+  const showWallColumn =
+    wallSurface === 'column' && boardPresenceEnabled && boardPresenceBoardId !== null && activeBoard != null;
+  // The detail (play) pane scales with the window (clamped 320–400pt) when it is
+  // the only trailing pane. When the wall column is visible, the wall keeps its
+  // fixed width and the content + detail columns split the remaining space evenly.
+  const playPaneWidth = resolveDetailPaneWidth({
+    width: windowWidth,
+    sidebarWidth: SIDEBAR_WIDTH,
+    wallColumnVisible: showWallColumn,
+  });
+  // The detail (play) pane is width-budgeted exactly like the wall column: it only
+  // mounts when the browse list still clears the readable floor after the sidebar
+  // and a minimum pane width. On the tightest regular portraits (iPad mini /
+  // 9.7–10.2", 744–810pt) it's suppressed and the compact bottom-sheet PlayDrawer
+  // hosts the drawer instead (see drawer-host-provider), so the list keeps room.
+  const showDetailPane =
+    resolveDetailPaneSurface({
+      width: windowWidth,
+      widthClass: deviceLayout.widthClass,
+      sidebarWidth: SIDEBAR_WIDTH,
+    }) === 'pane';
+  const showWallStrip =
+    showDetailPane &&
+    wallSurface === 'strip' &&
+    boardPresenceEnabled &&
+    boardPresenceBoardId !== null &&
+    activeBoard != null;
+  const showRichWallSurface = showWallColumn || showWallStrip;
+
+  // The five tab screens are identical across the JS `Tabs` variants (Material
+  // bar vs. the hidden-bar iPad shell), so share one definition. A flat keyed
+  // ARRAY (not a Fragment) — Expo Router walks the navigator's direct children
+  // for `Tabs.Screen`, and a Fragment wrapper makes it ignore their `options`
+  // (titles/icons/badge/lazy). The NativeTabs path uses its own Trigger API below
+  // and does not consume this.
+  const tabScreens = [
+    <Tabs.Screen
+      key="home"
+      name="home"
+      options={{ title: t('mobile.nav.home'), tabBarIcon: materialTabIcon('home', 'home-outline') }}
+    />,
+    <Tabs.Screen
+      key="climbs"
+      name="climbs"
+      options={{ title: t('mobile.nav.climbs'), tabBarIcon: materialTabIcon('magnify', 'magnify') }}
+    />,
+    <Tabs.Screen
+      key="record"
+      name="record"
+      options={{
+        title: tSession('mobile.session.recordTab'),
+        tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
+        tabBarBadge: showRecordBadge ? '' : undefined,
+        // Android can stall the first lazy mount of this nested stack,
+        // leaving the Record tab blank until another tab forces a remount.
+        lazy: eagerMountRecord ? false : undefined,
+      }}
+    />,
+    <Tabs.Screen
+      key="discover"
+      name="discover"
+      options={{
+        title: tPlaylists('bottomTabBar.discover'),
+        tabBarIcon: materialTabIcon('bookmark-multiple', 'bookmark-multiple-outline'),
+      }}
+    />,
+    <Tabs.Screen
+      key="profile"
+      name="profile"
+      options={{
+        title: t('mobile.nav.profile'),
+        tabBarIcon: materialTabIcon('account-circle', 'account-circle-outline'),
+      }}
+    />,
+  ];
+
+  // iPad adaptive shell. ONE JS `Tabs` navigator is mounted across the
+  // regular↔compact boundary, so resizing an iPad window across the breakpoint (a
+  // Split View drag, a Stage Manager resize) swaps only the CHROME — the glass
+  // sidebar + content panes at regular width, the Material tab bar in a narrow
+  // split — and keeps each tab's scroll offset and nested-stack depth instead of
+  // remounting the navigator. The navigator still owns routing; at regular width
+  // its bar is hidden and the sidebar drives it through the global router. iPad
+  // never uses NativeTabs (that would swap navigator *types* on the boundary cross
+  // and remount); NativeTabs stays the iPhone-only glass path below. The `content`
+  // View carries a stable key so the navigator survives the chrome swap.
+  if (deviceLayout.isPad) {
+    const isRegular = deviceLayout.widthClass === 'regular';
+    const tabsNavigator = (
+      <Tabs
+        tabBar={isRegular ? renderHiddenTabBar : (props) => <MaterialTabBar {...props} />}
+        screenOptions={{ headerShown: false }}
+      >
+        {tabScreens}
+      </Tabs>
+    );
+    return (
+      <View style={isRegular ? styles.shell : styles.shellCompact}>
+        {isRegular ? <IpadSidebar key="sidebar" showWallCell={!showRichWallSurface} /> : null}
+        <View key="content" style={styles.shellContent}>
+          {tabsNavigator}
+        </View>
+        {/* Persistent right column: the PlayDrawer for the SELECTED climb (iPad
+            master-detail). Width-budgeted like the wall column (resolveDetailPaneSurface):
+            the tightest regular portraits — iPad mini and 9.7–10.2" (744–810pt) — suppress
+            it rather than squeeze the browse list below the readable floor; there the
+            compact bottom-sheet PlayDrawer takes over (see drawer-host-provider). */}
+        {isRegular && showDetailPane ? (
+          <View key="pane" style={[styles.playPane, { width: playPaneWidth, borderLeftColor: systemColors.separator }]}>
+            <IpadPlayPane />
+          </View>
+        ) : null}
+        {/* Dedicated "Now on the wall" column — landscape only, where the width
+            budget leaves room for it (see resolveWallSurface). In portrait the wall
+            rides a strip atop the pane (IpadPlayPane) instead. */}
+        {isRegular && showWallColumn ? (
+          <View
+            key="wall"
+            style={[styles.wallColumn, { width: WALL_COLUMN_WIDTH, borderLeftColor: systemColors.separator }]}
+          >
+            <IpadWallColumn />
+          </View>
+        ) : null}
+      </View>
+    );
+  }
 
   if (!nativeTabBar) {
     return (
       <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
-        <Tabs.Screen
-          name="home"
-          options={{ title: t('mobile.nav.home'), tabBarIcon: materialTabIcon('home', 'home-outline') }}
-        />
-        <Tabs.Screen
-          name="climbs"
-          options={{ title: t('mobile.nav.climbs'), tabBarIcon: materialTabIcon('magnify', 'magnify') }}
-        />
-        <Tabs.Screen
-          name="record"
-          options={{
-            title: tSession('mobile.session.recordTab'),
-            tabBarIcon: materialTabIcon('record-circle', 'record-circle-outline'),
-            tabBarBadge: showRecordBadge ? '' : undefined,
-            // Android can stall the first lazy mount of this nested stack,
-            // leaving the Record tab blank until another tab forces a remount.
-            lazy: eagerMountRecord ? false : undefined,
-          }}
-        />
-        <Tabs.Screen
-          name="discover"
-          options={{
-            title: tPlaylists('bottomTabBar.discover'),
-            tabBarIcon: materialTabIcon('bookmark-multiple', 'bookmark-multiple-outline'),
-          }}
-        />
-        <Tabs.Screen
-          name="profile"
-          options={{
-            title: t('mobile.nav.profile'),
-            tabBarIcon: materialTabIcon('account-circle', 'account-circle-outline'),
-          }}
-        />
+        {tabScreens}
       </Tabs>
     );
   }
@@ -161,3 +294,15 @@ export default function TabLayout() {
     </NativeTabs>
   );
 }
+
+const styles = StyleSheet.create({
+  // Sidebar + content laid out as a row; the sidebar owns a fixed width and the
+  // content pane flexes to fill the rest.
+  shell: { flex: 1, flexDirection: 'row' },
+  // iPad in a narrow split (compact): the same single `Tabs` navigator, no rail,
+  // just filling the window — so the navigator stays mounted across the boundary.
+  shellCompact: { flex: 1 },
+  shellContent: { flex: 1 },
+  playPane: { borderLeftWidth: StyleSheet.hairlineWidth },
+  wallColumn: { borderLeftWidth: StyleSheet.hairlineWidth },
+});

--- a/packages/mobile/plugins/with-screenshot-dev-menu.js
+++ b/packages/mobile/plugins/with-screenshot-dev-menu.js
@@ -13,10 +13,20 @@ const { createRunOncePlugin, withInfoPlist } = require('expo/config-plugins');
 // the registered defaults (Bundle.main Info dictionary), so baking them in keeps
 // the chrome suppressed no matter how the app is (re)launched.
 //
+const DEFAULT_SCREENSHOT_METRO_PORT = 8081;
+
+function resolveScreenshotMetroPort(env = process.env) {
+  return Number.parseInt(env.BOARDSESH_METRO_PORT ?? '', 10) || DEFAULT_SCREENSHOT_METRO_PORT;
+}
+
+function resolveScreenshotMetroUrl(env = process.env) {
+  return `http://localhost:${resolveScreenshotMetroPort(env)}`;
+}
+
 // Only applied to the dedicated screenshots build (gated in app.config.ts on
 // BOARDSESH_SCREENSHOT_BUILD, set by scripts/mobile-build-sim-app.ts), so normal
 // `vp run mobile:ios` dev builds keep the full dev menu + floating button.
-function applyScreenshotDevMenuInfoPlist(infoPlist) {
+function applyScreenshotDevMenuInfoPlist(infoPlist, env = process.env) {
   infoPlist.EXDevMenuIsOnboardingFinished = true;
   infoPlist.EXDevMenuShowFloatingActionButton = false;
   infoPlist.EXDevMenuShowsAtLaunch = false;
@@ -26,9 +36,10 @@ function applyScreenshotDevMenuInfoPlist(infoPlist) {
   // point: a fresh CI sim raises an "Open in Boardsesh?" confirmation for any
   // openurl of the custom scheme, and Maestro can't dismiss it reliably. With this
   // the orchestrator just `simctl launch`es the app and it connects to Metro —
-  // no openurl, no dialog. Fixed to 8081 (the screenshots Metro port); a
-  // BOARDSESH_METRO_PORT override would need this rebuilt to match.
-  infoPlist.DEV_CLIENT_DEFAULT_LAUNCHER_URL = 'http://localhost:8081';
+  // no openurl, no dialog. The port is baked into the app during prebuild; if the
+  // screenshot runner uses BOARDSESH_METRO_PORT, this value must be rebuilt with
+  // the same override.
+  infoPlist.DEV_CLIENT_DEFAULT_LAUNCHER_URL = resolveScreenshotMetroUrl(env);
   return infoPlist;
 }
 
@@ -41,3 +52,5 @@ function withScreenshotDevMenu(config) {
 
 module.exports = createRunOncePlugin(withScreenshotDevMenu, 'with-screenshot-dev-menu', '1.0.0');
 module.exports.applyScreenshotDevMenuInfoPlist = applyScreenshotDevMenuInfoPlist;
+module.exports.resolveScreenshotMetroPort = resolveScreenshotMetroPort;
+module.exports.resolveScreenshotMetroUrl = resolveScreenshotMetroUrl;

--- a/packages/mobile/src/components/PressableSurface.tsx
+++ b/packages/mobile/src/components/PressableSurface.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ComponentProps, type ReactNode } from 'react';
 import {
   Pressable,
   Platform,
@@ -11,6 +11,8 @@ import {
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
+
+type RNPressableProps = ComponentProps<typeof Pressable>;
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { springs } from '../theme/animations';
 import { androidRipple } from '../theme/tokens';
@@ -32,6 +34,13 @@ type PressableSurfaceProps = {
   onPressOut?: (event: GestureResponderEvent) => void;
   onLongPress?: (event: GestureResponderEvent) => void;
   onLayout?: (event: LayoutChangeEvent) => void;
+  /** Pointer hover (iPad trackpad / pointer) — no-op on touch-only platforms. Lets
+   *  callers light up a hovered state on the iPad regular-width surfaces. */
+  onHoverIn?: RNPressableProps['onHoverIn'];
+  onHoverOut?: RNPressableProps['onHoverOut'];
+  /** Hardware-keyboard focus (iPad Magic Keyboard) — no-op on touch-only platforms. */
+  onFocus?: RNPressableProps['onFocus'];
+  onBlur?: RNPressableProps['onBlur'];
   disabled?: boolean;
   /** iOS feedback style (default 'scale'). Android uses a ripple either way. */
   feedback?: PressFeedback;
@@ -71,6 +80,10 @@ export function PressableSurface({
   onPressOut,
   onLongPress,
   onLayout,
+  onHoverIn,
+  onHoverOut,
+  onFocus,
+  onBlur,
   disabled = false,
   feedback = 'scale',
   scaleTo = 0.96,
@@ -127,6 +140,10 @@ export function PressableSurface({
         onPressOut={onPressOut}
         onLongPress={onLongPress}
         onLayout={onLayout}
+        onHoverIn={onHoverIn}
+        onHoverOut={onHoverOut}
+        onFocus={onFocus}
+        onBlur={onBlur}
         disabled={disabled}
         // Static brand tint by design: this is a core primitive and the default
         // ripple is an Android-only, rarely-hit fallback (most callers pass an
@@ -155,6 +172,10 @@ export function PressableSurface({
       onPressOut={handlePressOut}
       onLongPress={onLongPress}
       onLayout={onLayout}
+      onHoverIn={onHoverIn}
+      onHoverOut={onHoverOut}
+      onFocus={onFocus}
+      onBlur={onBlur}
       disabled={disabled}
       hitSlop={hitSlop}
       accessibilityRole={accessibilityRole}

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -1,143 +1,50 @@
 // Board sheet — "now on the wall" (the board-presence primary surface).
 //
-// A gorhom BottomSheetModal sibling of QueueSheet: same visible→present/dismiss
-// split, GlassSheetBackground, stackBehavior="push". (No FullWindowOverlay — it
-// prevented the sheet from presenting in this app; QueueSheet/PlayDrawer omit it.)
-// Renders the wall's now-on-the-wall hero, a VIRTUALIZED history list
-// (BottomSheetFlatList — never .map), light stat tiles, and a discoverable
-// "Switch board" footer row that opens the existing board switcher.
+// A native BottomSheetModal (`@expo/ui/community/bottom-sheet`) sibling of
+// QueueSheet, presented/dismissed through the shared sheet coordinator
+// (`useManagedSheet`) so it never overlaps another sheet's transition. The wall's
+// now-on-the-wall hero, VIRTUALIZED history list, stat tiles, pull-to-refresh and
+// the "Switch board" footer all live in `NowOnTheWallPanel` (variant="sheet"),
+// which this sheet renders as its body. Keeping the body in a shared panel lets
+// the iPad shell render the same content inline as a standalone column
+// (variant="column").
 //
 // State comes from `@boardsesh/board-presence-react`'s split current/feed
-// contexts, which are inert when the `board-presence` flag is off — so this
-// sheet is only ever opened from the board glyph when the flag is on.
+// contexts, which are inert when the `board-presence` flag is off — so this sheet
+// is only ever opened from the board glyph when the flag is on. This wrapper keeps
+// current/feed reads ONLY for the now-playing + history-view analytics; the panel
+// owns the volatile action state so the always-mounted wrapper doesn't re-render
+// in ways that interfere with the native present()/dismiss() coordination.
 //
-// Presence-consuming content is gated on `isPresented` (see `BoardSheetContent`)
-// so a dismissed sheet does zero work; `BoardNowPlayingReceived` telemetry lives
-// in the provider's `BoardPresenceInstrument` so it fires while dismissed.
+// `NowOnTheWallPanel` (the presence-consuming hero/stats/history list) is gated on
+// `isPresented` so a dismissed sheet mounts none of it and does zero list/hero
+// work. `isPresented` flips true SYNCHRONOUSLY in `present()` (before the sheet's
+// own animation starts) and false once the dismiss has fully SETTLED (see
+// `handleFullyDismissed`); `handleSheetChange` re-arms it as a backstop for a
+// re-present queued inside the dismiss settle window. `BoardNowPlayingReceived`
+// telemetry stays unconditional (fires while dismissed); `BoardHistoryViewed`
+// fires once per presentation, keyed on `isPresented` — kept in this sheet-only
+// wrapper so the inline iPad column never double-fires it.
 
-import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { Platform, Pressable, RefreshControl, StyleSheet, View, type ColorValue } from 'react-native';
-// SPIKE(spike/expo-bottom-sheet): swap gorhom -> Expo's native drop-in. The native
-// sheet draws its own scrim, so SheetBackdrop + stackBehavior are dropped.
-import { BottomSheetModal, BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useManagedSheet } from '../../providers/sheet-presentation-provider';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useTranslation } from 'react-i18next';
-import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import {
-  boardHistoryEntryKey,
-  useBoardHistoryPagination,
-  useBoardPresenceActions,
-  useBoardPresenceCurrent,
-  useBoardPresenceFeed,
-} from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import type { BoardName, BoardPresenceClimb, BoardPresenceHardestSend, Climb } from '@boardsesh/shared-schema';
-import { Text } from '../Text';
-import { Icon } from '../Icon';
-import { ActivityIndicator } from '../ActivityIndicator';
-import { ClimbListRow, type ClimbListRowRenderContentArgs } from '../ClimbListRow';
-import { PressableAvatar } from '../PressableAvatar';
-import { BoardDriverAvatar } from './BoardDriverAvatar';
-import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
+import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
 import { useTheme } from '../../providers/theme-provider';
-import { useToast } from '../../providers/toast-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
-import { useGradeFormat } from '../../hooks/use-grade-format';
 import { track } from '../../lib/analytics';
-import { getHttpClient } from '../../lib/graphql/client';
-import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
-import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
-import { withAlpha } from '../../theme/colors';
-import { spacing, borderRadius } from '../../theme/tokens';
+import { NowOnTheWallPanel } from './NowOnTheWallPanel';
+import type { BoardSheetClimbAction, NowOnTheWallPanelHandle } from './NowOnTheWallPanel';
 
-const ACTION_CLIMB_CACHE_LIMIT = 50;
-
-type BoardSheetRowBoard = {
-  boardName: BoardName;
-  layoutId: number;
-  sizeId: number;
-  setIds: string;
-  angle: number;
-};
-
-export type BoardSheetClimbAction = {
-  climb: Climb;
-  queueItemUuid: string | null;
-  boardConfig: BoardConfig;
-};
-
-type BoardSheetActionContext = {
-  actionBoardConfig: BoardConfig;
-  cacheKey: string;
-};
-
-function actionBoardConfigForPresenceClimb(boardConfig: BoardConfig, presenceClimb: BoardPresenceClimb): BoardConfig {
-  const angle = presenceClimb.angle ?? boardConfig.angle;
-  return angle === boardConfig.angle ? boardConfig : { ...boardConfig, angle };
-}
-
-function rowBoardForBoardConfig(boardConfig: BoardConfig): BoardSheetRowBoard {
-  return {
-    boardName: boardConfig.boardName as BoardName,
-    layoutId: boardConfig.layoutId,
-    sizeId: boardConfig.sizeId,
-    setIds: boardConfig.setIds,
-    angle: boardConfig.angle,
-  };
-}
-
-function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
-  return [
-    boardConfig.boardName,
-    boardConfig.layoutId,
-    boardConfig.sizeId,
-    boardConfig.setIds,
-    boardConfig.angle,
-    climbUuid,
-  ].join(':');
-}
-
-function boardConfigActionSignature(boardConfig: BoardConfig | null): string {
-  if (!boardConfig) return 'none';
-  return [boardConfig.boardName, boardConfig.layoutId, boardConfig.sizeId, boardConfig.setIds, boardConfig.angle].join(
-    ':',
-  );
-}
-
-function actionContextForPresenceClimb(
-  boardConfig: BoardConfig | null,
-  presenceClimb: BoardPresenceClimb,
-): BoardSheetActionContext | null {
-  if (!boardConfig) return null;
-  const actionBoardConfig = actionBoardConfigForPresenceClimb(boardConfig, presenceClimb);
-  return {
-    actionBoardConfig,
-    cacheKey: actionCacheKey(actionBoardConfig, presenceClimb.climbUuid),
-  };
-}
-
-function getActionClimbCacheEntry(cache: Map<string, Climb>, key: string): Climb | null {
-  const cachedClimb = cache.get(key);
-  if (!cachedClimb) return null;
-  cache.delete(key);
-  cache.set(key, cachedClimb);
-  return cachedClimb;
-}
-
-function setActionClimbCacheEntry(cache: Map<string, Climb>, key: string, climb: Climb): void {
-  if (cache.has(key)) cache.delete(key);
-  cache.set(key, climb);
-  if (cache.size <= ACTION_CLIMB_CACHE_LIMIT) return;
-  const oldestKey = cache.keys().next().value;
-  if (oldestKey !== undefined) cache.delete(oldestKey);
-}
+export type { BoardSheetClimbAction } from './NowOnTheWallPanel';
 
 /**
  * Imperative handle — the host presents/dismisses the sheet by calling these
- * directly from the tap handler (PlayDrawer's proven pattern). Driving gorhom's
- * `present()` from a `visible`-prop effect was a silent no-op in this build.
+ * directly from the tap handler (PlayDrawer's proven pattern). Driving the sheet
+ * from a `visible`-prop effect was a silent no-op in this build.
  */
 export type BoardSheetHandle = {
   present: () => void;
@@ -151,12 +58,12 @@ type BoardSheetProps = {
    * Active board config for the climb thumbnails. Passed by the host (NOT read
    * via `useDrawerHost`) so BoardSheet stays out of the drawer-host require cycle
    * and doesn't subscribe to that volatile context — re-renders from it were
-   * interfering with gorhom's `present()`, so the sheet never appeared.
+   * interfering with `present()`, so the sheet never appeared.
    */
   boardConfig: BoardConfig | null;
   /** Request an animated close (header chevron) — the host calls `dismiss()`. */
   onClose: () => void;
-  /** Optional: fired AFTER the dismiss animation finishes (gorhom `onDismiss`). */
+  /** Optional: fired AFTER the dismiss animation has actually settled. */
   onDismissed?: () => void;
   /** Open the existing board switcher from the footer control. */
   onSwitchBoard: () => void;
@@ -184,257 +91,115 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   },
   ref,
 ) {
-  const { t } = useTranslation('session');
-  const insets = useSafeAreaInsets();
-  const { systemColors, sheet } = useTheme();
-  const { showToast } = useToast();
+  const { sheet } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
-  const boardConfigRef = useRef(boardConfig);
-  boardConfigRef.current = boardConfig;
-  const boardConfigSignature = useMemo(() => boardConfigActionSignature(boardConfig), [boardConfig]);
-  const boardConfigSignatureRef = useRef(boardConfigSignature);
-  boardConfigSignatureRef.current = boardConfigSignature;
+  const panelRef = useRef<NowOnTheWallPanelHandle>(null);
 
-  // Gates `BoardSheetContent` (the presence-consuming hero/stats/history list)
-  // so it does zero work while dismissed. Flipped true SYNCHRONOUSLY in the
-  // imperative `present()` below (before the sheet's own present animation
-  // starts) and false once the dismiss animation has fully settled — see
-  // `handleFullyDismissed`.
+  // Gates `NowOnTheWallPanel` (the presence-consuming hero/stats/history list) so
+  // it does zero work while dismissed. Set true synchronously in `present()`
+  // (before the sheet's own present animation) and false once the dismiss
+  // animation has fully settled — see `handleFullyDismissed`.
   const [isPresented, setIsPresented] = useState(false);
 
-  const actionClimbCacheRef = useRef(new Map<string, Climb>());
-  const actionClimbRequestRef = useRef(new Map<string, Promise<Climb | null>>());
-  const pendingActionKeysRef = useRef(new Set<string>());
-  const actionGenerationRef = useRef(0);
-  const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
+  // Current/feed reads kept here ONLY for the now-playing + history-view
+  // analytics; the panel owns the wall-feed content and the volatile action
+  // state, so those re-renders don't reach this always-mounted wrapper.
+  const { currentClimb } = useBoardPresenceCurrent();
+  const { history } = useBoardPresenceFeed();
+  const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
+  const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
+  boardPresenceBoardIdRef.current = boardPresenceBoardId;
+
+  const visibleHistory = useMemo(
+    () =>
+      currentClimb
+        ? history.filter((historyClimb) => {
+            return historyClimb.climbUuid !== currentClimb.climbUuid || historyClimb.seq !== currentClimb.seq;
+          })
+        : history,
+    [currentClimb, history],
+  );
+
+  // Fires once per presentation, when history is FIRST non-empty while presented
+  // — not only on present(), because presenting before the initial backfill
+  // resolves would find an empty list and never fire for that presentation. The
+  // ref resets on full dismiss so it re-arms per presentation. Mirrors web's
+  // `BoardSheetBody`. Lives here (sheet-only) so the inline column never fires it.
+  const historyViewedForPresentationRef = useRef(false);
+  useEffect(() => {
+    if (!isPresented || historyViewedForPresentationRef.current || visibleHistory.length === 0) return;
+    historyViewedForPresentationRef.current = true;
+    track(SHARED_EVENTS.BoardHistoryViewed, {
+      boardId: boardPresenceBoardIdRef.current ?? undefined,
+      itemCount: visibleHistory.length,
+    });
+  }, [isPresented, visibleHistory.length]);
+
+  const lastReceivedWallClimbRef = useRef<string | null>(null);
+  // `seq` rides along in the telemetry payload but must NOT trigger the effect —
+  // a same-uuid seq bump (e.g. a backfill merge) shouldn't re-evaluate the
+  // "new climb on the wall" event. Read it from a ref so the effect keys only on
+  // the climb uuid.
+  const currentClimbSeqRef = useRef(currentClimb?.seq);
+  currentClimbSeqRef.current = currentClimb?.seq;
+  useEffect(() => {
+    const currentClimbUuid = currentClimb?.climbUuid;
+    if (!currentClimbUuid) return;
+    if (lastReceivedWallClimbRef.current === currentClimbUuid) return;
+    lastReceivedWallClimbRef.current = currentClimbUuid;
+    track(SHARED_EVENTS.BoardNowPlayingReceived, {
+      boardId: boardPresenceBoardIdRef.current ?? undefined,
+      climbUuid: currentClimbUuid,
+      // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
+      seq: currentClimbSeqRef.current ?? undefined,
+    });
+  }, [currentClimb?.climbUuid]);
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
-  const rowBoard = useMemo<BoardSheetRowBoard | null>(
-    () => (boardConfig ? rowBoardForBoardConfig(boardConfig) : null),
-    [boardConfig],
-  );
-  const canUseInteractiveRows = !!rowBoard && (!!onClimbPress || !!onAddToQueue || !!onOpenPlaylist || !!onOpenActions);
 
-  const getActionContext = useCallback((presenceClimb: BoardPresenceClimb) => {
-    return actionContextForPresenceClimb(boardConfigRef.current, presenceClimb);
+  const invalidatePanelActions = useCallback(() => {
+    panelRef.current?.invalidatePendingActions();
   }, []);
-
-  const isActionLoading = useCallback(
-    (presenceClimb: BoardPresenceClimb) => {
-      const actionContext = getActionContext(presenceClimb);
-      return actionContext ? pendingActionKeys.has(actionContext.cacheKey) : false;
-    },
-    [getActionContext, pendingActionKeys],
-  );
-
-  const setActionLoading = useCallback((cacheKey: string, loading: boolean) => {
-    const pendingKeys = pendingActionKeysRef.current;
-    if (loading) {
-      if (pendingKeys.has(cacheKey)) return;
-      pendingKeys.add(cacheKey);
-    } else if (!pendingKeys.delete(cacheKey)) {
-      return;
-    }
-    setPendingActionKeys(new Set(pendingKeys));
-  }, []);
-
-  const clearPendingActionKeys = useCallback(() => {
-    const pendingKeys = pendingActionKeysRef.current;
-    if (pendingKeys.size === 0) return;
-    pendingKeys.clear();
-    setPendingActionKeys(new Set());
-  }, []);
-
-  const invalidatePendingActions = useCallback(() => {
-    actionGenerationRef.current += 1;
-    clearPendingActionKeys();
-  }, [clearPendingActionKeys]);
-
-  useEffect(() => {
-    invalidatePendingActions();
-  }, [boardConfigSignature, invalidatePendingActions]);
-
-  const notifyActionFailed = useCallback(() => {
-    showToast(t('mobile.boardPresence.actionFailed'), 'error');
-  }, [showToast, t]);
-
-  const resolveAction = useCallback(
-    async (
-      presenceClimb: BoardPresenceClimb,
-      actionContext: BoardSheetActionContext,
-    ): Promise<BoardSheetClimbAction | null> => {
-      const { actionBoardConfig, cacheKey } = actionContext;
-      const cachedClimb = getActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey);
-      if (cachedClimb) {
-        return {
-          climb: cachedClimb,
-          queueItemUuid: presenceClimb.queueItemUuid ?? null,
-          boardConfig: actionBoardConfig,
-        };
-      }
-
-      let climbRequest = actionClimbRequestRef.current.get(cacheKey);
-      if (!climbRequest) {
-        climbRequest = getHttpClient()
-          .request<GetClimbQueryResponse>(GET_CLIMB, {
-            boardName: actionBoardConfig.boardName,
-            layoutId: actionBoardConfig.layoutId,
-            sizeId: actionBoardConfig.sizeId,
-            setIds: actionBoardConfig.setIds,
-            angle: actionBoardConfig.angle,
-            climbUuid: presenceClimb.climbUuid,
-          })
-          .then((response): Climb | null => {
-            if (!response.climb) {
-              console.warn('Board-sheet climb action returned no climb', presenceClimb.climbUuid);
-              return null;
-            }
-            setActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey, response.climb);
-            return response.climb;
-          })
-          .catch((error: unknown): null => {
-            console.warn('Failed to load board-sheet climb action', error);
-            return null;
-          })
-          .finally(() => {
-            actionClimbRequestRef.current.delete(cacheKey);
-          });
-        actionClimbRequestRef.current.set(cacheKey, climbRequest);
-      }
-
-      const loadedClimb = await climbRequest;
-      if (!loadedClimb) return null;
-      return {
-        climb: loadedClimb,
-        queueItemUuid: presenceClimb.queueItemUuid ?? null,
-        boardConfig: actionBoardConfig,
-      };
-    },
-    [],
-  );
-
-  const runInteractiveAction = useCallback(
-    (presenceClimb: BoardPresenceClimb, callback: (action: BoardSheetClimbAction) => void, closeOnSuccess = false) => {
-      const actionContext = getActionContext(presenceClimb);
-      if (!actionContext) {
-        notifyActionFailed();
-        return;
-      }
-
-      if (pendingActionKeysRef.current.has(actionContext.cacheKey)) return;
-
-      const actionGeneration = actionGenerationRef.current;
-      const actionBoardSignature = boardConfigSignatureRef.current;
-      setActionLoading(actionContext.cacheKey, true);
-      void resolveAction(presenceClimb, actionContext)
-        .then((action) => {
-          if (
-            actionGeneration !== actionGenerationRef.current ||
-            actionBoardSignature !== boardConfigSignatureRef.current
-          ) {
-            return;
-          }
-          if (!action) {
-            notifyActionFailed();
-            return;
-          }
-          try {
-            callback(action);
-            if (closeOnSuccess) {
-              invalidatePendingActions();
-              onClose();
-            }
-          } catch (error) {
-            console.warn('Failed to run board-sheet climb action', error);
-            notifyActionFailed();
-          }
-        })
-        .finally(() => {
-          setActionLoading(actionContext.cacheKey, false);
-        });
-    },
-    [getActionContext, invalidatePendingActions, notifyActionFailed, onClose, resolveAction, setActionLoading],
-  );
-
-  const handleInteractiveClimbPress = useCallback(
-    (presenceClimb: BoardPresenceClimb) => {
-      if (!onClimbPress) return;
-      runInteractiveAction(presenceClimb, onClimbPress, true);
-    },
-    [onClimbPress, runInteractiveAction],
-  );
-
-  const handleInteractiveAddToQueue = useCallback(
-    (presenceClimb: BoardPresenceClimb) => {
-      if (!onAddToQueue) return;
-      runInteractiveAction(presenceClimb, onAddToQueue);
-    },
-    [onAddToQueue, runInteractiveAction],
-  );
-
-  const handleInteractiveOpenPlaylist = useCallback(
-    (presenceClimb: BoardPresenceClimb) => {
-      if (!onOpenPlaylist) return;
-      runInteractiveAction(presenceClimb, onOpenPlaylist);
-    },
-    [onOpenPlaylist, runInteractiveAction],
-  );
-
-  const handleInteractiveOpenActions = useCallback(
-    (presenceClimb: BoardPresenceClimb) => {
-      if (!onOpenActions) return;
-      runInteractiveAction(presenceClimb, onOpenActions);
-    },
-    [onOpenActions, runInteractiveAction],
-  );
-
-  const handleClose = useCallback(() => {
-    invalidatePendingActions();
-    onClose();
-  }, [invalidatePendingActions, onClose]);
 
   // Fired once the dismiss animation has actually SETTLED (coordinator), not on
   // the synchronous early callback — so we never tear anything down mid-animation.
-  // This is also where `BoardSheetContent` unmounts (zero work while dismissed).
+  // This is also where the panel unmounts (zero work while dismissed) and the
+  // history-viewed guard re-arms for the next presentation.
   const handleFullyDismissed = useCallback(() => {
-    invalidatePendingActions();
+    invalidatePanelActions();
+    historyViewedForPresentationRef.current = false;
     setIsPresented(false);
     onDismissed?.();
-  }, [invalidatePendingActions, onDismissed]);
+  }, [invalidatePanelActions, onDismissed]);
 
   // Present/dismiss route through the coordinator so the board sheet never
   // overlaps another sheet's transition (the iOS UIKit deadlock). The sheet stays
   // mounted (like QueueSheet) and is re-presented on the next open.
   const managed = useManagedSheet({ sheetRef, onFullyDismissed: handleFullyDismissed });
 
-  const handleSwitchBoard = useCallback(() => {
-    invalidatePendingActions();
-    onSwitchBoard();
-  }, [invalidatePendingActions, onSwitchBoard]);
-
   useImperativeHandle(
     ref,
     () => ({
       present: () => {
-        // Synchronous, before the sheet's own present animation starts, so
-        // `BoardSheetContent` mounts (and its history/hero read) right away —
-        // no reliance on the sheet library's own child-mounting timing.
+        // Synchronous, before the sheet's own present animation starts, so the
+        // panel mounts right away — no reliance on the sheet library's own
+        // child-mounting timing.
         setIsPresented(true);
         managed.handle.present();
       },
       dismiss: () => {
-        invalidatePendingActions();
+        invalidatePanelActions();
         managed.handle.dismiss();
       },
     }),
-    [managed.handle, invalidatePendingActions],
+    [managed.handle, invalidatePanelActions],
   );
 
-  // Re-mount backstop: a re-present queued inside a dismiss settle window gets
-  // its isPresented(true) clobbered by the late-settling `handleFullyDismissed`
-  // BEFORE the coordinator presents the native sheet — which would leave the
-  // sheet up with the content unmounted. index >= 0 means the sheet is really
-  // up, so re-mount here; the synchronous set in `present()` is the fast path.
+  // Re-mount backstop: a re-present queued inside a dismiss settle window gets its
+  // isPresented(true) clobbered by the late-settling `handleFullyDismissed` BEFORE
+  // the coordinator presents the native sheet — which would leave the sheet up
+  // with the panel unmounted. index >= 0 means the sheet is really up, so re-mount
+  // here; the synchronous set in `present()` is the fast path.
   const managedOnChange = managed.onChange;
   const handleSheetChange = useCallback(
     (index: number) => {
@@ -451,9 +216,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       ref={sheetRef}
       index={0}
       snapPoints={snapPoints}
-      // Height is driven by explicit snapPoints, so disable gorhom's dynamic
-      // content sizing — it doesn't play well with a BottomSheetFlatList (no
-      // bounded content height to measure).
+      // Height is driven by explicit snapPoints, so disable dynamic content
+      // sizing — it doesn't play well with a BottomSheetFlatList (no bounded
+      // content height to measure).
       enableDynamicSizing={false}
       enablePanDownToClose
       onChange={handleSheetChange}
@@ -461,911 +226,23 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >
-      <View style={[styles.header, { borderBottomColor: systemColors.separator }]}>
-        <Pressable
-          onPress={handleClose}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.boardPresence.close')}
-          style={styles.headerAction}
-        >
-          <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
-        </Pressable>
-        <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
-          {boardLabel ?? t('mobile.boardPresence.title')}
-        </Text>
-        <View pointerEvents="none" style={styles.headerAction} />
-      </View>
-
       {isPresented ? (
-        <BoardSheetContent
+        <NowOnTheWallPanel
+          ref={panelRef}
+          variant="sheet"
+          boardLabel={boardLabel}
           boardConfig={boardConfig}
-          rowBoard={rowBoard}
-          canUseInteractiveRows={canUseInteractiveRows}
+          onClose={onClose}
+          onSwitchBoard={onSwitchBoard}
           onClimbPress={onClimbPress}
-          isActionLoading={isActionLoading}
-          pendingActionKeys={pendingActionKeys}
-          onInteractiveClimbPress={handleInteractiveClimbPress}
-          onInteractiveAddToQueue={handleInteractiveAddToQueue}
-          onInteractiveOpenPlaylist={handleInteractiveOpenPlaylist}
-          onInteractiveOpenActions={handleInteractiveOpenActions}
+          onAddToQueue={onAddToQueue}
+          onOpenPlaylist={onOpenPlaylist}
+          onOpenActions={onOpenActions}
         />
       ) : null}
-
-      <Pressable
-        onPress={handleSwitchBoard}
-        accessibilityRole="button"
-        accessibilityLabel={t('mobile.boardPresence.switchBoardAria')}
-        style={[styles.footer, { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] }]}
-      >
-        <View style={[styles.footerIcon, { backgroundColor: systemColors.secondaryBackground }]}>
-          <Icon name="transfer" size={20} color={systemColors.label} />
-        </View>
-        <View style={styles.footerText}>
-          <Text variant="body" color={systemColors.label}>
-            {t('mobile.boardPresence.switchBoard')}
-          </Text>
-          {boardLabel ? (
-            <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
-              {boardLabel}
-            </Text>
-          ) : null}
-        </View>
-        <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
-      </Pressable>
     </BottomSheetModal>
   );
 });
-
-type BoardSheetContentProps = {
-  boardConfig: BoardConfig | null;
-  rowBoard: BoardSheetRowBoard | null;
-  canUseInteractiveRows: boolean;
-  onClimbPress?: (action: BoardSheetClimbAction) => void;
-  isActionLoading: (presenceClimb: BoardPresenceClimb) => boolean;
-  pendingActionKeys: ReadonlySet<string>;
-  onInteractiveClimbPress: (presenceClimb: BoardPresenceClimb) => void;
-  onInteractiveAddToQueue: (presenceClimb: BoardPresenceClimb) => void;
-  onInteractiveOpenPlaylist: (presenceClimb: BoardPresenceClimb) => void;
-  onInteractiveOpenActions: (presenceClimb: BoardPresenceClimb) => void;
-};
-
-/**
- * Everything that reads the wall's live state: the hero, stat tiles, and the
- * virtualized history list. Mounted by `BoardSheet` only while `isPresented`
- * is true, so a dismissed sheet subscribes to none of the presence contexts
- * and does none of this rendering work — this component mounts fresh on every
- * `present()` and unmounts on `handleFullyDismissed`.
- *
- * The action-hydration state (`pendingActionKeys`, the climb cache, generation
- * counter) stays in the parent `BoardSheet` — it doesn't depend on presence
- * data, and keeping it there means an in-flight action survives this
- * component's own mount/unmount cycle exactly as before (the parent's
- * `invalidatePendingActions` on close/dismiss is unaffected by this refactor).
- */
-function BoardSheetContent({
-  boardConfig,
-  rowBoard,
-  canUseInteractiveRows,
-  onClimbPress,
-  isActionLoading,
-  pendingActionKeys,
-  onInteractiveClimbPress,
-  onInteractiveAddToQueue,
-  onInteractiveOpenPlaylist,
-  onInteractiveOpenActions,
-}: BoardSheetContentProps) {
-  const { t } = useTranslation('session');
-  const { systemColors, brandColors } = useTheme();
-  const { formatGrade } = useGradeFormat();
-  const { currentClimb } = useBoardPresenceCurrent();
-  const { history, stats } = useBoardPresenceFeed();
-  const { refresh } = useBoardPresenceActions();
-  const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
-
-  // Pull-to-refresh: a manual catch-up for when a user notices the wall feed is
-  // stale. `refresh()` is fire-and-forget (the durable history merges back in
-  // via context), so show the spinner briefly, then clear it.
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const handleRefresh = useCallback(() => {
-    refresh('manual');
-    setIsRefreshing(true);
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-    }
-    refreshTimerRef.current = setTimeout(() => setIsRefreshing(false), 800);
-  }, [refresh]);
-  useEffect(
-    () => () => {
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  const visibleHistory = useMemo(
-    () =>
-      currentClimb
-        ? history.filter((historyClimb) => {
-            return historyClimb.climbUuid !== currentClimb.climbUuid || historyClimb.seq !== currentClimb.seq;
-          })
-        : history,
-    [currentClimb, history],
-  );
-
-  // "Load older" — pages further back through the durable history log, past
-  // the live feed's in-memory HISTORY_CAP window.
-  const handleHistoryPageLoaded = useCallback(
-    (info: { pageSize: number; returnedCount: number }) => {
-      track(SHARED_EVENTS.BoardHistoryPageLoaded, {
-        boardId: boardPresenceBoardId ?? undefined,
-        pageSize: info.pageSize,
-        returnedCount: info.returnedCount,
-      });
-    },
-    [boardPresenceBoardId],
-  );
-  const { olderHistory, isLoadingOlder, hasMore, loadOlder } = useBoardHistoryPagination(
-    undefined,
-    handleHistoryPageLoaded,
-  );
-  // The hook dedupes each page only at resolve time; the live window can gain
-  // lower seqs AFTERWARDS (backfill / pull-to-refresh merge — seam 2 in the
-  // hook's header), so re-filter here or overlapping entries would render
-  // twice with duplicate list keys. Filter against the FULL feed history, not
-  // `visibleHistory`: the current climb is excluded from the list but its key
-  // must still suppress a durable copy of it leaking in from a page.
-  const combinedHistory = useMemo(() => {
-    if (olderHistory.length === 0) return visibleHistory;
-    const liveKeys = new Set(history.map(boardHistoryEntryKey));
-    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(boardHistoryEntryKey(climb)));
-    return dedupedOlder.length === 0 ? visibleHistory : [...visibleHistory, ...dedupedOlder];
-  }, [visibleHistory, history, olderHistory]);
-
-  // FlatList fires onEndReached immediately when the content is shorter than
-  // the viewport, so without this gate every presentation of a quiet wall
-  // would auto-fire a durable history fetch (guaranteed-rejected for
-  // logged-out users). Require a real user scroll first. The ref lives in
-  // this component, which mounts fresh per presentation, so the gate re-arms
-  // on every open.
-  const hasUserScrolledRef = useRef(false);
-  const handleScrollBeginDrag = useCallback(() => {
-    hasUserScrolledRef.current = true;
-  }, []);
-  const handleEndReached = useCallback(() => {
-    if (!hasUserScrolledRef.current) return;
-    loadOlder();
-  }, [loadOlder]);
-
-  // Fires once per presentation, when history is FIRST non-empty — not only at
-  // mount, because presenting before the initial backfill resolves would find
-  // an empty list and never fire for that presentation. This component mounts
-  // fresh every time the sheet opens (`BoardSheet`'s `isPresented` gate), so
-  // the ref naturally resets per presentation. Mirrors web's `BoardSheetBody`.
-  const historyViewedForPresentationRef = useRef(false);
-  useEffect(() => {
-    if (historyViewedForPresentationRef.current || visibleHistory.length === 0) return;
-    historyViewedForPresentationRef.current = true;
-    track(SHARED_EVENTS.BoardHistoryViewed, {
-      boardId: boardPresenceBoardId ?? undefined,
-      itemCount: visibleHistory.length,
-    });
-  }, [visibleHistory.length, boardPresenceBoardId]);
-
-  const renderHistoryItem = useCallback(
-    ({ item }: { item: BoardPresenceClimb }) => {
-      const formattedGrade = item.grade ? formatGrade(item.grade) : null;
-      const gradeColor = getGradeColor(item.grade ?? '') ?? DEFAULT_GRADE_COLOR;
-
-      if (canUseInteractiveRows && rowBoard) {
-        return (
-          <InteractiveHistoryRow
-            climb={item}
-            rowBoard={rowBoard}
-            boardConfig={boardConfig}
-            labelColor={systemColors.label}
-            secondaryColor={systemColors.secondaryLabel}
-            formattedGrade={formattedGrade}
-            gradeColor={gradeColor}
-            isActionLoading={isActionLoading(item)}
-            onPress={onClimbPress ? onInteractiveClimbPress : undefined}
-            onAddToQueue={onInteractiveAddToQueue}
-            onOpenPlaylist={onInteractiveOpenPlaylist}
-            onOpenActions={onInteractiveOpenActions}
-          />
-        );
-      }
-
-      return (
-        <HistoryRow
-          climb={item}
-          boardConfig={boardConfig}
-          labelColor={systemColors.label}
-          secondaryColor={systemColors.secondaryLabel}
-          formattedGrade={formattedGrade}
-          gradeColor={gradeColor}
-        />
-      );
-    },
-    [
-      boardConfig,
-      canUseInteractiveRows,
-      rowBoard,
-      systemColors.label,
-      systemColors.secondaryLabel,
-      formatGrade,
-      onInteractiveClimbPress,
-      onInteractiveAddToQueue,
-      onInteractiveOpenPlaylist,
-      onInteractiveOpenActions,
-      // `isActionLoading` (a function of `pendingActionKeys`, ANY row's action
-      // state) is intentionally kept here — rows are `React.memo`'d, so this
-      // only re-renders the specific row whose own loading flag actually
-      // changed. `listHeader` below deliberately does NOT depend on this same
-      // function for the hero — see `heroActionLoading`.
-      isActionLoading,
-      onClimbPress,
-    ],
-  );
-
-  // Primitive derived from `pendingActionKeys` for just the hero's own climb —
-  // NOT the `isActionLoading` function itself, which changes identity on every
-  // row's action-state flip. Keeping `listHeader` keyed on this boolean instead
-  // means an unrelated history-row tap no longer rebuilds the whole header
-  // (hero + stat tiles + hardest-send row).
-  const heroActionLoading =
-    currentClimb && boardConfig
-      ? pendingActionKeys.has(
-          actionCacheKey(actionBoardConfigForPresenceClimb(boardConfig, currentClimb), currentClimb.climbUuid),
-        )
-      : false;
-
-  const listHeader = useMemo(
-    () => (
-      <View>
-        {canUseInteractiveRows && rowBoard && currentClimb ? (
-          <InteractiveHeroRow
-            climb={currentClimb}
-            rowBoard={rowBoard}
-            boardConfig={boardConfig}
-            labelColor={systemColors.label}
-            secondaryColor={systemColors.secondaryLabel}
-            accentColor={brandColors.warning}
-            surfaceColor={systemColors.secondaryBackground}
-            formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-            isActionLoading={heroActionLoading}
-            onPress={onClimbPress ? onInteractiveClimbPress : undefined}
-            onAddToQueue={onInteractiveAddToQueue}
-            onOpenPlaylist={onInteractiveOpenPlaylist}
-            onOpenActions={onInteractiveOpenActions}
-          />
-        ) : (
-          <NowOnTheWallHero
-            climb={currentClimb}
-            boardConfig={boardConfig}
-            labelColor={systemColors.label}
-            secondaryColor={systemColors.secondaryLabel}
-            accentColor={brandColors.warning}
-            surfaceColor={systemColors.secondaryBackground}
-            formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-          />
-        )}
-        {stats ? (
-          <View style={styles.statsBlock}>
-            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
-              {t('mobile.boardPresence.statsHeader')}
-            </Text>
-            <View style={styles.statTiles}>
-              <StatTile
-                value={String(stats.climbsSentCount)}
-                label={t('mobile.boardPresence.statSent')}
-                surfaceColor={systemColors.secondaryBackground}
-                labelColor={systemColors.secondaryLabel}
-                valueColor={systemColors.label}
-              />
-              <StatTile
-                value={String(stats.distinctClimbersCount)}
-                label={t('mobile.boardPresence.statClimbers')}
-                surfaceColor={systemColors.secondaryBackground}
-                labelColor={systemColors.secondaryLabel}
-                valueColor={systemColors.label}
-              />
-              <StatTile
-                value={stats.hardestGrade ? (formatGrade(stats.hardestGrade) ?? '–') : '–'}
-                label={t('mobile.boardPresence.statHardest')}
-                surfaceColor={systemColors.secondaryBackground}
-                labelColor={systemColors.secondaryLabel}
-                valueColor={systemColors.label}
-              />
-              <StatTile
-                value={stats.topGrade ? (formatGrade(stats.topGrade) ?? '–') : '–'}
-                label={t('mobile.boardPresence.statTopGrade')}
-                surfaceColor={systemColors.secondaryBackground}
-                labelColor={systemColors.secondaryLabel}
-                valueColor={systemColors.label}
-              />
-            </View>
-            {stats.hardestSend ? (
-              <HardestSendRow
-                hardestSend={stats.hardestSend}
-                labelColor={systemColors.label}
-                secondaryColor={systemColors.secondaryLabel}
-                surfaceColor={systemColors.secondaryBackground}
-                crownColor={brandColors.warning}
-                formattedGrade={formatGrade(stats.hardestSend.grade) ?? stats.hardestSend.grade}
-                gradeColor={getGradeColor(stats.hardestSend.grade) ?? DEFAULT_GRADE_COLOR}
-              />
-            ) : null}
-          </View>
-        ) : null}
-        {visibleHistory.length > 0 ? (
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
-            {t('mobile.boardPresence.historyHeader')}
-          </Text>
-        ) : null}
-      </View>
-    ),
-    [
-      currentClimb,
-      boardConfig,
-      stats,
-      visibleHistory.length,
-      systemColors,
-      brandColors.warning,
-      formatGrade,
-      t,
-      canUseInteractiveRows,
-      rowBoard,
-      onInteractiveClimbPress,
-      onInteractiveAddToQueue,
-      onInteractiveOpenPlaylist,
-      onInteractiveOpenActions,
-      heroActionLoading,
-      onClimbPress,
-    ],
-  );
-
-  const listEmpty = useMemo(
-    () => (
-      <View>
-        {currentClimb ? null : (
-          <View style={styles.empty}>
-            <Icon name="lightbulb" size={36} color={systemColors.tertiaryLabel} />
-            <Text variant="headline" color={systemColors.label} style={styles.emptyTitle}>
-              {t('mobile.boardPresence.emptyTitle')}
-            </Text>
-            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
-              {t('mobile.boardPresence.emptyBody')}
-            </Text>
-          </View>
-        )}
-        {/* A wall that's been quiet longer than the Redis window's TTL has an
-            EMPTY live window but durable boardHistory rows. An empty list
-            can't scroll, so the scroll-gated onEndReached above can never
-            fire — this button is then the only path into the durable log
-            (the hook supports a cursor-less first page). */}
-        {hasMore ? (
-          <Pressable
-            onPress={loadOlder}
-            disabled={isLoadingOlder}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.boardPresence.loadMore')}
-            style={styles.emptyLoadMore}
-          >
-            <Text variant="subheadline" color={brandColors.primary}>
-              {isLoadingOlder ? t('mobile.boardPresence.loadingMore') : t('mobile.boardPresence.loadMore')}
-            </Text>
-          </Pressable>
-        ) : null}
-      </View>
-    ),
-    [currentClimb, systemColors, t, hasMore, isLoadingOlder, loadOlder, brandColors.primary],
-  );
-
-  const listFooter = useMemo(
-    () =>
-      isLoadingOlder ? (
-        <View style={styles.historyFooter}>
-          <ActivityIndicator size="small" accessibilityLabel={t('mobile.boardPresence.loadingMore')} />
-        </View>
-      ) : null,
-    [isLoadingOlder, t],
-  );
-
-  return (
-    <BottomSheetFlatList
-      data={combinedHistory}
-      keyExtractor={boardHistoryEntryKey}
-      renderItem={renderHistoryItem}
-      ListHeaderComponent={listHeader}
-      ListEmptyComponent={listEmpty}
-      ListFooterComponent={listFooter}
-      // `loadOlder` already no-ops once `hasMore` is false, but skipping the
-      // prop entirely once there's nothing left avoids FlatList re-evaluating
-      // the end-reached threshold on every scroll frame for no reason. The
-      // handler itself is additionally gated on a real user scroll — see
-      // `hasUserScrolledRef` above.
-      onEndReached={hasMore ? handleEndReached : undefined}
-      onEndReachedThreshold={0.6}
-      onScrollBeginDrag={handleScrollBeginDrag}
-      contentContainerStyle={{ paddingBottom: spacing[4] }}
-      refreshControl={
-        <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />
-      }
-    />
-  );
-}
-
-type HeroProps = {
-  climb: BoardPresenceClimb | null;
-  boardConfig: BoardConfig | null;
-  labelColor: ColorValue;
-  secondaryColor: ColorValue;
-  accentColor: ColorValue;
-  surfaceColor: ColorValue;
-  formattedGrade: string | null;
-  gradeColor: string;
-};
-
-type InteractiveRowActionProps = {
-  onPress?: (climb: BoardPresenceClimb) => void;
-  onAddToQueue?: (climb: BoardPresenceClimb) => void;
-  onOpenPlaylist?: (climb: BoardPresenceClimb) => void;
-  onOpenActions?: (climb: BoardPresenceClimb) => void;
-};
-
-type HeroContentProps = Omit<HeroProps, 'climb' | 'surfaceColor'> & {
-  climb: BoardPresenceClimb;
-  renderClimb: Climb;
-  thumbnailSize?: number;
-  isActionLoading?: boolean;
-  /**
-   * Make the driver avatar open the climber's profile on tap. Off inside an
-   * interactive ClimbListRow, whose own tap gesture owns the row (a nested
-   * pressable would double-fire the climb action + the profile push, and the
-   * row's collapsed a11y node would hide it anyway). The row opens the climb;
-   * the avatar there is identity only.
-   */
-  pressableAvatar?: boolean;
-};
-
-function NowOnTheWallHeroContent({
-  climb,
-  renderClimb,
-  boardConfig,
-  labelColor,
-  secondaryColor,
-  accentColor,
-  formattedGrade,
-  gradeColor,
-  thumbnailSize,
-  isActionLoading = false,
-  pressableAvatar = true,
-}: HeroContentProps) {
-  const { t } = useTranslation('session');
-  const litBy = climb.sentByDisplayName?.trim() || null;
-  const setter = climb.setter?.trim();
-
-  return (
-    <>
-      <AccessoryClimbThumbnail climb={renderClimb} boardConfig={boardConfig} size={thumbnailSize} />
-      <View style={styles.heroBody}>
-        <View style={styles.heroNameRow}>
-          <Text variant="headline" color={labelColor} numberOfLines={1} style={styles.heroName}>
-            {climb.name ?? ''}
-          </Text>
-          {formattedGrade ? (
-            <Text variant="headline" style={[styles.heroGrade, { color: gradeColor }]}>
-              {formattedGrade}
-            </Text>
-          ) : null}
-          {isActionLoading ? (
-            <ActivityIndicator
-              size="small"
-              accessibilityLabel={t('mobile.boardPresence.actionLoading')}
-              style={styles.actionSpinner}
-            />
-          ) : null}
-        </View>
-        {setter ? (
-          <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
-            {t('mobile.boardPresence.setByLine', { setter })}
-          </Text>
-        ) : null}
-        {litBy ? (
-          <View style={styles.heroDriverRow}>
-            <BoardDriverAvatar
-              size={20}
-              userId={pressableAvatar ? climb.sentByUserId : null}
-              uri={climb.sentByAvatarUrl}
-              name={litBy}
-              status="connected"
-              accessibilityLabel={t('mobile.boardPresence.drivenByA11y', { name: litBy })}
-            />
-            <Text variant="caption1" color={accentColor} numberOfLines={1} style={styles.heroDriverName}>
-              {litBy}
-            </Text>
-          </View>
-        ) : null}
-      </View>
-    </>
-  );
-}
-
-type InteractiveHeroRowProps = HeroProps & {
-  climb: BoardPresenceClimb;
-  rowBoard: BoardSheetRowBoard;
-  isActionLoading: boolean;
-} & InteractiveRowActionProps;
-
-const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
-  climb,
-  rowBoard,
-  boardConfig,
-  labelColor,
-  secondaryColor,
-  accentColor,
-  surfaceColor,
-  formattedGrade,
-  gradeColor,
-  isActionLoading,
-  onPress,
-  onAddToQueue,
-  onOpenPlaylist,
-  onOpenActions,
-}: InteractiveHeroRowProps) {
-  const rowClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
-  const climbBoardConfig = useMemo(
-    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
-    [boardConfig, climb],
-  );
-  const climbRowBoard = useMemo(
-    () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
-    [climbBoardConfig, rowBoard],
-  );
-  const contentRowStyle = useMemo(() => [styles.heroInteractiveRow, { backgroundColor: surfaceColor }], [surfaceColor]);
-  const handlePress = useCallback(() => {
-    onPress?.(climb);
-  }, [climb, onPress]);
-  const handleAddToQueue = useCallback(() => {
-    onAddToQueue?.(climb);
-  }, [climb, onAddToQueue]);
-  const handleOpenPlaylist = useCallback(() => {
-    onOpenPlaylist?.(climb);
-  }, [climb, onOpenPlaylist]);
-  const handleOpenActions = useCallback(() => {
-    onOpenActions?.(climb);
-  }, [climb, onOpenActions]);
-  const renderContent = useCallback(
-    ({ climb: renderClimb }: ClimbListRowRenderContentArgs) => (
-      <NowOnTheWallHeroContent
-        climb={climb}
-        renderClimb={renderClimb}
-        boardConfig={climbBoardConfig}
-        labelColor={labelColor}
-        secondaryColor={secondaryColor}
-        accentColor={accentColor}
-        formattedGrade={formattedGrade}
-        gradeColor={gradeColor}
-        thumbnailSize={52}
-        isActionLoading={isActionLoading}
-        // The row's tap opens the climb; the avatar is identity only here.
-        pressableAvatar={false}
-      />
-    ),
-    [accentColor, climb, climbBoardConfig, formattedGrade, gradeColor, isActionLoading, labelColor, secondaryColor],
-  );
-
-  return (
-    <ClimbListRow
-      climb={rowClimb}
-      boardName={climbRowBoard.boardName}
-      layoutId={climbRowBoard.layoutId}
-      sizeId={climbRowBoard.sizeId}
-      setIds={climbRowBoard.setIds}
-      angle={climbRowBoard.angle}
-      onPress={onPress ? handlePress : undefined}
-      onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
-      onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
-      onOpenActions={onOpenActions ? handleOpenActions : undefined}
-      containerStyle={styles.heroInteractiveContainer}
-      contentRowStyle={contentRowStyle}
-      showSeparator={false}
-      renderContent={renderContent}
-    />
-  );
-});
-
-const NowOnTheWallHero = memo(function NowOnTheWallHeroInner({
-  climb,
-  boardConfig,
-  labelColor,
-  secondaryColor,
-  accentColor,
-  surfaceColor,
-  formattedGrade,
-  gradeColor,
-}: HeroProps) {
-  const renderClimb = useMemo(() => (climb ? boardPresenceClimbToClimb(climb) : null), [climb]);
-  const climbBoardConfig = useMemo(
-    () => (boardConfig && climb ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
-    [boardConfig, climb],
-  );
-
-  if (!climb || !renderClimb) return null;
-
-  return (
-    <View style={[styles.hero, { backgroundColor: surfaceColor }]}>
-      <NowOnTheWallHeroContent
-        climb={climb}
-        renderClimb={renderClimb}
-        boardConfig={climbBoardConfig}
-        labelColor={labelColor}
-        secondaryColor={secondaryColor}
-        accentColor={accentColor}
-        formattedGrade={formattedGrade}
-        gradeColor={gradeColor}
-      />
-    </View>
-  );
-});
-
-type HistoryRowProps = {
-  climb: BoardPresenceClimb;
-  boardConfig: BoardConfig | null;
-  labelColor: ColorValue;
-  secondaryColor: ColorValue;
-  formattedGrade: string | null;
-  gradeColor: string;
-};
-
-type HistoryRowContentProps = HistoryRowProps & {
-  renderClimb: Climb;
-  isActionLoading?: boolean;
-  /** See HeroContentProps.pressableAvatar — off inside an interactive row. */
-  pressableAvatar?: boolean;
-};
-
-function HistoryRowContent({
-  climb,
-  renderClimb,
-  boardConfig,
-  labelColor,
-  secondaryColor,
-  formattedGrade,
-  gradeColor,
-  isActionLoading = false,
-  pressableAvatar = true,
-}: HistoryRowContentProps) {
-  const { t } = useTranslation('session');
-  const litBy = climb.sentByDisplayName?.trim() || null;
-
-  return (
-    <>
-      <AccessoryClimbThumbnail climb={renderClimb} boardConfig={boardConfig} />
-      <View style={styles.historyBody}>
-        <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.historyName}>
-          {climb.name ?? ''}
-        </Text>
-        {litBy ? (
-          <View style={styles.historyDriverRow}>
-            {/* Past send — no Bluetooth glyph (nobody's driving it now); just a
-                pressable face for attribution. */}
-            <BoardDriverAvatar
-              size={18}
-              userId={pressableAvatar ? climb.sentByUserId : null}
-              uri={climb.sentByAvatarUrl}
-              name={litBy}
-              status="none"
-              accessibilityLabel={t('mobile.boardPresence.drivenByA11y', { name: litBy })}
-            />
-            <Text variant="caption1" color={secondaryColor} numberOfLines={1} style={styles.historyDriverName}>
-              {litBy}
-            </Text>
-          </View>
-        ) : null}
-      </View>
-      {formattedGrade ? (
-        <Text variant="headline" style={[styles.historyGrade, { color: gradeColor }]}>
-          {formattedGrade}
-        </Text>
-      ) : null}
-      {isActionLoading ? (
-        <ActivityIndicator
-          size="small"
-          accessibilityLabel={t('mobile.boardPresence.actionLoading')}
-          style={styles.actionSpinner}
-        />
-      ) : null}
-    </>
-  );
-}
-
-type InteractiveHistoryRowProps = HistoryRowProps & {
-  rowBoard: BoardSheetRowBoard;
-  isActionLoading: boolean;
-} & InteractiveRowActionProps;
-
-const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
-  climb,
-  rowBoard,
-  boardConfig,
-  labelColor,
-  secondaryColor,
-  formattedGrade,
-  gradeColor,
-  isActionLoading,
-  onPress,
-  onAddToQueue,
-  onOpenPlaylist,
-  onOpenActions,
-}: InteractiveHistoryRowProps) {
-  const rowClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
-  const climbBoardConfig = useMemo(
-    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
-    [boardConfig, climb],
-  );
-  const climbRowBoard = useMemo(
-    () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
-    [climbBoardConfig, rowBoard],
-  );
-  const handlePress = useCallback(() => {
-    onPress?.(climb);
-  }, [climb, onPress]);
-  const handleAddToQueue = useCallback(() => {
-    onAddToQueue?.(climb);
-  }, [climb, onAddToQueue]);
-  const handleOpenPlaylist = useCallback(() => {
-    onOpenPlaylist?.(climb);
-  }, [climb, onOpenPlaylist]);
-  const handleOpenActions = useCallback(() => {
-    onOpenActions?.(climb);
-  }, [climb, onOpenActions]);
-  const renderContent = useCallback(
-    ({ climb: renderClimb }: ClimbListRowRenderContentArgs) => (
-      <HistoryRowContent
-        climb={climb}
-        renderClimb={renderClimb}
-        boardConfig={climbBoardConfig}
-        labelColor={labelColor}
-        secondaryColor={secondaryColor}
-        formattedGrade={formattedGrade}
-        gradeColor={gradeColor}
-        isActionLoading={isActionLoading}
-        // The row's tap opens the climb; the avatar is identity only here.
-        pressableAvatar={false}
-      />
-    ),
-    [climb, climbBoardConfig, formattedGrade, gradeColor, isActionLoading, labelColor, secondaryColor],
-  );
-
-  return (
-    <ClimbListRow
-      climb={rowClimb}
-      boardName={climbRowBoard.boardName}
-      layoutId={climbRowBoard.layoutId}
-      sizeId={climbRowBoard.sizeId}
-      setIds={climbRowBoard.setIds}
-      angle={climbRowBoard.angle}
-      onPress={onPress ? handlePress : undefined}
-      onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
-      onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
-      onOpenActions={onOpenActions ? handleOpenActions : undefined}
-      contentRowStyle={styles.historyInteractiveRow}
-      showSeparator={false}
-      renderContent={renderContent}
-    />
-  );
-});
-
-const HistoryRow = memo(function HistoryRowInner({
-  climb,
-  boardConfig,
-  labelColor,
-  secondaryColor,
-  formattedGrade,
-  gradeColor,
-}: HistoryRowProps) {
-  const thumbnailClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
-  const climbBoardConfig = useMemo(
-    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
-    [boardConfig, climb],
-  );
-
-  return (
-    <View style={styles.historyRow}>
-      <HistoryRowContent
-        climb={climb}
-        renderClimb={thumbnailClimb}
-        boardConfig={climbBoardConfig}
-        labelColor={labelColor}
-        secondaryColor={secondaryColor}
-        formattedGrade={formattedGrade}
-        gradeColor={gradeColor}
-      />
-    </View>
-  );
-});
-
-type StatTileProps = {
-  value: string;
-  label: string;
-  surfaceColor: ColorValue;
-  labelColor: ColorValue;
-  valueColor: ColorValue;
-};
-
-function StatTile({ value, label, surfaceColor, labelColor, valueColor }: StatTileProps) {
-  return (
-    <View style={[styles.statTile, { backgroundColor: surfaceColor }]}>
-      <Text variant="title3" color={valueColor} numberOfLines={1}>
-        {value}
-      </Text>
-      <Text variant="caption1" color={labelColor} numberOfLines={1}>
-        {label}
-      </Text>
-    </View>
-  );
-}
-
-type HardestSendRowProps = {
-  hardestSend: BoardPresenceHardestSend;
-  labelColor: ColorValue;
-  secondaryColor: ColorValue;
-  surfaceColor: ColorValue;
-  crownColor: string;
-  formattedGrade: string;
-  gradeColor: string;
-};
-
-function HardestSendRow({
-  hardestSend,
-  labelColor,
-  secondaryColor,
-  surfaceColor,
-  crownColor,
-  formattedGrade,
-  gradeColor,
-}: HardestSendRowProps) {
-  const { t } = useTranslation('session');
-  const climberName = hardestSend.sentByDisplayName?.trim();
-
-  return (
-    <View style={[styles.hardestSendRow, { backgroundColor: surfaceColor }]}>
-      <View style={styles.hardestAvatar}>
-        <PressableAvatar
-          userId={hardestSend.sentByUserId}
-          uri={hardestSend.sentByAvatarUrl}
-          name={climberName}
-          size={34}
-        />
-        <View style={[styles.crownBadge, { backgroundColor: withAlpha(crownColor, 0.18) }]}>
-          <Icon name="crown" size={11} color={crownColor} />
-        </View>
-      </View>
-      <View style={styles.hardestBody}>
-        <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
-          {t('mobile.boardPresence.hardestSendLabel')}
-        </Text>
-        <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.hardestName}>
-          {hardestSend.name ?? ''}
-        </Text>
-        {climberName ? (
-          <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
-            {t('mobile.boardPresence.sentByLine', { name: climberName })}
-          </Text>
-        ) : null}
-      </View>
-      <Text variant="headline" style={[styles.historyGrade, { color: gradeColor }]}>
-        {formattedGrade}
-      </Text>
-    </View>
-  );
-}
 
 const styles = StyleSheet.create({
   sheet: {
@@ -1380,197 +257,5 @@ const styles = StyleSheet.create({
         elevation: 16,
       },
     }),
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: spacing[3],
-    paddingBottom: spacing[3],
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  headerAction: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerTitle: {
-    flex: 1,
-    marginHorizontal: spacing[2],
-    textAlign: 'center',
-  },
-  hero: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[3],
-    margin: spacing[4],
-    padding: spacing[3],
-    borderRadius: borderRadius.lg,
-  },
-  heroInteractiveContainer: {
-    margin: spacing[4],
-    borderRadius: borderRadius.lg,
-  },
-  heroInteractiveRow: {
-    padding: spacing[3],
-    borderRadius: borderRadius.lg,
-  },
-  heroBody: {
-    flex: 1,
-    gap: 2,
-  },
-  heroNameRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-  },
-  heroName: {
-    flex: 1,
-  },
-  heroDriverRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-    // Headroom for the badge that pokes ~2pt past the avatar's top-right corner.
-    paddingTop: 2,
-  },
-  heroDriverName: {
-    flexShrink: 1,
-  },
-  heroGrade: {
-    fontVariant: ['tabular-nums'],
-    fontWeight: '700',
-  },
-  sectionHeader: {
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[3],
-    paddingBottom: spacing[2],
-  },
-  statsBlock: {
-    paddingBottom: spacing[2],
-  },
-  statTiles: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing[2],
-    paddingHorizontal: spacing[4],
-  },
-  statTile: {
-    flexGrow: 1,
-    flexBasis: '47%',
-    paddingVertical: spacing[3],
-    paddingHorizontal: spacing[3],
-    borderRadius: borderRadius.md,
-    gap: 2,
-  },
-  hardestSendRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[3],
-    marginHorizontal: spacing[4],
-    marginTop: spacing[2],
-    paddingVertical: spacing[3],
-    paddingHorizontal: spacing[3],
-    borderRadius: borderRadius.md,
-  },
-  hardestAvatar: {
-    width: 42,
-    height: 42,
-    justifyContent: 'flex-end',
-  },
-  crownBadge: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    width: 18,
-    height: 18,
-    borderRadius: 9,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  hardestBody: {
-    flex: 1,
-    gap: 2,
-  },
-  hardestName: {
-    fontWeight: '600',
-  },
-  historyRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[3],
-    paddingHorizontal: spacing[4],
-    paddingVertical: spacing[2],
-  },
-  historyInteractiveRow: {
-    paddingHorizontal: spacing[4],
-    paddingVertical: spacing[2],
-  },
-  historyBody: {
-    flex: 1,
-    gap: 2,
-  },
-  historyName: {
-    fontWeight: '600',
-  },
-  historyDriverRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-  },
-  historyDriverName: {
-    flexShrink: 1,
-  },
-  historyGrade: {
-    fontVariant: ['tabular-nums'],
-    fontWeight: '700',
-    minWidth: 40,
-    textAlign: 'right',
-  },
-  actionSpinner: {
-    width: 20,
-    height: 20,
-  },
-  empty: {
-    alignItems: 'center',
-    gap: spacing[2],
-    paddingHorizontal: spacing[6],
-    paddingVertical: spacing[8],
-  },
-  emptyTitle: {
-    textAlign: 'center',
-  },
-  emptyBody: {
-    textAlign: 'center',
-  },
-  historyFooter: {
-    paddingVertical: spacing[5],
-    alignItems: 'center',
-  },
-  emptyLoadMore: {
-    alignItems: 'center',
-    paddingVertical: spacing[3],
-  },
-  footer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[3],
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[3],
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  footerIcon: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  footerText: {
-    flex: 1,
-    gap: 2,
   },
 });

--- a/packages/mobile/src/components/board-presence/IpadWallColumn.tsx
+++ b/packages/mobile/src/components/board-presence/IpadWallColumn.tsx
@@ -1,0 +1,19 @@
+import { memo } from 'react';
+import { NowOnTheWallPanel } from './NowOnTheWallPanel';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+
+/**
+ * The dedicated "Now on the wall" column on the iPad shell's trailing edge, shown
+ * in landscape where there's room beside the browse list and the detail pane (see
+ * `resolveWallSurface`). It renders the same wall feed / history / stats /
+ * switch-board content as the BoardSheet modal, inline. The shell only mounts it
+ * when a board is bound and the width budget allows, so the null case is just
+ * defensive (no board resolved → nothing to show).
+ */
+function IpadWallColumnComponent() {
+  const { boardPanelProps } = useDrawerHost();
+  if (!boardPanelProps) return null;
+  return <NowOnTheWallPanel variant="column" {...boardPanelProps} />;
+}
+
+export const IpadWallColumn = memo(IpadWallColumnComponent);

--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -1,0 +1,1443 @@
+// Now-on-the-wall panel — the board-presence "now on the wall" content, factored
+// out of BoardSheet so it can render either inside the native BottomSheetModal
+// (variant 'sheet', using `@expo/ui`'s BottomSheetFlatList) or as a standalone
+// inline column (variant 'column', using a plain react-native FlatList) for the
+// iPad shell.
+//
+// Owns the action-resolution machinery (GET_CLIMB hydration + LRU cache, pending
+// generation guards), the interactive row handlers, and pull-to-refresh. The
+// hero, stat tiles, hardest-send row and history rows are VIRTUALIZED (the list,
+// never .map). State comes from `@boardsesh/board-presence-react`'s split
+// current/feed contexts. The now-playing / history-view analytics stay in the
+// BoardSheet wrapper so they don't double-fire from the inline column.
+
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type Ref,
+} from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, View, type ColorValue } from 'react-native';
+import { BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import {
+  boardHistoryEntryKey,
+  useBoardHistoryPagination,
+  useBoardPresenceActions,
+  useBoardPresenceCurrent,
+  useBoardPresenceFeed,
+} from '@boardsesh/board-presence-react';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { BoardName, BoardPresenceClimb, BoardPresenceHardestSend, Climb } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { ClimbListRow, type ClimbListRowRenderContentArgs } from '../ClimbListRow';
+import { PressableAvatar } from '../PressableAvatar';
+import { BoardDriverAvatar } from './BoardDriverAvatar';
+import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
+import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+import { useBoardPresenceControls } from '../../providers/board-presence-provider';
+import { track } from '../../lib/analytics';
+import type { BoardConfig } from '../../providers/drawer-host-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { getHttpClient } from '../../lib/graphql/client';
+import { GET_CLIMB, type GetClimbQueryResponse } from '../../lib/graphql/operations';
+import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
+import { withAlpha } from '../../theme/colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+const ACTION_CLIMB_CACHE_LIMIT = 50;
+
+type BoardSheetRowBoard = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+export type BoardSheetClimbAction = {
+  climb: Climb;
+  queueItemUuid: string | null;
+  boardConfig: BoardConfig;
+};
+
+export type NowOnTheWallPanelHandle = {
+  invalidatePendingActions: () => void;
+};
+
+type BoardSheetActionContext = {
+  actionBoardConfig: BoardConfig;
+  cacheKey: string;
+};
+
+function actionBoardConfigForPresenceClimb(boardConfig: BoardConfig, presenceClimb: BoardPresenceClimb): BoardConfig {
+  const angle = presenceClimb.angle ?? boardConfig.angle;
+  return angle === boardConfig.angle ? boardConfig : { ...boardConfig, angle };
+}
+
+function rowBoardForBoardConfig(boardConfig: BoardConfig): BoardSheetRowBoard {
+  return {
+    boardName: boardConfig.boardName as BoardName,
+    layoutId: boardConfig.layoutId,
+    sizeId: boardConfig.sizeId,
+    setIds: boardConfig.setIds,
+    angle: boardConfig.angle,
+  };
+}
+
+function actionCacheKey(boardConfig: BoardConfig, climbUuid: string): string {
+  return [
+    boardConfig.boardName,
+    boardConfig.layoutId,
+    boardConfig.sizeId,
+    boardConfig.setIds,
+    boardConfig.angle,
+    climbUuid,
+  ].join(':');
+}
+
+function boardConfigActionSignature(boardConfig: BoardConfig | null): string {
+  if (!boardConfig) return 'none';
+  return [boardConfig.boardName, boardConfig.layoutId, boardConfig.sizeId, boardConfig.setIds, boardConfig.angle].join(
+    ':',
+  );
+}
+
+function actionContextForPresenceClimb(
+  boardConfig: BoardConfig | null,
+  presenceClimb: BoardPresenceClimb,
+): BoardSheetActionContext | null {
+  if (!boardConfig) return null;
+  const actionBoardConfig = actionBoardConfigForPresenceClimb(boardConfig, presenceClimb);
+  return {
+    actionBoardConfig,
+    cacheKey: actionCacheKey(actionBoardConfig, presenceClimb.climbUuid),
+  };
+}
+
+function getActionClimbCacheEntry(cache: Map<string, Climb>, key: string): Climb | null {
+  const cachedClimb = cache.get(key);
+  if (!cachedClimb) return null;
+  cache.delete(key);
+  cache.set(key, cachedClimb);
+  return cachedClimb;
+}
+
+function setActionClimbCacheEntry(cache: Map<string, Climb>, key: string, climb: Climb): void {
+  if (cache.has(key)) cache.delete(key);
+  cache.set(key, climb);
+  if (cache.size <= ACTION_CLIMB_CACHE_LIMIT) return;
+  const oldestKey = cache.keys().next().value;
+  if (oldestKey !== undefined) cache.delete(oldestKey);
+}
+
+export type NowOnTheWallPanelProps = {
+  /** 'sheet' renders inside the native modal (BottomSheetFlatList); 'column' renders inline (FlatList). */
+  variant: 'sheet' | 'column';
+  /** The active board label, shown as the panel title. */
+  boardLabel: string | null;
+  /**
+   * Active board config for the climb thumbnails. Passed by the host (NOT read
+   * via `useDrawerHost`) so this panel stays out of the drawer-host require cycle
+   * and doesn't subscribe to that volatile context.
+   */
+  boardConfig: BoardConfig | null;
+  /** Sheet only: when set, the header renders a close chevron that calls this. */
+  onClose?: () => void;
+  /** Open the existing board switcher from the footer control. */
+  onSwitchBoard: () => void;
+  /** Activate/open a climb from the wall feed. The panel closes itself after this (sheet). */
+  onClimbPress?: (action: BoardSheetClimbAction) => void;
+  /** Swipe action: append this wall-feed climb to the queue. */
+  onAddToQueue?: (action: BoardSheetClimbAction) => void;
+  /** Swipe action: open the add-to-playlist sheet for this climb. */
+  onOpenPlaylist?: (action: BoardSheetClimbAction) => void;
+  /** Long press action: open the existing climb actions sheet. */
+  onOpenActions?: (action: BoardSheetClimbAction) => void;
+};
+
+function NowOnTheWallPanelComponent(
+  {
+    variant,
+    boardLabel,
+    boardConfig,
+    onClose,
+    onSwitchBoard,
+    onClimbPress,
+    onAddToQueue,
+    onOpenPlaylist,
+    onOpenActions,
+  }: NowOnTheWallPanelProps,
+  ref: Ref<NowOnTheWallPanelHandle>,
+) {
+  const { t } = useTranslation('session');
+  const insets = useSafeAreaInsets();
+  const { systemColors, brandColors } = useTheme();
+  const { showToast } = useToast();
+  const { formatGrade } = useGradeFormat();
+  const boardConfigRef = useRef(boardConfig);
+  boardConfigRef.current = boardConfig;
+  const boardConfigSignature = useMemo(() => boardConfigActionSignature(boardConfig), [boardConfig]);
+  const boardConfigSignatureRef = useRef(boardConfigSignature);
+  boardConfigSignatureRef.current = boardConfigSignature;
+
+  const { currentClimb } = useBoardPresenceCurrent();
+  const { history, stats } = useBoardPresenceFeed();
+  const { refresh } = useBoardPresenceActions();
+  const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
+
+  // Pull-to-refresh: a manual catch-up for when a user notices the wall feed is
+  // stale. `refresh()` is fire-and-forget (the durable history merges back in
+  // via context), so show the spinner briefly, then clear it.
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleRefresh = useCallback(() => {
+    refresh('manual');
+    setIsRefreshing(true);
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+    }
+    refreshTimerRef.current = setTimeout(() => setIsRefreshing(false), 800);
+  }, [refresh]);
+  useEffect(
+    () => () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const visibleHistory = useMemo(
+    () =>
+      currentClimb
+        ? history.filter((historyClimb) => {
+            return historyClimb.climbUuid !== currentClimb.climbUuid || historyClimb.seq !== currentClimb.seq;
+          })
+        : history,
+    [currentClimb, history],
+  );
+
+  // "Load older" — pages further back through the durable history log, past
+  // the live feed's in-memory HISTORY_CAP window.
+  const handleHistoryPageLoaded = useCallback(
+    (info: { pageSize: number; returnedCount: number }) => {
+      track(SHARED_EVENTS.BoardHistoryPageLoaded, {
+        boardId: boardPresenceBoardId ?? undefined,
+        pageSize: info.pageSize,
+        returnedCount: info.returnedCount,
+      });
+    },
+    [boardPresenceBoardId],
+  );
+  const { olderHistory, isLoadingOlder, hasMore, loadOlder } = useBoardHistoryPagination(
+    undefined,
+    handleHistoryPageLoaded,
+  );
+  // The hook dedupes each page only at resolve time; the live window can gain
+  // lower seqs AFTERWARDS (backfill / pull-to-refresh merge — seam 2 in the
+  // hook's header), so re-filter here or overlapping entries would render
+  // twice with duplicate list keys. Filter against the FULL feed history, not
+  // `visibleHistory`: the current climb is excluded from the list but its key
+  // must still suppress a durable copy of it leaking in from a page.
+  const combinedHistory = useMemo(() => {
+    if (olderHistory.length === 0) return visibleHistory;
+    const liveKeys = new Set(history.map(boardHistoryEntryKey));
+    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(boardHistoryEntryKey(climb)));
+    return dedupedOlder.length === 0 ? visibleHistory : [...visibleHistory, ...dedupedOlder];
+  }, [visibleHistory, history, olderHistory]);
+
+  // FlatList fires onEndReached immediately when the content is shorter than
+  // the viewport, so without this gate every presentation of a quiet wall
+  // would auto-fire a durable history fetch (guaranteed-rejected for
+  // logged-out users). Require a real user scroll first.
+  const hasUserScrolledRef = useRef(false);
+  const handleScrollBeginDrag = useCallback(() => {
+    hasUserScrolledRef.current = true;
+  }, []);
+  const handleEndReached = useCallback(() => {
+    if (!hasUserScrolledRef.current) return;
+    loadOlder();
+  }, [loadOlder]);
+
+  const actionClimbCacheRef = useRef(new Map<string, Climb>());
+  const actionClimbRequestRef = useRef(new Map<string, Promise<Climb | null>>());
+  const pendingActionKeysRef = useRef(new Set<string>());
+  const actionGenerationRef = useRef(0);
+  const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
+
+  const rowBoard = useMemo<BoardSheetRowBoard | null>(
+    () => (boardConfig ? rowBoardForBoardConfig(boardConfig) : null),
+    [boardConfig],
+  );
+  const canUseInteractiveRows = !!rowBoard && (!!onClimbPress || !!onAddToQueue || !!onOpenPlaylist || !!onOpenActions);
+
+  const getActionContext = useCallback((presenceClimb: BoardPresenceClimb) => {
+    return actionContextForPresenceClimb(boardConfigRef.current, presenceClimb);
+  }, []);
+
+  const isActionLoading = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      const actionContext = getActionContext(presenceClimb);
+      return actionContext ? pendingActionKeys.has(actionContext.cacheKey) : false;
+    },
+    [getActionContext, pendingActionKeys],
+  );
+
+  const setActionLoading = useCallback((cacheKey: string, loading: boolean) => {
+    const pendingKeys = pendingActionKeysRef.current;
+    if (loading) {
+      if (pendingKeys.has(cacheKey)) return;
+      pendingKeys.add(cacheKey);
+    } else if (!pendingKeys.delete(cacheKey)) {
+      return;
+    }
+    setPendingActionKeys(new Set(pendingKeys));
+  }, []);
+
+  const clearPendingActionKeys = useCallback(() => {
+    const pendingKeys = pendingActionKeysRef.current;
+    if (pendingKeys.size === 0) return;
+    pendingKeys.clear();
+    setPendingActionKeys(new Set());
+  }, []);
+
+  const invalidatePendingActions = useCallback(() => {
+    actionGenerationRef.current += 1;
+    clearPendingActionKeys();
+  }, [clearPendingActionKeys]);
+
+  useImperativeHandle(ref, () => ({ invalidatePendingActions }), [invalidatePendingActions]);
+
+  useEffect(() => {
+    invalidatePendingActions();
+  }, [boardConfigSignature, invalidatePendingActions]);
+
+  const notifyActionFailed = useCallback(() => {
+    showToast(t('mobile.boardPresence.actionFailed'), 'error');
+  }, [showToast, t]);
+
+  const resolveAction = useCallback(
+    async (
+      presenceClimb: BoardPresenceClimb,
+      actionContext: BoardSheetActionContext,
+    ): Promise<BoardSheetClimbAction | null> => {
+      const { actionBoardConfig, cacheKey } = actionContext;
+      const cachedClimb = getActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey);
+      if (cachedClimb) {
+        return {
+          climb: cachedClimb,
+          queueItemUuid: presenceClimb.queueItemUuid ?? null,
+          boardConfig: actionBoardConfig,
+        };
+      }
+
+      let climbRequest = actionClimbRequestRef.current.get(cacheKey);
+      if (!climbRequest) {
+        climbRequest = getHttpClient()
+          .request<GetClimbQueryResponse>(GET_CLIMB, {
+            boardName: actionBoardConfig.boardName,
+            layoutId: actionBoardConfig.layoutId,
+            sizeId: actionBoardConfig.sizeId,
+            setIds: actionBoardConfig.setIds,
+            angle: actionBoardConfig.angle,
+            climbUuid: presenceClimb.climbUuid,
+          })
+          .then((response): Climb | null => {
+            if (!response.climb) {
+              console.warn('Board-sheet climb action returned no climb', presenceClimb.climbUuid);
+              return null;
+            }
+            setActionClimbCacheEntry(actionClimbCacheRef.current, cacheKey, response.climb);
+            return response.climb;
+          })
+          .catch((error: unknown): null => {
+            console.warn('Failed to load board-sheet climb action', error);
+            return null;
+          })
+          .finally(() => {
+            actionClimbRequestRef.current.delete(cacheKey);
+          });
+        actionClimbRequestRef.current.set(cacheKey, climbRequest);
+      }
+
+      const loadedClimb = await climbRequest;
+      if (!loadedClimb) return null;
+      return {
+        climb: loadedClimb,
+        queueItemUuid: presenceClimb.queueItemUuid ?? null,
+        boardConfig: actionBoardConfig,
+      };
+    },
+    [],
+  );
+
+  const runInteractiveAction = useCallback(
+    (presenceClimb: BoardPresenceClimb, callback: (action: BoardSheetClimbAction) => void, closeOnSuccess = false) => {
+      const actionContext = getActionContext(presenceClimb);
+      if (!actionContext) {
+        notifyActionFailed();
+        return;
+      }
+
+      if (pendingActionKeysRef.current.has(actionContext.cacheKey)) return;
+
+      const actionGeneration = actionGenerationRef.current;
+      const actionBoardSignature = boardConfigSignatureRef.current;
+      setActionLoading(actionContext.cacheKey, true);
+      void resolveAction(presenceClimb, actionContext)
+        .then((action) => {
+          if (
+            actionGeneration !== actionGenerationRef.current ||
+            actionBoardSignature !== boardConfigSignatureRef.current
+          ) {
+            return;
+          }
+          if (!action) {
+            notifyActionFailed();
+            return;
+          }
+          try {
+            callback(action);
+            if (closeOnSuccess && onClose) {
+              invalidatePendingActions();
+              onClose();
+            }
+          } catch (error) {
+            console.warn('Failed to run board-sheet climb action', error);
+            notifyActionFailed();
+          }
+        })
+        .finally(() => {
+          setActionLoading(actionContext.cacheKey, false);
+        });
+    },
+    [getActionContext, invalidatePendingActions, notifyActionFailed, onClose, resolveAction, setActionLoading],
+  );
+
+  const handleInteractiveClimbPress = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onClimbPress) return;
+      runInteractiveAction(presenceClimb, onClimbPress, true);
+    },
+    [onClimbPress, runInteractiveAction],
+  );
+
+  const handleInteractiveAddToQueue = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onAddToQueue) return;
+      runInteractiveAction(presenceClimb, onAddToQueue);
+    },
+    [onAddToQueue, runInteractiveAction],
+  );
+
+  const handleInteractiveOpenPlaylist = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onOpenPlaylist) return;
+      runInteractiveAction(presenceClimb, onOpenPlaylist);
+    },
+    [onOpenPlaylist, runInteractiveAction],
+  );
+
+  const handleInteractiveOpenActions = useCallback(
+    (presenceClimb: BoardPresenceClimb) => {
+      if (!onOpenActions) return;
+      runInteractiveAction(presenceClimb, onOpenActions);
+    },
+    [onOpenActions, runInteractiveAction],
+  );
+
+  const handleClose = useCallback(() => {
+    invalidatePendingActions();
+    onClose?.();
+  }, [invalidatePendingActions, onClose]);
+
+  const handleSwitchBoard = useCallback(() => {
+    invalidatePendingActions();
+    onSwitchBoard();
+  }, [invalidatePendingActions, onSwitchBoard]);
+
+  const renderHistoryItem = useCallback(
+    ({ item }: { item: BoardPresenceClimb }) => {
+      const formattedGrade = item.grade ? formatGrade(item.grade) : null;
+      const gradeColor = getGradeColor(item.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+
+      if (canUseInteractiveRows && rowBoard) {
+        return (
+          <InteractiveHistoryRow
+            climb={item}
+            rowBoard={rowBoard}
+            boardConfig={boardConfig}
+            labelColor={systemColors.label}
+            secondaryColor={systemColors.secondaryLabel}
+            formattedGrade={formattedGrade}
+            gradeColor={gradeColor}
+            isActionLoading={isActionLoading(item)}
+            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
+            onAddToQueue={handleInteractiveAddToQueue}
+            onOpenPlaylist={handleInteractiveOpenPlaylist}
+            onOpenActions={handleInteractiveOpenActions}
+          />
+        );
+      }
+
+      return (
+        <HistoryRow
+          climb={item}
+          boardConfig={boardConfig}
+          labelColor={systemColors.label}
+          secondaryColor={systemColors.secondaryLabel}
+          formattedGrade={formattedGrade}
+          gradeColor={gradeColor}
+        />
+      );
+    },
+    [
+      boardConfig,
+      canUseInteractiveRows,
+      rowBoard,
+      systemColors.label,
+      systemColors.secondaryLabel,
+      formatGrade,
+      handleInteractiveClimbPress,
+      handleInteractiveAddToQueue,
+      handleInteractiveOpenPlaylist,
+      handleInteractiveOpenActions,
+      isActionLoading,
+      onClimbPress,
+    ],
+  );
+
+  // Primitive derived from `pendingActionKeys` for just the hero's own climb —
+  // NOT the `isActionLoading` function itself, which changes identity on every
+  // row's action-state flip. Keeping `listHeader` keyed on this boolean instead
+  // means an unrelated history-row tap no longer rebuilds the whole header
+  // (hero + stat tiles + hardest-send row).
+  const heroActionLoading =
+    currentClimb && boardConfig
+      ? pendingActionKeys.has(
+          actionCacheKey(actionBoardConfigForPresenceClimb(boardConfig, currentClimb), currentClimb.climbUuid),
+        )
+      : false;
+
+  const listHeader = useMemo(
+    () => (
+      <View>
+        {canUseInteractiveRows && rowBoard && currentClimb ? (
+          <InteractiveHeroRow
+            climb={currentClimb}
+            rowBoard={rowBoard}
+            boardConfig={boardConfig}
+            labelColor={systemColors.label}
+            secondaryColor={systemColors.secondaryLabel}
+            accentColor={brandColors.warning}
+            surfaceColor={systemColors.secondaryBackground}
+            formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
+            gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+            isActionLoading={heroActionLoading}
+            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
+            onAddToQueue={handleInteractiveAddToQueue}
+            onOpenPlaylist={handleInteractiveOpenPlaylist}
+            onOpenActions={handleInteractiveOpenActions}
+          />
+        ) : (
+          <NowOnTheWallHero
+            climb={currentClimb}
+            boardConfig={boardConfig}
+            labelColor={systemColors.label}
+            secondaryColor={systemColors.secondaryLabel}
+            accentColor={brandColors.warning}
+            surfaceColor={systemColors.secondaryBackground}
+            formattedGrade={currentClimb?.grade ? formatGrade(currentClimb.grade) : null}
+            gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
+          />
+        )}
+        {stats ? (
+          <View style={styles.statsBlock}>
+            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
+              {t('mobile.boardPresence.statsHeader')}
+            </Text>
+            <View style={styles.statTiles}>
+              <StatTile
+                value={String(stats.climbsSentCount)}
+                label={t('mobile.boardPresence.statSent')}
+                surfaceColor={systemColors.secondaryBackground}
+                labelColor={systemColors.secondaryLabel}
+                valueColor={systemColors.label}
+              />
+              <StatTile
+                value={String(stats.distinctClimbersCount)}
+                label={t('mobile.boardPresence.statClimbers')}
+                surfaceColor={systemColors.secondaryBackground}
+                labelColor={systemColors.secondaryLabel}
+                valueColor={systemColors.label}
+              />
+              <StatTile
+                value={stats.hardestGrade ? (formatGrade(stats.hardestGrade) ?? '–') : '–'}
+                label={t('mobile.boardPresence.statHardest')}
+                surfaceColor={systemColors.secondaryBackground}
+                labelColor={systemColors.secondaryLabel}
+                valueColor={systemColors.label}
+              />
+              <StatTile
+                value={stats.topGrade ? (formatGrade(stats.topGrade) ?? '–') : '–'}
+                label={t('mobile.boardPresence.statTopGrade')}
+                surfaceColor={systemColors.secondaryBackground}
+                labelColor={systemColors.secondaryLabel}
+                valueColor={systemColors.label}
+              />
+            </View>
+            {stats.hardestSend ? (
+              <HardestSendRow
+                hardestSend={stats.hardestSend}
+                labelColor={systemColors.label}
+                secondaryColor={systemColors.secondaryLabel}
+                surfaceColor={systemColors.secondaryBackground}
+                crownColor={brandColors.warning}
+                formattedGrade={formatGrade(stats.hardestSend.grade) ?? stats.hardestSend.grade}
+                gradeColor={getGradeColor(stats.hardestSend.grade) ?? DEFAULT_GRADE_COLOR}
+              />
+            ) : null}
+          </View>
+        ) : null}
+        {visibleHistory.length > 0 ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
+            {t('mobile.boardPresence.historyHeader')}
+          </Text>
+        ) : null}
+      </View>
+    ),
+    [
+      currentClimb,
+      boardConfig,
+      stats,
+      visibleHistory.length,
+      systemColors,
+      brandColors.warning,
+      formatGrade,
+      t,
+      canUseInteractiveRows,
+      rowBoard,
+      handleInteractiveClimbPress,
+      handleInteractiveAddToQueue,
+      handleInteractiveOpenPlaylist,
+      handleInteractiveOpenActions,
+      heroActionLoading,
+      onClimbPress,
+    ],
+  );
+
+  const listEmpty = useMemo(
+    () => (
+      <View>
+        {currentClimb ? null : (
+          <View style={styles.empty}>
+            <Icon name="lightbulb" size={36} color={systemColors.tertiaryLabel} />
+            <Text variant="headline" color={systemColors.label} style={styles.emptyTitle}>
+              {t('mobile.boardPresence.emptyTitle')}
+            </Text>
+            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
+              {t('mobile.boardPresence.emptyBody')}
+            </Text>
+          </View>
+        )}
+        {/* A wall that's been quiet longer than the Redis window's TTL has an
+            EMPTY live window but durable boardHistory rows. An empty list
+            can't scroll, so the scroll-gated onEndReached above can never
+            fire — this button is then the only path into the durable log
+            (the hook supports a cursor-less first page). */}
+        {hasMore ? (
+          <Pressable
+            onPress={loadOlder}
+            disabled={isLoadingOlder}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.boardPresence.loadMore')}
+            style={styles.emptyLoadMore}
+          >
+            <Text variant="subheadline" color={brandColors.primary}>
+              {isLoadingOlder ? t('mobile.boardPresence.loadingMore') : t('mobile.boardPresence.loadMore')}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    ),
+    [currentClimb, systemColors, t, hasMore, isLoadingOlder, loadOlder, brandColors.primary],
+  );
+
+  const listFooter = useMemo(
+    () =>
+      isLoadingOlder ? (
+        <View style={styles.historyFooter}>
+          <ActivityIndicator size="small" accessibilityLabel={t('mobile.boardPresence.loadingMore')} />
+        </View>
+      ) : null,
+    [isLoadingOlder, t],
+  );
+
+  const listContentContainerStyle = useMemo(() => ({ paddingBottom: spacing[4] }), []);
+
+  // Sheet mode sits inside the native sheet chrome (which owns the bottom safe
+  // area), so the footer only needs its own spacing. The inline column renders at
+  // the top of the shell with no chrome, so it owns both safe-area insets.
+  const headerTopPadding = variant === 'column' ? insets.top + spacing[2] : 0;
+  const footerBottomPadding = variant === 'sheet' ? spacing[3] : insets.bottom + spacing[3];
+
+  const refreshControl = (
+    <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />
+  );
+
+  return (
+    <>
+      <View style={[styles.header, { borderBottomColor: systemColors.separator, paddingTop: headerTopPadding }]}>
+        {onClose ? (
+          <Pressable
+            onPress={handleClose}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.boardPresence.close')}
+            style={styles.headerAction}
+          >
+            <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
+          </Pressable>
+        ) : (
+          <View pointerEvents="none" style={styles.headerAction} />
+        )}
+        <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
+          {boardLabel ?? t('mobile.boardPresence.title')}
+        </Text>
+        <View pointerEvents="none" style={styles.headerAction} />
+      </View>
+
+      {variant === 'sheet' ? (
+        <BottomSheetFlatList
+          data={combinedHistory}
+          keyExtractor={boardHistoryEntryKey}
+          renderItem={renderHistoryItem}
+          ListHeaderComponent={listHeader}
+          ListEmptyComponent={listEmpty}
+          ListFooterComponent={listFooter}
+          // `loadOlder` already no-ops once `hasMore` is false, but skipping the
+          // prop entirely once there's nothing left avoids FlatList re-evaluating
+          // the end-reached threshold on every scroll frame for no reason. The
+          // handler itself is additionally gated on a real user scroll — see
+          // `hasUserScrolledRef` above.
+          onEndReached={hasMore ? handleEndReached : undefined}
+          onEndReachedThreshold={0.6}
+          onScrollBeginDrag={handleScrollBeginDrag}
+          contentContainerStyle={listContentContainerStyle}
+          refreshControl={refreshControl}
+        />
+      ) : (
+        <FlatList
+          data={combinedHistory}
+          keyExtractor={boardHistoryEntryKey}
+          renderItem={renderHistoryItem}
+          ListHeaderComponent={listHeader}
+          ListEmptyComponent={listEmpty}
+          ListFooterComponent={listFooter}
+          onEndReached={hasMore ? handleEndReached : undefined}
+          onEndReachedThreshold={0.6}
+          onScrollBeginDrag={handleScrollBeginDrag}
+          contentContainerStyle={listContentContainerStyle}
+          refreshControl={refreshControl}
+        />
+      )}
+
+      <Pressable
+        onPress={handleSwitchBoard}
+        accessibilityRole="button"
+        accessibilityLabel={t('mobile.boardPresence.switchBoardAria')}
+        style={[styles.footer, { borderTopColor: systemColors.separator, paddingBottom: footerBottomPadding }]}
+      >
+        <View style={[styles.footerIcon, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Icon name="transfer" size={20} color={systemColors.label} />
+        </View>
+        <View style={styles.footerText}>
+          <Text variant="body" color={systemColors.label}>
+            {t('mobile.boardPresence.switchBoard')}
+          </Text>
+          {boardLabel ? (
+            <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
+              {boardLabel}
+            </Text>
+          ) : null}
+        </View>
+        <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+      </Pressable>
+    </>
+  );
+}
+
+export const NowOnTheWallPanel = memo(forwardRef(NowOnTheWallPanelComponent));
+
+type HeroProps = {
+  climb: BoardPresenceClimb | null;
+  boardConfig: BoardConfig | null;
+  labelColor: ColorValue;
+  secondaryColor: ColorValue;
+  accentColor: ColorValue;
+  surfaceColor: ColorValue;
+  formattedGrade: string | null;
+  gradeColor: string;
+};
+
+type InteractiveRowActionProps = {
+  onPress?: (climb: BoardPresenceClimb) => void;
+  onAddToQueue?: (climb: BoardPresenceClimb) => void;
+  onOpenPlaylist?: (climb: BoardPresenceClimb) => void;
+  onOpenActions?: (climb: BoardPresenceClimb) => void;
+};
+
+type HeroContentProps = Omit<HeroProps, 'climb' | 'surfaceColor'> & {
+  climb: BoardPresenceClimb;
+  renderClimb: Climb;
+  thumbnailSize?: number;
+  isActionLoading?: boolean;
+  /**
+   * Make the driver avatar open the climber's profile on tap. Off inside an
+   * interactive ClimbListRow, whose own tap gesture owns the row (a nested
+   * pressable would double-fire the climb action + the profile push, and the
+   * row's collapsed a11y node would hide it anyway). The row opens the climb;
+   * the avatar there is identity only.
+   */
+  pressableAvatar?: boolean;
+};
+
+function NowOnTheWallHeroContent({
+  climb,
+  renderClimb,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  accentColor,
+  formattedGrade,
+  gradeColor,
+  thumbnailSize,
+  isActionLoading = false,
+  pressableAvatar = true,
+}: HeroContentProps) {
+  const { t } = useTranslation('session');
+  const litBy = climb.sentByDisplayName?.trim() || null;
+  const setter = climb.setter?.trim();
+
+  return (
+    <>
+      <AccessoryClimbThumbnail climb={renderClimb} boardConfig={boardConfig} size={thumbnailSize} />
+      <View style={styles.heroBody}>
+        <View style={styles.heroNameRow}>
+          <Text variant="headline" color={labelColor} numberOfLines={1} style={styles.heroName}>
+            {climb.name ?? ''}
+          </Text>
+          {formattedGrade ? (
+            <Text variant="headline" style={[styles.heroGrade, { color: gradeColor }]}>
+              {formattedGrade}
+            </Text>
+          ) : null}
+          {isActionLoading ? (
+            <ActivityIndicator
+              size="small"
+              accessibilityLabel={t('mobile.boardPresence.actionLoading')}
+              style={styles.actionSpinner}
+            />
+          ) : null}
+        </View>
+        {setter ? (
+          <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
+            {t('mobile.boardPresence.setByLine', { setter })}
+          </Text>
+        ) : null}
+        {litBy ? (
+          <View style={styles.heroDriverRow}>
+            <BoardDriverAvatar
+              size={20}
+              userId={pressableAvatar ? climb.sentByUserId : null}
+              uri={climb.sentByAvatarUrl}
+              name={litBy}
+              status="connected"
+              accessibilityLabel={t('mobile.boardPresence.drivenByA11y', { name: litBy })}
+            />
+            <Text variant="caption1" color={accentColor} numberOfLines={1} style={styles.heroDriverName}>
+              {litBy}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </>
+  );
+}
+
+type InteractiveHeroRowProps = HeroProps & {
+  climb: BoardPresenceClimb;
+  rowBoard: BoardSheetRowBoard;
+  isActionLoading: boolean;
+} & InteractiveRowActionProps;
+
+const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
+  climb,
+  rowBoard,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  accentColor,
+  surfaceColor,
+  formattedGrade,
+  gradeColor,
+  isActionLoading,
+  onPress,
+  onAddToQueue,
+  onOpenPlaylist,
+  onOpenActions,
+}: InteractiveHeroRowProps) {
+  const rowClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+  const climbRowBoard = useMemo(
+    () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
+    [climbBoardConfig, rowBoard],
+  );
+  const contentRowStyle = useMemo(() => [styles.heroInteractiveRow, { backgroundColor: surfaceColor }], [surfaceColor]);
+  const handlePress = useCallback(() => {
+    onPress?.(climb);
+  }, [climb, onPress]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue?.(climb);
+  }, [climb, onAddToQueue]);
+  const handleOpenPlaylist = useCallback(() => {
+    onOpenPlaylist?.(climb);
+  }, [climb, onOpenPlaylist]);
+  const handleOpenActions = useCallback(() => {
+    onOpenActions?.(climb);
+  }, [climb, onOpenActions]);
+  const renderContent = useCallback(
+    ({ climb: renderClimb }: ClimbListRowRenderContentArgs) => (
+      <NowOnTheWallHeroContent
+        climb={climb}
+        renderClimb={renderClimb}
+        boardConfig={climbBoardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        accentColor={accentColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+        thumbnailSize={52}
+        isActionLoading={isActionLoading}
+        // The row's tap opens the climb; the avatar is identity only here.
+        pressableAvatar={false}
+      />
+    ),
+    [accentColor, climb, climbBoardConfig, formattedGrade, gradeColor, isActionLoading, labelColor, secondaryColor],
+  );
+
+  return (
+    <ClimbListRow
+      climb={rowClimb}
+      boardName={climbRowBoard.boardName}
+      layoutId={climbRowBoard.layoutId}
+      sizeId={climbRowBoard.sizeId}
+      setIds={climbRowBoard.setIds}
+      angle={climbRowBoard.angle}
+      onPress={onPress ? handlePress : undefined}
+      onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
+      onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
+      onOpenActions={onOpenActions ? handleOpenActions : undefined}
+      containerStyle={styles.heroInteractiveContainer}
+      contentRowStyle={contentRowStyle}
+      showSeparator={false}
+      renderContent={renderContent}
+    />
+  );
+});
+
+const NowOnTheWallHero = memo(function NowOnTheWallHeroInner({
+  climb,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  accentColor,
+  surfaceColor,
+  formattedGrade,
+  gradeColor,
+}: HeroProps) {
+  const renderClimb = useMemo(() => (climb ? boardPresenceClimbToClimb(climb) : null), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig && climb ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+
+  if (!climb || !renderClimb) return null;
+
+  return (
+    <View style={[styles.hero, { backgroundColor: surfaceColor }]}>
+      <NowOnTheWallHeroContent
+        climb={climb}
+        renderClimb={renderClimb}
+        boardConfig={climbBoardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        accentColor={accentColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+      />
+    </View>
+  );
+});
+
+type HistoryRowProps = {
+  climb: BoardPresenceClimb;
+  boardConfig: BoardConfig | null;
+  labelColor: ColorValue;
+  secondaryColor: ColorValue;
+  formattedGrade: string | null;
+  gradeColor: string;
+};
+
+type HistoryRowContentProps = HistoryRowProps & {
+  renderClimb: Climb;
+  isActionLoading?: boolean;
+  /** See HeroContentProps.pressableAvatar — off inside an interactive row. */
+  pressableAvatar?: boolean;
+};
+
+function HistoryRowContent({
+  climb,
+  renderClimb,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  formattedGrade,
+  gradeColor,
+  isActionLoading = false,
+  pressableAvatar = true,
+}: HistoryRowContentProps) {
+  const { t } = useTranslation('session');
+  const litBy = climb.sentByDisplayName?.trim() || null;
+
+  return (
+    <>
+      <AccessoryClimbThumbnail climb={renderClimb} boardConfig={boardConfig} />
+      <View style={styles.historyBody}>
+        <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.historyName}>
+          {climb.name ?? ''}
+        </Text>
+        {litBy ? (
+          <View style={styles.historyDriverRow}>
+            {/* Past send — no Bluetooth glyph (nobody's driving it now); just a
+                pressable face for attribution. */}
+            <BoardDriverAvatar
+              size={18}
+              userId={pressableAvatar ? climb.sentByUserId : null}
+              uri={climb.sentByAvatarUrl}
+              name={litBy}
+              status="none"
+              accessibilityLabel={t('mobile.boardPresence.drivenByA11y', { name: litBy })}
+            />
+            <Text variant="caption1" color={secondaryColor} numberOfLines={1} style={styles.historyDriverName}>
+              {litBy}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+      {formattedGrade ? (
+        <Text variant="headline" style={[styles.historyGrade, { color: gradeColor }]}>
+          {formattedGrade}
+        </Text>
+      ) : null}
+      {isActionLoading ? (
+        <ActivityIndicator
+          size="small"
+          accessibilityLabel={t('mobile.boardPresence.actionLoading')}
+          style={styles.actionSpinner}
+        />
+      ) : null}
+    </>
+  );
+}
+
+type InteractiveHistoryRowProps = HistoryRowProps & {
+  rowBoard: BoardSheetRowBoard;
+  isActionLoading: boolean;
+} & InteractiveRowActionProps;
+
+const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
+  climb,
+  rowBoard,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  formattedGrade,
+  gradeColor,
+  isActionLoading,
+  onPress,
+  onAddToQueue,
+  onOpenPlaylist,
+  onOpenActions,
+}: InteractiveHistoryRowProps) {
+  const rowClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+  const climbRowBoard = useMemo(
+    () => (climbBoardConfig ? rowBoardForBoardConfig(climbBoardConfig) : rowBoard),
+    [climbBoardConfig, rowBoard],
+  );
+  const handlePress = useCallback(() => {
+    onPress?.(climb);
+  }, [climb, onPress]);
+  const handleAddToQueue = useCallback(() => {
+    onAddToQueue?.(climb);
+  }, [climb, onAddToQueue]);
+  const handleOpenPlaylist = useCallback(() => {
+    onOpenPlaylist?.(climb);
+  }, [climb, onOpenPlaylist]);
+  const handleOpenActions = useCallback(() => {
+    onOpenActions?.(climb);
+  }, [climb, onOpenActions]);
+  const renderContent = useCallback(
+    ({ climb: renderClimb }: ClimbListRowRenderContentArgs) => (
+      <HistoryRowContent
+        climb={climb}
+        renderClimb={renderClimb}
+        boardConfig={climbBoardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+        isActionLoading={isActionLoading}
+        // The row's tap opens the climb; the avatar is identity only here.
+        pressableAvatar={false}
+      />
+    ),
+    [climb, climbBoardConfig, formattedGrade, gradeColor, isActionLoading, labelColor, secondaryColor],
+  );
+
+  return (
+    <ClimbListRow
+      climb={rowClimb}
+      boardName={climbRowBoard.boardName}
+      layoutId={climbRowBoard.layoutId}
+      sizeId={climbRowBoard.sizeId}
+      setIds={climbRowBoard.setIds}
+      angle={climbRowBoard.angle}
+      onPress={onPress ? handlePress : undefined}
+      onAddToQueue={onAddToQueue ? handleAddToQueue : undefined}
+      onOpenPlaylist={onOpenPlaylist ? handleOpenPlaylist : undefined}
+      onOpenActions={onOpenActions ? handleOpenActions : undefined}
+      contentRowStyle={styles.historyInteractiveRow}
+      showSeparator={false}
+      renderContent={renderContent}
+    />
+  );
+});
+
+const HistoryRow = memo(function HistoryRowInner({
+  climb,
+  boardConfig,
+  labelColor,
+  secondaryColor,
+  formattedGrade,
+  gradeColor,
+}: HistoryRowProps) {
+  const thumbnailClimb = useMemo(() => boardPresenceClimbToClimb(climb), [climb]);
+  const climbBoardConfig = useMemo(
+    () => (boardConfig ? actionBoardConfigForPresenceClimb(boardConfig, climb) : null),
+    [boardConfig, climb],
+  );
+
+  return (
+    <View style={styles.historyRow}>
+      <HistoryRowContent
+        climb={climb}
+        renderClimb={thumbnailClimb}
+        boardConfig={climbBoardConfig}
+        labelColor={labelColor}
+        secondaryColor={secondaryColor}
+        formattedGrade={formattedGrade}
+        gradeColor={gradeColor}
+      />
+    </View>
+  );
+});
+
+type StatTileProps = {
+  value: string;
+  label: string;
+  surfaceColor: ColorValue;
+  labelColor: ColorValue;
+  valueColor: ColorValue;
+};
+
+function StatTile({ value, label, surfaceColor, labelColor, valueColor }: StatTileProps) {
+  return (
+    <View style={[styles.statTile, { backgroundColor: surfaceColor }]}>
+      <Text variant="title3" color={valueColor} numberOfLines={1}>
+        {value}
+      </Text>
+      <Text variant="caption1" color={labelColor} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+type HardestSendRowProps = {
+  hardestSend: BoardPresenceHardestSend;
+  labelColor: ColorValue;
+  secondaryColor: ColorValue;
+  surfaceColor: ColorValue;
+  crownColor: string;
+  formattedGrade: string;
+  gradeColor: string;
+};
+
+function HardestSendRow({
+  hardestSend,
+  labelColor,
+  secondaryColor,
+  surfaceColor,
+  crownColor,
+  formattedGrade,
+  gradeColor,
+}: HardestSendRowProps) {
+  const { t } = useTranslation('session');
+  const climberName = hardestSend.sentByDisplayName?.trim();
+
+  return (
+    <View style={[styles.hardestSendRow, { backgroundColor: surfaceColor }]}>
+      <View style={styles.hardestAvatar}>
+        <PressableAvatar
+          userId={hardestSend.sentByUserId}
+          uri={hardestSend.sentByAvatarUrl}
+          name={climberName}
+          size={34}
+        />
+        <View style={[styles.crownBadge, { backgroundColor: withAlpha(crownColor, 0.18) }]}>
+          <Icon name="crown" size={11} color={crownColor} />
+        </View>
+      </View>
+      <View style={styles.hardestBody}>
+        <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
+          {t('mobile.boardPresence.hardestSendLabel')}
+        </Text>
+        <Text variant="subheadline" color={labelColor} numberOfLines={1} style={styles.hardestName}>
+          {hardestSend.name ?? ''}
+        </Text>
+        {climberName ? (
+          <Text variant="caption1" color={secondaryColor} numberOfLines={1}>
+            {t('mobile.boardPresence.sentByLine', { name: climberName })}
+          </Text>
+        ) : null}
+      </View>
+      <Text variant="headline" style={[styles.historyGrade, { color: gradeColor }]}>
+        {formattedGrade}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[3],
+    paddingBottom: spacing[3],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerAction: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    flex: 1,
+    marginHorizontal: spacing[2],
+    textAlign: 'center',
+  },
+  hero: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    margin: spacing[4],
+    padding: spacing[3],
+    borderRadius: borderRadius.lg,
+  },
+  heroInteractiveContainer: {
+    margin: spacing[4],
+    borderRadius: borderRadius.lg,
+  },
+  heroInteractiveRow: {
+    padding: spacing[3],
+    borderRadius: borderRadius.lg,
+  },
+  heroBody: {
+    flex: 1,
+    gap: 2,
+  },
+  heroNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  heroName: {
+    flex: 1,
+  },
+  heroDriverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    // Headroom for the badge that pokes ~2pt past the avatar's top-right corner.
+    paddingTop: 2,
+  },
+  heroDriverName: {
+    flexShrink: 1,
+  },
+  heroGrade: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+  },
+  sectionHeader: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
+  },
+  statsBlock: {
+    paddingBottom: spacing[2],
+  },
+  statTiles: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+  },
+  statTile: {
+    flexGrow: 1,
+    flexBasis: '47%',
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+    gap: 2,
+  },
+  hardestSendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginHorizontal: spacing[4],
+    marginTop: spacing[2],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+  },
+  hardestAvatar: {
+    width: 42,
+    height: 42,
+    justifyContent: 'flex-end',
+  },
+  crownBadge: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  hardestBody: {
+    flex: 1,
+    gap: 2,
+  },
+  hardestName: {
+    fontWeight: '600',
+  },
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  historyInteractiveRow: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  historyBody: {
+    flex: 1,
+    gap: 2,
+  },
+  historyName: {
+    fontWeight: '600',
+  },
+  historyDriverRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  historyDriverName: {
+    flexShrink: 1,
+  },
+  historyGrade: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+    minWidth: 40,
+    textAlign: 'right',
+  },
+  actionSpinner: {
+    width: 20,
+    height: 20,
+  },
+  empty: {
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[6],
+    paddingVertical: spacing[8],
+  },
+  emptyTitle: {
+    textAlign: 'center',
+  },
+  emptyBody: {
+    textAlign: 'center',
+  },
+  historyFooter: {
+    paddingVertical: spacing[5],
+    alignItems: 'center',
+  },
+  emptyLoadMore: {
+    alignItems: 'center',
+    paddingVertical: spacing[3],
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  footerIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  footerText: {
+    flex: 1,
+    gap: 2,
+  },
+});

--- a/packages/mobile/src/components/board-presence/WallStrip.tsx
+++ b/packages/mobile/src/components/board-presence/WallStrip.tsx
@@ -1,0 +1,118 @@
+import { memo, useCallback } from 'react';
+import { View, StyleSheet, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
+import { useWallClimbIfDistinct } from '../queue-control/use-wall-or-queue-climb';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { WALL_LIVE_DOT_SIZE } from '../../theme/layout';
+
+const STRIP_THUMBNAIL_SIZE = 40;
+
+/**
+ * Compact "Now on the wall" strip docked atop the iPad detail pane in portrait,
+ * where a dedicated wall column would crush the browse list (see
+ * `resolveWallSurface`). Shows the lit climb (thumbnail + name + grade + a warm
+ * live dot) or a dark state, and taps through to the full BoardSheet. The shell
+ * sets PlayDrawer's `paneTopInset={false}` whenever this is shown, so the strip
+ * owns the top safe-area inset. Memoized + isolated so wall events re-render only
+ * the strip, not the pane.
+ */
+function WallStripComponent() {
+  const { t } = useTranslation('session');
+  const insets = useSafeAreaInsets();
+  const { systemColors, brandColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+  // Pass `null`: the strip always mirrors whatever's lit on the wall, so it never
+  // hides the climb as a duplicate of the local queue head.
+  const litClimb = useWallClimbIfDistinct(null);
+  const { openBoardSheet, boardPanelProps } = useDrawerHost();
+  const boardConfig = boardPanelProps?.boardConfig ?? null;
+
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    openBoardSheet();
+  }, [openBoardSheet]);
+
+  const grade = litClimb ? formatGrade(litClimb.grade ?? '') : null;
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={
+        litClimb ? t('boardPresence.openAriaWithClimb', { name: litClimb.name ?? '' }) : t('boardPresence.openAria')
+      }
+      style={[styles.strip, { paddingTop: insets.top + spacing[2], borderBottomColor: systemColors.separator }]}
+    >
+      {litClimb ? (
+        <View style={styles.thumbWrap}>
+          <AccessoryClimbThumbnail
+            climb={{ frames: litClimb.frames ?? '' }}
+            boardConfig={boardConfig}
+            size={STRIP_THUMBNAIL_SIZE}
+          />
+          <View
+            style={[styles.dot, { backgroundColor: brandColors.live, borderColor: systemColors.secondaryBackground }]}
+          />
+        </View>
+      ) : (
+        <View style={styles.bulbSlot}>
+          <Icon name="lightbulb" size={24} color={systemColors.tertiaryLabel} />
+        </View>
+      )}
+      <View style={styles.body}>
+        <Text variant="caption2" color={systemColors.secondaryLabel} numberOfLines={1}>
+          {t('boardPresence.open')}
+        </Text>
+        <Text variant="subheadline" color={systemColors.label} numberOfLines={1} style={styles.name}>
+          {litClimb ? (litClimb.name ?? '') : t('boardPresence.railDark')}
+        </Text>
+      </View>
+      {grade ? (
+        <Text variant="subheadline" color={brandColors.live} numberOfLines={1} style={styles.grade}>
+          {grade}
+        </Text>
+      ) : null}
+      <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+    </Pressable>
+  );
+}
+
+export const WallStrip = memo(WallStripComponent);
+
+const styles = StyleSheet.create({
+  strip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  thumbWrap: { position: 'relative' },
+  dot: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    width: WALL_LIVE_DOT_SIZE,
+    height: WALL_LIVE_DOT_SIZE,
+    borderRadius: borderRadius.full,
+    borderWidth: 2,
+  },
+  bulbSlot: {
+    width: STRIP_THUMBNAIL_SIZE,
+    height: STRIP_THUMBNAIL_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: { flex: 1, minWidth: 0 },
+  name: { fontWeight: '600' },
+  grade: { fontWeight: '700' },
+});

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -400,7 +400,7 @@ describe('BoardSheet', () => {
     expect(sheetModal.dismiss).toHaveBeenCalled();
   });
 
-  it('renders no presence content while dismissed — zero list/hero work', () => {
+  it('renders no presence content while dismissed — zero list/hero/chrome work', () => {
     presence.currentClimb = makeClimb('c1', 3);
     presence.history = [makeClimb('c1', 3)];
     presence.stats = {
@@ -411,7 +411,7 @@ describe('BoardSheet', () => {
       lastSentAt: null,
     };
 
-    const { container, queryByLabelText, getAllByText } = render(
+    const { container, queryByLabelText, queryByText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose: noop,
@@ -420,10 +420,11 @@ describe('BoardSheet', () => {
       }),
     );
 
-    // The header/footer chrome (cheap, presence-free) still renders — both the
-    // header title and the footer subtitle show the board label.
-    expect(getAllByText('Garage Wall')).toHaveLength(2);
-    // ...but nothing that reads the wall's presence state does.
+    // The sheet container mounts, but the whole NowOnTheWallPanel (chrome + hero
+    // + stats + list) is gated behind isPresented — a dismissed sheet renders
+    // none of it and subscribes to none of the presence state.
+    expect(container.querySelector('[data-sheet="true"]')).not.toBeNull();
+    expect(queryByText('Garage Wall')).toBeNull();
     expect(container.querySelector('[data-list="true"]')).toBeNull();
     expect(queryByLabelText('refresh')).toBeNull();
     expect(container.textContent).not.toContain('Climb c1');
@@ -996,6 +997,49 @@ describe('BoardSheet', () => {
     expect(toast.showToast).not.toHaveBeenCalled();
   });
 
+  it('drops stale action results after an imperative dismiss', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, {
+      frames: 'hero-frames',
+      grade: 'V7',
+      queueItemUuid: 'queue-hero',
+    });
+    const ref = createRef<BoardSheetHandle>();
+    const onClimbPress = vi.fn();
+    const heroDetail = makeFullClimb('hero-climb', { name: 'Hydrated Hero' });
+    const climbRequest = createDeferred<{ climb: Climb | null }>();
+    graphql.request.mockReturnValueOnce(climbRequest.promise);
+
+    const { getByLabelText, queryByLabelText } = render(
+      createElement(BoardSheet, {
+        ref,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+        onClimbPress,
+      }),
+    );
+    act(() => ref.current?.present());
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
+
+    act(() => {
+      ref.current?.dismiss();
+    });
+    expect(sheetModal.dismiss).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
+
+    await act(async () => {
+      climbRequest.resolve({ climb: heroDetail });
+      await climbRequest.promise;
+    });
+
+    expect(onClimbPress).not.toHaveBeenCalled();
+    expect(toast.showToast).not.toHaveBeenCalled();
+  });
+
   it('shows a toast instead of leaking errors thrown by action callbacks', async () => {
     presence.currentClimb = makeClimb('hero-climb', 3);
     const callbackError = new Error('callback failed');
@@ -1162,8 +1206,10 @@ describe('BoardSheet', () => {
 
   it('fires onSwitchBoard from the footer switch control', () => {
     const onSwitchBoard = vi.fn();
+    const ref = createRef<BoardSheetHandle>();
     const { container, getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -1171,6 +1217,7 @@ describe('BoardSheet', () => {
         onSwitchBoard,
       }),
     );
+    act(() => ref.current?.present());
     expect(container.querySelector('[data-icon="transfer"]')).not.toBeNull();
     expect(container.textContent).toContain('mobile.boardPresence.switchBoard');
     fireEvent.click(getByLabelText('mobile.boardPresence.switchBoardAria'));
@@ -1179,8 +1226,10 @@ describe('BoardSheet', () => {
 
   it('fires onClose from the header chevron', () => {
     const onClose = vi.fn();
+    const ref = createRef<BoardSheetHandle>();
     const { container, getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose,
         onDismissed: noop,
@@ -1188,6 +1237,7 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
+    act(() => ref.current?.present());
     expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     expect(container.querySelector('[data-icon="close"]')).toBeNull();
     fireEvent.click(getByLabelText('mobile.boardPresence.close'));
@@ -1330,12 +1380,16 @@ describe('BoardSheet', () => {
       expect(queryByLabelText('mobile.boardPresence.loadingMore')).not.toBeNull();
 
       historyPagination.isLoadingOlder = false;
+      // The real `useBoardHistoryPagination` re-renders the panel from its own
+      // state when loading resolves (memo doesn't gate internal state updates).
+      // The mock reads a plain flag, so pass a fresh boardConfig (same values,
+      // new identity) to bust NowOnTheWallPanel's memo and re-read the flag.
       rerender(
         createElement(BoardSheet, {
           ref,
           boardLabel: 'Garage Wall',
           onClose: noop,
-          boardConfig,
+          boardConfig: { ...boardConfig },
           onSwitchBoard: noop,
         }),
       );

--- a/packages/mobile/src/components/board-presence/__tests__/now-on-the-wall-panel.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/now-on-the-wall-panel.test.tsx
@@ -1,0 +1,416 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BoardPresenceClimb, BoardPresenceStats, Climb } from '@boardsesh/shared-schema';
+import type { NowOnTheWallPanelProps } from '../NowOnTheWallPanel';
+
+const presence = vi.hoisted(() => ({
+  currentClimb: null as BoardPresenceClimb | null,
+  history: [] as BoardPresenceClimb[],
+  stats: null as BoardPresenceStats | null,
+  refresh: vi.fn(),
+}));
+
+const safeArea = vi.hoisted(() => ({
+  insets: { top: 0, bottom: 0, left: 0, right: 0 },
+}));
+
+const graphql = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+const pressableAvatar = vi.hoisted(() => vi.fn());
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+const presenceControls = vi.hoisted(() => ({ boardId: 123 as number | null }));
+const historyPagination = vi.hoisted(() => ({
+  olderHistory: [] as BoardPresenceClimb[],
+  isLoadingOlder: false,
+  hasMore: false,
+  loadOlder: vi.fn(),
+  capturedOnPageLoaded: null as ((info: { pageSize: number; returnedCount: number }) => void) | null,
+}));
+
+type ViewMockProps = { children?: ReactNode; style?: unknown };
+type PressableMockProps = ViewMockProps & {
+  onPress?: () => void;
+  accessibilityLabel?: string;
+};
+type ListMockProps = {
+  data: BoardPresenceClimb[];
+  renderItem: (info: { item: BoardPresenceClimb }) => ReactNode;
+  ListHeaderComponent?: ReactNode;
+  ListEmptyComponent?: ReactNode;
+  keyExtractor: (item: BoardPresenceClimb) => string;
+};
+type ClimbListRowMockProps = {
+  climb?: { uuid?: string; name?: string };
+  boardName?: string;
+  layoutId?: number;
+  sizeId?: number;
+  setIds?: string;
+  angle?: number;
+  renderContent?: (args: {
+    climb?: { uuid?: string; name?: string };
+    boardName?: string;
+    layoutId?: number;
+    sizeId?: number;
+    setIds?: string;
+    angle?: number;
+  }) => ReactNode;
+  onPress?: () => void;
+  onAddToQueue?: () => void;
+  onOpenPlaylist?: () => void;
+  onOpenActions?: () => void;
+};
+
+vi.mock('react-native', () => {
+  const flattenStyle = (style: unknown): Record<string, unknown> => {
+    if (Array.isArray(style)) {
+      return style.reduce<Record<string, unknown>>((mergedStyle, styleEntry) => {
+        return { ...mergedStyle, ...flattenStyle(styleEntry) };
+      }, {});
+    }
+    if (style && typeof style === 'object') return style as Record<string, unknown>;
+    return {};
+  };
+  const renderList = ({ data, renderItem, ListHeaderComponent, ListEmptyComponent, keyExtractor }: ListMockProps) =>
+    createElement(
+      'div',
+      { 'data-list': 'flat' },
+      ListHeaderComponent,
+      data.length === 0
+        ? ListEmptyComponent
+        : data.map((item) => createElement('div', { key: keyExtractor(item) }, renderItem({ item }))),
+    );
+
+  return {
+    StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+    View: ({ children }: ViewMockProps) => createElement('div', null, children),
+    Pressable: ({ children, onPress, accessibilityLabel, style }: PressableMockProps) => {
+      const flatStyle = flattenStyle(style);
+      return createElement(
+        'button',
+        {
+          onClick: onPress,
+          'aria-label': accessibilityLabel,
+          // paddings are numbers; narrow before stringifying (no-base-to-string).
+          'data-padding-bottom': String(typeof flatStyle.paddingBottom === 'number' ? flatStyle.paddingBottom : ''),
+          'data-padding-top': String(typeof flatStyle.paddingTop === 'number' ? flatStyle.paddingTop : ''),
+        },
+        children,
+      );
+    },
+    FlatList: renderList,
+    // Surface onRefresh as a clickable element so the pull-to-refresh wiring is testable.
+    RefreshControl: ({ onRefresh }: { onRefresh?: () => void }) =>
+      createElement('button', { onClick: onRefresh, 'aria-label': 'refresh' }),
+  };
+});
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetFlatList: (props: ListMockProps & { refreshControl?: ReactNode }) =>
+    createElement(
+      'div',
+      { 'data-bottom-sheet-list': 'true' },
+      props.refreshControl,
+      props.ListHeaderComponent,
+      props.data.length === 0
+        ? props.ListEmptyComponent
+        : props.data.map((item) => createElement('div', { key: props.keyExtractor(item) }, props.renderItem({ item }))),
+    ),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => safeArea.insets,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key}:${Object.values(opts).join(',')}` : key),
+  }),
+}));
+
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#999999',
+}));
+
+vi.mock('@boardsesh/board-presence-react', () => ({
+  useBoardPresenceCurrent: () => ({
+    currentClimb: presence.currentClimb,
+    previousClimb: null,
+    undoTarget: null,
+    isLive: true,
+  }),
+  useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
+  useBoardPresenceActions: () => ({ refresh: presence.refresh }),
+  useBoardHistoryPagination: (
+    _pageSize?: number,
+    onPageLoaded?: (info: { pageSize: number; returnedCount: number }) => void,
+  ) => {
+    historyPagination.capturedOnPageLoaded = onPageLoaded ?? null;
+    return {
+      olderHistory: historyPagination.olderHistory,
+      isLoadingOlder: historyPagination.isLoadingOlder,
+      hasMore: historyPagination.hasMore,
+      loadOlder: historyPagination.loadOlder,
+    };
+  },
+  boardHistoryEntryKey: (climb: BoardPresenceClimb) => `${climb.climbUuid}:${climb.seq}`,
+}));
+
+vi.mock('../../../providers/board-presence-provider', () => ({
+  useBoardPresenceControls: () => ({
+    enabled: true,
+    boardId: presenceControls.boardId,
+    resolveAndBindBoard: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock('../../../lib/analytics', () => ({
+  track: analytics.track,
+}));
+
+vi.mock('../../../lib/graphql/client', () => ({
+  getHttpClient: () => graphql,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../PressableAvatar', () => ({
+  PressableAvatar: (props: Record<string, unknown>) => {
+    pressableAvatar(props);
+    return createElement('span', {
+      'data-avatar': props.name ?? '',
+      'data-user-id': props.userId ?? '',
+    });
+  },
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: ({ accessibilityLabel }: { accessibilityLabel?: string }) =>
+    createElement('span', { 'aria-label': accessibilityLabel, 'data-loading': 'true' }),
+}));
+vi.mock('../../ClimbListRow', () => ({
+  ClimbListRow: (props: ClimbListRowMockProps) => {
+    const content = props.renderContent
+      ? props.renderContent({
+          climb: props.climb,
+          boardName: props.boardName,
+          layoutId: props.layoutId,
+          sizeId: props.sizeId,
+          setIds: props.setIds,
+          angle: props.angle,
+        })
+      : props.climb?.name;
+    const climbUuid = props.climb?.uuid ?? 'unknown';
+    return createElement(
+      'div',
+      { 'data-climb-row': climbUuid },
+      createElement('button', { 'aria-label': `press ${climbUuid}`, onClick: props.onPress }, content),
+      createElement('button', { 'aria-label': `queue ${climbUuid}`, onClick: props.onAddToQueue }, 'queue'),
+      createElement('button', { 'aria-label': `playlist ${climbUuid}`, onClick: props.onOpenPlaylist }, 'playlist'),
+      createElement('button', { 'aria-label': `actions ${climbUuid}`, onClick: props.onOpenActions }, 'actions'),
+    );
+  },
+}));
+vi.mock('../../queue-control/AccessoryClimbThumbnail', () => ({
+  AccessoryClimbThumbnail: () => createElement('div', { 'data-thumb': 'true' }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      label: '#000',
+      secondaryLabel: '#666',
+      tertiaryLabel: '#999',
+      secondaryBackground: '#f2f2f7',
+      separator: '#ccc',
+    },
+    brandColors: { warning: '#B45309', primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+vi.mock('../../../theme/colors', () => ({
+  withAlpha: (color: string, alpha: number) => `${color}|${alpha}`,
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
+  borderRadius: { md: 8, lg: 12 },
+}));
+
+import { NowOnTheWallPanel } from '../NowOnTheWallPanel';
+
+const noop = () => {};
+const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+
+function makeClimb(climbUuid: string, seq: number, overrides: Partial<BoardPresenceClimb> = {}): BoardPresenceClimb {
+  return {
+    climbUuid,
+    seq,
+    sentAt: '2026-06-09T00:00:00.000Z',
+    name: `Climb ${climbUuid}`,
+    grade: 'V5',
+    angle: 40,
+    setter: 'Some Setter',
+    sentByDisplayName: 'Marco',
+    ...overrides,
+  };
+}
+
+function makeFullClimb(uuid: string, overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid,
+    name: `Hydrated ${uuid}`,
+    frames: 'hydrated-frames',
+    setter_username: 'Hydrated Setter',
+    angle: 40,
+    ascensionist_count: 12,
+    difficulty: 'V6',
+    quality_average: '3.5',
+    stars: 4,
+    difficulty_error: '0.4',
+    benchmark_difficulty: null,
+    framesCount: 3,
+    framesPace: 700,
+    ...overrides,
+  };
+}
+
+function createDeferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function panelElement(overrides: Partial<NowOnTheWallPanelProps> = {}) {
+  return createElement(NowOnTheWallPanel, {
+    variant: 'sheet',
+    boardLabel: 'Garage Wall',
+    boardConfig,
+    onSwitchBoard: noop,
+    ...overrides,
+  });
+}
+
+describe('NowOnTheWallPanel', () => {
+  beforeEach(() => {
+    presence.currentClimb = null;
+    presence.history = [];
+    presence.stats = null;
+    safeArea.insets = { top: 0, bottom: 0, left: 0, right: 0 };
+    graphql.request.mockReset();
+    toast.showToast.mockClear();
+    pressableAvatar.mockClear();
+    presence.refresh.mockClear();
+  });
+
+  it('does not double-count the bottom safe area when rendered inside the sheet', () => {
+    safeArea.insets = { top: 0, bottom: 34, left: 0, right: 0 };
+    const { getByLabelText, rerender } = render(panelElement({ variant: 'sheet' }));
+
+    expect(getByLabelText('mobile.boardPresence.switchBoardAria').getAttribute('data-padding-bottom')).toBe('12');
+
+    rerender(panelElement({ variant: 'column' }));
+
+    expect(getByLabelText('mobile.boardPresence.switchBoardAria').getAttribute('data-padding-bottom')).toBe('46');
+  });
+
+  it('drops in-flight action results and clears loading when the board config changes', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, { queueItemUuid: 'queue-hero' });
+    const onClimbPress = vi.fn();
+    const climbRequest = createDeferred<{ climb: Climb | null }>();
+    graphql.request.mockReturnValueOnce(climbRequest.promise);
+
+    const { getByLabelText, queryByLabelText, rerender } = render(panelElement({ onClimbPress }));
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
+
+    rerender(panelElement({ onClimbPress, boardConfig: { ...boardConfig, layoutId: 2 } }));
+    await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull());
+
+    await act(async () => {
+      climbRequest.resolve({ climb: makeFullClimb('hero-climb') });
+      await climbRequest.promise;
+    });
+
+    expect(onClimbPress).not.toHaveBeenCalled();
+    expect(toast.showToast).not.toHaveBeenCalled();
+  });
+
+  it('closes after a successful primary press but leaves secondary actions open', async () => {
+    presence.currentClimb = makeClimb('hero-climb', 3, { queueItemUuid: 'queue-hero' });
+    const onClose = vi.fn();
+    const onClimbPress = vi.fn();
+    const onAddToQueue = vi.fn();
+    const heroDetail = makeFullClimb('hero-climb', { name: 'Hydrated Hero' });
+    graphql.request.mockResolvedValueOnce({ climb: heroDetail });
+
+    const { getByLabelText } = render(panelElement({ onClose, onClimbPress, onAddToQueue }));
+
+    fireEvent.click(getByLabelText('queue hero-climb'));
+    await waitFor(() =>
+      expect(onAddToQueue).toHaveBeenCalledWith({
+        climb: heroDetail,
+        queueItemUuid: 'queue-hero',
+        boardConfig,
+      }),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(getByLabelText('press hero-climb'));
+    await waitFor(() =>
+      expect(onClimbPress).toHaveBeenCalledWith({
+        climb: heroDetail,
+        queueItemUuid: 'queue-hero',
+        boardConfig,
+      }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(graphql.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the hardest-send avatar linked to the climber profile', () => {
+    presence.stats = {
+      climbsSentCount: 9,
+      distinctClimbersCount: 3,
+      hardestGrade: 'V8',
+      hardestSend: {
+        climbUuid: 'hardest-1',
+        name: 'Hardest One',
+        grade: 'V8',
+        sentByUserId: 'user-hardest',
+        sentByDisplayName: 'Alex',
+        sentByAvatarUrl: 'https://example.com/avatar.png',
+        sentAt: '2026-06-09T00:00:00.000Z',
+      },
+      topGrade: 'V8',
+      lastSentAt: '2026-06-09T00:00:00.000Z',
+    };
+
+    const { container } = render(panelElement());
+
+    expect(container.textContent).toContain('Hardest One');
+    expect(pressableAvatar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-hardest',
+        name: 'Alex',
+        uri: 'https://example.com/avatar.png',
+        size: 34,
+      }),
+    );
+  });
+});

--- a/packages/mobile/src/components/board-presence/__tests__/wall-status-surfaces.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/wall-status-surfaces.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const wallSelector = vi.hoisted(() => ({
+  // BoardPresenceClimb shape: WallStrip and SidebarWallCell both read the raw wall
+  // climb (grade, name, frames, climbUuid) via useWallClimbIfDistinct. The extra
+  // difficulty/uuid/mirrored fields are a harmless superset for the one fixture.
+  climb: null as null | {
+    uuid: string;
+    climbUuid: string;
+    name: string;
+    grade: string;
+    difficulty: string;
+    frames: string;
+    mirrored?: boolean;
+  },
+}));
+
+const drawerHost = vi.hoisted(() => ({
+  openBoardSheet: vi.fn(),
+  boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 },
+  boardPanelProps: {
+    boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 },
+  },
+}));
+
+const presenceControls = vi.hoisted(() => ({
+  enabled: true,
+  boardId: 1 as number | null,
+}));
+
+const haptics = vi.hoisted(() => ({
+  selection: vi.fn(),
+}));
+
+type PressableMockProps = {
+  children?: ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+};
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  Pressable: ({ children, onPress, accessibilityLabel }: PressableMockProps) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key}:${Object.values(opts).join(',')}` : key),
+  }),
+}));
+
+vi.mock('../../queue-control/use-wall-or-queue-climb', () => ({
+  // WallStrip and SidebarWallCell both consume the raw wall climb via useWallClimbIfDistinct.
+  useWallClimbIfDistinct: () => wallSelector.climb,
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => drawerHost,
+}));
+
+vi.mock('../../../providers/board-presence-provider', () => ({
+  useBoardPresenceControls: () => ({ enabled: presenceControls.enabled, boardId: presenceControls.boardId }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      label: '#000',
+      secondaryLabel: '#666',
+      tertiaryLabel: '#999',
+      secondaryBackground: '#f2f2f7',
+      separator: '#ccc',
+    },
+    brandColors: { warning: '#B45309' },
+  }),
+}));
+
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: haptics.selection }));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { full: 999 },
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress, accessibilityLabel }: PressableMockProps) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('../../queue-control/AccessoryClimbThumbnail', () => ({
+  AccessoryClimbThumbnail: ({
+    climb,
+    boardConfig,
+    size,
+  }: {
+    climb: { frames?: string; mirrored?: boolean };
+    boardConfig?: { boardName?: string } | null;
+    size?: number;
+  }) =>
+    createElement('span', {
+      'data-thumb': 'true',
+      'data-frames': climb.frames ?? '',
+      'data-mirrored': String(climb.mirrored ?? false),
+      'data-board-name': boardConfig?.boardName ?? '',
+      'data-size': String(size ?? ''),
+    }),
+}));
+
+import { WallStrip } from '../WallStrip';
+import { SidebarWallCell } from '../../navigation/SidebarWallCell';
+
+function litWallClimb() {
+  return {
+    uuid: 'climb-1',
+    climbUuid: 'climb-1',
+    name: 'Moon Patrol',
+    grade: 'V6',
+    difficulty: 'V6',
+    frames: 'lit-frames',
+    mirrored: true,
+  };
+}
+
+describe('wall status surfaces', () => {
+  beforeEach(() => {
+    wallSelector.climb = null;
+    presenceControls.enabled = true;
+    presenceControls.boardId = 1;
+    drawerHost.openBoardSheet.mockClear();
+    haptics.selection.mockClear();
+  });
+
+  it('WallStrip renders the lit wall climb and opens the board sheet', () => {
+    wallSelector.climb = litWallClimb();
+
+    const { container, getByLabelText } = render(createElement(WallStrip));
+
+    expect(container.textContent).toContain('boardPresence.open');
+    expect(container.textContent).toContain('Moon Patrol');
+    expect(container.textContent).toContain('V6');
+    expect(container.querySelector('[data-thumb="true"]')?.getAttribute('data-frames')).toBe('lit-frames');
+    // Presence climbs carry no mirror flag, so the strip renders the un-mirrored render.
+    expect(container.querySelector('[data-thumb="true"]')?.getAttribute('data-mirrored')).toBe('false');
+    expect(container.querySelector('[data-thumb="true"]')?.getAttribute('data-board-name')).toBe('kilter');
+
+    fireEvent.click(getByLabelText('boardPresence.openAriaWithClimb:Moon Patrol'));
+
+    expect(haptics.selection).toHaveBeenCalledTimes(1);
+    expect(drawerHost.openBoardSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('WallStrip renders the dark state when no wall climb is selected', () => {
+    const { container, getByLabelText } = render(createElement(WallStrip));
+
+    expect(getByLabelText('boardPresence.openAria')).not.toBeNull();
+    expect(container.textContent).toContain('boardPresence.railDark');
+    expect(container.querySelector('[data-icon="lightbulb"]')).not.toBeNull();
+    expect(container.querySelector('[data-thumb="true"]')).toBeNull();
+    expect(container.textContent).not.toContain('V6');
+  });
+
+  it('SidebarWallCell renders nothing until board presence is active and bound', () => {
+    presenceControls.enabled = false;
+    const disabledRender = render(createElement(SidebarWallCell));
+    expect(disabledRender.container.textContent).toBe('');
+
+    presenceControls.enabled = true;
+    presenceControls.boardId = null;
+    const unboundRender = render(createElement(SidebarWallCell));
+    expect(unboundRender.container.textContent).toBe('');
+  });
+
+  it('SidebarWallCell renders lit and dark board-presence states', () => {
+    wallSelector.climb = litWallClimb();
+    const litRender = render(createElement(SidebarWallCell));
+
+    expect(litRender.container.textContent).toContain('boardPresence.open');
+    expect(litRender.container.textContent).toContain('V6');
+    expect(litRender.container.querySelector('[data-thumb="true"]')?.getAttribute('data-size')).toBe('36');
+
+    fireEvent.click(litRender.getByLabelText('boardPresence.openAriaWithClimb:Moon Patrol'));
+    expect(haptics.selection).toHaveBeenCalledTimes(1);
+    expect(drawerHost.openBoardSheet).toHaveBeenCalledTimes(1);
+
+    wallSelector.climb = null;
+    const darkRender = render(createElement(SidebarWallCell));
+
+    expect(darkRender.getByLabelText('boardPresence.openAria')).not.toBeNull();
+    expect(darkRender.container.querySelector('[data-icon="lightbulb"]')).not.toBeNull();
+    expect(darkRender.container.querySelector('[data-thumb="true"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -8,7 +8,11 @@ type IconMapping = {
 };
 
 export const iconMap = {
-  // Tab bar
+  // Tab bar / iPad sidebar
+  home: { ios: 'house', android: 'home-outline' },
+  'home.fill': { ios: 'house.fill', android: 'home' },
+  record: { ios: 'record.circle', android: 'record-circle-outline' },
+  discover: { ios: 'bookmark', android: 'bookmark-multiple-outline' },
   boards: { ios: 'square.grid.2x2', android: 'view-dashboard' },
   'boards.fill': { ios: 'square.grid.2x2.fill', android: 'view-dashboard' },
   search: { ios: 'magnifyingglass', android: 'magnify' },

--- a/packages/mobile/src/components/navigation/IpadSidebar.tsx
+++ b/packages/mobile/src/components/navigation/IpadSidebar.tsx
@@ -1,0 +1,209 @@
+import { memo, useCallback, useMemo, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useRouter, useSegments } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { GlassSurface } from '../GlassSurface';
+import { PressableSurface } from '../PressableSurface';
+import { SidebarWallCell } from './SidebarWallCell';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import type { IconName } from '../icon-map';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { tabsActiveSegment } from '../../lib/route-segments';
+import {
+  SIDEBAR_WIDTH,
+  SIDEBAR_NAV_PILL_HEIGHT,
+  SIDEBAR_NAV_PILL_WIDTH,
+  SIDEBAR_NAV_ICON_SIZE,
+} from '../../theme/layout';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+/**
+ * iPad adaptive-shell sidebar — the glass left rail that replaces the bottom tab
+ * bar at `regular` width (see `size-class.ts`). It drives navigation through the
+ * global Expo Router `router` (so it needs no tab-navigator context) and reads
+ * the focused tab from `useSegments()[1]` — segment 0 is the `(tabs)` group.
+ * Compact width never mounts this; `_layout.tsx` renders the native tab bar
+ * there, so the phone UI is unchanged.
+ *
+ * The selected-climb pane lives to the right of this rail; the bottom
+ * PersistentQueueBar stays compact-only. The rail owns only navigation plus the
+ * compact board-presence cell.
+ */
+
+type SidebarDestination = {
+  /** Tab route segment under `(tabs)` — also the active-state key. */
+  segment: string;
+  /** Router path (typed routes are off, so a plain string is the href). */
+  href: string;
+  icon: IconName;
+  label: string;
+};
+
+function SidebarItem({
+  destination,
+  focused,
+  onPress,
+}: {
+  destination: SidebarDestination;
+  focused: boolean;
+  onPress: (destination: SidebarDestination) => void;
+}) {
+  const { systemColors } = useTheme();
+  // Pointer-hover / keyboard-focus on the iPad rail (no-op on touch). Treated as
+  // a single "active-ish" cue: it brightens the glyph and fills the pill, the
+  // same affordance selection uses, so hovering/focusing previews selection.
+  const [interactive, setInteractive] = useState(false);
+  const active = focused || interactive;
+  // Neutral chrome glyphs, matching NativeTabs / MaterialTabBar (the systemFill
+  // pill is the sole active affordance, not a brand tint). See
+  // docs/ai-design-guidelines.md — chrome carries state with fills, not colour.
+  const tint = active ? systemColors.label : systemColors.secondaryLabel;
+  const handlePress = useCallback(() => onPress(destination), [onPress, destination]);
+  const handleInteractiveOn = useCallback(() => setInteractive(true), []);
+  const handleInteractiveOff = useCallback(() => setInteractive(false), []);
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      onHoverIn={handleInteractiveOn}
+      onHoverOut={handleInteractiveOff}
+      onFocus={handleInteractiveOn}
+      onBlur={handleInteractiveOff}
+      feedback="scale"
+      accessibilityRole="tab"
+      accessibilityState={{ selected: focused }}
+      accessibilityLabel={destination.label}
+      style={styles.item}
+    >
+      <View style={[styles.iconPill, active ? { backgroundColor: systemColors.fill } : null]}>
+        <Icon name={destination.icon} size={SIDEBAR_NAV_ICON_SIZE} color={tint} />
+      </View>
+      <Text variant="caption2" color={tint} numberOfLines={2} style={styles.label}>
+        {destination.label}
+      </Text>
+    </PressableSurface>
+  );
+}
+
+function IpadSidebarComponent({ showWallCell = true }: { showWallCell?: boolean }) {
+  const { t } = useTranslation('common');
+  const { t: tSession } = useTranslation('session');
+  const { t: tPlaylists } = useTranslation('playlists');
+  const router = useRouter();
+  const segments = useSegments();
+  const insets = useSafeAreaInsets();
+  const { systemColors } = useTheme();
+
+  // Default to the cold-start tab so the rail always shows a selection on first
+  // paint. `tabsActiveSegment` reads the focused tab without indexing the
+  // route-typed tuple directly (see route-segments.ts).
+  const activeSegment = tabsActiveSegment(segments) ?? 'home';
+
+  // Primary destinations sit at the top; the account row pins to the bottom (HIG
+  // sidebar convention). Labels reuse the same i18n keys as the tab bars.
+  const primary = useMemo<SidebarDestination[]>(
+    () => [
+      { segment: 'home', href: '/home', icon: 'home', label: t('mobile.nav.home') },
+      { segment: 'climbs', href: '/climbs', icon: 'search', label: t('mobile.nav.climbs') },
+      { segment: 'record', href: '/record', icon: 'record', label: tSession('mobile.session.recordTab') },
+      { segment: 'discover', href: '/discover', icon: 'discover', label: tPlaylists('bottomTabBar.discover') },
+    ],
+    [t, tSession, tPlaylists],
+  );
+  const account = useMemo<SidebarDestination>(
+    () => ({ segment: 'profile', href: '/profile', icon: 'profile', label: t('mobile.nav.profile') }),
+    [t],
+  );
+
+  const handleNavigate = useCallback(
+    (destination: SidebarDestination) => {
+      // Always acknowledge the tap with a haptic so the active row is never a dead
+      // control. `router.navigate` to a tab already in the stack pops it back to
+      // the tab root (the iPhone tab-bar active-tap convention); a fresh tab just
+      // switches. Scroll-to-top on re-tap is a future refinement.
+      hapticSelection();
+      router.navigate(destination.href);
+    },
+    [router],
+  );
+
+  return (
+    <View
+      style={[
+        styles.rail,
+        {
+          width: SIDEBAR_WIDTH,
+          paddingTop: insets.top + spacing[3],
+          paddingBottom: insets.bottom + spacing[3],
+          borderRightColor: systemColors.separator,
+        },
+      ]}
+    >
+      {/* Glass fill behind the rail; nav items render as siblings on top. */}
+      <GlassSurface
+        style={StyleSheet.absoluteFill}
+        fallbackColor={systemColors.secondaryBackground}
+        pointerEvents="none"
+      />
+      {/* The primary destinations form one tab group; the account row and the
+          wall cell are labelled siblings outside it, so VoiceOver reads a coherent
+          set rather than a flat run of tabs split by a button. */}
+      <View style={styles.navGroup} accessibilityRole="tablist">
+        {primary.map((destination) => (
+          <SidebarItem
+            key={destination.segment}
+            destination={destination}
+            focused={destination.segment === activeSegment}
+            onPress={handleNavigate}
+          />
+        ))}
+      </View>
+      <View style={styles.spacer} />
+      {/* Ambient "now on the wall" anchor, pinned above the account row. Hidden
+          when the shell shows the full wall column (landscape) so there's one
+          wall surface per layout. */}
+      {showWallCell ? <SidebarWallCell /> : null}
+      <SidebarItem destination={account} focused={account.segment === activeSegment} onPress={handleNavigate} />
+    </View>
+  );
+}
+
+export const IpadSidebar = memo(IpadSidebarComponent);
+
+const styles = StyleSheet.create({
+  rail: {
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: spacing[1],
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  navGroup: {
+    width: '100%',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  item: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[2],
+    gap: 4,
+    width: '100%',
+  },
+  iconPill: {
+    width: SIDEBAR_NAV_PILL_WIDTH,
+    height: SIDEBAR_NAV_PILL_HEIGHT,
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    textAlign: 'center',
+    paddingHorizontal: spacing[1],
+  },
+  spacer: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/navigation/SidebarWallCell.tsx
+++ b/packages/mobile/src/components/navigation/SidebarWallCell.tsx
@@ -1,0 +1,110 @@
+import { memo, useCallback } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { PressableSurface } from '../PressableSurface';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
+import { useWallClimbIfDistinct } from '../queue-control/use-wall-or-queue-climb';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useBoardPresenceControls } from '../../providers/board-presence-provider';
+import { useTheme } from '../../providers/theme-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { WALL_LIVE_DOT_SIZE } from '../../theme/layout';
+
+const WALL_THUMBNAIL_SIZE = 36;
+
+/**
+ * Ambient "now on the wall" cell pinned to the bottom of the iPad sidebar rail
+ * (above the account row). It's the always-glanceable, minimal status pin for
+ * the physical wall — a board thumbnail + grade + a warm live dot when a climb
+ * is lit, a dim bulb when the wall is dark. Tapping opens the full BoardSheet
+ * ("Now on the wall": hero, history, stats, switch board), which is also the
+ * basis for the planned Gym Wall destination. The rich always-visible wall
+ * surface (strip in portrait, column in landscape) is owned by the shell; this
+ * cell is the cross-tab anchor. Renders nothing when board presence isn't active
+ * (no board bound).
+ *
+ * Memoized + isolated so wall events re-render only this cell, not the whole rail.
+ */
+function SidebarWallCellComponent() {
+  const { t } = useTranslation('session');
+  const { systemColors, brandColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+  const { enabled, boardId } = useBoardPresenceControls();
+  const litClimb = useWallClimbIfDistinct(null);
+  const { openBoardSheet, boardPanelProps } = useDrawerHost();
+  const boardConfig = boardPanelProps?.boardConfig ?? null;
+
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    openBoardSheet();
+  }, [openBoardSheet]);
+
+  // The wall concept is inactive (no board bound) — leave the rail as-is.
+  if (!enabled || boardId === null) return null;
+
+  const grade = litClimb ? formatGrade(litClimb.grade ?? '') : null;
+  const accessibilityLabel = litClimb
+    ? t('boardPresence.openAriaWithClimb', { name: litClimb.name ?? '' })
+    : t('boardPresence.openAria');
+
+  return (
+    <PressableSurface
+      onPress={handlePress}
+      feedback="scale"
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      style={styles.cell}
+    >
+      <Text variant="caption2" color={systemColors.secondaryLabel} numberOfLines={1} style={styles.label}>
+        {t('boardPresence.open')}
+      </Text>
+      {litClimb ? (
+        <View style={styles.thumbWrap}>
+          <AccessoryClimbThumbnail
+            climb={{ frames: litClimb.frames ?? '' }}
+            boardConfig={boardConfig}
+            size={WALL_THUMBNAIL_SIZE}
+          />
+          <View
+            style={[styles.dot, { backgroundColor: brandColors.live, borderColor: systemColors.secondaryBackground }]}
+          />
+        </View>
+      ) : (
+        <Icon name="lightbulb" size={24} color={systemColors.tertiaryLabel} />
+      )}
+      {grade ? (
+        <Text variant="caption2" color={brandColors.live} numberOfLines={1} style={styles.grade}>
+          {grade}
+        </Text>
+      ) : null}
+    </PressableSurface>
+  );
+}
+
+export const SidebarWallCell = memo(SidebarWallCellComponent);
+
+const styles = StyleSheet.create({
+  cell: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[2],
+    gap: 4,
+    width: '100%',
+  },
+  label: { textAlign: 'center', paddingHorizontal: spacing[1] },
+  thumbWrap: { position: 'relative' },
+  dot: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    width: WALL_LIVE_DOT_SIZE,
+    height: WALL_LIVE_DOT_SIZE,
+    borderRadius: borderRadius.full,
+    borderWidth: 2,
+  },
+  grade: { fontWeight: '600' },
+});

--- a/packages/mobile/src/components/play-drawer/IpadPlayPane.tsx
+++ b/packages/mobile/src/components/play-drawer/IpadPlayPane.tsx
@@ -1,0 +1,65 @@
+import { memo } from 'react';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { PlayDrawer } from './PlayDrawer';
+import { PanePlaceholder } from './PanePlaceholder';
+import { WallStrip } from '../board-presence/WallStrip';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useBoardPresenceControls } from '../../providers/board-presence-provider';
+import { useDeviceLayout } from '../../hooks/use-device-layout';
+import { resolveWallSurface } from '../../theme/size-class';
+import { SIDEBAR_WIDTH } from '../../theme/layout';
+import { spacing } from '../../theme/tokens';
+
+/**
+ * The persistent right column on the iPad shell: the PlayDrawer for the user's
+ * selected climb, rendered as a pane (not a bottom sheet). It follows selection
+ * like the iPad master-detail pattern — tapping a list row updates it — so the
+ * browse→inspect flow works on iPad. The live wall is shown elsewhere (the
+ * sidebar footer cell, a column in landscape, and — here — a compact strip docked
+ * atop the pane in portrait, where there's no room for a column). The pane also
+ * annotates its own header with an "On the wall" chip when the selected climb is
+ * the one physically lit (see PlayDrawer's pane header). The drawer props come
+ * from DrawerHostProvider so the pane and the compact bottom sheet stay identical;
+ * the sheet is not mounted at regular width (see drawer-host-provider).
+ */
+function IpadPlayPaneComponent() {
+  const { playDrawerPaneProps } = useDrawerHost();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation('session');
+  const { width } = useWindowDimensions();
+  const { widthClass } = useDeviceLayout();
+  const { enabled, boardId } = useBoardPresenceControls();
+
+  // In portrait/narrow regular there's no room for a wall column, so the wall
+  // lives as a strip atop the pane. It shows only when board presence is active;
+  // when it does, the strip owns the top inset (PlayDrawer skips it).
+  const wallSurface = resolveWallSurface({ width, widthClass, sidebarWidth: SIDEBAR_WIDTH });
+  const showStrip = wallSurface === 'strip' && enabled && boardId !== null;
+
+  // No board resolved yet — the pane has no selection to show.
+  if (!playDrawerPaneProps) {
+    return (
+      <PanePlaceholder
+        title={t('playView.paneEmpty.title')}
+        subtitle={t('playView.paneEmpty.subtitle')}
+        paddingTop={insets.top + spacing[8]}
+        paddingBottom={insets.bottom}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.paneRoot}>
+      {showStrip ? <WallStrip /> : null}
+      <PlayDrawer presentation="pane" {...playDrawerPaneProps} paneTopInset={!showStrip} />
+    </View>
+  );
+}
+
+export const IpadPlayPane = memo(IpadPlayPaneComponent);
+
+const styles = StyleSheet.create({
+  paneRoot: { flex: 1 },
+});

--- a/packages/mobile/src/components/play-drawer/PanePlaceholder.tsx
+++ b/packages/mobile/src/components/play-drawer/PanePlaceholder.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+
+/**
+ * The iPad detail-pane "nothing to show yet" placeholder, shared by `IpadPlayPane`
+ * (no board resolved) and `PlayDrawer`'s pane branch (no climb selected) so the two
+ * states can't drift. De-emphasis uses the theme label roles (secondaryLabel /
+ * tertiaryLabel) rather than opacity, so it deepens correctly in dark mode and
+ * matches adjacent text; the icon is an adaptive system colour, not a fixed gray.
+ * Callers pass the resolved safe-area padding (a top-of-shell column owns its inset).
+ */
+export const PanePlaceholder = memo(function PanePlaceholder({
+  title,
+  subtitle,
+  paddingTop,
+  paddingBottom,
+}: {
+  title: string;
+  subtitle: string;
+  paddingTop: number;
+  paddingBottom: number;
+}) {
+  const { systemColors } = useTheme();
+  return (
+    <View style={[styles.root, { paddingTop, paddingBottom }]}>
+      <Icon name="search" size={40} color={systemColors.tertiaryLabel} />
+      <Text variant="headline" color={systemColors.secondaryLabel} style={styles.title}>
+        {title}
+      </Text>
+      <Text variant="subheadline" color={systemColors.tertiaryLabel} style={styles.subtitle}>
+        {subtitle}
+      </Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[6],
+    gap: spacing[2],
+  },
+  title: { marginTop: spacing[2], textAlign: 'center' },
+  subtitle: { textAlign: 'center' },
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -144,6 +144,16 @@ type PlayDrawerProps = {
   onOpenClimbActions?: (climb: Climb) => void;
   /** The climb to show; applied on mount and whenever `nonce` changes. */
   openTarget: PlayDrawerOpenTarget | null;
+  /** Rendering context. `'route'` (default) is the full-screen `/play` modal — a
+   *  pull-down gesture + the close chevron dismiss it. `'pane'` is the persistent
+   *  iPad right-column pane: it's always on screen, so the dismiss gesture, the
+   *  close chevron, and the grabber are all suppressed and `router.dismiss()` is
+   *  never called. */
+  presentation?: 'route' | 'pane';
+  /** Pane mode only: include the top safe-area inset above the first screen. False
+   *  when a WallStrip is docked above the pane and already owns that inset. Ignored
+   *  in route mode (the modal always owns the top inset). */
+  paneTopInset?: boolean;
 };
 
 // Fallback used for the first-screen reserve before the Beta Videos header has
@@ -168,7 +178,12 @@ export function PlayDrawer({
   onSwitchBoard,
   onOpenClimbActions,
   openTarget,
+  presentation = 'route',
+  paneTopInset = true,
 }: PlayDrawerProps) {
+  // The iPad right-column pane is persistent — it has no dismiss. Suppresses the
+  // pull-down dismiss gesture, the close chevron, the grabber, and router.dismiss.
+  const isPane = presentation === 'pane';
   const { t } = useTranslation('session');
   // The copy/share affordance strings live in the `climbs` namespace alongside
   // the climb-actions sheet's "Link copied" toast.
@@ -226,8 +241,10 @@ export function PlayDrawer({
     [scrollYSV],
   );
   const handleDismiss = useCallback(() => {
+    // The pane is persistent — nothing to dismiss (and no modal to pop).
+    if (isPane) return;
     router.dismiss();
-  }, []);
+  }, [isPane]);
 
   // The header (title + grade) rides this exact value as the board so they swipe
   // in lockstep; the carousel's gesture writes into it (externalTranslateX). The
@@ -690,7 +707,7 @@ export function PlayDrawer({
     // behind this on its cheap first frame (so the native present can start
     // before this heavier content mounts). See app/play.tsx.
     <View style={styles.root}>
-      <GestureDetector gesture={dismissGesture}>
+      <GestureDetector gesture={dismissGesture.enabled(!isPane)}>
         <Animated.View style={[styles.content, dismissAnimatedStyle]}>
           <ScrollView
             ref={scrollRef}
@@ -710,19 +727,34 @@ export function PlayDrawer({
             {displayedClimb && (
               <>
                 {/* The firstScreen container owns the top safe area, so the grabber +
-                close + climb name sit at the very top. */}
-                <View style={[styles.firstScreen, { height: firstScreenHeight, paddingTop: insets.top + spacing[2] }]}>
+                close + climb name sit at the very top. In the pane a docked WallStrip
+                can already own the top inset (paneTopInset=false). */}
+                <View
+                  style={[
+                    styles.firstScreen,
+                    {
+                      height: firstScreenHeight,
+                      paddingTop: isPane && !paneTopInset ? spacing[2] : insets.top + spacing[2],
+                    },
+                  ]}
+                >
                   <View style={styles.topRow}>
-                    <View style={sheetStyles.indicator} />
-                    <Pressable
-                      onPress={handleDismiss}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('playView.closeAria')}
-                      style={styles.closeButton}
-                      hitSlop={8}
-                    >
-                      <Icon name="chevron.down" size={20} color={iosSystemColors.systemGray} />
-                    </Pressable>
+                    {/* The persistent pane has no dismiss, so it shows no grabber or
+                        close chevron; the route keeps both. */}
+                    {!isPane ? (
+                      <>
+                        <View style={sheetStyles.indicator} />
+                        <Pressable
+                          onPress={handleDismiss}
+                          accessibilityRole="button"
+                          accessibilityLabel={t('playView.closeAria')}
+                          style={styles.closeButton}
+                          hitSlop={8}
+                        >
+                          <Icon name="chevron.down" size={20} color={iosSystemColors.systemGray} />
+                        </Pressable>
+                      </>
+                    ) : null}
                   </View>
 
                   {/* Title + grade swipe with the board: same translateX, same

--- a/packages/mobile/src/components/play-drawer/__tests__/IpadPlayPane.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/IpadPlayPane.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// resolveWallSurface (real, pure) decides strip vs column from these. SIDEBAR_WIDTH
+// (real, 96) is used too, so the widths below mirror real iPad geometry:
+// 834 (11" portrait) → strip; 1366 (13" landscape) → column.
+const cfg = vi.hoisted(() => ({
+  width: 834,
+  widthClass: 'regular' as 'compact' | 'regular',
+  presenceEnabled: true,
+  presenceBoardId: 1 as number | null,
+  paneProps: { boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } } as Record<
+    string,
+    unknown
+  > | null,
+}));
+
+const captured = vi.hoisted(() => ({ playDrawerProps: null as Record<string, unknown> | null }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: cfg.width, height: 1024 }),
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  PlatformColor: (name: string) => name,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 24, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('../PlayDrawer', () => ({
+  PlayDrawer: (props: Record<string, unknown>) => {
+    captured.playDrawerProps = props;
+    return createElement('div', { 'data-play-drawer': 'true' });
+  },
+}));
+
+vi.mock('../PanePlaceholder', () => ({
+  PanePlaceholder: () => createElement('div', { 'data-pane-placeholder': 'true' }),
+}));
+
+vi.mock('../../board-presence/WallStrip', () => ({
+  WallStrip: () => createElement('div', { 'data-wall-strip': 'true' }),
+}));
+
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span') }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ playDrawerPaneProps: cfg.paneProps }),
+}));
+
+vi.mock('../../../providers/board-presence-provider', () => ({
+  useBoardPresenceControls: () => ({ enabled: cfg.presenceEnabled, boardId: cfg.presenceBoardId }),
+}));
+
+vi.mock('../../../hooks/use-device-layout', () => ({
+  useDeviceLayout: () => ({ widthClass: cfg.widthClass, expanded: false }),
+}));
+
+import { IpadPlayPane } from '../IpadPlayPane';
+
+describe('IpadPlayPane wall surface', () => {
+  beforeEach(() => {
+    cfg.width = 834;
+    cfg.widthClass = 'regular';
+    cfg.presenceEnabled = true;
+    cfg.presenceBoardId = 1;
+    cfg.paneProps = { boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } };
+    captured.playDrawerProps = null;
+  });
+
+  it('docks the wall strip atop the pane in portrait and tells PlayDrawer to skip the top inset', () => {
+    // 834pt regular → no room for a column → strip; a board is bound.
+    const { container } = render(<IpadPlayPane />);
+    expect(container.querySelector('[data-wall-strip="true"]')).not.toBeNull();
+    expect(captured.playDrawerProps?.paneTopInset).toBe(false);
+  });
+
+  it('shows no strip in landscape (the column carries the wall) and keeps the pane top inset', () => {
+    cfg.width = 1366; // → column surface; the strip is not docked here
+    const { container } = render(<IpadPlayPane />);
+    expect(container.querySelector('[data-wall-strip="true"]')).toBeNull();
+    expect(captured.playDrawerProps?.paneTopInset).toBe(true);
+  });
+
+  it('shows no strip when board presence is not bound, keeping the pane top inset', () => {
+    cfg.presenceBoardId = null;
+    const { container } = render(<IpadPlayPane />);
+    expect(container.querySelector('[data-wall-strip="true"]')).toBeNull();
+    expect(captured.playDrawerProps?.paneTopInset).toBe(true);
+  });
+
+  it('renders the shared placeholder (not the drawer) when no board is resolved', () => {
+    // No pane props → nothing selected: the pane shows the shared PanePlaceholder
+    // instead of the drawer, and there's no wall strip to dock.
+    cfg.paneProps = null;
+    const { container } = render(<IpadPlayPane />);
+    expect(container.querySelector('[data-pane-placeholder="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-play-drawer="true"]')).toBeNull();
+    expect(container.querySelector('[data-wall-strip="true"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -17,6 +17,8 @@ const cfg = vi.hoisted(() => ({
   measuredTabBarHeight: null as number | null,
   nativeAccessoryActive: false,
   nativeTabBar: false,
+  widthClass: 'compact' as 'compact' | 'regular',
+  windowWidth: 430,
 }));
 
 // useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
@@ -30,6 +32,7 @@ vi.mock('react-native', () => ({
   View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
     createElement('div', { 'data-style': JSON.stringify(style) }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  useWindowDimensions: () => ({ width: cfg.windowWidth, height: 932 }),
 }));
 
 vi.mock('react-native-reanimated', () => ({
@@ -57,6 +60,11 @@ vi.mock('../../../lib/route-segments', () => ({
   isTopLevelTabRoute: () => cfg.onTopLevelTab,
   isAccessorySurfaceRoute: () => cfg.onAccessorySurface,
 }));
+// useBottomChromeMetrics now reads the device layout; in jsdom this test runs as
+// a compact phone (no sidebar), so the bottom-chrome arithmetic is unchanged.
+vi.mock('../../../hooks/use-device-layout', () => ({
+  useDeviceLayout: () => ({ widthClass: cfg.widthClass, expanded: cfg.windowWidth >= 1024 }),
+}));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
   useHasActiveClimb: () => cfg.currentClimbQueueItem?.climb != null,
@@ -73,6 +81,7 @@ vi.mock('../../../theme/layout', () => ({
   TOOLBAR_FAB_SIZE: 56,
   TOOLBAR_GAP_ABOVE_TABBAR: 10,
   TABBAR_SEAM_OVERLAP: 1,
+  SIDEBAR_WIDTH: 96,
   glassSize: { hero: 64, inline: 44 },
 }));
 // The docked Material bar reads the tab bar's measured height to position itself.
@@ -140,6 +149,8 @@ describe('PersistentQueueBar', () => {
     cfg.measuredTabBarHeight = null;
     cfg.nativeAccessoryActive = false;
     cfg.nativeTabBar = false;
+    cfg.widthClass = 'compact';
+    cfg.windowWidth = 430;
   });
 
   it('renders nothing when no climb is current', () => {
@@ -266,5 +277,25 @@ describe('PersistentQueueBar', () => {
     expect(container.querySelector('[data-animated]')?.parentElement?.getAttribute('data-style')).toContain(
       '"bottom":79',
     );
+  });
+
+  it('renders in tight regular iPad widths where the detail pane is suppressed', () => {
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 744;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).not.toBeNull();
+    expect(container.querySelector('[data-tick]')).not.toBeNull();
+  });
+
+  it('stays hidden in regular iPad widths where the detail pane owns the current climb', () => {
+    cfg.widthClass = 'regular';
+    cfg.windowWidth = 1024;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -16,13 +16,22 @@
  * pair, so `jsQueueToolbarVisible` is false here and this returns null.
  */
 
+import { useWindowDimensions } from 'react-native';
 import { useSegments } from 'expo-router';
-import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
+import {
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  SIDEBAR_WIDTH,
+  TOOLBAR_RESERVE,
+  TAB_BAR_HEIGHT,
+  glassSize,
+} from '../../theme/layout';
+import { resolveDetailPaneSurface } from '../../theme/size-class';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { isTopLevelTabRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useDeviceLayout } from '../../hooks/use-device-layout';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
@@ -37,10 +46,16 @@ export function PersistentQueueBar() {
   const { variant } = useTheme();
   const segments = useSegments();
   const bottomChrome = useBottomChromeMetrics();
+  const { widthClass } = useDeviceLayout();
+  const { width } = useWindowDimensions();
 
   // Queue head only — the wall's lit climb lives in the top "On the wall" strip.
   const currentClimb = state.currentClimbQueueItem?.climb ?? null;
+  const detailPaneOwnsQueue = resolveDetailPaneSurface({ width, widthClass, sidebarWidth: SIDEBAR_WIDTH }) === 'pane';
 
+  // The iPad shell shows the current climb in the persistent right-column pane
+  // (IpadPlayPane), so the floating bar must not also render there.
+  if (detailPaneOwnsQueue) return null;
   if (!currentClimb) return null;
   // Show the climb bar only on a top-level tab page (a tab's own index), never on a
   // pushed sub-route or any root push/modal. This single gate subsumes the old

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -286,4 +286,101 @@ describe('computeBottomChromeMetrics', () => {
       expect(metrics.preSessionFooterBottom).toBe(34);
     });
   });
+
+  describe('regular-width iPad sidebar (usesSidebar)', () => {
+    it('collapses every bottom offset to the safe-area inset', () => {
+      // The left sidebar owns navigation and hosts the queue "now playing" in its
+      // footer, so nothing floats at the bottom — every offset is the raw inset.
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: 20,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+        usesSidebar: true,
+      });
+      expect(metrics.tabBarHeight).toBe(0);
+      expect(metrics.tabBarBottom).toBe(20);
+      expect(metrics.jsQueueToolbarVisible).toBe(false);
+      expect(metrics.nativeAccessoryVisible).toBe(false);
+      expect(metrics.jsQueueReserve).toBe(0);
+      expect(metrics.nativeAccessoryReserve).toBe(0);
+      expect(metrics.scrollBottomPadding).toBe(20);
+      expect(metrics.floatingControlBottom).toBe(20);
+      expect(metrics.fixedFooterBottom).toBe(20);
+      expect(metrics.inSessionListBottom).toBe(20);
+      expect(metrics.preSessionFooterBottom).toBe(20);
+    });
+
+    it('short-circuits the tab-bar / accessory inputs entirely in sidebar mode', () => {
+      // Even with a climb + the native accessory mounted, sidebar mode reserves
+      // nothing — it returns before the phone arithmetic runs.
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'material',
+        usesNativeTabBar: false,
+        insetsBottom: 0,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+        usesSidebar: true,
+      });
+      expect(metrics.scrollBottomPadding).toBe(0);
+      expect(metrics.floatingControlBottom).toBe(0);
+      expect(metrics.nativeAccessoryMounted).toBe(false);
+    });
+
+    it('keeps the JS queue toolbar when the sidebar is visible but the detail pane is suppressed', () => {
+      const metrics = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: false,
+        insetsBottom: 20,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: true,
+        nativeAccessoryMounted: true,
+        usesSidebar: true,
+        detailPaneOwnsQueue: false,
+      });
+
+      expect(metrics.tabBarHeight).toBe(0);
+      expect(metrics.tabBarBottom).toBe(20);
+      expect(metrics.nativeAccessoryMounted).toBe(false);
+      expect(metrics.nativeAccessoryVisible).toBe(false);
+      expect(metrics.jsQueueToolbarVisible).toBe(true);
+      expect(metrics.jsQueueReserve).toBe(TOOLBAR_RESERVE);
+      expect(metrics.nativeAccessoryReserve).toBe(0);
+      expect(metrics.scrollBottomPadding).toBe(20 + TOOLBAR_RESERVE);
+      expect(metrics.floatingControlBottom).toBe(20 + TOOLBAR_RESERVE);
+      expect(metrics.fixedFooterBottom).toBe(TOOLBAR_RESERVE);
+      expect(metrics.inSessionListBottom).toBe(20 + TOOLBAR_RESERVE);
+      expect(metrics.preSessionFooterBottom).toBe(20);
+    });
+
+    it('defaults usesSidebar to false so existing compact call sites are unchanged', () => {
+      const withFlag = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: 34,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: false,
+        nativeAccessoryMounted: false,
+        usesSidebar: false,
+      });
+      const withoutFlag = computeBottomChromeMetrics({
+        uiVariant: 'liquidGlass',
+        usesNativeTabBar: true,
+        insetsBottom: 34,
+        insideTabs: true,
+        onAccessorySurface: true,
+        hasCurrentClimb: false,
+        nativeAccessoryMounted: false,
+      });
+      expect(withFlag).toEqual(withoutFlag);
+      expect(withoutFlag.scrollBottomPadding).toBe(34 + TAB_BAR_HEIGHT);
+    });
+  });
 });

--- a/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-bottom-accessory.test.ts
@@ -13,6 +13,13 @@ const cfg = vi.hoisted(() => ({
   nativeTabs: {} as unknown,
   bottomAccessory: {} as unknown,
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  // 'regular' models the iPad sidebar shell (no native tab bar); 'compact' is
+  // every phone and the default for these variant/capability tests.
+  widthClass: 'compact' as 'compact' | 'regular',
+  // iPad in a narrow split: compact width but still an iPad, which the shell keeps
+  // on JS Tabs (never NativeTabs). Independent of widthClass so this case is
+  // expressible; a 'regular' width always implies an iPad too.
+  isPad: false,
 }));
 
 vi.mock('react-native', () => ({
@@ -47,6 +54,16 @@ vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({ variant: cfg.variant }),
 }));
 
+vi.mock('../use-device-layout', () => ({
+  // A 'regular' width only ever resolves on an iPad, so isPad is true there; the
+  // explicit cfg.isPad covers the iPad-in-a-narrow-split (compact) case.
+  useDeviceLayout: () => ({
+    widthClass: cfg.widthClass,
+    expanded: false,
+    isPad: cfg.widthClass === 'regular' || cfg.isPad,
+  }),
+}));
+
 import { isBottomAccessoryAvailable, useNativeAccessoryActive, useNativeTabBar } from '../use-bottom-accessory';
 
 describe('use-bottom-accessory', () => {
@@ -58,6 +75,8 @@ describe('use-bottom-accessory', () => {
     cfg.nativeTabs = {};
     cfg.bottomAccessory = {};
     cfg.variant = 'liquidGlass';
+    cfg.widthClass = 'compact';
+    cfg.isPad = false;
   });
 
   it('uses the native BottomAccessory export as the capability check', () => {
@@ -125,6 +144,16 @@ describe('use-bottom-accessory', () => {
     expect(result.current).toBe(false);
   });
 
+  it('does not report the native accessory active on the iPad sidebar shell', () => {
+    // The regular-width iPad shell has no native tab bar, so the accessory that
+    // lives inside it must be inactive even on a glass-capable device.
+    cfg.widthClass = 'regular';
+
+    const { result } = renderHook(() => useNativeAccessoryActive());
+
+    expect(result.current).toBe(false);
+  });
+
   describe('useNativeTabBar', () => {
     it('is true only for the Liquid Glass variant on a glass-capable device', () => {
       const { result, rerender } = renderHook(() => useNativeTabBar());
@@ -148,6 +177,30 @@ describe('use-bottom-accessory', () => {
 
     it('is false off iOS even on the Liquid Glass variant', () => {
       cfg.platformOS = 'android';
+
+      const { result } = renderHook(() => useNativeTabBar());
+
+      expect(result.current).toBe(false);
+    });
+
+    it('is false on the iPad sidebar shell (regular width), even when glass-capable', () => {
+      // The regular-width iPad renders JS Tabs + a glass sidebar, so the native
+      // tab bar is not on screen there — and everything that branches on this
+      // predicate (search mode, accessory, bottom-chrome geometry) must agree.
+      cfg.widthClass = 'regular';
+
+      const { result } = renderHook(() => useNativeTabBar());
+
+      expect(result.current).toBe(false);
+    });
+
+    it('is false on an iPad in a narrow split (compact width), even when glass-capable', () => {
+      // The single-navigator shell keeps an iPad on JS Tabs + the Material bar at
+      // compact width too (never NativeTabs), so the native bar is not on screen.
+      // If this returned true, the bottom-chrome metrics would suppress the JS queue
+      // bar for a native accessory that never mounts — dropping the now-playing bar.
+      cfg.isPad = true;
+      cfg.widthClass = 'compact';
 
       const { result } = renderHook(() => useNativeTabBar());
 

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -46,6 +46,19 @@ export type BottomChromeInputs = {
   hasCurrentClimb: boolean;
   /** Whether the iOS 26 native bottom accessory is mounted (it replaces the JS toolbar). */
   nativeAccessoryMounted: boolean;
+  /**
+   * Whether the regular-width iPad shell is on screen: a left sidebar replaces
+   * the bottom tab bar. Optional and defaults to `false` — every existing
+   * (phone / compact-iPad) call site keeps its current behavior unchanged.
+   */
+  usesSidebar?: boolean;
+  /**
+   * Whether the selected-climb detail pane is mounted and owns the queue toolbar.
+   * Defaults to `usesSidebar` for backward-compatible pure calls: full iPad
+   * pane mode has no bottom chrome, but narrow regular iPad windows still need
+   * the JS queue toolbar because the pane is suppressed there.
+   */
+  detailPaneOwnsQueue?: boolean;
 };
 
 export type BottomChromeMetrics = {
@@ -109,18 +122,48 @@ export function computeBottomChromeMetrics({
   onAccessorySurface,
   hasCurrentClimb,
   nativeAccessoryMounted,
+  usesSidebar = false,
+  detailPaneOwnsQueue = usesSidebar,
 }: BottomChromeInputs): BottomChromeMetrics {
-  const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
+  // Regular-width iPad with the detail pane mounted: the left sidebar replaces
+  // the bottom tab bar and the selected-climb pane replaces the floating queue
+  // toolbar, so nothing floats at the bottom. Every offset collapses to the raw
+  // safe-area inset. Narrow regular iPad windows still pass `usesSidebar=true`,
+  // but `detailPaneOwnsQueue=false`, so they skip this branch and keep the JS
+  // queue toolbar while still removing the bottom tab bar height below.
+  if (usesSidebar && detailPaneOwnsQueue) {
+    return {
+      hasCurrentClimb,
+      insideTabs,
+      nativeAccessoryMounted: false,
+      nativeAccessoryVisible: false,
+      jsQueueToolbarVisible: false,
+      tabBarHeight: 0,
+      tabBarBottom: insetsBottom,
+      jsQueueReserve: 0,
+      nativeAccessoryReserve: 0,
+      scrollBottomPadding: insetsBottom,
+      floatingControlBottom: insetsBottom,
+      fixedFooterBottom: insetsBottom,
+      inSessionListBottom: insetsBottom,
+      preSessionFooterBottom: insetsBottom,
+    };
+  }
+
+  // On the regular-width sidebar shell the native accessory never mounts (the
+  // sidebar owns the chrome), so fold that into `effectiveNativeAccessoryMounted`.
+  const effectiveNativeAccessoryMounted = usesSidebar ? false : nativeAccessoryMounted;
+  const nativeAccessoryVisible = effectiveNativeAccessoryMounted && hasCurrentClimb;
   // The JS toolbar only mounts on an accessory surface (a top-level tab) when the
   // native accessory isn't owning the climb. On a pushed sub-route `onAccessorySurface`
   // is false, so no JS bar — and no `jsQueueReserve` for a bar that isn't there.
-  const jsQueueToolbarVisible = onAccessorySurface && hasCurrentClimb && !nativeAccessoryMounted;
+  const jsQueueToolbarVisible = onAccessorySurface && hasCurrentClimb && !effectiveNativeAccessoryMounted;
   // The native iOS tab bar is 49pt; the JS M3 `MaterialTabBar` is taller. Key this
   // on the *rendered* bar, not the variant — Liquid Glass on iOS < 26 / Android
   // falls back to the JS bar. Floating overlays (FAB, snackbar) and scroll padding
   // clear this height, so it has to track the real bar on screen.
   const tabBarConstant = usesNativeTabBar ? TAB_BAR_HEIGHT : MATERIAL_TAB_BAR_HEIGHT;
-  const tabBarHeight = insideTabs ? tabBarConstant : 0;
+  const tabBarHeight = insideTabs && !usesSidebar ? tabBarConstant : 0;
   // Only the native tab bar overlays content (UIKit draws it over the scroll view);
   // the JS `MaterialTabBar` sits in flow.
   const tabBarOverlaysContent = insideTabs && usesNativeTabBar;
@@ -140,7 +183,7 @@ export function computeBottomChromeMetrics({
   return {
     hasCurrentClimb,
     insideTabs,
-    nativeAccessoryMounted,
+    nativeAccessoryMounted: effectiveNativeAccessoryMounted,
     nativeAccessoryVisible,
     jsQueueToolbarVisible,
     tabBarHeight,

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -3,6 +3,7 @@ import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useTheme } from '../providers/theme-provider';
 import { useGlassCapability } from './use-glass-capability';
+import { useDeviceLayout } from './use-device-layout';
 
 /**
  * Whether the device *can* host `NativeTabs.BottomAccessory` — the pure
@@ -24,6 +25,19 @@ export function isBottomAccessoryAvailable(): boolean {
 export function useNativeTabBar(): boolean {
   const { variant } = useTheme();
   const glassCapable = useGlassCapability();
+  const { isPad } = useDeviceLayout();
+  // The iPad adaptive shell renders JS `Tabs` at EVERY iPad width — a glass rail at
+  // regular width, the Material bar in a narrow split (Slide Over / Split View) — and
+  // never `NativeTabs`, so a resize across the breakpoint keeps one navigator mounted
+  // (see `_layout`). So the native tab bar — and the bottom accessory + tab-bar search
+  // role it hosts — is never on screen on iPad. Everything that branches on this
+  // predicate (the climb-list search mode, the accessory mount, bottom-chrome
+  // geometry) must treat iPad as "no native tab bar", or it reaches for a native
+  // accessory / search bar that has no bar to live in — and on an iPad in a narrow
+  // split that would skip the native accessory AND suppress the JS PersistentQueueBar,
+  // dropping the now-playing bar entirely. (`isPad` subsumes the old regular-width
+  // check, since a `regular` width only ever resolves on an iPad.)
+  if (isPad) return false;
   return variant === 'liquidGlass' && glassCapable;
 }
 

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -1,11 +1,15 @@
 import { useMemo } from 'react';
 import { useSegments } from 'expo-router';
+import { useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../providers/theme-provider';
 import { isAccessorySurfaceRoute, isTabsChromeRoute } from '../lib/route-segments';
 import { useStickyAccessoryPresence } from './use-sticky-accessory-presence';
 import { useNativeAccessoryActive, useNativeTabBar } from './use-bottom-accessory';
+import { useDeviceLayout } from './use-device-layout';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
+import { resolveDetailPaneSurface } from '../theme/size-class';
+import { SIDEBAR_WIDTH } from '../theme/layout';
 
 /**
  * Reserves and offsets for chrome that floats over scrollable content (the
@@ -36,6 +40,15 @@ export function useBottomChromeMetrics() {
   const nativeAccessoryMounted = onAccessorySurface && nativeAccessoryActive;
   const nativeTabBar = useNativeTabBar();
   const usesNativeTabBar = insideTabs && nativeTabBar;
+  // Regular-width iPad replaces the bottom tab bar with the left sidebar. Only
+  // widths that also mount the selected-climb detail pane suppress the floating
+  // queue toolbar; tight regular windows keep that toolbar because the pane is
+  // intentionally absent there.
+  const { width: windowWidth } = useWindowDimensions();
+  const { widthClass } = useDeviceLayout();
+  const usesSidebar = insideTabs && widthClass === 'regular';
+  const detailPaneOwnsQueue =
+    usesSidebar && resolveDetailPaneSurface({ width: windowWidth, widthClass, sidebarWidth: SIDEBAR_WIDTH }) === 'pane';
 
   return useMemo(
     () =>
@@ -47,7 +60,19 @@ export function useBottomChromeMetrics() {
         onAccessorySurface,
         hasCurrentClimb,
         nativeAccessoryMounted,
+        usesSidebar,
+        detailPaneOwnsQueue,
       }),
-    [variant, usesNativeTabBar, insets.bottom, insideTabs, onAccessorySurface, hasCurrentClimb, nativeAccessoryMounted],
+    [
+      variant,
+      usesNativeTabBar,
+      insets.bottom,
+      insideTabs,
+      onAccessorySurface,
+      hasCurrentClimb,
+      nativeAccessoryMounted,
+      usesSidebar,
+      detailPaneOwnsQueue,
+    ],
   );
 }

--- a/packages/mobile/src/hooks/use-device-layout.ts
+++ b/packages/mobile/src/hooks/use-device-layout.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { Platform, useWindowDimensions } from 'react-native';
+import { resolveDeviceLayout, type DeviceLayout } from '../theme/size-class';
+
+/**
+ * The adaptive shell's size class, recomputed as the app window resizes —
+ * rotation, Stage Manager, Split View / Slide Over. iPhone is always `compact`;
+ * an iPad is `regular` once its window is wide enough for the sidebar plus a
+ * content pane, and falls back to `compact` (the phone UI verbatim) in a narrow
+ * split. The arithmetic lives in the pure `resolveDeviceLayout` so it is
+ * unit-tested without react-native.
+ *
+ * `isPad` is surfaced alongside the size class so the shell can keep iPad on a
+ * single JS `Tabs` navigator across the regular↔compact boundary (an iPad in a
+ * narrow split is `compact` but must NOT swap to NativeTabs, or the boundary
+ * cross would remount the navigator). It is launch-fixed (`Platform.isPad`),
+ * unlike `widthClass`, which is live.
+ */
+export function useDeviceLayout(): DeviceLayout & { isPad: boolean } {
+  const { width } = useWindowDimensions();
+  // `Platform.isPad` is iOS-only (undefined on Android), so guard on the OS too.
+  const isPad = Platform.OS === 'ios' && Platform.isPad === true;
+  return useMemo(() => ({ ...resolveDeviceLayout({ width, isPad }), isPad }), [width, isPad]);
+}

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -77,3 +77,13 @@ export function isPlayerRoute(segments: Segments): boolean {
 export function isAccessorySurfaceRoute(segments: Segments): boolean {
   return isTopLevelTabRoute(segments) || isPlayerRoute(segments);
 }
+
+/**
+ * The focused tab's route segment (e.g. `'climbs'`), or `null` when the focused
+ * route is not inside the tab navigator. Segment 0 is the `(tabs)` group, so the
+ * tab name is segment 1. Used by the iPad sidebar to highlight the active row
+ * without indexing the route-typed tuple directly.
+ */
+export function tabsActiveSegment(segments: Segments): string | null {
+  return isTabsRoute(segments) ? (segments[1] ?? null) : null;
+}

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -9,6 +9,7 @@ import type { Climb, UserBoard } from '@boardsesh/shared-schema';
 const queue = vi.hoisted(() => ({
   sessionId: 'session-1' as string | null,
   participantId: 'participant-self' as string | null,
+  activeClimbUuid: null as string | null,
   setCurrentClimb: vi.fn(),
   addToQueue: vi.fn(),
   setSessionBoardPath: vi.fn(async () => {}),
@@ -105,6 +106,17 @@ vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
     createElement('button', { onClick: onPress }, children),
+  // The host width-budgets pane vs. sheet (resolveDetailPaneSurface). 1024 clears
+  // the budget, so the regular-width describe takes the pane path; compact stays sheet.
+  useWindowDimensions: () => ({ width: 1024, height: 1366 }),
+}));
+
+// The host reads the device layout to decide sheet (compact) vs pane (regular).
+// Defaults to compact (the bottom-sheet path most tests exercise); the
+// regular-width pane describe flips it.
+const layoutCfg = vi.hoisted(() => ({ widthClass: 'compact' as 'compact' | 'regular' }));
+vi.mock('../../hooks/use-device-layout', () => ({
+  useDeviceLayout: () => ({ widthClass: layoutCfg.widthClass, expanded: false }),
 }));
 
 vi.mock('expo-crypto', () => ({
@@ -217,6 +229,7 @@ vi.mock('../bluetooth-provider', () => ({
 }));
 
 vi.mock('../queue-provider', () => ({
+  useActiveClimbUuid: () => queue.activeClimbUuid,
   useQueueActions: () => ({
     addToQueue: queue.addToQueue,
     setSessionBoardPath: queue.setSessionBoardPath,
@@ -322,6 +335,9 @@ beforeEach(() => {
   presence.resolveAndBindBoardByConfig.mockClear();
   presence.resolveAndBindBoardByUuid.mockClear();
   presence.resetPresence.mockClear();
+  queue.setCurrentClimb.mockClear();
+  queue.activeClimbUuid = null;
+  layoutCfg.widthClass = 'compact';
 });
 
 describe('DrawerHostProvider board presence binding', () => {
@@ -979,5 +995,212 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
     expect(routerDismiss).toHaveBeenCalledTimes(1);
     expect(routerPush).toHaveBeenCalledWith(expect.objectContaining({ pathname: '/boards' }));
     expect(activeBoard.setActiveBoard).not.toHaveBeenCalled();
+  });
+});
+
+describe('DrawerHostProvider iPad pane open (regular width)', () => {
+  beforeEach(() => {
+    // Regular width (1024 window, 96 sidebar) resolves to the detail pane, so
+    // openPlayDrawer drives the right-column PlayDrawer via `openTarget` instead
+    // of navigating to the `/play` route. Committing to the queue is now the
+    // drawer's job (via openTarget.options), so the host never calls
+    // setCurrentClimb on a pane open.
+    layoutCfg.widthClass = 'regular';
+  });
+
+  it('drives the pane open target without navigating to /play', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'pane-open-1').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb);
+    });
+
+    // The pane's selected climb is set on playDrawerPaneProps.openTarget.
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-open-1');
+    });
+    // No override, no caller options → the open target carries an empty options bag.
+    expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.options).toEqual({});
+    // The pane hosts the drawer in place — no full-screen /play navigation.
+    expect(routerNavigate).not.toHaveBeenCalled();
+  });
+
+  it('passes a view-only open through openTarget.options, stripping the analytics source', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'pane-view-1').climb as unknown as Climb;
+    const previewItem = makeQueueItem('queue-preview-1', 'pane-view-1');
+    act(() => {
+      // Feed / beta / climb-view preview: show it in the pane; PlayDrawer decides
+      // whether to commit from openTarget.options (the host doesn't).
+      hosts.at(-1)?.openPlayDrawer(climb, { previewQueueItem: previewItem, source: 'climb_view' });
+    });
+
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-view-1');
+    });
+    const openTarget = hosts.at(-1)?.playDrawerPaneProps?.openTarget;
+    expect(openTarget?.options?.previewQueueItem).toBe(previewItem);
+    // `source` is analytics-only and is stripped before it reaches the open target
+    // (toEqual asserts nothing else — no `source`, no `boardConfig` — leaks through).
+    expect(openTarget?.options).toEqual({ previewQueueItem: previewItem });
+    expect(routerNavigate).not.toHaveBeenCalled();
+  });
+
+  it('forwards the playlist suggestion source through openTarget.options', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const sourceItem = makeQueueItem('queue-source', 'pane-source-climb');
+    const previewItem = makeQueueItem('queue-preview-2', 'pane-preview-2');
+    const playlistSuggestionSource: PlaylistSuggestionSource = {
+      playlistUuid: 'playlist-pane',
+      activatedClimbUuid: sourceItem.climb.uuid,
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [sourceItem.climb, previewItem.climb],
+    };
+
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(previewItem.climb as unknown as Climb, {
+        previewQueueItem: previewItem,
+        playlistSuggestionSource,
+        source: 'climb_view',
+      });
+    });
+
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-preview-2');
+    });
+    const openTarget = hosts.at(-1)?.playDrawerPaneProps?.openTarget;
+    expect(openTarget?.options?.playlistSuggestionSource).toBe(playlistSuggestionSource);
+    // `source` stripped; previewQueueItem + playlistSuggestionSource pass through.
+    expect(openTarget?.options).toEqual({ previewQueueItem: previewItem, playlistSuggestionSource });
+    expect(routerNavigate).not.toHaveBeenCalled();
+  });
+
+  it('applies a cross-board override to the pane board while the wall column stays on the stored board', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const override: BoardConfig = {
+      boardName: 'tension',
+      layoutId: 8,
+      sizeId: 7,
+      setIds: '5,6',
+      angle: 55,
+    };
+    const climb = makeQueueItem('queue-x', 'pane-override-1').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb, { boardConfig: override });
+    });
+
+    await waitFor(() => {
+      // The override differs from the stored kilter board → the pane's drawer
+      // board becomes the override, and it carries the opened climb.
+      expect(hosts.at(-1)?.playDrawerPaneProps?.boardConfig).toMatchObject(override);
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-override-1');
+    });
+    // The persistent "Now on the wall" column stays bound to the stored board.
+    expect(hosts.at(-1)?.boardPanelProps?.boardConfig).toMatchObject({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 40,
+    });
+    // The board is applied via the override state, not the open target — boardConfig
+    // is stripped from options like the /play route path.
+    expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.options).toEqual({});
+    expect(routerNavigate).not.toHaveBeenCalled();
+  });
+
+  it('applies onAngleChange to the pane override board, leaving the wall column board unchanged', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const override: BoardConfig = {
+      boardName: 'tension',
+      layoutId: 8,
+      sizeId: 7,
+      setIds: '5,6',
+      angle: 55,
+    };
+    const climb = makeQueueItem('queue-x', 'pane-angle-1').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb, { boardConfig: override });
+    });
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.boardConfig).toMatchObject(override);
+    });
+
+    act(() => {
+      hosts.at(-1)?.playDrawerPaneProps?.onAngleChange(30);
+    });
+
+    // The angle write targets the override board the pane is showing…
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.boardConfig).toMatchObject({ ...override, angle: 30 });
+    });
+    // …not the stored active board the wall column renders against.
+    expect(hosts.at(-1)?.boardPanelProps?.boardConfig).toMatchObject({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 40,
+    });
+  });
+
+  it('bumps openTarget.nonce when the same climb is re-opened so the pane re-applies', async () => {
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'pane-renonce-1').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb);
+    });
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-renonce-1');
+    });
+    const firstNonce = hosts.at(-1)?.playDrawerPaneProps?.openTarget?.nonce;
+    expect(firstNonce).toBeDefined();
+
+    // Re-tap the same climb: a new open target (bumped nonce) so the pane re-applies
+    // even though the shown climb is unchanged.
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb);
+    });
+    await waitFor(() => {
+      expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.nonce).not.toBe(firstNonce);
+    });
+    expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget?.climb.uuid).toBe('pane-renonce-1');
+    expect(routerNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /play and leaves the pane open target null on compact width', async () => {
+    // Compact width has no persistent pane — the open falls back to the /play route.
+    layoutCfg.widthClass = 'compact';
+    const hosts: Array<HostValue> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'pane-compact-1').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb);
+    });
+
+    expect(routerNavigate).toHaveBeenCalledWith('/play');
+    // The pane props still resolve (a board is loaded) but the pane never receives
+    // an open target on compact — that path drives the route's playTarget instead.
+    expect(hosts.at(-1)?.playDrawerPaneProps?.openTarget).toBeNull();
   });
 });

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -12,6 +12,7 @@
  */
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useWindowDimensions } from 'react-native';
 import { router } from 'expo-router';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { buildBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
@@ -36,6 +37,9 @@ import { useAuth } from './auth-provider';
 import { useReduceMotion } from '../hooks/use-reduce-motion';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
 import { useQueueActions, useQueueSessionControls } from './queue-provider';
+import { useDeviceLayout } from '../hooks/use-device-layout';
+import { resolveDetailPaneSurface } from '../theme/size-class';
+import { SIDEBAR_WIDTH } from '../theme/layout';
 import { useQueueSnackbar } from './queue-snackbar-provider';
 import { useBoardPresenceControls, type ResolveBoardUuidArgs } from './board-presence-provider';
 import { useOptionalBluetoothContext } from './bluetooth-provider';
@@ -97,6 +101,40 @@ export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
   source?: 'climb_view' | 'current_queue_item' | 'mobile' | 'board_presence';
 };
 
+/** Props the iPad right-column PlayDrawer pane consumes (regular width). Mirrors
+ *  the `/play` route's PlayDrawer props (see app/play.tsx) so the pane and the
+ *  full-screen route render the same drawer; the pane just drives it via
+ *  `openTarget` instead of navigating. Null in the context while no board is
+ *  resolved. Consumed by `IpadPlayPane`. */
+export type PlayDrawerPaneProps = {
+  boardConfig: BoardConfig;
+  onAngleChange: (angle: number) => void;
+  isAngleAdjustable: boolean;
+  onOpenQueue: () => void;
+  boardMismatch: boolean;
+  mismatchBoardLabel: string | undefined;
+  onSwitchBoard: () => void;
+  onOpenClimbActions: (climb: Climb) => void;
+  /** The climb to show in the pane, with a bumped nonce per selection so the pane
+   *  re-applies even when the same climb is re-tapped. Set by `openPlayDrawer` on
+   *  iPad regular width (where it drives the pane instead of the `/play` route). */
+  openTarget: PlayDrawerOpenTarget | null;
+};
+
+/** Props for the iPad "Now on the wall" column (regular landscape) — the same
+ *  wall feed / history / stats / switch-board content the BoardSheet modal shows,
+ *  rendered inline. Mirrors the BoardSheet props passed below; null while no board
+ *  is resolved. Consumed by `IpadWallColumn`. */
+export type NowOnTheWallColumnProps = {
+  boardLabel: string | null;
+  boardConfig: BoardConfig | null;
+  onSwitchBoard: () => void;
+  onClimbPress: (action: BoardSheetClimbAction) => void;
+  onAddToQueue: (action: BoardSheetClimbAction) => void;
+  onOpenPlaylist: (action: BoardSheetClimbAction) => void;
+  onOpenActions: (action: BoardSheetClimbAction) => void;
+};
+
 type DrawerHostValue = {
   /** User's stored active board config. Temporary PlayDrawer overrides are not
    *  reflected here, so persistent queue/log-ascent surfaces stay bound to the
@@ -123,6 +161,13 @@ type DrawerHostValue = {
    *  separate Switch-board control). Wired to the board glyph when the
    *  `board-presence` flag is on. */
   openBoardSheet: () => void;
+  /** Props for the iPad right-column PlayDrawer pane (regular width); null while
+   *  no board is resolved. Consumed by `IpadPlayPane` in the shell. On iPad regular
+   *  width `openPlayDrawer` drives this pane instead of the `/play` route. */
+  playDrawerPaneProps: PlayDrawerPaneProps | null;
+  /** Props for the iPad "Now on the wall" column (regular landscape); null while
+   *  no board is resolved. Consumed by `IpadWallColumn` in the shell. */
+  boardPanelProps: NowOnTheWallColumnProps | null;
 };
 
 const DrawerHostContext = createContext<DrawerHostValue | null>(null);
@@ -202,6 +247,12 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // route consumes this via usePlayDrawerRoute and runs PlayDrawer's openDrawer.
   const [playTarget, setPlayTarget] = useState<PlayDrawerOpenTarget | null>(null);
   const playTargetNonceRef = useRef(0);
+  // iPad regular width shows the PlayDrawer inline in the right-column pane
+  // (IpadPlayPane) instead of the full-screen `/play` route. `paneTarget` is the
+  // pane's equivalent of `playTarget`: the selected climb with a per-selection
+  // nonce so re-tapping the same climb still re-applies it in the pane.
+  const [paneTarget, setPaneTarget] = useState<PlayDrawerOpenTarget | null>(null);
+  const paneTargetNonceRef = useRef(0);
   // QueueSheet stays mounted (whenever a board is resolved) and is opened via its
   // imperative handle. gorhom `present()` driven from a `visible`-prop effect is
   // a silent no-op in this app, so we present/dismiss synchronously from the
@@ -209,6 +260,17 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const queueSheetRef = useRef<QueueSheetHandle>(null);
   const boardSheetRef = useRef<BoardSheetHandle>(null);
   const { data: activeBoard } = useActiveBoard();
+  // iPad regular width hosts the PlayDrawer as a persistent right-column pane
+  // rather than the `/play` route. `usesDetailPane` mirrors the shell's pane
+  // budget (resolveDetailPaneSurface — the tightest regular portraits fall back
+  // to the route + compact sheets). A ref lets the empty-dep `openPlayDrawer`
+  // read it without churning its identity.
+  const { width: windowWidth } = useWindowDimensions();
+  const { widthClass } = useDeviceLayout();
+  const usesDetailPane =
+    resolveDetailPaneSurface({ width: windowWidth, widthClass, sidebarWidth: SIDEBAR_WIDTH }) === 'pane';
+  const usesDetailPaneRef = useRef(usesDetailPane);
+  usesDetailPaneRef.current = usesDetailPane;
   // Auth gates two things here. (1) myBoards requires authentication: running it
   // while logged out throws "Authentication required to perform this operation"
   // (pure noise in error tracking) and returns nothing useful — every other call
@@ -345,12 +407,28 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     } else {
       setBoardConfigOverride(null);
     }
+    // iPad regular width hosts the drawer as a persistent right-column pane, so
+    // drive it in place instead of navigating to `/play`. The pane reads
+    // `paneTarget` via playDrawerPaneProps and re-applies on the bumped nonce (a
+    // re-tap of the same climb still re-applies). No router.navigate → no modal.
+    if (usesDetailPaneRef.current) {
+      paneTargetNonceRef.current += 1;
+      setPaneTarget({ climb, options: openOptions, nonce: paneTargetNonceRef.current });
+      return;
+    }
     // Stash the target (bumped nonce) and navigate. When `/play` is already up the
     // navigate is a no-op, but the new nonce re-applies the target in place.
     playTargetNonceRef.current += 1;
     setPlayTarget({ climb, options: openOptions, nonce: playTargetNonceRef.current });
     router.navigate('/play');
   }, []);
+
+  // Drop the pane's selected climb when the pane goes away (a resize into compact,
+  // or a narrow-regular split where the /play route takes over), so a later return
+  // to the pane starts from the current climb rather than a stale selection.
+  useEffect(() => {
+    if (!usesDetailPane) setPaneTarget(null);
+  }, [usesDetailPane]);
 
   // Reset on route unmount (close): drop the board override so non-drawer surfaces
   // snap back to the stored board, and clear the open target so a stray remount
@@ -608,6 +686,67 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const boardSheetLabel = useMemo(() => formatActiveBoardLabel(activeBoard), [activeBoard]);
 
+  const isAngleAdjustable = activeBoard?.isAngleAdjustable ?? true;
+
+  // One source of truth for the iPad pane's PlayDrawer props, mirroring the `/play`
+  // route's props (see app/play.tsx). `boardConfig` is the override-inclusive
+  // active board so a foreign-board climb renders on its own board; `openTarget`
+  // is the pane's selected climb. Null while no board is resolved.
+  const playDrawerPaneProps = useMemo<PlayDrawerPaneProps | null>(
+    () =>
+      activeBoardConfig
+        ? {
+            boardConfig: activeBoardConfig,
+            onAngleChange: handleAngleChange,
+            isAngleAdjustable,
+            onOpenQueue: openQueueSheet,
+            boardMismatch,
+            mismatchBoardLabel,
+            onSwitchBoard: handleSwitchBoardFromDrawer,
+            onOpenClimbActions: openClimbActions,
+            openTarget: paneTarget,
+          }
+        : null,
+    [
+      activeBoardConfig,
+      handleAngleChange,
+      isAngleAdjustable,
+      openQueueSheet,
+      boardMismatch,
+      mismatchBoardLabel,
+      handleSwitchBoardFromDrawer,
+      openClimbActions,
+      paneTarget,
+    ],
+  );
+
+  // Props for the iPad "Now on the wall" column — the same handlers passed to the
+  // BoardSheet modal below, surfaced via context so the inline column renders the
+  // identical wall feed. Mirrors playDrawerPaneProps; null while no board resolved.
+  const boardPanelProps = useMemo<NowOnTheWallColumnProps | null>(
+    () =>
+      storedActiveBoardConfig
+        ? {
+            boardLabel: boardSheetLabel,
+            boardConfig: storedActiveBoardConfig,
+            onSwitchBoard: handleSwitchBoardFromSheet,
+            onClimbPress: handleBoardSheetClimbPress,
+            onAddToQueue: handleBoardSheetAddToQueue,
+            onOpenPlaylist: handleBoardSheetOpenPlaylist,
+            onOpenActions: handleBoardSheetOpenActions,
+          }
+        : null,
+    [
+      storedActiveBoardConfig,
+      boardSheetLabel,
+      handleSwitchBoardFromSheet,
+      handleBoardSheetClimbPress,
+      handleBoardSheetAddToQueue,
+      handleBoardSheetOpenPlaylist,
+      handleBoardSheetOpenActions,
+    ],
+  );
+
   const value = useMemo<DrawerHostValue>(
     () => ({
       boardConfig: storedActiveBoardConfig,
@@ -619,6 +758,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openAddBetaVideo,
       openQueueSheet,
       openBoardSheet,
+      playDrawerPaneProps,
+      boardPanelProps,
     }),
     [
       storedActiveBoardConfig,
@@ -630,10 +771,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openAddBetaVideo,
       openQueueSheet,
       openBoardSheet,
+      playDrawerPaneProps,
+      boardPanelProps,
     ],
   );
-
-  const isAngleAdjustable = activeBoard?.isAngleAdjustable ?? true;
 
   // Volatile player state for the `app/play.tsx` route (separate context — see
   // PlayDrawerRouteValue — so the wide useDrawerHost consumers don't re-render

--- a/packages/mobile/src/theme/__tests__/size-class.test.ts
+++ b/packages/mobile/src/theme/__tests__/size-class.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveDeviceLayout,
+  resolveWallSurface,
+  resolveDetailPaneSurface,
+  resolveDetailPaneWidth,
+  REGULAR_WIDTH_BREAKPOINT,
+  EXPANDED_WIDTH_BREAKPOINT,
+} from '../size-class';
+
+const SIDEBAR_WIDTH = 96;
+
+describe('resolveDeviceLayout', () => {
+  it('keeps every iPhone compact regardless of width', () => {
+    // An iPhone is never an iPad, so even a wide landscape phone stays compact
+    // (renders the phone UI verbatim).
+    expect(resolveDeviceLayout({ width: 932, isPad: false })).toEqual({ widthClass: 'compact', expanded: false });
+    expect(resolveDeviceLayout({ width: 430, isPad: false })).toEqual({ widthClass: 'compact', expanded: false });
+  });
+
+  it('keeps an iPad compact in a narrow split (Slide Over / ⅓ / ½)', () => {
+    // 12.9" iPad split widths: Slide Over ~320, ½ ~507, ⅔ ~664 — all below 700.
+    for (const width of [320, 375, 507, 664, REGULAR_WIDTH_BREAKPOINT - 1]) {
+      expect(resolveDeviceLayout({ width, isPad: true })).toEqual({ widthClass: 'compact', expanded: false });
+    }
+  });
+
+  it('is regular but not expanded for a narrow-regular iPad window', () => {
+    // 11" iPad portrait (834) and a ⅔ split that clears 700 but not 1024.
+    expect(resolveDeviceLayout({ width: 834, isPad: true })).toEqual({ widthClass: 'regular', expanded: false });
+    expect(resolveDeviceLayout({ width: REGULAR_WIDTH_BREAKPOINT, isPad: true })).toEqual({
+      widthClass: 'regular',
+      expanded: false,
+    });
+    expect(resolveDeviceLayout({ width: EXPANDED_WIDTH_BREAKPOINT - 1, isPad: true })).toEqual({
+      widthClass: 'regular',
+      expanded: false,
+    });
+  });
+
+  it('is regular but not expanded across the tightest real iPad portraits', () => {
+    // iPad mini portrait (744), 9.7"/10.2" portrait (768/810) — the narrow-regular
+    // band where a persistent detail pane squeezes the browse list. All clear 700
+    // (sidebar shows) but not 1024 (no master+detail). See resolveDetailPaneSurface.
+    for (const width of [744, 768, 810]) {
+      expect(resolveDeviceLayout({ width, isPad: true })).toEqual({ widthClass: 'regular', expanded: false });
+    }
+  });
+
+  it('is expanded for a full-screen iPad (portrait 1024+ and any landscape)', () => {
+    for (const width of [EXPANDED_WIDTH_BREAKPOINT, 1194, 1366]) {
+      expect(resolveDeviceLayout({ width, isPad: true })).toEqual({ widthClass: 'regular', expanded: true });
+    }
+  });
+});
+
+describe('resolveWallSurface', () => {
+  it('shows no wall surface at compact width (phone UI owns its own wall chrome)', () => {
+    for (const width of [320, 507, 664, 932]) {
+      expect(resolveWallSurface({ width, widthClass: 'compact', sidebarWidth: SIDEBAR_WIDTH })).toBe('none');
+    }
+  });
+
+  it('shows a strip in portrait, where a 4th column would crush the list', () => {
+    // 11" portrait 834 → 118pt list; 13" portrait 1032 → 316pt list — both below the floor.
+    expect(resolveWallSurface({ width: 834, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('strip');
+    expect(resolveWallSurface({ width: 1032, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('strip');
+  });
+
+  it('shows a dedicated column in landscape on both iPad sizes', () => {
+    // Wall column stays fixed at 300pt; content + detail split the remaining width.
+    // 11" landscape 1194 → 399/399pt; 13" landscape 1366 → 485/485pt.
+    expect(resolveWallSurface({ width: 1194, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('column');
+    expect(resolveWallSurface({ width: 1366, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('column');
+  });
+
+  it('flips strip→column exactly at the content floor', () => {
+    // balancedContentWidth = (width - 96 - 300) / 2; column requires >= 390 → width >= 1176.
+    expect(resolveWallSurface({ width: 1175, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('strip');
+    expect(resolveWallSurface({ width: 1176, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('column');
+  });
+});
+
+describe('resolveDetailPaneWidth', () => {
+  it('splits content and detail evenly when the wall column is visible', () => {
+    expect(resolveDetailPaneWidth({ width: 1366, sidebarWidth: SIDEBAR_WIDTH, wallColumnVisible: true })).toBe(485);
+    expect(resolveDetailPaneWidth({ width: 1194, sidebarWidth: SIDEBAR_WIDTH, wallColumnVisible: true })).toBe(399);
+  });
+
+  it('uses the standalone detail-pane clamp when the wall column is hidden', () => {
+    expect(resolveDetailPaneWidth({ width: 744, sidebarWidth: SIDEBAR_WIDTH, wallColumnVisible: false })).toBe(320);
+    expect(resolveDetailPaneWidth({ width: 1024, sidebarWidth: SIDEBAR_WIDTH, wallColumnVisible: false })).toBe(348);
+    expect(resolveDetailPaneWidth({ width: 1366, sidebarWidth: SIDEBAR_WIDTH, wallColumnVisible: false })).toBe(400);
+  });
+});
+
+describe('resolveDetailPaneSurface', () => {
+  it('uses the compact sheet outside regular iPad width', () => {
+    expect(resolveDetailPaneSurface({ width: 932, widthClass: 'compact', sidebarWidth: SIDEBAR_WIDTH })).toBe('sheet');
+  });
+
+  it('suppresses the pane when the browse list would fall below the readable floor', () => {
+    expect(resolveDetailPaneSurface({ width: 744, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('sheet');
+    expect(resolveDetailPaneSurface({ width: 815, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('sheet');
+  });
+
+  it('mounts the pane once the browse list clears the readable floor', () => {
+    expect(resolveDetailPaneSurface({ width: 816, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('pane');
+    expect(resolveDetailPaneSurface({ width: 834, widthClass: 'regular', sidebarWidth: SIDEBAR_WIDTH })).toBe('pane');
+  });
+});

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -44,6 +44,9 @@ export const iosSystemColors: Record<string, OpaqueColorValue> | null =
  * - `primaryFill`: brand colour for a FILLED surface/button background.
  * - `onPrimary`: text/icon colour sitting on `primaryFill`.
  * - `accent`: warm amber spark for highlights — FILL-ONLY, always pair with dark text.
+ * - `live`: the "this climb is physically lit / now on the wall" status hue. A
+ *   dedicated role (not `warning`) so a future warning retune can't silently shift
+ *   the board-presence affordance. Resolves to the warm amber per scheme.
  *
  * Contrast (WCAG, light): white-on-primary #6D28D9 = 7.10:1; black-on-accent = 8.95:1.
  */
@@ -56,6 +59,7 @@ export const brandColors = {
   success: '#047857',
   warning: '#B45309',
   error: '#C81E1E',
+  live: '#B45309',
 } as const;
 
 /**
@@ -76,6 +80,7 @@ export const brandColorsDark = {
   success: '#34D399',
   warning: '#FBBF24',
   error: '#F87171',
+  live: '#FBBF24',
 } as const;
 
 /**

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -90,3 +90,24 @@ export const MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT = glassSize.standard;
  *  rounding — not absorb a constant-vs-reality mismatch — so it stays a fixed hairline
  *  instead of a hand-tuned per-device offset. */
 export const TABBAR_SEAM_OVERLAP = 1;
+
+/** Width of the iPad adaptive-shell sidebar rail (the glass left rail that
+ *  replaces the bottom tab bar at `regular` width — see `size-class.ts`). An
+ *  icon-over-label rail: wide enough for a 44pt touch target plus a caption,
+ *  narrow enough to leave the content panes the bulk of the canvas. */
+export const SIDEBAR_WIDTH = 96;
+
+/**
+ * iPad sidebar nav-row chrome dimensions, kept here on the token ladder rather
+ * than as raw numbers in `IpadSidebar` so the active-destination affordance is
+ * tunable and reads as one system with the M3 nav indicator. The active pill
+ * height snaps to the 8pt grid (the M3 nav indicator is 32 tall); the width
+ * seats the {@link SIDEBAR_NAV_ICON_SIZE} glyph with breathing room.
+ */
+export const SIDEBAR_NAV_PILL_HEIGHT = 32;
+export const SIDEBAR_NAV_PILL_WIDTH = 48;
+export const SIDEBAR_NAV_ICON_SIZE = 26;
+
+/** Diameter of the "live"/now-on-the-wall status dot in the rail cell and wall
+ *  strip — one value so every board-presence surface uses the same dot. */
+export const WALL_LIVE_DOT_SIZE = 10;

--- a/packages/mobile/src/theme/size-class.ts
+++ b/packages/mobile/src/theme/size-class.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure size-class arbitration for the adaptive iPad shell. No react-native
+ * imports, so it unit-tests as plain functions (mirrors the pure
+ * `bottom-chrome-metrics.ts` pattern). The React wrapper that feeds it window
+ * dimensions lives in `hooks/use-device-layout.ts`.
+ *
+ * - `compact` — every iPhone, plus an iPad whose window is too narrow for a
+ *   sidebar + content (Slide Over, a ⅓/½/⅔ Split View). Compact renders the
+ *   existing phone UI verbatim, so no phase can regress the phone.
+ * - `regular` — an iPad window wide enough for the left sidebar + at least one
+ *   content pane.
+ * - `expanded` — additionally wide enough for a master + detail pane side by
+ *   side (the Climbs two-pane browser, Phase 3). A flag on top of `regular`.
+ */
+
+/** Below this width an iPad falls back to the compact phone UI. */
+export const REGULAR_WIDTH_BREAKPOINT = 700;
+
+/** At/above this width a regular layout also fits a master + detail pane. */
+export const EXPANDED_WIDTH_BREAKPOINT = 1024;
+
+export type WidthClass = 'compact' | 'regular';
+
+export type DeviceLayout = {
+  widthClass: WidthClass;
+  /** True when the width also has room for a master + detail pane side by side. */
+  expanded: boolean;
+};
+
+/**
+ * Resolve the size class from the app window width and whether the device is an
+ * iPad. Only iPad opts into the adaptive shell — every iPhone stays `compact`
+ * regardless of width — and an iPad in a narrow split is `compact` too, so the
+ * sidebar appears only when there is genuinely room for two columns.
+ */
+export function resolveDeviceLayout({ width, isPad }: { width: number; isPad: boolean }): DeviceLayout {
+  if (!isPad || width < REGULAR_WIDTH_BREAKPOINT) {
+    return { widthClass: 'compact', expanded: false };
+  }
+  return { widthClass: 'regular', expanded: width >= EXPANDED_WIDTH_BREAKPOINT };
+}
+
+/**
+ * The live-wall surface in the regular-width shell. `column` is a dedicated
+ * "Now on the wall" column on the trailing edge (landscape, where there's room);
+ * `strip` is a slim header docked atop the detail pane (portrait/narrow, where a
+ * 4th column would crush the browse list); `none` is compact width, which renders
+ * the phone UI and carries its own wall chrome.
+ */
+export type WallSurface = 'none' | 'strip' | 'column';
+
+/** Width of the dedicated wall column when it is shown. */
+export const WALL_COLUMN_WIDTH = 300;
+
+/** Max detail (play) pane width when it is the only persistent trailing pane. */
+export const DETAIL_PANE_MAX_WIDTH = 400;
+
+/** The browse list must keep at least this width; below it the wall drops from a
+ *  dedicated column to a compact strip atop the detail pane. */
+export const WALL_COLUMN_CONTENT_FLOOR = 400;
+
+/** The dedicated wall column keeps the trailing column fixed, then lets content
+ *  and detail split the remaining width. This slightly-lower floor preserves the
+ *  11" iPad landscape column while keeping portrait/narrow layouts on the strip. */
+export const WALL_COLUMN_BALANCED_CONTENT_FLOOR = 390;
+
+/**
+ * Decide how the wall surface appears, from the window width and the resolved
+ * size class. A dedicated column only when sidebar + fixed wall column +
+ * balanced content/detail columns fit; otherwise a compact strip. Pure (the
+ * sidebar width is injected) so it unit-tests without react-native.
+ *
+ * Worked examples (sidebar 96): 11" landscape 1194 → 399/399 content+detail
+ * → `column`; 11" portrait 834 → 219/219 → `strip`; 13" portrait 1032 →
+ * 318/318 → `strip`; 13" landscape 1366 → 485/485 → `column`.
+ */
+export function resolveWallSurface({
+  width,
+  widthClass,
+  sidebarWidth,
+}: {
+  width: number;
+  widthClass: WidthClass;
+  sidebarWidth: number;
+}): WallSurface {
+  if (widthClass !== 'regular') return 'none';
+  const balancedContentWidth = (width - sidebarWidth - WALL_COLUMN_WIDTH) / 2;
+  return balancedContentWidth >= WALL_COLUMN_BALANCED_CONTENT_FLOOR ? 'column' : 'strip';
+}
+
+/** Minimum width the persistent detail (play) pane needs to be useful — the floor
+ *  of its standalone clamp. Below the content floor the pane is suppressed so the
+ *  browse list keeps room (see {@link resolveDetailPaneSurface}). */
+export const DETAIL_PANE_MIN_WIDTH = 320;
+
+export function resolveDetailPaneWidth({
+  width,
+  sidebarWidth,
+  wallColumnVisible,
+}: {
+  width: number;
+  sidebarWidth: number;
+  wallColumnVisible: boolean;
+}): number {
+  if (wallColumnVisible) {
+    return Math.round((width - sidebarWidth - WALL_COLUMN_WIDTH) / 2);
+  }
+  return Math.round(Math.min(DETAIL_PANE_MAX_WIDTH, Math.max(DETAIL_PANE_MIN_WIDTH, width * 0.34)));
+}
+
+/**
+ * How the detail (play) pane appears in the regular-width shell. `pane` is the
+ * persistent right-column master-detail surface; `sheet` falls back to the
+ * compact bottom-sheet PlayDrawer so the browse list keeps the full content
+ * column.
+ */
+export type DetailPaneSurface = 'pane' | 'sheet';
+
+/**
+ * Decide whether the persistent detail pane is mounted, from the same width
+ * budget `resolveWallSurface` uses — never a raw breakpoint. The pane only
+ * mounts when, after the sidebar and a minimum pane width, the browse list still
+ * clears `WALL_COLUMN_CONTENT_FLOOR`. The narrowest regular windows — iPad mini
+ * portrait (744) and 9.7–10.2" portrait (768/810) — would otherwise squeeze the
+ * list to ~iPhone-SE width beneath a persistent pane, so there it drops to a
+ * sheet; 11"+ portrait (≥834 → ≥418 list) keeps the pane. Pure (sidebar width
+ * injected) so it unit-tests without react-native.
+ */
+export function resolveDetailPaneSurface({
+  width,
+  widthClass,
+  sidebarWidth,
+}: {
+  width: number;
+  widthClass: WidthClass;
+  sidebarWidth: number;
+}): DetailPaneSurface {
+  if (widthClass !== 'regular') return 'sheet';
+  const contentWidth = width - sidebarWidth - DETAIL_PANE_MIN_WIDTH;
+  return contentWidth >= WALL_COLUMN_CONTENT_FLOOR ? 'pane' : 'sheet';
+}

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -26,6 +26,7 @@
   "boardPresence": {
     "title": "Now on the wall",
     "open": "On the wall",
+    "railDark": "Nothing lit right now",
     "openAria": "See what's on the wall",
     "openAriaWithClimb": "See what's on the wall: {{name}}",
     "nowOnWallAnnouncement": "Now on the wall: {{name}}",
@@ -526,6 +527,10 @@
   "playView": {
     "previewBadge": "Preview",
     "setActive": "Set active",
+    "paneEmpty": {
+      "title": "Pick a climb",
+      "subtitle": "Tap a climb to see it here."
+    },
     "previousFrame": "Previous frame",
     "nextFrame": "Next frame",
     "play": "Play",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -26,6 +26,7 @@
   "boardPresence": {
     "title": "Ahora en el muro",
     "open": "En el muro",
+    "railDark": "Nada encendido ahora",
     "openAria": "Ver qué hay en el muro",
     "openAriaWithClimb": "Ver qué hay en el muro: {{name}}",
     "nowOnWallAnnouncement": "Ahora en el muro: {{name}}",
@@ -526,6 +527,10 @@
   "playView": {
     "previewBadge": "Vista previa",
     "setActive": "Activar",
+    "paneEmpty": {
+      "title": "Elige un bloque",
+      "subtitle": "Toca un bloque para verlo aquí."
+    },
     "previousFrame": "Fotograma anterior",
     "nextFrame": "Fotograma siguiente",
     "play": "Reproducir",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -26,6 +26,7 @@
   "boardPresence": {
     "title": "Sur le mur maintenant",
     "open": "Sur le mur",
+    "railDark": "Rien d'allumé pour l'instant",
     "openAria": "Voir ce qui est sur le mur",
     "openAriaWithClimb": "Voir ce qui est sur le mur : {{name}}",
     "nowOnWallAnnouncement": "Sur le mur maintenant : {{name}}",
@@ -526,6 +527,10 @@
   "playView": {
     "previewBadge": "Aperçu",
     "setActive": "Activer",
+    "paneEmpty": {
+      "title": "Choisis un bloc",
+      "subtitle": "Touche un bloc pour le voir ici."
+    },
     "previousFrame": "Image précédente",
     "nextFrame": "Image suivante",
     "play": "Lire",

--- a/scripts/__tests__/assert-screenshot-dimensions.test.ts
+++ b/scripts/__tests__/assert-screenshot-dimensions.test.ts
@@ -67,6 +67,32 @@ describe('findOffenders', () => {
     ).toMatch(/no accepted-size list/);
   });
 
+  it('accepts the iPad landscape App Store sizes', () => {
+    expect(
+      findOffenders('ipad-pro-13-inch-m5', [
+        { name: 'ipad-pro-13-inch-m5/00-home.png', buffer: pngHeader({ width: 2752, height: 2064 }) },
+      ]),
+    ).toEqual([]);
+    expect(
+      findOffenders('ipad-pro-13-inch-m5', [
+        { name: 'ipad-pro-13-inch-m5/00-home.png', buffer: pngHeader({ width: 2732, height: 2048 }) },
+      ]),
+    ).toEqual([]);
+    expect(
+      findOffenders('ipad-pro-11-inch-m5', [
+        { name: 'ipad-pro-11-inch-m5/00-home.png', buffer: pngHeader({ width: 2420, height: 1668 }) },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('rejects portrait iPad screenshots for the landscape store slots', () => {
+    const offenders = findOffenders('ipad-pro-13-inch-m5', [
+      { name: 'ipad-pro-13-inch-m5/00-home.png', buffer: pngHeader({ width: 2064, height: 2752 }) },
+    ]);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0].reason).toMatch(/2064x2752/);
+  });
+
   it('flags a wrong size, reporting both file and dimensions', () => {
     const offenders = findOffenders(slug, [
       { name: `${slug}/bad.png`, buffer: pngHeader({ width: 1284, height: 2778 }) },
@@ -101,6 +127,18 @@ describe('findScreenshotTreeOffenders', () => {
             buffer: pngHeader({ width: 1320, height: 2868 }),
           },
         ],
+        'ipad-pro-13-inch-m5': [
+          {
+            name: `${locale}/ipad-pro-13-inch-m5/00-home.png`,
+            buffer: pngHeader({ width: 2752, height: 2064 }),
+          },
+        ],
+        'ipad-pro-11-inch-m5': [
+          {
+            name: `${locale}/ipad-pro-11-inch-m5/00-home.png`,
+            buffer: pngHeader({ width: 2420, height: 1668 }),
+          },
+        ],
       };
     }
     for (const [locale, devices] of Object.entries(overrides)) {
@@ -113,6 +151,20 @@ describe('findScreenshotTreeOffenders', () => {
 
   it('accepts a complete localized common-device tree', () => {
     expect(findScreenshotTreeOffenders(screenshotTree())).toEqual([]);
+  });
+
+  it('flags a missing expected iPad device folder even when every locale is consistent', () => {
+    const tree = screenshotTree();
+    for (const devices of Object.values(tree)) {
+      delete devices['ipad-pro-11-inch-m5'];
+    }
+    const offenders = findScreenshotTreeOffenders(tree);
+    expect(
+      offenders.some(
+        (offender) =>
+          offender.file === 'en-US/ipad-pro-11-inch-m5' && /missing device screenshot folder/.test(offender.reason),
+      ),
+    ).toBe(true);
   });
 
   it('flags missing App Store locales', () => {
@@ -129,6 +181,18 @@ describe('findScreenshotTreeOffenders', () => {
           {
             name: 'de-DE/iphone-16-pro-max/00-home.png',
             buffer: pngHeader({ width: 1320, height: 2868 }),
+          },
+        ],
+        'ipad-pro-13-inch-m5': [
+          {
+            name: 'de-DE/ipad-pro-13-inch-m5/00-home.png',
+            buffer: pngHeader({ width: 2752, height: 2064 }),
+          },
+        ],
+        'ipad-pro-11-inch-m5': [
+          {
+            name: 'de-DE/ipad-pro-11-inch-m5/00-home.png',
+            buffer: pngHeader({ width: 2420, height: 1668 }),
           },
         ],
       },

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   buildScreenshotEnv,
   deviceSlug,
+  metroDevClientUrl,
   parseArgs,
+  renderMaestroFlowForIosDevice,
   resolveAppStoreLocaleTargets,
+  rotationDegreesForIosOrientation,
+  validateIosAppLauncherUrl,
+  type IosScreenshotDevice,
   type ScreenshotOptions,
 } from '../mobile-screenshots';
 
-const commonDevices = ['iPhone 16 Pro Max'];
+const phoneDevices = ['iPhone 16 Pro Max'];
+const ipadDevices = ['iPad Pro 13-inch (M5)', 'iPad Pro 11-inch (M5)'];
+const commonDevices = [...phoneDevices, ...ipadDevices];
 const allAppLocales: ScreenshotOptions['appLocales'] = ['en-US', 'es', 'fr'];
 
 function makeOptions(overrides: Partial<ScreenshotOptions> = {}): ScreenshotOptions {
@@ -44,6 +55,7 @@ describe('deviceSlug', () => {
   it('collapses runs of non-alphanumerics and trims edges', () => {
     expect(deviceSlug('  Pixel 8 (Pro) ')).toBe('pixel-8-pro');
     expect(deviceSlug('iPad Pro 13"')).toBe('ipad-pro-13');
+    expect(deviceSlug('iPad Pro 13-inch (M5)')).toBe('ipad-pro-13-inch-m5');
   });
 });
 
@@ -117,6 +129,11 @@ describe('parseArgs', () => {
     expect(parseArgs(['--devices', 'common', '--locales', 'all'])).toEqual(makeOptions());
   });
 
+  it('maps --devices phones and --devices ipads to their platform groups', () => {
+    expect(parseArgs(['--devices', 'phones']).devices).toEqual(phoneDevices);
+    expect(parseArgs(['--devices', 'ipads']).devices).toEqual(ipadDevices);
+  });
+
   it('rejects invalid locales and empty comma lists', () => {
     expect(() => parseArgs(['--locales', 'de'])).toThrow(/supported app locales/);
     expect(() => parseArgs(['--devices', ','])).toThrow(/at least one device/);
@@ -188,6 +205,98 @@ describe('buildScreenshotEnv', () => {
     );
     expect(overridden.EXPO_PUBLIC_SCREENSHOT_USER_EMAIL).toBe('shots@boardsesh.com');
     expect(overridden.EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD).toBe('secret');
+  });
+});
+
+describe('metroDevClientUrl', () => {
+  it('uses the Expo app scheme that iOS dev launcher accepts', () => {
+    expect(metroDevClientUrl(8091)).toBe('exp+boardsesh://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8091');
+  });
+});
+
+describe('validateIosAppLauncherUrl', () => {
+  function hasPlutil() {
+    return spawnSync('command', ['-v', 'plutil'], { shell: true, stdio: 'ignore' }).status === 0;
+  }
+
+  function writeInfoPlist(appPath: string, launcherUrl: string) {
+    writeFileSync(
+      join(appPath, 'Info.plist'),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>DEV_CLIENT_DEFAULT_LAUNCHER_URL</key>
+  <string>${launcherUrl}</string>
+</dict>
+</plist>
+`,
+    );
+  }
+
+  it('accepts an iOS app path baked for the active Metro port', () => {
+    if (!hasPlutil()) return;
+    const tempDir = mkdtempSync(join(tmpdir(), 'boardsesh-test-app-'));
+    const appPath = join(tempDir, 'Boardsesh.app');
+    mkdirSync(appPath);
+    try {
+      writeInfoPlist(appPath, 'http://localhost:8091');
+      expect(() => validateIosAppLauncherUrl(appPath, 8091)).not.toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an iOS app path baked for a different Metro port', () => {
+    if (!hasPlutil()) return;
+    const tempDir = mkdtempSync(join(tmpdir(), 'boardsesh-test-app-'));
+    const appPath = join(tempDir, 'Boardsesh.app');
+    mkdirSync(appPath);
+    try {
+      writeInfoPlist(appPath, 'http://localhost:8081');
+      expect(() => validateIosAppLauncherUrl(appPath, 8091)).toThrow(/expected http:\/\/localhost:8091/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('renderMaestroFlowForIosDevice', () => {
+  it('renders the setOrientation placeholder to the target iOS device orientation', () => {
+    const ipadDevice: IosScreenshotDevice = {
+      name: 'iPad Pro 13-inch (M5)',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
+      orientation: 'LANDSCAPE_LEFT',
+    };
+
+    const rendered = renderMaestroFlowForIosDevice(
+      '- setOrientation: ${MAESTRO_DEVICE_ORIENTATION}\n- takeScreenshot: 00-home\n',
+      ipadDevice,
+    );
+
+    expect(rendered).toContain('- setOrientation: LANDSCAPE_LEFT');
+    expect(rendered).not.toContain('${MAESTRO_DEVICE_ORIENTATION}');
+  });
+
+  it('keeps real iOS flows orientable for iPad screenshot captures', () => {
+    const ipadDevice: IosScreenshotDevice = {
+      name: 'iPad Pro 13-inch (M5)',
+      typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
+      orientation: 'LANDSCAPE_LEFT',
+    };
+
+    for (const flowPath of ['packages/mobile/.maestro/app-store.yaml', 'packages/mobile/.maestro/onboarding.yaml']) {
+      const flowSource = readFileSync(flowPath, 'utf8');
+      expect(flowSource).toContain('${MAESTRO_DEVICE_ORIENTATION}');
+      expect(renderMaestroFlowForIosDevice(flowSource, ipadDevice)).toContain('- setOrientation: LANDSCAPE_LEFT');
+    }
+  });
+});
+
+describe('rotationDegreesForIosOrientation', () => {
+  it('normalizes raw iPad landscape-left captures into upright landscape PNGs', () => {
+    expect(rotationDegreesForIosOrientation('LANDSCAPE_LEFT')).toBe(-90);
+    expect(rotationDegreesForIosOrientation('PORTRAIT')).toBeNull();
   });
 });
 

--- a/scripts/__tests__/with-screenshot-dev-menu.test.ts
+++ b/scripts/__tests__/with-screenshot-dev-menu.test.ts
@@ -1,0 +1,32 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type ScreenshotDevMenuPlugin = {
+  applyScreenshotDevMenuInfoPlist: (
+    infoPlist: Record<string, unknown>,
+    env?: NodeJS.ProcessEnv,
+  ) => Record<string, unknown>;
+  resolveScreenshotMetroPort: (env?: NodeJS.ProcessEnv) => number;
+  resolveScreenshotMetroUrl: (env?: NodeJS.ProcessEnv) => string;
+};
+
+const plugin = require('../../packages/mobile/plugins/with-screenshot-dev-menu.js') as ScreenshotDevMenuPlugin;
+
+describe('with-screenshot-dev-menu', () => {
+  it('defaults the baked dev-client launcher URL to the screenshot Metro port', () => {
+    expect(plugin.resolveScreenshotMetroPort({})).toBe(8081);
+    expect(plugin.resolveScreenshotMetroUrl({})).toBe('http://localhost:8081');
+  });
+
+  it('uses BOARDSESH_METRO_PORT for the baked dev-client launcher URL', () => {
+    const infoPlist = plugin.applyScreenshotDevMenuInfoPlist({}, { BOARDSESH_METRO_PORT: '8091' });
+
+    expect(infoPlist.DEV_CLIENT_DEFAULT_LAUNCHER_URL).toBe('http://localhost:8091');
+    expect(infoPlist.EXDevMenuIsOnboardingFinished).toBe(true);
+    expect(infoPlist.EXDevMenuShowFloatingActionButton).toBe(false);
+    expect(infoPlist.EXDevMenuShowsAtLaunch).toBe(false);
+  });
+});

--- a/scripts/assert-screenshot-dimensions.ts
+++ b/scripts/assert-screenshot-dimensions.ts
@@ -39,6 +39,11 @@ export interface Dimensions {
 }
 
 export const EXPECTED_APP_STORE_LOCALES = ['en-US', 'es-ES', 'es-MX', 'fr-FR'] as const;
+export const EXPECTED_APP_STORE_DEVICE_SLUGS = [
+  'iphone-16-pro-max',
+  'ipad-pro-13-inch-m5',
+  'ipad-pro-11-inch-m5',
+] as const;
 
 /**
  * Portrait sizes App Store Connect accepts, keyed by the capture device slug
@@ -54,6 +59,20 @@ export const ACCEPTED_SIZES: Record<string, readonly Dimensions[]> = {
   'iphone-16-pro-max': [
     { width: 1320, height: 2868 },
     { width: 1290, height: 2796 },
+  ],
+  // 13" iPad slot, captured in landscape. Apple accepts the current 13" native
+  // size and the earlier 12.9"/13" 2048x2732 family in the same slot.
+  'ipad-pro-13-inch-m5': [
+    { width: 2752, height: 2064 },
+    { width: 2732, height: 2048 },
+  ],
+  // 11" iPad slot, captured in landscape. Keep the allow-list aligned with
+  // App Store Connect's accepted 11" iPad screenshot sizes.
+  'ipad-pro-11-inch-m5': [
+    { width: 2266, height: 1488 },
+    { width: 2420, height: 1668 },
+    { width: 2388, height: 1668 },
+    { width: 2360, height: 1640 },
   ],
 };
 
@@ -200,7 +219,11 @@ export function findScreenshotTreeOffenders(tree: ScreenshotTree): Offender[] {
   }
 
   const firstExpectedLocale = EXPECTED_APP_STORE_LOCALES.find((locale) => tree[locale]);
-  const referenceDevices = firstExpectedLocale ? sortedKeys(tree[firstExpectedLocale]) : [];
+  const referenceDevices = firstExpectedLocale
+    ? sortedKeys(tree[firstExpectedLocale]).filter((deviceSlug) =>
+        (EXPECTED_APP_STORE_DEVICE_SLUGS as readonly string[]).includes(deviceSlug),
+      )
+    : [];
   if (referenceDevices.length === 0 && firstExpectedLocale) {
     offenders.push({ file: firstExpectedLocale, reason: 'contains no device screenshot folders' });
   }
@@ -213,10 +236,26 @@ export function findScreenshotTreeOffenders(tree: ScreenshotTree): Offender[] {
       offenders.push({ file: expectedLocale, reason: 'contains no device screenshot folders' });
       continue;
     }
-    if (referenceDevices.length > 0 && !listsMatch(deviceNames, referenceDevices)) {
+
+    for (const deviceName of deviceNames) {
+      if (!(EXPECTED_APP_STORE_DEVICE_SLUGS as readonly string[]).includes(deviceName)) {
+        offenders.push({ file: `${expectedLocale}/${deviceName}`, reason: 'unknown App Store device folder' });
+      }
+    }
+
+    for (const expectedDeviceSlug of EXPECTED_APP_STORE_DEVICE_SLUGS) {
+      if (!devices[expectedDeviceSlug]) {
+        offenders.push({ file: `${expectedLocale}/${expectedDeviceSlug}`, reason: 'missing device screenshot folder' });
+      }
+    }
+
+    const knownDeviceNames = deviceNames.filter((deviceName) =>
+      (EXPECTED_APP_STORE_DEVICE_SLUGS as readonly string[]).includes(deviceName),
+    );
+    if (referenceDevices.length > 0 && !listsMatch(knownDeviceNames, referenceDevices)) {
       offenders.push({
         file: expectedLocale,
-        reason: `device folders are ${deviceNames.join(', ')}, expected ${referenceDevices.join(', ')}`,
+        reason: `device folders are ${knownDeviceNames.join(', ')}, expected ${referenceDevices.join(', ')}`,
       });
     }
 

--- a/scripts/mobile-build-sim-app.ts
+++ b/scripts/mobile-build-sim-app.ts
@@ -27,6 +27,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -35,6 +36,7 @@ const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
 const IOS_DIR = resolve(MOBILE_DIR, 'ios');
 const DERIVED_DATA_DIR = resolve(IOS_DIR, 'build');
 const WORKSPACE_PATH = resolve(IOS_DIR, 'Boardsesh.xcworkspace');
+const INFO_PLIST_PATH = resolve(IOS_DIR, 'Boardsesh', 'Info.plist');
 const SCHEME = 'Boardsesh';
 // Literal entitlements for the sim build — see the file's comment for why the
 // generated ones can't be used (profile-dependent $(AppIdentifierPrefix)).
@@ -42,6 +44,10 @@ const SIM_ENTITLEMENTS = resolve(ROOT_DIR, 'scripts', 'screenshot-sim.entitlemen
 const APP_NAME = 'Boardsesh.app';
 const DEFAULT_APP_OUT = resolve(MOBILE_DIR, '.app-cache');
 const LOG = '[mobile:build-sim-app]';
+const require = createRequire(import.meta.url);
+const screenshotDevMenuPlugin = require('../packages/mobile/plugins/with-screenshot-dev-menu.js') as {
+  resolveScreenshotMetroUrl: (env?: NodeJS.ProcessEnv) => string;
+};
 
 export interface BuildSimAppOptions {
   appOut: string;
@@ -109,6 +115,57 @@ function expoPrebuild(clean: boolean): void {
   }
 }
 
+function readPlistString(plistPath: string, key: string): string | null {
+  const result = spawnSync('plutil', ['-extract', key, 'raw', '-o', '-', plistPath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+function readPlistJson(plistPath: string, key: string): unknown {
+  const result = spawnSync('plutil', ['-extract', key, 'json', '-o', '-', plistPath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0) return null;
+  try {
+    return JSON.parse(result.stdout) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function plistArrayIncludes(plistPath: string, key: string, expectedValue: string | number): boolean {
+  const value = readPlistJson(plistPath, key);
+  return Array.isArray(value) && value.includes(expectedValue);
+}
+
+function screenshotNativeProjectNeedsRefresh(): boolean {
+  const expectedLauncherUrl = screenshotDevMenuPlugin.resolveScreenshotMetroUrl(process.env);
+  const actualLauncherUrl = readPlistString(INFO_PLIST_PATH, 'DEV_CLIENT_DEFAULT_LAUNCHER_URL');
+  if (actualLauncherUrl !== expectedLauncherUrl) {
+    console.log(
+      `${LOG} Existing ios/ screenshot launcher URL is ${actualLauncherUrl ?? '(missing)'}, expected ${expectedLauncherUrl}; regenerating.`,
+    );
+    return true;
+  }
+  if (!plistArrayIncludes(INFO_PLIST_PATH, 'UIDeviceFamily', 2)) {
+    console.log(`${LOG} Existing ios/ project does not support iPad; regenerating.`);
+    return true;
+  }
+  const iPadOrientationKey = 'UISupportedInterfaceOrientations~ipad';
+  if (
+    !plistArrayIncludes(INFO_PLIST_PATH, iPadOrientationKey, 'UIInterfaceOrientationLandscapeLeft') ||
+    !plistArrayIncludes(INFO_PLIST_PATH, iPadOrientationKey, 'UIInterfaceOrientationLandscapeRight')
+  ) {
+    console.log(`${LOG} Existing ios/ project is missing iPad landscape orientations; regenerating.`);
+    return true;
+  }
+  return false;
+}
+
 function ensureNativeProject(clean: boolean): void {
   if (clean) {
     // CI / deterministic: wipe ios/ and regenerate from scratch. --clean is
@@ -121,6 +178,10 @@ function ensureNativeProject(clean: boolean): void {
     return;
   }
   if (existsSync(WORKSPACE_PATH)) {
+    if (screenshotNativeProjectNeedsRefresh()) {
+      expoPrebuild(true);
+      return;
+    }
     // ios/ already generated (e.g. by `vp run mobile:ios`). Skip prebuild — see
     // the incremental-crash note above — and trust the existing project. The dev
     // owns ios/ freshness locally; CI always passes --clean. Pass --clean here to

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -21,7 +21,7 @@
  *
  * Usage:
  *   vp run mobile:screenshots -- [--platform ios] [--flow app-store|onboarding]
- *                                 [--backend local|prod] [--devices common|<comma-list>]
+ *                                 [--backend local|prod] [--devices common|phones|ipads|<comma-list>]
  *                                 [--locales all|<comma-list>] [--device "iPhone 16 Pro Max"]
  *                                 [--variant material|liquidGlass] [--shutdown]
  *                                 [--app-path <path/to/Boardsesh.app|app.apk>]
@@ -35,7 +35,7 @@
  */
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -61,6 +61,8 @@ const STORE_BY_PLATFORM: Record<'ios' | 'android', string> = { ios: 'apple', and
 const LOG = '[mobile:screenshots]';
 
 const APP_ID = 'com.boardsesh.app';
+const DEV_CLIENT_URL_SCHEME = 'exp+boardsesh';
+const MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER = '${MAESTRO_DEVICE_ORIENTATION}';
 const DEFAULT_ANDROID_DEVICE = 'Pixel 2';
 const DEFAULT_ANDROID_APK = resolve(
   MOBILE_DIR,
@@ -85,26 +87,53 @@ export type ScreenshotFlow = 'app-store' | 'onboarding';
 export type ScreenshotBackend = 'local' | 'prod';
 
 export type ScreenshotTheme = 'light' | 'dark';
+export type IosDeviceOrientation = 'PORTRAIT' | 'LANDSCAPE_LEFT';
 
 export interface IosScreenshotDevice {
   name: string;
   typeId: string;
+  orientation: IosDeviceOrientation;
 }
 
-// Just the 6.9" iPhone 16 Pro Max. App Store Connect auto-scales the largest size
-// down to every smaller iPhone, so a single 6.9" set covers the whole range — extra
-// device sizes are invisible to users and add no ranking value, only CI time (see
-// app-stores/apple/app-store-submission-guide.md). Locale, not device size, is the
-// axis that helps the listing, so the orchestrator still captures every app locale.
-export const IOS_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
+// iPhones: just the 6.9" iPhone 16 Pro Max. App Store Connect auto-scales the
+// largest iPhone size down to every smaller iPhone, so a single 6.9" set covers the
+// whole iPhone range — extra iPhone sizes are invisible to users and add no ranking
+// value, only CI time (see app-stores/apple/app-store-submission-guide.md). iPad is
+// a separate App Store slot that does NOT auto-scale from the iPhone screenshots, so
+// it gets its own captures below. Locale, not iPhone size, is the axis that helps the
+// listing, so the orchestrator still captures every app locale.
+export const IOS_PHONE_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
   {
     name: 'iPhone 16 Pro Max',
     typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
+    orientation: 'PORTRAIT',
   },
 ];
 
+export const IOS_IPAD_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
+  {
+    name: 'iPad Pro 13-inch (M5)',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M5-12GB',
+    orientation: 'LANDSCAPE_LEFT',
+  },
+  {
+    name: 'iPad Pro 11-inch (M5)',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB',
+    orientation: 'LANDSCAPE_LEFT',
+  },
+];
+
+export const IOS_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
+  ...IOS_PHONE_SCREENSHOT_DEVICES,
+  ...IOS_IPAD_SCREENSHOT_DEVICES,
+];
+
 const COMMON_IOS_DEVICE_NAMES = IOS_SCREENSHOT_DEVICES.map((device) => device.name);
+const PHONE_IOS_DEVICE_NAMES = IOS_PHONE_SCREENSHOT_DEVICES.map((device) => device.name);
+const IPAD_IOS_DEVICE_NAMES = IOS_IPAD_SCREENSHOT_DEVICES.map((device) => device.name);
 const DEFAULT_IOS_DEVICES_ARGUMENT = 'common';
+const PHONE_IOS_DEVICES_ARGUMENT = 'phones';
+const IPAD_IOS_DEVICES_ARGUMENT = 'ipads';
 const DEFAULT_LOCALES_ARGUMENT = 'all';
 
 export interface AppStoreLocaleTarget {
@@ -218,6 +247,12 @@ function parseDevicesArgument(value: string): string[] {
   if (value === DEFAULT_IOS_DEVICES_ARGUMENT) {
     return [...COMMON_IOS_DEVICE_NAMES];
   }
+  if (value === PHONE_IOS_DEVICES_ARGUMENT) {
+    return [...PHONE_IOS_DEVICE_NAMES];
+  }
+  if (value === IPAD_IOS_DEVICES_ARGUMENT) {
+    return [...IPAD_IOS_DEVICE_NAMES];
+  }
   const devices = value
     .split(',')
     .map((deviceName) => deviceName.trim())
@@ -326,6 +361,28 @@ function runCapture(command: string, args: string[]): { status: number; stdout: 
   return { status: result.status ?? 1, stdout: result.stdout ?? '' };
 }
 
+function readPlistString(plistPath: string, key: string): string | null {
+  const result = spawnSync('plutil', ['-extract', key, 'raw', '-o', '-', plistPath], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+export function validateIosAppLauncherUrl(appPath: string, metroPort = METRO_PORT): void {
+  if (!appPath.endsWith('.app')) return;
+  const infoPlist = join(appPath, 'Info.plist');
+  const expectedLauncherUrl = `http://localhost:${metroPort}`;
+  const actualLauncherUrl = readPlistString(infoPlist, 'DEV_CLIENT_DEFAULT_LAUNCHER_URL');
+  if (actualLauncherUrl !== expectedLauncherUrl) {
+    throw new Error(
+      `${appPath} was built for DEV_CLIENT_DEFAULT_LAUNCHER_URL=${actualLauncherUrl ?? '(missing)'}, ` +
+        `expected ${expectedLauncherUrl}. Rebuild it with BOARDSESH_METRO_PORT=${metroPort} or omit --app-path.`,
+    );
+  }
+}
+
 function commandExists(command: string): boolean {
   return spawnSync('command', ['-v', command], { shell: true, stdio: 'ignore' }).status === 0;
 }
@@ -385,6 +442,7 @@ export function resolveIosScreenshotDevices(deviceNames: readonly string[]): Ios
     return {
       name: deviceName,
       typeId: '',
+      orientation: 'PORTRAIT',
     };
   });
 }
@@ -527,6 +585,54 @@ function flowFileForPlatform(options: ScreenshotOptions, platform: 'ios' | 'andr
   return join(MAESTRO_DIR, `${options.flow}.yaml`);
 }
 
+export function renderMaestroFlowForIosDevice(flowSource: string, screenshotDevice: IosScreenshotDevice): string {
+  return flowSource.replaceAll(MAESTRO_DEVICE_ORIENTATION_PLACEHOLDER, screenshotDevice.orientation);
+}
+
+export function rotationDegreesForIosOrientation(orientation: IosDeviceOrientation): number | null {
+  return orientation === 'LANDSCAPE_LEFT' ? -90 : null;
+}
+
+function renderedFlowFileForIosDevice(
+  options: ScreenshotOptions,
+  screenshotDevice: IosScreenshotDevice,
+  captureDir: string,
+): string {
+  const flowFile = flowFileForPlatform(options, 'ios');
+  if (!existsSync(flowFile)) return flowFile;
+  const renderedFlowFile = join(captureDir, `${options.flow}-${deviceSlug(screenshotDevice.name)}.yaml`);
+  writeFileSync(renderedFlowFile, renderMaestroFlowForIosDevice(readFileSync(flowFile, 'utf8'), screenshotDevice));
+  return renderedFlowFile;
+}
+
+function readPngDimensions(filePath: string): { width: number; height: number } | null {
+  const { status, stdout } = runCapture('sips', ['-g', 'pixelWidth', '-g', 'pixelHeight', filePath]);
+  if (status !== 0) return null;
+  const widthMatch = stdout.match(/pixelWidth:\s*(\d+)/);
+  const heightMatch = stdout.match(/pixelHeight:\s*(\d+)/);
+  const width = widthMatch ? Number.parseInt(widthMatch[1], 10) : Number.NaN;
+  const height = heightMatch ? Number.parseInt(heightMatch[1], 10) : Number.NaN;
+  return Number.isFinite(width) && Number.isFinite(height) ? { width, height } : null;
+}
+
+function normalizeCapturedIosScreenshots(captureDir: string, screenshotDevice: IosScreenshotDevice): number {
+  const rotationDegrees = rotationDegreesForIosOrientation(screenshotDevice.orientation);
+  if (rotationDegrees === null) return 0;
+
+  const pngs = readdirSync(captureDir).filter((file) => file.toLowerCase().endsWith('.png'));
+  for (const png of pngs) {
+    const screenshotPath = join(captureDir, png);
+    const dimensions = readPngDimensions(screenshotPath);
+    if (dimensions && dimensions.width > dimensions.height) continue;
+    const { status } = runCapture('sips', ['-r', String(rotationDegrees), screenshotPath]);
+    if (status !== 0) {
+      console.error(`${LOG} FAILED: could not rotate landscape iOS screenshot ${png}.`);
+      return status;
+    }
+  }
+  return 0;
+}
+
 function captureIosDevice(
   options: ScreenshotOptions,
   screenshotDevice: IosScreenshotDevice,
@@ -570,10 +676,10 @@ function captureIosDevice(
     // on a stale marker and capture a blank/loading frame.
     const homeReadyBaseline = homeReadyMarkerCount();
 
-    // Just launch the app — no `simctl openurl`. The screenshots build bakes
-    // DEV_CLIENT_DEFAULT_LAUNCHER_URL=http://localhost:8081 into Info.plist (see
-    // ./plugins/with-screenshot-dev-menu), so the dev-client auto-connects to
-    // Metro on a plain launch and — auto-signed-in (see auth-provider's
+    // First try a plain launch — no `simctl openurl`. The screenshots build bakes
+    // DEV_CLIENT_DEFAULT_LAUNCHER_URL=http://localhost:${METRO_PORT} into
+    // Info.plist (see ./plugins/with-screenshot-dev-menu), so the dev-client
+    // auto-connects to Metro on a plain launch and — auto-signed-in (see auth-provider's
     // SCREENSHOT_MODE branch) — lands straight on home, without ever opening the
     // custom-scheme URL or showing a login screen. That matters because a fresh CI
     // sim raises an "Open in Boardsesh?" confirmation for ANY openurl of the
@@ -586,19 +692,24 @@ function captureIosDevice(
     // there before Maestro runs — this is what login.yaml's readiness wait used to
     // do (now deleted; there's no login screen to gate on).
     console.log(`${LOG} Waiting for the app to auto-sign-in and reach home...`);
+    if (!waitForHomeReady(homeReadyBaseline, 45)) {
+      console.log(`${LOG} Plain launch did not reach home; retrying with the explicit dev-client URL...`);
+      runCapture('xcrun', ['simctl', 'openurl', device.udid, metroDevClientUrl()]);
+    }
     if (!waitForHomeReady(homeReadyBaseline)) {
       console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
       return 1;
     }
 
-    const flowFile = flowFileForPlatform(options, 'ios');
-    if (!existsSync(flowFile)) {
-      console.error(`${LOG} FAILED: flow not found: ${flowFile}`);
+    const sourceFlowFile = flowFileForPlatform(options, 'ios');
+    if (!existsSync(sourceFlowFile)) {
+      console.error(`${LOG} FAILED: flow not found: ${sourceFlowFile}`);
       return 1;
     }
+    const flowFile = renderedFlowFileForIosDevice(options, screenshotDevice, captureDir);
     const email = process.env.SCREENSHOT_USER_EMAIL ?? DEFAULT_USER_EMAIL;
     const password = process.env.SCREENSHOT_USER_PASSWORD ?? DEFAULT_USER_PASSWORD;
-    console.log(`${LOG} Running Maestro flow ${options.flow} on ${device.udid}...`);
+    console.log(`${LOG} Running Maestro flow ${options.flow} on ${device.udid} (${screenshotDevice.orientation})...`);
     // Credentials are passed via `-e`, which is the ONLY mechanism Maestro 2.6.1
     // offers: `maestro test` has no `--env-file` and does not read `${VAR}` from
     // the shell environment (verified — env-only resolves to empty and login
@@ -628,6 +739,9 @@ function captureIosDevice(
       console.error(`${LOG} FAILED: Maestro exited with ${maestroStatus}.`);
       return maestroStatus;
     }
+
+    const normalizeStatus = normalizeCapturedIosScreenshots(captureDir, screenshotDevice);
+    if (normalizeStatus !== 0) return normalizeStatus;
 
     const saved = collectScreenshots(captureDir, 'ios', device.name, localeTarget.appStoreLocales);
     if (saved.length === 0) {
@@ -761,6 +875,7 @@ function resolveAndroidAppPath(options: ScreenshotOptions): string {
     if (!existsSync(options.appPath)) {
       throw new Error(`--app-path not found: ${options.appPath}`);
     }
+    validateIosAppLauncherUrl(options.appPath);
     return options.appPath;
   }
   if (existsSync(DEFAULT_ANDROID_APK)) {
@@ -944,8 +1059,8 @@ export function resolveAppPath(options: ScreenshotOptions): string {
 }
 
 /** expo-development-client deep link that loads the JS bundle from our Metro. */
-export function metroDevClientUrl(): string {
-  return `${APP_ID}://expo-development-client/?url=${encodeURIComponent(`http://localhost:${METRO_PORT}`)}`;
+export function metroDevClientUrl(metroPort = METRO_PORT): string {
+  return `${DEV_CLIENT_URL_SCHEME}://expo-development-client/?url=${encodeURIComponent(`http://localhost:${metroPort}`)}`;
 }
 
 /** True if anything is already listening on the port (a foreign Metro). */


### PR DESCRIPTION
**Phase 1 of the iPad app** (follows the merged backend wiring in #2901). Enables iPad and gives it a first-class **left glass sidebar** in place of the bottom tab bar — the foundation the Gym Wall (Phase 2) and the Climbs two-pane browser (Phase 3) build on.

## The no-regression guarantee

The whole thing is gated behind one size-class hook. **Compact width — every iPhone, plus an iPad in Slide Over or a narrow Split View — renders today's `NativeTabs` / `MaterialTabBar` tree verbatim.** The sidebar only appears when the window is genuinely wide enough for two columns. No phase can regress the phone app.

## What's in this PR

- **`size-class.ts` (pure) + `use-device-layout.ts`** — `compact | regular` from a 700pt threshold + `Platform.isPad`, with an `expanded` flag at 1024pt for the future master+detail pane. Mirrors the proven `bottom-chrome-metrics.ts` pure-arbitration-plus-thin-hook pattern. Unit-tested with the ⅓/½/⅔/full iPad split widths.
- **`computeBottomChromeMetrics` → optional `usesSidebar`** — collapses every bottom offset to the safe-area inset (there's no bottom tab bar to clear at regular width). Defaults to `false`, so all existing call sites are byte-for-byte unchanged (asserted in a test).
- **`(tabs)/_layout.tsx` third branch** — at regular width renders `IpadSidebar` + the `Tabs` navigator with its bar hidden (`tabBar={() => null}`). The navigator still owns routing + per-tab state; the sidebar drives it through the global Expo Router `router` and highlights the focused tab via `useSegments()` (new `tabsActiveSegment` helper, so we never index the route-typed tuple directly). All five tabs map 1:1 — no rename, no dissolve.
- **`IpadSidebar.tsx`** — a `GlassSurface` rail: Home · Climbs · Record · Discover at the top, You pinned to the bottom (HIG convention), active row tinted + pilled, `hapticSelection` on tab change. Reuses the existing `Icon` / `Text` / `PressableSurface` primitives and the same i18n keys as the tab bars (3 new semantic glyphs added to `icon-map`).
- **`app.config.ts`** — `supportsTablet: true`; iPad rotates freely via `UISupportedInterfaceOrientations~ipad` while iPhone stays portrait-locked; `requireFullScreen` left `false` so Slide Over / Split View work (which is what makes the compact fall-through valuable).

## Validation

- `vp run typecheck:mobile` — green (incl. the new SF Symbol names).
- `vp test run --project mobile` — **303 files / 2195 tests pass**, including new `size-class`, `usesSidebar` chrome-metrics, and a `tab-layout` test asserting the regular-width branch renders the sidebar and hides the native tab bar.
- `vp run check:mobile-bundle` — OK (10.7 MB).
- `vp check` on all 14 changed files — clean.

## Needs a native rebuild + on-device check

`app.config.ts` changes are native. Per the repo's prebuild gotcha, run **`expo prebuild --clean -p ios`** (don't rely on `vp run mobile:ios`, which skips prebuild when `ios/` exists) and build for an **iPad simulator** to verify the sidebar in landscape + portrait and confirm Slide Over falls back to the phone UI. The JS logic is unit-tested but the orientation/`supportsTablet` plist + the live layout want an iPad sim pass.

## Deliberately deferred (follow-ups)

- The current-climb "now playing" chrome stays on the existing floating `PersistentQueueBar` (it clears the now-zero tab bar and floats bottom-center, clear of the 96pt rail). Re-hosting it into the sidebar footer is a follow-up.
- A universal iPad bottom-sheet max-width cap (centering sheets instead of full-width) — wants iPad-visual verification to get right, so it's split out rather than shipped blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)