### PR TITLE
refactor(mobile): real M3 tonal surface-container ladder (Phase 3, slice 1)

### DIFF
--- a/packages/mobile/src/components/GlassCluster.tsx
+++ b/packages/mobile/src/components/GlassCluster.tsx
@@ -2,6 +2,9 @@ import { type ReactNode } from 'react';
 import { View, type StyleProp, type ViewProps, type ViewStyle } from 'react-native';
 import { GlassContainer } from 'expo-glass-effect';
 import { useNativeGlass } from '../hooks/use-native-glass';
+import { useTheme } from '../providers/theme-provider';
+import { useVariantValue } from '../theme/variants';
+import { borderRadius } from '../theme/tokens';
 
 type GlassClusterProps = {
   children?: ReactNode;
@@ -28,6 +31,14 @@ type GlassClusterProps = {
  */
 export function GlassCluster({ children, style, spacing, pointerEvents }: GlassClusterProps) {
   const nativeGlass = useNativeGlass();
+  const { m3SurfaceContainers } = useTheme();
+  // Material groups the row into one M3 `surfaceContainer` lozenge (the M3 answer
+  // to the merged-glass look); Liquid Glass without native glass (iOS < 26 /
+  // Android) stays a plain pass-through so the members keep their own shapes.
+  const materialGroupStyle = useVariantValue<ViewStyle | undefined>({
+    material: { backgroundColor: m3SurfaceContainers.base, borderRadius: borderRadius.full },
+    liquidGlass: undefined,
+  });
 
   if (nativeGlass) {
     return (
@@ -38,7 +49,7 @@ export function GlassCluster({ children, style, spacing, pointerEvents }: GlassC
   }
 
   return (
-    <View style={style} pointerEvents={pointerEvents}>
+    <View style={[materialGroupStyle, style]} pointerEvents={pointerEvents}>
       {children}
     </View>
   );

--- a/packages/mobile/src/components/GlassSheetBackground.tsx
+++ b/packages/mobile/src/components/GlassSheetBackground.tsx
@@ -37,6 +37,9 @@ export function GlassSheetBackground({ style, pointerEvents, flatTop, opaqueMate
   return (
     <GlassSurface
       glassEffectStyle="regular"
+      // Modal bottom sheet = M3 surfaceContainerLow; the scrim carries the
+      // separation, so the sheet tone stays low (not "high because it floats").
+      role="low"
       fallbackColor={systemColors.secondaryBackground}
       tintColor={opaqueMaterial ? playDrawerMaterialTint[colorScheme] : undefined}
       style={[style, sheetStyles.background, sheet.corners, flatTop && styles.flatTop, styles.clip]}

--- a/packages/mobile/src/components/GlassSurface.tsx
+++ b/packages/mobile/src/components/GlassSurface.tsx
@@ -3,8 +3,9 @@ import { StyleSheet, View, type ColorValue, type StyleProp, type ViewProps, type
 import { BlurView } from '@react-native-community/blur';
 import { GlassView, type GlassStyle } from 'expo-glass-effect';
 import { useTheme } from '../providers/theme-provider';
+import type { MaterialSurfaceContainers } from '../theme/colors';
 import { iosDarkColors, iosLightColors } from '../theme/ios-colors';
-import { shadows } from '../theme/tokens';
+import { shadows, type MaterialElevationLevel } from '../theme/tokens';
 import { useEffectiveSurfaceMode } from '../hooks/use-effective-surface-mode';
 
 type GlassSurfaceProps = {
@@ -44,6 +45,20 @@ type GlassSurfaceProps = {
    */
   isInteractive?: boolean;
   pointerEvents?: ViewProps['pointerEvents'];
+  /**
+   * Material-only: the M3 surface-container TONE this surface carries (depth is
+   * tonal first on Material). Omit to keep the legacy opaque `secondaryBackground`
+   * base. Ignored on glass/blur (Liquid Glass expresses depth through the glass).
+   * Pair with `level` per the canonical M3 role map (sheet → `low`, nav/menu →
+   * `base`, dialog → `high`, filled card → `highest`).
+   */
+  role?: keyof MaterialSurfaceContainers;
+  /**
+   * Material-only: the M3 elevation CAST (level0–5). Omit to keep the legacy
+   * `shadows.sm`. The material branch applies it on the same view as the
+   * background + radius (no `overflow:'hidden'`), so a rounded surface still casts.
+   */
+  level?: MaterialElevationLevel;
 };
 
 /**
@@ -69,8 +84,10 @@ export function GlassSurface({
   blurAmount = 20,
   isInteractive = false,
   pointerEvents,
+  role,
+  level,
 }: GlassSurfaceProps) {
-  const { systemColors, colorScheme } = useTheme();
+  const { systemColors, colorScheme, m3SurfaceContainers, materialElevation } = useTheme();
   const mode = useEffectiveSurfaceMode();
   const isDark = colorScheme === 'dark';
 
@@ -99,14 +116,20 @@ export function GlassSurface({
     );
   }
 
-  // Material: opaque M3 tonal surface. Background + radius + shadow live on the
-  // same view (no `overflow: 'hidden'`, which would clip the iOS shadow) so the
-  // surface casts a real elevation shadow with rounded corners. The fallback and
-  // tint composite over the opaque base, matching the blur path.
+  // Material: opaque M3 tonal surface. Depth is tone-FIRST — `role` picks the
+  // surface-container tone, `level` adds the elevation cast (both default to the
+  // legacy base + `shadows.sm` so unmigrated consumers don't shift). Background +
+  // radius + cast live on the SAME view (no `overflow: 'hidden'`, which would clip
+  // the shadow) so even a rounded surface casts. Fallback/tint composite on top.
   if (mode === 'material') {
+    const materialBg = role ? m3SurfaceContainers[role] : baseColor;
+    const elevationStyle = level ? materialElevation[level] : shadows.sm;
+    // When a `role` tone is given it IS the surface — an opaque `fallbackColor`
+    // would paint over and hide it, so skip the fallback layer (the translucent
+    // `tint` still composites). Without a role, keep the legacy fallback-over-base.
     return (
-      <View style={[style, radius, shadows.sm, { backgroundColor: baseColor }]} pointerEvents={pointerEvents}>
-        {fallbackColor ? (
+      <View style={[style, radius, elevationStyle, { backgroundColor: materialBg }]} pointerEvents={pointerEvents}>
+        {!role && fallbackColor ? (
           <View pointerEvents="none" style={[StyleSheet.absoluteFill, radius, { backgroundColor: fallbackColor }]} />
         ) : null}
         {tintColor ? (

--- a/packages/mobile/src/components/__tests__/glass-sheet-background.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-sheet-background.test.tsx
@@ -51,6 +51,8 @@ describe('GlassSheetBackground', () => {
     expect(glass.props?.glassEffectStyle).toBe('regular');
     expect(glass.props?.fallbackColor).toBe('#1C1C1E');
     expect(glass.props?.pointerEvents).toBe('auto');
+    // M3 modal bottom sheet = surfaceContainerLow (the scrim carries separation).
+    expect(glass.props?.role).toBe('low');
   });
 
   it('leaves the material untinted by default so sibling sheets keep the lighter glass', () => {

--- a/packages/mobile/src/components/__tests__/glass-surface.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-surface.test.tsx
@@ -52,6 +52,15 @@ vi.mock('../../providers/theme-provider', () => ({
     systemColors: { secondaryBackground: '#1C1C1E', elevatedSurface: '#2C2C2E' },
     colorScheme: 'dark',
     variant: ctrl.variant,
+    m3SurfaceContainers: { lowest: '#101018', low: '#202028', base: '#303038', high: '#404048', highest: '#505058' },
+    materialElevation: {
+      level0: { elevation: 0 },
+      level1: { elevation: 1, shadowOpacity: 0.1 },
+      level2: { elevation: 2 },
+      level3: { elevation: 3, shadowOpacity: 0.14 },
+      level4: { elevation: 4 },
+      level5: { elevation: 5 },
+    },
   }),
 }));
 
@@ -154,5 +163,25 @@ describe('GlassSurface fallback hierarchy', () => {
     const { queryByTestId, container } = render(<GlassSurface tintColor="rgba(1, 2, 3, 0.2)" />);
     expect(queryByTestId('glass-view')?.getAttribute('data-tint')).toBe('rgba(1, 2, 3, 0.2)');
     expect(container.querySelector('[data-bg="rgba(1, 2, 3, 0.2)"]')).toBeNull();
+  });
+});
+
+describe('GlassSurface Material surface-container role', () => {
+  it('paints the role tone (not the legacy base) on the Material branch', () => {
+    ctrl.variant = 'material';
+    const { container } = render(<GlassSurface role="low" />);
+    // The `low` container tone is the surface...
+    expect(container.querySelector('[data-bg="#202028"]')).not.toBeNull();
+    // ...and the legacy opaque secondary-background base is no longer used.
+    expect(container.querySelector('[data-bg="#1C1C1E"]')).toBeNull();
+  });
+
+  it('lets the role tone win over an opaque fallbackColor (no cover-up)', () => {
+    // A role IS the surface; an opaque fallback would hide it, so it must be
+    // skipped (unlike the no-role case, where the fallback composites over base).
+    ctrl.variant = 'material';
+    const { container } = render(<GlassSurface role="base" fallbackColor="#FFFFFF" />);
+    expect(container.querySelector('[data-bg="#303038"]')).not.toBeNull();
+    expect(container.querySelector('[data-bg="#FFFFFF"]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/chrome/GlassActionToolbar.tsx
+++ b/packages/mobile/src/components/chrome/GlassActionToolbar.tsx
@@ -34,6 +34,8 @@ export function GlassActionToolbar({ actionCount, children }: { actionCount: num
         // `clear` (lighter, content-forward) for the floating islands — more
         // transparent than `regular`, the right variant for floating bars.
         glassEffectStyle="clear"
+        // Floating toolbar island = M3 surfaceContainer tone on Material.
+        role="base"
         fallbackColor={systemColors.elevatedSurface}
         borderRadius={TOP_TOOLBAR_RADIUS}
         style={StyleSheet.absoluteFill}

--- a/packages/mobile/src/components/feed/FeedScopeTitle.tsx
+++ b/packages/mobile/src/components/feed/FeedScopeTitle.tsx
@@ -62,6 +62,8 @@ export function FeedScopeTitle({ title, actions, onSelectIndex, accessibilityHin
             translucent control rather than frosted chrome. */}
         <GlassSurface
           glassEffectStyle="clear"
+          // Floating scope pill = M3 surfaceContainer tone on Material.
+          role="base"
           fallbackColor={systemColors.elevatedSurface}
           borderRadius={PILL_RADIUS}
           style={StyleSheet.absoluteFill}

--- a/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
@@ -38,7 +38,7 @@ export function AccessoryBarSurface({
   children,
 }: AccessoryBarSurfaceProps) {
   const mode = useEffectiveSurfaceMode();
-  const { systemColors, variant } = useTheme();
+  const { systemColors, variant, m3SurfaceContainers, materialElevation } = useTheme();
   const radius = treatment === 'docked' ? 0 : (borderRadius ?? height / 2);
   const shape: ViewStyle = { height, borderRadius: radius };
 
@@ -61,18 +61,19 @@ export function AccessoryBarSurface({
   // Reduce Transparency resolves translucent surfaces to solid. Genuine dual-axis
   // check (surface capability OR aesthetic variant) — see theme/variants/README.md.
   if (mode === 'material' || variant === 'material') {
-    // Docked: neutral M3 surface that reads one elevation step above the tab bar
-    // (hairline separator + elevation shadow). Floating: the same surface as a
-    // lifted pill. The grade colour lives in the bar's leading accent, not here.
+    // M3 bottom-bar surface: the `surfaceContainer` tone + a level-2 cast (the
+    // canonical nav/bottom-bar role). Docked adds a hairline top separator;
+    // floating is the same tone as a lifted pill. The grade colour lives in the
+    // bar's leading accent, not here. No clip on this View, so the cast shows.
     const materialSurfaceStyle: ViewStyle =
       treatment === 'docked'
         ? {
-            backgroundColor: systemColors.elevatedSurface,
+            backgroundColor: m3SurfaceContainers.base,
             borderTopWidth: StyleSheet.hairlineWidth,
             borderTopColor: systemColors.separator,
-            ...shadows.sm,
+            ...materialElevation.level2,
           }
-        : { backgroundColor: systemColors.elevatedSurface, ...shadows.sm };
+        : { backgroundColor: m3SurfaceContainers.base, ...materialElevation.level2 };
     return <View style={[shape, materialSurfaceStyle, style]}>{children}</View>;
   }
 

--- a/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
@@ -29,6 +29,10 @@ vi.mock('../../../providers/theme-provider', () => ({
       elevatedSurface: '#FFFFFF',
       separator: '#CCCCCC',
     },
+    m3SurfaceContainers: { lowest: '#101018', low: '#202028', base: '#2A2138', high: '#33293F', highest: '#3B2F49' },
+    materialElevation: {
+      level2: { elevation: 2, shadowOpacity: 0.12, shadowRadius: 3, shadowOffset: { width: 0, height: 1 } },
+    },
   }),
 }));
 
@@ -55,10 +59,11 @@ describe('AccessoryBarSurface', () => {
     const style = surface?.getAttribute('data-style') ?? '';
     expect(style).toContain('"height":48');
     expect(style).toContain('"borderRadius":0');
-    expect(style).toContain('"backgroundColor":"#FFFFFF"');
+    // M3 bottom-bar surface: the surfaceContainer tone (not the old elevatedSurface).
+    expect(style).toContain('"backgroundColor":"#2A2138"');
     expect(style).toContain('"borderTopWidth":1');
     expect(style).toContain('"borderTopColor":"#CCCCCC"');
-    // The docked bar lifts one elevation step above the tab bar (M3 separation).
+    // The docked bar lifts one elevation step above the tab bar (M3 nav-bar = level 2).
     expect(style).toContain('"elevation":2');
     expect(container.querySelector('[data-glass]')).toBeNull();
   });
@@ -73,6 +78,6 @@ describe('AccessoryBarSurface', () => {
     );
 
     expect(container.querySelector('[data-glass]')).toBeNull();
-    expect(container.querySelector('[data-view]')?.getAttribute('data-style')).toContain('"backgroundColor":"#FFFFFF"');
+    expect(container.querySelector('[data-view]')?.getAttribute('data-style')).toContain('"backgroundColor":"#2A2138"');
   });
 });

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -14,6 +14,8 @@ import {
   brandColorsDark,
   androidFallbackColors,
   materialSurfaces,
+  materialSurfaceContainers,
+  type MaterialSurfaceContainers,
 } from '../theme/colors';
 import { textStylesByVariant, type TextVariant, type TypeStyle } from '../theme/typography';
 import { buildPaperTheme } from '../theme/paper-theme';
@@ -25,6 +27,7 @@ import {
   opacity,
   radiiByVariant,
   sheetChromeByVariant,
+  materialElevationByLevel,
   type Radii,
   type SheetChrome,
 } from '../theme/tokens';
@@ -114,6 +117,19 @@ type Theme = {
    * roles, so use the `elevation.levelN` ladder for surface-container surfaces.
    */
   m3: MD3Theme['colors'];
+  /**
+   * M3 tonal surface-container ramp ({lowest,low,base,high,highest}) for the
+   * current colour scheme. Material surfaces read a role here to express depth by
+   * TONE (the canonical M3 mechanism); pair with `materialElevation` for the cast.
+   * Only meaningful on Material — Liquid Glass never reads it.
+   */
+  m3SurfaceContainers: MaterialSurfaceContainers;
+  /**
+   * M3 elevation casts keyed by level (`level0`–`level5`), each a full ViewStyle
+   * (iOS `shadow*` + Android `elevation`). Scheme-independent. Apply on the same
+   * view as the tonal background — never under `overflow:'hidden'`.
+   */
+  materialElevation: typeof materialElevationByLevel;
   /**
    * Semantic foregrounds for action rows / action FABs, resolved per variant:
    * monochrome (`systemColors.label`) on Liquid Glass, tinted by role on Material.
@@ -325,6 +341,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       radii: radiiByVariant[variant],
       sheet: sheetChromeByVariant[variant],
       m3: m3Colors,
+      m3SurfaceContainers: materialSurfaceContainers[colorScheme],
+      materialElevation: materialElevationByLevel,
       actionColors: resolveActionColors(variant, {
         label: resolvedSystemColors.label,
         accent: resolvedSystemColors.accent,

--- a/packages/mobile/src/test/theme-mock.ts
+++ b/packages/mobile/src/test/theme-mock.ts
@@ -1,8 +1,22 @@
 import type { Theme } from '../providers/theme-provider';
-import { spacing, borderRadius, shadows, opacity, radiiByVariant, sheetChromeByVariant } from '../theme/tokens';
+import {
+  spacing,
+  borderRadius,
+  shadows,
+  opacity,
+  radiiByVariant,
+  sheetChromeByVariant,
+  materialElevationByLevel,
+} from '../theme/tokens';
 import { springs, timing } from '../theme/animations';
 import { textStylesByVariant } from '../theme/typography';
-import { brandColors, brandColorsDark, materialSurfaces, androidFallbackColors } from '../theme/colors';
+import {
+  brandColors,
+  brandColorsDark,
+  materialSurfaces,
+  androidFallbackColors,
+  materialSurfaceContainers,
+} from '../theme/colors';
 import { buildPaperTheme } from '../theme/paper-theme';
 import { resolveActionColors, resolveChartColors, sectionCaptionByVariant } from '../theme/variants/variant-tokens';
 import { variantFeatures } from '../theme/variants/variant-features';
@@ -46,6 +60,8 @@ export function makeThemeMock(overrides: Partial<Theme> = {}): Theme {
     radii: radiiByVariant[variant],
     sheet: sheetChromeByVariant[variant],
     m3: buildPaperTheme(colorScheme).colors,
+    m3SurfaceContainers: materialSurfaceContainers[colorScheme],
+    materialElevation: materialElevationByLevel,
     actionColors: resolveActionColors(variant, {
       label: systemColors.label,
       accent: systemColors.accent,

--- a/packages/mobile/src/theme/__tests__/material-surfaces.test.ts
+++ b/packages/mobile/src/theme/__tests__/material-surfaces.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+// colors.ts (and tokens.ts → ios-colors.ts) touch Platform/PlatformColor at
+// import; the Android branch skips the iOS PlatformColor path.
+vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
+
+import { materialSurfaceContainers, materialElevationLevels } from '../colors';
+import { materialElevationByLevel } from '../tokens';
+
+const SCHEMES = ['light', 'dark'] as const;
+const HEX = /^#[0-9a-f]{6}$/;
+
+describe('materialSurfaceContainers', () => {
+  it.each(SCHEMES)('resolves five distinct opaque tones (%s)', (scheme) => {
+    const ramp = materialSurfaceContainers[scheme];
+    const tones = [ramp.lowest, ramp.low, ramp.base, ramp.high, ramp.highest];
+    // Every tone is opaque hex (so a surface never shows the screen through it)…
+    tones.forEach((tone) => expect(tone).toMatch(HEX));
+    // …and all five are DISTINCT — the bug this replaces collapsed light
+    // secondaryBackground/tertiaryBackground/elevatedSurface all to #FFFFFF.
+    expect(new Set(tones).size).toBe(5);
+    // The ramp climbs (more primary tint at each step), so the ends differ.
+    expect(ramp.lowest).not.toBe(ramp.highest);
+  });
+});
+
+describe('materialElevationLevels', () => {
+  it.each(SCHEMES)('gives Paper five distinct elevation tones (%s)', (scheme) => {
+    const levels = materialElevationLevels(scheme);
+    const tones = [levels.level1, levels.level2, levels.level3, levels.level4, levels.level5];
+    tones.forEach((tone) => expect(tone).toMatch(HEX));
+    expect(new Set(tones).size).toBe(5);
+  });
+});
+
+describe('materialElevationByLevel', () => {
+  it('level 0 is flat (no cast)', () => {
+    expect(materialElevationByLevel.level0.shadowOpacity).toBe(0);
+    expect(materialElevationByLevel.level0.elevation).toBe(0);
+  });
+
+  it('the shadowed levels (sheet L1, dialog/FAB L3) carry a real iOS cast', () => {
+    for (const level of ['level1', 'level3'] as const) {
+      const cast = materialElevationByLevel[level];
+      // iOS renders depth from shadow* props, not `elevation` — so these must be
+      // present, or Material-on-iOS would be flat.
+      expect(cast.shadowOpacity).toBeGreaterThan(0);
+      expect(cast.shadowRadius).toBeGreaterThan(0);
+      expect(cast.shadowOffset.height).toBeGreaterThan(0);
+    }
+  });
+
+  it('Android elevation increases monotonically level0 → level5', () => {
+    const elevations = (['level0', 'level1', 'level2', 'level3', 'level4', 'level5'] as const).map(
+      (level) => materialElevationByLevel[level].elevation,
+    );
+    for (let i = 1; i < elevations.length; i++) {
+      expect(elevations[i]).toBeGreaterThan(elevations[i - 1]);
+    }
+  });
+});

--- a/packages/mobile/src/theme/__tests__/paper-theme.test.ts
+++ b/packages/mobile/src/theme/__tests__/paper-theme.test.ts
@@ -19,12 +19,25 @@ describe('buildPaperTheme', () => {
     expect(theme.colors.background).toBe('#F3EFFA'); // materialSurfaces.light.background
     expect(theme.colors.surface).toBe('#FFFFFF'); // secondaryBackground
     expect(theme.colors.error).toBe('#C81E1E');
-    expect(theme.colors.elevation.level2).toBe('#FFFFFF'); // elevatedSurface (light)
+    // The five elevation levels are now DISTINCT, monotonic surface-tint tones
+    // (not all collapsed onto one `elevatedSurface`), so Paper's elevated
+    // components tier instead of looking identical.
+    const { level0, level1, level2, level3, level4, level5 } = theme.colors.elevation;
+    expect(level0).toBe('transparent');
+    expect(new Set([level1, level2, level3, level4, level5]).size).toBe(5);
     // The two grade stat tiles use the brand-violet primary/secondary containers
     // (not the vestigial amber tertiary), so they read as one tonal family.
     expect(theme.colors.primaryContainer).toContain('109, 40, 217'); // brand violet #6D28D9
     expect(theme.colors.secondaryContainer).toContain('109, 40, 217');
-    expect(theme.colors.onSecondaryContainer).toBe(theme.colors.onSurface);
+    // Container ink is an explicit dark violet — not the near-white `onSurface`,
+    // which was illegible on the (dark-scheme) container.
+    expect(theme.colors.onPrimaryContainer).toBe('#21005D');
+    expect(theme.colors.onSecondaryContainer).toBe('#21005D');
+    // `surfaceVariant` is a real toned container (filled text fields were
+    // invisible when it aliased `#FFFFFF`).
+    expect(theme.colors.surfaceVariant).not.toBe('#FFFFFF');
+    // `outline` (form border) is distinct from `outlineVariant` (faint divider).
+    expect(theme.colors.outline).not.toBe(theme.colors.outlineVariant);
   });
 
   it('uses the dark tonal surfaces for the dark scheme', () => {

--- a/packages/mobile/src/theme/colors.ts
+++ b/packages/mobile/src/theme/colors.ts
@@ -248,3 +248,72 @@ export function blendOpaque(foreground: string, background: string, alpha: numbe
   const mix = (channel: 0 | 1 | 2) => fg[channel] * alpha + bg[channel] * (1 - alpha);
   return `#${toHexByte(mix(0))}${toHexByte(mix(1))}${toHexByte(mix(2))}`;
 }
+
+/**
+ * M3 surface-tint percentages for the elevation overlay (levels 1–5). The brand
+ * primary is alpha-composited over the base surface at these alphas to build the
+ * tonal surface-container ramp — this IS M3's mechanism for expressing depth
+ * (higher surface = more primary tint), so depth is tonal, not just a shadow.
+ */
+const m3SurfaceTint = { level1: 0.05, level2: 0.08, level3: 0.11, level4: 0.12, level5: 0.14 } as const;
+
+/**
+ * One container tone: the scheme's brand primary tinted over its base surface.
+ * In light the ramp tones toward violet as it rises; in dark the brighter fill
+ * lifts the near-black base — the canonical M3 direction in each scheme.
+ */
+function tintTone(scheme: 'light' | 'dark', alpha: number): string {
+  const base = materialSurfaces[scheme].background;
+  const primary = (scheme === 'dark' ? brandColorsDark : brandColors).primaryFill;
+  return blendOpaque(primary, base, alpha);
+}
+
+/**
+ * M3 surface-container tones for the Material variant, **computed** per scheme
+ * (the hand-tuned `materialSurfaces` collapsed these to one or two values — light
+ * `secondaryBackground`/`tertiaryBackground`/`elevatedSurface` were all `#FFFFFF`).
+ * Computing from `base + primary` (not tuned hexes) keeps the five steps monotonic
+ * and distinct, and lets a future Material You palette recompute them from a
+ * dynamic primary without a rewrite. Named roles map onto Paper's elevation
+ * levels: `low`↔level1, `base`↔level2, `high`↔level3, `highest`↔level5.
+ */
+export const materialSurfaceContainers = {
+  light: {
+    lowest: tintTone('light', 0.02),
+    low: tintTone('light', m3SurfaceTint.level1),
+    base: tintTone('light', m3SurfaceTint.level2),
+    high: tintTone('light', m3SurfaceTint.level3),
+    highest: tintTone('light', m3SurfaceTint.level5),
+  },
+  dark: {
+    lowest: tintTone('dark', 0.02),
+    low: tintTone('dark', m3SurfaceTint.level1),
+    base: tintTone('dark', m3SurfaceTint.level2),
+    high: tintTone('dark', m3SurfaceTint.level3),
+    highest: tintTone('dark', m3SurfaceTint.level5),
+  },
+} as const;
+
+/**
+ * Paper elevation-level tones (level1–5) for the MD3 theme — the SAME ramp as the
+ * named containers, so Paper's own elevated components (Surface/Menu/FAB/Card/
+ * Dialog/Appbar) tier identically to our app surfaces instead of collapsing to
+ * one `elevatedSurface` colour.
+ */
+export function materialElevationLevels(scheme: 'light' | 'dark'): {
+  level1: string;
+  level2: string;
+  level3: string;
+  level4: string;
+  level5: string;
+} {
+  return {
+    level1: tintTone(scheme, m3SurfaceTint.level1),
+    level2: tintTone(scheme, m3SurfaceTint.level2),
+    level3: tintTone(scheme, m3SurfaceTint.level3),
+    level4: tintTone(scheme, m3SurfaceTint.level4),
+    level5: tintTone(scheme, m3SurfaceTint.level5),
+  };
+}
+
+export type MaterialSurfaceContainers = typeof materialSurfaceContainers.light;

--- a/packages/mobile/src/theme/paper-theme.ts
+++ b/packages/mobile/src/theme/paper-theme.ts
@@ -1,5 +1,13 @@
 import { MD3DarkTheme, MD3LightTheme, type MD3Theme } from 'react-native-paper';
-import { brandColors, brandColorsDark, materialSurfaces, withAlpha } from './colors';
+import {
+  brandColors,
+  brandColorsDark,
+  materialSurfaces,
+  materialSurfaceContainers,
+  materialElevationLevels,
+  withAlpha,
+  blendOpaque,
+} from './colors';
 
 type ColorScheme = 'light' | 'dark';
 
@@ -24,10 +32,16 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
   }
 
   const surfaces = materialSurfaces[colorScheme];
+  const containers = materialSurfaceContainers[colorScheme];
   const isDark = colorScheme === 'dark';
   const brand = isDark ? brandColorsDark : brandColors;
   const onSurface = surfaces.label as string;
   const onSurfaceVariant = surfaces.secondaryLabel as string;
+  const surface = surfaces.secondaryBackground as string;
+  // Explicit container ink — a near-black/near-white VIOLET that clears contrast
+  // on the translucent-violet `primaryContainer`. Aliasing `onSurface` made it
+  // near-white in dark, illegible on the dark-scheme container.
+  const onPrimaryContainer = isDark ? '#EADDFF' : '#21005D';
 
   return {
     ...base,
@@ -36,11 +50,11 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
       primary: brand.primaryFill,
       onPrimary: brand.onPrimary,
       primaryContainer: withAlpha(brand.primaryFill, isDark ? 0.32 : 0.14),
-      onPrimaryContainer: onSurface,
+      onPrimaryContainer,
       secondary: brand.primaryFill,
       onSecondary: brand.onPrimary,
       secondaryContainer: withAlpha(brand.primaryFill, isDark ? 0.28 : 0.16),
-      onSecondaryContainer: onSurface,
+      onSecondaryContainer: onPrimaryContainer,
       // Amber accent is the M3 tertiary role — fill-only, so it carries dark text
       // in BOTH schemes (white fails on amber). Pin to the light-scheme label
       // token (the dark ink) rather than the per-scheme `onSurface`, which would
@@ -51,21 +65,25 @@ export function buildPaperTheme(colorScheme: ColorScheme, dynamic?: MD3Theme['co
       onBackground: onSurface,
       surface: surfaces.secondaryBackground as string,
       onSurface,
-      surfaceVariant: surfaces.tertiaryBackground as string,
+      // Neutral-variant surface for filled text fields / tonal fills — a real
+      // toned container, not `tertiaryBackground` (`#FFFFFF` in light, which made
+      // filled fields invisible).
+      surfaceVariant: containers.base,
       onSurfaceVariant,
-      outline: surfaces.separator as string,
+      // `outline` is the stronger form/component border (M3 ~ neutral-variant
+      // mid-tone); `outlineVariant` is the faint divider. They were both aliased
+      // to `separator` (0.18α), so borders and dividers were indistinguishable.
+      outline: blendOpaque(onSurface, surface, 0.45),
       outlineVariant: surfaces.separator as string,
       error: brand.error,
       onError: '#FFFFFF',
-      // Surface-tint ladder: map Paper's elevation levels onto our tonal surfaces
-      // so elevated Paper components match the rest of the Material chrome.
+      // Surface-tint ladder: the five elevation levels are now DISTINCT, monotonic
+      // tonal steps (computed brand-over-surface), so Paper's elevated components
+      // (Surface/Menu/FAB/Card/Dialog/Appbar) tier instead of collapsing to one
+      // `elevatedSurface` colour — and "+1 level on press/focus" shows real depth.
       elevation: {
         level0: 'transparent',
-        level1: surfaces.secondaryBackground as string,
-        level2: surfaces.elevatedSurface as string,
-        level3: surfaces.elevatedSurface as string,
-        level4: surfaces.elevatedSurface as string,
-        level5: surfaces.elevatedSurface as string,
+        ...materialElevationLevels(colorScheme),
       },
     },
   };

--- a/packages/mobile/src/theme/tokens.ts
+++ b/packages/mobile/src/theme/tokens.ts
@@ -72,6 +72,27 @@ export const shadows = {
   },
 } as const;
 
+/**
+ * Material 3 elevation as a full ViewStyle per level — iOS `shadow*` props AND
+ * Android `elevation` in one object, because iOS ignores `elevation` (a bare
+ * number renders flat on Material-on-iOS) and Android ignores `shadow*`. Pair
+ * with the tonal `m3SurfaceContainers` ramp: depth on Material is tone-FIRST,
+ * with these casts layered on the components M3 actually shadows (sheet L1, nav/
+ * menu L2, dialog/FAB L3+). Level 0 is flat (app-bar-at-rest, filled card). Apply
+ * on the SAME view as the background + radius (never under `overflow:'hidden'`,
+ * which clips the cast) — see `GlassSurface`'s material branch.
+ */
+export const materialElevationByLevel = {
+  level0: { shadowColor, shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0, shadowRadius: 0, elevation: 0 },
+  level1: { shadowColor, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.1, shadowRadius: 2, elevation: 1 },
+  level2: { shadowColor, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.12, shadowRadius: 3, elevation: 2 },
+  level3: { shadowColor, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.14, shadowRadius: 5, elevation: 3 },
+  level4: { shadowColor, shadowOffset: { width: 0, height: 3 }, shadowOpacity: 0.15, shadowRadius: 6, elevation: 4 },
+  level5: { shadowColor, shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.16, shadowRadius: 8, elevation: 5 },
+} as const;
+
+export type MaterialElevationLevel = keyof typeof materialElevationByLevel;
+
 export const opacity = {
   subtle: 0.7,
   peek: 0.62,
@@ -109,15 +130,20 @@ export const sheetStyles = {
  * parallel Material design system.
  */
 export const material = {
-  /** M3 pressed state-layer opacity, used to tint ripples. */
+  /** M3 pressed state-layer opacity, used to tint ripples (and the iOS-on-Material
+   *  pressed overlay, where there is no `android_ripple`). */
   pressedStateLayer: 0.12,
+  /** M3 disabled opacities: content (text/icon) at 38%, container fill at 12% —
+   *  replaces the single Liquid-Glass `opacity.disabled` (0.5) on Material. */
+  disabledContentOpacity: 0.38,
+  disabledContainerOpacity: 0.12,
   navBar: {
     /** Tonal pill behind the focused tab's icon (M3 spec: 64×32). */
     activeIndicatorWidth: 64,
     activeIndicatorHeight: 32,
     activeIndicatorRadius: 16,
-    /** Resting elevation of the solid Android nav surface. */
-    surfaceElevation: 3,
+    /** Resting elevation of the solid Android nav surface (M3 nav bar = level 2). */
+    surfaceElevation: 2,
   },
   sheet: {
     /** M3 bottom-sheet top corner radius (iOS keeps borderRadius.xl = 16). */


### PR DESCRIPTION
## Phase 3, slice 1 — make Material a real M3 surface (tonal depth)

Phase 3 closes the gap the codebase admits in `tokens.ts`: Material is still "a hybrid skin … not a parallel Material design system." This first slice fixes **depth**.

### The problem
- `theme.m3.elevation` was consumed in **0 places**, and its levels 2–5 collapsed to one colour — not a real M3 tonal ladder.
- The hand-tuned `materialSurfaces` had no distinct container tones (light `secondaryBackground`/`tertiaryBackground`/`elevatedSurface` were **all `#FFFFFF`**).
- `GlassSurface`'s material branch hardcoded a single `shadows.sm`.

### What changed
- **Computed surface-container ramp** (`colors.ts`): the five M3 roles `surfaceContainerLowest → Highest`, computed as brand-primary-over-base at M3's surface-tint percentages — monotonic, distinct, and Material-You-ready (function of base+primary, not tuned hexes).
- **`materialElevationByLevel`** (`tokens.ts`): a full ViewStyle per level — iOS `shadow*` **and** Android `elevation` (a bare number renders flat on Material-on-iOS). `navBar` elevation 3 → **2**; M3 disabled tokens (38% / 12%).
- **Paper theme fixes** (`paper-theme.ts`): `elevation.level1–5` now map to five **distinct** tones so Paper's elevated components tier instead of looking identical; `outline` ≠ `outlineVariant`; `surfaceVariant` off `#FFFFFF` (filled text fields were invisible); explicit `onPrimaryContainer` ink.
- **`GlassSurface` `role`/`level`**: the material branch reads the container tone + cast (a `role` tone wins over an opaque `fallbackColor`). Wired: sheets → `surfaceContainerLow`, accessory bar → `surfaceContainer`/L2, toolbar + scope pill → `surfaceContainer`, cluster → a `surfaceContainer` grouping. `Card` already routes to Paper's elevated `Card` (picks up the fixed `level1`).

### Canonical M3 mapping this implements
Sheets are `surfaceContainerLow`/level 1 (the **scrim** carries separation, not a "high because it floats" tone); top app bar rests at `surface`/0; nav/menu at `surfaceContainer`/2; dialog `surfaceContainerHigh`/3; FAB `primaryContainer`/3. Tone-first, with **real shadows kept** on FAB/menu/dialog. These corrections (and "iOS needs `shadow*`, not `elevation`") came from two M3/RN design-review passes on the plan.

### Deferred to a follow-up
The Material-on-iOS 12% pressed **state-layer overlay** and the broad disabled-opacity sweep — both touch the hot `PressableSurface` primitive, and Android (the primary Material platform) already ripples at the M3 layer; iOS-on-Material is a forced-variant edge case. Tokens are in place.

### Validation
- `vp run typecheck` ✓
- `vp test run --project mobile` — **305 files / 2201 tests** ✓ (new `material-surfaces.test.ts` + `GlassSurface` role→tone + updated `paper-theme`/`accessory-bar` assertions)
- `vp run check:mobile-variants` ✓ · `vp check` (16 files) ✓ · `vp run check:mobile-bundle` (Android) ✓
- **Visual tone tiering** is best verified on device/sim via the EAS preview OTA (tone changes don't show in unit tests).

First of ~4 slices (next: variant-aware app bars; then Dialog/Menu/FAB; then motion tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)