### PR TITLE
iPad: center the climb tick bar, size up the tick FAB, narrow the tick sheet

### DIFF
--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -17,6 +17,7 @@ import {
 import { FullWindowOverlay } from 'react-native-screens';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../providers/theme-provider';
+import { isIpad } from '../lib/is-ipad';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { Icon } from './Icon';
@@ -115,6 +116,9 @@ export function LogAscentSheet({
       keyboardBehavior="extend"
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
+      // Full-width on phones; on iPad cap the width and center so the tick form
+      // doesn't stretch into an awkwardly wide sheet.
+      style={isIpad ? styles.ipadSheet : undefined}
     >
       <BottomSheetView style={styles.content}>
         <View style={styles.closeButtonRow}>
@@ -151,6 +155,12 @@ export function LogAscentSheet({
 }
 
 const styles = StyleSheet.create({
+  // iPad: a centered ~form-sheet width rather than the full screen width.
+  ipadSheet: {
+    width: '100%',
+    maxWidth: 480,
+    alignSelf: 'center',
+  },
   indicator: {
     backgroundColor: iosSystemColors.separator,
     width: 36,

--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -13,7 +13,7 @@
  */
 
 import { type ReactNode } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { useWindowDimensions, View, StyleSheet } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { timing } from '../../theme/animations';
 import {
@@ -22,8 +22,10 @@ import {
   TOOLBAR_FAB_SIZE,
   TOOLBAR_GAP_ABOVE_TABBAR,
   TABBAR_SEAM_OVERLAP,
+  IPAD_TOOLBAR_MAX_WIDTH,
   glassSize,
 } from '../../theme/layout';
+import { isIpad } from '../../lib/is-ipad';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useMeasuredTabBarHeight } from '../../providers/tab-bar-height-provider';
@@ -62,6 +64,15 @@ export function ActiveContextBar({
   const reduceMotion = useReduceMotion();
   const bottomChrome = useBottomChromeMetrics();
   const measuredTabBarHeight = useMeasuredTabBarHeight();
+  const { width: screenWidth } = useWindowDimensions();
+
+  // On iPad the floating glass bar would otherwise span the whole width — stranding
+  // the capsule mid-screen and flinging the tick FAB to the far edge. Center it as
+  // a phone-like cluster. The docked Material bar keeps its edge-to-edge width.
+  const effectiveInset =
+    isIpad && !fillPrimary && !dockToTabBar
+      ? Math.max(horizontalInset, (screenWidth - IPAD_TOOLBAR_MAX_WIDTH) / 2)
+      : horizontalInset;
 
   // Docked (Material): sit on the tab bar's REAL measured top, tucked under its hairline
   // by one px. Before the first measurement, fall back to the constant-estimated top
@@ -79,8 +90,8 @@ export function ActiveContextBar({
         styles.toolbar,
         {
           bottom,
-          left: horizontalInset,
-          right: horizontalInset,
+          left: effectiveInset,
+          right: effectiveInset,
         },
       ]}
     >

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -18,6 +18,7 @@ const cfg = vi.hoisted(() => ({
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
+  useWindowDimensions: () => ({ width: 390, height: 844, scale: 2, fontScale: 1 }),
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -16,7 +16,14 @@
  * pair, so `jsQueueToolbarVisible` is false here and this returns null.
  */
 
-import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
+import {
+  MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT,
+  TOOLBAR_RESERVE,
+  TAB_BAR_HEIGHT,
+  IPAD_TICK_FAB_SIZE,
+  glassSize,
+} from '../../theme/layout';
+import { isIpad } from '../../lib/is-ipad';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
@@ -61,5 +68,14 @@ export function PersistentQueueBar() {
     );
   }
 
-  return <ActiveContextBar primary={<ClimbCapsule />} trailing={<LogAscentFab climb={currentClimb} />} />;
+  // iPad bumps the hero tick up a step so it reads at arm's length; the bar's
+  // trailing slot widens to match.
+  const tickSize = isIpad ? IPAD_TICK_FAB_SIZE : glassSize.hero;
+  return (
+    <ActiveContextBar
+      primary={<ClimbCapsule />}
+      trailing={<LogAscentFab climb={currentClimb} size={tickSize} />}
+      trailingWidth={tickSize}
+    />
+  );
 }

--- a/packages/mobile/src/hooks/use-bottom-accessory.ts
+++ b/packages/mobile/src/hooks/use-bottom-accessory.ts
@@ -2,14 +2,20 @@ import { Platform } from 'react-native';
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { useTheme } from '../providers/theme-provider';
+import { isIpad } from '../lib/is-ipad';
 import { useGlassCapability } from './use-glass-capability';
 
 /**
  * Whether the device *can* host `NativeTabs.BottomAccessory` — the pure
  * capability check. The native accessory is tied to the system Liquid Glass tab
  * bar, so it only exists on that path.
+ *
+ * Excluded on iPad: iPadOS positions the system bottom accessory against its own
+ * tab-bar layout, where it lands mis-placed and undersized. The climb + tick ride
+ * the centered JS `PersistentQueueBar` there instead (the native tab bar stays).
  */
 export function isBottomAccessoryAvailable(): boolean {
+  if (isIpad) return false;
   return Platform.OS === 'ios' && NativeTabs?.BottomAccessory != null && isLiquidGlassAvailable();
 }
 

--- a/packages/mobile/src/lib/is-ipad.ts
+++ b/packages/mobile/src/lib/is-ipad.ts
@@ -1,0 +1,11 @@
+import { Platform } from 'react-native';
+
+/**
+ * True on iPad. iPadOS lays out the system tab bar — and its Liquid Glass bottom
+ * accessory — differently from iPhone: the accessory can land mis-placed and
+ * undersized. A few surfaces opt out of the native accessory / edge-to-edge
+ * chrome here and use the centered JS treatments instead.
+ *
+ * Resolved once at module load (the idiom is fixed for the app's lifetime).
+ */
+export const isIpad = Platform.OS === 'ios' && (Platform as { isPad?: boolean }).isPad === true;

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -60,6 +60,15 @@ export const TOOLBAR_CAPSULE_HEIGHT = glassSize.capsule;
  *  FABs and stays Photos-style centered on wide phones. */
 export const TOOLBAR_CAPSULE_MAX_WIDTH = 260;
 
+/** On iPad the floating glass climb bar is centered at this max width instead of
+ *  stretching edge-to-edge (which strands the capsule mid-screen and flings the
+ *  tick FAB to the far corner). */
+export const IPAD_TOOLBAR_MAX_WIDTH = 440;
+
+/** Hero log-ascent tick diameter on iPad — a step up from the phone hero so the
+ *  one defining action reads at arm's length on the larger display. */
+export const IPAD_TICK_FAB_SIZE = 64;
+
 /** Screen-edge gutter for the toolbar's side FABs. Matches ClimbTopChrome. */
 export const TOOLBAR_SIDE_MARGIN = 16;
 


### PR DESCRIPTION
## Problem (iPad)

On iPad the log-ascent **tick FAB** ended up mis-placed (far to one side) and small, and the **tick sheet** stretched the full screen width.

Root cause: on iPad the climb + tick ride the iOS 26 **system bottom accessory** (`NativeTabs.BottomAccessory`). iPadOS positions that accessory against its own tab-bar layout, where it lands off to a corner and undersized; and `LogAscentSheet` (shared by every ticking entry point) is a full-width bottom sheet.

## Fix

- **Opt iPad out of the native bottom accessory** (`isBottomAccessoryAvailable()` → false on iPad). The native tab bar stays; the climb + tick fall back to the JS `PersistentQueueBar`, which we control. `jsQueueToolbarVisible` already flips on when the accessory isn't mounted, so space reservation is handled.
- **Center the floating glass bar on iPad** at a phone-like max width (`IPAD_TOOLBAR_MAX_WIDTH = 440`) so the capsule + tick read as one cluster instead of spanning the display.
- **Bump the hero tick FAB to 64 on iPad** (`IPAD_TICK_FAB_SIZE`) — it's already a glass `GlassIconButton`; the bar's trailing slot widens to match.
- **Cap `LogAscentSheet` at 480 and center it on iPad** so the tick form isn't awkwardly wide.
- New `isIpad` helper centralizes the check. **Phone / Android unchanged.**

## Validation

`vp run typecheck:mobile` · queue/accessory tests (`persistent-queue-bar`, `use-bottom-accessory`, `queue-bottom-accessory`, `native-accessory-climb-row`, `tab-layout` — 53 pass) · `vp run check:mobile-bundle` (Android OK) · `vp check`.

Device QA on a real iPad still recommended — in particular confirm the gorhom sheet centers (vs. just narrows) on iPad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)