### PR TITLE
[codex] Add mobile store review prompt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -259,6 +259,7 @@
         "expo-share-intent": "^7.0.0",
         "expo-splash-screen": "~56.0.10",
         "expo-status-bar": "~56.0.4",
+        "expo-store-review": "~56.0.3",
         "expo-symbols": "~56.0.5",
         "expo-updates": "~56.0.17",
         "expo-web-browser": "~56.0.5",
@@ -2873,6 +2874,8 @@
     "expo-splash-screen": ["expo-splash-screen@56.0.10", "", { "dependencies": { "@expo/config-plugins": "~56.0.8", "@expo/image-utils": "^0.10.1", "xml2js": "0.6.0" }, "peerDependencies": { "expo": "*" } }, "sha512-vDIlo8hzt9HlCZQ0kSY66v83D1WEXOJbVMeyPDfXDu9tbDdPMNUyDpi4WGJXikAjxnAKfbt5Mv5NnEbxINy+VA=="],
 
     "expo-status-bar": ["expo-status-bar@56.0.4", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA=="],
+
+    "expo-store-review": ["expo-store-review@56.0.3", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-pLlSmizlcXC3dYdydKpYtNslEEr1pyUMHH4YV/zc/HmnEIAIG752N0NadAQ+jxX5i5B8iDwOfYc9iJe9Qyc0UA=="],
 
     "expo-structured-headers": ["expo-structured-headers@56.0.0", "", {}, "sha512-Yv4x+SQxNnMQm4nu8NFfzx197YaDhdYH2N0u7tGErwWTmH9Tm1SAhqo7bLbBWLC9kf7W+kdzTshLU9rTiCXWGw=="],
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -3,6 +3,8 @@ import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 const DEFAULT_EAS_PROJECT_ID = '87499648-655e-4fb8-9856-65da37e55fb1';
 const EAS_PROJECT_ID = process.env.EXPO_PUBLIC_EAS_PROJECT_ID ?? DEFAULT_EAS_PROJECT_ID;
+const IOS_APP_STORE_URL = 'https://apps.apple.com/app/boardsesh/id6761350784';
+const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.boardsesh.app';
 const HEALTH_UPDATE_USAGE_DESCRIPTION = 'Boardsesh saves your finished climbing sessions to Apple Health as workouts.';
 const HEALTH_SHARE_USAGE_DESCRIPTION =
   'Boardsesh reads your body weight to estimate calories and your saved Boardsesh workouts to prevent duplicates.';
@@ -133,6 +135,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       : {}),
     ios: {
       bundleIdentifier: 'com.boardsesh.app',
+      appStoreUrl: IOS_APP_STORE_URL,
       // Required by @bacons/apple-targets to assign the widget extension
       // target's DEVELOPMENT_TEAM build setting. Matches the existing main
       // target value baked into Boardsesh.xcodeproj/project.pbxproj.
@@ -185,6 +188,7 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
     },
     android: {
       package: 'com.boardsesh.app',
+      playStoreUrl: ANDROID_PLAY_STORE_URL,
       // App Links for the multiplayer join flow:
       // https://www.boardsesh.com/join/{sessionId} (and the apex domain).
       // autoVerify lets Android open the link directly in the app once the

--- a/packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx
+++ b/packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 type SummaryResult = {
@@ -22,10 +22,16 @@ const hook = vi.hoisted(() => ({
 }));
 
 const router = vi.hoisted(() => ({ back: vi.fn() }));
+const routeParams = vi.hoisted(() => ({
+  current: { sessionId: 'session-1' } as { sessionId: string; reviewCandidate?: string },
+}));
+const storeReview = vi.hoisted(() => ({
+  maybeRequestSessionStoreReview: vi.fn(),
+}));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({
-  useLocalSearchParams: () => ({ sessionId: 'session-1' }),
+  useLocalSearchParams: () => routeParams.current,
   useRouter: () => router,
 }));
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ bottom: 0 }) }));
@@ -45,6 +51,12 @@ vi.mock('../../../../src/providers/theme-provider', () => ({
 }));
 vi.mock('../../../../src/hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGrade: (grade: string) => grade }),
+}));
+vi.mock('../../../../src/lib/store-review', () => ({
+  SESSION_STORE_REVIEW_CANDIDATE_PARAM: '1',
+  STORE_REVIEW_PROMPT_DELAY_MS: 1000,
+  isSessionStoreReviewEligible: (summary: { totalSends: number }) => summary.totalSends >= 3,
+  maybeRequestSessionStoreReview: storeReview.maybeRequestSessionStoreReview,
 }));
 
 vi.mock('react-native', () => ({
@@ -94,7 +106,14 @@ function setSummary(partial: Partial<SummaryResult>) {
 describe('SessionSummaryScreen settled error/empty state', () => {
   beforeEach(() => {
     router.back.mockClear();
+    routeParams.current = { sessionId: 'session-1' };
+    storeReview.maybeRequestSessionStoreReview.mockReset();
+    storeReview.maybeRequestSessionStoreReview.mockResolvedValue(false);
     hook.result.refetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('shows a spinner while the summary is still loading', () => {
@@ -129,5 +148,86 @@ describe('SessionSummaryScreen settled error/empty state', () => {
     const { getByText } = render(<SessionSummaryScreen />);
     fireEvent.click(getByText('summary.retry'));
     expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('requests store review once after a review-candidate summary settles', async () => {
+    vi.useFakeTimers();
+    routeParams.current = { sessionId: 'session-1', reviewCandidate: '1' };
+    const summary = {
+      sessionId: 'session-1',
+      totalSends: 3,
+      totalAttempts: 0,
+      durationMinutes: null,
+      gradeDistribution: [],
+      participants: [],
+      hardestClimb: null,
+      goal: null,
+    };
+    setSummary({ data: summary });
+
+    render(<SessionSummaryScreen />);
+    expect(storeReview.maybeRequestSessionStoreReview).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(storeReview.maybeRequestSessionStoreReview).toHaveBeenCalledOnce();
+    expect(storeReview.maybeRequestSessionStoreReview).toHaveBeenCalledWith(summary);
+  });
+
+  it('still requests store review when the summary refetches before the delay expires', async () => {
+    vi.useFakeTimers();
+    routeParams.current = { sessionId: 'session-1', reviewCandidate: '1' };
+    const firstSummary = {
+      sessionId: 'session-1',
+      totalSends: 3,
+      totalAttempts: 0,
+      durationMinutes: null,
+      gradeDistribution: [],
+      participants: [],
+      hardestClimb: null,
+      goal: null,
+    };
+    const refetchedSummary = { ...firstSummary };
+    setSummary({ data: firstSummary });
+
+    const { rerender } = render(<SessionSummaryScreen />);
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    setSummary({ data: refetchedSummary });
+    rerender(<SessionSummaryScreen />);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(storeReview.maybeRequestSessionStoreReview).toHaveBeenCalledOnce();
+    expect(storeReview.maybeRequestSessionStoreReview).toHaveBeenCalledWith(refetchedSummary);
+  });
+
+  it('does not request store review without the post-end route flag', async () => {
+    vi.useFakeTimers();
+    const summary = {
+      sessionId: 'session-1',
+      totalSends: 3,
+      totalAttempts: 0,
+      durationMinutes: null,
+      gradeDistribution: [],
+      participants: [],
+      hardestClimb: null,
+      goal: null,
+    };
+    setSummary({ data: summary });
+
+    render(<SessionSummaryScreen />);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(storeReview.maybeRequestSessionStoreReview).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/app/(tabs)/record/summary.tsx
+++ b/packages/mobile/app/(tabs)/record/summary.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { View, ScrollView, StyleSheet, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +14,12 @@ import { useSessionSummary } from '../../../src/lib/graphql/hooks';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { SaveToAppleHealthButton } from '../../../src/components/integrations/SaveToAppleHealthButton';
 import { ShareToStravaButton } from '../../../src/components/integrations/ShareToStravaButton';
+import {
+  SESSION_STORE_REVIEW_CANDIDATE_PARAM,
+  STORE_REVIEW_PROMPT_DELAY_MS,
+  isSessionStoreReviewEligible,
+  maybeRequestSessionStoreReview,
+} from '../../../src/lib/store-review';
 import { brandColors } from '../../../src/theme/colors';
 import { spacing, borderRadius as br } from '../../../src/theme/tokens';
 
@@ -49,13 +56,29 @@ function getGradeColor(index: number): string {
 }
 
 export default function SessionSummaryScreen() {
-  const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
+  const { sessionId, reviewCandidate } = useLocalSearchParams<{ sessionId: string; reviewCandidate?: string }>();
   const { data: summary, isPending, isFetching, isError, refetch } = useSessionSummary(sessionId ?? null);
   const { t } = useTranslation('session');
   const { systemColors, brandColors: brand } = useTheme();
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { formatGrade } = useGradeFormat();
+  const promptedSessionIdRef = useRef<string | null>(null);
+  const reviewCandidateParam = Array.isArray(reviewCandidate) ? reviewCandidate[0] : reviewCandidate;
+
+  useEffect(() => {
+    if (!summary) return undefined;
+    if (reviewCandidateParam !== SESSION_STORE_REVIEW_CANDIDATE_PARAM) return undefined;
+    if (!isSessionStoreReviewEligible(summary)) return undefined;
+    if (promptedSessionIdRef.current === summary.sessionId) return undefined;
+
+    const timer = setTimeout(() => {
+      promptedSessionIdRef.current = summary.sessionId;
+      void maybeRequestSessionStoreReview(summary);
+    }, STORE_REVIEW_PROMPT_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [summary, reviewCandidateParam]);
 
   // Still loading: query hasn't settled yet (first fetch in flight or refetching
   // after a retry). isPending covers the disabled (no sessionId) case too.

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -70,6 +70,7 @@
     "expo-share-intent": "^7.0.0",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
+    "expo-store-review": "~56.0.3",
     "expo-symbols": "~56.0.5",
     "expo-updates": "~56.0.17",
     "expo-web-browser": "~56.0.5",

--- a/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/InSessionView.tsx
@@ -26,6 +26,7 @@ import { useQueueSessionControls, useQueueActions, useQueueLiveStats } from '../
 import { useDrawerHost } from '../../../providers/drawer-host-provider';
 import { useSessionDetail, useSessionSummary } from '../../../lib/graphql/hooks';
 import { runSessionEndExports } from '../../../lib/integrations';
+import { SESSION_STORE_REVIEW_CANDIDATE_PARAM, isSessionStoreReviewEligible } from '../../../lib/store-review';
 import { climbToQueueItem } from '../../../lib/climb-to-queue-item';
 import { getBoardConfigForPlaylist } from '../../../lib/playlists/board-details-for-playlist';
 import { tickToClimb } from '../../../lib/tick-to-climb';
@@ -434,7 +435,10 @@ export function InSessionView({
         // rejection. The manual save button on the summary screen shares the same
         // dedup guard, so this won't double-write.
         runSessionEndExports(summary, {});
-        router.push({ pathname: '/(tabs)/record/summary', params: { sessionId: summary.sessionId } });
+        const summaryParams = isSessionStoreReviewEligible(summary)
+          ? { sessionId: summary.sessionId, reviewCandidate: SESSION_STORE_REVIEW_CANDIDATE_PARAM }
+          : { sessionId: summary.sessionId };
+        router.push({ pathname: '/(tabs)/record/summary', params: summaryParams });
       }
     } catch (error) {
       // Surface the failure (the sheet stays open so the user can retry) rather than

--- a/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx
@@ -33,6 +33,7 @@ const theme = vi.hoisted(() => ({
 // error path (endSession rejects) can assert the spinner clears.
 const queue = vi.hoisted(() => ({ endSession: vi.fn() }));
 const sheet = vi.hoisted(() => ({ isEnding: false as boolean, onConfirm: null as (() => void) | null }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
 
 vi.mock('react-native', () => ({
   Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
@@ -81,7 +82,7 @@ vi.mock('@shopify/flash-list', () => ({
 }));
 
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-uuid' }));
-vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
 vi.mock('@boardsesh/play-view', () => ({ formatGrade: (grade: string) => grade, getGradeTextColor: () => '#fff' }));
@@ -136,6 +137,10 @@ vi.mock('../../../../lib/graphql/hooks', () => ({
   }),
   useSessionSummary: () => ({ data: { startedAt: '2026-01-01T00:00:00.000Z' } }),
 }));
+vi.mock('../../../../lib/store-review', () => ({
+  SESSION_STORE_REVIEW_CANDIDATE_PARAM: '1',
+  isSessionStoreReviewEligible: (summary: { totalSends: number }) => summary.totalSends >= 3,
+}));
 vi.mock('../../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => ({ data: null }) }));
 vi.mock('../../../../lib/integrations', () => ({
   runSessionEndExports: integrations.runSessionEndExports,
@@ -169,6 +174,7 @@ describe('InSessionView footer', () => {
     theme.variant = 'liquidGlass';
     queue.endSession.mockReset();
     queue.endSession.mockResolvedValue(null);
+    router.push.mockClear();
     sheet.isEnding = false;
     sheet.onConfirm = null;
     integrations.runSessionEndExports.mockReset();
@@ -244,5 +250,45 @@ describe('InSessionView footer', () => {
     });
 
     expect(integrations.runSessionEndExports).toHaveBeenCalledWith(summary, {});
+  });
+
+  it('marks the summary route as a store-review candidate after 3 ascents', async () => {
+    queue.endSession.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      totalSends: 3,
+      totalAttempts: 0,
+    });
+
+    render(createElement(InSessionView));
+
+    await act(async () => {
+      sheet.onConfirm?.();
+      await Promise.resolve();
+    });
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/record/summary',
+      params: { sessionId: 'session-1', reviewCandidate: '1' },
+    });
+  });
+
+  it('does not mark the summary route as a store-review candidate after 2 ascents', async () => {
+    queue.endSession.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      totalSends: 2,
+      totalAttempts: 0,
+    });
+
+    render(createElement(InSessionView));
+
+    await act(async () => {
+      sheet.onConfirm?.();
+      await Promise.resolve();
+    });
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/record/summary',
+      params: { sessionId: 'session-1' },
+    });
   });
 });

--- a/packages/mobile/src/lib/__tests__/store-review.test.ts
+++ b/packages/mobile/src/lib/__tests__/store-review.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storeReview = vi.hoisted(() => ({
+  hasAction: vi.fn(),
+  requestReview: vi.fn(),
+}));
+
+const asyncStorage = vi.hoisted(() => {
+  let storage: Record<string, string> = {};
+  return {
+    getItem: vi.fn(async (key: string) => storage[key] ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storage[key] = value;
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      delete storage[key];
+    }),
+    __reset: () => {
+      storage = {};
+    },
+  };
+});
+
+vi.mock('expo-store-review', () => storeReview);
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }));
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function loadStoreReviewModule() {
+  return import('../store-review');
+}
+
+describe('session store review prompt', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    asyncStorage.__reset();
+    storeReview.hasAction.mockReset();
+    storeReview.requestReview.mockReset();
+    storeReview.hasAction.mockResolvedValue(true);
+    storeReview.requestReview.mockResolvedValue(undefined);
+  });
+
+  it('requests the native store review flow for a fresh eligible session', async () => {
+    const { maybeRequestSessionStoreReview } = await loadStoreReviewModule();
+
+    await expect(maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 3 }, 1000)).resolves.toBe(true);
+
+    expect(storeReview.hasAction).toHaveBeenCalledOnce();
+    expect(storeReview.requestReview).toHaveBeenCalledOnce();
+  });
+
+  it('does not request review for sessions with 2 or fewer ascents', async () => {
+    const { maybeRequestSessionStoreReview } = await loadStoreReviewModule();
+
+    await expect(maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 2 }, 1000)).resolves.toBe(false);
+
+    expect(storeReview.hasAction).not.toHaveBeenCalled();
+    expect(storeReview.requestReview).not.toHaveBeenCalled();
+  });
+
+  it('skips when the native store review action is unavailable', async () => {
+    const { maybeRequestSessionStoreReview } = await loadStoreReviewModule();
+    storeReview.hasAction.mockResolvedValueOnce(false);
+
+    await expect(maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 3 }, 1000)).resolves.toBe(false);
+
+    expect(storeReview.requestReview).not.toHaveBeenCalled();
+  });
+
+  it('does not request review twice for the same session', async () => {
+    const { maybeRequestSessionStoreReview, SESSION_STORE_REVIEW_COOLDOWN_MS } = await loadStoreReviewModule();
+
+    await maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 3 }, 1000);
+    storeReview.requestReview.mockClear();
+
+    await expect(
+      maybeRequestSessionStoreReview(
+        { sessionId: 'session-1', totalSends: 3 },
+        1000 + SESSION_STORE_REVIEW_COOLDOWN_MS,
+      ),
+    ).resolves.toBe(false);
+
+    expect(storeReview.requestReview).not.toHaveBeenCalled();
+  });
+
+  it('enforces the 90-day cooldown across different sessions', async () => {
+    const { maybeRequestSessionStoreReview } = await loadStoreReviewModule();
+
+    await maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 3 }, 1000);
+    storeReview.requestReview.mockClear();
+
+    await expect(
+      maybeRequestSessionStoreReview({ sessionId: 'session-2', totalSends: 4 }, 1000 + 89 * DAY_MS),
+    ).resolves.toBe(false);
+    expect(storeReview.requestReview).not.toHaveBeenCalled();
+
+    await expect(
+      maybeRequestSessionStoreReview({ sessionId: 'session-2', totalSends: 4 }, 1000 + 90 * DAY_MS),
+    ).resolves.toBe(true);
+    expect(storeReview.requestReview).toHaveBeenCalledOnce();
+  });
+
+  it('records the attempt before calling the OS review API', async () => {
+    const { maybeRequestSessionStoreReview, SESSION_STORE_REVIEW_COOLDOWN_MS } = await loadStoreReviewModule();
+    storeReview.requestReview.mockRejectedValueOnce(new Error('store failed'));
+
+    await expect(maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 3 }, 1000)).resolves.toBe(false);
+    storeReview.requestReview.mockClear();
+
+    await expect(
+      maybeRequestSessionStoreReview(
+        { sessionId: 'session-2', totalSends: 3 },
+        1000 + SESSION_STORE_REVIEW_COOLDOWN_MS - 1,
+      ),
+    ).resolves.toBe(false);
+    expect(storeReview.requestReview).not.toHaveBeenCalled();
+  });
+
+  it('does not request review when the cooldown state cannot be saved', async () => {
+    const { maybeRequestSessionStoreReview } = await loadStoreReviewModule();
+    asyncStorage.setItem.mockRejectedValueOnce(new Error('storage failed'));
+
+    await expect(maybeRequestSessionStoreReview({ sessionId: 'session-1', totalSends: 3 }, 1000)).resolves.toBe(false);
+
+    expect(storeReview.requestReview).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/store-review.ts
+++ b/packages/mobile/src/lib/store-review.ts
@@ -1,0 +1,73 @@
+import * as StoreReview from 'expo-store-review';
+import type { SessionSummary } from '@boardsesh/shared-schema';
+import { getPreference, setPreference } from './preference-store';
+
+type SessionStoreReviewPromptState = {
+  lastPromptedAtMs: number;
+  lastPromptedSessionId: string | null;
+};
+
+const SESSION_STORE_REVIEW_PROMPT_KEY = 'sessionStoreReviewPrompt';
+
+export const SESSION_STORE_REVIEW_MIN_SENDS = 3;
+export const SESSION_STORE_REVIEW_COOLDOWN_MS = 90 * 24 * 60 * 60 * 1000;
+export const SESSION_STORE_REVIEW_CANDIDATE_PARAM = '1';
+export const STORE_REVIEW_PROMPT_DELAY_MS = 1000;
+
+export function isSessionStoreReviewEligible(summary: Pick<SessionSummary, 'totalSends'>): boolean {
+  return summary.totalSends >= SESSION_STORE_REVIEW_MIN_SENDS;
+}
+
+async function readPromptState(): Promise<SessionStoreReviewPromptState | null> {
+  const storedState = await getPreference<SessionStoreReviewPromptState>(SESSION_STORE_REVIEW_PROMPT_KEY);
+  if (!storedState || typeof storedState.lastPromptedAtMs !== 'number') return null;
+  return {
+    lastPromptedAtMs: storedState.lastPromptedAtMs,
+    lastPromptedSessionId:
+      typeof storedState.lastPromptedSessionId === 'string' ? storedState.lastPromptedSessionId : null,
+  };
+}
+
+async function writePromptState(state: SessionStoreReviewPromptState): Promise<void> {
+  await setPreference(SESSION_STORE_REVIEW_PROMPT_KEY, state);
+}
+
+export async function shouldRequestSessionStoreReview(
+  summary: Pick<SessionSummary, 'sessionId' | 'totalSends'>,
+  nowMs = Date.now(),
+): Promise<boolean> {
+  try {
+    if (!isSessionStoreReviewEligible(summary)) return false;
+
+    const promptState = await readPromptState();
+    if (promptState?.lastPromptedSessionId === summary.sessionId) return false;
+    if (promptState && nowMs - promptState.lastPromptedAtMs < SESSION_STORE_REVIEW_COOLDOWN_MS) return false;
+
+    return await StoreReview.hasAction();
+  } catch {
+    return false;
+  }
+}
+
+export async function maybeRequestSessionStoreReview(
+  summary: Pick<SessionSummary, 'sessionId' | 'totalSends'>,
+  nowMs = Date.now(),
+): Promise<boolean> {
+  if (!(await shouldRequestSessionStoreReview(summary, nowMs))) return false;
+
+  try {
+    await writePromptState({
+      lastPromptedAtMs: nowMs,
+      lastPromptedSessionId: summary.sessionId,
+    });
+  } catch {
+    return false;
+  }
+
+  try {
+    await StoreReview.requestReview();
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What changed

- Added `expo-store-review` to the mobile app and configured App Store / Play Store URLs in Expo config.
- Added a mobile session store-review gate that only prompts after 3+ sends, records the attempt before calling the OS API, skips unavailable review actions, and enforces a 90-day cooldown.
- Marked eligible post-session summary routes from the manual end-session flow, then delayed the native review request until the finished-session summary screen has settled.
- Added focused tests for helper eligibility/throttling, end-session routing, and summary-screen triggering.

## Why

The app should ask for useful public store feedback after a meaningful climbing session, without nagging users or collecting a separate in-app rating that does not help store discovery.

## Validation

- `vp test run packages/mobile/src/lib/__tests__/store-review.test.ts 'packages/mobile/app/(tabs)/record/__tests__/summary-error-state.test.tsx' packages/mobile/src/components/session-screen/in-session/__tests__/in-session-view-footer.test.tsx`
- `vp run typecheck:mobile`
- `vp check` still fails on pre-existing unrelated formatting issues in `POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend/db files, and `packages/mobile/.maestro/README.md`; none of the changed files are listed.