### PR TITLE
fix(mobile): purge stale Live Activity thumbnail cache (board photo missing after update)

### DIFF
--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -32,6 +32,12 @@ enum SharedConstants {
     /// board art over the network (the no-network-board-art rule). Empty when no
     /// bundled background resolved — the overlay is then written as-is.
     static let boardBackgroundPathsKey = "bs_board_background_paths"
+    /// Version of the cached Live Activity thumbnail's content contract. When it
+    /// differs from `ThumbnailFetcher.cacheVersion`, the (update-surviving) App
+    /// Group thumbnail cache is purged so an upgraded build doesn't serve the
+    /// previous build's images (e.g. overlay-only thumbnails from before board
+    /// compositing).
+    static let thumbnailCacheVersionKey = "bs_thumbnail_cache_version"
     static let pendingActionKey = "bs_pending_action"
     /// Action ("next" | "previous") associated with the most recent Darwin
     /// notification. Always written by the intent; the Darwin handler reads

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import os.log
 
 // MARK: - ThumbnailFetcher
 
@@ -20,12 +21,25 @@ actor ThumbnailFetcher {
     /// Subdirectory inside the shared container where thumbnails are stored.
     static let thumbnailsDirectory = "thumbnails"
 
+    /// Bumped when the cached thumbnail's content contract changes, so a build
+    /// with new compositing logic discards thumbnails written by older builds
+    /// instead of serving them stale. The App Group container survives app
+    /// updates, so without this an upgrading user keeps seeing the previous
+    /// build's images. v1 = overlay-only (no board art); v2 = board background
+    /// composited behind the holds overlay. Mirrors `RENDERER_VERSION` in
+    /// use-native-climb-render.ts, which solved the same transition in-app.
+    static let cacheVersion = 2
+
     // MARK: - Dependencies
 
     private let urlSession: URLSession
     private let fileManager: FileManager
     private let sharedDefaults: UserDefaults?
     private let sharedContainerUrl: URL?
+    private let logger = Logger(subsystem: "com.boardsesh.app", category: "ThumbnailFetcher")
+
+    /// Guards the one-per-process stale-cache purge.
+    private var didPurgeStaleCache = false
 
     // MARK: - In-flight deduplication
 
@@ -68,6 +82,10 @@ actor ThumbnailFetcher {
     ///
     /// Returns `nil` if any step fails (network error, missing config, etc.).
     func fetchThumbnail(for item: SharedQueueItem) async -> URL? {
+        // Drop thumbnails written by an older build before any cache hit, so a
+        // version bump (e.g. overlay-only → board-composited) forces a re-render.
+        purgeStaleCacheIfNeeded()
+
         // Return cached file if it already exists.
         if let cached = cachedFileURL(for: item.climbUuid), fileManager.fileExists(atPath: cached.path) {
             // Touch the file so eviction treats it as recently used.
@@ -111,6 +129,28 @@ actor ThumbnailFetcher {
                 }
             }
         }
+    }
+
+    /// Clears the thumbnail cache once per process when the stored cache version
+    /// differs from `cacheVersion` — i.e. after an app update whose compositing
+    /// contract changed. Without this, the App Group container (which survives
+    /// updates) would keep serving a prior build's thumbnails (e.g. overlay-only
+    /// images from before board compositing) straight from the cache check.
+    private func purgeStaleCacheIfNeeded() {
+        guard !didPurgeStaleCache else { return }
+        didPurgeStaleCache = true
+
+        let storedVersion = sharedDefaults?.integer(forKey: SharedConstants.thumbnailCacheVersionKey) ?? 0
+        guard storedVersion != Self.cacheVersion else { return }
+
+        if let directory = thumbnailsDirectoryURL(),
+           let files = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil, options: .skipsHiddenFiles) {
+            for file in files {
+                try? fileManager.removeItem(at: file)
+            }
+            logger.notice("Purged \(files.count) stale thumbnail(s) (cache version \(storedVersion, privacy: .public) → \(Self.cacheVersion, privacy: .public))")
+        }
+        sharedDefaults?.set(Self.cacheVersion, forKey: SharedConstants.thumbnailCacheVersionKey)
     }
 
     /// Removes the oldest thumbnails when the cache exceeds `maxCachedThumbnails`.
@@ -250,10 +290,24 @@ actor ThumbnailFetcher {
         // entirely when nothing is staged) so the cache tracks the active board.
         let activePaths = Set(paths)
         backgroundLayerCache = backgroundLayerCache.filter { activePaths.contains($0.key) }
-        guard !paths.isEmpty, let overlay = UIImage(data: overlayData) else { return nil }
+
+        // These notices are the on-device diagnostic for "board photo missing":
+        // they pinpoint whether JS staged paths, and whether they decoded.
+        guard !paths.isEmpty else {
+            logger.notice("composite skipped: no board-background paths staged → holds-only overlay")
+            return nil
+        }
+        guard let overlay = UIImage(data: overlayData) else {
+            logger.error("composite skipped: server overlay failed to decode")
+            return nil
+        }
 
         let backgroundLayers = paths.compactMap { backgroundLayer(at: $0) }
-        guard !backgroundLayers.isEmpty else { return nil }
+        guard !backgroundLayers.isEmpty else {
+            logger.error("composite skipped: \(paths.count, privacy: .public) staged path(s) but 0 decoded via UIImage(contentsOfFile:) — first: \(paths.first ?? "?", privacy: .public)")
+            return nil
+        }
+        logger.notice("composite: \(backgroundLayers.count, privacy: .public)/\(paths.count, privacy: .public) background layer(s) under overlay")
 
         let nativeSize = overlay.size
         guard nativeSize.width > 0, nativeSize.height > 0 else { return nil }

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -80,8 +80,21 @@ async function resolveBoardBackgroundPaths(board: BoardConfig): Promise<string[]
       setIds,
       variant: 'thumb',
     });
