### PR TITLE
fix(mobile): Live Activity Next/Prev double-step + restore board background

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -412,6 +412,20 @@ In the backend logs, look for:
 
 If you see `0 sent, N failed`, check the [Common Issues](#common-issues) section.
 
+### Board-photo thumbnail compositing
+
+The thumbnail in the Live Activity is built in two layers, never as a single network fetch (the no-network-board-art rule — see `scripts/mobile-board-art-network-check.ts`):
+
+1. The **climb's holds overlay** is fetched from `/api/internal/board-render?...&thumbnail=1` (no `include_background`) — a transparent PNG of just this climb's holds.
+2. The **board background** is the bundled board art (the per-set hold renders, mostly transparent webp shipped in the IPA). JS resolves these in `use-live-activity.ts` (`resolveBoardBackgroundPaths`) and stages their file paths into the App Group (`SharedConstants.boardBackgroundPathsKey`) at `startSession`.
+
+`ThumbnailFetcher.compositeWithBoardBackground` (main-app process) draws the background layer(s) under the overlay, downscales to the widget display size, and writes a transparent PNG to the App Group `thumbnails/` dir — what the widget renders.
+
+If the Live Activity shows only the climb's holds and no board behind them, the background layers didn't resolve or stage. Check:
+
+- `[background-image-cache] No bundled asset for "…"` warnings (a board added to the schema but its art not bundled — re-run `scripts/sync-mobile-board-backgrounds.sh`).
+- That `boardBackgroundPaths` is non-empty in the `startSession` payload for the active board.
+
 ## Debugging
 
 ### Backend APNs Logs

--- a/packages/mobile/modules/live-activity/ios/LiveActivityManager.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityManager.swift
@@ -74,6 +74,12 @@ actor LiveActivityManager {
         // Clean up any existing activities first.
         await endAllActivities()
 
+        // A new session/board is starting — drop the previous board's decoded
+        // background layers now instead of waiting for the next composite to
+        // prune them (which never runs if no thumbnail is requested before the
+        // app backgrounds).
+        await thumbnailFetcher.clearBackgroundLayerCache()
+
         // Install the push-token callback before requesting the activity.
         // ActivityKit can emit the first token between Activity.request returning
         // and any later setOnPushTokenUpdate call, which would silently drop it.

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -605,6 +605,7 @@ public class LiveActivityModule: Module {
         let graphqlUrl = options.graphqlUrl
         let widgetNavigationAllowed = options.widgetNavigationAllowed
         let isPartySession = options.isPartySession
+        let boardBackgroundPaths = options.boardBackgroundPaths
 
         // Store session details for push token registration.
         tokenQueue.sync {
@@ -643,6 +644,16 @@ public class LiveActivityModule: Module {
             defaults.set(layoutId, forKey: SharedConstants.layoutIdKey)
             defaults.set(sizeId, forKey: SharedConstants.sizeIdKey)
             defaults.set(setIds, forKey: SharedConstants.setIdsKey)
+            // Bundled board-background file paths for ThumbnailFetcher to
+            // composite behind the holds overlay. Staged here (before the first
+            // thumbnail pre-fetch) so the initial composite already has the
+            // board photo. Removed when empty so a board with no resolved
+            // background falls back to overlay-only instead of a stale path.
+            if boardBackgroundPaths.isEmpty {
+                defaults.removeObject(forKey: SharedConstants.boardBackgroundPathsKey)
+            } else {
+                defaults.set(boardBackgroundPaths, forKey: SharedConstants.boardBackgroundPathsKey)
+            }
             SharedWidgetWallControlState.save(
                 navigationAllowed: widgetNavigationAllowed,
                 isPartySession: isPartySession,
@@ -899,6 +910,10 @@ struct StartSessionOptions: Record {
     @Field var graphqlUrl: String?
     @Field var widgetNavigationAllowed: Bool = true
     @Field var isPartySession: Bool = false
+    /// Bundled board-background webp file paths (JS-resolved via expo-asset).
+    /// Empty when none resolved. iOS-only; the Android SessionPresence Record
+    /// ignores the extra key.
+    @Field var boardBackgroundPaths: [String] = []
 }
 
 struct UpdateActivityQueueItem: Record {

--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -25,6 +25,13 @@ enum SharedConstants {
     static let layoutIdKey = "bs_layout_id"
     static let sizeIdKey = "bs_size_id"
     static let setIdsKey = "bs_set_ids"
+    /// File paths to the bundled board-background webp layer(s) for the active
+    /// board, resolved on the JS side (expo-asset) and staged here by
+    /// `startSession`. ThumbnailFetcher composites these behind the server's
+    /// holds-only overlay so the widget shows the board photo without fetching
+    /// board art over the network (the no-network-board-art rule). Empty when no
+    /// bundled background resolved — the overlay is then written as-is.
+    static let boardBackgroundPathsKey = "bs_board_background_paths"
     static let pendingActionKey = "bs_pending_action"
     /// Action ("next" | "previous") associated with the most recent Darwin
     /// notification. Always written by the intent; the Darwin handler reads

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -1,11 +1,15 @@
 import Foundation
+import UIKit
 
 // MARK: - ThumbnailFetcher
 
 /// Fetches climb hold-overlay thumbnails from the server and caches them in
 /// the App Group shared container so Live Activities can display them. The
 /// request intentionally omits `include_background=1`; bundled board photos
-/// must not be fetched over the network from native widget code.
+/// must not be fetched over the network from native widget code. Instead the
+/// holds overlay is composited on top of the bundled board-background webp(s)
+/// staged by `LiveActivityModule.startSession` (the no-network-board-art rule),
+/// so the cached thumbnail the widget renders carries the full board photo.
 actor ThumbnailFetcher {
 
     // MARK: - Configuration
@@ -163,7 +167,11 @@ actor ThumbnailFetcher {
                 return nil
             }
 
-            try data.write(to: fileURL, options: .atomic)
+            // Composite the holds overlay over the bundled board background(s)
+            // when they're staged; otherwise persist the raw overlay (the
+            // graceful holds-only fallback for an unbundled board).
+            let imageData = compositeWithBoardBackground(overlayData: data) ?? data
+            try imageData.write(to: fileURL, options: .atomic)
 
             // Evict after writing so we stay within the cache limit.
             // Note: called within the actor, so file I/O runs on the actor's
@@ -176,5 +184,50 @@ actor ThumbnailFetcher {
             // Network or I/O error -- return nil gracefully.
             return nil
         }
+    }
+
+    // MARK: - Background Compositing
+
+    /// Bundled board-background webp file paths staged by `startSession`
+    /// (`SharedConstants.boardBackgroundPathsKey`). Empty when no bundled
+    /// background resolved for the active board.
+    private func stagedBackgroundPaths() -> [String] {
+        sharedDefaults?.stringArray(forKey: SharedConstants.boardBackgroundPathsKey) ?? []
+    }
+
+    /// Draws the holds overlay on top of the staged board-background layer(s),
+    /// returning encoded PNG data. Returns `nil` when there's no usable
+    /// background (so the caller keeps the raw overlay) — never throws.
+    ///
+    /// Both background and overlay fill the same frame at the overlay's pixel
+    /// size: the server renders the overlay in the board's coordinate space and
+    /// each bundled background is that same board image, so an identical fill
+    /// rect keeps the climb circles aligned over the holds. `scale = 1` keeps
+    /// the canvas at the overlay's native pixel size (no 2x/3x upscaling); a
+    /// non-opaque context preserves transparency for boards whose layers don't
+    /// fully cover the frame.
+    private func compositeWithBoardBackground(overlayData: Data) -> Data? {
+        let paths = stagedBackgroundPaths()
+        guard !paths.isEmpty, let overlay = UIImage(data: overlayData) else { return nil }
+
+        let backgroundLayers = paths.compactMap { UIImage(contentsOfFile: $0) }
+        guard !backgroundLayers.isEmpty else { return nil }
+
+        let size = overlay.size
+        guard size.width > 0, size.height > 0 else { return nil }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = false
+
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        let composed = renderer.image { _ in
+            let rect = CGRect(origin: .zero, size: size)
+            for layer in backgroundLayers {
+                layer.draw(in: rect)
+            }
+            overlay.draw(in: rect)
+        }
+        return composed.pngData()
     }
 }

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -32,6 +32,14 @@ actor ThumbnailFetcher {
     /// Prevents duplicate fetches for the same climb UUID.
     private var inFlightTasks: [String: Task<URL?, Never>] = [:]
 
+    /// Decoded board-background layers keyed by file path, so a multi-set board
+    /// and adjacent-thumbnail pre-fetches don't re-read the same files from disk
+    /// on every composite. Pruned to the active board's paths in
+    /// `compositeWithBoardBackground`, so it holds only the current board's
+    /// handful of layers. Lives in the main-app process (this actor is owned by
+    /// LiveActivityManager), not the memory-constrained widget extension.
+    private var backgroundLayerCache: [String: UIImage] = [:]
+
     // MARK: - Init
 
     init(
@@ -195,6 +203,14 @@ actor ThumbnailFetcher {
         sharedDefaults?.stringArray(forKey: SharedConstants.boardBackgroundPathsKey) ?? []
     }
 
+    /// Decoded background layer for a path, memoized in `backgroundLayerCache`.
+    private func backgroundLayer(at path: String) -> UIImage? {
+        if let cached = backgroundLayerCache[path] { return cached }
+        guard let image = UIImage(contentsOfFile: path) else { return nil }
+        backgroundLayerCache[path] = image
+        return image
+    }
+
     /// Largest dimension (px) of the cached composite. The widget never shows
     /// the thumbnail larger than the 80×100pt lock-screen image (~240×300px at
     /// 3×), so capping the long side here keeps the PNG small without visible
@@ -222,9 +238,13 @@ actor ThumbnailFetcher {
     /// the cache also stays bounded to `maxCachedThumbnails`.
     private func compositeWithBoardBackground(overlayData: Data) -> Data? {
         let paths = stagedBackgroundPaths()
+        // Evict cached layers for boards we've navigated away from (and clear
+        // entirely when nothing is staged) so the cache tracks the active board.
+        let activePaths = Set(paths)
+        backgroundLayerCache = backgroundLayerCache.filter { activePaths.contains($0.key) }
         guard !paths.isEmpty, let overlay = UIImage(data: overlayData) else { return nil }
 
-        let backgroundLayers = paths.compactMap { UIImage(contentsOfFile: $0) }
+        let backgroundLayers = paths.compactMap { backgroundLayer(at: $0) }
         guard !backgroundLayers.isEmpty else { return nil }
 
         let nativeSize = overlay.size

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -196,16 +196,21 @@ actor ThumbnailFetcher {
     }
 
     /// Draws the holds overlay on top of the staged board-background layer(s),
-    /// returning encoded PNG data. Returns `nil` when there's no usable
+    /// returning encoded image data. Returns `nil` when there's no usable
     /// background (so the caller keeps the raw overlay) — never throws.
     ///
     /// Both background and overlay fill the same frame at the overlay's pixel
     /// size: the server renders the overlay in the board's coordinate space and
     /// each bundled background is that same board image, so an identical fill
     /// rect keeps the climb circles aligned over the holds. `scale = 1` keeps
-    /// the canvas at the overlay's native pixel size (no 2x/3x upscaling); a
-    /// non-opaque context preserves transparency for boards whose layers don't
-    /// fully cover the frame.
+    /// the canvas at the overlay's native pixel size (no 2x/3x upscaling).
+    ///
+    /// Encoded as JPEG: the bottom background layer is a full-frame opaque board
+    /// photo, so the composite is opaque photo content where PNG would be 2–5×
+    /// larger — a meaningful difference for a 10-entry App Group thumbnail cache.
+    /// `opaque = true` drops the unused alpha channel to match. The raw overlay
+    /// (the no-background fallback in `_fetchAndSave`) stays PNG so its
+    /// transparency survives. PNG is kept only as an encode-failure fallback.
     private func compositeWithBoardBackground(overlayData: Data) -> Data? {
         let paths = stagedBackgroundPaths()
         guard !paths.isEmpty, let overlay = UIImage(data: overlayData) else { return nil }
@@ -218,7 +223,7 @@ actor ThumbnailFetcher {
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = 1
-        format.opaque = false
+        format.opaque = true
 
         let renderer = UIGraphicsImageRenderer(size: size, format: format)
         let composed = renderer.image { _ in
@@ -228,6 +233,6 @@ actor ThumbnailFetcher {
             }
             overlay.draw(in: rect)
         }
-        return composed.pngData()
+        return composed.jpegData(compressionQuality: 0.85) ?? composed.pngData()
     }
 }

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -196,7 +196,7 @@ actor ThumbnailFetcher {
     }
 
     /// Draws the holds overlay on top of the staged board-background layer(s),
-    /// returning encoded image data. Returns `nil` when there's no usable
+    /// returning encoded PNG data. Returns `nil` when there's no usable
     /// background (so the caller keeps the raw overlay) — never throws.
     ///
     /// Both background and overlay fill the same frame at the overlay's pixel
@@ -205,12 +205,13 @@ actor ThumbnailFetcher {
     /// rect keeps the climb circles aligned over the holds. `scale = 1` keeps
     /// the canvas at the overlay's native pixel size (no 2x/3x upscaling).
     ///
-    /// Encoded as JPEG: the bottom background layer is a full-frame opaque board
-    /// photo, so the composite is opaque photo content where PNG would be 2–5×
-    /// larger — a meaningful difference for a 10-entry App Group thumbnail cache.
-    /// `opaque = true` drops the unused alpha channel to match. The raw overlay
-    /// (the no-background fallback in `_fetchAndSave`) stays PNG so its
-    /// transparency survives. PNG is kept only as an encode-failure fallback.
+    /// PNG, with a non-opaque context, is required — NOT JPEG. The bundled board
+    /// art is a per-set hold render on transparency (measured 74–90% fully
+    /// transparent pixels), not an opaque board photo, and the server overlay is
+    /// likewise transparent. The composite must keep its alpha so the widget's
+    /// dark `activityBackgroundTint` shows through; flattening to JPEG would turn
+    /// the transparent board into a solid black block. PNG also compresses these
+    /// sparse renders well, and the cache is bounded to `maxCachedThumbnails`.
     private func compositeWithBoardBackground(overlayData: Data) -> Data? {
         let paths = stagedBackgroundPaths()
         guard !paths.isEmpty, let overlay = UIImage(data: overlayData) else { return nil }
@@ -223,7 +224,7 @@ actor ThumbnailFetcher {
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = 1
-        format.opaque = true
+        format.opaque = false
 
         let renderer = UIGraphicsImageRenderer(size: size, format: format)
         let composed = renderer.image { _ in
@@ -233,6 +234,6 @@ actor ThumbnailFetcher {
             }
             overlay.draw(in: rect)
         }
-        return composed.jpegData(compressionQuality: 0.85) ?? composed.pngData()
+        return composed.pngData()
     }
 }

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -195,23 +195,31 @@ actor ThumbnailFetcher {
         sharedDefaults?.stringArray(forKey: SharedConstants.boardBackgroundPathsKey) ?? []
     }
 
+    /// Largest dimension (px) of the cached composite. The widget never shows
+    /// the thumbnail larger than the 80×100pt lock-screen image (~240×300px at
+    /// 3×), so capping the long side here keeps the PNG small without visible
+    /// loss — and bounds it regardless of the server overlay's native size.
+    private static let maxCompositeDimension: CGFloat = 384
+
     /// Draws the holds overlay on top of the staged board-background layer(s),
     /// returning encoded PNG data. Returns `nil` when there's no usable
     /// background (so the caller keeps the raw overlay) — never throws.
     ///
-    /// Both background and overlay fill the same frame at the overlay's pixel
-    /// size: the server renders the overlay in the board's coordinate space and
-    /// each bundled background is that same board image, so an identical fill
-    /// rect keeps the climb circles aligned over the holds. `scale = 1` keeps
-    /// the canvas at the overlay's native pixel size (no 2x/3x upscaling).
+    /// Background and overlay fill the same frame: the server renders the overlay
+    /// in the board's coordinate space and each bundled background is that same
+    /// board image, so an identical fill rect keeps the climb circles aligned
+    /// over the holds. The canvas is the overlay aspect ratio scaled down to fit
+    /// `maxCompositeDimension` (never up), at `scale = 1` so points map 1:1 to px.
     ///
     /// PNG, with a non-opaque context, is required — NOT JPEG. The bundled board
     /// art is a per-set hold render on transparency (measured 74–90% fully
     /// transparent pixels), not an opaque board photo, and the server overlay is
     /// likewise transparent. The composite must keep its alpha so the widget's
     /// dark `activityBackgroundTint` shows through; flattening to JPEG would turn
-    /// the transparent board into a solid black block. PNG also compresses these
-    /// sparse renders well, and the cache is bounded to `maxCachedThumbnails`.
+    /// the transparent board into a solid black block. iOS ImageIO can't encode
+    /// the smaller webp (decode-only — no runtime encoder without libwebp), so
+    /// PNG + the downscale above is the alpha-preserving, dependency-free option;
+    /// the cache also stays bounded to `maxCachedThumbnails`.
     private func compositeWithBoardBackground(overlayData: Data) -> Data? {
         let paths = stagedBackgroundPaths()
         guard !paths.isEmpty, let overlay = UIImage(data: overlayData) else { return nil }
@@ -219,8 +227,15 @@ actor ThumbnailFetcher {
         let backgroundLayers = paths.compactMap { UIImage(contentsOfFile: $0) }
         guard !backgroundLayers.isEmpty else { return nil }
 
-        let size = overlay.size
-        guard size.width > 0, size.height > 0 else { return nil }
+        let nativeSize = overlay.size
+        guard nativeSize.width > 0, nativeSize.height > 0 else { return nil }
+
+        // Downscale only — preserve aspect ratio, never upscale a small overlay.
+        let downscale = min(1, Self.maxCompositeDimension / max(nativeSize.width, nativeSize.height))
+        let size = CGSize(
+            width: (nativeSize.width * downscale).rounded(),
+            height: (nativeSize.height * downscale).rounded()
+        )
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = 1

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -211,6 +211,14 @@ actor ThumbnailFetcher {
         return image
     }
 
+    /// Drops all cached background layers. Called on a board/session change so
+    /// the previous board's decoded images don't linger until the next composite
+    /// (the only other place the cache is pruned) — e.g. when a new session
+    /// starts but no thumbnail is requested before the app backgrounds.
+    func clearBackgroundLayerCache() {
+        backgroundLayerCache.removeAll()
+    }
+
     /// Largest dimension (px) of the cached composite. The widget never shows
     /// the thumbnail larger than the 80×100pt lock-screen image (~240×300px at
     /// 3×), so capping the long side here keeps the PNG small without visible

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -81,6 +81,14 @@ export type LiveActivityStartSessionOptions = {
   widgetNavigationAllowed: boolean;
   isPartySession: boolean;
   /**
+   * Bundled board-background webp file paths for the active board, resolved on
+   * the JS side (expo-asset) and staged into the App Group so the iOS
+   * ThumbnailFetcher can composite them behind the server's holds-only overlay —
+   * keeping board art off the network. Ordered base layers (drawn first). iOS
+   * only; the Android foreground service ignores it.
+   */
+  boardBackgroundPaths?: string[];
+  /**
    * Localized strings for the Android foreground-service notification. Ignored
    * on iOS (ActivityKit builds its UI in Swift). Supplied so the ongoing
    * notification + its Previous/Next actions respect the app locale instead of

--- a/packages/mobile/src/components/you/PublicProfileHeaderBlock.tsx
+++ b/packages/mobile/src/components/you/PublicProfileHeaderBlock.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { hapticLight } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { selectByVariant } from '../../theme/variants';
 
 const AVATAR_SIZE = 80;
 
@@ -110,7 +111,7 @@ function FollowButton({
   const isPending = toggleFollow.isPending && toggleFollow.variables?.userId === targetUserId;
 
   // Following at rest reads as middle-emphasis: M3 → tonal, HIG → outlined capsule.
-  const followingVariant = variant === 'material' ? 'tonal' : 'outlined';
+  const followingVariant = selectByVariant(variant, { liquidGlass: 'outlined', material: 'tonal' } as const);
 
   return (
     <Button

--- a/packages/mobile/src/components/you/SocialTab.tsx
+++ b/packages/mobile/src/components/you/SocialTab.tsx
@@ -33,6 +33,7 @@ import {
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { borderRadius, spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { ScreenTitle } from '../ScreenTitle';
 
 type SocialMode = 'followers' | 'following' | 'search';
 
@@ -47,7 +48,7 @@ const EMPTY_PEOPLE: SocialPerson[] = [];
 
 export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop }: SocialTabProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors, variant } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
 
@@ -139,11 +140,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
   const header = useMemo(
     () => (
       <View>
-        {variant === 'material' ? null : (
-          <Text variant="largeTitle" style={styles.screenTitle}>
-            {t('metadata.dashboard.title')}
-          </Text>
-        )}
+        <ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>
 
         <View style={styles.summaryRow}>
           <SocialStatCard
@@ -179,7 +176,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
         ) : null}
       </View>
     ),
-    [followerCount, followingCount, mode, searchQuery, segmentOptions, systemColors.fill, t, variant],
+    [followerCount, followingCount, mode, searchQuery, segmentOptions, systemColors.fill, t],
   );
 
   if (!userId) {

--- a/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
@@ -170,6 +170,9 @@ vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#9
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
+vi.mock('../../ScreenTitle', () => ({
+  ScreenTitle: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
 vi.mock('../../Icon', () => ({
   Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
 }));

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -4,10 +4,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { LiveActivityBridge } from '../live-activity-bridge';
 
+type QueueNavigateEvent = {
+  action: 'next' | 'previous';
+  currentIndex: number;
+  correlationId: string;
+};
+
+function makeItem(index: number): ClimbQueueItem {
+  return {
+    uuid: `queue-item-${index}`,
+    climb: { uuid: `climb-${index}` },
+  } as unknown as ClimbQueueItem;
+}
+
 const queue = vi.hoisted(() => ({
   sessionId: 'session-1' as string | null,
-  nextClimb: vi.fn(),
-  previousClimb: vi.fn(),
+  dispatchWidgetNavigation: vi.fn(),
   state: {
     queue: [] as ClimbQueueItem[],
     currentClimbQueueItem: null as ClimbQueueItem | null,
@@ -15,7 +27,7 @@ const queue = vi.hoisted(() => ({
 }));
 
 const widget = vi.hoisted(() => ({
-  listener: null as null | ((event: { action: 'next' | 'previous' }) => void),
+  listener: null as null | ((event: QueueNavigateEvent) => void),
   useLiveActivity: vi.fn(),
 }));
 
@@ -27,8 +39,7 @@ vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({
     state: queue.state,
     sessionId: queue.sessionId,
-    nextClimb: queue.nextClimb,
-    previousClimb: queue.previousClimb,
+    dispatchWidgetNavigation: queue.dispatchWidgetNavigation,
   }),
 }));
 
@@ -37,7 +48,7 @@ vi.mock('../use-live-activity', () => ({
 }));
 
 vi.mock('../live-activity-plugin', () => ({
-  addWidgetQueueNavigateListener: (listener: (event: { action: 'next' | 'previous' }) => void) => {
+  addWidgetQueueNavigateListener: (listener: (event: QueueNavigateEvent) => void) => {
     widget.listener = listener;
     return () => {
       widget.listener = null;
@@ -45,35 +56,61 @@ vi.mock('../live-activity-plugin', () => ({
   },
 }));
 
-const climbItem = {
-  uuid: 'queue-item-1',
-  climb: { uuid: 'climb-1' },
-} as unknown as ClimbQueueItem;
+const climbItem = makeItem(0);
 
 function renderBridge() {
   return render(<LiveActivityBridge boardName="kilter" layoutId={1} sizeId={10} setIds="1,2" />);
 }
 
 describe('LiveActivityBridge widget navigation (always-live)', () => {
+  const threeItemQueue = [makeItem(0), makeItem(1), makeItem(2)];
+
   beforeEach(() => {
     queue.sessionId = 'session-1';
-    queue.state = { queue: [], currentClimbQueueItem: null };
-    queue.nextClimb.mockClear();
-    queue.previousClimb.mockClear();
+    queue.state = { queue: threeItemQueue, currentClimbQueueItem: threeItemQueue[0] };
+    queue.dispatchWidgetNavigation.mockClear();
     widget.listener = null;
     widget.useLiveActivity.mockClear();
+  });
+
+  it('navigates to the absolute index the widget reports (not a relative step)', () => {
+    renderBridge();
+
+    act(() => {
+      widget.listener?.({ action: 'next', currentIndex: 1, correlationId: 'widget-navigate' });
+    });
+
+    // Maps currentIndex → queue[currentIndex] and forwards the correlationId so
+    // the racing CurrentClimbChanged echo is suppressed by the reducer.
+    expect(queue.dispatchWidgetNavigation).toHaveBeenCalledTimes(1);
+    expect(queue.dispatchWidgetNavigation).toHaveBeenCalledWith(threeItemQueue[1], 'widget-navigate');
+  });
+
+  it('does not double-advance: a single tap dispatches exactly one absolute move', () => {
+    renderBridge();
+
+    act(() => {
+      widget.listener?.({ action: 'previous', currentIndex: 0, correlationId: 'widget-navigate' });
+    });
+
+    expect(queue.dispatchWidgetNavigation).toHaveBeenCalledTimes(1);
+    expect(queue.dispatchWidgetNavigation).toHaveBeenCalledWith(threeItemQueue[0], 'widget-navigate');
+  });
+
+  it('ignores out-of-range indices instead of wrapping or crashing', () => {
+    renderBridge();
+
+    act(() => {
+      widget.listener?.({ action: 'next', currentIndex: 99, correlationId: 'widget-navigate' });
+      widget.listener?.({ action: 'previous', currentIndex: -1, correlationId: 'widget-navigate' });
+    });
+
+    expect(queue.dispatchWidgetNavigation).not.toHaveBeenCalled();
   });
 
   it('always allows widget navigation in a party session (no driver gate)', () => {
     renderBridge();
 
-    act(() => {
-      widget.listener?.({ action: 'next' });
-      widget.listener?.({ action: 'previous' });
-    });
-
-    expect(queue.nextClimb).toHaveBeenCalledOnce();
-    expect(queue.previousClimb).toHaveBeenCalledOnce();
     expect(widget.useLiveActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         widgetNavigationAllowed: true,
@@ -87,10 +124,10 @@ describe('LiveActivityBridge widget navigation (always-live)', () => {
     renderBridge();
 
     act(() => {
-      widget.listener?.({ action: 'next' });
+      widget.listener?.({ action: 'next', currentIndex: 1, correlationId: 'widget-navigate' });
     });
 
-    expect(queue.nextClimb).toHaveBeenCalledOnce();
+    expect(queue.dispatchWidgetNavigation).toHaveBeenCalledWith(threeItemQueue[1], 'widget-navigate');
     expect(widget.useLiveActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         widgetNavigationAllowed: true,

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-start-failure.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-start-failure.test.tsx
@@ -12,6 +12,13 @@ vi.mock('../../auth-store', () => ({
   getAuthToken: vi.fn().mockResolvedValue('token-abc'),
 }));
 
+// Stub the bundled board-art resolver the start path lazily imports on iOS, so
+// the dynamic import resolves deterministically (and never pulls expo-asset into
+// the test env). The start-failure behaviour under test is independent of it.
+vi.mock('../../background-image-cache', () => ({
+  ensureBackgroundsCached: vi.fn().mockResolvedValue({ paths: [], missingCount: 0 }),
+}));
+
 const plugin = vi.hoisted(() => ({
   startLiveActivitySession: vi.fn(),
   endLiveActivitySession: vi.fn().mockResolvedValue(undefined),
@@ -57,12 +64,14 @@ function Harness() {
   return null;
 }
 
-// Flush the availability + auth-token promises and the resulting effects.
+// Flush the availability + auth-token promises, the lazily-imported board-art
+// resolver, and the resulting effects. Macrotask turns drain the dynamic
+// import()'s microtask chain reliably regardless of how many ticks it needs.
 async function flushStart() {
   await act(async () => {
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    for (let turn = 0; turn < 4; turn++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
   });
 }
 

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-start-failure.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-start-failure.test.tsx
@@ -14,9 +14,13 @@ vi.mock('../../auth-store', () => ({
 
 // Stub the bundled board-art resolver the start path lazily imports on iOS, so
 // the dynamic import resolves deterministically (and never pulls expo-asset into
-// the test env). The start-failure behaviour under test is independent of it.
+// the test env). Hoisted so individual tests can vary its resolved paths.
+const backgroundCache = vi.hoisted(() => ({
+  ensureBackgroundsCached: vi.fn(),
+}));
+
 vi.mock('../../background-image-cache', () => ({
-  ensureBackgroundsCached: vi.fn().mockResolvedValue({ paths: [], missingCount: 0 }),
+  ensureBackgroundsCached: backgroundCache.ensureBackgroundsCached,
 }));
 
 const plugin = vi.hoisted(() => ({
@@ -80,6 +84,8 @@ describe('useLiveActivity start-failure cleanup', () => {
     plugin.startLiveActivitySession.mockReset();
     plugin.endLiveActivitySession.mockClear();
     plugin.endLiveActivitySession.mockResolvedValue(undefined);
+    backgroundCache.ensureBackgroundsCached.mockReset();
+    backgroundCache.ensureBackgroundsCached.mockResolvedValue({ paths: [], missingCount: 0 });
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
@@ -107,5 +113,37 @@ describe('useLiveActivity start-failure cleanup', () => {
 
     expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1);
     expect(plugin.endLiveActivitySession).not.toHaveBeenCalled();
+  });
+});
+
+describe('useLiveActivity board-background staging', () => {
+  beforeEach(() => {
+    plugin.startLiveActivitySession.mockReset();
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+    backgroundCache.ensureBackgroundsCached.mockReset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves bundled backgrounds for the board and passes them to startLiveActivitySession', async () => {
+    backgroundCache.ensureBackgroundsCached.mockResolvedValue({
+      paths: ['/bg/kilter-1.webp', '/bg/kilter-2.webp'],
+      missingCount: 0,
+    });
+
+    render(<Harness />);
+    await flushStart();
+
+    // Board string + comma setIds are validated/parsed (toBoardName + parseSetIds)
+    // before the lookup, and the resolved paths flow through to the native start.
+    expect(backgroundCache.ensureBackgroundsCached).toHaveBeenCalledWith(
+      expect.objectContaining({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: [1, 2], variant: 'thumb' }),
+    );
+    expect(plugin.startLiveActivitySession).toHaveBeenCalledWith(
+      expect.objectContaining({ boardBackgroundPaths: ['/bg/kilter-1.webp', '/bg/kilter-2.webp'] }),
+    );
   });
 });

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueue } from '../../providers/queue-provider';
 import { useLiveActivity } from './use-live-activity';
@@ -21,7 +21,7 @@ type LiveActivityBridgeProps = {
 // selected) so a guest user without a board doesn't trigger Live Activity
 // authorization prompts at random.
 export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: LiveActivityBridgeProps) {
-  const { state, sessionId, nextClimb, previousClimb } = useQueue();
+  const { state, sessionId, dispatchWidgetNavigation } = useQueue();
   const { t } = useTranslation('session');
   // Always-live: widget Next/Previous drive the shared current climb for the
   // whole session, just like in-app navigation — no driver/preview gate.
@@ -55,20 +55,38 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
     androidNotification,
   });
 
-  // Subscribe to widget Next/Previous taps. Native already updates the
-  // optimistic Live Activity state and persists the new index to App Group
-  // UserDefaults; this listener brings the JS-side reducer in line so that
-  // when the app foregrounds, its currentClimbQueueItem matches the wall.
+  // Subscribe to widget Next/Previous taps. Native already advanced the shared
+  // index, updated the optimistic Live Activity, and sent the server mutation;
+  // this listener brings the JS reducer in line using the ABSOLUTE index native
+  // computed (event.currentIndex), not a relative nextClimb()/previousClimb().
+  //
+  // Why absolute: in a server-authorized session the backend's CurrentClimbChanged
+  // broadcast (correlationId 'widget-navigate') often reaches JS before this
+  // Darwin event and already moves the current climb. A relative advance would
+  // then step a second time → the queue jumps by two. Dispatching the absolute
+  // item with the event's correlationId is idempotent (re-applying the same
+  // index is a no-op) and registers the correlationId so the racing echo is
+  // suppressed. Mirrors web's LiveActivityBridge.
+  //
+  // Refs keep the listener subscribed once: the queue + dispatch read the latest
+  // values without re-running the effect (and re-registering the native listener)
+  // on every queue mutation.
+  const queueRef = useRef(state.queue);
+  queueRef.current = state.queue;
+  const dispatchWidgetNavigationRef = useRef(dispatchWidgetNavigation);
+  dispatchWidgetNavigationRef.current = dispatchWidgetNavigation;
+
   useEffect(() => {
     const unsubscribe = addWidgetQueueNavigateListener((event) => {
-      if (event.action === 'next') {
-        nextClimb();
-      } else if (event.action === 'previous') {
-        previousClimb();
-      }
+      const queue = queueRef.current;
+      // Out-of-range can arrive if the JS queue and the widget's snapshot have
+      // momentarily diverged (e.g. a queue edit mid-tap). Drop it rather than
+      // crash or wrap around.
+      if (event.currentIndex < 0 || event.currentIndex >= queue.length) return;
+      dispatchWidgetNavigationRef.current(queue[event.currentIndex], event.correlationId);
     });
     return unsubscribe;
-  }, [nextClimb, previousClimb]);
+  }, []);
 
   return null;
 }

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -63,7 +63,9 @@ async function resolveBoardBackgroundPaths(board: BoardConfig): Promise<string[]
   if (Platform.OS !== 'ios') return [];
   const setIds = board.setIds
     .split(',')
-    .map((value) => Number(value.trim()))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .map((value) => Number(value))
     .filter((value) => Number.isInteger(value));
   try {
     // Imported lazily so module load doesn't pull in expo-asset + the bundled

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { BoardName } from '@boardsesh/shared-schema';
 import { getAuthToken } from '../auth-store';
 import { BACKEND_URL, WEB_BASE_URL } from '../env';
 import {
@@ -48,6 +49,39 @@ function getGraphqlHttpUrl(): string {
 
 function getGraphqlWsUrl(): string {
   return BACKEND_URL.replace(/^http(s?):\/\//, 'ws$1://').replace(/\/+$/, '') + '/graphql';
+}
+
+// Resolve the bundled board-background webp file path(s) for a board config so
+// the iOS widget can composite them behind the server's holds-only overlay
+// (the no-network-board-art rule — board photos ship in the bundle, never
+// fetched). iOS-only: Android's foreground service has no board thumbnail.
+// Resolving BEFORE startSession means the paths are staged ahead of the first
+// thumbnail pre-fetch, so the initial composite already carries the board photo.
+// Never rejects: a missing/partial bundle yields fewer (or zero) layers and the
+// widget falls back to overlay-only.
+async function resolveBoardBackgroundPaths(board: BoardConfig): Promise<string[]> {
+  if (Platform.OS !== 'ios') return [];
+  const setIds = board.setIds
+    .split(',')
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isInteger(value));
+  try {
+    // Imported lazily so module load doesn't pull in expo-asset + the bundled
+    // board-art manifest (which require()s every board background) until a Live
+    // Activity actually starts on iOS — and so non-iOS / test environments
+    // without the native asset bridge never evaluate it.
+    const { ensureBackgroundsCached } = await import('../background-image-cache');
+    const result = await ensureBackgroundsCached({
+      boardName: board.boardName as BoardName,
+      layoutId: board.layoutId,
+      sizeId: board.sizeId,
+      setIds,
+      variant: 'thumb',
+    });
+    return result?.paths ?? [];
+  } catch {
+    return [];
+  }
 }
 
 // React Native port of `packages/web/app/lib/live-activity/use-live-activity.ts`.
@@ -160,20 +194,28 @@ export function useLiveActivity({
       isActiveRef.current = true;
       const startGeneration = ++generationRef.current;
 
-      void startLiveActivitySession({
-        sessionId: sessionIdRef.current ?? `local-${Date.now()}`,
-        serverUrl: WEB_BASE_URL,
-        wsUrl: getGraphqlWsUrl(),
-        graphqlUrl: getGraphqlHttpUrl(),
-        authToken: authTokenRef.current ?? undefined,
-        boardName: stableBoard.boardName,
-        layoutId: stableBoard.layoutId,
-        sizeId: stableBoard.sizeId,
-        setIds: stableBoard.setIds,
-        widgetNavigationAllowed: widgetNavigationAllowedRef.current,
-        isPartySession: isPartySessionRef.current,
-        androidNotification: androidNotificationRef.current,
-      })
+      void resolveBoardBackgroundPaths(stableBoard)
+        .then((boardBackgroundPaths) => {
+          // A teardown or board/session change during background resolution
+          // supersedes this start — bail before requesting the activity so we
+          // don't leave a dangling one the cleanup already tried to end.
+          if (!isActiveRef.current || generationRef.current !== startGeneration) return undefined;
+          return startLiveActivitySession({
+            sessionId: sessionIdRef.current ?? `local-${Date.now()}`,
+            serverUrl: WEB_BASE_URL,
+            wsUrl: getGraphqlWsUrl(),
+            graphqlUrl: getGraphqlHttpUrl(),
+            authToken: authTokenRef.current ?? undefined,
+            boardName: stableBoard.boardName,
+            layoutId: stableBoard.layoutId,
+            sizeId: stableBoard.sizeId,
+            setIds: stableBoard.setIds,
+            widgetNavigationAllowed: widgetNavigationAllowedRef.current,
+            isPartySession: isPartySessionRef.current,
+            boardBackgroundPaths,
+            androidNotification: androidNotificationRef.current,
+          });
+        })
         .then(() => {
           if (!isActiveRef.current || generationRef.current !== startGeneration) return;
           // Send an initial update so the widget doesn't stay on "Loading...".

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import type { ClimbQueueItem } from '@boardsesh/queue';
-import type { BoardName } from '@boardsesh/shared-schema';
+import { parseSetIds, toBoardName } from '@boardsesh/board-config';
 import { getAuthToken } from '../auth-store';
 import { BACKEND_URL, WEB_BASE_URL } from '../env';
 import {
@@ -61,12 +61,12 @@ function getGraphqlWsUrl(): string {
 // widget falls back to overlay-only.
 async function resolveBoardBackgroundPaths(board: BoardConfig): Promise<string[]> {
   if (Platform.OS !== 'ios') return [];
-  const setIds = board.setIds
-    .split(',')
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-    .map((value) => Number(value))
-    .filter((value) => Number.isInteger(value));
+  // Validate the loose board string against the BoardName union instead of an
+  // unchecked cast — an unknown board (or empty config) skips compositing and
+  // the widget falls back to the holds-only overlay.
+  const boardName = toBoardName(board.boardName);
+  if (!boardName) return [];
+  const setIds = parseSetIds(board.setIds);
   try {
     // Imported lazily so module load doesn't pull in expo-asset + the bundled
     // board-art manifest (which require()s every board background) until a Live
@@ -74,7 +74,7 @@ async function resolveBoardBackgroundPaths(board: BoardConfig): Promise<string[]
     // without the native asset bridge never evaluate it.
     const { ensureBackgroundsCached } = await import('../background-image-cache');
     const result = await ensureBackgroundsCached({
-      boardName: board.boardName as BoardName,
+      boardName,
       layoutId: board.layoutId,
       sizeId: board.sizeId,
       setIds,

--- a/packages/mobile/src/providers/__tests__/queue-provider.test.ts
+++ b/packages/mobile/src/providers/__tests__/queue-provider.test.ts
@@ -349,6 +349,48 @@ describe('DELTA_UPDATE_CURRENT_CLIMB', () => {
 
     expect(result.currentClimbQueueItem).toBeNull();
   });
+
+  // Widget Next/Prev: the bridge calls dispatchWidgetNavigation(item, correlationId),
+  // which dispatches exactly this action — absolute item, shouldAddToQueue:false, and
+  // the native correlationId — WITHOUT a fresh JS mutation (native already sent it).
+  // This guards the double-advance fix: the action registers the correlationId so the
+  // racing CurrentClimbChanged broadcast echoes back as own-echo and is suppressed,
+  // instead of moving the current climb a second time.
+  it('widget navigation sets current by absolute item, no queue growth, and registers the correlationId', () => {
+    const first = makeClimbQueueItem({ uuid: 'q1' });
+    const second = makeClimbQueueItem({ uuid: 'q2' });
+    const state = makeState({ queue: [first, second], currentClimbQueueItem: first });
+
+    const afterNav = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item: second, shouldAddToQueue: false, correlationId: 'widget-navigate' },
+    });
+
+    expect(afterNav.currentClimbQueueItem?.uuid).toBe('q2');
+    expect(afterNav.queue).toHaveLength(2); // shouldAddToQueue:false → the already-queued item isn't re-added
+    expect(afterNav.pendingCurrentClimbUpdates).toContain('widget-navigate');
+  });
+
+  it('suppresses the widget-navigate server echo so it cannot double-advance', () => {
+    const first = makeClimbQueueItem({ uuid: 'q1' });
+    const second = makeClimbQueueItem({ uuid: 'q2' });
+    const afterNav = makeState({
+      queue: [first, second],
+      currentClimbQueueItem: second,
+      pendingCurrentClimbUpdates: ['widget-navigate'],
+    });
+
+    // The backend broadcasts CurrentClimbChanged with the same correlationId after the
+    // widget's HTTP navigate. It must be treated as our own echo: current climb unchanged
+    // and the correlationId consumed.
+    const afterEcho = queueReducer(afterNav, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item: second, isServerEvent: true, serverCorrelationId: 'widget-navigate' },
+    });
+
+    expect(afterEcho.currentClimbQueueItem?.uuid).toBe('q2');
+    expect(afterEcho.pendingCurrentClimbUpdates).not.toContain('widget-navigate');
+  });
 });
 
 // ── Queue navigation helpers ────────────────────────────────────────────

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -130,6 +130,16 @@ type QueueContextValue = {
   setCurrentClimb: (item: ClimbQueueItem, options?: SetCurrentClimbOptions) => void;
   nextClimb: () => void;
   previousClimb: () => void;
+  /**
+   * Apply a widget Next/Previous navigation by absolute index. Dispatches the
+   * current-climb change with the provided correlationId (so the racing
+   * `CurrentClimbChanged` server echo is suppressed) WITHOUT sending a fresh JS
+   * mutation — the native widget intent already sent the server mutation. Using
+   * the absolute item (not a relative `nextClimb`) keeps this idempotent, so it
+   * can't double-advance when the WebSocket echo lands before the Darwin event.
+   * Mirrors web's `dispatchWidgetNavigation`.
+   */
+  dispatchWidgetNavigation: (item: ClimbQueueItem, correlationId: string) => void;
   /** Replace the playlist suggestion source that drives swipe-through climbs. */
   setPlaylistSuggestionSource: (source: PlaylistSuggestionSource | null) => void;
   /** Refresh the suggestion source in place (no-op unless it matches the active one). */
@@ -1478,6 +1488,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     if (prevItem) dispatchSetCurrent(prevItem, false);
   }, [dispatchSetCurrent]);
 
+  // Optimistic dispatch for widget Next/Previous taps. The native widget intent
+  // already sent the server mutation (HTTP /api/widget/navigate or the WS
+  // fallback), so we only update the local reducer with the absolute item and
+  // register the correlationId for echo suppression — no fresh JS mutation, and
+  // no relative advance that could double-step against the racing broadcast.
+  const dispatchWidgetNavigation = useCallback((item: ClimbQueueItem, correlationId: string) => {
+    dispatch({
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item, shouldAddToQueue: false, correlationId },
+    });
+  }, []);
+
   const setPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource | null) => {
     setPlaylistSuggestionSourceState(source);
   }, []);
@@ -1595,6 +1617,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setCurrentClimb,
       nextClimb,
       previousClimb,
+      dispatchWidgetNavigation,
       setPlaylistSuggestionSource,
       refreshPlaylistSuggestionSource,
       clearSession,
@@ -1617,6 +1640,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setCurrentClimb,
       nextClimb,
       previousClimb,
+      dispatchWidgetNavigation,
       setPlaylistSuggestionSource,
       refreshPlaylistSuggestionSource,
       clearSession,

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -25,6 +25,13 @@ enum SharedConstants {
     static let layoutIdKey = "bs_layout_id"
     static let sizeIdKey = "bs_size_id"
     static let setIdsKey = "bs_set_ids"
+    /// File paths to the bundled board-background webp layer(s) for the active
+    /// board, resolved on the JS side (expo-asset) and staged here by
+    /// `startSession`. ThumbnailFetcher composites these behind the server's
+    /// holds-only overlay so the widget shows the board photo without fetching
+    /// board art over the network (the no-network-board-art rule). Empty when no
+    /// bundled background resolved — the overlay is then written as-is.
+    static let boardBackgroundPathsKey = "bs_board_background_paths"
     static let pendingActionKey = "bs_pending_action"
     /// Action ("next" | "previous") associated with the most recent Darwin
     /// notification. Always written by the intent; the Darwin handler reads

--- a/packages/shared/board-config/src/__tests__/set-ids.test.ts
+++ b/packages/shared/board-config/src/__tests__/set-ids.test.ts
@@ -14,6 +14,12 @@ describe('parseSetIds', () => {
     expect(parseSetIds('2,foo,10')).toEqual([2, 10]);
   });
 
+  it('drops empty tokens instead of coercing them to 0', () => {
+    expect(parseSetIds('')).toEqual([]);
+    expect(parseSetIds('2,')).toEqual([2]);
+    expect(parseSetIds('2,,10')).toEqual([2, 10]);
+  });
+
   it('passes an array through unchanged', () => {
     expect(parseSetIds([2, 10])).toEqual([2, 10]);
   });

--- a/packages/shared/board-config/src/set-ids.ts
+++ b/packages/shared/board-config/src/set-ids.ts
@@ -7,7 +7,9 @@ export function parseSetIds(setIds: string | number[]): number[] {
   if (Array.isArray(setIds)) return setIds;
   return setIds
     .split(',')
-    .map((part) => Number(part.trim()))
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0) // drop empty tokens ('', trailing/double commas) so '' → [] not [0]
+    .map((part) => Number(part))
     .filter((value) => Number.isFinite(value));
 }
 


### PR DESCRIPTION
## What

Fixes two regressions in the iOS Live Activity (both present on `main`, not new to a branch).

### Bug 1 — Next/Prev jumped by two
The mobile widget bridge handled the native `queueNavigate` event with **relative** navigation (`nextClimb()`/`previousClimb()`), ignoring the absolute `currentIndex` + `correlationId` the native intent already sends.

After the "always-live" change every session is server-authorized, so the backend's `CurrentClimbChanged` WebSocket broadcast (correlationId `widget-navigate`) reliably lands **before** the Darwin event and already moves the current climb. The mobile reducer never registered `widget-navigate` for echo suppression, so it applied the broadcast — then the Darwin event ran `nextClimb()` and advanced a **second** time. Net: +2.

Web's bridge already does this correctly. Mirrored it on mobile:
- New `dispatchWidgetNavigation(item, correlationId)` on the queue provider — dispatches `DELTA_UPDATE_CURRENT_CLIMB` with the event's correlationId (registers it for echo suppression) and sends **no** fresh JS mutation (the native intent already sent the server one).
- The bridge now picks `queue[event.currentIndex]` (bounds-checked) and dispatches that absolute item. Idempotent → re-applying the racing broadcast is a no-op, so it can't double-step.

### Bug 2 — Live Activity lost the board background
`8e65f9601` ("Enforce bundled board art on mobile") deliberately dropped `include_background=1` from the widget thumbnail URL (no-network-board-art rule), so the server now returns a transparent holds-only overlay and the board photo disappeared.

Restored the board photo **without** re-fetching board art over the network:
- JS resolves the bundled board-background webp path(s) (`ensureBackgroundsCached`, `thumb` variant) and passes them to `startSession`, which stages them in the App Group (`boardBackgroundPathsKey`).
- `ThumbnailFetcher` composites the staged background layer(s) behind the server's holds overlay (`UIGraphicsImageRenderer`) before writing the cached thumbnail the widget renders.
- `include_background` stays out → `check:mobile-board-art-network` stays green. The widget needs no rendering changes (it already reads the cached thumbnail).

The bundled background is lazily imported inside an iOS-gated resolver, so module load no longer pulls the board-art manifest / expo-asset into non-iOS or test environments.

## Files
- `live-activity-bridge.tsx`, `queue-provider.tsx` — absolute-index nav + `dispatchWidgetNavigation` (Bug 1)
- `use-live-activity.ts`, `modules/live-activity/src/index.ts`, `LiveActivityModule.swift`, `SharedConstants.swift` (×2, kept byte-identical) — stage bundled background paths (Bug 2)
- `ThumbnailFetcher.swift` — composite background + overlay (Bug 2)

## Validation
- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (2241 tests, incl. widget-target-drift byte-identity)
- `vp run check:mobile-bundle` ✅ (10.8 MB)
- `vp check` (lint + format) ✅
- `vp run check:mobile-board-art-network` ✅ (no `include_background`)

The Swift compositor isn't unit-tested (private method, needs image fixtures, Xcode-only); it relies on the device check below. The existing `LiveActivityWidgetTests` assertion that `boardRenderUrl` omits `include_background=1` still passes.

## Manual verification (device / iPhone 15 Pro sim)
Start a session, open the Live Activity / Dynamic Island:
- Tap Next/Previous repeatedly → moves exactly one climb per tap; the in-app current climb stays in sync.
- Thumbnail shows the **board photo with the climb's circles**, aligned, on the lock screen + expanded/compact island.
- Spot-check a multi-set board and a board whose `thumb` variant isn't bundled (graceful holds-only fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)