### PR TITLE
Add tap/swipe/long-press interactions to mobile logbook rows

### DIFF
--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -105,7 +105,7 @@ export default function ShareBetaScreen() {
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: AscentFeedItem }) => <LogbookRow ascent={item} onPress={handleAttach} />,
+    ({ item }: { item: AscentFeedItem }) => <LogbookRow ascent={item} onActivate={handleAttach} />,
     [handleAttach],
   );
 
@@ -220,7 +220,7 @@ export default function ShareBetaScreen() {
                     {t('mobile.betaVideos.shareSuggestedTitle')}
                   </Text>
                   {suggestions.map((ascent) => (
-                    <LogbookRow key={ascent.uuid} ascent={ascent} onPress={handleAttach} />
+                    <LogbookRow key={ascent.uuid} ascent={ascent} onActivate={handleAttach} />
                   ))}
                   {listData.length > 0 && (
                     <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.sectionLabel}>

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -34,6 +34,9 @@ type ClimbActionsSheetProps = {
   onToggleFavorite?: () => void;
   /** When provided, shows a "Log a tick" row that opens the LogAscent sheet. */
   onTick?: () => void;
+  /** When provided, shows an "Edit entry" row that opens the logbook edit sheet
+   *  for the tick this climb was opened from (logbook context only). */
+  onEditEntry?: () => void;
   /** When provided, shows an "Add beta video" row that opens the share-your-beta sheet. */
   onAddBetaVideo?: () => void;
   onClose: () => void;
@@ -59,6 +62,7 @@ function ClimbActionsSheet({
   onOpenPlaylist,
   onToggleFavorite,
   onTick,
+  onEditEntry,
   onAddBetaVideo,
   onClose,
 }: ClimbActionsSheetProps) {
@@ -102,6 +106,11 @@ function ClimbActionsSheet({
     onTick?.();
     onClose();
   }, [onTick, onClose]);
+
+  const handleEditEntry = useCallback(() => {
+    onEditEntry?.();
+    onClose();
+  }, [onEditEntry, onClose]);
 
   const handleAddBetaVideo = useCallback(() => {
     onAddBetaVideo?.();
@@ -240,6 +249,14 @@ function ClimbActionsSheet({
             title={t('mobile.climbActions.tick')}
             leading={<Icon name="tick" size={22} color={successActionIconColor} />}
             onPress={handleTick}
+            showSeparator
+          />
+        )}
+        {onEditEntry && (
+          <ListRow
+            title={t('mobile.climbActions.editEntry')}
+            leading={<Icon name="edit" size={22} color={accentActionIconColor} />}
+            onPress={handleEditEntry}
             showSeparator
           />
         )}

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -218,4 +218,20 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
 
     expect(onOpenPlaylist).toHaveBeenCalledTimes(1);
   });
+
+  it('hides the Edit entry row unless onEditEntry is provided', () => {
+    render(<ClimbActionsSheet visible={true} {...baseProps} />);
+    expect(screen.queryByText('mobile.climbActions.editEntry')).toBeNull();
+  });
+
+  it('fires onEditEntry then onClose from the Edit entry row (logbook context)', () => {
+    const onEditEntry = vi.fn();
+    const onClose = vi.fn();
+    render(<ClimbActionsSheet visible={true} {...baseProps} onClose={onClose} onEditEntry={onEditEntry} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.editEntry'));
+
+    expect(onEditEntry).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/mobile/src/components/you/LogbookRow.tsx
+++ b/packages/mobile/src/components/you/LogbookRow.tsx
@@ -1,15 +1,24 @@
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import Animated, {
+  useAnimatedStyle,
+  useAnimatedReaction,
+  interpolate,
+  Extrapolation,
+  runOnJS,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations';
 import { getLayoutDisplayName, formatTickRelativeTime } from '@boardsesh/profile-stats';
 import { getGradeTextColor } from '@boardsesh/play-view';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { type IconName } from '../icon-map';
-import { ListRow } from '../ListRow';
-import { PressableSurface } from '../PressableSurface';
 import { ClimbListItemContent, type ClimbListItemClimb } from '../ClimbListItemContent';
+import { useSwipeArm } from '../use-swipe-arm';
 import { gradeBadgeColor } from './profile-chart-colors';
 import { brandColors, withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -17,12 +26,27 @@ import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
-import { hapticSelection } from '../../lib/haptics';
+import { hapticSelection, hapticMedium, hapticLight, hapticSuccess } from '../../lib/haptics';
 
 type LogbookRowProps = {
   ascent: AscentFeedItem;
-  onPress: (ascent: AscentFeedItem) => void;
+  /** Tap → the row's primary action (logbook: activate + open play drawer;
+   *  beta-share: attach the video to this climb). */
+  onActivate: (ascent: AscentFeedItem) => void;
+  /** Long press → open the climb actions sheet. Omit to disable long-press
+   *  (e.g. the beta-share picker, where the row is a plain selector). */
+  onOpenActions?: (ascent: AscentFeedItem) => void;
+  /** Swipe left-to-right → edit the logbook entry. Owner-only; when omitted the
+   *  left swipe action is disabled (you can't edit another climber's ticks). */
+  onEdit?: (ascent: AscentFeedItem) => void;
 };
+
+// Swipe tuning mirrors ClimbListRow: drag up to ACTION_REVEAL wide; dragging
+// past COMMIT_THRESHOLD and releasing commits the edit action (no resting-open
+// state). friction=1 tracks the finger 1:1.
+const ACTION_REVEAL = 150;
+const COMMIT_THRESHOLD = 96;
+const SWIPE_FRICTION = 1;
 
 // Module-level status metadata keeps the virtualised list from allocating icon
 // maps per row. The shared climb-list row uses these colours as tints; the
@@ -49,7 +73,42 @@ function ascentToClimb(ascent: AscentFeedItem): ClimbListItemClimb | null {
   };
 }
 
-export const LogbookRow = memo(function LogbookRow({ ascent, onPress }: LogbookRowProps) {
+/**
+ * Drag-driven inner of the leading "Edit" swipe action — the pencil grows in
+ * with the drag plus a haptic detent at the commit threshold. Only mounted while
+ * the row is being dragged; the edit itself fires from onSwipeableWillOpen.
+ */
+function EditSwipeActionInner({ translation }: { translation: SharedValue<number> }) {
+  useAnimatedReaction(
+    () => Math.abs(translation.value) >= COMMIT_THRESHOLD,
+    (armed, wasArmed) => {
+      if (armed && !wasArmed) runOnJS(hapticLight)();
+    },
+  );
+  const iconStyle = useAnimatedStyle(() => ({
+    opacity: Math.min(1, Math.abs(translation.value) / (COMMIT_THRESHOLD * 0.35)),
+    transform: [
+      { scale: interpolate(Math.abs(translation.value), [0, COMMIT_THRESHOLD], [0.6, 1], Extrapolation.CLAMP) },
+    ],
+  }));
+  return (
+    <Animated.View style={iconStyle}>
+      <Icon name="edit" size={24} color={iosSystemColors.white} />
+    </Animated.View>
+  );
+}
+
+/**
+ * Leading "Edit" swipe action (left-to-right swipe) — commit-on-release opens
+ * the logbook edit sheet. Cheap shell while resting; mounts the animated inner
+ * once a drag starts (`active`). At translation=0 the pencil is fully
+ * transparent, so the resting shell renders no icon.
+ */
+function EditSwipeAction({ translation, active }: { translation: SharedValue<number>; active: boolean }) {
+  return <View style={styles.swipeAction}>{active ? <EditSwipeActionInner translation={translation} /> : null}</View>;
+}
+
+export const LogbookRow = memo(function LogbookRow({ ascent, onActivate, onOpenActions, onEdit }: LogbookRowProps) {
   const { t } = useTranslation('you');
   const { systemColors } = useTheme();
   const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
@@ -69,55 +128,144 @@ export const LogbookRow = memo(function LogbookRow({ ascent, onPress }: LogbookR
   const climb = ascentToClimb(ascent);
   const boardConfig = getBoardConfigForPlaylist(ascent.boardType, ascent.layoutId);
 
-  const handlePress = () => {
+  const swipeableRef = useRef<SwipeableMethods>(null);
+
+  // Lazy swipe panel: the heavy animated inner only mounts once a drag actually
+  // starts on this row. The hook resets the machine on recycle (ascent.uuid) and
+  // exposes a ref so the render callback stays dep-free (see useSwipeArm).
+  const { armedRef: dragArmedRef, arm, disarm } = useSwipeArm(ascent.uuid);
+
+  // FlashList recycles rows (same instance, new ascent). Snap any open swipe shut
+  // so a recycled row never shows the previous ascent's open panel.
+  useEffect(() => {
+    swipeableRef.current?.reset();
+  }, [ascent.uuid]);
+
+  // Stable refs so gesture/worklet callbacks never close over stale props.
+  const onActivateRef = useRef(onActivate);
+  onActivateRef.current = onActivate;
+  const onOpenActionsRef = useRef(onOpenActions);
+  onOpenActionsRef.current = onOpenActions;
+  const onEditRef = useRef(onEdit);
+  onEditRef.current = onEdit;
+  const ascentRef = useRef(ascent);
+  ascentRef.current = ascent;
+
+  const handleRowPress = useCallback(() => {
     hapticSelection();
-    onPress(ascent);
-  };
+    onActivateRef.current(ascentRef.current);
+  }, []);
 
-  if (climb && boardConfig) {
-    return (
-      <View>
-        <PressableSurface
-          onPress={handlePress}
-          feedback="opacity"
-          opacityTo={0.7}
-          accessibilityRole="button"
-          accessibilityLabel={ascent.climbName}
-          style={[styles.row, { backgroundColor: systemColors.secondaryBackground }]}
-        >
-          <View style={styles.statusSlot}>
-            <View style={[styles.statusIcon, { backgroundColor: withAlpha(meta.color, 0.15) }]}>
-              <Icon name={meta.icon} size={14} color={meta.color} />
-            </View>
+  const handleLongPress = useCallback(() => {
+    const openActions = onOpenActionsRef.current;
+    if (!openActions) return;
+    hapticMedium();
+    openActions(ascentRef.current);
+  }, []);
+
+  const handleEdit = useCallback(() => {
+    const edit = onEditRef.current;
+    if (!edit) return;
+    hapticSuccess();
+    edit(ascentRef.current);
+  }, []);
+
+  // Snap shut once fully settled open (the edit already fired on willOpen).
+  const handleSwipeableOpened = useCallback(() => {
+    swipeableRef.current?.close();
+  }, []);
+
+  const handleSwipeableClosed = useCallback(() => {
+    disarm();
+  }, [disarm]);
+
+  const handleSwipeStartDrag = useCallback(() => {
+    arm();
+  }, [arm]);
+
+  const handleSwipeWillOpen = useCallback(
+    (direction: 'left' | 'right') => {
+      // ReanimatedSwipeable reports the SWIPE direction: 'right' fires when the
+      // LEFT actions (Edit) open (left-to-right swipe). Only the left side exists.
+      if (direction === 'right') handleEdit();
+    },
+    [handleEdit],
+  );
+
+  const singleTapGesture = useMemo(
+    () =>
+      Gesture.Tap()
+        .maxDuration(300)
+        .maxDistance(15)
+        .onStart(() => {
+          'worklet';
+          runOnJS(handleRowPress)();
+        }),
+    [handleRowPress],
+  );
+
+  const longPressGesture = useMemo(
+    () =>
+      Gesture.LongPress()
+        .minDuration(400)
+        .onStart(() => {
+          'worklet';
+          runOnJS(handleLongPress)();
+        }),
+    [handleLongPress],
+  );
+
+  // Long-press wins over tap; a quick tap fires once the long-press fails. With
+  // no long-press handler (beta-share picker) the row is tap-only.
+  const tapGesture = useMemo(
+    () => (onOpenActions ? Gesture.Exclusive(longPressGesture, singleTapGesture) : singleTapGesture),
+    [onOpenActions, longPressGesture, singleTapGesture],
+  );
+
+  // Reads dragArmedRef.current rather than the armed state directly so it stays
+  // dep-free: a changed render-callback reference makes ReanimatedSwipeable
+  // re-create the action-panel subtree (remounting the heavy inner). The armed
+  // state change re-renders the row, while the stable identity keeps the
+  // shell→inner swap in place.
+  const renderLeftActions = useCallback(
+    (_progress: SharedValue<number>, translation: SharedValue<number>) => (
+      <EditSwipeAction translation={translation} active={dragArmedRef.current} />
+    ),
+    [dragArmedRef],
+  );
+
+  const rowContent =
+    climb && boardConfig ? (
+      <View style={[styles.row, { backgroundColor: systemColors.secondaryBackground }]}>
+        <View style={styles.statusSlot}>
+          <View style={[styles.statusIcon, { backgroundColor: withAlpha(meta.color, 0.15) }]}>
+            <Icon name={meta.icon} size={14} color={meta.color} />
           </View>
-          <ClimbListItemContent
-            climb={climb}
-            boardName={boardConfig.boardName}
-            layoutId={boardConfig.layoutId}
-            sizeId={boardConfig.sizeId}
-            setIds={boardConfig.setIds.join(',')}
-            angle={ascent.angle}
-            subtitleDetailParts={subtitleParts}
-            showAscentStatus={false}
-          />
-        </PressableSurface>
-        <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
+        </View>
+        <ClimbListItemContent
+          climb={climb}
+          boardName={boardConfig.boardName}
+          layoutId={boardConfig.layoutId}
+          sizeId={boardConfig.sizeId}
+          setIds={boardConfig.setIds.join(',')}
+          angle={ascent.angle}
+          subtitleDetailParts={subtitleParts}
+          showAscentStatus={false}
+        />
       </View>
-    );
-  }
-
-  return (
-    <ListRow
-      title={ascent.climbName}
-      subtitle={subtitle}
-      onPress={handlePress}
-      showChevron
-      leading={
+    ) : (
+      <View style={[styles.fallbackRow, { backgroundColor: systemColors.background }]}>
         <View style={[styles.badge, { backgroundColor: meta.color }]}>
           <Icon name={meta.icon} size={14} color={iosSystemColors.white} />
         </View>
-      }
-      trailing={
+        <View style={styles.fallbackText}>
+          <Text variant="body" numberOfLines={1}>
+            {ascent.climbName}
+          </Text>
+          <Text variant="subheadline" style={styles.fallbackSubtitle} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        </View>
         <View style={styles.trailing}>
           {gradeLabel && gradeColor ? (
             <View style={[styles.gradePill, { backgroundColor: gradeColor }]}>
@@ -130,12 +278,40 @@ export const LogbookRow = memo(function LogbookRow({ ascent, onPress }: LogbookR
             {triesLabel}
           </Text>
         </View>
-      }
-    />
+      </View>
+    );
+
+  const separatorStyle = climb && boardConfig ? styles.separatorRich : styles.separatorFallback;
+
+  return (
+    <View style={styles.outerContainer}>
+      <ReanimatedSwipeable
+        ref={swipeableRef}
+        friction={SWIPE_FRICTION}
+        leftThreshold={COMMIT_THRESHOLD}
+        overshootLeft={false}
+        renderLeftActions={onEdit ? renderLeftActions : undefined}
+        onSwipeableOpenStartDrag={handleSwipeStartDrag}
+        onSwipeableWillOpen={handleSwipeWillOpen}
+        onSwipeableOpen={handleSwipeableOpened}
+        onSwipeableClose={handleSwipeableClosed}
+      >
+        <GestureDetector gesture={tapGesture}>
+          <View accessible accessibilityRole="button" accessibilityLabel={ascent.climbName}>
+            {rowContent}
+          </View>
+        </GestureDetector>
+      </ReanimatedSwipeable>
+      <View style={[separatorStyle, { backgroundColor: systemColors.separator }]} />
+    </View>
   );
 });
 
 const styles = StyleSheet.create({
+  outerContainer: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -155,9 +331,29 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  separator: {
+  separatorRich: {
     height: StyleSheet.hairlineWidth,
     marginLeft: spacing[3] + 28 + spacing[3],
+  },
+  separatorFallback: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: 16 + 12 + 28,
+  },
+  fallbackRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    minHeight: 44,
+  },
+  fallbackText: {
+    flex: 1,
+    justifyContent: 'center',
+    marginLeft: 12,
+  },
+  fallbackSubtitle: {
+    opacity: 0.6,
+    marginTop: 2,
   },
   badge: {
     width: 28,
@@ -169,6 +365,7 @@ const styles = StyleSheet.create({
   trailing: {
     alignItems: 'flex-end',
     gap: 2,
+    marginLeft: 8,
   },
   gradePill: {
     paddingHorizontal: spacing[2],
@@ -176,4 +373,11 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.sm,
   },
   gradeText: { fontWeight: '700' },
+  swipeAction: {
+    width: ACTION_REVEAL,
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    paddingLeft: 22,
+    backgroundColor: brandColors.primary,
+  },
 });

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -15,6 +15,8 @@ import { LogbookRow } from './LogbookRow';
 import { LogbookEditSheet } from './LogbookEditSheet';
 import { useUserAscentsFeed } from '../../lib/graphql/hooks';
 import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
+import { tickToClimb } from '../../lib/tick-to-climb';
+import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -37,7 +39,7 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
   const router = useRouter();
-  const { openPlayDrawer } = useDrawerHost();
+  const { openPlayDrawer, openClimbActions } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
 
@@ -48,28 +50,44 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
   // Stabilise the FlashList `data` identity so it doesn't re-diff every render.
   const items = useMemo(() => feed.data?.pages.flatMap((page) => page.userAscentsFeed.items) ?? [], [feed.data]);
 
-  const handlePress = useCallback(
+  // Tap → set the climb active and open the play drawer (own logbook and another
+  // climber's read-only logbook alike). AscentFeedItem structurally satisfies the
+  // `tick` kind, which builds the climb + board config from frames.
+  const handleActivate = useCallback(
     (ascent: AscentFeedItem) => {
       track(SHARED_EVENTS.LogbookRowClicked, { climbUuid: ascent.climbUuid });
-      // Another climber's logbook is read-only — open the climb itself rather
-      // than the tick-editing sheet, which only edits the signed-in user's ticks.
-      if (!viewerIsOwner) {
-        openClimbInPlayDrawer(
-          {
-            kind: 'ref',
-            climbUuid: ascent.climbUuid,
-            boardType: ascent.boardType,
-            layoutId: ascent.layoutId,
-            angle: ascent.angle,
-          },
-          { openPlayDrawer, router },
-        );
-        return;
-      }
-      setEditAscent(ascent);
-      editSheetRef.current?.snapToIndex(0);
+      openClimbInPlayDrawer({ kind: 'tick', tick: ascent }, { openPlayDrawer, router }, { setAsCurrent: true });
     },
-    [openPlayDrawer, router, viewerIsOwner],
+    [openPlayDrawer, router],
+  );
+
+  // Swipe left-to-right → edit this tick (owner-only). The old tap behaviour.
+  const handleEdit = useCallback((ascent: AscentFeedItem) => {
+    setEditAscent(ascent);
+    editSheetRef.current?.snapToIndex(0);
+  }, []);
+
+  // Long press → open the climb actions sheet. For the owner it carries an
+  // "Edit entry" row wired back to the tick editor. No-op when the board can't
+  // resolve (no frames / MoonBoard) — nothing to render in the actions sheet.
+  const handleOpenActions = useCallback(
+    (ascent: AscentFeedItem) => {
+      const climb = tickToClimb(ascent);
+      const config = getBoardConfigForPlaylist(ascent.boardType, ascent.layoutId);
+      if (!climb || !config) return;
+      openClimbActions(
+        climb,
+        {
+          boardName: config.boardName,
+          layoutId: config.layoutId,
+          sizeId: config.sizeId,
+          setIds: config.setIds.join(','),
+          angle: ascent.angle,
+        },
+        viewerIsOwner ? { onEditEntry: () => handleEdit(ascent) } : undefined,
+      );
+    },
+    [openClimbActions, viewerIsOwner, handleEdit],
   );
 
   const handleEndReached = useCallback(() => {
@@ -81,8 +99,15 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
   }, [feed]);
 
   const renderItem = useCallback(
-    ({ item }: { item: AscentFeedItem }) => <LogbookRow ascent={item} onPress={handlePress} />,
-    [handlePress],
+    ({ item }: { item: AscentFeedItem }) => (
+      <LogbookRow
+        ascent={item}
+        onActivate={handleActivate}
+        onOpenActions={handleOpenActions}
+        onEdit={viewerIsOwner ? handleEdit : undefined}
+      />
+    ),
+    [handleActivate, handleOpenActions, handleEdit, viewerIsOwner],
   );
 
   // The screen's identity, in-body under the floating chrome. Memoized so

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-analytics.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
 
-// Capture the per-row onPress LogbookTab wires up, so the test can fire a tap
+// Capture the per-row onActivate LogbookTab wires up, so the test can fire a tap
 // without a real list renderer.
 const row = vi.hoisted(() => ({ onPress: null as (() => void) | null }));
 
@@ -51,13 +51,13 @@ vi.mock('@shopify/flash-list', () => ({
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../LogbookRow', () => ({
   LogbookRow: ({
-    onPress,
+    onActivate,
     ascent,
   }: {
-    onPress: (ascent: { climbUuid: string }) => void;
+    onActivate: (ascent: { climbUuid: string }) => void;
     ascent: { climbUuid: string };
   }) => {
-    row.onPress = () => onPress(ascent);
+    row.onPress = () => onActivate(ascent);
     return createElement('div');
   },
 }));
@@ -75,7 +75,11 @@ vi.mock('../../../providers/theme-provider', () => ({
 }));
 vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock('../../../lib/open-climb-in-play-drawer', () => ({ openClimbInPlayDrawer: vi.fn() }));
-vi.mock('../../../providers/drawer-host-provider', () => ({ useDrawerHost: () => ({ openPlayDrawer: vi.fn() }) }));
+vi.mock('../../../lib/tick-to-climb', () => ({ tickToClimb: vi.fn() }));
+vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({ getBoardConfigForPlaylist: vi.fn() }));
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ openPlayDrawer: vi.fn(), openClimbActions: vi.fn() }),
+}));
 
 import { LogbookTab } from '../LogbookTab';
 

--- a/packages/mobile/src/lib/open-climb-in-play-drawer.ts
+++ b/packages/mobile/src/lib/open-climb-in-play-drawer.ts
@@ -35,6 +35,16 @@ export type OpenClimbArgs =
       setIds?: string;
     };
 
+export type OpenClimbOptions = {
+  /**
+   * When `true`, the opened climb is set as the current climb (and appended to
+   * the queue) — a tap-to-activate. Defaults to `false` (view-only), preserving
+   * the original behaviour for every existing caller. Ignored on the `ref`
+   * fallback, which routes through the climb page and opens with its own default.
+   */
+  setAsCurrent?: boolean;
+};
+
 /**
  * The single entry point for opening a climb anywhere in the app. Every former
  * caller of the standalone climb page routes through here so all climb viewing
@@ -43,11 +53,12 @@ export type OpenClimbArgs =
  * Plain function (not a hook) so it's callable from `useCallback` bodies — pass
  * the host's `openPlayDrawer` and the screen's `router` as deps.
  */
-export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps): void {
+export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, options?: OpenClimbOptions): void {
   const { openPlayDrawer, router } = deps;
+  const setAsCurrent = options?.setAsCurrent ?? false;
 
   if (args.kind === 'climb') {
-    openPlayDrawer(args.climb, { setAsCurrent: false, boardConfig: args.boardConfig, source: 'climb_view' });
+    openPlayDrawer(args.climb, { setAsCurrent, boardConfig: args.boardConfig, source: 'climb_view' });
     return;
   }
 
@@ -56,7 +67,7 @@ export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps):
     const config = getBoardConfigForPlaylist(args.tick.boardType, args.tick.layoutId);
     if (climb && config) {
       openPlayDrawer(climb, {
-        setAsCurrent: false,
+        setAsCurrent,
         boardConfig: {
           boardName: config.boardName,
           layoutId: config.layoutId,

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -49,6 +49,12 @@ export type BoardConfig = {
   angle: number;
 };
 
+export type OpenClimbActionsOptions = {
+  /** When set, the climb actions sheet shows an "Edit entry" row wired to this
+   *  callback (logbook rows pass it to open the tick editor). */
+  onEditEntry?: () => void;
+};
+
 export type LogAscentInput = {
   climbUuid: string;
   boardName: string;
@@ -99,8 +105,9 @@ type DrawerHostValue = {
   openPlayDrawer: (climb: Climb, options?: OpenPlayDrawerOptions) => void;
   openLogAscent: (input: LogAscentInput) => void;
   /** Opens the climb actions bottom sheet for the given climb. Uses the active
-   *  boardConfig at the time of opening. */
-  openClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig) => void;
+   *  boardConfig at the time of opening. Pass `onEditEntry` (logbook context) to
+   *  add an "Edit entry" row that edits the tick the climb was opened from. */
+  openClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => void;
   closeClimbActions: () => void;
   /** Opens the add-to-playlist bottom sheet for the given climb. Snapshots the
    *  active boardConfig (for the angle) at open time. */
@@ -134,7 +141,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const { data: myBoardsConn } = useMyBoards();
   const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
-  const [climbActions, setClimbActions] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
+  const [climbActions, setClimbActions] = useState<{
+    climb: Climb;
+    boardConfig: BoardConfig;
+    onEditEntry?: () => void;
+  } | null>(null);
   const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const [betaVideoClimb, setBetaVideoClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
@@ -309,11 +320,14 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // Snapshot the board config at open time so the sheet's per-row handlers
   // (queue / favorite / tick) keep operating on the same angle even if the
   // user switches their active board mid-interaction.
-  const openClimbActions = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
-    const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
-    if (!boardConfig) return;
-    setClimbActions({ climb, boardConfig });
-  }, []);
+  const openClimbActions = useCallback(
+    (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => {
+      const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
+      if (!boardConfig) return;
+      setClimbActions({ climb, boardConfig, onEditEntry: options?.onEditEntry });
+    },
+    [],
+  );
 
   const closeClimbActions = useCallback(() => {
     setClimbActions(null);
@@ -649,6 +663,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onOpenPlaylist={handleClimbActionsOpenPlaylist}
           onToggleFavorite={handleClimbActionsToggleFavorite}
           onTick={handleClimbActionsTick}
+          onEditEntry={climbActions.onEditEntry}
           onAddBetaVideo={isAuthenticated ? handleClimbActionsAddBetaVideo : undefined}
           onClose={closeClimbActions}
         />

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -690,7 +690,8 @@
       "addBetaVideo": "Add beta video",
       "openInApp": "Open in Aurora app",
       "fork": "Remix this climb",
-      "edit": "Edit climb"
+      "edit": "Edit climb",
+      "editEntry": "Edit logbook entry"
     },
     "create": {
       "brush": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -690,7 +690,8 @@
       "addBetaVideo": "Añadir vídeo de beta",
       "openInApp": "Abrir en la app Aurora",
       "fork": "Remix this climb",
-      "edit": "Editar vía"
+      "edit": "Editar vía",
+      "editEntry": "Editar registro"
     },
     "create": {
       "brush": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -690,7 +690,8 @@
       "addBetaVideo": "Ajouter une vidéo beta",
       "openInApp": "Ouvrir dans l'app Aurora",
       "fork": "Remix this climb",
-      "edit": "Modifier la voie"
+      "edit": "Modifier la voie",
+      "editEntry": "Modifier l'entrée du carnet"
     },
     "create": {
       "brush": {


### PR DESCRIPTION
## What

Reworks logbook rows in the mobile **You → Logbook** tab so they behave like climb rows elsewhere in the app:

- **Tap** → set the climb active and open the play drawer (previously opened the edit sheet). Applies to your own logbook and another climber's read-only logbook.
- **Swipe left-to-right** → edit the logbook entry (owner only). This is the old tap behaviour.
- **Long press** → open the **climb actions** sheet for that climb.
- The climb actions sheet, when opened from your own logbook, now shows an **"Edit entry"** row that opens the tick editor for that entry.

## How

- `LogbookRow` is rebuilt on the same gesture + swipe pattern as `ClimbListRow` — `ReanimatedSwipeable` (single leading "Edit" action) + `GestureDetector(Gesture.Exclusive(longPress, tap))`, with lazy swipe panels via `useSwipeArm`. The two existing visual variants (rich board-art row / no-frames fallback) are preserved as the swipeable's content. `onOpenActions`/`onEdit` are optional, so the beta-share picker keeps using the row as a plain tap selector.
- `openClimbInPlayDrawer` gains a `setAsCurrent` option (default `false`, preserving every existing caller); the logbook tap passes `true` to activate.
- `openClimbActions` accepts an `onEditEntry` callback that threads through `DrawerHostProvider` into `ClimbActionsSheet`, which renders the new **Edit entry** row.
- New i18n key `mobile.climbActions.editEntry` added to `en-US`, `es`, `fr`.

`AscentFeedItem` structurally satisfies the `tick` shape used by `tickToClimb` + `getBoardConfigForPlaylist`, so no new adapter was needed.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2240 passed (updated the logbook-tab analytics test for the renamed handler; added Edit-entry coverage to the climb-actions-sheet test)
- web tests incl. `i18n-catalog-completeness` — pass
- `vp run check:mobile-bundle` — OK
- `vp check` on changed files — clean

## Notes

- No-frames / unresolvable-board ticks (e.g. MoonBoard) can't render in the play drawer or actions sheet; tap falls back to the climb route and long-press no-ops, matching prior behaviour.
- Manual simulator pass still recommended (Linux CI can't drive the iOS simulator).

https://claude.ai/code/session_01PbDrHecLmnHumsuXnLwvxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbDrHecLmnHumsuXnLwvxz)_