### PR TITLE
refactor(mobile): one variant-aware native stack header (Phase 3, slice 2)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/_layout.tsx
+++ b/packages/mobile/app/(tabs)/climbs/_layout.tsx
@@ -1,12 +1,13 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { glassStackScreenOptions } from '../../../src/theme/navigation';
+import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
 
 export default function ClimbsLayout() {
   const { t } = useTranslation('common');
+  const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={glassStackScreenOptions}>
+    <Stack screenOptions={screenOptions}>
       <Stack.Screen
         name="index"
         options={{

--- a/packages/mobile/app/(tabs)/discover/_layout.tsx
+++ b/packages/mobile/app/(tabs)/discover/_layout.tsx
@@ -1,12 +1,13 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { glassStackScreenOptions } from '../../../src/theme/navigation';
+import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
 
 export default function DiscoverLayout() {
   const { t } = useTranslation('playlists');
+  const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={glassStackScreenOptions}>
+    <Stack screenOptions={screenOptions}>
       <Stack.Screen
         name="index"
         options={{

--- a/packages/mobile/app/(tabs)/home/_layout.tsx
+++ b/packages/mobile/app/(tabs)/home/_layout.tsx
@@ -1,9 +1,10 @@
 import { Stack } from 'expo-router';
-import { glassStackScreenOptions } from '../../../src/theme/navigation';
+import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
 
 export default function HomeLayout() {
+  const screenOptions = useStackScreenOptions();
   return (
-    <Stack screenOptions={glassStackScreenOptions}>
+    <Stack screenOptions={screenOptions}>
       {/* The Home feed owns its top via floating chrome (the avatar island + scope
           title), like the other tabs — so the stack header is hidden here. */}
       <Stack.Screen name="index" options={{ headerShown: false }} />

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -1,13 +1,14 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { glassStackScreenOptions } from '../../../src/theme/navigation';
+import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
 
 export default function ProfileLayout() {
   const { t } = useTranslation('common');
   const { t: tSettings } = useTranslation('settings');
+  const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={glassStackScreenOptions}>
+    <Stack screenOptions={screenOptions}>
       {/* The You screen owns its top via the floating ProfileTopChrome (large
           title collapsing into a glass capsule), like the Discover/Climbs tabs —
           so the stack header is hidden here. */}

--- a/packages/mobile/app/(tabs)/record/_layout.tsx
+++ b/packages/mobile/app/(tabs)/record/_layout.tsx
@@ -1,6 +1,6 @@
 import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { glassStackScreenOptions } from '../../../src/theme/navigation';
+import { useStackScreenOptions } from '../../../src/hooks/use-stack-screen-options';
 
 /**
  * The Record tab renders the session screen inline (its `index` route). The
@@ -9,9 +9,10 @@ import { glassStackScreenOptions } from '../../../src/theme/navigation';
  */
 export default function RecordLayout() {
   const { t } = useTranslation('common');
+  const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={glassStackScreenOptions}>
+    <Stack screenOptions={screenOptions}>
       <Stack.Screen name="index" options={{ headerShown: false }} />
       <Stack.Screen
         name="summary"

--- a/packages/mobile/app/about.tsx
+++ b/packages/mobile/app/about.tsx
@@ -9,6 +9,7 @@ import { PressableSurface } from '../src/components/PressableSurface';
 import { SectionHeader } from '../src/components/SectionHeader';
 import { Text } from '../src/components/Text';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
+import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
 import { openDiscordInvite } from '../src/lib/discord';
 import { openExternalUrl } from '../src/lib/open-url';
 import { openPartnershipsEmail, PARTNERSHIPS_EMAIL } from '../src/lib/partnerships';
@@ -28,6 +29,7 @@ type AboutCard = {
 export default function AboutScreen() {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
+  const screenOptions = useStackScreenOptions();
   const bottomChrome = useBottomChromeMetrics();
   const router = useRouter();
   const { showToast } = useToast();
@@ -61,9 +63,9 @@ export default function AboutScreen() {
 
   return (
     <>
-      {/* Inherits the transparent blur header + minimal back button from the
-          root stack's glassStackScreenOptions; just turns the header on. */}
-      <Stack.Screen options={{ title: t('mobile.about.title'), headerShown: true }} />
+      {/* Variant-aware header (transparent blur on Liquid Glass, opaque M3 on
+          Material) from the shared hook; this screen just turns it on + titles it. */}
+      <Stack.Screen options={{ ...screenOptions, title: t('mobile.about.title'), headerShown: true }} />
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { Stack, useRouter } from 'expo-router';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
@@ -8,6 +8,7 @@ import { PressableSurface } from '../src/components/PressableSurface';
 import { SectionHeader } from '../src/components/SectionHeader';
 import { Text } from '../src/components/Text';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
+import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
 import {
   contributors,
   sponsors,
@@ -19,7 +20,6 @@ import {
 import { openDiscordInvite } from '../src/lib/discord';
 import { openExternalUrl } from '../src/lib/open-url';
 import { useTheme } from '../src/providers/theme-provider';
-import { useVariantValue } from '../src/theme/variants';
 import { borderRadius, spacing } from '../src/theme/tokens';
 import type { IconName } from '../src/components/icon-map';
 
@@ -110,26 +110,15 @@ export default function AcknowledgementsScreen() {
     router.push('/licenses');
   }, [router]);
 
-  // The transparent, blur-under-content header is an iOS-only feature (headerBlurEffect):
-  // on iOS, Liquid Glass gets it and Material's opaque M3 app bar does not. On Android
-  // — including a forced Liquid Glass user, where there's no glass surface — keep the
-  // header opaque so scroll content doesn't slide under the status bar (dual-axis:
-  // aesthetic AND platform). The hook is called unconditionally; only the value is gated.
-  const prefersGlassHeader = useVariantValue({ liquidGlass: true, material: false });
-  const headerTransparent = Platform.OS === 'ios' && prefersGlassHeader;
+  // Variant-aware header from the shared hook: a transparent blur header on Liquid
+  // Glass (iOS), an opaque M3 app bar on Material — including the forced-Material-
+  // on-iOS / Android paths where a transparent header would slide content under the
+  // status bar.
+  const screenOptions = useStackScreenOptions();
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          title: t('mobile.acknowledgements.title'),
-          headerShown: true,
-          headerLargeTitle: false,
-          headerTransparent,
-          headerBlurEffect: 'systemMaterial',
-          contentStyle: { backgroundColor: 'transparent' },
-        }}
-      />
+      <Stack.Screen options={{ ...screenOptions, title: t('mobile.acknowledgements.title'), headerShown: true }} />
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}

--- a/packages/mobile/app/auth/_layout.tsx
+++ b/packages/mobile/app/auth/_layout.tsx
@@ -1,9 +1,10 @@
 import { Stack } from 'expo-router';
-import { glassStackScreenOptions } from '../../src/theme/navigation';
+import { useStackScreenOptions } from '../../src/hooks/use-stack-screen-options';
 
 export default function AuthLayout() {
+  const screenOptions = useStackScreenOptions();
   return (
-    <Stack screenOptions={{ ...glassStackScreenOptions, headerShown: false }}>
+    <Stack screenOptions={{ ...screenOptions, headerShown: false }}>
       <Stack.Screen name="login" />
       {/* register.tsx sets its own header (title + back chevron) via Stack.Screen. */}
       <Stack.Screen name="register" />

--- a/packages/mobile/app/boards/_layout.tsx
+++ b/packages/mobile/app/boards/_layout.tsx
@@ -2,14 +2,15 @@ import { Stack, router } from 'expo-router';
 import { Pressable } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../../src/components/Icon';
-import { glassStackScreenOptions } from '../../src/theme/navigation';
+import { useStackScreenOptions } from '../../src/hooks/use-stack-screen-options';
 
 export default function BoardsLayout() {
   const { t } = useTranslation('common');
   const { t: tBoards } = useTranslation('boards');
+  const screenOptions = useStackScreenOptions();
 
   return (
-    <Stack screenOptions={glassStackScreenOptions}>
+    <Stack screenOptions={screenOptions}>
       <Stack.Screen
         name="index"
         options={{

--- a/packages/mobile/app/licenses.tsx
+++ b/packages/mobile/app/licenses.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { Stack } from 'expo-router';
-import { Modal, Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Modal, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
@@ -10,10 +10,10 @@ import { Icon } from '../src/components/Icon';
 import { PressableSurface } from '../src/components/PressableSurface';
 import { Text } from '../src/components/Text';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
+import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
 import { loadOssLicenses, type OssLicense } from '../src/lib/oss-licenses';
 import { openExternalUrl } from '../src/lib/open-url';
 import { useTheme } from '../src/providers/theme-provider';
-import { useVariantValue } from '../src/theme/variants';
 import { spacing } from '../src/theme/tokens';
 
 const keyExtractor = (item: OssLicense) => `${item.name}@${item.version}`;
@@ -80,26 +80,15 @@ export default function LicensesScreen() {
     [handleSelect],
   );
 
-  // The transparent, blur-under-content header is an iOS-only feature (headerBlurEffect):
-  // on iOS, Liquid Glass gets it and Material's opaque M3 app bar does not. On Android
-  // — including a forced Liquid Glass user, where there's no glass surface — keep the
-  // header opaque so scroll content doesn't slide under the status bar (dual-axis:
-  // aesthetic AND platform). The hook is called unconditionally; only the value is gated.
-  const prefersGlassHeader = useVariantValue({ liquidGlass: true, material: false });
-  const headerTransparent = Platform.OS === 'ios' && prefersGlassHeader;
+  // Variant-aware header from the shared hook: a transparent blur header on Liquid
+  // Glass (iOS), an opaque M3 app bar on Material — including the forced-Material-
+  // on-iOS / Android paths where a transparent header would slide content under the
+  // status bar.
+  const screenOptions = useStackScreenOptions();
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          title: t('mobile.licenses.title'),
-          headerShown: true,
-          headerLargeTitle: false,
-          headerTransparent,
-          headerBlurEffect: 'systemMaterial',
-          contentStyle: { backgroundColor: 'transparent' },
-        }}
-      />
+      <Stack.Screen options={{ ...screenOptions, title: t('mobile.licenses.title'), headerShown: true }} />
       <View style={styles.flex}>
         {licenses === null ? (
           <View style={styles.loading}>

--- a/packages/mobile/app/scout.tsx
+++ b/packages/mobile/app/scout.tsx
@@ -1,38 +1,27 @@
 import { Stack } from 'expo-router';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { ScoutPhoto } from '../src/components/ScoutPhoto';
 import { Text } from '../src/components/Text';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
+import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
 import { dogName } from '../src/lib/acknowledgements';
 import { useTheme } from '../src/providers/theme-provider';
-import { useVariantValue } from '../src/theme/variants';
 import { borderRadius, spacing } from '../src/theme/tokens';
 
 export default function ScoutScreen() {
   const { t } = useTranslation('common');
   const { systemColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
-  // The transparent, blur-under-content header is an iOS-only feature (headerBlurEffect):
-  // on iOS, Liquid Glass gets it and Material's opaque M3 app bar does not. On Android
-  // — including a forced Liquid Glass user, where there's no glass surface — keep the
-  // header opaque so scroll content doesn't slide under the status bar (dual-axis:
-  // aesthetic AND platform). The hook is called unconditionally; only the value is gated.
-  const prefersGlassHeader = useVariantValue({ liquidGlass: true, material: false });
-  const headerTransparent = Platform.OS === 'ios' && prefersGlassHeader;
+  // Variant-aware header from the shared hook: a transparent blur header on Liquid
+  // Glass (iOS), an opaque M3 app bar on Material — including the forced-Material-
+  // on-iOS / Android paths where a transparent header would slide content under the
+  // status bar.
+  const screenOptions = useStackScreenOptions();
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          title: dogName,
-          headerShown: true,
-          headerLargeTitle: false,
-          headerTransparent,
-          headerBlurEffect: 'systemMaterial',
-          contentStyle: { backgroundColor: 'transparent' },
-        }}
-      />
+      <Stack.Screen options={{ ...screenOptions, title: dogName, headerShown: true }} />
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         contentContainerStyle={[styles.container, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[6] }]}

--- a/packages/mobile/src/hooks/__tests__/use-stack-screen-options.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-stack-screen-options.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+
+const ctrl = vi.hoisted(() => ({
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  systemColors: { background: '#F3EFFA', label: '#16111F' },
+}));
+
+// navigation.ts reads Platform.OS at import; pin iOS so the LG branch is the
+// transparent-blur header (the interesting case).
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant, systemColors: ctrl.systemColors }),
+}));
+
+import { useStackScreenOptions } from '../use-stack-screen-options';
+
+function readOptions(): Record<string, unknown> {
+  function Probe() {
+    return createElement('div', { 'data-opts': JSON.stringify(useStackScreenOptions()) });
+  }
+  const { container } = render(createElement(Probe));
+  return JSON.parse(container.querySelector('div')?.getAttribute('data-opts') ?? '{}');
+}
+
+describe('useStackScreenOptions', () => {
+  it('returns the unchanged glass header on Liquid Glass (transparent blur on iOS)', () => {
+    ctrl.variant = 'liquidGlass';
+    const opts = readOptions();
+    expect(opts.headerTransparent).toBe(true); // Platform.OS === 'ios'
+    expect(opts.headerBlurEffect).toBe('systemMaterial');
+    expect(opts.headerBackButtonDisplayMode).toBe('minimal');
+    // No opaque Material surface bleeds into the glass header.
+    expect(opts.headerStyle).toBeUndefined();
+  });
+
+  it('returns an opaque M3 app bar on Material (solid surface, onSurface tint, no blur)', () => {
+    ctrl.variant = 'material';
+    const opts = readOptions();
+    expect(opts.headerTransparent).toBe(false);
+    expect(opts.headerStyle).toEqual({ backgroundColor: '#F3EFFA' }); // systemColors.background
+    expect(opts.headerTintColor).toBe('#16111F'); // systemColors.label
+    expect(opts.headerTitleAlign).toBe('left');
+    expect(opts.headerShadowVisible).toBe(false);
+    // The iOS blur is a Liquid-Glass-only affordance — never on the Material header.
+    expect(opts.headerBlurEffect).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-stack-screen-options.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-stack-screen-options.test.tsx
@@ -1,23 +1,32 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement } from 'react';
 
 const ctrl = vi.hoisted(() => ({
+  os: 'ios' as 'ios' | 'android',
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   systemColors: { background: '#F3EFFA', label: '#16111F' },
 }));
 
-// navigation.ts reads Platform.OS at import; pin iOS so the LG branch is the
-// transparent-blur header (the interesting case).
-vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return ctrl.os;
+    },
+  },
+  PlatformColor: (name: string) => name,
+}));
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({ variant: ctrl.variant, systemColors: ctrl.systemColors }),
 }));
 
-import { useStackScreenOptions } from '../use-stack-screen-options';
-
-function readOptions(): Record<string, unknown> {
+// `glassStackScreenOptions` reads `Platform.OS` at MODULE LOAD, so re-import the
+// hook per case (after setting `ctrl.os`) to exercise the iOS vs Android branch —
+// a single pinned `Platform.OS` would hide the Android path entirely.
+async function readOptions(): Promise<Record<string, unknown>> {
+  vi.resetModules();
+  const { useStackScreenOptions } = await import('../use-stack-screen-options');
   function Probe() {
     return createElement('div', { 'data-opts': JSON.stringify(useStackScreenOptions()) });
   }
@@ -26,19 +35,35 @@ function readOptions(): Record<string, unknown> {
 }
 
 describe('useStackScreenOptions', () => {
-  it('returns the unchanged glass header on Liquid Glass (transparent blur on iOS)', () => {
+  beforeEach(() => {
+    ctrl.os = 'ios';
     ctrl.variant = 'liquidGlass';
-    const opts = readOptions();
-    expect(opts.headerTransparent).toBe(true); // Platform.OS === 'ios'
+  });
+
+  it('Liquid Glass on iOS → transparent blur header over transparent content', async () => {
+    const opts = await readOptions();
+    expect(opts.headerTransparent).toBe(true);
     expect(opts.headerBlurEffect).toBe('systemMaterial');
     expect(opts.headerBackButtonDisplayMode).toBe('minimal');
-    // No opaque Material surface bleeds into the glass header.
+    // The blur header floats over TRANSPARENT content — if this regresses (e.g.
+    // glassStackScreenOptions stops supplying it), content renders opaque under the
+    // blur on iOS. The screens dropped their own `contentStyle` to rely on this.
+    expect(opts.contentStyle).toEqual({ backgroundColor: 'transparent' });
     expect(opts.headerStyle).toBeUndefined();
   });
 
-  it('returns an opaque M3 app bar on Material (solid surface, onSurface tint, no blur)', () => {
+  it('Liquid Glass on Android → opaque (solid) header, not a transparent blur', async () => {
+    ctrl.os = 'android';
+    const opts = await readOptions();
+    // Edge-to-edge Android draws a transparent header under the status bar, so
+    // glassStackScreenOptions keeps it solid here. Covers the non-iOS branch the
+    // module-load `Platform.OS` read would otherwise hide.
+    expect(opts.headerTransparent).toBe(false);
+  });
+
+  it('Material → opaque M3 app bar (solid surface, onSurface tint, no blur)', async () => {
     ctrl.variant = 'material';
-    const opts = readOptions();
+    const opts = await readOptions();
     expect(opts.headerTransparent).toBe(false);
     expect(opts.headerStyle).toEqual({ backgroundColor: '#F3EFFA' }); // systemColors.background
     expect(opts.headerTintColor).toBe('#16111F'); // systemColors.label
@@ -46,5 +71,13 @@ describe('useStackScreenOptions', () => {
     expect(opts.headerShadowVisible).toBe(false);
     // The iOS blur is a Liquid-Glass-only affordance — never on the Material header.
     expect(opts.headerBlurEffect).toBeUndefined();
+  });
+
+  it('Material on Android → still the opaque M3 app bar (variant wins over platform)', async () => {
+    ctrl.os = 'android';
+    ctrl.variant = 'material';
+    const opts = await readOptions();
+    expect(opts.headerTransparent).toBe(false);
+    expect(opts.headerStyle).toEqual({ backgroundColor: '#F3EFFA' });
   });
 });

--- a/packages/mobile/src/hooks/use-stack-screen-options.ts
+++ b/packages/mobile/src/hooks/use-stack-screen-options.ts
@@ -1,25 +1,7 @@
+import type { NativeStackNavigationOptions } from 'expo-router';
 import { useTheme } from '../providers/theme-provider';
-import { useVariantValue } from '../theme/variants';
+import { selectByVariant } from '../theme/variants';
 import { glassStackScreenOptions } from '../theme/navigation';
-
-/**
- * The native-stack header props this hook resolves — a hand-written subset of
- * `NativeStackNavigationOptions` (the monorepo's bun layout makes a direct type
- * import from `@react-navigation/native-stack` unreliable, and `navigation.ts`
- * already avoids it with per-field `as const`). Every field is a real native-stack
- * option, so the result spreads into a stack's `screenOptions` or a `Stack.Screen`.
- */
-type StackScreenOptions = {
-  headerLargeTitle?: boolean;
-  headerTransparent?: boolean;
-  headerBlurEffect?: 'systemMaterial';
-  headerShadowVisible?: boolean;
-  headerStyle?: { backgroundColor: string };
-  headerTintColor?: string;
-  headerTitleAlign?: 'left' | 'center';
-  headerBackButtonDisplayMode?: 'minimal';
-  contentStyle?: { backgroundColor: string };
-};
 
 /**
  * The native-stack `screenOptions` for the active UI variant — one source of truth
@@ -30,7 +12,9 @@ type StackScreenOptions = {
  * pushed screens.
  *
  * - **liquidGlass** → `glassStackScreenOptions`, the value **unchanged** (a
- *   transparent blur header on iOS). Liquid Glass stays byte-identical.
+ *   transparent blur header that floats over transparent content on iOS; a solid
+ *   header on Android, where a transparent one would draw under the status bar).
+ *   Liquid Glass stays byte-identical.
  * - **material** → an opaque Material 3 small top app bar: a solid surface that
  *   blends with the screen, an `onSurface` tint, a left-aligned title, flat at rest
  *   (no shadow, no iOS blur). This fixes forced-Material-on-iOS getting a wrong
@@ -43,14 +27,13 @@ type StackScreenOptions = {
  * M3 caveat: a real M3 app bar shifts `surface → surfaceContainer` as content
  * scrolls under it; native-stack can't express that, so the Material header stays
  * flat (see `theme/variants/README.md`). Lives in `src/hooks` (guard-exempt) — it
- * RESOLVES the variant, it isn't a render-body branch.
- *
- * Per-field `as const` keeps the string enums assignable to the native-stack option
- * types without importing them (same trick as `glassStackScreenOptions`).
+ * RESOLVES the variant, it isn't a render-body branch. Uses `selectByVariant` over
+ * the already-destructured `theme` so it reads the theme once (not twice via
+ * `useVariantValue`).
  */
-export function useStackScreenOptions(): StackScreenOptions {
-  const { systemColors } = useTheme();
-  return useVariantValue<StackScreenOptions>({
+export function useStackScreenOptions(): NativeStackNavigationOptions {
+  const { variant, systemColors } = useTheme();
+  return selectByVariant<NativeStackNavigationOptions>(variant, {
     liquidGlass: glassStackScreenOptions,
     material: {
       headerLargeTitle: false,
@@ -61,8 +44,8 @@ export function useStackScreenOptions(): StackScreenOptions {
       // iOS PlatformColor union that never applies on the Material branch.
       headerStyle: { backgroundColor: systemColors.background as string },
       headerTintColor: systemColors.label as string,
-      headerTitleAlign: 'left' as const,
-      headerBackButtonDisplayMode: 'minimal' as const,
+      headerTitleAlign: 'left',
+      headerBackButtonDisplayMode: 'minimal',
       contentStyle: { backgroundColor: systemColors.background as string },
     },
   });

--- a/packages/mobile/src/hooks/use-stack-screen-options.ts
+++ b/packages/mobile/src/hooks/use-stack-screen-options.ts
@@ -1,0 +1,69 @@
+import { useTheme } from '../providers/theme-provider';
+import { useVariantValue } from '../theme/variants';
+import { glassStackScreenOptions } from '../theme/navigation';
+
+/**
+ * The native-stack header props this hook resolves — a hand-written subset of
+ * `NativeStackNavigationOptions` (the monorepo's bun layout makes a direct type
+ * import from `@react-navigation/native-stack` unreliable, and `navigation.ts`
+ * already avoids it with per-field `as const`). Every field is a real native-stack
+ * option, so the result spreads into a stack's `screenOptions` or a `Stack.Screen`.
+ */
+type StackScreenOptions = {
+  headerLargeTitle?: boolean;
+  headerTransparent?: boolean;
+  headerBlurEffect?: 'systemMaterial';
+  headerShadowVisible?: boolean;
+  headerStyle?: { backgroundColor: string };
+  headerTintColor?: string;
+  headerTitleAlign?: 'left' | 'center';
+  headerBackButtonDisplayMode?: 'minimal';
+  contentStyle?: { backgroundColor: string };
+};
+
+/**
+ * The native-stack `screenOptions` for the active UI variant — one source of truth
+ * for the header on pushed / secondary screens (session detail, the playlist list,
+ * the settings stack, the about/acknowledgements/scout/licenses screens, …). The
+ * five main tab screens hide the native header and render their own in-body chrome
+ * (a Material `Appbar` or a glass collapsing header), so this only styles the
+ * pushed screens.
+ *
+ * - **liquidGlass** → `glassStackScreenOptions`, the value **unchanged** (a
+ *   transparent blur header on iOS). Liquid Glass stays byte-identical.
+ * - **material** → an opaque Material 3 small top app bar: a solid surface that
+ *   blends with the screen, an `onSurface` tint, a left-aligned title, flat at rest
+ *   (no shadow, no iOS blur). This fixes forced-Material-on-iOS getting a wrong
+ *   glass blur header, and gives Material a themed header instead of the bare
+ *   Android default.
+ *
+ * Spread it as a stack's `screenOptions` (inside a `_layout` component) OR into a
+ * per-screen `<Stack.Screen options={{ ...useStackScreenOptions(), title }} />`.
+ *
+ * M3 caveat: a real M3 app bar shifts `surface → surfaceContainer` as content
+ * scrolls under it; native-stack can't express that, so the Material header stays
+ * flat (see `theme/variants/README.md`). Lives in `src/hooks` (guard-exempt) — it
+ * RESOLVES the variant, it isn't a render-body branch.
+ *
+ * Per-field `as const` keeps the string enums assignable to the native-stack option
+ * types without importing them (same trick as `glassStackScreenOptions`).
+ */
+export function useStackScreenOptions(): StackScreenOptions {
+  const { systemColors } = useTheme();
+  return useVariantValue<StackScreenOptions>({
+    liquidGlass: glassStackScreenOptions,
+    material: {
+      headerLargeTitle: false,
+      headerTransparent: false,
+      headerShadowVisible: false,
+      // Material resolves `systemColors` to plain hex, so the header blends with
+      // the screen (M3 at-rest container = `surface`). `as string` narrows the
+      // iOS PlatformColor union that never applies on the Material branch.
+      headerStyle: { backgroundColor: systemColors.background as string },
+      headerTintColor: systemColors.label as string,
+      headerTitleAlign: 'left' as const,
+      headerBackButtonDisplayMode: 'minimal' as const,
+      contentStyle: { backgroundColor: systemColors.background as string },
+    },
+  });
+}

--- a/packages/mobile/src/theme/variants/README.md
+++ b/packages/mobile/src/theme/variants/README.md
@@ -63,6 +63,26 @@ sites the type system can't reach: `resolveSystemColors` and `useEffectiveSurfac
 (guarded by `assertNever`), `theme.m3` (a Paper palette only meaningful on Material), and
 axis-D `Platform.OS` sites.
 
+## Navigation headers
+
+`useStackScreenOptions()` (`src/hooks/`) is the single source of truth for the **native stack
+header** on pushed/secondary screens: a transparent blur header on Liquid Glass (iOS), an opaque
+Material 3 small app bar on Material (solid surface, `onSurface` tint, flat at rest, no blur). Spread
+it as a stack's `screenOptions` in a `_layout`, or into a per-screen `<Stack.Screen options>`.
+
+- **Header XOR in-body `Appbar`.** A screen renders **either** the native stack header **or** its own
+  in-body top chrome (a Material `Appbar` / glass collapsing header) — never both. The five main tab
+  indexes (`climbs`/`discover`/`profile`/`record`/`home`) set `headerShown:false` and own their
+  chrome; everything pushed on top uses the native header via the hook. Don't render a body `Appbar`
+  under a shown native header.
+- **Deviation — no on-scroll tint.** A real M3 app bar shifts `surface → surfaceContainer` (level 2)
+  as content scrolls under it. Native-stack can't drive `headerStyle` from a scroll position, so the
+  Material header stays flat at the `surface` tone. Revisit with a scroll-driven `headerStyle` if the
+  flat look reads wrong.
+- **Genuinely-per-screen header intents stay local** (not in the hook): `climbs/index`'s
+  `headerBlurEffect:'none'` is the iOS-26 Liquid-Glass native-search header (Material hides it), and
+  `discover/all`'s `headerTransparent:false` is an intentional opaque list header on both variants.
+
 ## Scope
 
 Variant is **mobile-only** — no `packages/shared/*-react` package and nothing on web reads


### PR DESCRIPTION
## Phase 3, slice 2 — variant-aware native stack header

The native stack header (the one shown on **pushed / secondary** screens) was hardcoded to the glass config (`glassStackScreenOptions`), so the **Material** variant got an un-themed Android default header, and a **forced-Material-on-iOS** user got a wrong transparent-blur header.

### What changed
- **`useStackScreenOptions()`** — new hook (`src/hooks/`, guard-exempt) resolving the native-stack `screenOptions` per variant via `useVariantValue`:
  - **Liquid Glass** → `glassStackScreenOptions`, **value unchanged** (transparent blur on iOS) — LG stays byte-identical.
  - **Material** → an opaque M3 small app bar: solid `surface` background, `onSurface` tint, left-aligned title, flat at rest, no iOS blur.
- Adopted in the **7 stack layouts** (`home`/`climbs`/`discover`/`record`/`profile` + `boards` + `auth`), preserving each layout's own `headerShown:false`/`contentStyle`.
- Simplified `acknowledgements`/`scout`/`licenses` + `about` to spread the hook, dropping the per-screen `Platform.OS === 'ios' && useVariantValue(...)` + `headerBlurEffect` juggling.

### Scope (from the exploration)
The five main tab indexes already render their **own** in-body chrome (`ClimbTopChrome`/`ProfileTopChrome`/`RecordTopChrome`/`PlaylistDetailView` — Material `Appbar` vs glass collapsing header) with `headerShown:false`. The audit found **zero double-header risk**, so this slice only touches the pushed-screen native header, not the tab chrome.

Left alone as **genuine per-screen intents** (not the hook's job): `climbs/index`'s `headerBlurEffect:'none'` (the iOS-26 Liquid-Glass native-search header — Material hides it) and `discover/all`'s `headerTransparent:false` (an intentional opaque list header).

### Docs
`theme/variants/README.md` now records the **header XOR in-body `Appbar`** rule and the native-stack **deviation** (it can't drive the M3 on-scroll `surface → surfaceContainer` tint, so the Material header stays flat).

### Validation
- `vp run typecheck` ✓
- `vp test run --project mobile` — **306 files / 2203 tests** ✓ (new `use-stack-screen-options.test.tsx`)
- `vp run check:mobile-variants` ✓ · `vp check` (13 files) ✓ · `vp run check:mobile-bundle` (Android) ✓
- Manual (recommended): every pushed header in both variants + **forced Material-on-iOS** (opaque M3, never blur).

Independent of slice 1 (reads pre-existing `systemColors`) — branches off `main`. Next: slice 3 (Dialog/Menu/FAB), then slice 4 (motion tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)