### PR TITLE
fix(mobile/session): address session-detail PR review items

### DIFF
--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,7 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
-            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? null) : null}
+            primarySubtitleOverride={isMultiUser ? participant?.displayName : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,7 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
-            primarySubtitleOverride={isMultiUser ? participant?.displayName : null}
+            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? undefined) : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -97,8 +97,9 @@ export const SessionTickRow = memo(function SessionTickRow({
   // explicitly labelled, so it's never misread as the person who sent the climb.
   const setterText = tick.setterUsername ? t('detail.setBy', { username: tick.setterUsername }) : null;
   const detailParts = [attemptText, tick.comment ?? null, setterText].filter((part): part is string => !!part);
-  // Multi-user "who" is carried by the leading avatar + the climbers leaderboard,
-  // so the row subtitle stays attempt/comment/setter (no redundant name line).
+  // fallbackSubtitle is used only by the ListRow path (climb/boardConfig missing).
+  // In the ClimbListItemContent path, participant name is surfaced via
+  // primarySubtitleOverride and attempt/comment/setter via subtitleDetailParts.
   const fallbackSubtitle = detailParts.join(' · ') || undefined;
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -5,7 +5,7 @@ import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/share
 import { getGradeTextColor } from '@boardsesh/play-view';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { type IconName } from '../icon-map';
+import type { IconName } from '../icon-map';
 import { ListRow } from '../ListRow';
 import { PressableAvatar } from '../PressableAvatar';
 import { PressableSurface } from '../PressableSurface';

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,7 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
-            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? undefined) : null}
+            primarySubtitleOverride={isMultiUser ? participant?.displayName : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,7 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
-            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? null) : null}
+            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? undefined) : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,6 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
+            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? null) : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,7 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
-            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? undefined) : null}
+            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? null) : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -145,7 +145,7 @@ export const SessionTickRow = memo(function SessionTickRow({
             angle={tick.angle}
             subtitleDetailParts={detailParts}
             showAscentStatus={false}
-            primarySubtitleOverride={isMultiUser ? participant?.displayName : null}
+            primarySubtitleOverride={isMultiUser ? (participant?.displayName ?? null) : null}
           />
         </PressableSurface>
         <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
 import { createElement, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionDetail } from '@boardsesh/shared-schema';
 
-// Capture what FeedSocialRow receives so we can assert the correct entityId.
-const socialRow = vi.hoisted(() => ({ lastEntityId: null as string | null }));
+const mockFeedSocialRow = vi.hoisted(() => vi.fn());
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -23,9 +22,9 @@ vi.mock('../../you/AvatarGroup', () => ({
   AvatarGroup: () => createElement('div', { 'data-testid': 'avatar-group' }),
 }));
 vi.mock('../../you/FeedSocialRow', () => ({
-  FeedSocialRow: ({ entityId }: { entityId: string }) => {
-    socialRow.lastEntityId = entityId;
-    return createElement('div', { 'data-testid': 'social-row', 'data-entity': entityId });
+  FeedSocialRow: (props: { entityId: string }) => {
+    mockFeedSocialRow(props);
+    return createElement('div', { 'data-testid': 'social-row', 'data-entity': props.entityId });
   },
 }));
 vi.mock('../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#f00' }));
@@ -47,13 +46,18 @@ vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGrade: (g: string) => g }),
 }));
 vi.mock('@boardsesh/profile-stats', () => ({
-  formatTickAbsoluteTime: (_date: string, fmt: string) => fmt,
+  // Return a fixed sentinel distinct from any i18n key so assertions are stable.
+  formatTickAbsoluteTime: () => '__ABSOLUTE_TIME__',
 }));
 vi.mock('../../../lib/format-session-when', () => ({
   formatSessionWhen: () => 'Sunday morning',
 }));
 
 import { SessionSummaryCard } from '../SessionSummaryCard';
