### PR TITLE
fix(backend): add missing betaLinkTickUuid and boardId to fetchBetaLinksByClimb select

### DIFF
--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -1348,6 +1348,8 @@ async function fetchBetaLinksByClimb(
       thumbnail: dbSchema.boardBetaLinks.thumbnail,
       isListed: dbSchema.boardBetaLinks.isListed,
       createdAt: dbSchema.boardBetaLinks.createdAt,
+      betaLinkTickUuid: dbSchema.boardBetaLinks.tickUuid,
+      boardId: dbSchema.boardBetaLinks.boardId,
     })
     .from(dbSchema.boardBetaLinks)
     .where(


### PR DESCRIPTION
## Summary

- The Drizzle `.select()` in `fetchBetaLinksByClimb` was missing `betaLinkTickUuid` (aliased from `tickUuid`) and `boardId` columns
- This made the returned rows structurally incompatible with `BetaLinkRow`, causing a `TS2345` type error at line 1373 when the rows were passed to `mapBetaLinkRow`
- Fix adds both fields to the select so the shape matches `BetaLinkRow`

## Test plan

- [ ] CI typecheck passes (`boardsesh-backend build` no longer errors)
- [ ] `fetchBetaLinksByClimb` results now include `betaLinkTickUuid` and `boardId` fields, which `mapBetaLinkRow` uses to populate `tickUuid` and `boardId` on the GQL response

https://claude.ai/code/session_01EsMsPR6dJgw2FutETYJwUR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsMsPR6dJgw2FutETYJwUR)_