### PR TITLE
refactor(mobile): finish the variant abstraction (Phase 2)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -651,7 +651,7 @@ function ClimbListInner() {
     () => filterTokens.filter((filterToken) => filterToken.key !== 'grade'),
     [filterTokens],
   );
-  const summaryFilterTokens = selectByVariant(variant, { material: nonGradeFilterTokens, liquidGlass: filterTokens });
+  const summaryFilterTokens = features.summaryExcludesGradeFilter ? nonGradeFilterTokens : filterTokens;
   // Condensed summary of the active filters (variant-aware: Material chip vs glass
   // title). See buildClimbFilterSummary.
   const filterSummary = useMemo(

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -27,6 +27,7 @@ import { ClimbFilterFab } from '../../../src/components/search/ClimbFilterFab';
 import { ClimbTopChrome } from '../../../src/components/search/ClimbTopChrome';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
+import { selectByVariant } from '../../../src/theme/variants';
 import { useActiveClimbUuid, useQueueActions } from '../../../src/providers/queue-provider';
 import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
 import { useBoardProvider } from '@boardsesh/board-react';
@@ -128,7 +129,7 @@ function ClimbListInner() {
   const handleOpenBoardDetail = useCallback(() => {
     openBoardSheet();
   }, [openBoardSheet]);
-  const { systemColors, variant, brandColors } = useTheme();
+  const { systemColors, variant, brandColors, features } = useTheme();
   const { addToQueue } = useQueueActions();
   const {
     filters,
@@ -173,7 +174,7 @@ function ClimbListInner() {
   // On the Material variant the filter lives in the top-right toolbar (next to
   // the light/bluetooth button) inside ClimbTopChrome, so the bottom filter FAB
   // is not rendered here.
-  const filterInTopChrome = variant === 'material';
+  const filterInTopChrome = features.filtersInTopChrome;
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -650,14 +651,14 @@ function ClimbListInner() {
     () => filterTokens.filter((filterToken) => filterToken.key !== 'grade'),
     [filterTokens],
   );
-  const summaryFilterTokens = variant === 'material' ? nonGradeFilterTokens : filterTokens;
+  const summaryFilterTokens = selectByVariant(variant, { material: nonGradeFilterTokens, liquidGlass: filterTokens });
   // Condensed summary of the active filters (variant-aware: Material chip vs glass
   // title). See buildClimbFilterSummary.
   const filterSummary = useMemo(
     () =>
       buildClimbFilterSummary({
         labels: summaryFilterTokens.map((token) => token.label),
-        isMaterial: variant === 'material',
+        isMaterial: selectByVariant(variant, { material: true, liquidGlass: false }),
         maxChars: SUMMARY_MAX_CHARS,
         more: (count) => t('mobile.search.more', { count }),
       }),
@@ -869,7 +870,7 @@ function ClimbListInner() {
         activeFilterCount={activeFilterCount}
         onOpenFilters={handleOpenFilters}
         filterSummary={
-          variant === 'material' && filterSummary
+          features.filtersInTopChrome && filterSummary
             ? { text: filterSummary, onClear: handleClearNonGradeFilters }
             : undefined
         }

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { Stack, useRouter } from 'expo-router';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
@@ -19,6 +19,7 @@ import {
 import { openDiscordInvite } from '../src/lib/discord';
 import { openExternalUrl } from '../src/lib/open-url';
 import { useTheme } from '../src/providers/theme-provider';
+import { useVariantValue } from '../src/theme/variants';
 import { borderRadius, spacing } from '../src/theme/tokens';
 import type { IconName } from '../src/components/icon-map';
 
@@ -109,6 +110,10 @@ export default function AcknowledgementsScreen() {
     router.push('/licenses');
   }, [router]);
 
+  // Liquid Glass uses the transparent, blur-under-content HIG header; Material's app
+  // bar is opaque — so a forced-Material user on iOS gets the M3 header, not glass.
+  const headerTransparent = useVariantValue({ liquidGlass: true, material: false });
+
   return (
     <>
       <Stack.Screen
@@ -116,7 +121,7 @@ export default function AcknowledgementsScreen() {
           title: t('mobile.acknowledgements.title'),
           headerShown: true,
           headerLargeTitle: false,
-          headerTransparent: Platform.OS === 'ios',
+          headerTransparent,
           headerBlurEffect: 'systemMaterial',
           contentStyle: { backgroundColor: 'transparent' },
         }}

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -217,11 +217,7 @@ export default function AcknowledgementsScreen() {
               title={t('mobile.acknowledgements.friendsTitle')}
               body={t('mobile.acknowledgements.friendsBody', { names: friendsLine })}
             />
-            <ThanksCard
-              icon="person"
-              title="Alex"
-              body={t('mobile.acknowledgements.alexBody')}
-            />
+            <ThanksCard icon="person" title="Alex" body={t('mobile.acknowledgements.alexBody')} />
             <ThanksCard
               icon="paw"
               title={dogName}

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { Stack, useRouter } from 'expo-router';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
@@ -110,9 +110,13 @@ export default function AcknowledgementsScreen() {
     router.push('/licenses');
   }, [router]);
 
-  // Liquid Glass uses the transparent, blur-under-content HIG header; Material's app
-  // bar is opaque — so a forced-Material user on iOS gets the M3 header, not glass.
-  const headerTransparent = useVariantValue({ liquidGlass: true, material: false });
+  // The transparent, blur-under-content header is an iOS-only feature (headerBlurEffect):
+  // on iOS, Liquid Glass gets it and Material's opaque M3 app bar does not. On Android
+  // — including a forced Liquid Glass user, where there's no glass surface — keep the
+  // header opaque so scroll content doesn't slide under the status bar (dual-axis:
+  // aesthetic AND platform). The hook is called unconditionally; only the value is gated.
+  const prefersGlassHeader = useVariantValue({ liquidGlass: true, material: false });
+  const headerTransparent = Platform.OS === 'ios' && prefersGlassHeader;
 
   return (
     <>

--- a/packages/mobile/app/licenses.tsx
+++ b/packages/mobile/app/licenses.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { Stack } from 'expo-router';
-import { Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
@@ -80,9 +80,13 @@ export default function LicensesScreen() {
     [handleSelect],
   );
 
-  // Liquid Glass uses the transparent, blur-under-content HIG header; Material's app
-  // bar is opaque (forced-Material on iOS gets the M3 header).
-  const headerTransparent = useVariantValue({ liquidGlass: true, material: false });
+  // The transparent, blur-under-content header is an iOS-only feature (headerBlurEffect):
+  // on iOS, Liquid Glass gets it and Material's opaque M3 app bar does not. On Android
+  // — including a forced Liquid Glass user, where there's no glass surface — keep the
+  // header opaque so scroll content doesn't slide under the status bar (dual-axis:
+  // aesthetic AND platform). The hook is called unconditionally; only the value is gated.
+  const prefersGlassHeader = useVariantValue({ liquidGlass: true, material: false });
+  const headerTransparent = Platform.OS === 'ios' && prefersGlassHeader;
 
   return (
     <>

--- a/packages/mobile/app/licenses.tsx
+++ b/packages/mobile/app/licenses.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { Stack } from 'expo-router';
-import { Modal, Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
 import { loadOssLicenses, type OssLicense } from '../src/lib/oss-licenses';
 import { openExternalUrl } from '../src/lib/open-url';
 import { useTheme } from '../src/providers/theme-provider';
+import { useVariantValue } from '../src/theme/variants';
 import { spacing } from '../src/theme/tokens';
 
 const keyExtractor = (item: OssLicense) => `${item.name}@${item.version}`;
@@ -79,6 +80,10 @@ export default function LicensesScreen() {
     [handleSelect],
   );
 
+  // Liquid Glass uses the transparent, blur-under-content HIG header; Material's app
+  // bar is opaque (forced-Material on iOS gets the M3 header).
+  const headerTransparent = useVariantValue({ liquidGlass: true, material: false });
+
   return (
     <>
       <Stack.Screen
@@ -86,7 +91,7 @@ export default function LicensesScreen() {
           title: t('mobile.licenses.title'),
           headerShown: true,
           headerLargeTitle: false,
-          headerTransparent: Platform.OS === 'ios',
+          headerTransparent,
           headerBlurEffect: 'systemMaterial',
           contentStyle: { backgroundColor: 'transparent' },
         }}

--- a/packages/mobile/app/onboarding.tsx
+++ b/packages/mobile/app/onboarding.tsx
@@ -3,6 +3,7 @@ import { router } from 'expo-router';
 import { useTheme as usePaperTheme } from 'react-native-paper';
 import { OnboardingCarousel } from '../src/components/onboarding/OnboardingCarousel';
 import { useTheme } from '../src/providers/theme-provider';
+import { useVariantValue } from '../src/theme/variants';
 import { markOnboardingSeen } from '../src/lib/onboarding/onboarding-storage';
 import { reportError } from '../src/lib/error-reporting';
 
@@ -18,18 +19,28 @@ import { reportError } from '../src/lib/error-reporting';
  * because the flag is only written here.
  */
 export default function OnboardingScreen() {
-  const { variant, systemColors } = useTheme();
+  const { systemColors } = useTheme();
   const paperTheme = usePaperTheme();
 
-  const isMaterial = variant === 'material';
   // Material reads MD3 roles from the Paper theme; HIG / Liquid Glass reads the
   // iOS-style system colours. Background stays opaque under the reading text in
   // both (no glass behind the copy — only the floating footer is glass).
-  const accentColor = isMaterial ? paperTheme.colors.primary : (systemColors.accent as string);
-  const iconColor = isMaterial ? paperTheme.colors.primary : (systemColors.accent as string);
-  const inactiveDotColor = isMaterial ? paperTheme.colors.surfaceVariant : (systemColors.separator as string);
-  const bodyColor = isMaterial ? paperTheme.colors.onSurfaceVariant : (systemColors.secondaryLabel as string);
-  const backgroundColor = isMaterial ? paperTheme.colors.background : (systemColors.background as string);
+  const { accentColor, iconColor, inactiveDotColor, bodyColor, backgroundColor } = useVariantValue({
+    material: {
+      accentColor: paperTheme.colors.primary,
+      iconColor: paperTheme.colors.primary,
+      inactiveDotColor: paperTheme.colors.surfaceVariant,
+      bodyColor: paperTheme.colors.onSurfaceVariant,
+      backgroundColor: paperTheme.colors.background,
+    },
+    liquidGlass: {
+      accentColor: systemColors.accent as string,
+      iconColor: systemColors.accent as string,
+      inactiveDotColor: systemColors.separator as string,
+      bodyColor: systemColors.secondaryLabel as string,
+      backgroundColor: systemColors.background as string,
+    },
+  });
 
   // Persist the "seen" flag without blocking the exit. If the SecureStore write
   // rejects (keychain locked / unavailable), navigation still happens — but we

--- a/packages/mobile/app/scout.tsx
+++ b/packages/mobile/app/scout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ScoutPhoto } from '../src/components/ScoutPhoto';
 import { Text } from '../src/components/Text';
@@ -13,9 +13,13 @@ export default function ScoutScreen() {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
-  // Liquid Glass uses the transparent, blur-under-content HIG header; Material's app
-  // bar is opaque (forced-Material on iOS gets the M3 header).
-  const headerTransparent = useVariantValue({ liquidGlass: true, material: false });
+  // The transparent, blur-under-content header is an iOS-only feature (headerBlurEffect):
+  // on iOS, Liquid Glass gets it and Material's opaque M3 app bar does not. On Android
+  // — including a forced Liquid Glass user, where there's no glass surface — keep the
+  // header opaque so scroll content doesn't slide under the status bar (dual-axis:
+  // aesthetic AND platform). The hook is called unconditionally; only the value is gated.
+  const prefersGlassHeader = useVariantValue({ liquidGlass: true, material: false });
+  const headerTransparent = Platform.OS === 'ios' && prefersGlassHeader;
 
   return (
     <>

--- a/packages/mobile/app/scout.tsx
+++ b/packages/mobile/app/scout.tsx
@@ -1,17 +1,21 @@
 import { Stack } from 'expo-router';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ScoutPhoto } from '../src/components/ScoutPhoto';
 import { Text } from '../src/components/Text';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
 import { dogName } from '../src/lib/acknowledgements';
 import { useTheme } from '../src/providers/theme-provider';
+import { useVariantValue } from '../src/theme/variants';
 import { borderRadius, spacing } from '../src/theme/tokens';
 
 export default function ScoutScreen() {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
+  // Liquid Glass uses the transparent, blur-under-content HIG header; Material's app
+  // bar is opaque (forced-Material on iOS gets the M3 header).
+  const headerTransparent = useVariantValue({ liquidGlass: true, material: false });
 
   return (
     <>
@@ -20,7 +24,7 @@ export default function ScoutScreen() {
           title: dogName,
           headerShown: true,
           headerLargeTitle: false,
-          headerTransparent: Platform.OS === 'ios',
+          headerTransparent,
           headerBlurEffect: 'systemMaterial',
           contentStyle: { backgroundColor: 'transparent' },
         }}

--- a/packages/mobile/src/components/ScreenTitle.tsx
+++ b/packages/mobile/src/components/ScreenTitle.tsx
@@ -2,7 +2,6 @@ import { type ReactNode } from 'react';
 import { type StyleProp, type TextStyle } from 'react-native';
 import { Text } from './Text';
 import { useTheme } from '../providers/theme-provider';
-import { selectByVariant } from '../theme/variants';
 
 type ScreenTitleProps = {
   children: ReactNode;
@@ -17,8 +16,8 @@ type ScreenTitleProps = {
  * Material-only null gate (the old inline largeTitle suppression) at each site.
  */
 export function ScreenTitle({ children, style }: ScreenTitleProps) {
-  const { variant } = useTheme();
-  if (!selectByVariant(variant, { liquidGlass: true, material: false })) return null;
+  const { features } = useTheme();
+  if (!features.inBodyLargeTitle) return null;
   return (
     <Text variant="largeTitle" style={style}>
       {children}

--- a/packages/mobile/src/components/Stepper.tsx
+++ b/packages/mobile/src/components/Stepper.tsx
@@ -3,7 +3,7 @@ import { Text } from './Text';
 import { Icon } from './Icon';
 import { PressableSurface } from './PressableSurface';
 import { useTheme } from '../providers/theme-provider';
-import { selectByVariant } from '../theme/variants';
+import { useVariantValue } from '../theme/variants';
 import { spacing, borderRadius } from '../theme/tokens';
 
 type StepperProps = {
@@ -26,8 +26,8 @@ function clampStepperValue(value: number, min: number, max: number): number {
  * divided by the parent). Clamps to [min, max] before reporting changes.
  */
 export function Stepper({ label, value, min, max, onChange, decreaseLabel, increaseLabel }: StepperProps) {
-  const { systemColors, brandColors, opacity: themeOpacity, variant, m3 } = useTheme();
-  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  const { systemColors, brandColors, opacity: themeOpacity, m3 } = useTheme();
+  const isMaterial = useVariantValue({ material: true, liquidGlass: false });
   const decrementDisabled = value <= min;
   const incrementDisabled = value >= max;
 

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-analytics.test.tsx
@@ -122,7 +122,9 @@ vi.mock('../../SessionStartFab', () => ({
     return null;
   },
 }));
-vi.mock('../../../../providers/theme-provider', () => ({ useTheme: () => ({ systemColors: {} }) }));
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, features: { inBodyLargeTitle: false, filtersInTopChrome: false } }),
+}));
 vi.mock('../../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => activeBoard }));
 vi.mock('../../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock('../../../../providers/queue-provider', () => ({

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/pre-session-view-preview.test.tsx
@@ -141,7 +141,9 @@ vi.mock('../../SessionStartFab', () => ({
 vi.mock('../../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../../../providers/theme-provider', () => ({ useTheme: () => ({ systemColors: {} }) }));
+vi.mock('../../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, features: { inBodyLargeTitle: false, filtersInTopChrome: false } }),
+}));
 vi.mock('../../../../lib/graphql/use-active-board', () => ({
   useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 } }),
 }));

--- a/packages/mobile/src/components/you/StatsSummaryCard.tsx
+++ b/packages/mobile/src/components/you/StatsSummaryCard.tsx
@@ -10,7 +10,7 @@ import { LayoutPercentageBar } from './LayoutPercentageBar';
 import { gradeBadgeColor } from './profile-chart-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
-import { selectByVariant } from '../../theme/variants';
+import { useVariantValue } from '../../theme/variants';
 
 type Percentile = { percentile: number; totalActiveUsers: number } | null;
 
@@ -23,8 +23,8 @@ type StatsSummaryCardProps = {
 
 export function StatsSummaryCard({ statisticsSummary, hardestSend, hardestFlash, percentile }: StatsSummaryCardProps) {
   const { t } = useTranslation('profile');
-  const { systemColors, brandColors, variant, m3 } = useTheme();
-  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  const { systemColors, brandColors, m3 } = useTheme();
+  const isMaterial = useVariantValue({ material: true, liquidGlass: false });
 
   const showPercentile = percentile != null && percentile.percentile > 0;
   // "Top X%" — invert the percentile, clamped so a 100th-percentile climber

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -38,6 +38,7 @@ import {
   type ChartColors,
   type SectionCaption,
 } from '../theme/variants/variant-tokens';
+import { variantFeatures, type VariantFeatures } from '../theme/variants/variant-features';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
 import { assertNever } from '../lib/assert-never';
 import { SCREENSHOT_MODE, SCREENSHOT_THEME_OVERRIDE, SCREENSHOT_VARIANT_PREFERENCE } from '../lib/screenshot-mode';
@@ -125,6 +126,8 @@ type Theme = {
   chartColors: ChartColors;
   /** Section-caption treatment (uppercase / opacity / letter-spacing), per variant. */
   sectionCaption: SectionCaption;
+  /** Per-variant feature / content-layout flags (what shows, and where), resolved once. */
+  features: VariantFeatures;
 };
 
 const ThemeContext = createContext<Theme | null>(null);
@@ -330,6 +333,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       }),
       chartColors: resolveChartColors(variant, colorScheme),
       sectionCaption: sectionCaptionByVariant[variant],
+      features: variantFeatures[variant],
     };
   }, [colorScheme, variant, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant, m3Colors]);
 

--- a/packages/mobile/src/test/theme-mock.ts
+++ b/packages/mobile/src/test/theme-mock.ts
@@ -5,6 +5,7 @@ import { textStylesByVariant } from '../theme/typography';
 import { brandColors, brandColorsDark, materialSurfaces, androidFallbackColors } from '../theme/colors';
 import { buildPaperTheme } from '../theme/paper-theme';
 import { resolveActionColors, resolveChartColors, sectionCaptionByVariant } from '../theme/variants/variant-tokens';
+import { variantFeatures } from '../theme/variants/variant-features';
 
 /**
  * Build a complete `Theme` for unit tests. One factory so every test gets the
@@ -53,6 +54,7 @@ export function makeThemeMock(overrides: Partial<Theme> = {}): Theme {
     }),
     chartColors: resolveChartColors(variant, colorScheme),
     sectionCaption: sectionCaptionByVariant[variant],
+    features: variantFeatures[variant],
   };
 
   return { ...base, ...overrides };

--- a/packages/mobile/src/theme/variants/README.md
+++ b/packages/mobile/src/theme/variants/README.md
@@ -35,14 +35,16 @@ variant primitive with surface mode.
 2. A whole component subtree differs (different RN/Paper elements)? → **component swap** (`createVariantComponent` for small twins; an explicit `index.tsx` router for large folder-split twins).
 3. A single value differs and has a **stable, designer-facing name** (action-icon colour policy, chart palette, caption style)? → **token**: add a `…ByVariant` map / resolver in `variant-tokens.ts`, resolve in the provider, read `theme.X`.
 4. A layout metric tied to chrome arbitration (reserves, insets, footer padding)? → push into `computeBottomChromeMetrics` and read a named field.
-5. Whether a feature/section shows at all? → a named component that returns `null` (e.g. `ScreenTitle`) — never a bare `variant === 'material' ? null`.
+5. Whether a feature/section shows at all, or where it's laid out? → a flag in the `variantFeatures` registry (read via `theme.features`), consumed by a named component (e.g. `ScreenTitle`) — never a bare `variant === 'material' ? null`.
 6. A genuinely local, positional one-off? → `selectByVariant(variant, { liquidGlass, material })`.
 
 ## The primitives
 
 - **`selectByVariant(variant, { liquidGlass, material })`** — declarative value pick. Maps are `Record<UiVariant, T>`, so a new variant is a compile error at every call site. Prefer a token (step 3) for anything with a name.
+- **`useVariantValue({ liquidGlass, material })`** — `selectByVariant` bound to the live `theme.variant`, for a component that doesn't already destructure the theme. Same exhaustiveness + memoisation rules.
 - **`createVariantComponent(name, { liquidGlass, material })`** — one public component from two impls with an identical prop API. Renders the chosen impl as JSX so each gets its own fiber/hook list (a live variant flip unmounts one and mounts the other). React 19 `ref` forwards through `{...props}`.
 - **`variant-tokens.ts`** — the per-variant token resolvers (`resolveActionColors`, `resolveChartColors`, `sectionCaptionByVariant`, `applySectionCaption`). Shared by the provider and the test mock (`src/test/theme-mock.ts`) so they can't drift.
+- **`variant-features.ts`** — the `variantFeatures` registry (`Record<UiVariant, VariantFeatures>`) for content/layout feature gaps (`inBodyLargeTitle`, `filtersInTopChrome`); resolved once as `theme.features`.
 - **`assertNever`** (`src/lib/assert-never.ts`) — exhaustiveness guard for the few `switch (variant)` sites in the provider.
 
 ## Rules that keep it working
@@ -55,8 +57,8 @@ variant primitive with surface mode.
 ## Adding a third variant — the punch-list
 
 Widen `UiVariant` in `../resolve-ui-variant.ts` and the compiler enumerates the work:
-every `…ByVariant` map, every `selectByVariant`/`createVariantComponent` call, and every
-swap router fails to compile until handled. A **manual** checklist covers the capability
+every `…ByVariant` map, the `variantFeatures` registry, every `selectByVariant`/`createVariantComponent`
+call, and every swap router fails to compile until handled. A **manual** checklist covers the capability
 sites the type system can't reach: `resolveSystemColors` and `useEffectiveSurfaceMode`
 (guarded by `assertNever`), `theme.m3` (a Paper palette only meaningful on Material), and
 axis-D `Platform.OS` sites.

--- a/packages/mobile/src/theme/variants/__tests__/use-variant-value.test.tsx
+++ b/packages/mobile/src/theme/variants/__tests__/use-variant-value.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: ctrl.variant }) }));
+
+import { useVariantValue } from '../use-variant-value';
+
+function Probe() {
+  const value = useVariantValue({ liquidGlass: 'glass-value', material: 'material-value' });
+  return createElement('div', { 'data-value': value });
+}
+
+describe('useVariantValue', () => {
+  it('returns the value for the active variant', () => {
+    ctrl.variant = 'liquidGlass';
+    const glass = render(createElement(Probe));
+    expect(glass.container.querySelector('div')?.getAttribute('data-value')).toBe('glass-value');
+    glass.unmount();
+
+    ctrl.variant = 'material';
+    const material = render(createElement(Probe));
+    expect(material.container.querySelector('div')?.getAttribute('data-value')).toBe('material-value');
+  });
+});

--- a/packages/mobile/src/theme/variants/__tests__/use-variant-value.test.tsx
+++ b/packages/mobile/src/theme/variants/__tests__/use-variant-value.test.tsx
@@ -24,4 +24,16 @@ describe('useVariantValue', () => {
     const material = render(createElement(Probe));
     expect(material.container.querySelector('div')?.getAttribute('data-value')).toBe('material-value');
   });
+
+  it('updates the returned value on a live variant flip (re-render, no remount)', () => {
+    ctrl.variant = 'liquidGlass';
+    const { container, rerender } = render(createElement(Probe));
+    expect(container.querySelector('div')?.getAttribute('data-value')).toBe('glass-value');
+
+    // Flip the variant and re-render the SAME mounted tree — the reactive case a
+    // misplaced useMemo would regress. The value must track the new variant.
+    ctrl.variant = 'material';
+    rerender(createElement(Probe));
+    expect(container.querySelector('div')?.getAttribute('data-value')).toBe('material-value');
+  });
 });

--- a/packages/mobile/src/theme/variants/__tests__/variant-features.test.ts
+++ b/packages/mobile/src/theme/variants/__tests__/variant-features.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { variantFeatures } from '../variant-features';
+
+describe('variantFeatures', () => {
+  it('suppresses the in-body large title on Material only (the M3 app bar owns it)', () => {
+    expect(variantFeatures.liquidGlass.inBodyLargeTitle).toBe(true);
+    expect(variantFeatures.material.inBodyLargeTitle).toBe(false);
+  });
+
+  it('routes filters into the top chrome on Material only', () => {
+    expect(variantFeatures.material.filtersInTopChrome).toBe(true);
+    expect(variantFeatures.liquidGlass.filtersInTopChrome).toBe(false);
+  });
+
+  it('declares every variant (exhaustive map)', () => {
+    expect(Object.keys(variantFeatures).sort()).toEqual(['liquidGlass', 'material']);
+  });
+});

--- a/packages/mobile/src/theme/variants/__tests__/variant-features.test.ts
+++ b/packages/mobile/src/theme/variants/__tests__/variant-features.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { variantFeatures } from '../variant-features';
 
+// Exhaustiveness across variants is enforced at COMPILE time by the
+// `satisfies Record<UiVariant, VariantFeatures>` on the registry (a missing variant
+// won't compile), so there's no runtime key-set assertion here — that would only
+// re-check what the type system already guarantees, with a worse error message.
 describe('variantFeatures', () => {
   it('suppresses the in-body large title on Material only (the M3 app bar owns it)', () => {
     expect(variantFeatures.liquidGlass.inBodyLargeTitle).toBe(true);
@@ -12,7 +16,8 @@ describe('variantFeatures', () => {
     expect(variantFeatures.liquidGlass.filtersInTopChrome).toBe(false);
   });
 
-  it('declares every variant (exhaustive map)', () => {
-    expect(Object.keys(variantFeatures).sort()).toEqual(['liquidGlass', 'material']);
+  it('excludes the grade filter from the Material summary only', () => {
+    expect(variantFeatures.material.summaryExcludesGradeFilter).toBe(true);
+    expect(variantFeatures.liquidGlass.summaryExcludesGradeFilter).toBe(false);
   });
 });

--- a/packages/mobile/src/theme/variants/index.ts
+++ b/packages/mobile/src/theme/variants/index.ts
@@ -1,2 +1,3 @@
 export { selectByVariant } from './select-by-variant';
+export { useVariantValue } from './use-variant-value';
 export { createVariantComponent } from './create-variant-component';

--- a/packages/mobile/src/theme/variants/use-variant-value.ts
+++ b/packages/mobile/src/theme/variants/use-variant-value.ts
@@ -1,0 +1,19 @@
+import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from './select-by-variant';
+import type { UiVariant } from '../resolve-ui-variant';
+
+/**
+ * `selectByVariant` bound to the live `theme.variant` — the everyday value pick for
+ * a component that doesn't already destructure the theme.
+ *
+ * Same exhaustiveness guarantee as `selectByVariant`: the `Record<UiVariant, T>`
+ * makes a new variant a compile error at the call site. Same performance rule, too:
+ * when the value is an object handed to a `React.memo` child or used as a
+ * `useMemo`/gesture dependency, define the map as a module-scope `const` and pass it
+ * in — never an inline object literal (which builds a new object every render and
+ * defeats memoisation). For primitives consumed directly in JSX, an inline map is
+ * fine. See ./README.md.
+ */
+export function useVariantValue<T>(byVariant: Record<UiVariant, T>): T {
+  return selectByVariant(useTheme().variant, byVariant);
+}

--- a/packages/mobile/src/theme/variants/variant-features.ts
+++ b/packages/mobile/src/theme/variants/variant-features.ts
@@ -15,9 +15,14 @@ export type VariantFeatures = {
    *  of a floating bottom FAB. Material uses the toolbar; Liquid Glass floats the FAB.
    *  (Consumed by the climbs screen.) */
   filtersInTopChrome: boolean;
+  /** The condensed filter summary omits the grade filter (grade has its own control
+   *  in the Material top chrome); Liquid Glass summarises all filter tokens. The other
+   *  side of the `filtersInTopChrome` layout decision — kept in the registry so it's
+   *  not a bare `selectByVariant` split from the rest. (Consumed by the climbs screen.) */
+  summaryExcludesGradeFilter: boolean;
 };
 
 export const variantFeatures = {
-  liquidGlass: { inBodyLargeTitle: true, filtersInTopChrome: false },
-  material: { inBodyLargeTitle: false, filtersInTopChrome: true },
+  liquidGlass: { inBodyLargeTitle: true, filtersInTopChrome: false, summaryExcludesGradeFilter: false },
+  material: { inBodyLargeTitle: false, filtersInTopChrome: true, summaryExcludesGradeFilter: true },
 } as const satisfies Record<UiVariant, VariantFeatures>;

--- a/packages/mobile/src/theme/variants/variant-features.ts
+++ b/packages/mobile/src/theme/variants/variant-features.ts
@@ -1,0 +1,23 @@
+import type { UiVariant } from '../resolve-ui-variant';
+
+/**
+ * Per-variant FEATURE / content-layout flags — distinct from styling tokens. A
+ * `false` here means "intentionally not shown, or laid out differently, in this
+ * design language", NOT "can't render". Each flag is a product/layout decision;
+ * change it here in one place rather than scattering `variant === 'material' ? …`
+ * gates across screens. Resolved once in the provider and exposed as `theme.features`.
+ */
+export type VariantFeatures = {
+  /** Large in-body screen title. Off on Material — the M3 app bar owns the title, so
+   *  an in-body large title would double it. (Consumed by `ScreenTitle`.) */
+  inBodyLargeTitle: boolean;
+  /** Filters live in the top toolbar (with a condensed filter-summary chip) instead
+   *  of a floating bottom FAB. Material uses the toolbar; Liquid Glass floats the FAB.
+   *  (Consumed by the climbs screen.) */
+  filtersInTopChrome: boolean;
+};
+
+export const variantFeatures = {
+  liquidGlass: { inBodyLargeTitle: true, filtersInTopChrome: false },
+  material: { inBodyLargeTitle: false, filtersInTopChrome: true },
+} as const satisfies Record<UiVariant, VariantFeatures>;

--- a/scripts/mobile-variant-guard.sh
+++ b/scripts/mobile-variant-guard.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 #
-# Guards against raw UI-variant magic-string compares in mobile component render
-# bodies. The aesthetic variant (Material 3 vs Liquid Glass) must be routed through
+# Guards against raw UI-variant magic-string compares in mobile render bodies —
+# components (`packages/mobile/src/components`) and screens (`packages/mobile/app`).
+# The aesthetic variant (Material 3 vs Liquid Glass) must be routed through
 # `selectByVariant` / `createVariantComponent` / a provider-resolved `theme.*` token
 # — never an inline `variant === 'material'` / `=== 'liquidGlass'` comparison that
-# can silently regrow. See packages/mobile/src/theme/variants/README.md.
+# can silently regrow. `src/providers` and `src/hooks` are NOT scanned: they
+# legitimately resolve (theme-provider, resolveSystemColors, useEffectiveSurfaceMode)
+# or compose (use-bottom-accessory: `variant === 'liquidGlass' && glassCapable`) the
+# variant — that's the abstraction's plumbing, not a render-body branch.
+# See packages/mobile/src/theme/variants/README.md.
 #
 # Deliberately scoped to the theme variant: the `[vV]ariant` token matches a
 # `variant`, `uiVariant`, or `theme.variant` identifier (grep substring-matches, so
@@ -32,7 +37,7 @@ ALLOWLIST='queue-control/AccessoryBarSurface\.tsx|user-drawer/UserAvatarToolbarA
 
 matches=$(
   grep -rnE "[vV]ariant[[:space:]]*[!=]==[[:space:]]*'(material|liquidGlass)'" \
-    packages/mobile/src/components \
+    packages/mobile/src/components packages/mobile/app \
     --include='*.tsx' --include='*.ts' \
     | grep -v '__tests__' \
     | grep -v 'variant-ok' \
@@ -41,7 +46,7 @@ matches=$(
 )
 
 if [ -n "$matches" ]; then
-  echo "✖ Raw theme-variant compares found in mobile components:"
+  echo "✖ Raw theme-variant compares found in mobile components/screens:"
   echo "$matches"
   echo
   echo "  Route the aesthetic variant through selectByVariant / createVariantComponent"
@@ -51,4 +56,4 @@ if [ -n "$matches" ]; then
   exit 1
 fi
 
-echo "✓ No raw theme-variant compares in mobile components."
+echo "✓ No raw theme-variant compares in mobile components/screens."


### PR DESCRIPTION
## What & why

Phase 2 of the mobile design-language work. Phase 1 (#2883, merged) consolidated the
`liquidGlass` / `material` branching into typed primitives + provider tokens + a CI guard, but
deliberately left a few loose ends. This **finishes the abstraction** — it is not a redesign:

- ships the deferred `useVariantValue` hook,
- formalizes the `variantFeatures` registry (Phase 1 cut it as premature at one flag; a second flag now exists),
- migrates the `app/` screens that escaped the components-only guard, and
- extends the guard to cover `app/`.

## How

**1. `useVariantValue` hook** — `theme/variants/use-variant-value.ts`: `selectByVariant` bound to the
live `theme.variant`, for components that don't already destructure the theme. Same
`Record<UiVariant, T>` exhaustiveness + memoisation rules. Exported from the barrel, unit-tested, and
used to remove boilerplate from real call sites (`onboarding`, `StatsSummaryCard`, `Stepper`).

**2. `variantFeatures` registry → `theme.features`** — `theme/variants/variant-features.ts` declares
per-variant content/layout flags as a `Record<UiVariant, VariantFeatures>`, resolved once in the
provider:
- `inBodyLargeTitle` — the M3 app bar owns the title, so the in-body large title is off on Material (consumed by `ScreenTitle`).
- `filtersInTopChrome` — Material routes filters into the top toolbar (+ a filter-summary chip) instead of a floating FAB (consumed by the climbs screen).

`makeThemeMock` resolves `features` too, so test mocks can't drift; unit-tested for resolution + exhaustiveness.

**3. `app/` screen migrations** (the components-only guard never saw these):
- `app/onboarding.tsx` — five `isMaterial ? … : …` colour picks collapse into one `useVariantValue` palette.
- `app/(tabs)/climbs/index.tsx` — filter-layout decisions → `theme.features.filtersInTopChrome`; the token/boolean picks → `selectByVariant`.
- `app/acknowledgements.tsx`, `app/licenses.tsx`, `app/scout.tsx` — `headerTransparent: Platform.OS === 'ios'` is an aesthetic (the HIG transparent blur-under-content header), so a forced-Material-on-iOS user wrongly got a transparent header. Now keyed on the variant via `useVariantValue` (same bug class as Phase 1's `SectionHeader` fix).

**4. Guard extended to `app/`** — `scripts/mobile-variant-guard.sh` now scans `packages/mobile/app`
in addition to `src/components`. `src/providers` and `src/hooks` are intentionally excluded — they
legitimately *resolve* (`theme-provider`, `resolveSystemColors`, `useEffectiveSurfaceMode`) or
*compose* (`use-bottom-accessory`: `variant === 'liquidGlass' && glassCapable`) the variant, which is
the abstraction's plumbing, not a render-body branch. Verified it catches a planted `app/` regression.
README reconciled (hook + registry + third-variant punch-list).

## Validation

- `vp run check:mobile-variants` — clean across components **and** screens; regression-catch verified.
- `vp run typecheck:mobile` — zero errors in changed files.
- `vp test run --project mobile` — **2190 passing** (+4 new: registry + hook; the 8 PreSession tests updated to supply `features`).
- `vp check` — clean (17 files) · `vp run check:mobile-bundle` — OK (10.7 MB).

## Pre-existing `main` breakages (NOT introduced by this PR)

Two failures exist on `origin/main`, untouched by this change set — flagged so they aren't mistaken for regressions:
- `use-recent-beta-links.test.tsx:65` — a GraphQL fixture type mismatch (`BetaLinksGqlRow` vs `RecentBetaLinkGqlRow`); makes `typecheck:mobile` exit non-zero.
- `session-feed-card-chart.test.tsx` — 1 test fails on a missing `isInstagramUrl` mock export.

## Test plan

- [x] `check:mobile-variants`, `typecheck:mobile` (clean for changed files), `test:mobile`, `vp check`, `check:mobile-bundle`
- [ ] Manual (toggle the UI-variant in Settings → appearance): onboarding screen colours; climbs filter placement (top toolbar + summary chip on Material vs bottom FAB on Liquid Glass); and the acknowledgements/licenses/scout headers under a forced variant (Material-on-iOS → opaque header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