+
+beforeEach(() => {
+  mockFeedSocialRow.mockClear();
+});
 
 function session(overrides: Partial<SessionDetail> = {}): SessionDetail {
   return {
@@ -101,8 +105,7 @@ describe('SessionSummaryCard', () => {
 
   it('uses formatTickAbsoluteTime for a named session (titleIsDate=false)', () => {
     const { container } = render_(session(), 'Morning Sesh', false);
-    // The mock returns the format string itself, so assert on its content.
-    expect(container.textContent).toContain('MMM D, YYYY');
+    expect(container.textContent).toContain('__ABSOLUTE_TIME__');
   });
 
   it('uses formatSessionWhen for an unnamed session (titleIsDate=true)', () => {
@@ -166,6 +169,6 @@ describe('SessionSummaryCard', () => {
 
   it('passes the sessionId to FeedSocialRow', () => {
     render_(session({ sessionId: 'sess-42' }), 'Sesh', false);
-    expect(socialRow.lastEntityId).toBe('sess-42');
+    expect(mockFeedSocialRow).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'sess-42' }));
   });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -127,12 +127,12 @@ describe('SessionSummaryCard', () => {
 
   it('hides duration when durationMinutes is null', () => {
     const { container } = render_(session({ durationMinutes: null }), 'Sesh', false);
-    expect(container.textContent).not.toMatch(/\d+h|\d+m/);
+    expect(container.querySelector('[data-icon="clock"]')).toBeNull();
   });
 
   it('hides duration when durationMinutes is 0', () => {
     const { container } = render_(session({ durationMinutes: 0 }), 'Sesh', false);
-    expect(container.textContent).not.toMatch(/\d+h|\d+m/);
+    expect(container.querySelector('[data-icon="clock"]')).toBeNull();
   });
 
   it('shows the goal when set', () => {

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionDetail } from '@boardsesh/shared-schema';
+
+// Capture what FeedSocialRow receives so we can assert the correct entityId.
+const socialRow = vi.hoisted(() => ({ lastEntityId: null as string | null }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
+vi.mock('../../Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-testid': 'card' }, children),
+}));
+vi.mock('../../you/AvatarGroup', () => ({
+  AvatarGroup: () => createElement('div', { 'data-testid': 'avatar-group' }),
+}));
+vi.mock('../../you/FeedSocialRow', () => ({
+  FeedSocialRow: ({ entityId }: { entityId: string }) => {
+    socialRow.lastEntityId = entityId;
+    return createElement('div', { 'data-testid': 'social-row', 'data-entity': entityId });
+  },
+}));
+vi.mock('../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#f00' }));
+vi.mock('../../../theme/colors', () => ({ withAlpha: (c: string) => c }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { md: 8 },
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      secondaryLabel: '#888',
+      fill: '#eee',
+      label: '#000',
+    },
+  }),
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (g: string) => g }),
+}));
+vi.mock('@boardsesh/profile-stats', () => ({
+  formatTickAbsoluteTime: (_date: string, fmt: string) => fmt,
+}));
+vi.mock('../../../lib/format-session-when', () => ({
+  formatSessionWhen: () => 'Sunday morning',
+}));
+
+import { SessionSummaryCard } from '../SessionSummaryCard';
+
+function session(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    sessionId: 'sess-1',
+    sessionType: 'party',
+    sessionName: null,
+    ownerUserId: null,
+    participants: [],
+    totalSends: 5,
+    totalFlashes: 2,
+    totalAttempts: 12,
+    tickCount: 5,
+    gradeDistribution: [],
+    boardTypes: ['kilter'],
+    hardestGrade: 'V6',
+    firstTickAt: '2026-06-15T09:00:00.000Z',
+    lastTickAt: '2026-06-15T11:00:00.000Z',
+    durationMinutes: 120,
+    goal: null,
+    ticks: [],
+    upvotes: 3,
+    downvotes: 0,
+    voteScore: 3,
+    commentCount: 1,
+    ...overrides,
+  };
+}
+
+function render_(sess: SessionDetail, title: string, titleIsDate: boolean) {
+  return render(
+    createElement(SessionSummaryCard, {
+      session: sess,
+      title,
+      titleIsDate,
+      onOpenComments: () => {},
+    }),
+  );
+}
+
+describe('SessionSummaryCard', () => {
+  it('displays the title', () => {
+    const { container } = render_(session(), 'Morning Sesh', false);
+    expect(container.textContent).toContain('Morning Sesh');
+  });
+
+  it('uses formatTickAbsoluteTime for a named session (titleIsDate=false)', () => {
+    const { container } = render_(session(), 'Morning Sesh', false);
+    // The mock returns the format string itself, so assert on its content.
+    expect(container.textContent).toContain('MMM D, YYYY');
+  });
+
+  it('uses formatSessionWhen for an unnamed session (titleIsDate=true)', () => {
+    const { container } = render_(session(), 'Jun 15, 2026', true);
+    expect(container.textContent).toContain('Sunday morning');
+  });
+
+  it('displays board types in the meta row', () => {
+    const { container } = render_(session({ boardTypes: ['kilter', 'tension'] }), 'Sesh', false);
+    expect(container.textContent).toContain('kilter · tension');
+  });
+
+  it('displays duration when durationMinutes > 0', () => {
+    const { container } = render_(session({ durationMinutes: 90 }), 'Sesh', false);
+    expect(container.textContent).toContain('1h 30m');
+  });
+
+  it('formats sub-60-minute duration as Xm', () => {
+    const { container } = render_(session({ durationMinutes: 45 }), 'Sesh', false);
+    expect(container.textContent).toContain('45m');
+  });
+
+  it('hides duration when durationMinutes is null', () => {
+    const { container } = render_(session({ durationMinutes: null }), 'Sesh', false);
+    expect(container.textContent).not.toMatch(/\d+h|\d+m/);
+  });
+
+  it('hides duration when durationMinutes is 0', () => {
+    const { container } = render_(session({ durationMinutes: 0 }), 'Sesh', false);
+    expect(container.textContent).not.toMatch(/\d+h|\d+m/);
+  });
+
+  it('shows the goal when set', () => {
+    const { container } = render_(session({ goal: 'Flash the overhang' }), 'Sesh', false);
+    expect(container.textContent).toContain('Flash the overhang');
+  });
+
+  it('omits the goal row when goal is null', () => {
+    const { container } = render_(session({ goal: null }), 'Sesh', false);
+    expect(container.textContent).not.toContain('Flash the overhang');
+  });
+
+  it('renders the stat tile values', () => {
+    const { container } = render_(session({ totalSends: 7, totalFlashes: 3, totalAttempts: 20 }), 'Sesh', false);
+    const text = container.textContent ?? '';
+    expect(text).toContain('7');
+    expect(text).toContain('3');
+    expect(text).toContain('20');
+  });
+
+  it('renders the grade tile when hardestGrade is set', () => {
+    const { container } = render_(session({ hardestGrade: 'V8' }), 'Sesh', false);
+    expect(container.textContent).toContain('V8');
+  });
+
+  it('omits the grade tile when hardestGrade is null', () => {
+    const { container } = render_(session({ hardestGrade: null }), 'Sesh', false);
+    // hardest label key should not appear
+    expect(container.textContent).not.toContain('sessionFeedCard.hardest');
+  });
+
+  it('passes the sessionId to FeedSocialRow', () => {
+    render_(session({ sessionId: 'sess-42' }), 'Sesh', false);
+    expect(socialRow.lastEntityId).toBe('sess-42');
+  });
+});

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -151,9 +151,10 @@ describe('SessionSummaryCard', () => {
   it('renders the stat tile values', () => {
     const { container } = render_(session({ totalSends: 7, totalFlashes: 3, totalAttempts: 20 }), 'Sesh', false);
     const text = container.textContent ?? '';
-    expect(text).toContain('7');
-    expect(text).toContain('3');
-    expect(text).toContain('20');
+    // Assert value + i18n label key together to avoid matching stray digits elsewhere.
+    expect(text).toContain('7mobile.sessions.weekly.sends');
+    expect(text).toContain('3mobile.sessions.weekly.flashes');
+    expect(text).toContain('20mobile.sessions.weekly.attempts');
   });
 
   it('renders the grade tile when hardestGrade is set', () => {

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionDetail } from '@boardsesh/shared-schema';
 
 const mockFeedSocialRow = vi.hoisted(() => vi.fn());
+const mockAvatarGroup = vi.hoisted(() => vi.fn());
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -19,7 +20,10 @@ vi.mock('../../Card', () => ({
   Card: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-testid': 'card' }, children),
 }));
 vi.mock('../../you/AvatarGroup', () => ({
-  AvatarGroup: () => createElement('div', { 'data-testid': 'avatar-group' }),
+  AvatarGroup: (props: Record<string, unknown>) => {
+    mockAvatarGroup(props);
+    return createElement('div', { 'data-testid': 'avatar-group' });
+  },
 }));
 vi.mock('../../you/FeedSocialRow', () => ({
   FeedSocialRow: (props: { entityId: string }) => {
@@ -57,6 +61,7 @@ import { SessionSummaryCard } from '../SessionSummaryCard';
 
 beforeEach(() => {
   mockFeedSocialRow.mockClear();
+  mockAvatarGroup.mockClear();
 });
 
 function session(overrides: Partial<SessionDetail> = {}): SessionDetail {
@@ -171,5 +176,11 @@ describe('SessionSummaryCard', () => {
   it('passes the sessionId to FeedSocialRow', () => {
     render_(session({ sessionId: 'sess-42' }), 'Sesh', false);
     expect(mockFeedSocialRow).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'sess-42' }));
+  });
+
+  it('passes participants to AvatarGroup', () => {
+    const participants = [{ userId: 'u1', displayName: 'Alice', avatarUrl: null, sends: 3, flashes: 1, attempts: 7 }];
+    render_(session({ participants }), 'Party', false);
+    expect(mockAvatarGroup).toHaveBeenCalledWith(expect.objectContaining({ participants }));
   });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -9,7 +9,7 @@ const mockClimbListItemContent = vi.hoisted(() => vi.fn());
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  StyleSheet: { create: (styles: unknown) => styles },
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@boardsesh/play-view', () => ({ getGradeTextColor: () => '#fff' }));
@@ -31,7 +31,10 @@ vi.mock('../../ClimbListItemContent', () => ({
 }));
 vi.mock('../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#000' }));
 vi.mock('../../../hooks/use-grade-format', () => ({
-  useGradeFormat: () => ({ formatGrade: (g: string) => g, formatGradeByDifficultyId: () => null }),
+  useGradeFormat: () => ({
+    formatGrade: (g: string) => g,
+    formatGradeByDifficultyId: () => null,
+  }),
 }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: { secondaryBackground: '#fff', separator: '#ccc' } }),
@@ -41,7 +44,10 @@ vi.mock('../../../theme/colors', () => ({
   withAlpha: (c: string) => c,
 }));
 vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888', white: '#fff' } }));
-vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12 }, borderRadius: { sm: 4 } }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 2: 8, 3: 12 },
+  borderRadius: { sm: 4 },
+}));
 vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({
   getBoardConfigForPlaylist: () => ({
     boardName: 'kilter',

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -179,9 +179,7 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
         onPress: () => {},
       }),
     );
-    expect(mockClimbListItemContent).toHaveBeenCalledWith(
-      expect.objectContaining({ primarySubtitleOverride: null }),
-    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(expect.objectContaining({ primarySubtitleOverride: null }));
   });
 
   it('passes null when participant displayName is null (suppresses double-setter)', () => {
@@ -193,8 +191,6 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
         onPress: () => {},
       }),
     );
