### PR TITLE
chore(screenshots): always capture against prod, remove Colima

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -4,18 +4,15 @@ name: Mobile Screenshots (Native)
 # simulator via Maestro (scripts/mobile-screenshots.ts) and uploads them as an
 # artifact. Manual + nightly only — never gates PRs.
 #
+# All runs capture against PROD signed in as the test user (the canonical store
+# recipe), so there's no local backend / Colima — the build just talks to the
+# production backend.
+#
 # On a manual dispatch with `upload = true`, it also uploads the freshly captured
 # screenshots to App Store Connect via fastlane (fastlane/Fastfile, screenshots
 # ONLY — no binary, metadata, or review submission). The nightly cron never
 # uploads (it only captures); uploading mutates the live "Prepare for Submission"
 # version, so it's opt-in per dispatch. See app-stores/apple/app-store-submission-guide.md.
-#
-# Data source depends on the run:
-#   - upload runs capture against PROD (signed in as the test user) — the canonical
-#     store recipe, and it needs no local backend, so it skips the Colima/Docker/DB
-#     steps below entirely.
-#   - capture-only / nightly runs use the seeded dev DB (ghcr.io/boardsesh/boardsesh-dev-db)
-#     brought up with Colima, since macOS runners can't use Linux `services:` containers.
 
 on:
   workflow_dispatch:
@@ -52,20 +49,16 @@ jobs:
     timeout-minutes: 90
 
     env:
-      # An upload dispatch captures against PROD (no local backend, no Colima) —
-      # matching the canonical "capture against the prod test user" recipe and
-      # sidestepping the Colima VM, which doesn't boot on this runner image.
-      # Capture-only / nightly runs use the seeded local backend (Colima below).
+      # Marks an upload dispatch — gates the App Store Connect upload steps so the
+      # nightly cron and capture-only runs never touch ASC.
       UPLOAD_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.upload }}
       # Reused from ios-rn-ci.yml so the Expo build links the same native config.
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
-      DATABASE_URL: postgresql://postgres:password@localhost:5432/main
-      REDIS_URL: redis://localhost:6379
-      # Test account that ships in the seeded dev DB. Override via repo secrets
-      # if a different account is ever needed.
+      # The prod test/demo account the Maestro flow signs in with. Override via
+      # repo secrets if a different account is ever needed.
       SCREENSHOT_USER_EMAIL: ${{ secrets.SCREENSHOT_USER_EMAIL || 'test@boardsesh.com' }}
       SCREENSHOT_USER_PASSWORD: ${{ secrets.SCREENSHOT_USER_PASSWORD || 'test' }}
 
@@ -82,24 +75,6 @@ jobs:
 
       - name: Install Node.js dependencies
         run: bun install --frozen-lockfile
-
-      # The local seeded backend (Colima/Docker + dev DB + backend) is only needed
-      # for --backend local. Upload runs capture against prod, so skip all three.
-      - name: Start Docker (Colima) for the seeded dev DB
-        if: success() && env.UPLOAD_RUN != 'true'
-        run: |
-          brew install colima docker
-          colima start --cpu 3 --memory 6
-
-      - name: Bring up seeded dev DB (+ Redis)
-        if: success() && env.UPLOAD_RUN != 'true'
-        run: vp run db:up
-
-      - name: Start backend
-        if: success() && env.UPLOAD_RUN != 'true'
-        run: |
-          bun run --filter=boardsesh-backend start > backend.log 2>&1 &
-          bunx wait-on http-get://localhost:8080/health --timeout 120000
 
       - name: Install Maestro
         # Pinned to a specific GitHub Releases asset and verified against a
@@ -121,22 +96,14 @@ jobs:
           echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"
 
       - name: Capture screenshots
-        env:
-          # prod for upload runs, local otherwise. The local backend URLs are
-          # exported inline ONLY for local capture — they must NOT be in the
-          # environment for a prod build (the screenshot script spreads the env,
-          # so a stray EXPO_PUBLIC_BACKEND_URL would point a prod build at localhost).
-          SCREENSHOT_BACKEND: ${{ env.UPLOAD_RUN == 'true' && 'prod' || 'local' }}
+        # Always against prod (signed in as the test user). No EXPO_PUBLIC_BACKEND_URL
+        # override, so the build uses the app's production backend defaults.
         run: |
           set -euo pipefail
-          if [ "$SCREENSHOT_BACKEND" = "local" ]; then
-            export EXPO_PUBLIC_BACKEND_URL=http://localhost:8080
-            export EXPO_PUBLIC_WEB_URL=http://localhost:3000
-          fi
           vp run mobile:screenshots -- \
             --platform ios \
             --flow "${{ inputs.flow || 'app-store' }}" \
-            --backend "$SCREENSHOT_BACKEND" \
+            --backend prod \
             --device "${{ inputs.device || 'iPhone 16 Pro Max' }}"
 
       # Fail loudly if any capture isn't an App Store-accepted size for its slot,
@@ -190,10 +157,6 @@ jobs:
       - name: Clean up App Store Connect key
         if: always()
         run: rm -f "$HOME/.private_keys/AuthKey_"*.p8 2>/dev/null || true
-
-      - name: Dump backend log on failure
-        if: failure()
-        run: cat backend.log || true
 
       - name: Upload screenshots artifact
         if: always()


### PR DESCRIPTION
Follow-up to #2918. We always generate the App Store screenshots signed in as the test user on **prod**, so the local-DB/Colima path is dead weight — and it never booted on the `macos-26` runner anyway.

## Change

Removes the local-backend path from the `Mobile Screenshots (Native)` workflow entirely:
- Deletes the **Start Docker (Colima)**, **Bring up seeded dev DB**, and **Start backend** steps.
- Deletes the `DATABASE_URL` / `REDIS_URL` job env and the "Dump backend log on failure" step.
- Capture is now unconditionally `--backend prod` (no `EXPO_PUBLIC_BACKEND_URL` override → the build uses production backend defaults).
- `UPLOAD_RUN` now only gates the App Store Connect upload steps.

Net `−48 / +11`. Nightly + capture-only runs now also capture against prod (the intended behaviour).

## Why this is safe

The prod capture path is already validated by the #2918 dispatch (run [27589942349](https://github.com/boardsesh/boardsesh/actions/runs/27589942349)): the **Colima step is `skipped`** and capture-against-prod runs. This PR uses the identical `--backend prod` capture command, just without the now-unreachable local branch — so a green capture there proves this path too.

The `mobile-screenshots.ts` script keeps its `--backend local` flag for local dev with a seeded DB; only the CI workflow is pinned to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)