### PR TITLE
Update acknowledgements copy and add Alex card

### DIFF
--- a/packages/mobile/app/__tests__/acknowledgements.test.tsx
+++ b/packages/mobile/app/__tests__/acknowledgements.test.tsx
@@ -115,10 +115,11 @@ describe('AcknowledgementsScreen', () => {
     expect(screen.getByText('and 1 more sponsoring privately — thank you too')).toBeTruthy();
   });
 
-  it('thanks the crew and the dog', () => {
+  it('thanks the crew, Alex, and the dog', () => {
     render(<AcknowledgementsScreen />);
 
     expect(screen.getByText('The crew')).toBeTruthy();
+    expect(screen.getByText('Alex')).toBeTruthy();
     expect(screen.getByText('Scout')).toBeTruthy();
   });
 

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -209,6 +209,11 @@ export default function AcknowledgementsScreen() {
               body={t('mobile.acknowledgements.friendsBody', { names: friendsLine })}
             />
             <ThanksCard
+              icon="person"
+              title="Alex"
+              body={t('mobile.acknowledgements.alexBody')}
+            />
+            <ThanksCard
               icon="paw"
               title={dogName}
               body={t('mobile.acknowledgements.dogBody')}

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -132,7 +132,8 @@
       "discordTitle": "Everyone on our Discord",
       "discordBody": "Thanks for the beta, the psyche, and the bug reports. Tap to join.",
       "friendsTitle": "The crew",
-      "friendsBody": "{{names}} — for listening to me go on about Boardsesh, and for actually climbing on it.",
+      "friendsBody": "{{names}}, thanks for still wanting to sesh with me, despite me forcing everyone to beta test instead of climb. Your real world feedback has really helped set direction for Boardsesh.",
+      "alexBody": "For providing design feedback while in retirement from the other side of the globe — hope to cross climbing paths again some day.",
       "dogBody": "Thanks Scout for all the emotional support, she's the real MVP of Boardsesh. Despite not even climbing and just wanting to be a beach dog.",
       "ossLicensesLink": "Open source licenses",
       "ossLicensesBody": "The open source software Boardsesh is built on"

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -330,7 +330,8 @@
       "discordTitle": "Toda la gente de nuestro Discord",
       "discordBody": "Gracias por la beta, la motivación y los reportes de fallos. Toca para unirte.",
       "friendsTitle": "La cuerda",
-      "friendsBody": "{{names}}: por escucharme hablar sin parar de Boardsesh y por escalar de verdad en él.",
+      "friendsBody": "{{names}}, gracias por seguir queriendo sesionar conmigo, a pesar de haberles obligado a todos a hacer beta testing en vez de escalar. Vuestra experiencia real ha ayudado mucho a marcar el rumbo de Boardsesh.",
+      "alexBody": "Por dar feedback de diseño desde su retiro al otro lado del mundo — espero que volvamos a coincidir en la pared algún día.",
       "dogBody": "Gracias a Scout por todo el apoyo emocional, es la verdadera MVP de Boardsesh. A pesar de no escalar y solo querer ser una perra de playa.",
       "ossLicensesLink": "Licencias open source",
       "ossLicensesBody": "El software open source con el que se construye Boardsesh"

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -132,7 +132,8 @@
       "discordTitle": "Tout le monde sur notre Discord",
       "discordBody": "Merci pour la beta, la motivation et les rapports de bugs. Touchez pour rejoindre.",
       "friendsTitle": "La team",
-      "friendsBody": "{{names}} — pour m'avoir écouté parler sans fin de Boardsesh, et pour avoir vraiment grimpé dessus.",
+      "friendsBody": "{{names}} — merci de vouloir encore sesh avec moi, malgré le fait que je vous ai forcés à faire du bêta-test plutôt que grimper. Vos retours concrets ont vraiment aidé à donner une direction à Boardsesh.",
+      "alexBody": "Pour les retours de design depuis sa retraite à l'autre bout du globe — j'espère qu'on grimpera ensemble un jour.",
       "dogBody": "Merci à Scout pour tout le soutien moral, c'est la vraie MVP de Boardsesh. Même si elle ne grimpe pas et veut juste être une chienne de plage.",
       "ossLicensesLink": "Licences open source",
       "ossLicensesBody": "Les logiciels open source sur lesquels Boardsesh est construit"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Rewrites the friends card body to match revised personal thanks copy — mentions beta testing, seshing, and real-world feedback shaping Boardsesh's direction
- Adds a new **Alex** card (icon: person) between the crew and Scout, thanking him for design feedback from retirement on the other side of the globe
- Adds `alexBody` i18n key to all three locales (en-US, es, fr) to satisfy catalog parity checks
- Updates the acknowledgements test to assert Alex appears alongside the crew and Scout

## Test plan

- [ ] Open the Acknowledgements screen in the mobile app
- [ ] Verify the crew card body shows the new text ending with "...set direction for Boardsesh."
- [ ] Verify an "Alex" card appears between the crew and Scout cards
- [ ] Verify Scout card and all other cards are unchanged
- [ ] Switch device locale to Spanish / French and confirm the Alex card body renders (no missing-key fallback)

https://claude.ai/code/session_018Ls3UgVfL68XpGJvNXmkRt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Ls3UgVfL68XpGJvNXmkRt)_