### PR TITLE
fix(screenshots): pre-warm Metro so capture isn't flaky on slow CI runners

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -43,12 +43,14 @@ simulator keychain first so login authenticates cleanly against prod.
 - The app is a dev-client, so each flow first loads its JS from Metro with
   `openLink: ${MAESTRO_DEV_CLIENT_URL}` instead of `launchApp` — a bare launch
   would land on the launcher. The orchestrator passes that env via `maestro test
-  -e` (an `expo-development-client` deep link pointing at its Metro port, default
+-e` (an `expo-development-client` deep link pointing at its Metro port, default
   8081, override with `BOARDSESH_METRO_PORT`), so the flow isn't pinned to a port.
   Re-opening the deep link reloads the JS runtime (used to clear the play drawer
-  before the board-sheet shot). The first load waits up to 180s for the cold Metro
-  bundle. The orchestrator uninstalls + reinstalls and resets the keychain, so the
-  app cold-loads signed out with fresh app data (no Maestro `clearState` needed).
+  before the board-sheet shot). The orchestrator pre-warms the Metro bundle before
+  Maestro runs, but the first load still waits up to 300s as a safety net for a
+  cold bundle on a slow CI runner. The orchestrator uninstalls + reinstalls and
+  resets the keychain, so the app cold-loads signed out with fresh app data (no
+  Maestro `clearState` needed).
 - Navigation uses custom-scheme deep links (`com.boardsesh.app://<route>`); Expo
   Router maps tab routes with the `(tabs)` group stripped (`://climbs`, `://home`,
   `://boards`, …). Each `openLink` is followed by an optional `tapOn "Open"` to

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -38,7 +38,7 @@ name: app-store screenshots
 - extendedWaitUntil:
     visible:
       id: 'auth-email-input'
-    timeout: 180000
+    timeout: 300000
 - runFlow: login.yaml
 
 # Home — feed populated by the prod test user's follows.

--- a/packages/mobile/.maestro/onboarding.yaml
+++ b/packages/mobile/.maestro/onboarding.yaml
@@ -31,7 +31,7 @@ name: onboarding illustrations
 - extendedWaitUntil:
     visible:
       id: 'auth-email-input'
-    timeout: 180000
+    timeout: 300000
 - runFlow: login.yaml
 
 - openLink: com.boardsesh.app://climbs

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -402,6 +402,10 @@ function runIos(options: ScreenshotOptions): number {
       return 1;
     }
 
+    // Compile the bundle now so the dev-client load below isn't a cold bundle on
+    // Maestro's auth-screen wait (the slow-CI-runner timeout this guards against).
+    prewarmMetroBundle();
+
     // Pre-launch the app with UserDefaults argument-domain overrides so
     // expo-dev-client's dev-menu UI doesn't appear in the captures:
     //   -EXDevMenuIsOnboardingFinished YES     → skip the one-time "developer
@@ -532,6 +536,47 @@ function startMetro(env: NodeJS.ProcessEnv): ChildProcess {
     stdio: 'inherit',
     detached: true,
   });
+}
+
+/**
+ * Compile the JS bundle the dev-client will request, so its load in Maestro is a
+ * Metro transform-cache hit instead of a cold bundle (3900+ modules, ~100s+ on a
+ * fresh CI runner with no on-disk Metro cache) on the auth-screen wait's critical
+ * path — which has timed out there. We fetch the manifest the dev-client would
+ * and request its exact launchAsset URL (same hermes/bytecode transform params),
+ * so Metro caches the right variant. Best-effort: a miss just falls back to
+ * Maestro cold-loading the bundle (its wait is generous).
+ */
+function prewarmMetroBundle(): void {
+  const manifest = runCapture('curl', [
+    '-fsS',
+    '--max-time',
+    '30',
+    `http://localhost:${METRO_PORT}/`,
+    '-H',
+    'expo-platform: ios',
+    '-H',
+    'Accept: application/expo+json,application/json',
+  ]);
+  let bundleUrl: string | undefined;
+  if (manifest.status === 0) {
+    try {
+      bundleUrl = (JSON.parse(manifest.stdout) as { launchAsset?: { url?: string } }).launchAsset?.url;
+    } catch {
+      // Non-JSON manifest — fall through to skip.
+    }
+  }
+  if (!bundleUrl) {
+    console.log(`${LOG} Metro pre-warm skipped (no bundle URL); Maestro will cold-load the bundle.`);
+    return;
+  }
+  console.log(`${LOG} Pre-warming the Metro bundle...`);
+  const warmed = runCapture('curl', ['-fsS', '-o', '/dev/null', '--max-time', '300', bundleUrl]);
+  console.log(
+    warmed.status === 0
+      ? `${LOG} Metro bundle pre-warmed.`
+      : `${LOG} Metro pre-warm did not finish (non-fatal); Maestro will load the bundle.`,
+  );
 }
 
 /** Poll Metro's /status until it answers (or ~120s elapse). */


### PR DESCRIPTION
## What

Follow-up to #2929. The first `upload=true` dispatch on the new cached pipeline **failed at Capture** (so nothing reached App Store Connect): the dev-client's cold Metro bundle exceeded the 180s `auth-email-input` wait on a slow runner.

```
10:10:18  Open ${MAESTRO_DEV_CLIENT_URL}... COMPLETED   (deep link delivered)
10:13:28  Assert id: auth-email-input is visible... FAILED   (~181s → timed out)
```

The cache-hit path itself worked (build skipped). The flakiness is the **cold Metro bundle**: a fresh CI runner has no on-disk Metro transform cache, so bundling 3900+ modules takes ~100s+. One run bundled in 107s (passed); a slower run went past 180s (failed).

## Fix

- **`scripts/mobile-screenshots.ts`** — `prewarmMetroBundle()` compiles the bundle **before** Maestro runs, off the auth-screen wait's critical path. It fetches the dev-client manifest and requests its exact `launchAsset` URL (same `hermes`/`bytecode` transform params), so Metro caches the variant the dev-client will load. Best-effort: a miss falls back to Maestro cold-loading it.
- **`.maestro/app-store.yaml` + `onboarding.yaml`** — bump the first auth-screen wait **180s → 300s** as a safety net for when the pre-warm doesn't fully cover it.

## Validation

Verified locally that the manifest's `launchAsset` URL returns a valid compiled bundle (HTTP 200). The cold-bundle slowness only reproduces on a fresh CI runner (local Metro is disk-cached), so the real proof is the next `upload=true` dispatch — I'll run it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)