### PR TITLE
[codex] add Android Play Store screenshot automation

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -1,8 +1,8 @@
 name: Mobile Screenshots (Native)
 
-# Captures native App Store / onboarding screenshots from the RN app on an iOS
-# simulator via Maestro (scripts/mobile-screenshots.ts) and uploads them as an
-# artifact. Manual + nightly only — never gates PRs.
+# Captures native App Store / Play Store / onboarding screenshots from the RN app
+# via Maestro (scripts/mobile-screenshots.ts) and uploads them as artifacts.
+# Manual + nightly only — never gates PRs.
 #
 # The screenshot app is a Debug dev-client that loads its JS from Metro, so the
 # native .app is reusable: it's cached (actions/cache) keyed on native inputs and
@@ -14,10 +14,9 @@ name: Mobile Screenshots (Native)
 # production backend.
 #
 # On a manual dispatch with `upload = true`, it also uploads the freshly captured
-# screenshots to App Store Connect via fastlane (fastlane/Fastfile, screenshots
-# ONLY — no binary, metadata, or review submission). The nightly cron never
-# uploads (it only captures); uploading mutates the live "Prepare for Submission"
-# version, so it's opt-in per dispatch. See app-stores/apple/app-store-submission-guide.md.
+# screenshots via fastlane (fastlane/Fastfile, screenshots ONLY — no binary or
+# text metadata). The nightly cron never uploads (it only captures); uploading
+# mutates live store listing assets, so it's opt-in per dispatch.
 
 on:
   workflow_dispatch:
@@ -33,8 +32,12 @@ on:
         description: 'iOS simulator device name'
         type: string
         default: 'iPhone 16 Pro Max'
+      android_device:
+        description: 'Android emulator device label used for screenshot output'
+        type: string
+        default: 'Pixel 2'
       upload:
-        description: 'Upload the captured screenshots to App Store Connect (the App Store version must be in an editable state). Never runs on the nightly cron.'
+        description: 'Upload captured screenshots to App Store Connect and Google Play. Never runs on the nightly cron.'
         type: boolean
         default: false
   schedule:
@@ -142,7 +145,7 @@ jobs:
       # slot). Runs on every capture, including nightly — an early warning if a
       # future simulator/Xcode bump changes the capture resolution.
       - name: Assert screenshot dimensions
-        run: vp run check:screenshot-dimensions
+        run: vp run check:screenshot-dimensions -- --platform ios
 
       # --- Upload to App Store Connect (manual dispatch only; never on cron) ---
       # Screenshots ONLY — no binary, no metadata, no review submission. Gated
