### PR TITLE
fix(mobile): use person-add icon for Home find-climbers action

### DIFF
--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -442,11 +442,13 @@ export default function HomeTab() {
               accessibilityHint={t('mobile.home.scope.hint')}
             />
           </View>
-          {/* Search action: balances the avatar so the scope menu reads centred,
-              and opens the full-screen climber search. */}
+          {/* Find-climbers action: balances the avatar so the scope menu reads
+              centred, and opens the full-screen climber search. Uses a
+              person-add glyph (not a magnifier) so it doesn't read as a second
+              "search" next to the Climbs tab's bottom-bar magnifier. */}
           <GlassActionToolbar actionCount={1}>
             <GlassToolbarAction onPress={handleOpenSearch} accessibilityLabel={t('mobile.home.searchAction')}>
-              <Icon name="search" size={22} color={systemColors.label} />
+              <Icon name="person.badge.plus" size={22} color={systemColors.label} />
             </GlassToolbarAction>
           </GlassActionToolbar>
         </View>


### PR DESCRIPTION
## What

The mobile **Home** tab's top-right toolbar action opens the full-screen climber search (`/users/search`) — i.e. finding people to follow. It was using a generic magnifying-glass icon (`name="search"`).

The problem: the **Climbs** tab in the bottom bar already shows a magnifier (the climb-search surface). So the Home screen displayed **two magnifying-glass "search" buttons** that do completely different things, which read as confusing.

## Change

One-line icon swap in `packages/mobile/app/(tabs)/home/index.tsx`:

```diff
- <Icon name="search" size={22} color={systemColors.label} />
+ <Icon name="person.badge.plus" size={22} color={systemColors.label} />
```

- `person.badge.plus` (iOS `person.badge.plus` / Android `account-plus-outline`) already exists in `icon-map.ts` and is the established convention for find/follow-people actions (`SocialTab`, `RecordTopChrome`, `InSessionView`, `PlaylistFollowButton`).
- Behaviour is unchanged — still opens `/users/search`. The accessibility label was already "Find climbers" in en-US/es/fr, so no i18n change was needed.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2238 tests pass
- `vp run check:mobile-bundle` — bundle OK

https://claude.ai/code/session_01RoN29Avyj15rAQJ79XTyW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoN29Avyj15rAQJ79XTyW4)_