### PR TITLE
Cache the screenshots sim app, skip the native rebuild on JS-only runs (#2920)

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -4,6 +4,11 @@ name: Mobile Screenshots (Native)
 # simulator via Maestro (scripts/mobile-screenshots.ts) and uploads them as an
 # artifact. Manual + nightly only — never gates PRs.
 #
+# The screenshot app is a Debug dev-client that loads its JS from Metro, so the
+# native .app is reusable: it's cached (actions/cache) keyed on native inputs and
+# only rebuilt when those change. A JS-only run is a cache hit → install + Metro +
+# Maestro (~5 min) instead of a ~30-min from-scratch native compile.
+#
 # All runs capture against PROD signed in as the test user (the canonical store
 # recipe), so there's no local backend / Colima — the build just talks to the
 # production backend.
@@ -76,6 +81,29 @@ jobs:
       - name: Install Node.js dependencies
         run: bun install --frozen-lockfile
 
+      # Restore the prebuilt simulator dev-client .app. It's a dev-client shell
+      # that loads its JS from Metro, so the native binary only changes when
+      # NATIVE inputs change — the key hashes exactly those (Expo/RN/native-module
+      # versions in packages/mobile/package.json, native config in app.config.ts,
+      # the config plugins + native modules, patch-package patches, and the root
+      # @expo/cli / react-native-screens pins). JS/TS-only and web-only changes
+      # (incl. bun.lock churn) do NOT bust it, so the common path is a cache hit
+      # and skips the ~30-min native build. Bump `-v1-` to force a rebuild.
+      # runner.arch is in the key because a simulator .app is arch-specific.
+      - name: Restore prebuilt simulator app
+        id: app-cache
+        uses: actions/cache@v4
+        with:
+          path: packages/mobile/.app-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-screenshot-sim-app-v1-${{ hashFiles('packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'packages/mobile/package.json', 'patches/**', 'package.json') }}
+
+      # Cache miss (a native-input change) → build the .app from scratch with
+      # xcodebuild (runs to completion; no `expo run:ios` launch-step hang).
+      # actions/cache saves packages/mobile/.app-cache at job end for the next run.
+      - name: Build simulator dev-client app
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: vp run mobile:build-sim-app -- --app-out packages/mobile/.app-cache --clean
+
       - name: Install Maestro
         # Pinned to a specific GitHub Releases asset and verified against a
         # checksum committed in this repo — NOT `curl … get.maestro.mobile.dev | bash`,
@@ -96,15 +124,18 @@ jobs:
           echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"
 
       - name: Capture screenshots
-        # Always against prod (signed in as the test user). No EXPO_PUBLIC_BACKEND_URL
-        # override, so the build uses the app's production backend defaults.
+        # Installs the prebuilt .app, starts Metro with the screenshot env, and
+        # runs Maestro — no native build on this path. Always against prod (signed
+        # in as the test user); no EXPO_PUBLIC_BACKEND_URL override, so the bundle
+        # uses the app's production backend defaults.
         run: |
           set -euo pipefail
           vp run mobile:screenshots -- \
             --platform ios \
             --flow "${{ inputs.flow || 'app-store' }}" \
             --backend prod \
-            --device "${{ inputs.device || 'iPhone 16 Pro Max' }}"
+            --device "${{ inputs.device || 'iPhone 16 Pro Max' }}" \
+            --app-path packages/mobile/.app-cache/Boardsesh.app
 
       # Fail loudly if any capture isn't an App Store-accepted size for its slot,
       # so deliver can't get silently rejected by Apple (or route to the wrong

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,8 @@ packages/mobile/modules/**/android/.cxx/
 packages/mobile/modules/**/android/build/
 packages/mobile/dist/
 packages/mobile/.bundle-check-output/
+# Prebuilt simulator dev-client .app for the screenshots pipeline (CI-cached).
+packages/mobile/.app-cache/
 .claude/worktrees/
 
 # Local analysis workspace (out-of-tree artifacts, not source)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,13 @@ Full rationale + repo examples: `docs/react-native-performance.md`.
 
 Use `vp run mobile:ios` for local `packages/mobile` iOS builds instead of raw `expo run:ios`. The wrapper points generated `packages/mobile/ios/build` at a shared cache under `~/Library/Caches/boardsesh/xcode/packages-mobile-ios/build`, so separate git worktrees reuse the same Xcode build products. Override with `BOARDSESH_IOS_BUILD_CACHE_DIR=/path/to/cache` only when deliberately isolating a cache. Do not pass `--no-build-cache`; it clears iOS derived data and defeats the shared-cache workflow.
 
+### App Store screenshots (cached dev-client + Metro)
+
+`vp run mobile:screenshots` (`scripts/mobile-screenshots.ts`) drives Maestro over an iOS simulator. The app it installs is a Debug **dev-client** that loads its JS from **Metro** at runtime — the screenshot behaviour (`EXPO_PUBLIC_SCREENSHOT_MODE`, theme, workout) is baked into the Metro JS bundle, **not** the native binary. So the native `.app` is reusable: only the JS regenerates per run.
+
+- Pass `--app-path <Boardsesh.app>` to install a prebuilt/cached app (CI's common path). Without it, the script builds one via `vp run mobile:build-sim-app` (`scripts/mobile-build-sim-app.ts` → `expo prebuild` + `pod install` + `xcodebuild build -sdk iphonesimulator -configuration Debug`; **not** `expo run:ios`, whose launch step hangs in CI). Use `--clean` for a deterministic from-scratch build.
+- `.github/workflows/mobile-screenshots.yml` caches the `.app` (`actions/cache`) keyed on **native inputs only**: `packages/mobile/app.config.ts`, `plugins/**`, `modules/**`, `package.json`, `patches/**`, and the root `package.json` (which pins `@expo/cli` / `react-native-screens`), plus `runner.os`/`runner.arch`. JS/TS-only and web-only changes (including `bun.lock` churn) are a cache hit and skip the ~30-min native build; any native-input change busts the key and rebuilds. Bump the `-v1-` salt to force a rebuild. A native-dep change must invalidate the key — when adding native config, confirm it's covered by one of those globs.
+
 ### OTA preview distribution (EAS Update)
 
 Multiple worktrees can publish independent previews. Testers install the "preview" build once and receive JS-only OTA updates.

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -3,10 +3,16 @@
 Native App Store / onboarding screenshot capture for the Boardsesh mobile app.
 Driven by [Maestro](https://maestro.mobile.dev). Don't run these by hand — the
 orchestrator (`scripts/mobile-screenshots.ts`, exposed as `vp run
-mobile:screenshots`) boots the simulator, applies a clean status bar, resets the
-keychain, builds and installs a clean Release app with
-`EXPO_PUBLIC_SCREENSHOT_MODE=1`, then runs the flow and collects the PNGs into
-`app-stores/<apple|google>/screenshots/<device>/`.
+mobile:screenshots`) boots the simulator, applies a clean status bar, installs a
+Debug **dev-client** `.app` (prebuilt/cached, or built on the fly when no
+`--app-path` is given), resets the keychain, then starts **Metro** with
+`EXPO_PUBLIC_SCREENSHOT_MODE=1`. The flow loads the JS bundle from Metro (via the
+expo-development-client deep link), captures each screen, and the orchestrator
+collects the PNGs into `app-stores/<apple|google>/screenshots/<device>/`.
+
+The screenshot behaviour lives in the **Metro JS bundle**, not the native binary,
+so the `.app` is reusable and CI caches it (keyed on native inputs) — a JS-only
+run skips the ~30-min native build. See `scripts/mobile-build-sim-app.ts`.
 
 ## Backend
 
@@ -34,6 +40,15 @@ simulator keychain first so login authenticates cleanly against prod.
 
 ## Notes
 
+- The app is a dev-client, so each flow first loads its JS from Metro with
+  `openLink: ${MAESTRO_DEV_CLIENT_URL}` instead of `launchApp` — a bare launch
+  would land on the launcher. The orchestrator passes that env via `maestro test
+  -e` (an `expo-development-client` deep link pointing at its Metro port, default
+  8081, override with `BOARDSESH_METRO_PORT`), so the flow isn't pinned to a port.
+  Re-opening the deep link reloads the JS runtime (used to clear the play drawer
+  before the board-sheet shot). The first load waits up to 180s for the cold Metro
+  bundle. The orchestrator uninstalls + reinstalls and resets the keychain, so the
+  app cold-loads signed out with fresh app data (no Maestro `clearState` needed).
 - Navigation uses custom-scheme deep links (`com.boardsesh.app://<route>`); Expo
   Router maps tab routes with the `(tabs)` group stripped (`://climbs`, `://home`,
   `://boards`, …). Each `openLink` is followed by an optional `tapOn "Open"` to

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -14,24 +14,32 @@ name: app-store screenshots
 #   board view  = '50%,26%' (first climb row in the list)
 #
 # Other notes:
-# - The orchestrator resets the simulator keychain first, so the app launches
-#   signed out and login authenticates against prod.
-# - clearState wipes the client-side active board (AsyncStorage); it's re-picked
-#   via the board picker below.
-# - The Record/session screen renders the WORKOUT GENERATOR because the build
-#   bakes EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume) — its shelf is a
+# - The .app is a Debug dev-client that loads its JS from Metro; the first step
+#   opens ${MAESTRO_DEV_CLIENT_URL} (an expo-development-client deep link the
+#   orchestrator passes via `-e`) so it loads the bundle from Metro, not the
+#   launcher.
+# - The orchestrator uninstalled + reinstalled the app (fresh AsyncStorage, so no
+#   stale active board — re-picked via the board picker below) and reset the
+#   simulator keychain, so this cold-loads signed out and login authenticates
+#   against the target backend.
+# - The Record/session screen renders the WORKOUT GENERATOR because Metro bundles
+#   EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume) — its shelf is a
 #   gesture-handler ScrollView Maestro can't tap, so the selection is pre-seeded.
 # - iOS shows an "Open in 'Boardsesh'?" confirmation for simctl deep links; each
 #   openLink is followed by an optional tapOn "Open".
 # - Board-independent captures (home/discover/profile) run first so a board-pick
 #   miss can't lose them.
-- launchApp:
-    clearState: true
-- runFlow:
-    when:
-      visible:
-        id: 'auth-email-input'
-    file: login.yaml
+- openLink: ${MAESTRO_DEV_CLIENT_URL}
+- tapOn:
+    text: 'Open'
+    optional: true
+# Cold Metro bundle on the first load can take a while; wait for the signed-out
+# auth screen (the orchestrator guarantees a logged-out start), then log in.
+- extendedWaitUntil:
+    visible:
+      id: 'auth-email-input'
+    timeout: 180000
+- runFlow: login.yaml
 
 # Home — feed populated by the prod test user's follows.
 - waitForAnimationToEnd
@@ -94,10 +102,14 @@ name: app-store screenshots
 - takeScreenshot: 02-board-view
 
 # Board sheet — LAST, because the drawer-host overlays (board sheet, play drawer)
-# persist across deep-link tab switches. Relaunch first (no clearState — keeps the
-# Keychain login + the active board) to clear the play drawer left open by the
-# board-view step, then open Climbs and tap the board-switcher glyph.
-- launchApp
+# persist across deep-link tab switches. Reload the bundle first (a fresh JS
+# runtime; the Keychain login + active board survive it) to clear the play drawer
+# left open by the board-view step, then open Climbs and tap the board-switcher
+# glyph. The bundle is warm by now, so the reload is quick.
+- openLink: ${MAESTRO_DEV_CLIENT_URL}
+- tapOn:
+    text: 'Open'
+    optional: true
 - waitForAnimationToEnd
 - openLink: com.boardsesh.app://climbs
 - tapOn:

--- a/packages/mobile/.maestro/login.yaml
+++ b/packages/mobile/.maestro/login.yaml
@@ -1,14 +1,15 @@
 appId: com.boardsesh.app
 name: login (subflow)
 ---
-# Reusable login subflow. The screenshots build cold-launches signed out, so the
-# auth screen is already up. Fill the seeded test credentials (passed by the
-# orchestrator via `maestro test -e SCREENSHOT_USER_EMAIL=... -e
-# SCREENSHOT_USER_PASSWORD=...`) and wait until the app redirects out of auth.
+# Reusable login subflow. The caller loads the Metro bundle into the dev-client
+# and waits for the signed-out auth screen before invoking this. Fill the seeded
+# test credentials (passed by the orchestrator via `maestro test -e
+# SCREENSHOT_USER_EMAIL=... -e SCREENSHOT_USER_PASSWORD=...`) and wait until the
+# app redirects out of auth.
 #
 # A "Sign in to your Apple Account" system alert can linger on the simulator from
-# a prior Apple-auth attempt and cover the login form (clearState resets app data
-# but not system modals). Dismiss it if present.
+# a prior Apple-auth attempt and cover the login form (the orchestrator's app
+# reinstall resets app data but not system modals). Dismiss it if present.
 - tapOn:
     text: 'Close'
     optional: true

--- a/packages/mobile/.maestro/onboarding.yaml
+++ b/packages/mobile/.maestro/onboarding.yaml
@@ -19,8 +19,19 @@ name: onboarding illustrations
 #   (the simulator has no Bluetooth). Mirror web's e2e-bluetooth-picker flag.
 # TODO(find): board/climb detail — needs a deterministic deep link to a seeded
 #   climb (com.boardsesh.app://climbs/<uuid>) or a stable climb-row testID to tap.
-- launchApp:
-    clearState: true
+#
+# The .app is a Debug dev-client: load the JS bundle from Metro via
+# ${MAESTRO_DEV_CLIENT_URL} (passed by the orchestrator via `-e`) rather than the
+# launcher. The orchestrator uninstalled+reinstalled and reset the keychain, so
+# this cold-loads signed out.
+- openLink: ${MAESTRO_DEV_CLIENT_URL}
+- tapOn:
+    text: 'Open'
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: 'auth-email-input'
+    timeout: 180000
 - runFlow: login.yaml
 
 - openLink: com.boardsesh.app://climbs

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { LogBox, Pressable, StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo
 // SDK 56's expo-router is not compatible with a separately-installed
 // @react-navigation/* package, so import these from `expo-router` directly.
@@ -53,8 +53,17 @@ import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
+import { SCREENSHOT_MODE } from '../src/lib/screenshot-mode';
 
 void SplashScreen.preventAutoHideAsync();
+
+// The screenshots build is a Debug dev-client (__DEV__ true) so it can load its
+// JS from Metro; a stray warning would pop a LogBox toast into a captured
+// screenshot. Suppress all LogBox UI in screenshot mode. SCREENSHOT_MODE is a
+// build/bundle-time flag, so this dead-strips from every normal build.
+if (SCREENSHOT_MODE) {
+  LogBox.ignoreAllLogs(true);
+}
 
 const layoutStyles = StyleSheet.create({
   root: { flex: 1 },

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -11,6 +11,7 @@ function makeOptions(overrides: Partial<ScreenshotOptions> = {}): ScreenshotOpti
     variant: null,
     theme: 'dark',
     workout: 'volume',
+    appPath: null,
     shutdown: false,
     ...overrides,
   };
@@ -61,6 +62,8 @@ describe('parseArgs', () => {
         'Pixel 8',
         '--workout',
         'ladder',
+        '--app-path',
+        '/tmp/Boardsesh.app',
         '--shutdown',
       ]),
     ).toEqual({
@@ -71,6 +74,7 @@ describe('parseArgs', () => {
       variant: 'material',
       theme: 'light',
       workout: 'ladder',
+      appPath: '/tmp/Boardsesh.app',
       shutdown: true,
     });
   });

--- a/scripts/mobile-build-sim-app.ts
+++ b/scripts/mobile-build-sim-app.ts
@@ -1,0 +1,230 @@
+/// <reference types="node" />
+
+/**
+ * Builds a Debug iOS *simulator* dev-client app (.app) for the screenshots
+ * pipeline and copies it to --app-out.
+ *
+ * Why this exists as a separate, cacheable step: the screenshot app is a
+ * dev-client shell that loads its JS from Metro at runtime (see
+ * scripts/mobile-screenshots.ts). The screenshot behaviour
+ * (EXPO_PUBLIC_SCREENSHOT_MODE, theme, workout) is baked into the Metro JS
+ * bundle, NOT the native binary, so this .app only changes when *native* inputs
+ * change — Expo/RN/native-module versions, app.config.ts, plugins/**,
+ * modules/**, patches/**. CI caches the finished .app keyed on those inputs
+ * (actions/cache) and reuses it across JS-only runs, turning a ~30-min
+ * from-scratch compile into a ~5-min install + Metro + Maestro run.
+ *
+ * It builds with `xcodebuild build` (NOT `expo run:ios`, whose post-install
+ * launch step opens a dev-client URL and hangs in CI), so it runs to completion
+ * and emits a cacheable product. Debug config means the app loads from Metro
+ * rather than embedding a frozen bundle.
+ *
+ * Usage:
+ *   vp run mobile:build-sim-app -- --app-out <dir> [--clean] [--configuration Debug]
+ *
+ * Requires: macOS + Xcode + CocoaPods.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
+const IOS_DIR = resolve(MOBILE_DIR, 'ios');
+const DERIVED_DATA_DIR = resolve(IOS_DIR, 'build');
+const WORKSPACE_PATH = resolve(IOS_DIR, 'Boardsesh.xcworkspace');
+const SCHEME = 'Boardsesh';
+// Literal entitlements for the sim build — see the file's comment for why the
+// generated ones can't be used (profile-dependent $(AppIdentifierPrefix)).
+const SIM_ENTITLEMENTS = resolve(ROOT_DIR, 'scripts', 'screenshot-sim.entitlements');
+const APP_NAME = 'Boardsesh.app';
+const DEFAULT_APP_OUT = resolve(MOBILE_DIR, '.app-cache');
+const LOG = '[mobile:build-sim-app]';
+
+export interface BuildSimAppOptions {
+  appOut: string;
+  clean: boolean;
+  configuration: string;
+}
+
+export function parseArgs(argv: readonly string[]): BuildSimAppOptions {
+  const args = argv.filter((argument) => argument !== '--');
+  const options: BuildSimAppOptions = {
+    appOut: DEFAULT_APP_OUT,
+    clean: false,
+    configuration: 'Debug',
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const flag = args[index];
+    const value = args[index + 1];
+    switch (flag) {
+      case '--app-out':
+        options.appOut = resolve(expectValue(flag, value));
+        index++;
+        break;
+      case '--configuration':
+        options.configuration = expectValue(flag, value);
+        index++;
+        break;
+      case '--clean':
+        options.clean = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+function expectValue(flag: string, value: string | undefined): string {
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function run(command: string, args: string[], cwd: string): number {
+  console.log(`${LOG} $ ${command} ${args.join(' ')} (cwd: ${cwd})`);
+  const result = spawnSync(command, args, { cwd, stdio: 'inherit', env: { ...process.env } });
+  return result.status ?? 1;
+}
+
+/** The Debug simulator product xcodebuild writes under -derivedDataPath. */
+export function builtAppPath(configuration: string): string {
+  return join(DERIVED_DATA_DIR, 'Build', 'Products', `${configuration}-iphonesimulator`, APP_NAME);
+}
+
+function expoPrebuild(clean: boolean): void {
+  // `--no-install` so pod install is an explicit, separately-logged step (a
+  // common CI failure point).
+  const prebuildArgs = ['expo', 'prebuild', '--platform', 'ios', '--no-install'];
+  if (clean) prebuildArgs.push('--clean');
+  const status = run('bunx', prebuildArgs, MOBILE_DIR);
+  if (status !== 0) {
+    throw new Error(`expo prebuild failed with exit code ${status}`);
+  }
+}
+
+function ensureNativeProject(clean: boolean): void {
+  if (clean) {
+    // CI / deterministic: wipe ios/ and regenerate from scratch. --clean is
+    // REQUIRED for this project, not just nice-to-have: an *incremental* prebuild
+    // over an existing ios/ crashes in @bacons/apple-targets — it tries to
+    // "update" the already-present BoardseshWidgets target and throws
+    // ("Cannot read properties of undefined (reading 'removeFromProject')").
+    // A clean run CREATES the target fresh, so it never hits that path.
+    expoPrebuild(true);
+    return;
+  }
+  if (existsSync(WORKSPACE_PATH)) {
+    // ios/ already generated (e.g. by `vp run mobile:ios`). Skip prebuild — see
+    // the incremental-crash note above — and trust the existing project. The dev
+    // owns ios/ freshness locally; CI always passes --clean. Pass --clean here to
+    // force a regenerate after a native-config change.
+    console.log(`${LOG} Reusing existing ios/ project (skip prebuild). Pass --clean to regenerate.`);
+    return;
+  }
+  // No project yet → generate it. ios/ is absent, so this is effectively clean
+  // (apple-targets CREATES the widget target) and won't hit the update crash.
+  expoPrebuild(false);
+}
+
+function podInstall(): void {
+  const status = run('pod', ['install'], IOS_DIR);
+  if (status !== 0) {
+    throw new Error(`pod install failed with exit code ${status}`);
+  }
+}
+
+function xcodebuild(configuration: string): number {
+  return run(
+    'xcodebuild',
+    [
+      'build',
+      '-workspace',
+      WORKSPACE_PATH,
+      '-scheme',
+      SCHEME,
+      '-configuration',
+      configuration,
+      '-destination',
+      'generic/platform=iOS Simulator',
+      '-derivedDataPath',
+      DERIVED_DATA_DIR,
+      // Ad-hoc sign with LITERAL entitlements: the app must carry a
+      // keychain-access-group or expo-secure-store fails ("a required entitlement
+      // isn't present"), so the auth token can't persist and login fails. The
+      // generated entitlements use $(AppIdentifierPrefix), which only resolves
+      // from a provisioning profile a simulator build doesn't have — Xcode then
+      // strips them to nothing. SIM_ENTITLEMENTS uses literal values the sim
+      // accepts. Ad-hoc signing ("-") needs no team/profile. Applied to every
+      // target (the widget + share extension also build under this scheme); the
+      // sim doesn't enforce extra keychain groups, so that's harmless.
+      'CODE_SIGN_IDENTITY=-',
+      `CODE_SIGN_ENTITLEMENTS=${SIM_ENTITLEMENTS}`,
+      // arm64 only: macos-26 runners and Boardsesh dev machines are all Apple
+      // Silicon, so building the x86_64 sim slice just doubles the time (and can
+      // fail on a pod that lacks x86_64-sim support) for an arch nothing installs.
+      // The actions/cache key pins runner.arch, so a future arch change busts it.
+      'ARCHS=arm64',
+    ],
+    IOS_DIR,
+  );
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  let options: BuildSimAppOptions;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    console.error(`${LOG} ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  if (process.platform !== 'darwin') {
+    console.log(`${LOG} Skipped: simulator builds require macOS + Xcode.`);
+    return 0;
+  }
+
+  try {
+    ensureNativeProject(options.clean);
+    podInstall();
+
+    let status = xcodebuild(options.configuration);
+    const appPath = builtAppPath(options.configuration);
+    if (status !== 0 && !existsSync(appPath)) {
+      // RN New Architecture codegen ("Generate Specs") can race the compile on a
+      // cold/clean build ("Build input file cannot be found: …/ReactCodegen/
+      // *-generated.mm"). The specs land during that first attempt, so a second
+      // build finds them — the well-known "build twice on a clean checkout"
+      // quirk that bites every fresh CI runner. Retry once.
+      console.log(
+        `${LOG} First build failed without producing the .app (likely the cold-build codegen race); retrying once...`,
+      );
+      status = xcodebuild(options.configuration);
+    }
+
+    if (!existsSync(appPath)) {
+      console.error(`${LOG} FAILED: ${appPath} not found after build (exit ${status}).`);
+      return status === 0 ? 1 : status;
+    }
+
+    mkdirSync(options.appOut, { recursive: true });
+    const destination = join(options.appOut, APP_NAME);
+    rmSync(destination, { force: true, recursive: true });
+    cpSync(appPath, destination, { recursive: true });
+    console.log(`${LOG} Built ${options.configuration} simulator app -> ${destination}`);
+    return 0;
+  } catch (error) {
+    console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -3,24 +3,35 @@
 /**
  * Automated native screenshot capture for packages/mobile.
  *
- * Boots a simulator, applies a clean status bar, builds + installs a clean
- * Release app (no Expo dev-menu bubble) with EXPO_PUBLIC_SCREENSHOT_MODE=1, runs
- * a Maestro flow that deep-links to each screen and captures it, then collects
- * the PNGs into app-stores/<store>/screenshots/<device>/ (ios -> apple, android
- * -> google).
+ * The screenshot app is a Debug *dev-client* that loads its JS from Metro at
+ * runtime. The screenshot behaviour (EXPO_PUBLIC_SCREENSHOT_MODE, theme,
+ * workout) is baked into the Metro JS bundle, NOT the native binary — so the
+ * .app is reusable and only the JS regenerates per run. This is why CI can cache
+ * the .app (see scripts/mobile-build-sim-app.ts) keyed on native inputs and skip
+ * the ~30-min from-scratch compile on JS-only changes.
+ *
+ * Flow: boot a simulator, apply a clean status bar, get the .app (--app-path, or
+ * build one via mobile-build-sim-app), uninstall+install it, reset the keychain,
+ * start Metro with EXPO_PUBLIC_SCREENSHOT_MODE=1, then run a Maestro flow that
+ * loads the bundle from Metro (dev-client deep link), deep-links to each screen
+ * and captures it. PNGs land in app-stores/<store>/screenshots/<device>/ (ios ->
+ * apple, android -> google).
  *
  * Usage:
  *   vp run mobile:screenshots -- [--platform ios] [--flow app-store|onboarding]
  *                                 [--backend local|prod] [--device "iPhone 16 Pro Max"]
  *                                 [--variant material|liquidGlass] [--shutdown]
+ *                                 [--app-path <path/to/Boardsesh.app>]
  *
  * Requires: macOS + Xcode simulators, and Maestro (https://maestro.mobile.dev).
  * For --backend local, bring up the seeded dev DB + backend first (`vp run dev`).
- * Credentials come from SCREENSHOT_USER_EMAIL / SCREENSHOT_USER_PASSWORD
+ * Without --app-path the script builds a Debug simulator .app first (slow); CI
+ * passes a cached/prebuilt .app so the common path is just install + Metro +
+ * Maestro. Credentials come from SCREENSHOT_USER_EMAIL / SCREENSHOT_USER_PASSWORD
  * (default test@boardsesh.com / test).
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -29,8 +40,14 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
 const MAESTRO_DIR = resolve(MOBILE_DIR, '.maestro');
-const IOS_RUN_SCRIPT = resolve(ROOT_DIR, 'scripts', 'mobile-ios-run.ts');
+const BUILD_SIM_APP_SCRIPT = resolve(ROOT_DIR, 'scripts', 'mobile-build-sim-app.ts');
+const APP_CACHE_DIR = resolve(MOBILE_DIR, '.app-cache');
 const OUTPUT_ROOT = resolve(ROOT_DIR, 'app-stores');
+// Metro dev server port the dev-client loads its JS bundle from. Defaults to
+// 8081; override with BOARDSESH_METRO_PORT when it's taken (this repo runs a
+// Metro per worktree). The orchestrator passes the matching dev-client URL to
+// Maestro via `-e MAESTRO_DEV_CLIENT_URL`, so the flows never hard-code a port.
+const METRO_PORT = Number.parseInt(process.env.BOARDSESH_METRO_PORT ?? '', 10) || 8081;
 // Output is grouped by store (the directory name), not by platform id.
 const STORE_BY_PLATFORM: Record<'ios' | 'android', string> = { ios: 'apple', android: 'google' };
 const LOG = '[mobile:screenshots]';
@@ -61,6 +78,8 @@ export interface ScreenshotOptions {
   theme: ScreenshotTheme;
   /** Workout type the Record/session screen pre-selects (generator screenshot); null = Off. */
   workout: string | null;
+  /** Prebuilt/cached Boardsesh.app to install; null builds one (slow, local only). */
+  appPath: string | null;
   shutdown: boolean;
 }
 
@@ -78,6 +97,7 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
     // a visible, selected tile (its shelf is a gesture-handler ScrollView Maestro
     // can't tap/scroll). `--workout off` leaves the generator Off ("Start a session").
     workout: 'volume',
+    appPath: null,
     shutdown: false,
   };
 
@@ -115,6 +135,10 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
         index++;
         break;
       }
+      case '--app-path':
+        options.appPath = resolve(expectValue(flag, value));
+        index++;
+        break;
       case '--shutdown':
         options.shutdown = true;
         break;
@@ -150,10 +174,11 @@ export function deviceSlug(deviceName: string): string {
 }
 
 /**
- * Build the env for the Release build. Always sets screenshot mode; for
- * --backend local it points the build at the local dev backend unless the caller
- * already exported an override. --backend prod leaves the URLs unset so the app's
- * production defaults apply.
+ * Build the env Metro bundles with (EXPO_PUBLIC_* are inlined into the JS bundle
+ * at bundle time, so these shape the dev-client's JS, not the native compile).
+ * Always sets screenshot mode; for --backend local it points the app at the
+ * local dev backend unless the caller already exported an override. --backend
+ * prod leaves the URLs unset so the app's production defaults apply.
  */
 export function buildScreenshotEnv(
   options: ScreenshotOptions,
@@ -302,11 +327,6 @@ function clearStatusBar(udid: string): void {
   runCapture('xcrun', ['simctl', 'status_bar', udid, 'clear']);
 }
 
-/** True once the app bundle is installed on the simulator. */
-function appInstalled(udid: string): boolean {
-  return runCapture('xcrun', ['simctl', 'get_app_container', udid, APP_ID, 'app']).status === 0;
-}
-
 function collectScreenshots(captureDir: string, platform: 'ios' | 'android', deviceName: string): string[] {
   const outputDir = join(OUTPUT_ROOT, STORE_BY_PLATFORM[platform], 'screenshots', deviceSlug(deviceName));
   mkdirSync(outputDir, { recursive: true });
@@ -331,46 +351,84 @@ function runIos(options: ScreenshotOptions): number {
   bootDevice(device);
   applyCleanStatusBar(device.udid);
 
-  const buildEnv = buildScreenshotEnv(options);
-  console.log(
-    `${LOG} Building Release app for ${device.name} (backend=${options.backend}, theme=${options.theme}, flow=${options.flow}${options.variant ? `, variant=${options.variant}` : ''})...`,
-  );
-  const runBuild = (): number =>
-    runInherit('bunx', ['tsx', IOS_RUN_SCRIPT, '--', '--configuration', 'Release', '--device', device.udid], buildEnv);
-  let buildStatus = runBuild();
-  if (buildStatus !== 0 && !appInstalled(device.udid)) {
-    // RN New Architecture codegen ("Generate Specs") can race the compile step
-    // on a cold/clean build, failing with "Build input file cannot be found:
-    // …/ReactCodegen/*-generated.mm". The specs are written during that first
-    // attempt, so a second build finds them — the well-known "build twice on a
-    // clean checkout" quirk. This bites every fresh CI runner, so retry once.
-    console.log(`${LOG} First build did not install the app (likely the cold-build codegen race); retrying once...`);
-    buildStatus = runBuild();
-  }
-  // Gate on the app actually being installed, not on expo's exit code: for a
-  // Release build, `expo run:ios` succeeds at build+install but then fails its
-  // post-install launch step (it opens the app via the dev-client URL, which a
-  // Release build doesn't handle — `simctl openurl` times out). Maestro launches
-  // the app itself, so that launch-step failure is harmless.
-  if (!appInstalled(device.udid)) {
-    console.error(`${LOG} FAILED: app not installed after build (exit ${buildStatus}).`);
-    return buildStatus === 0 ? 1 : buildStatus;
-  }
-  if (buildStatus !== 0) {
-    console.log(`${LOG} Build + install OK; ignoring expo's post-install launch step (Maestro launches the app).`);
+  // Resolve the dev-client .app: a cached/prebuilt one (--app-path, the CI common
+  // path) or build one now (slow; local convenience). The .app loads its JS from
+  // Metro, so it's reusable across JS changes.
+  const appPath = resolveAppPath(options);
+  console.log(`${LOG} Installing ${appPath} on ${device.name}...`);
+  // Uninstall first so the run starts from a clean container (fresh AsyncStorage,
+  // so no stale active board). The dev-client + Metro path drops Maestro's
+  // `clearState`, which can't run before the bundle has loaded — the uninstall +
+  // install gives the same fresh-data guarantee.
+  runCapture('xcrun', ['simctl', 'uninstall', device.udid, APP_ID]);
+  const install = runCapture('xcrun', ['simctl', 'install', device.udid, appPath]);
+  if (install.status !== 0) {
+    console.error(`${LOG} FAILED: simctl install exited ${install.status}.`);
+    return install.status;
   }
 
   // Reset the simulator keychain so the app launches signed out and login runs
   // against the target backend. The auth token lives in a shared keychain access
-  // group (group.com.boardsesh.app) that survives both `clearState` and an app
-  // uninstall — so without this a stale token (e.g. from a previous --backend
-  // local run) makes login skip and the app talk to the wrong backend with an
-  // invalid session. The login subflow re-authenticates from a clean slate.
+  // group (group.com.boardsesh.app) that survives both an app uninstall and the
+  // fresh install above — so without this a stale token (e.g. from a previous
+  // --backend local run) makes login skip and the app talk to the wrong backend
+  // with an invalid session. The login subflow re-authenticates from a clean slate.
   console.log(`${LOG} Resetting simulator keychain (clears any stale auth token)...`);
   runCapture('xcrun', ['simctl', 'keychain', device.udid, 'reset']);
 
+  // Start Metro so the dev-client can load its JS bundle. EXPO_PUBLIC_SCREENSHOT_*
+  // + the backend URLs are inlined here, at bundle time — that's what makes the
+  // native .app reusable. Killed in the finally below.
+  // Abort if the port is already taken: expo would silently skip starting our
+  // dev server (non-interactive), and the flow would then load whatever foreign
+  // Metro is on the port — capturing the wrong app's bundle. Fail loud instead.
+  if (portInUse(METRO_PORT)) {
+    console.error(
+      `${LOG} FAILED: port ${METRO_PORT} is already in use; another Metro would serve the wrong bundle. ` +
+        `Stop it, or set BOARDSESH_METRO_PORT to a free port.`,
+    );
+    return 1;
+  }
+
+  const metroEnv = buildScreenshotEnv(options);
+  console.log(
+    `${LOG} Starting Metro on ${METRO_PORT} (backend=${options.backend}, theme=${options.theme}, flow=${options.flow}${options.variant ? `, variant=${options.variant}` : ''})...`,
+  );
+  const metro = startMetro(metroEnv);
   const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-shots-'));
   try {
+    if (!waitForMetro()) {
+      console.error(`${LOG} FAILED: Metro did not become ready on port ${METRO_PORT}.`);
+      return 1;
+    }
+
+    // Pre-launch the app with UserDefaults argument-domain overrides so
+    // expo-dev-client's dev-menu UI doesn't appear in the captures:
+    //   -EXDevMenuIsOnboardingFinished YES     → skip the one-time "developer
+    //      menu" onboarding sheet (shown on every fresh install — we uninstall
+    //      each run).
+    //   -EXDevMenuDisableAutoLaunch YES        → don't auto-present the dev menu
+    //      when the bundle loads.
+    //   -EXDevMenuShowFloatingActionButton NO  → hide the floating gear button
+    //      that otherwise sits in the top-right corner of every screen.
+    // These are read by DevMenuPreferences/DevMenuManager at the highest-priority
+    // arg domain. The app lands on the dev launcher; Maestro's first openLink then
+    // loads the bundle into this same process, where the overrides persist across
+    // the JS reload.
+    console.log(`${LOG} Pre-launching to suppress the dev-client menu + floating button...`);
+    runCapture('xcrun', [
+      'simctl',
+      'launch',
+      device.udid,
+      APP_ID,
+      '-EXDevMenuIsOnboardingFinished',
+      'YES',
+      '-EXDevMenuDisableAutoLaunch',
+      'YES',
+      '-EXDevMenuShowFloatingActionButton',
+      'NO',
+    ]);
+
     const flowFile = join(MAESTRO_DIR, `${options.flow}.yaml`);
     if (!existsSync(flowFile)) {
       console.error(`${LOG} FAILED: flow not found: ${flowFile}`);
@@ -393,6 +451,9 @@ function runIos(options: ScreenshotOptions): number {
         device.udid,
         'test',
         flowFile,
+        // The flows load their JS via this dev-client deep link (port-agnostic).
+        '-e',
+        `MAESTRO_DEV_CLIENT_URL=${metroDevClientUrl()}`,
         '-e',
         `SCREENSHOT_USER_EMAIL=${email}`,
         '-e',
@@ -416,6 +477,7 @@ function runIos(options: ScreenshotOptions): number {
     );
     for (const file of saved) console.log(`${LOG}   ${file}`);
   } finally {
+    stopMetro(metro);
     rmSync(captureDir, { force: true, recursive: true });
     clearStatusBar(device.udid);
     if (options.shutdown) {
@@ -424,6 +486,85 @@ function runIos(options: ScreenshotOptions): number {
   }
 
   return 0;
+}
+
+/**
+ * Resolve the Boardsesh.app to install: a prebuilt/cached one (--app-path, the CI
+ * common path) or a freshly built Debug simulator app (local one-command DX).
+ */
+function resolveAppPath(options: ScreenshotOptions): string {
+  if (options.appPath) {
+    if (!existsSync(options.appPath)) {
+      throw new Error(`--app-path not found: ${options.appPath}`);
+    }
+    return options.appPath;
+  }
+  console.log(`${LOG} No --app-path given; building a Debug simulator app (slow — CI passes a cached .app)...`);
+  const status = runInherit('bunx', ['tsx', BUILD_SIM_APP_SCRIPT, '--', '--app-out', APP_CACHE_DIR], process.env);
+  if (status !== 0) {
+    throw new Error(`simulator app build failed (exit ${status})`);
+  }
+  const built = join(APP_CACHE_DIR, 'Boardsesh.app');
+  if (!existsSync(built)) {
+    throw new Error(`build reported success but ${built} is missing`);
+  }
+  return built;
+}
+
+/** expo-development-client deep link that loads the JS bundle from our Metro. */
+function metroDevClientUrl(): string {
+  return `${APP_ID}://expo-development-client/?url=${encodeURIComponent(`http://localhost:${METRO_PORT}`)}`;
+}
+
+/** True if anything is already listening on the port (a foreign Metro). */
+function portInUse(port: number): boolean {
+  return spawnSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t']).status === 0;
+}
+
+/**
+ * Start Metro in the background. `detached` so cleanup can kill the whole process
+ * group; `CI=1` keeps expo non-interactive (no keypress menu / TTY expectations).
+ */
+function startMetro(env: NodeJS.ProcessEnv): ChildProcess {
+  return spawn('bunx', ['expo', 'start', '--port', String(METRO_PORT)], {
+    cwd: MOBILE_DIR,
+    env: { ...env, CI: '1' },
+    stdio: 'inherit',
+    detached: true,
+  });
+}
+
+/** Poll Metro's /status until it answers (or ~120s elapse). */
+function waitForMetro(): boolean {
+  const statusUrl = `http://localhost:${METRO_PORT}/status`;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    if (runCapture('curl', ['-fsS', '-o', '/dev/null', statusUrl]).status === 0) {
+      console.log(`${LOG} Metro is ready on port ${METRO_PORT}.`);
+      return true;
+    }
+    sleepSeconds(2);
+  }
+  return false;
+}
+
+function stopMetro(metro: ChildProcess | null): void {
+  if (!metro || metro.pid === undefined) return;
+  console.log(`${LOG} Stopping Metro...`);
+  try {
+    // Negative PID targets the detached process group, so Metro's node children
+    // die with it.
+    process.kill(-metro.pid, 'SIGTERM');
+  } catch {
+    try {
+      metro.kill('SIGTERM');
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+function sleepSeconds(seconds: number): void {
+  spawnSync('sleep', [String(seconds)]);
 }
 
 export function main(argv: readonly string[] = process.argv.slice(2)): number {

--- a/scripts/screenshot-sim.entitlements
+++ b/scripts/screenshot-sim.entitlements
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <!--
+    Entitlements for the screenshots simulator build (scripts/mobile-build-sim-app.ts).
+
+    The generated packages/mobile/ios/Boardsesh/Boardsesh.entitlements uses
+    `$(AppIdentifierPrefix)group.com.boardsesh.app`, which only resolves from a
+    provisioning profile. A simulator build has no profile, so Xcode strips that
+    entitlement to nothing — and with NO keychain-access-group the app has no
+    default keychain access group, so expo-secure-store fails ("a required
+    entitlement isn't present") and the auth token can't be saved, breaking login.
+
+    These are literal values (no profile-dependent prefix). The simulator doesn't
+    enforce the team-id prefix on keychain access groups, so this is enough for
+    SecureStore to work. Only the keychain + app-group keys are needed for the
+    screenshot flow; push/associated-domains/healthkit aren't exercised on the sim.
+  -->
+  <dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+      <string>group.com.boardsesh.app</string>
+    </array>
+    <key>keychain-access-groups</key>
+    <array>
+      <string>group.com.boardsesh.app</string>
+    </array>
+  </dict>
+</plist>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -522,6 +522,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-screenshots.ts',
         cache: false,
       },
+      'mobile:build-sim-app': {
+        command: 'tsx scripts/mobile-build-sim-app.ts',
+        cache: false,
+      },
       'check:screenshot-dimensions': {
         command: 'tsx scripts/assert-screenshot-dimensions.ts',
         cache: false,


### PR DESCRIPTION
## What

Fixes the `mobile-screenshots` workflow (#2920, prong 1). It was doing a from-scratch `expo run:ios --configuration Release` native build every run — a ~30-min cold compile (doubled by the codegen-race retry) that overran the 90-min CI timeout ("expo never finishes"). A Release build embeds the JS, so the native binary rebuilt even when only JS/TS changed.

## How

The screenshot app is now a Debug **dev-client that loads its JS from Metro**, so the native `.app` is reusable and only the JS regenerates per run:

- **`scripts/mobile-build-sim-app.ts`** (new) builds a Debug iphonesimulator `.app` with `xcodebuild` (runs to completion — no `expo run:ios` launch-step hang), arm64-only, ad-hoc signed with literal entitlements.
- **`scripts/mobile-screenshots.ts`** installs that `.app` (`--app-path`), starts Metro with the screenshot env, and runs Maestro. The flows load the bundle via `${MAESTRO_DEV_CLIENT_URL}` (port-agnostic, passed through `maestro test -e`).
- **`.github/workflows/mobile-screenshots.yml`** caches the `.app` (`actions/cache`) keyed on native inputs only (`app.config.ts`, `plugins/**`, `modules/**`, `package.json`, `patches/**`, the root `package.json`, plus `runner.os`/`runner.arch`). JS/TS-only and web-only changes (incl. `bun.lock` churn) hit the cache (~5 min); any native-dep change rebuilds. Bump the `-v1-` salt to force a rebuild. Rebased onto main's prod-backend + ASC-upload version of the workflow — the cache + build steps slot in before Maestro; the prod capture, dimension assert, and upload steps are unchanged.

## Validated locally, end to end

Built the cached `.app` and ran the full pipeline on a local sim: login succeeds and **7 clean 1320×2868 PNGs** capture (home, discover, profile, climbs, workout-generator, board-view, board-sheet). (Validated against a local backend; the install + Metro + Maestro pipeline is backend-agnostic, so it applies to the workflow's `--backend prod` too.) `vp check`, `vp run typecheck:mobile`, and the screenshots unit tests pass.

## Fixes found while validating (the pipeline couldn't finish without them)

- Incremental `expo prebuild` crashes in `@bacons/apple-targets` → the build script `--clean`s in CI / skips prebuild when `ios/` already exists.
- expo-dev-client chrome (onboarding sheet, dev menu, floating gear) covered the app → suppressed via `simctl launch` UserDefaults args (`EXDevMenuIsOnboardingFinished` / `EXDevMenuDisableAutoLaunch` / `EXDevMenuShowFloatingActionButton`).
- The unsigned sim build stripped `keychain-access-groups` (the generated entitlements use `$(AppIdentifierPrefix)`, which needs a provisioning profile), so `expo-secure-store` failed and the token couldn't persist → added `scripts/screenshot-sim.entitlements` (literal values) + ad-hoc signing.

## Still to verify in CI

A workflow dispatch to confirm the cache-miss (build + save) and cache-hit (fast) paths. The cache key + how it busts is documented in `mobile-screenshots.yml` and `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)