@@ -195,5 +198,165 @@ jobs:
         with:
           name: mobile-screenshots-ios
           path: app-stores/apple/screenshots/**
+          if-no-files-found: warn
+          retention-days: 14
+
+  android:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+
+    env:
+      UPLOAD_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.upload }}
+      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+      EXPO_PUBLIC_SCREENSHOT_MODE: '1'
+      EXPO_PUBLIC_SCREENSHOT_THEME: dark
+      EXPO_PUBLIC_SCREENSHOT_WORKOUT: volume
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
+      SCREENSHOT_USER_EMAIL: ${{ secrets.SCREENSHOT_USER_EMAIL || 'test@boardsesh.com' }}
+      SCREENSHOT_USER_PASSWORD: ${{ secrets.SCREENSHOT_USER_PASSWORD || 'test' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Install Node.js dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Accept licenses and install SDK components
+        run: |
+          yes | sdkmanager --licenses > /dev/null 2>&1 || true
+          sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-rn-screenshots-${{ hashFiles('packages/mobile/package.json', 'bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-rn-screenshots-
+
+      - name: Write .env for screenshot bundle
+        working-directory: packages/mobile
+        run: |
+          cat > .env <<EOF
+          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+          EXPO_PUBLIC_SCREENSHOT_MODE=$EXPO_PUBLIC_SCREENSHOT_MODE
+          EXPO_PUBLIC_SCREENSHOT_THEME=$EXPO_PUBLIC_SCREENSHOT_THEME
+          EXPO_PUBLIC_SCREENSHOT_WORKOUT=$EXPO_PUBLIC_SCREENSHOT_WORKOUT
+          EOF
+
+      - name: Expo prebuild (generate android/)
+        working-directory: packages/mobile
+        env:
+          TAILSCALE_HOSTS: ''
+        run: bunx expo prebuild --platform android --clean --no-install
+
+      - name: Build x86_64 screenshot APK
+        working-directory: packages/mobile/android
+        env:
+          SENTRY_DISABLE_AUTO_UPLOAD: 'true'
+        run: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64 -PboardseshAbiFilters=x86_64 --no-daemon --console=plain --stacktrace
+
+      - name: Normalize screenshot APK path
+        run: |
+          set -euo pipefail
+          release_dir=packages/mobile/android/app/build/outputs/apk/release
+          mapfile -t apks < <(find "$release_dir" -maxdepth 1 -type f -name '*.apk' | sort)
+          if [ "${#apks[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one screenshot APK, found ${#apks[@]}."
+            printf '%s\n' "${apks[@]}"
+            exit 1
+          fi
+          cp -f "${apks[0]}" /tmp/boardsesh-screenshot.apk
+
+      - name: Install Maestro
+        env:
+          MAESTRO_VERSION: 2.6.1
+          MAESTRO_SHA256: 3440825f514f537c6a96bcf5de995780c2a4a7f83a43208fdc95d4f1fecfad3b
+        run: |
+          set -euo pipefail
+          url="https://github.com/mobile-dev-inc/maestro/releases/download/cli-${MAESTRO_VERSION}/maestro.zip"
+          curl -fsSL "$url" -o maestro.zip
+          echo "${MAESTRO_SHA256}  maestro.zip" | shasum -a 256 -c -
+          unzip -q maestro.zip -d "$HOME/.maestro-dist"
+          echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Capture Android screenshots
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 36
+          target: google_apis
+          arch: x86_64
+          profile: pixel_2
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            set -euo pipefail
+            adb shell wm size 1080x1920
+            adb shell wm density 420
+            vp run mobile:screenshots -- \
+              --platform android \
+              --flow "${{ inputs.flow || 'app-store' }}" \
+              --backend prod \
+              --device "${{ inputs.android_device || 'Pixel 2' }}" \
+              --app-path /tmp/boardsesh-screenshot.apk
+
+      - name: Assert screenshot dimensions
+        run: vp run check:screenshot-dimensions -- --platform android
+
+      - name: Set up Ruby + fastlane
+        if: success() && env.UPLOAD_RUN == 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+          working-directory: fastlane
+
+      - name: Upload screenshots to Google Play
+        if: success() && env.UPLOAD_RUN == 'true'
+        working-directory: fastlane
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+        run: |
+          set -euo pipefail
+          [ -n "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" ] || { echo "::error::Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON."; exit 1; }
+          bundle exec fastlane android screenshots
+
+      - name: Upload screenshots artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-screenshots-android
+          path: app-stores/google/screenshots/**
           if-no-files-found: warn
           retention-days: 14

--- a/app-stores/README.md
+++ b/app-stores/README.md
@@ -13,7 +13,7 @@ app-stores/
   google/
     play-store-submission-guide.md
     play-store-metadata.md
-    screenshots/<device>/           # populated when the Android capture lands
+    screenshots/<device>/           # generated on demand, gitignored (not committed)
 ```
 
 ## Screenshots
@@ -22,6 +22,7 @@ The screenshots are captured from the real native app by the Maestro pipeline:
 
 ```bash
 vp run mobile:screenshots -- --platform ios --backend prod --theme dark
+vp run mobile:screenshots -- --platform android --backend prod --theme dark --app-path /path/to/app.apk
 ```
 
 It writes to `app-stores/<store>/screenshots/<device>/` (`ios` → `apple`,
@@ -29,5 +30,6 @@ It writes to `app-stores/<store>/screenshots/<device>/` (`ios` → `apple`,
 See `packages/mobile/.maestro/README.md` for prerequisites and how it works.
 
 The captured PNGs are **gitignored** — they're regenerated on demand and uploaded
-to App Store Connect by the `Mobile Screenshots (Native)` workflow (run it with
-`upload = true`). See `apple/app-store-submission-guide.md` for the upload flow.
+to App Store Connect / Google Play by the `Mobile Screenshots (Native)` workflow
+(run it with `upload = true`). See the Apple and Google submission guides for
+store-specific upload notes.

--- a/app-stores/google/play-store-submission-guide.md
+++ b/app-stores/google/play-store-submission-guide.md
@@ -49,12 +49,18 @@ Verify the generated assets look correct before proceeding.
 Automated native capture (the real RN app, dark theme) via Maestro:
 
 ```bash
-vp run mobile:screenshots -- --platform android --backend prod --theme dark
+vp run mobile:screenshots -- --platform android --backend prod --theme dark --app-path /path/to/screenshot.apk
 ```
 
-Screenshots are saved to `app-stores/google/screenshots/<device>/`. (The Android
-pipeline is a planned follow-up; until it lands, capture from an emulator
-manually — see the manual alternative below.)
+Screenshots are saved to `app-stores/google/screenshots/<device>/`. The
+`Mobile Screenshots (Native)` GitHub workflow builds an x86_64 screenshot APK,
+runs it on a Pixel 2 emulator, validates the PNGs, and uploads them as an
+artifact on nightly and manual runs.
+
+To update Google Play automatically, dispatch **Mobile Screenshots (Native)** with
+`upload = true`. The workflow runs `fastlane android screenshots`, which uploads
+the phone screenshots only — no APK/AAB and no text metadata. The nightly cron
+never uploads.
 
 ### Required screenshot specs
 
@@ -95,11 +101,12 @@ The Play Store requires AAB format, not APK. (APKs are fine for sideloading and 
 
 ### Local build
 
-The signing config in `build.gradle` reads credentials from environment variables:
+`packages/mobile/` is a managed Expo project. Generate the Android project, then
+build the AAB from the generated Gradle project:
 
 ```bash
-cd mobile
-bunx cap sync android
+cd packages/mobile
+bunx expo prebuild --platform android --clean --no-install
 cd android
 
 ANDROID_KEYSTORE_PATH=/path/to/release.keystore \
@@ -109,15 +116,21 @@ ANDROID_KEY_PASSWORD=yourkeypass \
 ./gradlew bundleRelease --stacktrace
 ```
 
-Output: `mobile/android/app/build/outputs/bundle/release/app-release.aab`
+Output: `packages/mobile/android/app/build/outputs/bundle/release/app-release.aab`
 
 ### CI build
 
-The GitHub Actions workflow (`.github/workflows/android-release.yml`) builds both a signed APK and AAB on every push to `main` that touches `mobile/`. If the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret is configured, it also uploads the AAB to the Google Play internal testing track automatically.
+The GitHub Actions workflow (`.github/workflows/android-apk-rn.yml`) builds the
+React Native APK/AAB on every push to `main` that touches `packages/mobile/`. If
+the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret is configured, it also uploads the
+AAB to the Google Play internal testing track automatically.
 
 ### Increment version code
 
-Before each Play Store upload, increment `versionCode` in `mobile/android/app/build.gradle`. The CI workflow does this automatically using the GitHub Actions run number. For local builds, edit the value manually:
+Before each Play Store upload, increment `versionCode` in the generated
+`packages/mobile/android/app/build.gradle`. The CI workflow does this
+automatically using an offset plus the GitHub Actions run number. For local
+builds, edit the value manually:
 
 ```groovy
 versionCode = 2  // Must be higher than previous upload
@@ -389,13 +402,13 @@ After uploading, check **Quality > Pre-launch report** for crashes, ANRs, and pe
 
 The GitHub Actions workflow requires these repository secrets for automated builds and Play Store uploads:
 
-| Secret                             | Description                                                         |
-| ---------------------------------- | ------------------------------------------------------------------- |
-| `ANDROID_KEYSTORE_BASE64`          | Base64-encoded upload keystore file (`base64 -w0 release.keystore`) |
-| `ANDROID_KEYSTORE_PASSWORD`        | Keystore password                                                   |
-| `ANDROID_KEY_ALIAS`                | Key alias (e.g., `boardsesh`)                                       |
-| `ANDROID_KEY_PASSWORD`             | Key password                                                        |
-| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Google Play API service account JSON for automated uploads          |
+| Secret                             | Description                                                                   |
+| ---------------------------------- | ----------------------------------------------------------------------------- |
+| `ANDROID_KEYSTORE_BASE64`          | Base64-encoded upload keystore file (`base64 -w0 release.keystore`)           |
+| `ANDROID_KEYSTORE_PASSWORD`        | Keystore password                                                             |
+| `ANDROID_KEY_ALIAS`                | Key alias (e.g., `boardsesh`)                                                 |
+| `ANDROID_KEY_PASSWORD`             | Key password                                                                  |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Google Play API service account JSON for automated AAB and screenshot uploads |
 
 ### Create the Google Play service account
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,4 @@
-# Uploads the native App Store screenshots to App Store Connect.
+# Uploads native store screenshots to App Store Connect / Google Play.
 #
 # Screenshots only — no binary, no text metadata, no review submission. The
 # screenshots are captured fresh by `vp run mobile:screenshots` (see
@@ -24,7 +24,9 @@ default_platform(:ios)
 
 REPO_ROOT = File.expand_path("..", __dir__)
 APPLE_SCREENSHOTS_DIR = File.join(REPO_ROOT, "app-stores", "apple", "screenshots", "iphone-16-pro-max")
+GOOGLE_SCREENSHOTS_DIR = File.join(REPO_ROOT, "app-stores", "google", "screenshots", "pixel-2")
 DELIVER_LOCALE = "en-US"
+SUPPLY_LOCALE = "en-US"
 
 platform :ios do
   desc "Upload App Store screenshots to App Store Connect (no binary, no metadata, no review)"
@@ -69,6 +71,48 @@ platform :ios do
         # force: true is mandatory in CI — without it deliver opens an HTML
         # preview in a browser and blocks until timeout.
         force: true
+      )
+    ensure
+      FileUtils.remove_entry(staging_dir) if staging_dir && Dir.exist?(staging_dir)
+    end
+  end
+end
+
+platform :android do
+  desc "Upload Play Store phone screenshots to Google Play (no binary, no text metadata)"
+  lane :screenshots do
+    unless Dir.exist?(GOOGLE_SCREENSHOTS_DIR)
+      UI.user_error!("No screenshots directory at #{GOOGLE_SCREENSHOTS_DIR}. Run `vp run mobile:screenshots -- --platform android` first.")
+    end
+
+    pngs = Dir.glob(File.join(GOOGLE_SCREENSHOTS_DIR, "*.png")).sort
+    if pngs.length < 2
+      UI.user_error!("Found #{pngs.length} PNG(s) in #{GOOGLE_SCREENSHOTS_DIR}. Refusing to upload fewer than 2 Play phone screenshots.")
+    end
+    if pngs.length > 8
+      UI.user_error!("Found #{pngs.length} PNG(s) in #{GOOGLE_SCREENSHOTS_DIR}. Google Play accepts at most 8 phone screenshots.")
+    end
+
+    staging_dir = Dir.mktmpdir("play-screenshots-")
+    begin
+      metadata_dir = File.join(staging_dir, "android")
+      phone_dir = File.join(metadata_dir, SUPPLY_LOCALE, "images", "phoneScreenshots")
+      FileUtils.mkdir_p(phone_dir)
+      pngs.each { |png| FileUtils.cp(png, File.join(phone_dir, File.basename(png))) }
+      UI.message("Staged #{pngs.length} Play phone screenshot(s) into #{phone_dir}")
+
+      upload_to_play_store(
+        package_name: "com.boardsesh.app",
+        json_key_data: ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"),
+        metadata_path: metadata_dir,
+        skip_upload_apk: true,
+        skip_upload_aab: true,
+        skip_upload_metadata: true,
+        skip_upload_changelogs: true,
+        skip_upload_images: true,
+        skip_upload_screenshots: false,
+        sync_image_upload: true,
+        timeout: 300
       )
     ensure
       FileUtils.remove_entry(staging_dir) if staging_dir && Dir.exist?(staging_dir)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,18 +1,24 @@
 # fastlane
 
-One lane: upload the native App Store screenshots to App Store Connect.
+Two screenshot upload lanes: one for App Store Connect, one for Google Play.
 
 ```bash
 cd fastlane && bundle exec fastlane ios screenshots
+cd fastlane && bundle exec fastlane android screenshots
 ```
 
-It uploads the PNGs in `app-stores/apple/screenshots/iphone-16-pro-max/`
-(captured by `vp run mobile:screenshots`) as **screenshots only** — no binary,
-no text metadata, no review submission. deliver routes each image to its display
-slot by pixel dimensions; the `NN-` filename prefixes set the display order.
+The iOS lane uploads PNGs in `app-stores/apple/screenshots/iphone-16-pro-max/`
+to App Store Connect as **screenshots only** — no binary, no text metadata, no
+review submission. `deliver` routes each image to its display slot by pixel
+dimensions; the `NN-` filename prefixes set the display order.
 
-Auth is an App Store Connect API key, read from the environment (same key as the
-TestFlight workflows):
+The Android lane uploads PNGs in `app-stores/google/screenshots/pixel-2/` to the
+Google Play phone screenshot slot as **screenshots only** — no APK/AAB and no
+text metadata. It stages them into fastlane `supply`'s expected
+`en-US/images/phoneScreenshots/` structure.
+
+iOS auth is an App Store Connect API key, read from the environment (same key as
+the TestFlight workflows):
 
 | Env var                        | Purpose                               |
 | ------------------------------ | ------------------------------------- |
@@ -20,8 +26,11 @@ TestFlight workflows):
 | `APP_STORE_CONNECT_ISSUER_ID`  | ASC API issuer id                     |
 | `ASC_KEY_PATH`                 | path to the decoded `.p8` private key |
 
-In CI this runs from the `Mobile Screenshots (Native)` workflow when dispatched
-with `upload = true` (it's never on the nightly cron). The upload targets the
-currently **editable** App Store version — see the "Automated screenshot upload"
-section of `../app-stores/apple/app-store-submission-guide.md` for the
-editable-version caveat and the full flow.
+Android auth is the Play service account JSON:
+
+| Env var                            | Purpose                                   |
+| ---------------------------------- | ----------------------------------------- |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Google Play Developer API service account |
+
+In CI these lanes run from the `Mobile Screenshots (Native)` workflow when
+dispatched with `upload = true` (never on the nightly cron).

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -3,16 +3,20 @@
 Native App Store / onboarding screenshot capture for the Boardsesh mobile app.
 Driven by [Maestro](https://maestro.mobile.dev). Don't run these by hand — the
 orchestrator (`scripts/mobile-screenshots.ts`, exposed as `vp run
-mobile:screenshots`) boots the simulator, applies a clean status bar, installs a
-Debug **dev-client** `.app` (prebuilt/cached, or built on the fly when no
-`--app-path` is given), resets the keychain, then starts **Metro** with
-`EXPO_PUBLIC_SCREENSHOT_MODE=1`. The flow loads the JS bundle from Metro (via the
-expo-development-client deep link), captures each screen, and the orchestrator
-collects the PNGs into `app-stores/<apple|google>/screenshots/<device>/`.
+mobile:screenshots`) prepares the simulator/emulator, applies a clean status bar,
+installs the native app artifact, captures each screen, and collects the PNGs
+into `app-stores/<apple|google>/screenshots/<device>/`.
 
+On iOS, the artifact is a Debug **dev-client** `.app` (prebuilt/cached, or built
+on the fly when no `--app-path` is given). The flow starts **Metro** with
+`EXPO_PUBLIC_SCREENSHOT_MODE=1` and opens the expo-development-client deep link.
 The screenshot behaviour lives in the **Metro JS bundle**, not the native binary,
 so the `.app` is reusable and CI caches it (keyed on native inputs) — a JS-only
 run skips the ~30-min native build. See `scripts/mobile-build-sim-app.ts`.
+
+On Android, the artifact is a standalone screenshot APK built with the same
+`EXPO_PUBLIC_SCREENSHOT_*` values present during Gradle's JS bundle step. The
+Android flows use `launchApp`, not the iOS dev-client deep link.
 
 ## Backend
 
@@ -27,10 +31,10 @@ simulator keychain first so login authenticates cleanly against prod.
 - `login.yaml` — reusable subflow. Fills the test credentials, submits via the
   keyboard return key, and dismisses the iOS "Save Password" prompt. Only runs
   when the auth screen is showing (the Keychain token survives `clearState`).
-- `app-store.yaml` — logs in, then captures Home, Discover, Profile, Climbs,
-  Record, and the board view.
-- `onboarding.yaml` — captures app screens for onboarding-card illustrations
-  (`--flow onboarding`).
+- `app-store.yaml` / `app-store-android.yaml` — log in, then capture Home,
+  Discover, Profile, Climbs, Record, board view, and board sheet.
+- `onboarding.yaml` / `onboarding-android.yaml` — capture app screens for
+  onboarding-card illustrations (`--flow onboarding`).
 
 ## Required env (passed by the orchestrator via `maestro test -e`)
 
@@ -40,7 +44,7 @@ simulator keychain first so login authenticates cleanly against prod.
 
 ## Notes
 
-- The app is a dev-client, so each flow first loads its JS from Metro with
+- The iOS app is a dev-client, so each iOS flow first loads its JS from Metro with
   `openLink: ${MAESTRO_DEV_CLIENT_URL}` instead of `launchApp` — a bare launch
   would land on the launcher. The orchestrator passes that env via `maestro test
 -e` (an `expo-development-client` deep link pointing at its Metro port, default
@@ -51,6 +55,9 @@ simulator keychain first so login authenticates cleanly against prod.
   cold bundle on a slow CI runner. The orchestrator uninstalls + reinstalls and
   resets the keychain, so the app cold-loads signed out with fresh app data (no
   Maestro `clearState` needed).
+- The Android app is a standalone screenshot APK, so Android flows use
+  `launchApp`. The orchestrator uninstalls + reinstalls the APK and clears app
+  data before capture.
 - Navigation uses custom-scheme deep links (`com.boardsesh.app://<route>`); Expo
   Router maps tab routes with the `(tabs)` group stripped (`://climbs`, `://home`,
   `://boards`, …). Each `openLink` is followed by an optional `tapOn "Open"` to

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -1,0 +1,68 @@
+appId: com.boardsesh.app
+name: app-store screenshots android
+---
+# Play Store screenshots from the standalone screenshot APK. Unlike iOS, this
+# APK already contains the screenshot-mode JS bundle, so launch the app directly
+# instead of opening an expo-development-client URL.
+#
+# Coordinate taps are pinned to the CI Pixel 2 emulator at 1080x1920:
+#   board pick = '24%,45%' (first "Your boards" card on /boards)
+#   board sheet = '78%,10%' (board-switcher glyph in the climbs top chrome)
+#   board view  = '50%,26%' (first climb row in the list)
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'auth-email-input'
+    timeout: 180000
+- runFlow: login.yaml
+
+# Home — feed populated by the prod test user's follows.
+- waitForAnimationToEnd
+- takeScreenshot: 00-home
+
+# Discover — playlists.
+- openLink: com.boardsesh.app://discover
+- waitForAnimationToEnd
+- takeScreenshot: 03-discover
+
+# Profile — stats, sessions, logbook.
+- openLink: com.boardsesh.app://profile
+- waitForAnimationToEnd
+- takeScreenshot: 05-profile
+
+# Activate a board so Climbs / board-view / board-sheet / generator render real
+# content. Open the board picker and tap the first card under "Your boards".
+- openLink: com.boardsesh.app://boards
+- waitForAnimationToEnd
+- tapOn:
+    point: '24%,45%'
+- waitForAnimationToEnd
+
+# Climbs — the main browse surface.
+- openLink: com.boardsesh.app://climbs
+- waitForAnimationToEnd
+- takeScreenshot: 01-climbs
+
+# Workout generator — the Record/session screen with a workout pre-selected.
+- openLink: com.boardsesh.app://record
+- waitForAnimationToEnd
+- takeScreenshot: 04-workout-generator
+
+# Board view — open the first climb.
+- openLink: com.boardsesh.app://climbs
+- waitForAnimationToEnd
+- tapOn:
+    point: '50%,26%'
+- waitForAnimationToEnd
+- takeScreenshot: 02-board-view
+
+# Board sheet — relaunch first so the play drawer from the board-view shot is
+# gone, then open Climbs and tap the board-switcher glyph.
+- launchApp
+- waitForAnimationToEnd
+- openLink: com.boardsesh.app://climbs
+- waitForAnimationToEnd
+- tapOn:
+    point: '78%,10%'
+- waitForAnimationToEnd
+- takeScreenshot: 06-board-sheet

--- a/packages/mobile/.maestro/onboarding-android.yaml
+++ b/packages/mobile/.maestro/onboarding-android.yaml
@@ -1,0 +1,22 @@
+appId: com.boardsesh.app
+name: onboarding illustrations android
+---
+# Android version of onboarding.yaml for the standalone screenshot APK.
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'auth-email-input'
+    timeout: 180000
+- runFlow: login.yaml
+
+- openLink: com.boardsesh.app://climbs
+- extendedWaitUntil:
+    visible:
+      id: 'climb-list'
+    timeout: 30000
+- waitForAnimationToEnd
+- takeScreenshot: onboarding-welcome
+
+- openLink: com.boardsesh.app://discover
+- waitForAnimationToEnd
+- takeScreenshot: onboarding-play

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -352,6 +352,9 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // Caps Gradle heap + parallel workers so the heavy native build (CMake ×4
       // ABIs + Kotlin + JS bundle + R8) doesn't OOM-kill the daemon. EAS-safe.
       './plugins/with-android-gradle-memory',
+      // Pins the generated Android wrapper below Gradle 9 until React Native's
+      // included Foojay toolchain resolver plugin is compatible with Gradle 9.
+      './plugins/with-android-gradle-wrapper-version',
       // Register this before @bacons/apple-targets so Expo's mod chain runs it
       // after the widget target has been created, while keeping the provider last.
       './plugins/with-boardsesh-widget-build-settings',

--- a/packages/mobile/plugins/with-android-gradle-wrapper-version.js
+++ b/packages/mobile/plugins/with-android-gradle-wrapper-version.js
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { createRunOncePlugin, withDangerousMod } = require('expo/config-plugins');
+
+// React Native 0.85.3's included Gradle plugin still pins the Foojay resolver
+// convention plugin at 0.5.0. That resolver fails under Gradle 9.3.x, which Expo
+// 56 currently generates locally. Pin the generated app wrapper to a compatible
+// Gradle runtime until React Native updates the included build plugin.
+const GRADLE_VERSION = '8.14.3';
+const DISTRIBUTION_URL = `https\\://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip`;
+
+function applyAndroidGradleWrapperVersion(contents) {
+  if (/^distributionUrl=/m.test(contents)) {
+    return contents.replace(/^distributionUrl=.*$/m, `distributionUrl=${DISTRIBUTION_URL}`);
+  }
+
+  return `${contents.trimEnd()}\ndistributionUrl=${DISTRIBUTION_URL}\n`;
+}
+
+function withAndroidGradleWrapperVersion(config) {
+  return withDangerousMod(config, [
+    'android',
+    (modConfig) => {
+      const wrapperPath = path.join(
+        modConfig.modRequest.platformProjectRoot,
+        'gradle',
+        'wrapper',
+        'gradle-wrapper.properties',
+      );
+      const contents = fs.readFileSync(wrapperPath, 'utf8');
+      fs.writeFileSync(wrapperPath, applyAndroidGradleWrapperVersion(contents));
+      return modConfig;
+    },
+  ]);
+}
+
+module.exports = createRunOncePlugin(withAndroidGradleWrapperVersion, 'with-android-gradle-wrapper-version', '1.0.0');
+module.exports.applyAndroidGradleWrapperVersion = applyAndroidGradleWrapperVersion;
+module.exports.GRADLE_VERSION = GRADLE_VERSION;
+module.exports.DISTRIBUTION_URL = DISTRIBUTION_URL;

--- a/packages/mobile/src/lib/__tests__/android-gradle-wrapper-version-plugin.test.ts
+++ b/packages/mobile/src/lib/__tests__/android-gradle-wrapper-version-plugin.test.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type AndroidGradleWrapperVersionPlugin = {
+  applyAndroidGradleWrapperVersion(contents: string): string;
+  DISTRIBUTION_URL: string;
+  GRADLE_VERSION: string;
+};
+
+const plugin = require('../../../plugins/with-android-gradle-wrapper-version.js') as AndroidGradleWrapperVersionPlugin;
+
+describe('with-android-gradle-wrapper-version', () => {
+  it('pins an existing distributionUrl to the supported Gradle runtime', () => {
+    const result = plugin.applyAndroidGradleWrapperVersion(
+      [
+        'distributionBase=GRADLE_USER_HOME',
+        'distributionPath=wrapper/dists',
+        'distributionUrl=https\\://services.gradle.org/distributions/gradle-9.3.1-bin.zip',
+        'zipStoreBase=GRADLE_USER_HOME',
+      ].join('\n'),
+    );
+
+    expect(result).toContain(`distributionUrl=${plugin.DISTRIBUTION_URL}`);
+    expect(result).toContain('zipStoreBase=GRADLE_USER_HOME');
+    expect(result).not.toContain('gradle-9.3.1');
+  });
+
+  it('appends distributionUrl when the wrapper file is missing it', () => {
+    const result = plugin.applyAndroidGradleWrapperVersion('distributionBase=GRADLE_USER_HOME\n');
+
+    expect(result).toBe(`distributionBase=GRADLE_USER_HOME\ndistributionUrl=${plugin.DISTRIBUTION_URL}\n`);
+  });
+
+  it('documents the Gradle version being pinned', () => {
+    expect(plugin.GRADLE_VERSION).toBe('8.14.3');
+  });
+});

--- a/scripts/__tests__/assert-screenshot-dimensions.test.ts
+++ b/scripts/__tests__/assert-screenshot-dimensions.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { type Dimensions, findOffenders, readPngDimensions } from '../assert-screenshot-dimensions';
+import {
+  type Dimensions,
+  findGooglePlayOffenders,
+  findOffenders,
+  readPngDimensions,
+} from '../assert-screenshot-dimensions';
 
 /** Build a minimal valid PNG header: signature + IHDR length + "IHDR" + width/height. */
 function pngHeader({ width, height }: Dimensions): Buffer {
@@ -67,5 +72,53 @@ describe('findOffenders', () => {
   it('reports a corrupt PNG as an offender rather than throwing', () => {
     const offenders = findOffenders(slug, [{ name: `${slug}/corrupt.png`, buffer: Buffer.alloc(4) }]);
     expect(offenders).toHaveLength(1);
+  });
+});
+
+describe('findGooglePlayOffenders', () => {
+  const slug = 'pixel-2';
+
+  it('accepts 2-8 Play phone screenshots in the allowed size range', () => {
+    const offenders = findGooglePlayOffenders(slug, [
+      { name: `${slug}/00-home.png`, buffer: pngHeader({ width: 1080, height: 1920 }) },
+      { name: `${slug}/01-climbs.png`, buffer: pngHeader({ width: 1080, height: 1920 }) },
+    ]);
+    expect(offenders).toEqual([]);
+  });
+
+  it('requires at least two Play phone screenshots', () => {
+    const offenders = findGooglePlayOffenders(slug, [
+      { name: `${slug}/00-home.png`, buffer: pngHeader({ width: 1080, height: 1920 }) },
+    ]);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0].reason).toMatch(/at least 2/);
+  });
+
+  it('rejects more than eight Play phone screenshots', () => {
+    const files = Array.from({ length: 9 }, (_, index) => ({
+      name: `${slug}/0${index}-shot.png`,
+      buffer: pngHeader({ width: 1080, height: 1920 }),
+    }));
+    const offenders = findGooglePlayOffenders(slug, files);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0].reason).toMatch(/at most 8/);
+  });
+
+  it('rejects Play screenshots below the minimum side length', () => {
+    const offenders = findGooglePlayOffenders(slug, [
+      { name: `${slug}/00-home.png`, buffer: pngHeader({ width: 319, height: 568 }) },
+      { name: `${slug}/01-climbs.png`, buffer: pngHeader({ width: 1080, height: 1920 }) },
+    ]);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0].reason).toMatch(/at least 320px/);
+  });
+
+  it('rejects Play screenshots whose long side is more than twice the short side', () => {
+    const offenders = findGooglePlayOffenders(slug, [
+      { name: `${slug}/00-home.png`, buffer: pngHeader({ width: 1000, height: 2100 }) },
+      { name: `${slug}/01-climbs.png`, buffer: pngHeader({ width: 1080, height: 1920 }) },
+    ]);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0].reason).toMatch(/no more than 2x/);
   });
 });

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -79,6 +79,10 @@ describe('parseArgs', () => {
     });
   });
 
