### PR TITLE
fix(mobile): Slice 3a dialog review fixes (missed the #2924 merge)

### DIFF
--- a/packages/mobile/src/components/integrations/__tests__/strava-card.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/strava-card.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   autoSyncMutate: vi.fn(),
   disconnectMutate: vi.fn(),
   alert: vi.fn(),
+  confirmResult: true,
   statuses: undefined as IntegrationStatus[] | undefined,
   isLoading: false,
 }));
@@ -51,7 +52,7 @@ vi.mock('../../../providers/toast-provider', () => ({
   useToast: () => ({ showToast: mocks.showToast }),
 }));
 vi.mock('../../../providers/dialog-provider', () => ({
-  useConfirm: () => () => Promise.resolve(true),
+  useConfirm: () => () => Promise.resolve(mocks.confirmResult),
 }));
 
 type TextMockProps = { children?: ReactNode };
@@ -112,6 +113,7 @@ describe('StravaCard', () => {
     mocks.autoSyncMutate.mockReset();
     mocks.disconnectMutate.mockReset();
     mocks.alert.mockReset();
+    mocks.confirmResult = true;
     mocks.statuses = undefined;
     mocks.isLoading = false;
   });
@@ -131,6 +133,27 @@ describe('StravaCard', () => {
     expect(container.querySelector('[data-switch="integrations.strava.autoSync"]')).not.toBeNull();
     expect(button(container, 'integrations.strava.disconnect')).not.toBeNull();
     expect(button(container, 'integrations.strava.connect')).toBeNull();
+  });
+
+  it('disconnects when the confirm is accepted', async () => {
+    mocks.statuses = [connectedStatus];
+    mocks.confirmResult = true;
+    const { container } = render(<StravaCard />);
+    fireEvent.click(button(container, 'integrations.strava.disconnect')!);
+    await waitFor(() => {
+      expect(mocks.disconnectMutate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does NOT disconnect when the confirm is cancelled', async () => {
+    mocks.statuses = [connectedStatus];
+    mocks.confirmResult = false;
+    const { container } = render(<StravaCard />);
+    fireEvent.click(button(container, 'integrations.strava.disconnect')!);
+    // Give the awaited confirm a tick to settle, then assert the mutation never fired.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.disconnectMutate).not.toHaveBeenCalled();
   });
 
   it('shows a success toast and refetches when a connection succeeds', async () => {

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -246,7 +246,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
     updateTick,
   ]);
 
-  const confirmDelete = async () => {
+  const confirmDelete = useCallback(async () => {
     if (!ascent || isMutating) return;
     const confirmed = await confirm({
       title: t('mobile.logbook.deleteTitle'),
@@ -263,7 +263,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
         showToast(t('mobile.logbook.deleteError'), 'error');
       },
     });
-  };
+  }, [ascent, isMutating, confirm, deleteTick, sheetRef, showToast, t]);
 
   return (
     <Sheet

--- a/packages/mobile/src/providers/__tests__/dialog-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/dialog-provider.test.tsx
@@ -3,14 +3,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-const ctrl = vi.hoisted(() => ({ variant: 'material' as 'material' | 'liquidGlass' }));
+const ctrl = vi.hoisted(() => ({
+  variant: 'material' as 'material' | 'liquidGlass',
+  os: 'android' as 'ios' | 'android',
+}));
 type AlertButton = { text: string; style?: string; onPress?: () => void };
 const alertMock = vi.hoisted(() => ({
   calls: [] as Array<{ title: string; message?: string; buttons: AlertButton[]; onDismiss?: () => void }>,
 }));
 
-// The provider only needs Alert from react-native; mock it to capture the args.
+// The provider needs Alert + Platform from react-native; mock both (Platform.OS is
+// controllable because the Paper dialog is Android-Material-only — iOS uses Alert).
 vi.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return ctrl.os;
+    },
+  },
   Alert: {
     alert: (
       title: string,
@@ -65,10 +74,11 @@ const OPTS = { title: 'Delete?', message: 'This cannot be undone.', confirmLabel
 
 beforeEach(() => {
   ctrl.variant = 'material';
+  ctrl.os = 'android';
   alertMock.calls = [];
 });
 
-describe('useConfirm — Material (Paper Dialog)', () => {
+describe('useConfirm — Android Material (Paper Dialog)', () => {
   it('resolves true when the confirm action is pressed', async () => {
     const { container } = setup();
     let promise!: Promise<boolean>;
@@ -104,6 +114,47 @@ describe('useConfirm — Material (Paper Dialog)', () => {
     // The second confirm now surfaces and resolves on its own.
     act(() => materialButton(container, 'Second').click());
     await expect(second).resolves.toBe(true);
+  });
+
+  it('settles each confirm once — a re-press / dismiss race cannot drop the next confirm', async () => {
+    const { container } = setup();
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    act(() => {
+      first = confirmFn({ ...OPTS, confirmLabel: 'First' });
+      second = confirmFn({ ...OPTS, confirmLabel: 'Second' });
+    });
+    // Double-tap the first confirm's action in the same tick (the race the
+    // one-shot guard protects): it must resolve once and NOT pop the second.
+    const firstButton = materialButton(container, 'First');
+    act(() => {
+      firstButton.click();
+      firstButton.click();
+    });
+    await expect(first).resolves.toBe(true);
+    // The second confirm survived and still resolves on its own.
+    act(() => materialButton(container, 'Second').click());
+    await expect(second).resolves.toBe(true);
+  });
+});
+
+describe('useConfirm — iOS Material (native Alert, not the Paper Portal)', () => {
+  beforeEach(() => {
+    ctrl.variant = 'material';
+    ctrl.os = 'ios';
+  });
+
+  it('uses Alert on iOS even on Material (the Paper Portal renders under FullWindowOverlay sheets)', async () => {
+    const { container } = setup();
+    let promise!: Promise<boolean>;
+    act(() => {
+      promise = confirmFn(OPTS);
+    });
+    // No Paper dialog rendered; routed to the native Alert instead.
+    expect(container.querySelector('[data-dialog]')).toBeNull();
+    expect(alertMock.calls).toHaveLength(1);
+    act(() => alertMock.calls[0].buttons.find((b) => b.text === 'Delete')?.onPress?.());
+    await expect(promise).resolves.toBe(true);
   });
 });
 

--- a/packages/mobile/src/providers/dialog-provider.tsx
+++ b/packages/mobile/src/providers/dialog-provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { Button, Dialog, Portal, Text } from 'react-native-paper';
 import { useTheme } from './theme-provider';
 
@@ -37,19 +37,35 @@ type PendingConfirm = ConfirmOptions & { id: number; resolve: (value: boolean) =
  * provider that calls `confirm`. Providers are exempt from the variant guard, so the
  * `variant ===` branch here is the sanctioned place to resolve it.
  *
- * Concurrent confirms queue (one Material dialog shows at a time; the native iOS
- * Alert queues itself), so a Bluetooth confirm racing a UI confirm can't clobber the
- * other's resolver. Scrim / back dismiss resolves `false`.
+ * The Paper `Dialog` is used on **Android Material only**. On iOS we always fall back
+ * to the native `Alert` — even on the Material variant — because confirms are often
+ * launched from a sheet rendered in a `FullWindowOverlay` (iOS-only), and the Paper
+ * `Portal` lives in the normal React tree *underneath* that overlay: the dialog would
+ * be invisible and its promise would never resolve. The native `Alert` always sits on
+ * top. iOS Material is a forced-variant edge case, so the lost M3 chrome there is an
+ * acceptable trade for a confirm that actually works.
+ *
+ * Concurrent confirms queue (one Android dialog shows at a time; the native Alert
+ * queues itself). Each confirm settles exactly once, by id — a double-tap, or an
+ * action racing `onDismiss`, can't drop a different queued confirm or leave a caller
+ * awaiting forever. Scrim / back dismiss resolves `false`.
  */
 export function DialogProvider({ children }: { children: ReactNode }) {
   const { variant, m3 } = useTheme();
   const [queue, setQueue] = useState<PendingConfirm[]>([]);
   const idRef = useRef(0);
+  // One-shot guard: a confirm settles at most once even if its dialog fires
+  // onPress and onDismiss in the same tick, or is double-tapped before re-render.
+  const settledIdsRef = useRef<Set<number>>(new Set());
+
+  // Native Alert on Liquid Glass everywhere, and on iOS regardless of variant (see
+  // the FullWindowOverlay note above). The Paper dialog queue is Android-Material only.
+  const useNativeAlert = variant === 'liquidGlass' || Platform.OS === 'ios';
 
   const confirm = useCallback(
     (options: ConfirmOptions) =>
       new Promise<boolean>((resolve) => {
-        if (variant === 'liquidGlass') {
+        if (useNativeAlert) {
           Alert.alert(
             options.title,
             options.message,
@@ -68,25 +84,29 @@ export function DialogProvider({ children }: { children: ReactNode }) {
         idRef.current += 1;
         setQueue((q) => [...q, { ...options, id: idRef.current, resolve }]);
       }),
-    [variant],
+    [useNativeAlert],
   );
 
   const value = useMemo<DialogContextValue>(() => ({ confirm }), [confirm]);
 
+  // Resolve a SPECIFIC pending confirm by id and drop just that one from the queue.
+  // Stable (no `current` dep) and one-shot, so racing handlers can't slice the wrong
+  // entry or resolve twice.
+  const settle = useCallback((target: PendingConfirm, result: boolean) => {
+    if (settledIdsRef.current.has(target.id)) return;
+    settledIdsRef.current.add(target.id);
+    target.resolve(result);
+    setQueue((q) => q.filter((item) => item.id !== target.id));
+  }, []);
+
   const current = queue[0];
-  // `current` is captured per render (the head of the queue), so each settle
-  // resolves exactly that confirm's promise, then advances to the next queued one.
-  const settle = (result: boolean) => {
-    current?.resolve(result);
-    setQueue((q) => q.slice(1));
-  };
 
   return (
     <DialogContext value={value}>
       {children}
-      {variant === 'material' && current ? (
+      {current ? (
         <Portal>
-          <Dialog visible onDismiss={() => settle(false)}>
+          <Dialog visible onDismiss={() => settle(current, false)}>
             <Dialog.Title>{current.title}</Dialog.Title>
             {current.message ? (
               <Dialog.Content>
@@ -94,8 +114,8 @@ export function DialogProvider({ children }: { children: ReactNode }) {
               </Dialog.Content>
             ) : null}
             <Dialog.Actions>
-              <Button onPress={() => settle(false)}>{current.cancelLabel}</Button>
-              <Button textColor={current.destructive ? m3.error : undefined} onPress={() => settle(true)}>
+              <Button onPress={() => settle(current, false)}>{current.cancelLabel}</Button>
+              <Button textColor={current.destructive ? m3.error : undefined} onPress={() => settle(current, true)}>
                 {current.confirmLabel}
               </Button>
             </Dialog.Actions>


### PR DESCRIPTION
## Follow-up: Slice 3a (`useConfirm`) review fixes

PR #2924 was squash-merged **before** its review feedback was addressed, so these fixes never reached `main`. This lands them as a follow-up (cherry-picked clean onto current `main`).

### Fixes
- **iOS overlay hang (Codex P2)** — the Paper `Dialog`'s `Portal` renders *underneath* a `FullWindowOverlay` sheet on iOS, so a confirm launched from one (e.g. the LogbookEditSheet delete) was invisible and its promise never resolved. The Paper dialog is now **Android-Material only**; iOS uses the native `Alert` regardless of variant (it always sits on top). iOS Material is a forced-variant edge case, so the lost M3 chrome there is an acceptable trade for a confirm that works.
- **`settle` race (Codex P2)** — `settle` now resolves a *specific* confirm by id with a one-shot guard (and is a stable `useCallback`), so a double-tap or an action racing `onDismiss` can't drop a different queued confirm or leave a caller awaiting forever.
- **`LogbookEditSheet.confirmDelete`** wrapped in `useCallback` (claude).
- **Tests**: iOS-Material → Alert (no Paper Portal); the one-shot/race guard; and a StravaCard cancel-path test (confirm = false ⇒ disconnect mutation does NOT fire).

### Validation
- `vp run typecheck` ✓
- `vp test run --project mobile` — **2224 tests** ✓
- `vp run check:mobile-variants` ✓ · `vp check` (4 files) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)