-    return result?.paths ?? [];
-  } catch {
+    const paths = result?.paths ?? [];
+    if (paths.length === 0) {
+      // Pairs with the native "no board-background paths staged" log: if this
+      // fires, the board photo is missing because resolution came back empty
+      // (board not bundled / manifest miss), not because native couldn't read it.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[LiveActivity] no bundled backgrounds for ${boardName}/${board.layoutId}/${board.sizeId}/${board.setIds} ` +
+          `(missing ${result?.missingCount ?? 'n/a'})`,
+      );
+    }
+    return paths;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('[LiveActivity] board-background resolution threw:', error instanceof Error ? error.message : error);
     return [];
   }
 }

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -32,6 +32,12 @@ enum SharedConstants {
     /// board art over the network (the no-network-board-art rule). Empty when no
     /// bundled background resolved — the overlay is then written as-is.
     static let boardBackgroundPathsKey = "bs_board_background_paths"
+    /// Version of the cached Live Activity thumbnail's content contract. When it
+    /// differs from `ThumbnailFetcher.cacheVersion`, the (update-surviving) App
+    /// Group thumbnail cache is purged so an upgraded build doesn't serve the
+    /// previous build's images (e.g. overlay-only thumbnails from before board
+    /// compositing).
+    static let thumbnailCacheVersionKey = "bs_thumbnail_cache_version"
     static let pendingActionKey = "bs_pending_action"
     /// Action ("next" | "previous") associated with the most recent Darwin
     /// notification. Always written by the intent; the Darwin handler reads


### PR DESCRIPTION
## Problem

After #2932 merged, the Live Activity board photo **still didn't render** on a TestFlight build installed *over* a previous one (fresh native build; the in-app board view renders fine).

## Root cause

The App Group thumbnail cache **survives app updates**, and `ThumbnailFetcher.fetchThumbnail` returns a cached file *without recompositing*:

```swift
if let cached = cachedFileURL(...), fileManager.fileExists(...) { return cached }  // ← stale
```

So any climb viewed on a pre-compositing build keeps serving its **overlay-only** thumbnail (circles, no board) forever. Anyone who's been on the dev builds has a cache full of these.

This is the same trap the in-app renderer already solved: `use-native-climb-render.ts` carries `RENDERER_VERSION` and deletes stale-version files on warmup, with the comment *"v2 marks the switch from composited PNGs to overlay-only PNGs."* The Live Activity cache had **no versioning**.

## Fix

- `ThumbnailFetcher.cacheVersion = 2` + a one-per-process purge that clears the thumbnails dir when the version stored in the App Group (`thumbnailCacheVersionKey`, added to both byte-identical `SharedConstants` copies) differs — run **before** the cache check in `fetchThumbnail`. v1 = overlay-only, v2 = board composited.
- **Diagnostics** so a future "board photo missing" report is debuggable from Console.app instead of guesswork:
  - native `os_log` on the composite path — distinguishes *no paths staged* vs *staged N but 0 decoded* vs *N layers under overlay*.
  - JS `console.warn` when background resolution returns empty (board not bundled / manifest miss).

## Ruled out (so the version bump is the remaining cause)

- **Native code present** — confirmed it's a fresh native build, not an OTA JS push.
- **webp decode** — verified iOS ImageIO decodes the bundled webp (full + thumb) via a `CGImageSource` test on macOS (same engine).
- **Asset resolution** — the in-app board view renders in this build using the same `background-image-cache` resolver.

## Verify
1. `vp run typecheck:mobile`, `vp run check:mobile-board-art-network`, mobile tests (incl. the `widget-target-drift` byte-identity check). ✅ locally.
2. On device: install over an existing build → the cache purges once on first thumbnail fetch and climbs recomposite with the board behind the circles. As a no-rebuild check on the current build, deleting + reinstalling and opening a *new* climb also renders the board (confirming the cache was the cause).
3. If a board is still missing, Console.app (filter `ThumbnailFetcher`) now says exactly why.

Follow-up to #2932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)