### PR TITLE
feat(mobile): variant-aware M3 motion tokens (Phase 3, slice 4)

### DIFF
--- a/docs/ai-design-guidelines.md
+++ b/docs/ai-design-guidelines.md
@@ -323,6 +323,15 @@ borderless)` builds a Pressable `android_ripple` config at that state-layer opac
 
 **Timing** (`withTiming`): `instant` 50ms · `fast` 150ms · `normal` 250ms · `slow` 350ms.
 
+**Variant-aware motion** (`theme.motion`, resolved from `motionByVariant`): for `withTiming`
+transitions that should follow the active design language. `theme.motion.standard` (utility:
+fades, small moves) and `theme.motion.emphasized` (hero: sheet/FAB moves, larger layout shifts)
+are pure-data `MotionConfig`s — Material carries an M3 easing curve + M3 duration (200 / 350ms),
+Liquid Glass carries the prior `timing` durations with no easing override. Build the reanimated
+config at the call site with `timingFor` (it stays out of the token modules so they remain
+reanimated-free for `makeThemeMock`): `value.value = withTiming(target, timingFor(theme.motion.emphasized))`.
+Springs (press/gesture feedback) stay variant-agnostic — these tokens cover the shared `withTiming` moves.
+
 **Haptics** (`packages/mobile/src/lib/haptics.ts`, expo-haptics, no-ops where unsupported). Visual
 press feedback is separate (that's `PressableSurface`); fire haptics from the handler:
 
@@ -381,6 +390,7 @@ type Theme = {
   opacity;
   springs;
   timing;
+  motion; // variant-aware withTiming configs: motion.standard / motion.emphasized (+ timingFor)
   variant; // 'liquidGlass' | 'material' (already resolved from 'auto')
   radii; // variant corner radii (e.g. radii.button)
   sheet; // variant sheet chrome (scrim/handle/corners)

--- a/packages/mobile/src/components/search/ClimbFilterFab.tsx
+++ b/packages/mobile/src/components/search/ClimbFilterFab.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import type { Grade } from '@boardsesh/shared-schema';
@@ -35,11 +35,15 @@ export function ClimbFilterFab({
   const { motion } = useTheme();
   const animatedBottom = useSharedValue(bottom);
 
+  // The FAB slot slides when the grade rail opens/closes — a layout move, so
+  // emphasized motion (M3 easing + 350ms on Material; the prior 250ms on glass).
+  // Memoised so the slide effect re-fires only on a real `bottom` change, not on
+  // every theme recompute (e.g. a colour-scheme flip).
+  const slideTiming = useMemo(() => timingFor(motion.emphasized), [motion]);
+
   useEffect(() => {
-    // The FAB slot slides when the grade rail opens/closes — a layout move, so
-    // emphasized motion (M3 easing + 350ms on Material; the prior 250ms on glass).
-    animatedBottom.value = withTiming(bottom, timingFor(motion.emphasized));
-  }, [animatedBottom, bottom, motion]);
+    animatedBottom.value = withTiming(bottom, slideTiming);
+  }, [animatedBottom, bottom, slideTiming]);
 
   const fabSlotStyle = useAnimatedStyle(() => ({ bottom: animatedBottom.value }));
   const gradeRailSlotStyle = useAnimatedStyle(() => ({

--- a/packages/mobile/src/components/search/ClimbFilterFab.tsx
+++ b/packages/mobile/src/components/search/ClimbFilterFab.tsx
@@ -4,7 +4,8 @@ import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-na
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import { spacing } from '../../theme/tokens';
-import { timing } from '../../theme/animations';
+import { timingFor } from '../../theme/motion-config';
+import { useTheme } from '../../providers/theme-provider';
 import { FILTER_FAB_SIZE, FilterButton } from './FilterButton';
 import { GradeRangeRail } from '../grade';
 
@@ -31,11 +32,14 @@ export function ClimbFilterFab({
   onCloseGrade,
   onGradeChange,
 }: ClimbFilterFabProps) {
+  const { motion } = useTheme();
   const animatedBottom = useSharedValue(bottom);
 
   useEffect(() => {
-    animatedBottom.value = withTiming(bottom, { duration: timing.normal });
-  }, [animatedBottom, bottom]);
+    // The FAB slot slides when the grade rail opens/closes — a layout move, so
+    // emphasized motion (M3 easing + 350ms on Material; the prior 250ms on glass).
+    animatedBottom.value = withTiming(bottom, timingFor(motion.emphasized));
+  }, [animatedBottom, bottom, motion]);
 
   const fabSlotStyle = useAnimatedStyle(() => ({ bottom: animatedBottom.value }));
   const gradeRailSlotStyle = useAnimatedStyle(() => ({

--- a/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
@@ -18,7 +18,10 @@ vi.mock('react-native-reanimated', () => ({
 }));
 
 vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 4: 16 } }));
-vi.mock('../../../theme/animations', () => ({ timing: { normal: 250 } }));
+vi.mock('../../../theme/motion-config', () => ({ timingFor: (config: { duration: number }) => config }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ motion: { standard: { duration: 150 }, emphasized: { duration: 250 } } }),
+}));
 vi.mock('../FilterButton', () => ({
   FILTER_FAB_SIZE: 48,
   FilterButton: ({

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -31,7 +31,7 @@ import {
   type Radii,
   type SheetChrome,
 } from '../theme/tokens';
-import { springs, timing } from '../theme/animations';
+import { springs, timing, motionByVariant, type Motion } from '../theme/animations';
 import { resolveUiVariant, type UiVariant } from '../theme/resolve-ui-variant';
 import {
   resolveActionColors,
@@ -96,6 +96,12 @@ type Theme = {
   opacity: typeof opacity;
   springs: typeof springs;
   timing: typeof timing;
+  /**
+   * Variant-aware `withTiming` motion (`standard` / `emphasized`): M3 easing curves +
+   * standard durations on Material, the prior durations (default ease) on Liquid
+   * Glass. Pure data — build the reanimated config with `timingFor` (theme/motion-config).
+   */
+  motion: Motion;
   themeOverride: ThemeOverride;
   setThemeOverride: (next: ThemeOverride) => Promise<void>;
   /** Resolved visual variant the app renders in ('auto' already resolved). */
@@ -333,6 +339,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       opacity,
       springs,
       timing,
+      motion: motionByVariant[variant],
       themeOverride,
       setThemeOverride,
       variant,

--- a/packages/mobile/src/test/theme-mock.ts
+++ b/packages/mobile/src/test/theme-mock.ts
@@ -8,7 +8,7 @@ import {
   sheetChromeByVariant,
   materialElevationByLevel,
 } from '../theme/tokens';
-import { springs, timing } from '../theme/animations';
+import { springs, timing, motionByVariant } from '../theme/animations';
 import { textStylesByVariant } from '../theme/typography';
 import {
   brandColors,
@@ -52,6 +52,7 @@ export function makeThemeMock(overrides: Partial<Theme> = {}): Theme {
     opacity,
     springs,
     timing,
+    motion: motionByVariant[variant],
     themeOverride: 'system',
     setThemeOverride: () => Promise.resolve(),
     variant,

--- a/packages/mobile/src/theme/__tests__/motion.test.ts
+++ b/packages/mobile/src/theme/__tests__/motion.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// motion-config builds Easing.bezier from reanimated; mock it (animations.ts itself
+// is pure data and pulls in nothing).
+vi.mock('react-native-reanimated', () => ({
+  Easing: { bezier: (...args: number[]) => ({ __bezier: args }) },
+}));
+
+import { motionByVariant } from '../animations';
+import { timingFor } from '../motion-config';
+
+describe('motionByVariant', () => {
+  it('gives Material M3 easing curves + standard durations', () => {
+    expect(motionByVariant.material.standard).toEqual({ duration: 200, easingBezier: [0.2, 0, 0, 1] });
+    expect(motionByVariant.material.emphasized).toEqual({ duration: 350, easingBezier: [0.2, 0, 0, 1] });
+  });
+
+  it('keeps the prior glass durations with no easing override (default ease)', () => {
+    expect(motionByVariant.liquidGlass.standard).toEqual({ duration: 150 });
+    expect(motionByVariant.liquidGlass.emphasized).toEqual({ duration: 250 });
+    expect('easingBezier' in motionByVariant.liquidGlass.standard).toBe(false);
+  });
+});
+
+describe('timingFor', () => {
+  it('builds an Easing.bezier curve from a Material config', () => {
+    const config = timingFor(motionByVariant.material.standard);
+    expect(config.duration).toBe(200);
+    expect(config.easing).toEqual({ __bezier: [0.2, 0, 0, 1] });
+  });
+
+  it('omits easing for a glass config (so reanimated uses its default ease)', () => {
+    const config = timingFor(motionByVariant.liquidGlass.emphasized);
+    expect(config.duration).toBe(250);
+    expect(config.easing).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/theme/__tests__/motion.test.ts
+++ b/packages/mobile/src/theme/__tests__/motion.test.ts
@@ -10,9 +10,15 @@ import { motionByVariant } from '../animations';
 import { timingFor } from '../motion-config';
 
 describe('motionByVariant', () => {
-  it('gives Material M3 easing curves + standard durations', () => {
+  it('gives Material distinct M3 easing curves + standard durations', () => {
+    // standard = M3 standard-easing; emphasized approximates M3's two-part
+    // accelerate→decelerate spline with its dominant emphasized-decelerate segment,
+    // so it reads as a slower settle — not merely a longer duration than standard.
     expect(motionByVariant.material.standard).toEqual({ duration: 200, easingBezier: [0.2, 0, 0, 1] });
-    expect(motionByVariant.material.emphasized).toEqual({ duration: 350, easingBezier: [0.2, 0, 0, 1] });
+    expect(motionByVariant.material.emphasized).toEqual({ duration: 350, easingBezier: [0.05, 0.7, 0.1, 1] });
+    expect(motionByVariant.material.standard.easingBezier).not.toEqual(
+      motionByVariant.material.emphasized.easingBezier,
+    );
   });
 
   it('keeps the prior glass durations with no easing override (default ease)', () => {

--- a/packages/mobile/src/theme/animations.ts
+++ b/packages/mobile/src/theme/animations.ts
@@ -44,25 +44,26 @@ export const timing = {
 export type SpringPreset = keyof typeof springs;
 export type TimingPreset = keyof typeof timing;
 
-/**
- * Material 3 easing curves as raw cubic-bezier control points (NOT
- * `Easing.bezier(...)` — this module stays reanimated-free so it's safe to import
- * from `makeThemeMock` and other non-RN contexts; the curve is constructed at the
- * call site via `theme/motion-config.ts`). `emphasized` is a two-part spline in the
- * M3 spec that no single cubic-bezier captures exactly — approximated here.
- */
-export const m3Easing = {
+// Material 3 easing curves as raw cubic-bezier control points — NOT
+// `Easing.bezier(...)`, so this module stays reanimated-free and safe to import from
+// `makeThemeMock`/non-RN contexts; the curve is built at the call site via
+// `theme/motion-config.ts`. Internal (only `motionByVariant` consumes them). Just the
+// two curves the tokens use today — add more when a token needs one (dead-code rule).
+//
+// `standard` is M3's standard-easing. `emphasized` approximates M3's emphasized
+// motion — a two-part accelerate→decelerate spline no single bezier captures — with
+// its dominant emphasized-decelerate segment (so it reads distinctly from `standard`,
+// a slower settle, not just a longer duration).
+const m3Easing = {
   standard: [0.2, 0, 0, 1],
-  emphasized: [0.2, 0, 0, 1],
-  decelerate: [0, 0, 0, 1],
-  accelerate: [0.3, 0, 1, 1],
+  emphasized: [0.05, 0.7, 0.1, 1],
 } as const satisfies Record<string, readonly [number, number, number, number]>;
 
-/** Material 3 standard durations (ms): utility motions short, hero motions medium+. */
-export const m3Duration = {
+// Material 3 standard durations (ms). Internal; add more (M3 has short1–4 / medium1–4
+// / long1–4) when a token needs them.
+const m3Duration = {
   short: 200, // M3 short4 — small utility transitions
   medium: 350, // M3 medium3 — standard component/layout transitions
-  long: 500, // M3 long2 — large/hero transitions
 } as const;
 
 /**

--- a/packages/mobile/src/theme/animations.ts
+++ b/packages/mobile/src/theme/animations.ts
@@ -43,3 +43,60 @@ export const timing = {
 
 export type SpringPreset = keyof typeof springs;
 export type TimingPreset = keyof typeof timing;
+
+/**
+ * Material 3 easing curves as raw cubic-bezier control points (NOT
+ * `Easing.bezier(...)` — this module stays reanimated-free so it's safe to import
+ * from `makeThemeMock` and other non-RN contexts; the curve is constructed at the
+ * call site via `theme/motion-config.ts`). `emphasized` is a two-part spline in the
+ * M3 spec that no single cubic-bezier captures exactly — approximated here.
+ */
+export const m3Easing = {
+  standard: [0.2, 0, 0, 1],
+  emphasized: [0.2, 0, 0, 1],
+  decelerate: [0, 0, 0, 1],
+  accelerate: [0.3, 0, 1, 1],
+} as const satisfies Record<string, readonly [number, number, number, number]>;
+
+/** Material 3 standard durations (ms): utility motions short, hero motions medium+. */
+export const m3Duration = {
+  short: 200, // M3 short4 — small utility transitions
+  medium: 350, // M3 medium3 — standard component/layout transitions
+  long: 500, // M3 long2 — large/hero transitions
+} as const;
+
+/**
+ * A variant-resolved timing config: a duration, plus (Material only) an M3 easing
+ * curve. Pure DATA — `Easing.bezier` is built from `easingBezier` at the call site
+ * (`timingFor`), so this stays importable anywhere. Liquid Glass omits the curve and
+ * keeps reanimated's default ease, preserving its feel; only the durations are
+ * shared, mapped to each variant's prior values.
+ */
+export type MotionConfig = {
+  duration: number;
+  easingBezier?: readonly [number, number, number, number];
+};
+
+export type Motion = {
+  /** Utility transitions (fades, small moves). */
+  standard: MotionConfig;
+  /** Hero / emphasized transitions (sheet/FAB moves, larger layout shifts). */
+  emphasized: MotionConfig;
+};
+
+/**
+ * Per-variant motion. Material uses M3 easing curves + standard durations; Liquid
+ * Glass keeps its prior `timing` durations (no easing override) so its feel is
+ * unchanged. Springs (press/gesture feedback) stay separate — these tokens cover
+ * the `withTiming` transitions the two variants share.
+ */
+export const motionByVariant = {
+  liquidGlass: {
+    standard: { duration: timing.fast },
+    emphasized: { duration: timing.normal },
+  },
+  material: {
+    standard: { duration: m3Duration.short, easingBezier: m3Easing.standard },
+    emphasized: { duration: m3Duration.medium, easingBezier: m3Easing.emphasized },
+  },
+} as const satisfies Record<'liquidGlass' | 'material', Motion>;

--- a/packages/mobile/src/theme/motion-config.ts
+++ b/packages/mobile/src/theme/motion-config.ts
@@ -1,0 +1,18 @@
+import { Easing, type WithTimingConfig } from 'react-native-reanimated';
+import type { MotionConfig } from './animations';
+
+/**
+ * Turn a (pure-data) `MotionConfig` from `theme.motion` into a reanimated
+ * `withTiming` config, constructing the M3 `Easing.bezier` curve here so the token
+ * modules (`animations.ts`, the theme, `makeThemeMock`) stay reanimated-free. Liquid
+ * Glass configs carry no curve, so they fall through to reanimated's default ease.
+ *
+ *   animatedValue.value = withTiming(target, timingFor(theme.motion.emphasized));
+ */
+export function timingFor(config: MotionConfig): WithTimingConfig {
+  if (!config.easingBezier) {
+    return { duration: config.duration };
+  }
+  const [x1, y1, x2, y2] = config.easingBezier;
+  return { duration: config.duration, easing: Easing.bezier(x1, y1, x2, y2) };
+}


### PR DESCRIPTION
## Phase 3, slice 4 — Material 3 motion tokens

Shared `withTiming` transitions used the generic `timing.*` durations + reanimated's default ease on both variants. This adds M3 motion tokens so **Material** animates with M3 easing curves + standard durations, while **Liquid Glass** keeps its current feel.

### What changed
- **`animations.ts`** (kept **reanimated-free** so it stays safe to import from `makeThemeMock` and other non-RN contexts):
  - `m3Easing` as raw cubic-bezier control points (standard / emphasized / decelerate / accelerate). `emphasized` is a two-part M3 spline that no single bezier captures — approximated + documented.
  - `m3Duration` (short 200 / medium 350 / long 500).
  - `motionByVariant` — a `{ standard, emphasized }` `MotionConfig` per variant: Material = M3 bezier + durations; Liquid Glass = its prior `timing` durations with no easing override (feel unchanged).
- **`theme.motion`** = `motionByVariant[variant]` (+ `Theme` type + `makeThemeMock`).
- **`theme/motion-config.ts` `timingFor(config)`** builds the reanimated `Easing.bezier` config **at the call site**, so the token modules (and the theme) stay reanimated-free — this is what keeps the whole test suite (which loads `makeThemeMock`) from pulling in reanimated.
- **Migrated `ClimbFilterFab`'s slot slide** to `timingFor(motion.emphasized)`: Material's FAB now slides with M3 easing at 350ms; glass keeps 250ms.

### Design notes
- Springs (press/gesture feedback) stay **separate** — these tokens cover the `withTiming` transitions the two variants share, so a config object fits (the migrated sites are timing-based on both variants; no spring/timing dispatch needed).
- `GlassIconButton`'s morph was evaluated but it's the **Liquid-Glass cross-fade** (Material renders a Paper `IconButton`, no morph) — migrating it would add a theme subscription to a hot button for zero Material change, so it's left as-is.

### Validation
- `vp run typecheck` ✓
- `vp test run --project mobile` — **309 files / 2216 tests** ✓ (new `motion.test.ts`: token data + `timingFor` with reanimated mocked)
- `vp run check:mobile-variants` ✓ · `vp check` (7 files) ✓ · `vp run check:mobile-bundle` (Android) ✓

This is the final planned Phase 3 slice. Builds on slice 1 (merged) — branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)