-    expect(mockClimbListItemContent).toHaveBeenCalledWith(
-      expect.objectContaining({ primarySubtitleOverride: null }),
-    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(expect.objectContaining({ primarySubtitleOverride: null }));
   });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -29,6 +29,15 @@ vi.mock('../../ClimbListItemContent', () => ({
     return createElement('div', { 'data-testid': 'climb-content' });
   },
 }));
+// ClimbListItemContent imports ClimbListThumbnail, which transitively imports
+// expo-file-system and expo-image (native packages whose untransformed TS
+// source throws `SyntaxError: Unexpected token 'typeof'` in Vitest's worker).
+// Mocking ClimbListThumbnail stops Rolldown from traversing into those packages.
+vi.mock('../../ClimbListThumbnail', () => ({
+  ClimbListThumbnail: () => null,
+  THUMBNAIL_WIDTH: 76,
+  THUMBNAIL_HEIGHT: 96,
+}));
 vi.mock('../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#000' }));
 vi.mock('../../../hooks/use-grade-format', () => ({
   useGradeFormat: () => ({

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -76,6 +76,7 @@ vi.mock('../../../lib/session-tick-mapping', () => ({
   }),
 }));
 vi.mock('../../../lib/haptics', () => ({ hapticSelection: () => {} }));
+vi.mock('../../icon-map', () => ({}));
 
 import { SessionTickRow } from '../SessionTickRow';
 

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/shared-schema';
+
+// Capture what ClimbListItemContent receives so we can assert primarySubtitleOverride.
+const mockClimbListItemContent = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/play-view', () => ({ getGradeTextColor: () => '#fff' }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../../ListRow', () => ({ ListRow: () => createElement('div', { 'data-testid': 'list-row' }) }));
+vi.mock('../../Avatar', () => ({ Avatar: () => createElement('span', { 'data-testid': 'avatar' }) }));
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('div', { onClick: onPress }, children),
+}));
+vi.mock('../../ClimbListItemContent', () => ({
+  ClimbListItemContent: (props: Record<string, unknown>) => {
+    mockClimbListItemContent(props);
+    return createElement('div', { 'data-testid': 'climb-content' });
+  },
+}));
+vi.mock('../../you/profile-chart-colors', () => ({ gradeBadgeColor: () => '#000' }));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (g: string) => g, formatGradeByDifficultyId: () => null }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#fff', separator: '#ccc' } }),
+}));
+vi.mock('../../../theme/colors', () => ({ brandColors: { warning: '#fa0', success: '#0a0' }, withAlpha: (c: string) => c }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888', white: '#fff' } }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12 }, borderRadius: { sm: 4 } }));
+vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({
+  getBoardConfigForPlaylist: () => ({
+    boardName: 'kilter',
+    layoutId: 1,
+    sizeId: 1,
+    setIds: [1],
+  }),
+}));
+vi.mock('../../../lib/session-tick-mapping', () => ({
+  sessionTickToClimb: () => ({
+    uuid: 'climb-1',
+    name: 'Test Climb',
+    frames: 'some-frames',
+    difficulty: 'V4',
+    ascensionist_count: 10,
+    quality_average: '3.5',
+    setter_username: 'setter',
+    benchmark_difficulty: null,
+    mirrored: false,
+    is_no_match: false,
+  }),
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: () => {} }));
+
+import { SessionTickRow } from '../SessionTickRow';
+
+function tick(overrides: Partial<SessionDetailTick> = {}): SessionDetailTick {
+  return {
+    uuid: 'tick-1',
+    userId: 'user-1',
+    climbUuid: 'climb-1',
+    climbName: 'Test Climb',
+    boardType: 'kilter',
+    layoutId: 1,
+    angle: 40,
+    status: 'send',
+    attemptCount: 1,
+    difficulty: 12,
+    difficultyName: 'V4',
+    quality: null,
+    isMirror: false,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: null,
+    frames: 'some-frames',
+    setterUsername: 'setter',
+    climbedAt: '2026-06-15T10:00:00.000Z',
+    upvotes: 0,
+    totalAttempts: 1,
+    betaLinks: [],
+    ...overrides,
+  };
+}
+
+function participant(displayName: string): SessionFeedParticipant {
+  return { userId: 'user-1', displayName, avatarUrl: null, sends: 1, flashes: 0, attempts: 0 };
+}
+
+beforeEach(() => {
+  mockClimbListItemContent.mockClear();
+});
+
+describe('SessionTickRow — primarySubtitleOverride', () => {
+  it('passes null in a solo session to suppress the default subtitle', () => {
+    render(
+      createElement(SessionTickRow, {
+        tick: tick(),
+        isMultiUser: false,
+        onPress: () => {},
+      }),
+    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(
+      expect.objectContaining({ primarySubtitleOverride: null }),
+    );
+  });
+
+  it('passes the participant display name in a multi-user session', () => {
+    render(
+      createElement(SessionTickRow, {
+        tick: tick(),
+        isMultiUser: true,
+        participant: participant('Cata'),
+        onPress: () => {},
+      }),
+    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(
+      expect.objectContaining({ primarySubtitleOverride: 'Cata' }),
+    );
+  });
+
+  it('falls back to undefined (computed subtitle) in multi-user when participant is absent', () => {
+    render(
+      createElement(SessionTickRow, {
+        tick: tick(),
+        isMultiUser: true,
+        participant: undefined,
+        onPress: () => {},
+      }),
+    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(
+      expect.objectContaining({ primarySubtitleOverride: undefined }),
+    );
+  });
+});

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -170,7 +170,7 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
     expect(mockClimbListItemContent).toHaveBeenCalledWith(expect.objectContaining({ primarySubtitleOverride: 'Cata' }));
   });
 
-  it('falls back to undefined (computed subtitle) in multi-user when participant is absent', () => {
+  it('passes null in multi-user when participant is absent (suppresses double-setter)', () => {
     render(
       createElement(SessionTickRow, {
         tick: tick(),
@@ -180,11 +180,11 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
       }),
     );
     expect(mockClimbListItemContent).toHaveBeenCalledWith(
-      expect.objectContaining({ primarySubtitleOverride: undefined }),
+      expect.objectContaining({ primarySubtitleOverride: null }),
     );
   });
 
-  it('falls back to undefined when participant displayName is null', () => {
+  it('passes null when participant displayName is null (suppresses double-setter)', () => {
     render(
       createElement(SessionTickRow, {
         tick: tick(),
@@ -194,7 +194,7 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
       }),
     );
     expect(mockClimbListItemContent).toHaveBeenCalledWith(
-      expect.objectContaining({ primarySubtitleOverride: undefined }),
+      expect.objectContaining({ primarySubtitleOverride: null }),
     );
   });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -124,9 +124,7 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
         onPress: () => {},
       }),
     );
-    expect(mockClimbListItemContent).toHaveBeenCalledWith(
-      expect.objectContaining({ primarySubtitleOverride: null }),
-    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(expect.objectContaining({ primarySubtitleOverride: null }));
   });
 
   it('passes the participant display name in a multi-user session', () => {
@@ -138,9 +136,7 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
         onPress: () => {},
       }),
     );
-    expect(mockClimbListItemContent).toHaveBeenCalledWith(
-      expect.objectContaining({ primarySubtitleOverride: 'Cata' }),
-    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(expect.objectContaining({ primarySubtitleOverride: 'Cata' }));
   });
 
   it('falls back to undefined (computed subtitle) in multi-user when participant is absent', () => {

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -23,6 +23,28 @@ vi.mock('../../PressableSurface', () => ({
   PressableSurface: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
     createElement('div', { onClick: onPress }, children),
 }));
+// PressableSurface statically imports `react-native-reanimated` and
+// `../theme/animations`. Rolldown traverses mocked modules' import graphs, so
+// we must also mock these to prevent parse errors in CI's module worker.
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+    createAnimatedComponent: (C: unknown) => C,
+  },
+  createAnimatedComponent: (C: unknown) => C,
+  useAnimatedStyle: () => ({}),
+  useSharedValue: (v: unknown) => ({ value: v }),
+  withSpring: (v: unknown) => v,
+  withTiming: (v: unknown) => v,
+  runOnJS:
+    (fn: (...args: unknown[]) => unknown) =>
+    (...args: unknown[]) =>
+      fn(...args),
+}));
+vi.mock('../../../theme/animations', () => ({
+  springs: { snappy: {}, interactive: {}, gentle: {}, bouncy: {} },
+  timing: { instant: 50, fast: 150, normal: 250, slow: 350 },
+}));
 vi.mock('../../ClimbListItemContent', () => ({
   ClimbListItemContent: (props: Record<string, unknown>) => {
     mockClimbListItemContent(props);

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -76,7 +76,6 @@ vi.mock('../../../lib/session-tick-mapping', () => ({
   }),
 }));
 vi.mock('../../../lib/haptics', () => ({ hapticSelection: () => {} }));
-vi.mock('../../icon-map', () => ({}));
 
 import { SessionTickRow } from '../SessionTickRow';
 

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -37,7 +37,12 @@ vi.mock('../../../hooks/use-grade-format', () => ({
   }),
 }));
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { secondaryBackground: '#fff', separator: '#ccc' } }),
+  useTheme: () => ({
+    systemColors: {
+      secondaryBackground: '#fff',
+      separator: '#ccc',
+    },
+  }),
 }));
 vi.mock('../../../theme/colors', () => ({
   brandColors: { warning: '#fa0', success: '#0a0' },

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -153,4 +153,18 @@ describe('SessionTickRow — primarySubtitleOverride', () => {
       expect.objectContaining({ primarySubtitleOverride: undefined }),
     );
   });
+
+  it('falls back to undefined when participant displayName is null', () => {
+    render(
+      createElement(SessionTickRow, {
+        tick: tick(),
+        isMultiUser: true,
+        participant: { userId: 'user-1', displayName: null, avatarUrl: null, sends: 1, flashes: 0, attempts: 0 },
+        onPress: () => {},
+      }),
+    );
+    expect(mockClimbListItemContent).toHaveBeenCalledWith(
+      expect.objectContaining({ primarySubtitleOverride: undefined }),
+    );
+  });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -36,7 +36,10 @@ vi.mock('../../../hooks/use-grade-format', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: { secondaryBackground: '#fff', separator: '#ccc' } }),
 }));
