### PR TITLE
[codex] Deduplicate mobile BLE scan results

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -135,8 +135,6 @@ describe('RNBleAdapter', () => {
     it('cancels device connection when connected', async () => {
       mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
 
-      const adapter = new RNBleAdapter(createMockDevicePicker());
-
       // Simulate a connected state by setting internal properties via
       // the requestAndConnect flow. We'll use a simplified approach by
       // directly testing disconnect after a mock connection.
@@ -644,6 +642,107 @@ describe('RNBleAdapter', () => {
 
       expect(mockBleManager.startDeviceScan).toHaveBeenCalledWith(['aurora-uuid'], null, expect.any(Function));
       expect(seenDevices.map((device) => device.deviceId)).toEqual(['kilter-device']);
+    });
+
+    it('deduplicates repeated board names even when the native device id changes', async () => {
+      mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+      mockBleManager.startDeviceScan.mockImplementation(
+        (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+          callback(null, {
+            id: 'first-native-id',
+            localName: 'Kilter Board#751737@3',
+            name: 'Kilter Board#751737@3',
+            rssi: -45,
+            serviceUUIDs: ['aurora-uuid'],
+          });
+          callback(null, {
+            id: 'second-native-id',
+            localName: 'Kilter Board#751737@3',
+            name: 'Kilter Board#751737@3',
+            rssi: -40,
+            serviceUUIDs: ['aurora-uuid'],
+          });
+        },
+      );
+
+      const seenDeviceIdsByUpdate: string[][] = [];
+      const devicePicker: DevicePickerFn = (subscribe) => {
+        subscribe((devices) => {
+          seenDeviceIdsByUpdate.push(devices.map((device) => device.deviceId));
+        });
+        return Promise.resolve('second-native-id');
+      };
+
+      const mockCharacteristic = { uuid: 'uart-write-uuid', writeWithoutResponse: vi.fn() };
+      const mockDeviceWithServices = {
+        id: 'second-native-id',
+        characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
+        requestMTU: vi.fn().mockResolvedValue(undefined),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+      };
+      mockBleManager.connectToDevice.mockResolvedValue({
+        id: 'second-native-id',
+        requestMTU: vi.fn().mockResolvedValue(undefined),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
+      });
+
+      const adapter = new RNBleAdapter(devicePicker, 'aurora');
+      await adapter.requestAndConnect();
+
+      expect(seenDeviceIdsByUpdate).toEqual([[], ['first-native-id'], ['second-native-id']]);
+      expect(mockBleManager.connectToDevice).toHaveBeenCalledWith('second-native-id');
+    });
+
+    it('replaces an unnamed row when a later scan response adds the board name', async () => {
+      mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+      mockBleManager.startDeviceScan.mockImplementation(
+        (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+          callback(null, {
+            id: 'late-name-device',
+            localName: undefined,
+            name: undefined,
+            rssi: -45,
+            serviceUUIDs: ['aurora-uuid'],
+          });
+          callback(null, {
+            id: 'late-name-device',
+            localName: 'Kilter Board#751737@3',
+            name: 'Kilter Board#751737@3',
+            rssi: -40,
+            serviceUUIDs: ['aurora-uuid'],
+          });
+        },
+      );
+
+      const seenDevicesByUpdate: Array<Array<{ deviceId: string; name?: string }>> = [];
+      const devicePicker: DevicePickerFn = (subscribe) => {
+        subscribe((devices) => {
+          seenDevicesByUpdate.push(devices.map((device) => ({ deviceId: device.deviceId, name: device.name })));
+        });
+        return Promise.resolve('late-name-device');
+      };
+
+      const mockCharacteristic = { uuid: 'uart-write-uuid', writeWithoutResponse: vi.fn() };
+      const mockDeviceWithServices = {
+        id: 'late-name-device',
+        characteristicsForService: vi.fn().mockResolvedValue([mockCharacteristic]),
+        requestMTU: vi.fn().mockResolvedValue(undefined),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+      };
+      mockBleManager.connectToDevice.mockResolvedValue({
+        id: 'late-name-device',
+        requestMTU: vi.fn().mockResolvedValue(undefined),
+        discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
+      });
+
+      const adapter = new RNBleAdapter(devicePicker, 'aurora');
+      await adapter.requestAndConnect();
+
+      expect(seenDevicesByUpdate).toEqual([
+        [],
+        [{ deviceId: 'late-name-device', name: undefined }],
+        [{ deviceId: 'late-name-device', name: 'Kilter Board#751737@3' }],
+      ]);
     });
   });
 

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -201,6 +201,79 @@ describe('NativeIosBleAdapter connect flow', () => {
     expect(nativeMock.startScan).toHaveBeenCalledWith(['AURORA-UUID']);
   });
 
+  it('deduplicates repeated board names even when native reports a different device id', async () => {
+    let manualPick: (deviceId: string) => void = () => {};
+    const seenDeviceIdsByUpdate: string[][] = [];
+    const adapter = new NativeIosBleAdapter(
+      (subscribe) =>
+        new Promise<string>((resolve) => {
+          manualPick = resolve;
+          subscribe((devices) => {
+            seenDeviceIdsByUpdate.push(devices.map((device) => device.deviceId));
+          });
+        }),
+    );
+    const connectPromise = adapter.requestAndConnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    scanListeners[0]?.({
+      device: { deviceId: 'first-native-id', name: 'Kilter Board#751737@3' },
+      localName: 'Kilter Board#751737@3',
+      rssi: -50,
+    });
+    scanListeners[0]?.({
+      device: { deviceId: 'second-native-id', name: 'Kilter Board#751737@3' },
+      localName: 'Kilter Board#751737@3',
+      rssi: -45,
+    });
+
+    manualPick('second-native-id');
+    await vi.runAllTimersAsync();
+    await connectPromise;
+
+    expect(seenDeviceIdsByUpdate).toEqual([[], ['first-native-id'], ['second-native-id']]);
+    expect(nativeMock.connect).toHaveBeenCalledWith('second-native-id');
+  });
+
+  it('replaces an unnamed row when a later scan response adds the board name', async () => {
+    let manualPick: (deviceId: string) => void = () => {};
+    const seenDevicesByUpdate: Array<Array<{ deviceId: string; name?: string }>> = [];
+    const adapter = new NativeIosBleAdapter(
+      (subscribe) =>
+        new Promise<string>((resolve) => {
+          manualPick = resolve;
+          subscribe((devices) => {
+            seenDevicesByUpdate.push(devices.map((device) => ({ deviceId: device.deviceId, name: device.name })));
+          });
+        }),
+    );
+    const connectPromise = adapter.requestAndConnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    scanListeners[0]?.({
+      device: { deviceId: 'late-name-device', name: '' },
+      localName: '',
+      rssi: -50,
+    });
+    scanListeners[0]?.({
+      device: { deviceId: 'late-name-device', name: 'Kilter Board#751737@3' },
+      localName: 'Kilter Board#751737@3',
+      rssi: -45,
+    });
+
+    manualPick('late-name-device');
+    await vi.runAllTimersAsync();
+    await connectPromise;
+
+    expect(seenDevicesByUpdate).toEqual([
+      [],
+      [{ deviceId: 'late-name-device', name: undefined }],
+      [{ deviceId: 'late-name-device', name: 'Kilter Board#751737@3' }],
+    ]);
+  });
+
   it('does not mask the original failure when stopScan rejects in the cleanup path', async () => {
     nativeMock.stopScan.mockRejectedValueOnce(new Error('bluetooth turned off'));
     const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('Device selection cancelled')));

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -10,6 +10,7 @@ import {
 import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
 import { isLikelyBoardDevice } from './board-device-filter';
+import { upsertDiscoveredDevice } from './scan-device-cache';
 import type { BluetoothAdapter, BleConnection, BoardScanFamily, DevicePickerFn, DiscoveredDevice } from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
@@ -80,9 +81,9 @@ export class RNBleAdapter implements BluetoothAdapter {
       // Aurora scans can stay service-filtered. MoonBoard scans stay unfiltered
       // so name-prefix controllers without advertised UART still surface.
       const scanServiceUuids = this.scanFamily === 'aurora' ? [AURORA_ADVERTISED_SERVICE_UUID] : null;
-      bleManager.startDeviceScan(scanServiceUuids, null, (scanError, scannedDevice) => {
+      void bleManager.startDeviceScan(scanServiceUuids, null, (scanError, scannedDevice) => {
         if (scanError) {
-          bleManager.stopDeviceScan();
+          void bleManager.stopDeviceScan();
           // Surface the failure immediately so the user sees feedback instead
           // of waiting out the 30s scan window (the picker, if open, closes too).
           rejectSelection(new Error(`BLE scan failed: ${scanError.message}`));
@@ -104,22 +105,14 @@ export class RNBleAdapter implements BluetoothAdapter {
           return;
         }
 
-        // Deduplicate by deviceId — react-native-ble-plx uses stable
-        // peripheral UUIDs on iOS and device addresses on Android. An
-        // unfiltered scan re-fires this callback for every repeat
-        // advertisement, so only update state (and re-render the picker) when
-        // something material changed: a new device, or its name arriving in a
-        // later scan-response packet.
-        const alreadyListed = devices.get(scannedDevice.id);
-        if (alreadyListed && alreadyListed.name === deviceName) return;
-
         const device: DiscoveredDevice = {
           deviceId: scannedDevice.id,
           name: deviceName,
           rssi: scannedDevice.rssi ?? -100,
         };
-        devices.set(device.deviceId, device);
-        pushDevices();
+        if (upsertDiscoveredDevice(devices, device)) {
+          pushDevices();
+        }
 
         // Auto-select the stored board only until the picker takes over.
         if (autoSelecting && targetSerial) {
@@ -142,7 +135,7 @@ export class RNBleAdapter implements BluetoothAdapter {
         : undefined;
 
       scanTimeoutId = setTimeout(() => {
-        bleManager.stopDeviceScan();
+        void bleManager.stopDeviceScan();
         // Belt-and-suspenders: make sure the picker is open even if the grace
         // window never fired.
         if (autoSelecting) openPicker();
@@ -161,7 +154,7 @@ export class RNBleAdapter implements BluetoothAdapter {
     } finally {
       if (pickerFallbackId) clearTimeout(pickerFallbackId);
       if (scanTimeoutId) clearTimeout(scanTimeoutId);
-      bleManager.stopDeviceScan();
+      void bleManager.stopDeviceScan();
     }
 
     let selectedDeviceName: string | undefined;

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -7,6 +7,7 @@ import {
 import type { BluetoothAdapter, BleConnection, BoardScanFamily, DevicePickerFn, DiscoveredDevice } from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 import { isLikelyBoardDevice } from './board-device-filter';
+import { upsertDiscoveredDevice } from './scan-device-cache';
 
 /**
  * True when the running binary ships the newer BoardBle native surface
@@ -109,19 +110,14 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       ) {
         return;
       }
-      // Repeat advertisements of an unchanged device don't need a state
-      // update (or a picker re-render) — only a new device or a late-arriving
-      // name does.
-      const alreadyListed = devices.get(payload.device.deviceId);
-      if (alreadyListed && alreadyListed.name === deviceName) return;
-
       const device: DiscoveredDevice = {
         deviceId: payload.device.deviceId,
         name: deviceName,
         rssi: payload.rssi,
       };
-      devices.set(device.deviceId, device);
-      pushDevices();
+      if (upsertDiscoveredDevice(devices, device)) {
+        pushDevices();
+      }
 
       // Auto-select the stored board only until the picker takes over.
       if (autoSelecting && targetSerial) {

--- a/packages/mobile/src/lib/ble/scan-device-cache.ts
+++ b/packages/mobile/src/lib/ble/scan-device-cache.ts
@@ -1,0 +1,23 @@
+import type { DiscoveredDevice } from './types';
+
+function getDiscoveredDeviceKey(device: DiscoveredDevice): string {
+  const trimmedName = device.name?.trim();
+  return trimmedName ? trimmedName : device.deviceId;
+}
+
+export function upsertDiscoveredDevice(devices: Map<string, DiscoveredDevice>, device: DiscoveredDevice): boolean {
+  const deviceKey = getDiscoveredDeviceKey(device);
+  const existingDevice = devices.get(deviceKey);
+  if (existingDevice?.deviceId === device.deviceId && existingDevice.name === device.name) {
+    return false;
+  }
+
+  for (const [existingKey, existingDeviceForKey] of devices.entries()) {
+    if (existingKey !== deviceKey && existingDeviceForKey.deviceId === device.deviceId) {
+      devices.delete(existingKey);
+    }
+  }
+
+  devices.set(deviceKey, device);
+  return true;
+}


### PR DESCRIPTION
## What changed

- Added a shared mobile BLE scan-result cache that deduplicates by trimmed advertised device name before falling back to native device id.
- Wired the cache into both mobile connection adapters: `RNBleAdapter` and `NativeIosBleAdapter`.
- Added regression coverage for duplicate board names with changing native ids and late-arriving scan response names.

## Why

The React Native board picker was deduping scan results by native device id. On mobile BLE stacks, the same physical board can appear with different ids across scan callbacks, so the picker could show duplicate rows for one board. The legacy Capacitor path already avoided this by keying primarily on the advertised board name.

## Validation

- `vp run test:mobile -- packages/mobile/src/lib/ble/__tests__/adapter.test.ts packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts` passed: 315 files, 2275 tests.
- `vp run typecheck:mobile` passed.
- `vp check packages/mobile/src/lib/ble/scan-device-cache.ts packages/mobile/src/lib/ble/adapter.ts packages/mobile/src/lib/ble/native-ios-adapter.ts packages/mobile/src/lib/ble/__tests__/adapter.test.ts packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts` passed.

Note: full `vp check` still reports pre-existing formatting drift in unrelated files (`CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend tick files, and db drizzle metadata).