### PR TITLE
feat(mobile): imperative M3 confirm dialog via useConfirm (Phase 3, slice 3a)

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -17,6 +17,7 @@ import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { QueryProvider } from '../src/providers/query-provider';
 import { ThemeProvider, useTheme } from '../src/providers/theme-provider';
 import { MaterialThemeProvider } from '../src/providers/material-theme-provider';
+import { DialogProvider } from '../src/providers/dialog-provider';
 import { AuthProvider } from '../src/providers/auth-provider';
 import { I18nProvider } from '../src/providers/i18n-provider';
 import { BluetoothProviderWrapper } from '../src/providers/bluetooth-provider-wrapper';
@@ -282,18 +283,21 @@ function RootLayout() {
           <QueryProvider>
             <ThemeProvider>
               <MaterialThemeProvider>
-                <FeatureFlagsProvider flags={STATIC_FEATURE_FLAGS}>
-                  <AuthProvider onReady={onAuthReady}>
-                    <PartyProfileProvider>
-                      <ConnectionSettingsProvider>
-                        <ToastProvider>
-                          <ClimbActionsDataWrapper>
-                            <QueueSnackbarProvider>
-                              <QueueProvider>
-                                <BoardAdapterWrapper>
-                                  <PlaylistsAdapterWrapper>
-                                    <BoardProviderWrapper>
-                                      {/* BottomSheetModalProvider sits inside the board
+                {/* Inside MaterialThemeProvider (Paper Portal host) and above every
+                    provider that may call useConfirm (incl. Bluetooth). */}
+                <DialogProvider>
+                  <FeatureFlagsProvider flags={STATIC_FEATURE_FLAGS}>
+                    <AuthProvider onReady={onAuthReady}>
+                      <PartyProfileProvider>
+                        <ConnectionSettingsProvider>
+                          <ToastProvider>
+                            <ClimbActionsDataWrapper>
+                              <QueueSnackbarProvider>
+                                <QueueProvider>
+                                  <BoardAdapterWrapper>
+                                    <PlaylistsAdapterWrapper>
+                                      <BoardProviderWrapper>
+                                        {/* BottomSheetModalProvider sits inside the board
                                     providers (gorhom's BottomSheetModal portals
                                     PlayDrawer → QuickTickBar here, so the host
                                     must be able to see BoardAdapter/BoardProvider
@@ -304,7 +308,7 @@ function RootLayout() {
                                     exist before the picker mounts or gorhom
                                     throws "BottomSheetModalInternalContext
                                     cannot be null". */}
-                                      {/* Board presence ("now on the wall") owns the
+                                        {/* Board presence ("now on the wall") owns the
                                     connected boardId + the wall feed. Wraps
                                     BottomSheetModalProvider so gorhom-portaled
                                     sheets (PlayDrawer, BoardSheet) — which render
@@ -313,87 +317,88 @@ function RootLayout() {
                                     Also OUTSIDE BluetoothProviderWrapper /
                                     DrawerHostProvider so the BLE flow + Board sheet
                                     can use it. */}
-                                      <MobileBoardPresenceProvider>
-                                        <BottomSheetModalProvider>
-                                          <BluetoothProviderWrapper>
-                                            <DrawerHostProvider>
-                                              <DeepLinkProvider>
-                                                <ShareTargetProvider>
-                                                  <TabBarHeightProvider>
-                                                    <UserDrawerProvider>
-                                                      <ThemedNavigation>
-                                                        <Stack
-                                                          // Root scenes keep the opaque, theme-aware nav background so a dark
-                                                          // backstop sits behind the tab screens (the tab stacks paint their own
-                                                          // transparent content over it). glassStackScreenOptions' transparent
-                                                          // contentStyle would expose the light window background at the top of the
-                                                          // screen in dark mode, where the floating chrome leaves it uncovered.
-                                                          // The header props still apply to root-level pushed screens (session, about).
-                                                          screenOptions={{
-                                                            ...glassStackScreenOptions,
-                                                            headerShown: false,
-                                                            contentStyle: undefined,
-                                                          }}
-                                                          initialRouteName="index"
-                                                        >
-                                                          <Stack.Screen name="index" />
-                                                          <Stack.Screen name="(tabs)" />
-                                                          <Stack.Screen
-                                                            name="auth"
-                                                            options={{ headerShown: false, gestureEnabled: false }}
-                                                          />
-                                                          <Stack.Screen
-                                                            name="join/[sessionId]"
-                                                            options={{ presentation: 'modal', headerShown: false }}
-                                                          />
-                                                          <Stack.Screen
-                                                            name="share-beta"
-                                                            options={{ presentation: 'modal', headerShown: false }}
-                                                          />
-                                                          {/* Board selection is a modal off the Climbs capsule /
+                                        <MobileBoardPresenceProvider>
+                                          <BottomSheetModalProvider>
+                                            <BluetoothProviderWrapper>
+                                              <DrawerHostProvider>
+                                                <DeepLinkProvider>
+                                                  <ShareTargetProvider>
+                                                    <TabBarHeightProvider>
+                                                      <UserDrawerProvider>
+                                                        <ThemedNavigation>
+                                                          <Stack
+                                                            // Root scenes keep the opaque, theme-aware nav background so a dark
+                                                            // backstop sits behind the tab screens (the tab stacks paint their own
+                                                            // transparent content over it). glassStackScreenOptions' transparent
+                                                            // contentStyle would expose the light window background at the top of the
+                                                            // screen in dark mode, where the floating chrome leaves it uncovered.
+                                                            // The header props still apply to root-level pushed screens (session, about).
+                                                            screenOptions={{
+                                                              ...glassStackScreenOptions,
+                                                              headerShown: false,
+                                                              contentStyle: undefined,
+                                                            }}
+                                                            initialRouteName="index"
+                                                          >
+                                                            <Stack.Screen name="index" />
+                                                            <Stack.Screen name="(tabs)" />
+                                                            <Stack.Screen
+                                                              name="auth"
+                                                              options={{ headerShown: false, gestureEnabled: false }}
+                                                            />
+                                                            <Stack.Screen
+                                                              name="join/[sessionId]"
+                                                              options={{ presentation: 'modal', headerShown: false }}
+                                                            />
+                                                            <Stack.Screen
+                                                              name="share-beta"
+                                                              options={{ presentation: 'modal', headerShown: false }}
+                                                            />
+                                                            {/* Board selection is a modal off the Climbs capsule /
                                                       no-board CTA — board switching is rare, so it doesn't
                                                       earn a tab. Its own _layout owns the headers. */}
-                                                          <Stack.Screen
-                                                            name="boards"
-                                                            options={{ presentation: 'modal', headerShown: false }}
-                                                          />
-                                                          {/* First-run welcome walkthrough. Full-screen cover
+                                                            <Stack.Screen
+                                                              name="boards"
+                                                              options={{ presentation: 'modal', headerShown: false }}
+                                                            />
+                                                            {/* First-run welcome walkthrough. Full-screen cover
                                                       over the Climbs tab; gesture disabled so the user
                                                       leaves only via Skip / finish / the final CTA, never
                                                       an accidental swipe-dismiss. */}
-                                                          <Stack.Screen
-                                                            name="onboarding"
-                                                            options={{
-                                                              presentation: 'fullScreenModal',
-                                                              headerShown: false,
-                                                              gestureEnabled: false,
-                                                              animation: 'fade',
-                                                            }}
-                                                          />
-                                                        </Stack>
-                                                      </ThemedNavigation>
-                                                      <PersistentQueueBar />
-                                                      <OnboardingGate ready={authReady && fontsReady} />
-                                                    </UserDrawerProvider>
-                                                  </TabBarHeightProvider>
-                                                  <AnalyticsScreenTracker />
-                                                </ShareTargetProvider>
-                                              </DeepLinkProvider>
-                                            </DrawerHostProvider>
-                                          </BluetoothProviderWrapper>
-                                        </BottomSheetModalProvider>
-                                      </MobileBoardPresenceProvider>
-                                    </BoardProviderWrapper>
-                                  </PlaylistsAdapterWrapper>
-                                </BoardAdapterWrapper>
-                              </QueueProvider>
-                            </QueueSnackbarProvider>
-                          </ClimbActionsDataWrapper>
-                        </ToastProvider>
-                      </ConnectionSettingsProvider>
-                    </PartyProfileProvider>
-                  </AuthProvider>
-                </FeatureFlagsProvider>
+                                                            <Stack.Screen
+                                                              name="onboarding"
+                                                              options={{
+                                                                presentation: 'fullScreenModal',
+                                                                headerShown: false,
+                                                                gestureEnabled: false,
+                                                                animation: 'fade',
+                                                              }}
+                                                            />
+                                                          </Stack>
+                                                        </ThemedNavigation>
+                                                        <PersistentQueueBar />
+                                                        <OnboardingGate ready={authReady && fontsReady} />
+                                                      </UserDrawerProvider>
+                                                    </TabBarHeightProvider>
+                                                    <AnalyticsScreenTracker />
+                                                  </ShareTargetProvider>
+                                                </DeepLinkProvider>
+                                              </DrawerHostProvider>
+                                            </BluetoothProviderWrapper>
+                                          </BottomSheetModalProvider>
+                                        </MobileBoardPresenceProvider>
+                                      </BoardProviderWrapper>
+                                    </PlaylistsAdapterWrapper>
+                                  </BoardAdapterWrapper>
+                                </QueueProvider>
+                              </QueueSnackbarProvider>
+                            </ClimbActionsDataWrapper>
+                          </ToastProvider>
+                        </ConnectionSettingsProvider>
+                      </PartyProfileProvider>
+                    </AuthProvider>
+                  </FeatureFlagsProvider>
+                </DialogProvider>
               </MaterialThemeProvider>
             </ThemeProvider>
           </QueryProvider>

--- a/packages/mobile/src/components/BranchSwitcherScreen.tsx
+++ b/packages/mobile/src/components/BranchSwitcherScreen.tsx
@@ -17,6 +17,7 @@ import { ListRow } from './ListRow';
 import { Icon } from './Icon';
 import { InfoRow } from './InfoRow';
 import { useTheme } from '../providers/theme-provider';
+import { useConfirm } from '../providers/dialog-provider';
 import { hapticLight, hapticError } from '../lib/haptics';
 import {
   isPreviewBuild,
@@ -68,6 +69,7 @@ function getCurrentBranchName(): string | null {
 }
 export function BranchSwitcherScreen() {
   const { systemColors, spacing, borderRadius } = useTheme();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const [switchingBranchId, setSwitchingBranchId] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -133,17 +135,22 @@ export function BranchSwitcherScreen() {
   }, [queryClient, projectId]);
 
   const handleSwitchBranch = useCallback(
-    (branch: EASBranch) => {
+    async (branch: EASBranch) => {
       hapticLight();
-      // i18n-ignore-next-line
-      Alert.alert('Switch Branch', `Switch to "${branch.name}"? The app will download the update and restart.`, [
+      const confirmed = await confirm({
+        // i18n-ignore-next-line — preview-only dev screen
+        title: 'Switch Branch',
         // i18n-ignore-next-line
-        { text: 'Cancel', style: 'cancel' },
+        message: `Switch to "${branch.name}"? The app will download the update and restart.`,
         // i18n-ignore-next-line
-        { text: 'Switch', onPress: () => switchMutation.mutate(branch) },
-      ]);
+        confirmLabel: 'Switch',
+        // i18n-ignore-next-line
+        cancelLabel: 'Cancel',
+      });
+      if (!confirmed) return;
+      switchMutation.mutate(branch);
     },
-    [switchMutation],
+    [confirm, switchMutation],
   );
   if (!preview) {
     return null;

--- a/packages/mobile/src/components/DevServerSwitcherScreen.tsx
+++ b/packages/mobile/src/components/DevServerSwitcherScreen.tsx
@@ -24,6 +24,7 @@ import { InfoRow } from './InfoRow';
 import { Button } from './Button';
 import { Sheet } from './Sheet';
 import { useTheme } from '../providers/theme-provider';
+import { useConfirm } from '../providers/dialog-provider';
 import { hapticLight, hapticError } from '../lib/haptics';
 import { discoverBundlers, type DiscoveredBundler } from '../lib/metro-discovery';
 import { addSavedMetroTarget, getSavedMetroTargets, removeSavedMetroTarget } from '../lib/metro-target-store';
@@ -59,6 +60,7 @@ function formatStartedAt(value: string | null | undefined): string {
 
 export function DevServerSwitcherScreen() {
   const { systemColors, spacing, borderRadius } = useTheme();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const infoSheetRef = useRef<BottomSheet>(null);
   const [switchingUrl, setSwitchingUrl] = useState<string | null>(null);
@@ -147,17 +149,22 @@ export function DevServerSwitcherScreen() {
   }, [queryClient]);
 
   const handleSwitchBundler = useCallback(
-    (bundler: DiscoveredBundler) => {
+    async (bundler: DiscoveredBundler) => {
       hapticLight();
-      // i18n-ignore-next-line
-      Alert.alert('Switch Metro Server', `Load JS bundle from ${bundler.host}:${bundler.port}? The app will reload.`, [
+      const confirmed = await confirm({
+        // i18n-ignore-next-line — preview-only dev screen
+        title: 'Switch Metro Server',
         // i18n-ignore-next-line
-        { text: 'Cancel', style: 'cancel' },
+        message: `Load JS bundle from ${bundler.host}:${bundler.port}? The app will reload.`,
         // i18n-ignore-next-line
-        { text: 'Switch', onPress: () => switchMutation.mutate(bundler) },
-      ]);
+        confirmLabel: 'Switch',
+        // i18n-ignore-next-line
+        cancelLabel: 'Cancel',
+      });
+      if (!confirmed) return;
+      switchMutation.mutate(bundler);
     },
-    [switchMutation],
+    [confirm, switchMutation],
   );
 
   const handleShowInfo = useCallback((bundler: DiscoveredBundler) => {
@@ -186,21 +193,22 @@ export function DevServerSwitcherScreen() {
   }, []);
 
   const handleRemoveTarget = useCallback(
-    (target: string) => {
+    async (target: string) => {
       hapticLight();
-      // i18n-ignore-next-line
-      Alert.alert('Remove Metro Server', target, [
+      const confirmed = await confirm({
+        // i18n-ignore-next-line — preview-only dev screen
+        title: 'Remove Metro Server',
+        message: target,
         // i18n-ignore-next-line
-        { text: 'Cancel', style: 'cancel' },
-        {
-          // i18n-ignore-next-line
-          text: 'Remove',
-          style: 'destructive',
-          onPress: () => removeTargetMutation.mutate(target),
-        },
-      ]);
+        confirmLabel: 'Remove',
+        // i18n-ignore-next-line
+        cancelLabel: 'Cancel',
+        destructive: true,
+      });
+      if (!confirmed) return;
+      removeTargetMutation.mutate(target);
     },
-    [removeTargetMutation],
+    [confirm, removeTargetMutation],
   );
 
   const isSwitching = switchingUrl !== null;
@@ -470,7 +478,7 @@ export function DevServerSwitcherScreen() {
               icon="chevron.right"
               onPress={() => {
                 infoSheetRef.current?.close();
-                handleSwitchBundler(selectedBundler);
+                void handleSwitchBundler(selectedBundler);
               }}
               loading={switchingUrl === selectedBundler.url}
               disabled={isSwitching && switchingUrl !== selectedBundler.url}

--- a/packages/mobile/src/components/create-climb/OpenDraftsSection.tsx
+++ b/packages/mobile/src/components/create-climb/OpenDraftsSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { View, StyleSheet, Alert } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Climb, ClimbSearchInput } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
@@ -7,6 +7,7 @@ import { ActivityIndicator } from '../ActivityIndicator';
 import { CollapsibleSection } from '../CollapsibleSection';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useConfirm } from '../../providers/dialog-provider';
 import { useSearchClimbs, useDeleteDraftClimb } from '../../lib/graphql/hooks';
 import { spacing } from '../../theme/tokens';
 import { DraftRow } from './DraftRow';
@@ -35,6 +36,7 @@ export function OpenDraftsSection({ board, onLoadDraft }: OpenDraftsSectionProps
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const { showToast } = useToast();
+  const confirm = useConfirm();
   const deleteDraft = useDeleteDraftClimb();
 
   // Defer the drafts query until the section is actually expanded. The drawer
@@ -62,25 +64,24 @@ export function OpenDraftsSection({ board, onLoadDraft }: OpenDraftsSectionProps
   const drafts = data?.climbs ?? [];
 
   const handleDelete = useCallback(
-    (climb: Climb) => {
-      Alert.alert(t('draftsDrawer.delete.title'), t('draftsDrawer.delete.description'), [
-        { text: t('createClimbForm.dismiss'), style: 'cancel' },
+    async (climb: Climb) => {
+      const confirmed = await confirm({
+        title: t('draftsDrawer.delete.title'),
+        message: t('draftsDrawer.delete.description'),
+        confirmLabel: t('draftsDrawer.delete.confirm'),
+        cancelLabel: t('createClimbForm.dismiss'),
+        destructive: true,
+      });
+      if (!confirmed) return;
+      deleteDraft.mutate(
+        { uuid: climb.uuid, boardType: board.boardName },
         {
-          text: t('draftsDrawer.delete.confirm'),
-          style: 'destructive',
-          onPress: () => {
-            deleteDraft.mutate(
-              { uuid: climb.uuid, boardType: board.boardName },
-              {
-                onSuccess: () => showToast(t('draftsDrawer.delete.success'), 'success'),
-                onError: () => showToast(t('draftsDrawer.delete.error'), 'error'),
-              },
-            );
-          },
+          onSuccess: () => showToast(t('draftsDrawer.delete.success'), 'success'),
+          onError: () => showToast(t('draftsDrawer.delete.error'), 'error'),
         },
-      ]);
+      );
     },
-    [board.boardName, deleteDraft, showToast, t],
+    [confirm, board.boardName, deleteDraft, showToast, t],
   );
 
   const summary = drafts.length > 0 ? t('draftsDrawer.count', { count: drafts.length }) : null;

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Linking,
   Modal,
@@ -30,6 +29,7 @@ import { SectionHeader } from '../SectionHeader';
 import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useConfirm } from '../../providers/dialog-provider';
 import { borderRadius, spacing } from '../../theme/tokens';
 import { iosSystemColors } from '../../theme/ios-colors';
 import {
@@ -108,6 +108,7 @@ export function BoardAccountsSection() {
   const { t: tCommon } = useTranslation('common');
   const { systemColors, brandColors, colorScheme } = useTheme();
   const { showToast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
 
   const credentialsQuery = useQuery({
@@ -233,18 +234,19 @@ export function BoardAccountsSection() {
   }, [showToast, t]);
 
   const handleUnlink = useCallback(
-    (boardType: AuroraBoardName) => {
+    async (boardType: AuroraBoardName) => {
       const boardName = boardDisplayName(boardType);
-      Alert.alert(t('aurora.card.unlinkConfirm.title'), t('aurora.card.unlinkConfirm.description', { boardName }), [
-        { text: tCommon('actions.cancel'), style: 'cancel' },
-        {
-          text: t('aurora.card.unlink'),
-          style: 'destructive',
-          onPress: () => deleteCredentialMutation.mutate(boardType),
-        },
-      ]);
+      const confirmed = await confirm({
+        title: t('aurora.card.unlinkConfirm.title'),
+        message: t('aurora.card.unlinkConfirm.description', { boardName }),
+        confirmLabel: t('aurora.card.unlink'),
+        cancelLabel: tCommon('actions.cancel'),
+        destructive: true,
+      });
+      if (!confirmed) return;
+      deleteCredentialMutation.mutate(boardType);
     },
-    [deleteCredentialMutation, t, tCommon],
+    [confirm, deleteCredentialMutation, t, tCommon],
   );
 
   const handleImportPress = useCallback(

--- a/packages/mobile/src/components/integrations/StravaCard.tsx
+++ b/packages/mobile/src/components/integrations/StravaCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { IntegrationStatus } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
@@ -8,6 +8,7 @@ import { ListRow } from '../ListRow';
 import { SwitchRow } from '../SwitchRow';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useConfirm } from '../../providers/dialog-provider';
 import { borderRadius, spacing } from '../../theme/tokens';
 import { connectStrava } from '../../lib/integrations';
 import { useDisconnectIntegration, useIntegrationStatuses, useSetIntegrationAutoSync } from '../../lib/graphql/hooks';
@@ -22,6 +23,7 @@ export function StravaCard() {
   const { t: tCommon } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
+  const confirm = useConfirm();
   const { data: statuses, isLoading, refetch } = useIntegrationStatuses();
   // Destructure .mutate (stable across renders per React Query) — the
   // mutation object itself is a fresh reference every render and would churn
@@ -60,30 +62,29 @@ export function StravaCard() {
     [setAutoSyncMutate],
   );
 
-  const handleDisconnect = useCallback(() => {
-    Alert.alert(t('integrations.strava.disconnectConfirmTitle'), t('integrations.strava.disconnectConfirmBody'), [
-      { text: tCommon('actions.cancel'), style: 'cancel' },
+  const handleDisconnect = useCallback(async () => {
+    const confirmed = await confirm({
+      title: t('integrations.strava.disconnectConfirmTitle'),
+      message: t('integrations.strava.disconnectConfirmBody'),
+      confirmLabel: t('integrations.strava.disconnect'),
+      cancelLabel: tCommon('actions.cancel'),
+      destructive: true,
+    });
+    if (!confirmed) return;
+    disconnectIntegrationMutate(
+      { provider: 'STRAVA' },
       {
-        text: t('integrations.strava.disconnect'),
-        style: 'destructive',
-        onPress: () => {
-          disconnectIntegrationMutate(
-            { provider: 'STRAVA' },
-            {
-              onSuccess: () => {
-                showToast(t('integrations.toast.disconnected'), 'success');
-              },
-              onError: () => {
-                // The card stays in its connected state (statuses are only
-                // invalidated on success) — tell the user the tap did nothing.
-                showToast(t('integrations.toast.disconnectFailed'), 'error');
-              },
-            },
-          );
+        onSuccess: () => {
+          showToast(t('integrations.toast.disconnected'), 'success');
+        },
+        onError: () => {
+          // The card stays in its connected state (statuses are only
+          // invalidated on success) — tell the user the tap did nothing.
+          showToast(t('integrations.toast.disconnectFailed'), 'error');
         },
       },
-    ]);
-  }, [disconnectIntegrationMutate, showToast, t, tCommon]);
+    );
+  }, [confirm, disconnectIntegrationMutate, showToast, t, tCommon]);
 
   if (isLoading && !strava) {
     return (

--- a/packages/mobile/src/components/integrations/__tests__/strava-card.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/strava-card.test.tsx
@@ -50,6 +50,9 @@ vi.mock('../../../providers/theme-provider', () => ({
 vi.mock('../../../providers/toast-provider', () => ({
   useToast: () => ({ showToast: mocks.showToast }),
 }));
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => () => Promise.resolve(true),
+}));
 
 type TextMockProps = { children?: ReactNode };
 vi.mock('../../Text', () => ({

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, useCallback, useEffect, useMemo, useState } from 'react';
-import { View, Pressable, Alert, Platform, StyleSheet } from 'react-native';
+import { View, Pressable, Platform, StyleSheet } from 'react-native';
 import BottomSheet, { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import DateTimePicker, {
   DateTimePickerAndroid,
@@ -22,6 +22,7 @@ import { hapticSuccess, hapticError } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useConfirm } from '../../providers/dialog-provider';
 
 type TickStatus = 'flash' | 'send' | 'attempt';
 
@@ -73,6 +74,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
+  const confirm = useConfirm();
   const updateTick = useUpdateTick();
   const deleteTick = useDeleteTick();
   // Save and delete hit the same tick UUID — never let one fire while the other
@@ -244,23 +246,23 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
     updateTick,
   ]);
 
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
     if (!ascent || isMutating) return;
-    Alert.alert(t('mobile.logbook.deleteTitle'), t('mobile.logbook.deleteConfirm'), [
-      { text: t('mobile.cancel'), style: 'cancel' },
-      {
-        text: t('mobile.logbook.delete'),
-        style: 'destructive',
-        onPress: () =>
-          deleteTick.mutate(ascent.uuid, {
-            onSuccess: () => sheetRef.current?.close(),
-            onError: () => {
-              hapticError();
-              showToast(t('mobile.logbook.deleteError'), 'error');
-            },
-          }),
+    const confirmed = await confirm({
+      title: t('mobile.logbook.deleteTitle'),
+      message: t('mobile.logbook.deleteConfirm'),
+      confirmLabel: t('mobile.logbook.delete'),
+      cancelLabel: t('mobile.cancel'),
+      destructive: true,
+    });
+    if (!confirmed) return;
+    deleteTick.mutate(ascent.uuid, {
+      onSuccess: () => sheetRef.current?.close(),
+      onError: () => {
+        hapticError();
+        showToast(t('mobile.logbook.deleteError'), 'error');
       },
-    ]);
+    });
   };
 
   return (

--- a/packages/mobile/src/components/you/__tests__/logbook-edit-sheet.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-edit-sheet.test.tsx
@@ -84,6 +84,9 @@ vi.mock('@boardsesh/board-react', () => ({
   useUpdateTick: () => ({ mutate: mutations.updateMutate, isPending: false }),
   useDeleteTick: () => ({ mutate: mutations.deleteMutate, isPending: false }),
 }));
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => () => Promise.resolve(true),
+}));
 vi.mock('../../Sheet', () => ({
   Sheet: ({ children, footer }: { children?: ReactNode; footer?: ReactNode }) =>
     createElement('div', null, children, footer),

--- a/packages/mobile/src/providers/__tests__/dialog-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/dialog-provider.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+type AlertButton = { text: string; style?: string; onPress?: () => void };
+const alertMock = vi.hoisted(() => ({
+  calls: [] as Array<{ title: string; message?: string; buttons: AlertButton[]; onDismiss?: () => void }>,
+}));
+
+// The provider only needs Alert from react-native; mock it to capture the args.
+vi.mock('react-native', () => ({
+  Alert: {
+    alert: (
+      title: string,
+      message: string | undefined,
+      buttons: AlertButton[],
+      options?: { onDismiss?: () => void },
+    ) => {
+      alertMock.calls.push({ title, message, buttons, onDismiss: options?.onDismiss });
+    },
+  },
+}));
+
+// Lightweight Paper stubs: Dialog renders its children inline (Portal is a
+// pass-through), Buttons are real <button>s so we can click them.
+vi.mock('react-native-paper', () => {
+  const Dialog = ({ children }: { children?: ReactNode }) => createElement('div', { 'data-dialog': 'true' }, children);
+  Dialog.Title = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  Dialog.Content = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  Dialog.Actions = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  return {
+    Portal: ({ children }: { children?: ReactNode }) => children,
+    Dialog,
+    Button: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+      createElement('button', { onClick: onPress }, children),
+    Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  };
+});
+
+vi.mock('../theme-provider', () => ({
+  useTheme: () => ({ variant: ctrl.variant, m3: { error: '#B00020' } }),
+}));
+
+import { DialogProvider, useConfirm } from '../dialog-provider';
+
+let confirmFn: ReturnType<typeof useConfirm>;
+function Consumer() {
+  confirmFn = useConfirm();
+  return null;
+}
+
+function setup() {
+  return render(createElement(DialogProvider, null, createElement(Consumer)));
+}
+
+function materialButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll('button')].find((b) => b.textContent === label);
+  if (!button) throw new Error(`no dialog button labelled "${label}"`);
+  return button as HTMLButtonElement;
+}
+
+const OPTS = { title: 'Delete?', message: 'This cannot be undone.', confirmLabel: 'Delete', cancelLabel: 'Cancel' };
+
+beforeEach(() => {
+  ctrl.variant = 'material';
+  alertMock.calls = [];
+});
+
+describe('useConfirm — Material (Paper Dialog)', () => {
+  it('resolves true when the confirm action is pressed', async () => {
+    const { container } = setup();
+    let promise!: Promise<boolean>;
+    act(() => {
+      promise = confirmFn({ ...OPTS, destructive: true });
+    });
+    act(() => materialButton(container, 'Delete').click());
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it('resolves false when cancelled', async () => {
+    const { container } = setup();
+    let promise!: Promise<boolean>;
+    act(() => {
+      promise = confirmFn(OPTS);
+    });
+    act(() => materialButton(container, 'Cancel').click());
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('queues concurrent confirms and resolves each independently', async () => {
+    const { container } = setup();
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    act(() => {
+      first = confirmFn({ ...OPTS, confirmLabel: 'First' });
+      second = confirmFn({ ...OPTS, confirmLabel: 'Second' });
+    });
+    // Only the head of the queue shows.
+    expect([...container.querySelectorAll('button')].some((b) => b.textContent === 'Second')).toBe(false);
+    act(() => materialButton(container, 'First').click());
+    await expect(first).resolves.toBe(true);
+    // The second confirm now surfaces and resolves on its own.
+    act(() => materialButton(container, 'Second').click());
+    await expect(second).resolves.toBe(true);
+  });
+});
+
+describe('useConfirm — Liquid Glass (native Alert)', () => {
+  beforeEach(() => {
+    ctrl.variant = 'liquidGlass';
+  });
+
+  it('routes to Alert.alert and resolves true on the confirm button', async () => {
+    setup();
+    let promise!: Promise<boolean>;
+    act(() => {
+      promise = confirmFn({ ...OPTS, destructive: true });
+    });
+    expect(alertMock.calls).toHaveLength(1);
+    const { buttons } = alertMock.calls[0];
+    expect(buttons.find((b) => b.text === 'Delete')?.style).toBe('destructive');
+    act(() => buttons.find((b) => b.text === 'Delete')?.onPress?.());
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it('resolves false on cancel and on scrim/back dismiss', async () => {
+    setup();
+    let cancelled!: Promise<boolean>;
+    act(() => {
+      cancelled = confirmFn(OPTS);
+    });
+    act(() => alertMock.calls[0].buttons.find((b) => b.text === 'Cancel')?.onPress?.());
+    await expect(cancelled).resolves.toBe(false);
+
+    let dismissed!: Promise<boolean>;
+    act(() => {
+      dismissed = confirmFn(OPTS);
+    });
+    act(() => alertMock.calls[1].onDismiss?.());
+    await expect(dismissed).resolves.toBe(false);
+  });
+});

--- a/packages/mobile/src/providers/dialog-provider.tsx
+++ b/packages/mobile/src/providers/dialog-provider.tsx
@@ -1,0 +1,119 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Alert } from 'react-native';
+import { Button, Dialog, Portal, Text } from 'react-native-paper';
+import { useTheme } from './theme-provider';
+
+export type ConfirmOptions = {
+  title: string;
+  /** Optional supporting text under the title. */
+  message?: string;
+  /** Label for the affirmative action (e.g. "Delete", "Switch"). */
+  confirmLabel: string;
+  /** Label for the dismissive action (e.g. "Cancel"). */
+  cancelLabel: string;
+  /** Style the confirm action as destructive (M3 error tint / iOS destructive). */
+  destructive?: boolean;
+};
+
+type DialogContextValue = {
+  /** Resolve `true` if the user confirms, `false` on cancel / scrim / back dismiss. */
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+};
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+type PendingConfirm = ConfirmOptions & { id: number; resolve: (value: boolean) => void };
+
+/**
+ * One imperative confirm dialog for the whole app, rendered the right way per UI
+ * variant: a Material 3 Paper `Dialog` (in a `Portal`) on Material, and the native
+ * iOS `Alert` on Liquid Glass — both behind `useConfirm()`, which returns a promise
+ * so callers can `if (await confirm(...))`.
+ *
+ * It's a provider (not a `createVariantComponent`) because the API is imperative
+ * context, not a rendered element — and it must be reachable from other providers
+ * (e.g. the Bluetooth board-config flow), not just screens. Mount it inside
+ * `MaterialThemeProvider` (so the Paper `Dialog`/`Portal` has a host) and above any
+ * provider that calls `confirm`. Providers are exempt from the variant guard, so the
+ * `variant ===` branch here is the sanctioned place to resolve it.
+ *
+ * Concurrent confirms queue (one Material dialog shows at a time; the native iOS
+ * Alert queues itself), so a Bluetooth confirm racing a UI confirm can't clobber the
+ * other's resolver. Scrim / back dismiss resolves `false`.
+ */
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const { variant, m3 } = useTheme();
+  const [queue, setQueue] = useState<PendingConfirm[]>([]);
+  const idRef = useRef(0);
+
+  const confirm = useCallback(
+    (options: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        if (variant === 'liquidGlass') {
+          Alert.alert(
+            options.title,
+            options.message,
+            [
+              { text: options.cancelLabel, style: 'cancel', onPress: () => resolve(false) },
+              {
+                text: options.confirmLabel,
+                style: options.destructive ? 'destructive' : 'default',
+                onPress: () => resolve(true),
+              },
+            ],
+            { onDismiss: () => resolve(false) },
+          );
+          return;
+        }
+        idRef.current += 1;
+        setQueue((q) => [...q, { ...options, id: idRef.current, resolve }]);
+      }),
+    [variant],
+  );
+
+  const value = useMemo<DialogContextValue>(() => ({ confirm }), [confirm]);
+
+  const current = queue[0];
+  // `current` is captured per render (the head of the queue), so each settle
+  // resolves exactly that confirm's promise, then advances to the next queued one.
+  const settle = (result: boolean) => {
+    current?.resolve(result);
+    setQueue((q) => q.slice(1));
+  };
+
+  return (
+    <DialogContext value={value}>
+      {children}
+      {variant === 'material' && current ? (
+        <Portal>
+          <Dialog visible onDismiss={() => settle(false)}>
+            <Dialog.Title>{current.title}</Dialog.Title>
+            {current.message ? (
+              <Dialog.Content>
+                <Text variant="bodyMedium">{current.message}</Text>
+              </Dialog.Content>
+            ) : null}
+            <Dialog.Actions>
+              <Button onPress={() => settle(false)}>{current.cancelLabel}</Button>
+              <Button textColor={current.destructive ? m3.error : undefined} onPress={() => settle(true)}>
+                {current.confirmLabel}
+              </Button>
+            </Dialog.Actions>
+          </Dialog>
+        </Portal>
+      ) : null}
+    </DialogContext>
+  );
+}
+
+/**
+ * Imperative confirm dialog. Returns a promise that resolves `true` on confirm,
+ * `false` on cancel / dismiss — so `if (await confirm({ … })) { …action… }`.
+ */
+export function useConfirm(): DialogContextValue['confirm'] {
+  const ctx = useContext(DialogContext);
+  if (!ctx) {
+    throw new Error('useConfirm must be used within a DialogProvider');
+  }
+  return ctx.confirm;
+}


### PR DESCRIPTION
## Phase 3, slice 3a — Material 3 confirm dialog

Confirmations across the app used iOS `Alert.alert` — a non-M3 system alert on the Material variant. This adds **one imperative confirm dialog**, rendered the right way per variant.

### What changed
- **`DialogProvider` + `useConfirm()`** — `confirm({ title, message, confirmLabel, cancelLabel, destructive? }): Promise<boolean>`:
  - **Material** → Paper `Dialog` in a `Portal` (M3 28dp container, text-button actions, error-tinted destructive action).
  - **Liquid Glass** → native `Alert.alert` wrapped in a Promise.
  - It's a **provider, not a `createVariantComponent`**, because the API is imperative context and must be reachable from other providers (the Bluetooth board-config flow), not just screens. Mounted inside `MaterialThemeProvider` (Paper's Portal host) and above `BluetoothProviderWrapper`.
  - **Concurrent confirms queue** (one Material dialog at a time; iOS Alert queues itself), so a Bluetooth confirm racing a UI confirm can't clobber the other's resolver. Scrim / back / cancel resolve `false`.
- **Migrated the 7 two-choice confirm sites** to `if (await confirm(...))`: StravaCard (disconnect), BoardAccountsSection (unlink), OpenDraftsSection (delete draft), LogbookEditSheet (delete ascent), DevServerSwitcherScreen (switch + remove), BranchSwitcherScreen (switch).

### Deferred (noted in the commit)
- The Bluetooth **board-config mismatch** dialog is a **3-way** choice (Cancel / Connect Anyway / Switch) that a boolean `confirm` can't express — needs a richer dialog API.
- The single-message **notification** alerts (`bluetooth-provider:815`, the switch/save/remove error alerts, and the ~11 BLE-error alerts in `use-board-bluetooth.ts`) are notifications, not confirms — a separate `notify`/toast follow-up.

### Validation
- `vp run typecheck` ✓
- `vp test run --project mobile` — **308 files / 2212 tests** ✓ (new `dialog-provider.test.tsx`: resolves true/false on both variants, dismiss=false, queued concurrent confirm)
- `vp run check:mobile-variants` ✓ · `vp check` (11 files) ✓ · `vp run check:mobile-bundle` (Android) ✓

Independent of slices 1/2 (Paper `Dialog` self-themes) — branches off `main`. **3b** (AppMenu + the FilterButton FAB) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)