-vi.mock('../../../theme/colors', () => ({ brandColors: { warning: '#fa0', success: '#0a0' }, withAlpha: (c: string) => c }));
+vi.mock('../../../theme/colors', () => ({
+  brandColors: { warning: '#fa0', success: '#0a0' },
+  withAlpha: (c: string) => c,
+}));
 vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888', white: '#fff' } }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12 }, borderRadius: { sm: 4 } }));
 vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({

--- a/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionTickRow.test.tsx
@@ -18,7 +18,11 @@ vi.mock('../../Text', () => ({
 }));
 vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
 vi.mock('../../ListRow', () => ({ ListRow: () => createElement('div', { 'data-testid': 'list-row' }) }));
-vi.mock('../../Avatar', () => ({ Avatar: () => createElement('span', { 'data-testid': 'avatar' }) }));
+// PressableAvatar wraps Avatar + PressableSurface and imports expo-router. Mocking
+// it prevents Rolldown from traversing into those packages during static analysis.
+vi.mock('../../PressableAvatar', () => ({
+  PressableAvatar: () => createElement('span', { 'data-testid': 'avatar' }),
+}));
 vi.mock('../../PressableSurface', () => ({
   PressableSurface: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
     createElement('div', { onClick: onPress }, children),
@@ -44,6 +48,7 @@ vi.mock('react-native-reanimated', () => ({
 vi.mock('../../../theme/animations', () => ({
   springs: { snappy: {}, interactive: {}, gentle: {}, bouncy: {} },
   timing: { instant: 50, fast: 150, normal: 250, slow: 350 },
+  motionByVariant: { liquidGlass: {}, material: {} },
 }));
 vi.mock('../../ClimbListItemContent', () => ({
   ClimbListItemContent: (props: Record<string, unknown>) => {

--- a/packages/mobile/src/theme/animations.ts
+++ b/packages/mobile/src/theme/animations.ts
@@ -41,8 +41,8 @@ export const timing = {
   slow: 350,
 } as const;
 
-export type SpringPreset = keyof typeof springs;
-export type TimingPreset = keyof typeof timing;
+export type SpringPreset = 'snappy' | 'interactive' | 'gentle' | 'bouncy';
+export type TimingPreset = 'instant' | 'fast' | 'normal' | 'slow';
 
 // Material 3 easing curves as raw cubic-bezier control points — NOT
 // `Easing.bezier(...)`, so this module stays reanimated-free and safe to import from

--- a/packages/mobile/test/expo-file-system-stub.ts
+++ b/packages/mobile/test/expo-file-system-stub.ts
@@ -1,0 +1,52 @@
+// Vitest stub for `expo-file-system`.
+//
+// expo-file-system's package.json points `main`/`exports` at TypeScript source
+// (src/index.ts). That source imports `expo-modules-core` native bindings whose
+// untransformed TS declarations (e.g. `FileSystemDirectory: typeof NativeFileSystemDirectory`)
+// throw `SyntaxError: Unexpected token 'typeof'` in Vitest's module worker
+// before the TypeScript plugin can strip the type annotations.
+//
+// No test in this repo exercises the real file-system; this stub only needs to
+// satisfy static imports so Vitest's module graph resolves cleanly.
+// Suites that assert file-system behaviour can register their own `vi.mock`
+// which takes precedence over this alias.
+//
+// Wired via the `expo-file-system` alias in packages/mobile/vite.config.ts.
+
+export class Directory {
+  constructor(..._args: unknown[]) {}
+  get exists(): boolean {
+    return false;
+  }
+  list(): unknown[] {
+    return [];
+  }
+  delete(): void {}
+}
+
+export class File {
+  constructor(..._args: unknown[]) {}
+  get exists(): boolean {
+    return false;
+  }
+  get uri(): string {
+    return '';
+  }
+  delete(): void {}
+}
+
+export const Paths = {
+  get cache(): Directory {
+    return new Directory();
+  },
+  get document(): Directory {
+    return new Directory();
+  },
+  get bundle(): Directory {
+    return new Directory();
+  },
+};
+
+export const EncodingType = { UTF8: 'utf8', Base64: 'base64' } as const;
+export const FileMode = { Read: 0, Write: 1, ReadWrite: 2 } as const;
+export const UploadType = { BinaryContent: 0, Multipart: 1 } as const;

--- a/packages/mobile/test/expo-image-stub.tsx
+++ b/packages/mobile/test/expo-image-stub.tsx
@@ -1,0 +1,24 @@
+// Vitest stub for `expo-image`.
+//
+// expo-image's package.json points `main` at TypeScript source (src/index.ts).
+// That source imports native Expo module bindings whose untransformed TS source
+// throws `SyntaxError: Unexpected token 'typeof'` in Vitest's module worker.
+//
+// No test in this repo renders the real Image; this stub only needs to satisfy
+// static imports so Vitest's module graph resolves cleanly. Suites that assert
+// Image props can register their own `vi.mock` which takes precedence.
+//
+// Wired via the `expo-image` alias in packages/mobile/vite.config.ts.
+
+import type { ReactNode } from 'react';
+
+type ImageProps = {
+  source?: unknown;
+  style?: unknown;
+  contentFit?: string;
+  recyclingKey?: string;
+  children?: ReactNode;
+  [key: string]: unknown;
+};
+
+export const Image = (_props: ImageProps) => null;

--- a/packages/mobile/test/theme-animations-stub.ts
+++ b/packages/mobile/test/theme-animations-stub.ts
@@ -1,0 +1,28 @@
+// Vitest stub for `packages/mobile/src/theme/animations`.
+//
+// The real animations.ts has `export type SpringPreset = keyof typeof springs`
+// and `export type TimingPreset = keyof typeof timing` — type exports using
+// `keyof typeof X`. In CI's Rolldown worker (Node.js 24), Rolldown's static
+// analysis phase traverses into this file even when it is vi.mock()'d, and
+// the TypeScript transform does not strip the `keyof typeof` before the parser
+// sees it, causing `SyntaxError: Unexpected token 'typeof'`.
+//
+// This stub exports the same runtime values without TypeScript-specific syntax,
+// avoiding the parse error at bundle-build time. Tests that assert on specific
+// animation values register their own vi.mock which takes precedence.
+//
+// Wired via the `/theme\/animations$/` alias in packages/mobile/vite.config.ts.
+
+export const springs = {
+  snappy: { damping: 20, stiffness: 300, mass: 0.7 },
+  interactive: { damping: 20, stiffness: 250, mass: 1.0 },
+  gentle: { damping: 15, stiffness: 150, mass: 1.0 },
+  bouncy: { damping: 10, stiffness: 200, mass: 0.7 },
+};
+
+export const timing = {
+  instant: 50,
+  fast: 150,
+  normal: 250,
+  slow: 350,
+};

--- a/packages/mobile/test/theme-animations-stub.ts
+++ b/packages/mobile/test/theme-animations-stub.ts
@@ -26,3 +26,14 @@ export const timing = {
   normal: 250,
   slow: 350,
 };
+
+export const motionByVariant = {
+  liquidGlass: {
+    standard: { duration: 150 },
+    emphasized: { duration: 250 },
+  },
+  material: {
+    standard: { duration: 200, easingBezier: [0.2, 0, 0, 1] },
+    emphasized: { duration: 350, easingBezier: [0.05, 0.7, 0.1, 1] },
+  },
+};

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -12,18 +12,24 @@ export default defineConfig({
     name: 'mobile',
     globals: true,
     environment: 'node',
-    alias: {
+    alias: [
       // The real `posthog-react-native` entry re-exports RN-native components
       // (PostHogProvider/PostHogMaskView) whose untransformed source throws a
       // `SyntaxError` under vitest's node env, breaking every suite that imports
       // `src/lib/analytics`. Analytics is a no-op in tests (isAnalyticsEnabled is
       // false), so a lightweight stub satisfies the static imports safely.
-      'posthog-react-native': fileURLToPath(new URL('./test/posthog-react-native-stub.ts', import.meta.url)),
+      {
+        find: 'posthog-react-native',
+        replacement: fileURLToPath(new URL('./test/posthog-react-native-stub.ts', import.meta.url)),
+      },
       // react-native-paper's real entry throws a SyntaxError under vitest's node
       // env (untransformed RN-native source + react-native-vector-icons). Stub it
       // so any suite can import a Paper-backed primitive; component tests that
       // assert Paper props register their own vi.mock which takes precedence.
-      'react-native-paper': fileURLToPath(new URL('./test/react-native-paper-stub.tsx', import.meta.url)),
+      {
+        find: 'react-native-paper',
+        replacement: fileURLToPath(new URL('./test/react-native-paper-stub.tsx', import.meta.url)),
+      },
       // @react-native-async-storage/async-storage's ESM entry imports
       // `./createAsyncStorage` without a file extension, which fails to resolve
       // under vitest's node ESM env — breaking any suite that transitively loads
@@ -32,16 +38,23 @@ export default defineConfig({
       // storage. A tiny in-memory stub satisfies the static imports; suites that
       // assert storage behaviour register their own vi.mock, which takes
       // precedence.
-      '@react-native-async-storage/async-storage': fileURLToPath(
-        new URL('./test/async-storage-stub.ts', import.meta.url),
-      ),
+      {
+        find: '@react-native-async-storage/async-storage',
+        replacement: fileURLToPath(new URL('./test/async-storage-stub.ts', import.meta.url)),
+      },
       // @react-native-masked-view/masked-view and @react-native-community/blur are
       // native modules that can't load under vitest's node/jsdom env. Stub them so
       // any suite can import a blur/glass primitive (GlassSurface, ProgressiveBlur)
       // without crashing; suites that assert their props register their own vi.mock,
       // which takes precedence over these aliases.
-      '@react-native-masked-view/masked-view': fileURLToPath(new URL('./test/masked-view-stub.tsx', import.meta.url)),
-      '@react-native-community/blur': fileURLToPath(new URL('./test/community-blur-stub.tsx', import.meta.url)),
+      {
+        find: '@react-native-masked-view/masked-view',
+        replacement: fileURLToPath(new URL('./test/masked-view-stub.tsx', import.meta.url)),
+      },
+      {
+        find: '@react-native-community/blur',
+        replacement: fileURLToPath(new URL('./test/community-blur-stub.tsx', import.meta.url)),
+      },
       // expo-file-system and expo-image point their `main`/`exports` at TypeScript
       // source (src/index.ts). That source imports expo-modules-core native bindings
       // whose untransformed TS declarations throw `SyntaxError: Unexpected token
@@ -50,9 +63,26 @@ export default defineConfig({
       // expo-file-system, or LayeredClimbImage → expo-image) resolves cleanly.
       // Suites that assert real expo-file-system / expo-image behaviour can register
       // their own vi.mock which takes precedence over these aliases.
-      'expo-file-system': fileURLToPath(new URL('./test/expo-file-system-stub.ts', import.meta.url)),
-      'expo-image': fileURLToPath(new URL('./test/expo-image-stub.tsx', import.meta.url)),
-    },
+      {
+        find: 'expo-file-system',
+        replacement: fileURLToPath(new URL('./test/expo-file-system-stub.ts', import.meta.url)),
+      },
+      { find: 'expo-image', replacement: fileURLToPath(new URL('./test/expo-image-stub.tsx', import.meta.url)) },
+      // src/theme/animations.ts has `export type SpringPreset = keyof typeof springs`
+      // and `export type TimingPreset = keyof typeof timing`. In CI's Rolldown worker
+      // (Node.js 24), Rolldown's static analysis traverses into this file even when
+      // the importing module is vi.mock()'d, and the TypeScript transform does not
+      // strip `keyof typeof` before the parser sees it, producing
+      // `SyntaxError: Unexpected token 'typeof'`. A path-regex alias redirects ALL
+      // imports of this module (e.g. `../theme/animations`, `../../theme/animations`)
+      // to a plain-JS stub before Rolldown reads the source, eliminating the error.
+      // Suites that need specific animation values can register their own vi.mock
+      // which takes precedence at runtime.
+      {
+        find: /^(.*\/)?theme\/animations$/,
+        replacement: fileURLToPath(new URL('./test/theme-animations-stub.ts', import.meta.url)),
+      },
+    ],
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React
     // providers in tests. Pure-logic tests stay node-env (faster).

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -42,6 +42,16 @@ export default defineConfig({
       // which takes precedence over these aliases.
       '@react-native-masked-view/masked-view': fileURLToPath(new URL('./test/masked-view-stub.tsx', import.meta.url)),
       '@react-native-community/blur': fileURLToPath(new URL('./test/community-blur-stub.tsx', import.meta.url)),
+      // expo-file-system and expo-image point their `main`/`exports` at TypeScript
+      // source (src/index.ts). That source imports expo-modules-core native bindings
+      // whose untransformed TS declarations throw `SyntaxError: Unexpected token
+      // 'typeof'` in Vitest's module worker. Stub them so any suite that transitively
+      // imports these packages (e.g. ClimbListThumbnail → use-native-climb-render →
+      // expo-file-system, or LayeredClimbImage → expo-image) resolves cleanly.
+      // Suites that assert real expo-file-system / expo-image behaviour can register
+      // their own vi.mock which takes precedence over these aliases.
+      'expo-file-system': fileURLToPath(new URL('./test/expo-file-system-stub.ts', import.meta.url)),
+      'expo-image': fileURLToPath(new URL('./test/expo-image-stub.tsx', import.meta.url)),
     },
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React

--- a/packages/shared/graphql/src/operations/activity-feed.ts
+++ b/packages/shared/graphql/src/operations/activity-feed.ts
@@ -183,6 +183,8 @@ export const GET_SESSION_DETAIL = gql`
         climbedAt
         upvotes
         totalAttempts
+        # boardId is kept for BetaLinksGqlRow type parity and flows through
+        # dedupeBetaLinks — it is not displayed by the session-detail carousel.
         betaLinks {
           climbUuid
           link

--- a/packages/shared/graphql/src/operations/activity-feed.ts
+++ b/packages/shared/graphql/src/operations/activity-feed.ts
@@ -183,8 +183,6 @@ export const GET_SESSION_DETAIL = gql`
         climbedAt
         upvotes
         totalAttempts
-        # boardId is kept for BetaLinksGqlRow type parity and flows through
-        # dedupeBetaLinks — it is not displayed by the session-detail carousel.
         betaLinks {
           climbUuid
           link
@@ -194,6 +192,8 @@ export const GET_SESSION_DETAIL = gql`
           isListed
           createdAt
           tickUuid
+          # boardId is kept for BetaLinksGqlRow type parity and flows through
+          # dedupeBetaLinks — it is not displayed by the session-detail carousel.
           boardId
         }
       }


### PR DESCRIPTION
## Summary

Addresses four issues raised in the session-detail PR code review:

- **`primarySubtitleOverride` bug in `SessionTickRow`**: `ClimbListItemContent` was computing its default subtitle (`sends · quality★ · setter`) while `detailParts` already contained a "set by X" entry — causing the setter to appear twice. Now passes `primarySubtitleOverride`: participant display name in multi-user sessions, `null` (suppress) in solo sessions.

- **`boardId` in `GET_SESSION_DETAIL`**: Added a GraphQL comment explaining the field is kept for `BetaLinksGqlRow` type parity and flows through `dedupeBetaLinks`, even though it's not rendered by the session-detail carousel.

- **`SessionSummaryCard` test coverage**: Added `SessionSummaryCard.test.tsx` (14 cases) covering title display, `titleIsDate` branching (`formatSessionWhen` vs `formatTickAbsoluteTime`), board-type and duration meta row, conditional goal row, stat-tile values (sends/flashes/attempts), hardest-grade tile presence, and `FeedSocialRow` `entityId` wiring.

- **Per-tick social removal (intentional)**: `FeedSocialRow` was removed from `SessionTickRow` as a deliberate design simplification — per-tick upvote/comment actions are replaced by session-level reactions in `SessionSummaryCard`. This was not a bug or accidental omission.

## Test plan

- [ ] `vp run typecheck:mobile` passes with no new errors
- [ ] `vp run test:mobile` passes, including the new `SessionSummaryCard` suite
- [ ] In a session-detail screen with a setter-named climb, verify the setter appears only once (in the "set by X" detail line, not also in the primary subtitle)
- [ ] In a multi-user session, verify the row subtitle shows the participant's display name
- [ ] In a solo session, verify no redundant subtitle line appears on tick rows

https://claude.ai/code/session_01XF2okNTAyW7TNeAXpeL4xZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF2okNTAyW7TNeAXpeL4xZ)_