### PR TITLE
fix(web): repair beta-links fixture missing tickUuid/boardId

### DIFF
--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -78,6 +78,8 @@ function betaRow(overrides: Partial<BetaLinksGqlRow> = {}): BetaLinksGqlRow {
     thumbnail: null,
     isListed: true,
     createdAt: '2026-04-30T08:00:00Z',
+    tickUuid: null,
+    boardId: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## What

`vp run typecheck:web` is red on `main` from a single error:

```
app/components/persistent-session/__tests__/event-processor-session-cache.test.ts:73
  error TS2322: '{ … tickUuid?: string | null | undefined; boardId?: … }' is not assignable to 'BetaLinksGqlRow'
```

`BetaLinksGqlRow` gained required `tickUuid: string | null` and `boardId: number | null` fields with the "Link beta videos to ticks" feature (`286a3a599`). The `betaRow()` test fixture wasn't updated. The earlier repair `13b6e02ba` fixed three sibling beta-links fixtures (beta-link-save-normalization, session-detail-beta-links, use-recent-beta-links) but missed this one.

## Fix

Add `tickUuid: null` / `boardId: null` to the `betaRow()` literal — the same pattern `13b6e02ba` used and that `beta-video-url.test.ts`'s `makeRow()` already follows.

## Verification
- `vp run typecheck:web` — clean (0 errors).
- `vp test run --project web event-processor-session-cache` — 11 passed.
- `vp check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)