+  it('defaults Android captures to the Play phone emulator device', () => {
+    expect(parseArgs(['--platform', 'android']).device).toBe('Pixel 2');
+  });
+
   it('maps --workout off to null', () => {
     expect(parseArgs(['--workout', 'off']).workout).toBeNull();
   });

--- a/scripts/assert-screenshot-dimensions.ts
+++ b/scripts/assert-screenshot-dimensions.ts
@@ -1,24 +1,22 @@
 /// <reference types="node" />
 
 /**
- * Dimension gate for the App Store screenshots before they're uploaded to
- * App Store Connect.
+ * Dimension gate for mobile store screenshots before they're uploaded.
  *
- * `fastlane deliver` routes each screenshot to a display slot by its pixel
- * dimensions, so a capture-resolution change (e.g. a new default simulator)
- * could silently produce PNGs Apple rejects, or that land in the wrong slot.
- * This gate runs after capture and fails loudly — listing every offender —
- * before fastlane ever talks to Apple.
+ * App Store Connect routes each screenshot to a display slot by exact pixel
+ * dimensions, so iOS captures are checked against device-specific allow-lists.
+ * Google Play accepts a broader phone screenshot range, so Android captures are
+ * checked against Play's generic size/count rules.
  *
  * It reads width/height straight from each PNG's IHDR header (no `sips` /
  * ImageMagick), so it runs identically on Linux CI and macOS.
  *
  * Usage:
- *   vp run check:screenshot-dimensions
+ *   vp run check:screenshot-dimensions -- --platform ios
+ *   vp run check:screenshot-dimensions -- --platform android
  *
- * Exit code 0 when every PNG under app-stores/apple/screenshots/<device>/ is an
- * App Store-accepted size for its device slot; 1 otherwise (including when no
- * PNGs are present, so a failed/empty capture can't pass silently).
+ * The default platform is ios for backwards compatibility with the original
+ * App Store-only gate.
  */
 
 import { readFileSync, readdirSync } from 'node:fs';
