### PR TITLE
[codex] Sort mobile playlist picker alphabetically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Boardsesh is a monorepo containing a Next.js 16 application for controlling stan
 - No AI-generated images ever. Real photos or diagrams only.
 - No buzzwords. Concrete numbers and simple language.
 - No unnecessary check-ins. Default to action. Full autonomy except no data deletion without asking.
+- Do not leave completed code or documentation changes local-only. Unless the user explicitly opts out, publish validated changes in a pull request and share the PR with the user.
 
 ## GitHub Issue Fix Workflow
 

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -12,6 +12,7 @@ import { PlaylistFormSheet, type PlaylistFormValues } from './playlist';
 import { useToast } from '../providers/toast-provider';
 import { usePlaylistsContext, type Playlist } from '../providers/playlists-provider';
 import { useTheme } from '../providers/theme-provider';
+import { sortPlaylistsByName } from '../lib/sort-filter-playlists';
 import { iosSystemColors } from '../theme/ios-colors';
 import { borderRadius, spacing } from '../theme/tokens';
 
@@ -54,6 +55,7 @@ function AddToPlaylistSheet({
   // then no-ops the next present()). Mirrors LogAscentSheet.
   const isPresentedRef = useRef(false);
   const createRequestIdRef = useRef(0);
+  const sortedPlaylists = useMemo(() => sortPlaylistsByName(playlists), [playlists]);
 
   useEffect(() => {
     if (visible && climb && !isPresentedRef.current) {
@@ -205,14 +207,14 @@ function AddToPlaylistSheet({
           <View style={styles.message}>
             <ActivityIndicator />
           </View>
-        ) : playlists.length === 0 ? (
+        ) : sortedPlaylists.length === 0 ? (
           <View style={styles.message}>
             <Text variant="subheadline" color={iosSystemColors.systemGray}>
               {t('actions.playlist.popover.empty')}
             </Text>
           </View>
         ) : (
-          playlists.map((playlist, index) => {
+          sortedPlaylists.map((playlist, index) => {
             const accent = validHexColor(playlist.color);
             return (
               <ListRow
@@ -223,7 +225,7 @@ function AddToPlaylistSheet({
                 onPress={() => {
                   void handleAddToPlaylist(playlist);
                 }}
-                showSeparator={index < playlists.length - 1}
+                showSeparator={index < sortedPlaylists.length - 1}
               />
             );
           })

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -160,6 +160,17 @@ const playlist = {
   updatedAt: '2026-01-01T00:00:00Z',
 } satisfies Playlist;
 
+function makeSheetPlaylist(uuid: string, name: string): Playlist {
+  return { ...playlist, id: uuid, uuid, name };
+}
+
+function renderedPlaylistRowLabels(container: HTMLElement, playlistNames: string[]): string[] {
+  const expectedNames = new Set(playlistNames);
+  return Array.from(container.querySelectorAll('button[aria-label]'))
+    .map((button) => button.getAttribute('aria-label') ?? '')
+    .filter((label) => expectedNames.has(label));
+}
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -196,6 +207,24 @@ describe('AddToPlaylistSheet', () => {
     playlistContext.addToPlaylist.mockReset();
     playlistContext.createPlaylist.mockReset();
     toast.showToast.mockReset();
+  });
+
+  it('renders existing playlist rows alphabetically by name', () => {
+    const unsortedPlaylists = [
+      makeSheetPlaylist('p-banana', 'banana'),
+      makeSheetPlaylist('p-apple', 'Apple'),
+      makeSheetPlaylist('p-eclair', 'Éclair'),
+      makeSheetPlaylist('p-cherry', 'cherry'),
+    ];
+    playlistContext.playlists = unsortedPlaylists;
+    const { container } = renderSheet();
+
+    expect(
+      renderedPlaylistRowLabels(
+        container,
+        unsortedPlaylists.map((entry) => entry.name),
+      ),
+    ).toEqual(['Apple', 'banana', 'cherry', 'Éclair']);
   });
 
   it('creates a playlist from the sheet and adds the current climb to it', async () => {

--- a/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
+++ b/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
-import { sortAndFilterPlaylists } from '../sort-filter-playlists';
+import { sortAndFilterPlaylists, sortPlaylistsByName } from '../sort-filter-playlists';
 
 // A minimal Playlist factory — the helper only reads `name`, so the rest is
 // padding to satisfy the type.
@@ -24,6 +24,17 @@ function playlist(name: string): Playlist {
 const names = (playlists: Playlist[]) => playlists.map((entry) => entry.name);
 
 describe('sortAndFilterPlaylists', () => {
+  it('sorts playlists by name without applying a filter', () => {
+    const input = [playlist('warmups'), playlist('Projects'), playlist('anti-style')];
+    expect(names(sortPlaylistsByName(input))).toEqual(['anti-style', 'Projects', 'warmups']);
+  });
+
+  it('does not mutate the input array when sorting by name', () => {
+    const input = [playlist('b'), playlist('a')];
+    sortPlaylistsByName(input);
+    expect(names(input)).toEqual(['b', 'a']);
+  });
+
   it('sorts alphabetically, case- and accent-insensitively', () => {
     const input = [playlist('banana'), playlist('Apple'), playlist('Éclair'), playlist('cherry')];
     expect(names(sortAndFilterPlaylists(input, ''))).toEqual(['Apple', 'banana', 'cherry', 'Éclair']);

--- a/packages/mobile/src/lib/sort-filter-playlists.ts
+++ b/packages/mobile/src/lib/sort-filter-playlists.ts
@@ -1,13 +1,19 @@
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 
 /**
- * Sort playlists alphabetically by name (case- and accent-insensitive), then
- * keep only those whose name contains the (trimmed, case-insensitive) query.
- * Pure so the "My Playlists" screen can test ordering + filtering without a
- * render. Does not mutate the input.
+ * Sort playlists alphabetically by name (case- and accent-insensitive). Pure so
+ * list surfaces can share the same ordering without mutating their inputs.
+ */
+export function sortPlaylistsByName(playlists: Playlist[]): Playlist[] {
+  return [...playlists].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+}
+
+/**
+ * Sort playlists alphabetically by name, then keep only those whose name
+ * contains the (trimmed, case-insensitive) query.
  */
 export function sortAndFilterPlaylists(playlists: Playlist[], query: string): Playlist[] {
-  const sorted = [...playlists].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+  const sorted = sortPlaylistsByName(playlists);
   const needle = query.trim().toLowerCase();
   if (!needle) return sorted;
   return sorted.filter((playlist) => playlist.name.toLowerCase().includes(needle));


### PR DESCRIPTION
## Summary

- Sort the React Native add-to-playlist sheet alphabetically by playlist name.
- Reuse a shared mobile playlist name sorter so the picker and full playlist list use the same case/accent-insensitive order.
- Add a Codex-readable repo guideline in `AGENTS.md` that validated code/documentation changes should be published in a PR unless explicitly opted out.

## Root Cause

The add-to-playlist sheet rendered `PlaylistsProvider` data in the backend `allUserPlaylists` order, which is intentionally recency-based for library surfaces. The swipe picker needs a scan-friendly alphabetical order instead.

## Validation

- `vp check AGENTS.md packages/mobile/src/components/AddToPlaylistSheet.tsx packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx packages/mobile/src/lib/sort-filter-playlists.ts packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts`
- `vp test run --project mobile packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx`
- `vp run typecheck:mobile`