### PR TITLE
[codex] Improve mobile filter FAB contrast

### DIFF
--- a/packages/mobile/src/components/GlassIconButton.tsx
+++ b/packages/mobile/src/components/GlassIconButton.tsx
@@ -42,6 +42,10 @@ type GlassIconButtonProps = {
   fallbackColor: ColorValue;
   /** Count badge (top-right). Rendered only when > 0. */
   badgeCount?: number;
+  /** Optional badge fill override for controls whose main surface already uses the default badge colour. */
+  badgeBackgroundColor?: ColorValue;
+  /** Optional badge text override paired with `badgeBackgroundColor`. */
+  badgeTextColor?: ColorValue;
   disabled?: boolean;
   /** Diameter of the circular target (default `glassSize.standard` — the standard
    *  floating FAB; pass `glassSize.hero` for a surface's defining action). */
@@ -94,6 +98,8 @@ function GlassIconButtonMaterial({
   accessibilityActions,
   onAccessibilityAction,
   badgeCount,
+  badgeBackgroundColor,
+  badgeTextColor,
   disabled = false,
   size = glassSize.standard,
 }: GlassIconButtonProps) {
@@ -121,7 +127,14 @@ function GlassIconButtonMaterial({
         accessibilityActions={accessibilityActions}
         onAccessibilityAction={onAccessibilityAction}
       />
-      {badgeLabel ? <BadgeLabel label={badgeLabel} style={styles.materialBadge} /> : null}
+      {badgeLabel ? (
+        <BadgeLabel
+          label={badgeLabel}
+          backgroundColor={badgeBackgroundColor}
+          textColor={badgeTextColor}
+          style={styles.materialBadge}
+        />
+      ) : null}
     </View>
   );
 }
@@ -148,6 +161,8 @@ function GlassIconButtonGlass({
   tintColor,
   fallbackColor,
   badgeCount,
+  badgeBackgroundColor,
+  badgeTextColor,
   disabled = false,
   size = glassSize.standard,
   secondaryIconName,
@@ -243,17 +258,29 @@ function GlassIconButtonGlass({
         )}
       </PressableSurface>
 
-      {badgeLabel ? <BadgeLabel label={badgeLabel} /> : null}
+      {badgeLabel ? (
+        <BadgeLabel label={badgeLabel} backgroundColor={badgeBackgroundColor} textColor={badgeTextColor} />
+      ) : null}
     </View>
   );
 }
 
-function BadgeLabel({ label, style }: { label: string; style?: StyleProp<ViewStyle> }) {
+function BadgeLabel({
+  label,
+  backgroundColor = brandColors.primary,
+  textColor = iosSystemColors.white,
+  style,
+}: {
+  label: string;
+  backgroundColor?: ColorValue;
+  textColor?: ColorValue;
+  style?: StyleProp<ViewStyle>;
+}) {
   return (
-    <View style={[styles.badge, style, { backgroundColor: brandColors.primary }]} pointerEvents="none">
+    <View style={[styles.badge, style, { backgroundColor }]} pointerEvents="none">
       <Text
         variant="caption2"
-        color={iosSystemColors.white}
+        color={textColor}
         maxFontSizeMultiplier={BADGE_MAX_FONT_SIZE_MULTIPLIER}
         style={styles.badgeText}
       >

--- a/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
+++ b/packages/mobile/src/components/__tests__/glass-icon-button.test.tsx
@@ -9,9 +9,25 @@ const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'material' | 'liquidG
 
 // Minimal RN surface: View → div, StyleSheet stubs the helpers the button reads.
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-bg': readBackgroundColor(style) }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
 }));
+
+function readBackgroundColor(style: unknown): string {
+  if (Array.isArray(style)) {
+    for (let index = style.length - 1; index >= 0; index -= 1) {
+      const color = readBackgroundColor(style[index]);
+      if (color) return color;
+    }
+    return '';
+  }
+  if (style != null && typeof style === 'object' && 'backgroundColor' in style) {
+    const { backgroundColor } = style as { backgroundColor?: unknown };
+    return typeof backgroundColor === 'string' ? backgroundColor : '';
+  }
+  return '';
+}
 
 // Paper IconButton → DOM node exposing the props the material test asserts on.
 vi.mock('react-native-paper', () => ({
@@ -85,11 +101,20 @@ vi.mock('../Icon', () => ({
 }));
 
 vi.mock('../Text', () => ({
-  Text: ({ children, maxFontSizeMultiplier }: { children?: ReactNode; maxFontSizeMultiplier?: number }) =>
+  Text: ({
+    children,
+    color,
+    maxFontSizeMultiplier,
+  }: {
+    children?: ReactNode;
+    color?: string;
+    maxFontSizeMultiplier?: number;
+  }) =>
     createElement(
       'span',
       {
         'data-text': 'true',
+        'data-color': color ?? '',
         'data-max-font-size-multiplier': maxFontSizeMultiplier == null ? '' : String(maxFontSizeMultiplier),
       },
       children,
@@ -141,6 +166,26 @@ describe('GlassIconButton (Liquid Glass variant)', () => {
     expect(container.textContent).toContain('3');
     rerender(<GlassIconButton {...base} iconName="filter" badgeCount={0} />);
     expect(container.textContent).not.toContain('3');
+  });
+
+  it('uses the default violet badge with white text', () => {
+    const { container } = render(<GlassIconButton {...base} iconName="filter" badgeCount={3} />);
+    expect(container.querySelector('[data-bg="#6D28D9"]')).not.toBeNull();
+    expect(container.querySelector('[data-text]')?.getAttribute('data-color')).toBe('#FFFFFF');
+  });
+
+  it('allows callers to override badge colors', () => {
+    const { container } = render(
+      <GlassIconButton
+        {...base}
+        iconName="filter"
+        badgeCount={3}
+        badgeBackgroundColor="#FFFFFF"
+        badgeTextColor="#6D28D9"
+      />,
+    );
+    expect(container.querySelector('[data-bg="#FFFFFF"]')).not.toBeNull();
+    expect(container.querySelector('[data-text]')?.getAttribute('data-color')).toBe('#6D28D9');
   });
 
   it('clamps large badges and caps badge text scaling', () => {

--- a/packages/mobile/src/components/search/ClimbFilterFab.tsx
+++ b/packages/mobile/src/components/search/ClimbFilterFab.tsx
@@ -66,7 +66,12 @@ export function ClimbFilterFab({
         </Animated.View>
       ) : null}
       <Animated.View pointerEvents="box-none" style={[styles.fabSlot, fabSlotStyle]}>
-        <FilterButton activeFilterCount={activeFilterCount} onPress={onOpenFilters} onLongPress={onOpenGrade} />
+        <FilterButton
+          activeFilterCount={activeFilterCount}
+          onPress={onOpenFilters}
+          onLongPress={onOpenGrade}
+          prominence="floating"
+        />
       </Animated.View>
     </>
   );

--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -16,18 +16,30 @@ type FilterButtonProps = {
   activeFilterCount: number;
   onPress: () => void;
   onLongPress?: () => void;
+  prominence?: 'standard' | 'floating';
 };
 
-export function FilterButton({ activeFilterCount, onPress, onLongPress }: FilterButtonProps) {
+export function FilterButton({ activeFilterCount, onPress, onLongPress, prominence = 'standard' }: FilterButtonProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors, variant } = useTheme();
   const active = activeFilterCount > 0;
-  // Liquid Glass paints the active button on a violet glass tint, so a violet
-  // glyph is low-contrast — use white there. Material has no tint behind the
-  // glyph, so it keeps the violet (white would vanish on the bare surface).
-  const iconColor = active
-    ? selectByVariant(variant, { liquidGlass: iosSystemColors.white, material: brandColors.primary })
-    : systemColors.secondaryLabel;
+  const floatingLiquidGlass =
+    prominence === 'floating' && selectByVariant(variant, { liquidGlass: true, material: false });
+  let iconColor = systemColors.secondaryLabel;
+  let tintColor: string | undefined;
+  let fallbackColor = systemColors.fill;
+
+  if (floatingLiquidGlass) {
+    iconColor = brandColors.onPrimary;
+    tintColor = brandColors.primaryFill;
+    fallbackColor = brandColors.primaryFill;
+  } else if (active) {
+    // Liquid Glass paints the active button on a violet glass tint, so a violet
+    // glyph is low-contrast. Material has no tint behind the glyph.
+    iconColor = selectByVariant(variant, { liquidGlass: iosSystemColors.white, material: brandColors.primary });
+    tintColor = withAlpha(brandColors.primary, 0.18);
+    fallbackColor = withAlpha(brandColors.primary, 0.16);
+  }
 
   return (
     <GlassIconButton
@@ -52,9 +64,11 @@ export function FilterButton({ activeFilterCount, onPress, onLongPress }: Filter
             }
           : undefined
       }
-      tintColor={active ? withAlpha(brandColors.primary, 0.18) : undefined}
-      fallbackColor={active ? withAlpha(brandColors.primary, 0.16) : systemColors.fill}
+      tintColor={tintColor}
+      fallbackColor={fallbackColor}
       badgeCount={activeFilterCount}
+      badgeBackgroundColor={floatingLiquidGlass ? brandColors.onPrimary : undefined}
+      badgeTextColor={floatingLiquidGlass ? brandColors.primaryFill : undefined}
     />
   );
 }

--- a/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx
@@ -28,10 +28,12 @@ vi.mock('../FilterButton', () => ({
     activeFilterCount,
     onPress,
     onLongPress,
+    prominence,
   }: {
     activeFilterCount: number;
     onPress: () => void;
     onLongPress?: () => void;
+    prominence?: string;
   }) =>
     createElement(
       'button',
@@ -39,6 +41,7 @@ vi.mock('../FilterButton', () => ({
         onClick: onPress,
         onDoubleClick: onLongPress,
         'data-filter-count': String(activeFilterCount),
+        'data-prominence': prominence ?? '',
       },
       'filter',
     ),
@@ -74,6 +77,7 @@ describe('ClimbFilterFab', () => {
     fireEvent.click(getByText('filter'));
 
     expect(onOpenFilters).toHaveBeenCalledTimes(1);
+    expect(getByText('filter').getAttribute('data-prominence')).toBe('floating');
   });
 
   it('opens the grade rail from a long press', () => {

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -21,6 +21,8 @@ type GlassMockProps = {
   tintColor?: string;
   fallbackColor?: string;
   badgeCount?: number;
+  badgeBackgroundColor?: string;
+  badgeTextColor?: string;
 };
 vi.mock('../../GlassIconButton', () => ({
   GlassIconButton: ({
@@ -37,6 +39,8 @@ vi.mock('../../GlassIconButton', () => ({
     tintColor,
     fallbackColor,
     badgeCount,
+    badgeBackgroundColor,
+    badgeTextColor,
   }: GlassMockProps) =>
     createElement('button', {
       onClick: onPress,
@@ -55,13 +59,15 @@ vi.mock('../../GlassIconButton', () => ({
       'data-tint': tintColor ?? '',
       'data-fallback': fallbackColor ?? '',
       'data-badge': badgeCount == null ? '' : String(badgeCount),
+      'data-badge-bg': badgeBackgroundColor ?? '',
+      'data-badge-color': badgeTextColor ?? '',
     }),
 }));
 
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { fill: '#EEE', secondaryLabel: '#999' },
-    brandColors: { primary: '#6D28D9' },
+    brandColors: { primary: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF' },
     variant: cfg.variant,
   }),
 }));
@@ -136,6 +142,14 @@ describe('FilterButton', () => {
     expect(filterButton.getAttribute('data-fallback')).toBe('#EEE');
   });
 
+  it('uses a filled brand surface for the floating Liquid Glass affordance', () => {
+    const { container } = render(<FilterButton activeFilterCount={0} onPress={() => {}} prominence="floating" />);
+    const filterButton = button(container);
+    expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
+    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9');
+    expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9');
+  });
+
   it('uses a white glyph on the violet glass tint when active (Liquid Glass)', () => {
     cfg.variant = 'liquidGlass';
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
@@ -146,10 +160,31 @@ describe('FilterButton', () => {
     expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9@0.16');
   });
 
+  it('keeps the floating Liquid Glass count badge visible on the filled button', () => {
+    const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} prominence="floating" />);
+    const filterButton = button(container);
+    expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
+    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9');
+    expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9');
+    expect(filterButton.getAttribute('data-badge-bg')).toBe('#FFFFFF');
+    expect(filterButton.getAttribute('data-badge-color')).toBe('#6D28D9');
+  });
+
   it('keeps the violet glyph on Material when active (no tint behind it)', () => {
     cfg.variant = 'material';
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} />);
     expect(button(container).getAttribute('data-icon-color')).toBe('#6D28D9');
+  });
+
+  it('keeps Material styling unchanged when floating prominence is requested', () => {
+    cfg.variant = 'material';
+    const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} prominence="floating" />);
+    const filterButton = button(container);
+    expect(filterButton.getAttribute('data-icon-color')).toBe('#6D28D9');
+    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9@0.18');
+    expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9@0.16');
+    expect(filterButton.getAttribute('data-badge-bg')).toBe('');
+    expect(filterButton.getAttribute('data-badge-color')).toBe('');
   });
 
   it('omits the count from the a11y label when no filters are active', () => {


### PR DESCRIPTION
## Summary

- Make the climb-search floating filter FAB use a high-contrast filled brand surface in Liquid Glass mode.
- Keep standard filter buttons and Material top-chrome behavior unchanged.
- Add badge color overrides to `GlassIconButton` so active filter counts remain legible on the filled FAB.

## Why

In light/daylight mode, the previous translucent filter affordance could be hard to see against bright search results. The floating climb-search FAB now follows the same accessible filled-control contrast used by the mobile theme while preserving the existing touch target, long-press grade shortcut, and assistive actions.

## Validation

- `vp test run --project mobile packages/mobile/src/components/search/__tests__/filter-button.test.tsx packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx packages/mobile/src/components/__tests__/glass-icon-button.test.tsx`
- `vp run typecheck:mobile`
- `vp run check:mobile-variants`
- `vp run test:mobile`
- `vp check packages/mobile/src/components/GlassIconButton.tsx packages/mobile/src/components/__tests__/glass-icon-button.test.tsx packages/mobile/src/components/search/ClimbFilterFab.tsx packages/mobile/src/components/search/FilterButton.tsx packages/mobile/src/components/search/__tests__/climb-filter-fab.test.tsx packages/mobile/src/components/search/__tests__/filter-button.test.tsx`
- `git diff --check`

Note: full `vp check` currently fails on unrelated pre-existing formatting issues outside this PR, including `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend files, and db drizzle metadata snapshots.