@@ -27,6 +25,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const APPLE_SHOTS_DIR = resolve(ROOT_DIR, 'app-stores', 'apple', 'screenshots');
+const GOOGLE_SHOTS_DIR = resolve(ROOT_DIR, 'app-stores', 'google', 'screenshots');
 const LOG = '[check:screenshot-dimensions]';
 
 // First 8 bytes of every PNG file.
@@ -44,8 +43,8 @@ export interface Dimensions {
  * slug can't sneak un-validated sizes past the gate.
  */
 export const ACCEPTED_SIZES: Record<string, readonly Dimensions[]> = {
-  // 6.9" iPhone slot. Apple accepts the iPhone 16 Pro Max native 1320×2868 or
-  // the prior-gen 1290×2796 in this slot.
+  // 6.9" iPhone slot. Apple accepts the iPhone 16 Pro Max native 1320x2868 or
+  // the prior-gen 1290x2796 in this slot.
   'iphone-16-pro-max': [
     { width: 1320, height: 2868 },
     { width: 1290, height: 2796 },
@@ -76,7 +75,7 @@ export interface Offender {
   reason: string;
 }
 
-/** Pure: validate one device folder's PNGs against its accepted-size allow-list. */
+/** Pure: validate one Apple device folder's PNGs against its accepted-size allow-list. */
 export function findOffenders(deviceSlug: string, files: readonly PngFile[]): Offender[] {
   const accepted = ACCEPTED_SIZES[deviceSlug];
   if (!accepted) {
@@ -107,46 +106,144 @@ export function findOffenders(deviceSlug: string, files: readonly PngFile[]): Of
   return offenders;
 }
 
-function main(): number {
+/** Pure: validate one Google Play phone screenshot folder. */
+export function findGooglePlayOffenders(deviceSlug: string, files: readonly PngFile[]): Offender[] {
+  const offenders: Offender[] = [];
+  if (files.length < 2) {
+    offenders.push({
+      file: `${deviceSlug}/`,
+      reason: `has ${files.length} screenshot(s), expected at least 2 for a Play phone listing`,
+    });
+  }
+  if (files.length > 8) {
+    offenders.push({
+      file: `${deviceSlug}/`,
+      reason: `has ${files.length} screenshot(s), expected at most 8 for a Play phone listing`,
+    });
+  }
+
+  for (const file of files) {
+    let dimensions: Dimensions;
+    try {
+      dimensions = readPngDimensions(file.buffer);
+    } catch (error) {
+      offenders.push({ file: file.name, reason: error instanceof Error ? error.message : String(error) });
+      continue;
+    }
+
+    const shorterSide = Math.min(dimensions.width, dimensions.height);
+    const longerSide = Math.max(dimensions.width, dimensions.height);
+    if (shorterSide < 320) {
+      offenders.push({
+        file: file.name,
+        reason: `is ${dimensions.width}x${dimensions.height}, expected both sides to be at least 320px`,
+      });
+      continue;
+    }
+    if (longerSide > 3840) {
+      offenders.push({
+        file: file.name,
+        reason: `is ${dimensions.width}x${dimensions.height}, expected both sides to be at most 3840px`,
+      });
+      continue;
+    }
+    if (longerSide > shorterSide * 2) {
+      offenders.push({
+        file: file.name,
+        reason: `is ${dimensions.width}x${dimensions.height}, expected the long side to be no more than 2x the short side`,
+      });
+    }
+  }
+  return offenders;
+}
+
+type ScreenshotPlatform = 'ios' | 'android' | 'all';
+
+function parsePlatform(argv: readonly string[]): ScreenshotPlatform {
+  const args = argv.filter((argument) => argument !== '--');
+  let platform: ScreenshotPlatform = 'ios';
+  for (let index = 0; index < args.length; index++) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag !== '--platform') {
+      throw new Error(`Unknown argument: ${flag}`);
+    }
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error('--platform requires a value');
+    }
+    if (value !== 'ios' && value !== 'android' && value !== 'all') {
+      throw new Error(`--platform must be one of: ios, android, all (got "${value}")`);
+    }
+    platform = value;
+    index++;
+  }
+  return platform;
+}
+
+function validateScreenshotRoot(
+  rootDir: string,
+  platformName: string,
+  validator: (deviceSlug: string, files: readonly PngFile[]) => Offender[],
+): number {
   let deviceDirs: string[];
   try {
-    deviceDirs = readdirSync(APPLE_SHOTS_DIR, { withFileTypes: true })
+    deviceDirs = readdirSync(rootDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
   } catch {
-    console.error(`${LOG} FAILED: ${APPLE_SHOTS_DIR} not found — run \`vp run mobile:screenshots\` first.`);
+    console.error(`${LOG} FAILED: ${rootDir} not found - run \`vp run mobile:screenshots\` first.`);
     return 1;
   }
 
   const offenders: Offender[] = [];
   let pngCount = 0;
   for (const slug of deviceDirs) {
-    const dir = join(APPLE_SHOTS_DIR, slug);
+    const dir = join(rootDir, slug);
     const pngNames = readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.png'));
     const files: PngFile[] = pngNames.map((name) => ({
       name: `${slug}/${name}`,
       buffer: readFileSync(join(dir, name)),
     }));
     pngCount += files.length;
-    offenders.push(...findOffenders(slug, files));
+    offenders.push(...validator(slug, files));
   }
 
   if (pngCount === 0) {
-    console.error(`${LOG} FAILED: no screenshots found under ${APPLE_SHOTS_DIR}.`);
+    console.error(`${LOG} FAILED: no screenshots found under ${rootDir}.`);
     return 1;
   }
   if (offenders.length > 0) {
-    console.error(`${LOG} FAILED: ${offenders.length} screenshot(s) are not an App Store-accepted size:`);
+    console.error(`${LOG} FAILED: ${offenders.length} ${platformName} screenshot issue(s):`);
     for (const offender of offenders) {
       console.error(`  - ${offender.file}: ${offender.reason}`);
     }
     return 1;
   }
 
-  console.log(`${LOG} OK: ${pngCount} screenshot(s) match an accepted App Store size.`);
+  console.log(`${LOG} OK: ${pngCount} ${platformName} screenshot(s) match accepted dimensions.`);
+  return 0;
+}
+
+function main(argv: readonly string[] = process.argv.slice(2)): number {
+  let platform: ScreenshotPlatform;
+  try {
+    platform = parsePlatform(argv);
+  } catch (error) {
+    console.error(`${LOG} ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  const platforms: Array<'ios' | 'android'> = platform === 'all' ? ['ios', 'android'] : [platform];
+  for (const selectedPlatform of platforms) {
+    const status =
+      selectedPlatform === 'ios'
+        ? validateScreenshotRoot(APPLE_SHOTS_DIR, 'App Store', findOffenders)
+        : validateScreenshotRoot(GOOGLE_SHOTS_DIR, 'Google Play', findGooglePlayOffenders);
+    if (status !== 0) return status;
+  }
   return 0;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  process.exit(main());
+  process.exit(main(process.argv.slice(2)));
 }

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -3,31 +3,33 @@
 /**
  * Automated native screenshot capture for packages/mobile.
  *
- * The screenshot app is a Debug *dev-client* that loads its JS from Metro at
+ * The iOS screenshot app is a Debug *dev-client* that loads its JS from Metro at
  * runtime. The screenshot behaviour (EXPO_PUBLIC_SCREENSHOT_MODE, theme,
  * workout) is baked into the Metro JS bundle, NOT the native binary — so the
  * .app is reusable and only the JS regenerates per run. This is why CI can cache
  * the .app (see scripts/mobile-build-sim-app.ts) keyed on native inputs and skip
  * the ~30-min from-scratch compile on JS-only changes.
  *
- * Flow: boot a simulator, apply a clean status bar, get the .app (--app-path, or
- * build one via mobile-build-sim-app), uninstall+install it, reset the keychain,
- * start Metro with EXPO_PUBLIC_SCREENSHOT_MODE=1, then run a Maestro flow that
- * loads the bundle from Metro (dev-client deep link), deep-links to each screen
- * and captures it. PNGs land in app-stores/<store>/screenshots/<device>/ (ios ->
- * apple, android -> google).
+ * The Android screenshot app is a standalone APK built by Gradle with those same
+ * EXPO_PUBLIC_* values present at JS bundle time. The orchestrator installs that
+ * APK on an already-booted emulator and runs a platform-specific Maestro flow.
+ *
+ * Flow: prepare a simulator/emulator, apply a clean status bar, install the app
+ * artifact, run a Maestro flow that deep-links to each screen and captures it.
+ * PNGs land in app-stores/<store>/screenshots/<device>/ (ios -> apple, android
+ * -> google).
  *
  * Usage:
  *   vp run mobile:screenshots -- [--platform ios] [--flow app-store|onboarding]
  *                                 [--backend local|prod] [--device "iPhone 16 Pro Max"]
  *                                 [--variant material|liquidGlass] [--shutdown]
- *                                 [--app-path <path/to/Boardsesh.app>]
+ *                                 [--app-path <path/to/Boardsesh.app|app.apk>]
  *
- * Requires: macOS + Xcode simulators, and Maestro (https://maestro.mobile.dev).
- * For --backend local, bring up the seeded dev DB + backend first (`vp run dev`).
- * Without --app-path the script builds a Debug simulator .app first (slow); CI
- * passes a cached/prebuilt .app so the common path is just install + Metro +
- * Maestro. Credentials come from SCREENSHOT_USER_EMAIL / SCREENSHOT_USER_PASSWORD
+ * Requires: Maestro (https://maestro.mobile.dev) plus platform tooling (xcrun for
+ * iOS, adb for Android). For --backend local, bring up the seeded dev DB +
+ * backend first (`vp run dev`). iOS can build a Debug simulator .app when
+ * --app-path is omitted; Android expects --app-path to point at a prebuilt APK.
+ * Credentials come from SCREENSHOT_USER_EMAIL / SCREENSHOT_USER_PASSWORD
  * (default test@boardsesh.com / test).
  */
 
@@ -54,7 +56,18 @@ const LOG = '[mobile:screenshots]';
 
 const APP_ID = 'com.boardsesh.app';
 const DEFAULT_IOS_DEVICE = 'iPhone 16 Pro Max';
+const DEFAULT_ANDROID_DEVICE = 'Pixel 2';
 const IOS_DEVICE_TYPE_ID = 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max';
+const DEFAULT_ANDROID_APK = resolve(
+  MOBILE_DIR,
+  'android',
+  'app',
+  'build',
+  'outputs',
+  'apk',
+  'release',
+  'app-release.apk',
+);
 // Mirrors packages/mobile/.env.example. iOS simulators reach the host directly,
 // so localhost is correct for a sim build pointed at the local dev backend.
 const LOCAL_BACKEND_URL = 'http://localhost:8080';
@@ -78,13 +91,14 @@ export interface ScreenshotOptions {
   theme: ScreenshotTheme;
   /** Workout type the Record/session screen pre-selects (generator screenshot); null = Off. */
   workout: string | null;
-  /** Prebuilt/cached Boardsesh.app to install; null builds one (slow, local only). */
+  /** Prebuilt/cached app artifact to install; iOS can build one when null. */
   appPath: string | null;
   shutdown: boolean;
 }
 
 export function parseArgs(argv: readonly string[]): ScreenshotOptions {
   const args = argv.filter((argument) => argument !== '--');
+  let deviceProvided = false;
   const options: ScreenshotOptions = {
     platform: 'ios',
     flow: 'app-store',
@@ -119,6 +133,7 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
         break;
       case '--device':
         options.device = expectValue(flag, value);
+        deviceProvided = true;
         index++;
         break;
       case '--variant':
@@ -145,6 +160,10 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
       default:
         throw new Error(`Unknown argument: ${flag}`);
     }
+  }
+
+  if (!deviceProvided && options.platform === 'android') {
+    options.device = DEFAULT_ANDROID_DEVICE;
   }
 
   return options;
@@ -337,6 +356,12 @@ function collectScreenshots(captureDir: string, platform: 'ios' | 'android', dev
   return pngs.map((png) => join(outputDir, png));
 }
 
+function flowFileForPlatform(options: ScreenshotOptions, platform: 'ios' | 'android'): string {
+  const platformFlowFile = join(MAESTRO_DIR, `${options.flow}-${platform}.yaml`);
+  if (existsSync(platformFlowFile)) return platformFlowFile;
+  return join(MAESTRO_DIR, `${options.flow}.yaml`);
+}
+
 function runIos(options: ScreenshotOptions): number {
   if (!commandExists('xcrun') || runCapture('xcrun', ['simctl', 'help']).status !== 0) {
     console.log(`${LOG} Skipped: iOS simulator tooling (xcrun simctl) not available.`);
@@ -433,7 +458,7 @@ function runIos(options: ScreenshotOptions): number {
       'NO',
     ]);
 
-    const flowFile = join(MAESTRO_DIR, `${options.flow}.yaml`);
+    const flowFile = flowFileForPlatform(options, 'ios');
     if (!existsSync(flowFile)) {
       console.error(`${LOG} FAILED: flow not found: ${flowFile}`);
       return 1;
@@ -490,6 +515,219 @@ function runIos(options: ScreenshotOptions): number {
   }
 
   return 0;
+}
+
+function runAndroid(options: ScreenshotOptions): number {
+  if (!commandExists('adb') || runCapture('adb', ['version']).status !== 0) {
+    console.error(`${LOG} FAILED: Android platform tooling (adb) is not available.`);
+    return 1;
+  }
+  if (!commandExists('maestro')) {
+    console.error(`${LOG} FAILED: Maestro not found on PATH. ${MAESTRO_INSTALL_HINT}`);
+    return 1;
+  }
+
+  const deviceId = resolveAndroidDeviceId();
+  if (!deviceId) {
+    console.error(`${LOG} FAILED: no ready Android device/emulator found in \`adb devices\`.`);
+    return 1;
+  }
+
+  const appPath = resolveAndroidAppPath(options);
+  const deviceName = androidDeviceName(options);
+  console.log(`${LOG} Installing ${appPath} on ${deviceId} (${deviceName})...`);
+  runCapture('adb', ['-s', deviceId, 'uninstall', APP_ID]);
+  const installStatus = runInherit('adb', ['-s', deviceId, 'install', '-r', appPath], process.env);
+  if (installStatus !== 0) {
+    console.error(`${LOG} FAILED: adb install exited ${installStatus}.`);
+    return installStatus;
+  }
+  // The uninstall should leave a fresh data directory. Clear again after install
+  // so reruns against an already-installed, same-signature APK also start signed
+  // out with no stale active board.
+  runCapture('adb', ['-s', deviceId, 'shell', 'pm', 'clear', APP_ID]);
+  applyCleanAndroidStatusBar(deviceId);
+
+  const flowFile = flowFileForPlatform(options, 'android');
+  if (!existsSync(flowFile)) {
+    console.error(`${LOG} FAILED: flow not found: ${flowFile}`);
+    return 1;
+  }
+
+  const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-android-shots-'));
+  try {
+    const email = process.env.SCREENSHOT_USER_EMAIL ?? DEFAULT_USER_EMAIL;
+    const password = process.env.SCREENSHOT_USER_PASSWORD ?? DEFAULT_USER_PASSWORD;
+    console.log(`${LOG} Running Maestro flow ${options.flow} on ${deviceId}...`);
+    const maestroStatus = runInherit(
+      'maestro',
+      [
+        '--device',
+        deviceId,
+        'test',
+        flowFile,
+        '-e',
+        `SCREENSHOT_USER_EMAIL=${email}`,
+        '-e',
+        `SCREENSHOT_USER_PASSWORD=${password}`,
+      ],
+      process.env,
+      captureDir,
+    );
+    if (maestroStatus !== 0) {
+      console.error(`${LOG} FAILED: Maestro exited with ${maestroStatus}.`);
+      return maestroStatus;
+    }
+
+    const saved = collectScreenshots(captureDir, 'android', deviceName);
+    if (saved.length === 0) {
+      console.error(`${LOG} WARNING: flow completed but no PNGs were captured.`);
+      return 1;
+    }
+    console.log(
+      `${LOG} Saved ${saved.length} screenshot(s) to app-stores/${STORE_BY_PLATFORM.android}/screenshots/${deviceSlug(deviceName)}/`,
+    );
+    for (const file of saved) console.log(`${LOG}   ${file}`);
+  } finally {
+    clearAndroidStatusBar(deviceId);
+    rmSync(captureDir, { force: true, recursive: true });
+    if (options.shutdown && deviceId.startsWith('emulator-')) {
+      runCapture('adb', ['-s', deviceId, 'emu', 'kill']);
+    }
+  }
+
+  return 0;
+}
+
+function resolveAndroidDeviceId(): string | null {
+  const explicitSerial = process.env.ANDROID_SERIAL;
+  if (explicitSerial && explicitSerial.length > 0) return explicitSerial;
+
+  const { status, stdout } = runCapture('adb', ['devices']);
+  if (status !== 0) return null;
+  const readyDevices = stdout
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(/\s+/))
+    .filter((parts) => parts[1] === 'device')
+    .map((parts) => parts[0]);
+  return readyDevices[0] ?? null;
+}
+
+function androidDeviceName(options: ScreenshotOptions): string {
+  return options.device === DEFAULT_IOS_DEVICE ? DEFAULT_ANDROID_DEVICE : options.device;
+}
+
+function resolveAndroidAppPath(options: ScreenshotOptions): string {
+  if (options.appPath) {
+    if (!existsSync(options.appPath)) {
+      throw new Error(`--app-path not found: ${options.appPath}`);
+    }
+    return options.appPath;
+  }
+  if (existsSync(DEFAULT_ANDROID_APK)) {
+    return DEFAULT_ANDROID_APK;
+  }
+  throw new Error(
+    `Android capture requires --app-path <path/to/app.apk>. Build the screenshot APK first, or place one at ${DEFAULT_ANDROID_APK}.`,
+  );
+}
+
+function applyCleanAndroidStatusBar(deviceId: string): void {
+  runCapture('adb', ['-s', deviceId, 'shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1']);
+  runCapture('adb', [
+    '-s',
+    deviceId,
+    'shell',
+    'am',
+    'broadcast',
+    '-a',
+    'com.android.systemui.demo',
+    '-e',
+    'command',
+    'enter',
+  ]);
+  runCapture('adb', [
+    '-s',
+    deviceId,
+    'shell',
+    'am',
+    'broadcast',
+    '-a',
+    'com.android.systemui.demo',
+    '-e',
+    'command',
+    'clock',
+    '-e',
+    'hhmm',
+    '0941',
+  ]);
+  runCapture('adb', [
+    '-s',
+    deviceId,
+    'shell',
+    'am',
+    'broadcast',
+    '-a',
+    'com.android.systemui.demo',
+    '-e',
+    'command',
+    'battery',
+    '-e',
+    'level',
+    '100',
+    '-e',
+    'plugged',
+    'true',
+  ]);
+  runCapture('adb', [
+    '-s',
+    deviceId,
+    'shell',
+    'am',
+    'broadcast',
+    '-a',
+    'com.android.systemui.demo',
+    '-e',
+    'command',
+    'network',
+    '-e',
+    'wifi',
+    'show',
+    '-e',
+    'level',
+    '4',
+    '-e',
+    'mobile',
+    'show',
+    '-e',
+    'datatype',
+    'lte',
+    '-e',
+    'sims',
+    '1',
+    '-e',
+    'nosim',
+    'false',
+  ]);
+  runCapture('adb', ['-s', deviceId, 'shell', 'cmd', 'notification', 'dismiss-all']);
+}
+
+function clearAndroidStatusBar(deviceId: string): void {
+  runCapture('adb', [
+    '-s',
+    deviceId,
+    'shell',
+    'am',
+    'broadcast',
+    '-a',
+    'com.android.systemui.demo',
+    '-e',
+    'command',
+    'exit',
+  ]);
 }
 
 /**
@@ -621,19 +859,19 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     return 1;
   }
 
-  if (options.platform === 'android' || options.platform === 'all') {
-    console.error(
-      `${LOG} Android capture isn't wired up yet — the iOS pipeline lands first. Rerun with --platform ios.`,
-    );
-    return 1;
+  const platforms: Array<'ios' | 'android'> = options.platform === 'all' ? ['ios', 'android'] : [options.platform];
+
+  for (const platform of platforms) {
+    try {
+      const status = platform === 'ios' ? runIos(options) : runAndroid(options);
+      if (status !== 0) return status;
+    } catch (error) {
+      console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
+      return 1;
+    }
   }
 
-  try {
-    return runIos(options);
-  } catch (error) {
-    console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
-    return 1;
-  }
+  return 0;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## What changed

Adds Android support to the existing mobile screenshot automation so the React Native app can generate Google Play phone screenshots and optionally upload them from the screenshot workflow.

- Extends `scripts/mobile-screenshots.ts` with Android APK install, emulator/device execution, Android-specific Maestro flow selection, and Google Play screenshot output paths.
- Adds Android Maestro flows for app store and onboarding screenshots.
- Adds Google Play screenshot dimension/count validation alongside the existing iOS checks.
- Extends `.github/workflows/mobile-screenshots.yml` with an Android job that builds an x86_64 screenshot APK, runs Maestro on a Pixel 2 emulator, validates screenshots, uploads artifacts, and can upload screenshots to Play Console when manually requested.
- Adds `fastlane android screenshots` for screenshot-only Play Console image sync.
- Pins the generated Android Gradle wrapper to Gradle 8.14.3 via an Expo config plugin so React Native 0.85.3's Foojay resolver does not fail under Gradle 9.
- Updates app store, Fastlane, Maestro, and Play submission docs.

## Impact

Manual screenshot workflow runs can now update Android Play Store screenshots without uploading a new APK/AAB. The Android lane expects `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` when upload is enabled.

## Validation

- `vp test run scripts/__tests__/mobile-screenshots.test.ts scripts/__tests__/assert-screenshot-dimensions.test.ts packages/mobile/src/lib/__tests__/android-gradle-wrapper-version-plugin.test.ts --reporter=agent`
- `vp run typecheck`
- `git diff --check`
- Local Android prebuild produced a generated wrapper pinned to Gradle 8.14.3.
- Local x86_64 screenshot APK build passed: `./gradlew assembleRelease -PreactNativeArchitectures=x86_64 -PboardseshAbiFilters=x86_64 --no-daemon --console=plain --stacktrace`.

`vp check` currently fails on unrelated pre-existing formatting issues outside this change in docs/backend/db files.

## Local emulator note

I attempted to run the Maestro screenshot flow locally after creating the PR. The APK build succeeded, but this host's Android emulator crashes during first boot with exit code 139 for both API 36 and API 35 x86_64 Pixel 2 AVDs, so I could not complete the local device run here. The workflow still runs the emulator on `ubuntu-latest` through `reactivecircus/android-emulator-runner`.