### PR TITLE
[codex] fix mobile wrong-board playlist suggestions

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -126,7 +126,8 @@ export default function PlaylistDetail() {
   const resolveViewOnlyBoard = useCallback(
     (climb: Climb) => {
       if (!shouldOpenViewOnly) return null;
-      return resolvePlaylistClimbRenderBoard(climb, renderBoard)?.renderBoard ?? renderBoard;
+      const resolvedRenderBoard = resolvePlaylistClimbRenderBoard(climb, renderBoard);
+      return resolvedRenderBoard?.incompatible ? resolvedRenderBoard.renderBoard : null;
     },
     [shouldOpenViewOnly, renderBoard],
   );

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -32,6 +32,7 @@ import { GlassIconButton } from '../../../src/components/GlassIconButton';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-render-board';
+import { resolvePlaylistClimbRenderBoard } from '../../../src/lib/playlists/playlist-climb-render-board';
 import { recordPlaylistOpen } from '../../../src/lib/playlists/recents-store';
 import { reportHandledError } from '../../../src/lib/error-reporting';
 import { toQueueClimbs } from '../../../src/lib/climb-types';
@@ -114,19 +115,29 @@ export default function PlaylistDetail() {
     [playlistUuid],
   );
 
-  const activate = usePlaylistActivation({
-    sourceId: `playlist:${playlistUuid}`,
-    allClimbs,
-    fetchPage,
-    refreshErrorMessage: 'Failed to refresh playlist suggestions:',
-  });
-
   // Prefer the active board for row rendering; mixed-board climbs resolve their
   // own board per row and dim when they do not fit the active board. The banner
   // still prompts a switch for list-level board mismatches.
   const { renderBoard, banner: boardBanner } = usePlaylistRenderBoard(
     playlist ? { boardType: playlist.boardType, layoutId: playlist.layoutId } : null,
   );
+
+  const shouldOpenViewOnly = !!boardBanner;
+  const resolveViewOnlyBoard = useCallback(
+    (climb: Climb) => {
+      if (!shouldOpenViewOnly) return null;
+      return resolvePlaylistClimbRenderBoard(climb, renderBoard)?.renderBoard ?? renderBoard;
+    },
+    [shouldOpenViewOnly, renderBoard],
+  );
+
+  const activate = usePlaylistActivation({
+    sourceId: `playlist:${playlistUuid}`,
+    allClimbs,
+    fetchPage,
+    viewOnlyBoard: resolveViewOnlyBoard,
+    refreshErrorMessage: 'Failed to refresh playlist suggestions:',
+  });
 
   const isOwner = playlist?.userRole === 'owner';
   const isFollowable = !!playlist?.isPublic && !isOwner;

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -3,10 +3,38 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Climb } from '@boardsesh/queue';
+
+type TestRenderBoard = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+};
+
+type TestBoardBanner = {
+  title: string;
+  subtitle: string;
+  cta: string;
+  onPress: () => void;
+};
+
+type CapturedActivationOptions = {
+  viewOnlyBoard?: TestRenderBoard | ((climb: Climb) => TestRenderBoard | null) | null;
+};
 
 // The metadata query goes through getHttpClient().request — mock it so we can
 // make GET_PLAYLIST reject (the error path) or resolve (the not-found path).
 const requestMock = vi.hoisted(() => vi.fn());
+const playlistMocks = vi.hoisted(() => ({
+  allClimbs: [] as Climb[],
+  activationOptions: null as CapturedActivationOptions | null,
+  renderBoardResult: {
+    renderBoard: null as TestRenderBoard | null,
+    banner: null as TestBoardBanner | null,
+  },
+}));
 vi.mock('../../../../src/lib/graphql/client', () => ({
   getHttpClient: () => ({ request: requestMock }),
 }));
@@ -24,7 +52,7 @@ vi.mock('@boardsesh/playlists-react', () => ({
       fetchNextPage: vi.fn(),
       refetch: climbsRefetch,
     },
-    allClimbs: [],
+    allClimbs: playlistMocks.allClimbs,
   }),
   usePlaylistMutations: () => ({
     updatePlaylist: updatePlaylistMock,
@@ -70,9 +98,14 @@ vi.mock('../../../../src/providers/theme-provider', () => ({
 }));
 vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
-vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({ usePlaylistActivation: () => vi.fn() }));
+vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
+  usePlaylistActivation: (options: CapturedActivationOptions) => {
+    playlistMocks.activationOptions = options;
+    return vi.fn();
+  },
+}));
 vi.mock('../../../../src/lib/playlists/use-playlist-render-board', () => ({
-  usePlaylistRenderBoard: () => ({ renderBoard: null, banner: null }),
+  usePlaylistRenderBoard: () => playlistMocks.renderBoardResult,
 }));
 vi.mock('../../../../src/lib/playlists/recents-store', () => ({ recordPlaylistOpen: vi.fn() }));
 vi.mock('../../../../src/lib/climb-types', () => ({ toQueueClimbs: (climbs: unknown) => climbs }));
@@ -132,7 +165,47 @@ beforeEach(() => {
   requestMock.mockReset();
   climbsRefetch.mockClear();
   updatePlaylistMock.mockReset();
+  playlistMocks.allClimbs = [];
+  playlistMocks.activationOptions = null;
+  playlistMocks.renderBoardResult = { renderBoard: null, banner: null };
 });
+
+function makePlaylist(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: 'p-1',
+    name: 'Playlist',
+    description: null,
+    color: '#8C4A52',
+    icon: null,
+    climbCount: 2,
+    boardType: 'tension',
+    layoutId: 9,
+    isPublic: false,
+    userRole: 'owner',
+    isPinnedByMe: false,
+    isFollowedByMe: false,
+    followerCount: 0,
+    ...overrides,
+  };
+}
+
+function makeClimb(uuid: string, boardType: string, layoutId: number, angle: number): Climb {
+  return {
+    uuid,
+    name: uuid,
+    setter_username: 'setter',
+    frames: '',
+    angle,
+    ascensionist_count: 0,
+    difficulty: 'V3',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+    boardType,
+    layoutId,
+  };
+}
 
 describe('PlaylistDetail metadata error handling', () => {
   it('renders an error + retry state (not a fallback-titled hero) when GET_PLAYLIST rejects', async () => {
@@ -170,6 +243,30 @@ describe('PlaylistDetail metadata error handling', () => {
 
     expect(await findByText('detail.errors.notFoundTitle')).toBeTruthy();
     expect(queryByText('detail.errors.loadTitle')).toBeNull();
+  });
+
+  it('only opens incompatible rows view-only when the playlist board is mismatched', async () => {
+    const compatibleClimb = makeClimb('compatible-kilter', 'kilter', 1, 40);
+    const incompatibleClimb = makeClimb('incompatible-tension', 'tension', 9, 35);
+    playlistMocks.allClimbs = [compatibleClimb, incompatibleClimb];
+    playlistMocks.renderBoardResult = {
+      renderBoard: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 },
+      banner: { title: 'title', subtitle: 'subtitle', cta: 'cta', onPress: vi.fn() },
+    };
+    requestMock.mockResolvedValue({ playlist: makePlaylist() });
+
+    renderDetail();
+
+    await waitFor(() => expect(playlistMocks.activationOptions?.viewOnlyBoard).toEqual(expect.any(Function)));
+    const resolveViewOnlyBoard = playlistMocks.activationOptions?.viewOnlyBoard;
+    if (typeof resolveViewOnlyBoard !== 'function') throw new Error('Expected a view-only resolver');
+
+    expect(resolveViewOnlyBoard(compatibleClimb)).toBeNull();
+    expect(resolveViewOnlyBoard(incompatibleClimb)).toMatchObject({
+      boardName: 'tension',
+      layoutId: 9,
+      angle: 35,
+    });
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -48,6 +48,7 @@ import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
 import { useDeferredSheetOpen } from './use-deferred-sheet-open';
 import { resolveFavoriteRollback } from './favorite-rollback';
 import { buildPlayDrawerBoardLayout } from './lightbulb-control';
+import { getViewOnlyPreviewNavigationTarget } from './play-drawer-navigation';
 import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { track } from '../../lib/analytics';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -381,22 +382,46 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   }, [flushOnDismiss]);
 
   const handlePrev = useCallback(() => {
+    const previewTarget = getViewOnlyPreviewNavigationTarget({
+      previewItem: drawerPreviewItem,
+      previewSuggestionSource: drawerPreviewSuggestionSource,
+      targetItem: navigationState.prevItem,
+    });
+    if (previewTarget.viewOnly) {
+      if (!previewTarget.targetItem) return;
+      setDrawerPreviewItem(previewTarget.targetItem);
+      setIsMirrored(false);
+      // The favorite override is cleared by the climb-change effect.
+      return;
+    }
     // Always-live: navigation commits the shared current climb for everyone.
     setDrawerPreviewItem(null);
     setDrawerPreviewIsWallClimb(false);
     previousClimb();
     setIsMirrored(false);
     // The favorite override is cleared by the climb-change effect.
-  }, [previousClimb]);
+  }, [drawerPreviewSuggestionSource, drawerPreviewItem, navigationState.prevItem, previousClimb]);
 
   const handleNext = useCallback(() => {
+    const previewTarget = getViewOnlyPreviewNavigationTarget({
+      previewItem: drawerPreviewItem,
+      previewSuggestionSource: drawerPreviewSuggestionSource,
+      targetItem: navigationState.nextItem,
+    });
+    if (previewTarget.viewOnly) {
+      if (!previewTarget.targetItem) return;
+      setDrawerPreviewItem(previewTarget.targetItem);
+      setIsMirrored(false);
+      // The favorite override is cleared by the climb-change effect.
+      return;
+    }
     // Always-live: navigation commits the shared current climb for everyone.
     setDrawerPreviewItem(null);
     setDrawerPreviewIsWallClimb(false);
     nextClimb();
     setIsMirrored(false);
     // The favorite override is cleared by the climb-change effect.
-  }, [nextClimb]);
+  }, [drawerPreviewSuggestionSource, drawerPreviewItem, navigationState.nextItem, nextClimb]);
 
   // Promote the previewed climb to the active/current queue item. The Preview
   // badge clears and the lightbulb (which acts on the current climb) now drives

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+import { getViewOnlyPreviewNavigationTarget } from '../play-drawer-navigation';
+
+function makeItem(id: string): ClimbQueueItem {
+  return {
+    uuid: `queue-${id}`,
+    climb: {
+      uuid: `climb-${id}`,
+      name: `Climb ${id}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+function makePreviewSource(currentItem: ClimbQueueItem): PlaylistSuggestionSource {
+  return {
+    playlistUuid: 'playlist:pl-1',
+    activatedClimbUuid: currentItem.climb.uuid,
+    boardKey: 'tension:9:5:1,2',
+    climbs: [currentItem.climb],
+  };
+}
+
+describe('getViewOnlyPreviewNavigationTarget', () => {
+  it('returns the previous preview item in view-only mode so callers do not fall through to queue navigation', () => {
+    const currentItem = makeItem('current');
+    const previousItem = makeItem('previous');
+    const previewSource = makePreviewSource(currentItem);
+
+    expect(
+      getViewOnlyPreviewNavigationTarget({
+        previewItem: currentItem,
+        previewSuggestionSource: previewSource,
+        targetItem: previousItem,
+      }),
+    ).toEqual({ viewOnly: true, targetItem: previousItem });
+  });
+
+  it('consumes view-only navigation even when there is no target item', () => {
+    const currentItem = makeItem('current');
+    const previewSource = makePreviewSource(currentItem);
+
+    expect(
+      getViewOnlyPreviewNavigationTarget({
+        previewItem: currentItem,
+        previewSuggestionSource: previewSource,
+        targetItem: null,
+      }),
+    ).toEqual({ viewOnly: true, targetItem: null });
+  });
+
+  it('returns a non-view-only result when there is no preview source', () => {
+    expect(
+      getViewOnlyPreviewNavigationTarget({
+        previewItem: makeItem('current'),
+        previewSuggestionSource: null,
+        targetItem: makeItem('previous'),
+      }),
+    ).toEqual({ viewOnly: false });
+  });
+
+  it('returns a non-view-only result when the preview source exists without a preview item', () => {
+    const currentItem = makeItem('current');
+    const previewSource = makePreviewSource(currentItem);
+
+    expect(
+      getViewOnlyPreviewNavigationTarget({
+        previewItem: null,
+        previewSuggestionSource: previewSource,
+        targetItem: makeItem('previous'),
+      }),
+    ).toEqual({ viewOnly: false });
+  });
+});

--- a/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
@@ -1,0 +1,18 @@
+import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+
+export type ViewOnlyPreviewNavigationTarget =
+  | { viewOnly: false }
+  | { viewOnly: true; targetItem: ClimbQueueItem | null };
+
+export function getViewOnlyPreviewNavigationTarget({
+  previewItem,
+  previewSuggestionSource,
+  targetItem,
+}: {
+  previewItem: ClimbQueueItem | null;
+  previewSuggestionSource: PlaylistSuggestionSource | null;
+  targetItem: ClimbQueueItem | null;
+}): ViewOnlyPreviewNavigationTarget {
+  if (!previewSuggestionSource || !previewItem) return { viewOnly: false };
+  return { viewOnly: true, targetItem };
+}

--- a/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
@@ -13,6 +13,9 @@ export function getViewOnlyPreviewNavigationTarget({
   previewSuggestionSource: PlaylistSuggestionSource | null;
   targetItem: ClimbQueueItem | null;
 }): ViewOnlyPreviewNavigationTarget {
+  // Mobile only sets previewSuggestionSource for the wrong-board view-only
+  // drawer path. Normal playlist activation commits navigation through the
+  // queue and must leave this value null.
   if (!previewSuggestionSource || !previewItem) return { viewOnly: false };
   return { viewOnly: true, targetItem };
 }

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -690,16 +690,6 @@ describe('PlaylistDetailView', () => {
       expect(banner.onPress).toHaveBeenCalledTimes(1);
     });
 
-    it('opens a mismatched climb row through the view-only activation path', () => {
-      const onActivateClimb = vi.fn();
-      const { getByText } = render(
-        <PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner, onActivateClimb })} />,
-      );
-      fireEvent.click(getByText(CLIMB.name));
-      expect(onActivateClimb).toHaveBeenCalledWith(CLIMB);
-      expect(banner.onPress).not.toHaveBeenCalled();
-    });
-
     it('renders no banner when boardBanner is absent', () => {
       const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB] })} />);
       expect(container.querySelector('[data-button]')).toBeNull();

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -104,16 +104,21 @@ vi.mock('@shopify/flash-list', () => ({
     ListEmptyComponent?: ReactNode;
     ListFooterComponent?: ReactNode;
     onEndReached?: () => void;
-  }) =>
-    createElement(
+  }) => {
+    const rowNodes = data?.map((item, index) => {
+      const key =
+        typeof item === 'object' && item !== null && 'uuid' in item ? String((item as { uuid?: unknown }).uuid) : index;
+      return renderItem ? createElement('div', { key }, renderItem({ item, index })) : null;
+    });
+    return createElement(
       'div',
       { 'data-list': 'true', onClick: onEndReached },
       ListHeaderComponent ?? null,
-      data && data.length > 0 && renderItem
-        ? data.map((item, index) => createElement('div', { key: index }, renderItem({ item, index })))
-        : (ListEmptyComponent ?? null),
+      data?.length === 0 ? (ListEmptyComponent ?? null) : null,
+      rowNodes ?? null,
       ListFooterComponent ?? null,
-    ),
+    );
+  },
 }));
 
 vi.mock('expo-router', () => ({ useRouter: () => ({ back: ctrl.back }) }));
@@ -683,6 +688,16 @@ describe('PlaylistDetailView', () => {
       const { getByText } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner })} />);
       fireEvent.click(getByText(banner.cta));
       expect(banner.onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens a mismatched climb row through the view-only activation path', () => {
+      const onActivateClimb = vi.fn();
+      const { getByText } = render(
+        <PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner, onActivateClimb })} />,
+      );
+      fireEvent.click(getByText(CLIMB.name));
+      expect(onActivateClimb).toHaveBeenCalledWith(CLIMB);
+      expect(banner.onPress).not.toHaveBeenCalled();
     });
 
     it('renders no banner when boardBanner is absent', () => {

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -28,6 +28,8 @@ const mocks = vi.hoisted(() => ({
   queueItemCounter: 0,
 }));
 
+const VIEW_ONLY_BOARD = { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: '1,2', angle: 35 };
+
 vi.mock('@boardsesh/playlists-react', () => ({
   usePlaylistClimbActivation: (options: UsePlaylistClimbActivationOptions) => {
     mocks.captured = options;
@@ -76,9 +78,22 @@ function makeClimb(uuid: string): Climb {
   };
 }
 
-function renderActivation(fetchPage = vi.fn()) {
+function renderActivation(
+  fetchPage = vi.fn(),
+  options: {
+    allClimbs?: Climb[];
+    sourceId?: string;
+    viewOnlyBoard?: typeof VIEW_ONLY_BOARD | ((climb: Climb) => typeof VIEW_ONLY_BOARD | null) | null;
+  } = {},
+) {
   return renderHook(() =>
-    usePlaylistActivation({ sourceId: 'pl-1', allClimbs: [], fetchPage, refreshErrorMessage: 'refresh failed:' }),
+    usePlaylistActivation({
+      sourceId: options.sourceId ?? 'playlist:pl-1',
+      allClimbs: options.allClimbs ?? [],
+      fetchPage,
+      viewOnlyBoard: options.viewOnlyBoard,
+      refreshErrorMessage: 'refresh failed:',
+    }),
   );
 }
 
@@ -181,8 +196,8 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
   it('re-tapping the active climb whose suggestions already follow this list just reopens', async () => {
     mocks.activeClimbUuid = 'a';
-    // Suggestions already anchored on 'a' from this very list (sourceId 'pl-1').
-    mocks.suggestionSource = { playlistUuid: 'pl-1', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
+    // Suggestions already anchored on 'a' from this very list (sourceId 'playlist:pl-1').
+    mocks.suggestionSource = { playlistUuid: 'playlist:pl-1', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
     const { result } = renderActivation();
     const climb = makeClimb('a');
     await result.current(climb);
@@ -196,7 +211,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
   it('re-tapping the active climb from a DIFFERENT list re-activates to follow it', async () => {
     mocks.activeClimbUuid = 'a';
     // 'a' is active, but its suggestions follow another list ('climblist'), not
-    // this one ('pl-1'). The drawer's next/previous must switch to follow 'pl-1'.
+    // this one ('playlist:pl-1'). The drawer's next/previous must switch to follow it.
     mocks.suggestionSource = { playlistUuid: 'climblist', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
     const { result } = renderActivation();
     const climb = makeClimb('a');
@@ -231,6 +246,54 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     // 'a' is not the active climb ('b' is), so this still starts a fresh pass.
     expect(mocks.activate).toHaveBeenCalledWith(climb);
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
+  });
+
+  it('opens wrong-board playlist climbs view-only without mutating the queue', async () => {
+    const climbA = { ...makeClimb('a'), angle: 20 };
+    const climbB = makeClimb('b');
+    const fetchPage = vi.fn();
+    const { result } = renderActivation(fetchPage, { allClimbs: [climbA, climbB], viewOnlyBoard: VIEW_ONLY_BOARD });
+
+    await result.current(climbA);
+
+    const viewOnlyOptions = mocks.openPlayDrawer.mock.calls[0][1];
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climbA, {
+      setAsCurrent: false,
+      boardConfig: { ...VIEW_ONLY_BOARD, angle: 20 },
+      previewQueueItem: expect.objectContaining({ climb: climbA, suggested: true }),
+      previewPlaylistSuggestionSource: expect.objectContaining({
+        playlistUuid: 'playlist:pl-1',
+        activatedClimbUuid: 'a',
+        boardKey: 'tension:9:5:1,2',
+        climbs: [climbA, climbB],
+      }),
+    });
+    expect(viewOnlyOptions.boardConfig).not.toBe(VIEW_ONLY_BOARD);
+    expect(mocks.activate).not.toHaveBeenCalled();
+    expect(mocks.setCurrentClimb).not.toHaveBeenCalled();
+    expect(mocks.refreshPlaylistSuggestionSource).not.toHaveBeenCalled();
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+
+  it('resolves the view-only board from the tapped climb', async () => {
+    const climb = { ...makeClimb('tension-a'), angle: 20 };
+    const viewOnlyResolver = vi.fn((tapped: Climb) =>
+      tapped.uuid === climb.uuid ? { boardName: 'tension', layoutId: 9, sizeId: 8, setIds: '4,5', angle: 0 } : null,
+    );
+    const { result } = renderActivation(vi.fn(), { allClimbs: [climb], viewOnlyBoard: viewOnlyResolver });
+
+    await result.current(climb);
+
+    expect(viewOnlyResolver).toHaveBeenCalledWith(climb);
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
+      setAsCurrent: false,
+      boardConfig: { boardName: 'tension', layoutId: 9, sizeId: 8, setIds: '4,5', angle: 20 },
+      previewQueueItem: expect.objectContaining({ climb, suggested: true }),
+      previewPlaylistSuggestionSource: expect.objectContaining({
+        boardKey: 'tension:9:8:4,5',
+      }),
+    });
+    expect(mocks.activate).not.toHaveBeenCalled();
   });
 
   it('fetchClimbsForBoard pages the playlist via the injected fetchPage', async () => {

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -258,10 +258,9 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
     const viewOnlyOptions = mocks.openPlayDrawer.mock.calls[0][1];
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climbA, {
-      setAsCurrent: false,
       boardConfig: { ...VIEW_ONLY_BOARD, angle: 20 },
       previewQueueItem: expect.objectContaining({ climb: climbA, suggested: true }),
-      previewPlaylistSuggestionSource: expect.objectContaining({
+      playlistSuggestionSource: expect.objectContaining({
         playlistUuid: 'playlist:pl-1',
         activatedClimbUuid: 'a',
         boardKey: 'tension:9:5:1,2',
@@ -286,10 +285,9 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
     expect(viewOnlyResolver).toHaveBeenCalledWith(climb);
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
-      setAsCurrent: false,
       boardConfig: { boardName: 'tension', layoutId: 9, sizeId: 8, setIds: '4,5', angle: 20 },
       previewQueueItem: expect.objectContaining({ climb, suggested: true }),
-      previewPlaylistSuggestionSource: expect.objectContaining({
+      playlistSuggestionSource: expect.objectContaining({
         boardKey: 'tension:9:8:4,5',
       }),
     });

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 import { usePlaylistRenderBoard } from '../use-playlist-render-board';
 
 type ActiveBoard = {
-  boardName: string;
+  boardType: string;
   layoutId: number;
   sizeId: number;
   setIds: string;
@@ -15,7 +15,7 @@ type ResolvedBoard = { boardName: string; layoutId: number; sizeId: number; setI
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
-  activeBoard: { boardName: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
+  activeBoard: { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
   resolved: { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: [1, 2] } as ResolvedBoard,
   getBoardConfigForPlaylist: vi.fn(),
 }));
@@ -34,8 +34,14 @@ vi.mock('@boardsesh/board-config', () => ({
   formatBoardDisplayName: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
 }));
 
+vi.mock('../../graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: mocks.activeBoard }),
+}));
+
 vi.mock('../../../providers/drawer-host-provider', () => ({
-  useDrawerHost: () => ({ boardConfig: mocks.activeBoard }),
+  useDrawerHost: () => ({
+    boardConfig: { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: '1,2', angle: 35 },
+  }),
 }));
 
 vi.mock('../board-details-for-playlist', () => ({
@@ -45,7 +51,7 @@ vi.mock('../board-details-for-playlist', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.activeBoard = { boardName: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
+  mocks.activeBoard = { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
   mocks.resolved = { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: [1, 2] };
   mocks.getBoardConfigForPlaylist.mockImplementation(() => mocks.resolved);
 });
@@ -53,7 +59,13 @@ beforeEach(() => {
 describe('usePlaylistRenderBoard', () => {
   it('renders against the active board with no banner when the boards match', () => {
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: 1 }));
-    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.renderBoard).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3',
+      angle: 40,
+    });
     expect(result.current.banner).toBeNull();
     // No need to resolve the playlist's own board when it matches the active one.
     expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
@@ -61,23 +73,42 @@ describe('usePlaylistRenderBoard', () => {
 
   it('matches on board name when the playlist carries no layout (Aurora circuit)', () => {
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: null }));
-    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.renderBoard).toMatchObject({ boardName: 'kilter', layoutId: 1 });
     expect(result.current.banner).toBeNull();
   });
 
   it('keeps the active board and shows a banner on a board-name mismatch', () => {
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'tension', layoutId: 9 }));
-    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.renderBoard).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3',
+      angle: 40,
+    });
     expect(result.current.banner?.title).toContain('Tension');
     expect(result.current.banner?.subtitle).toContain('Tension');
     expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('ignores drawer-host board overrides when deciding playlist mismatch', () => {
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'tension', layoutId: 9 }));
+    // Regression guard: the mocked drawer host above reports a matching Tension
+    // override, but playlist mismatch must be based on the stored active board.
+    expect(result.current.banner).not.toBeNull();
   });
 
   it('treats a layout mismatch on the same board as a mismatch', () => {
     mocks.resolved = { boardName: 'kilter', layoutId: 8, sizeId: 7, setIds: [3] };
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: 8 }));
     expect(result.current.banner).not.toBeNull();
-    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.renderBoard).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3',
+      angle: 40,
+    });
     expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
   });
 
@@ -92,7 +123,13 @@ describe('usePlaylistRenderBoard', () => {
   it('keeps the active board when the playlist board cannot be resolved', () => {
     mocks.resolved = null;
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'moonboard', layoutId: 1 }));
-    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.renderBoard).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 2,
+      setIds: '3',
+      angle: 40,
+    });
     expect(result.current.banner).not.toBeNull();
     expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
   });
@@ -113,7 +150,7 @@ describe('usePlaylistRenderBoard', () => {
 
   it('always renders against the active board with no banner for smart playlists (null input)', () => {
     const { result } = renderHook(() => usePlaylistRenderBoard(null));
-    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.renderBoard).toMatchObject({ boardName: 'kilter', layoutId: 1 });
     expect(result.current.banner).toBeNull();
     expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
   });

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -4,27 +4,32 @@
 // only difference between them is which GraphQL query backs the suggestion
 // refresh, so that fetcher is injected.
 //
-// Activation is two-phase (see the shared hook): it synchronously activates the
-// tapped climb with a suggestion source built from the loaded climbs, opens the
-// play drawer, then asynchronously fetches the full ordered board climb list and
-// swaps in a richer suggestion source so swiping through the play drawer walks
-// the whole playlist.
+// Active-board activation is two-phase (see the shared hook): it synchronously
+// activates the tapped climb with a suggestion source built from the loaded
+// climbs, opens the play drawer, then asynchronously fetches the full ordered
+// board climb list and swaps in a richer suggestion source so swiping through
+// the play drawer walks the whole playlist. Wrong-board playlists use a
+// view-only drawer path so they can be inspected without mutating the queue.
 
 import { useCallback, useMemo, useRef } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
-import { getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
+import { createPlaylistSuggestionSource, getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
 import { useActiveClimbUuid, usePlaylistSuggestionSource, useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
 import { reportHandledError } from '../error-reporting';
 import { toSchemaClimb } from '../climb-types';
+import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
 /** A single page of the suggestion-refresh fetch. */
 export type PlaylistActivationPage = {
   climbs: Climb[];
   hasMore: boolean;
 };
+
+/** Return a board config for view-only drawer preview, or null to activate normally. */
+type ViewOnlyBoardResolver = (climb: Climb) => PlaylistRenderBoard | null;
 
 export type UsePlaylistActivationOptions = {
   /** Stable suggestion-source id (e.g. `playlist:<uuid>` or `smart:<type>:<userId>`). */
@@ -42,6 +47,13 @@ export type UsePlaylistActivationOptions = {
     board: { boardName: string; layoutId: number; sizeId: number; setIds: string; angle: number };
     signal: AbortSignal;
   }) => Promise<PlaylistActivationPage>;
+  /**
+   * When set, the tap is view-only: open the drawer against this board config
+   * and keep playlist navigation local to the drawer without mutating the active
+   * queue. A resolver can return the specific board for the tapped row, or null
+   * when that row should activate normally.
+   */
+  viewOnlyBoard?: PlaylistRenderBoard | ViewOnlyBoardResolver | null;
   /** Logged when the async suggestion refresh fails (non-abort). */
   refreshErrorMessage: string;
 };
@@ -51,6 +63,7 @@ export function usePlaylistActivation({
   sourceId,
   allClimbs,
   fetchPage,
+  viewOnlyBoard,
   refreshErrorMessage,
 }: UsePlaylistActivationOptions): (climb: Climb) => Promise<void> {
   const { setCurrentClimb, setPlaylistSuggestionSource, refreshPlaylistSuggestionSource } = useQueueActions();
@@ -169,6 +182,39 @@ export function usePlaylistActivation({
   return useCallback(
     (climb: Climb) => {
       const schemaClimb = toSchemaClimb(climb);
+
+      // Wrong-board playlist climb: open a view-only drawer against the playlist's
+      // board instead of mutating the active-board queue. The drawer navigates the
+      // playlist locally (previewPlaylistSuggestionSource) until the user switches
+      // boards, and the tapped climb's angle rides along on the override.
+      const resolvedViewOnlyBoard = typeof viewOnlyBoard === 'function' ? viewOnlyBoard(climb) : viewOnlyBoard;
+
+      if (resolvedViewOnlyBoard) {
+        const item = climbToQueueItem(schemaClimb, { suggested: true });
+        const viewOnlyBoardConfig = {
+          ...resolvedViewOnlyBoard,
+          angle: climb.angle,
+        };
+        const previewPlaylistSuggestionSource = createPlaylistSuggestionSource({
+          playlistUuid: sourceId,
+          activatedClimb: climb,
+          climbs: allClimbs,
+          boardKey: getQueueBoardKey({
+            board_name: viewOnlyBoardConfig.boardName,
+            layout_id: viewOnlyBoardConfig.layoutId,
+            size_id: viewOnlyBoardConfig.sizeId,
+            set_ids: viewOnlyBoardConfig.setIds,
+          }),
+        });
+        openPlayDrawer(schemaClimb, {
+          setAsCurrent: false,
+          boardConfig: viewOnlyBoardConfig,
+          previewQueueItem: item,
+          previewPlaylistSuggestionSource,
+        });
+        return Promise.resolve();
+      }
+
       const isAlreadyActive = activeClimbUuidRef.current === climb.uuid;
       const source = playlistSuggestionSourceRef.current;
       const suggestionsAlreadyFollowThisList =
@@ -200,6 +246,6 @@ export function usePlaylistActivation({
         reportHandledError(error, { tags: { source: 'playlist', op: 'activate-climb' } });
       });
     },
-    [activate, openPlayDrawer, sourceId],
+    [activate, allClimbs, openPlayDrawer, sourceId, viewOnlyBoard],
   );
 }

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -195,7 +195,7 @@ export function usePlaylistActivation({
           ...resolvedViewOnlyBoard,
           angle: climb.angle,
         };
-        const previewPlaylistSuggestionSource = createPlaylistSuggestionSource({
+        const previewSuggestionSource = createPlaylistSuggestionSource({
           playlistUuid: sourceId,
           activatedClimb: climb,
           climbs: allClimbs,
@@ -207,10 +207,9 @@ export function usePlaylistActivation({
           }),
         });
         openPlayDrawer(schemaClimb, {
-          setAsCurrent: false,
           boardConfig: viewOnlyBoardConfig,
           previewQueueItem: item,
-          previewPlaylistSuggestionSource,
+          playlistSuggestionSource: previewSuggestionSource,
         });
         return Promise.resolve();
       }

--- a/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
@@ -13,8 +13,9 @@ import { useMemo } from 'react';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { formatBoardDisplayName } from '@boardsesh/board-config';
-import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
+import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { boardLooselyMatches } from '../boards/board-matches';
+import { useActiveBoard } from '../graphql/use-active-board';
 import { getBoardConfigForPlaylist } from './board-details-for-playlist';
 
 /** The board a playlist's rows render against — same shape as the active board
@@ -48,7 +49,7 @@ export type UsePlaylistRenderBoardResult = {
 export function usePlaylistRenderBoard(
   playlistBoard: { boardType: string; layoutId?: number | null } | null,
 ): UsePlaylistRenderBoardResult {
-  const { boardConfig: activeBoard } = useDrawerHost();
+  const activeBoard = useActiveBoard().data ?? null;
   const router = useRouter();
   const { t } = useTranslation('playlists');
 
@@ -57,20 +58,31 @@ export function usePlaylistRenderBoard(
   const boardType = playlistBoard?.boardType ?? null;
   const layoutId = playlistBoard?.layoutId ?? null;
 
+  const activeRenderBoard = useMemo<PlaylistRenderBoard | null>(() => {
+    if (!activeBoard) return null;
+    return {
+      boardName: activeBoard.boardType,
+      layoutId: activeBoard.layoutId,
+      sizeId: activeBoard.sizeId,
+      setIds: activeBoard.setIds,
+      angle: activeBoard.angle,
+    };
+  }, [activeBoard]);
+
   // Resolve the preferred render board + mismatch flag from the real board state only (no
   // `t`/`router`), so `renderBoard`'s identity is stable across unrelated
   // re-renders and never churns the FlashList rows that depend on it.
   const { renderBoard, mismatch } = useMemo<{ renderBoard: PlaylistRenderBoard | null; mismatch: boolean }>(() => {
     // Smart playlists (no board): always the active board, no mismatch concept.
-    if (boardType == null) return { renderBoard: activeBoard, mismatch: false };
+    if (boardType == null) return { renderBoard: activeRenderBoard, mismatch: false };
 
-    const matchesActive = boardLooselyMatches({ boardName: boardType, layoutId }, activeBoard);
-    if (matchesActive) return { renderBoard: activeBoard, mismatch: false };
+    const matchesActive = boardLooselyMatches({ boardName: boardType, layoutId }, activeRenderBoard);
+    if (matchesActive) return { renderBoard: activeRenderBoard, mismatch: false };
 
     // Mismatch with an active board: keep passing the active board into row
     // rendering so each row can decide whether it fits, or fall back to its own
     // board and mark itself incompatible.
-    if (activeBoard) return { renderBoard: activeBoard, mismatch: true };
+    if (activeRenderBoard) return { renderBoard: activeRenderBoard, mismatch: true };
 
     // No active board → render against the playlist's own board (largest size +
     // all sets). `null` when it can't resolve (e.g. MoonBoard), in which case
@@ -89,7 +101,7 @@ export function usePlaylistRenderBoard(
       },
       mismatch: true,
     };
-  }, [activeBoard, boardType, layoutId]);
+  }, [activeRenderBoard, boardType, layoutId]);
 
   // Banner copy + navigation depend on `t`/`router`; kept in a separate memo so
   // their (possible) identity churn can't recreate `renderBoard`.

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -26,6 +26,13 @@ const analytics = vi.hoisted(() => ({
 
 const queueSheet = vi.hoisted(() => ({
   props: null as null | {
+    board: {
+      boardName: string;
+      layoutId: number;
+      sizeId: number;
+      setIds: string;
+      angle: number;
+    };
     onClose: () => void;
     onClimbPress: (item: ClimbQueueItem) => void;
     onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
@@ -133,6 +140,13 @@ vi.mock('../../components/play-drawer/QueueSheet', async () => {
     QueueSheet: React.forwardRef(
       (
         props: {
+          board: {
+            boardName: string;
+            layoutId: number;
+            sizeId: number;
+            setIds: string;
+            angle: number;
+          };
           onClose: () => void;
           onClimbPress: (item: ClimbQueueItem) => void;
           onSuggestionPress: (climb: ClimbQueueItem['climb'], source: PlaylistSuggestionSource) => void;
@@ -522,15 +536,31 @@ describe('DrawerHostProvider board sheet climb actions', () => {
         committedExternally: true,
       }),
     );
-    await waitFor(() =>
+    await waitFor(() => {
       expect(hosts.at(-1)?.boardConfig).toMatchObject({
         boardName: 'kilter',
         layoutId: 1,
         sizeId: 10,
         setIds: '1,2',
-        angle: 30,
-      }),
-    );
+        angle: 40,
+      });
+      expect(queueSheet.props?.board).toMatchObject({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+        angle: 40,
+      });
+      expect(boardSheet.props).toMatchObject({
+        boardConfig: expect.objectContaining({
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,2',
+          angle: 40,
+        }),
+      });
+    });
   });
 
   it('reuses queue, playlist, and climb-actions handlers for board-sheet climbs', async () => {
@@ -761,6 +791,40 @@ describe('DrawerHostProvider play drawer open analytics source', () => {
     // No board override → the drawer opens synchronously with only the queue
     // options; `source` was pulled out and must not reach PlayDrawer.open.
     expect(playDrawer.open).toHaveBeenCalledWith(climb, { committedExternally: true });
+  });
+});
+
+describe('DrawerHostProvider play drawer board overrides', () => {
+  beforeEach(() => {
+    playDrawer.open.mockClear();
+  });
+
+  it('reopens immediately when the requested override already matches the active drawer override', async () => {
+    const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
+    renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const override: BoardConfig = {
+      boardName: 'tension',
+      layoutId: 8,
+      sizeId: 7,
+      setIds: '5,6',
+      angle: 35,
+    };
+    const firstClimb = makeQueueItem('queue-x', 'same-override-1').climb as unknown as Climb;
+    const secondClimb = makeQueueItem('queue-y', 'same-override-2').climb as unknown as Climb;
+
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(firstClimb, { setAsCurrent: false, boardConfig: override });
+    });
+    await waitFor(() => expect(playDrawer.open).toHaveBeenCalledWith(firstClimb, { setAsCurrent: false }));
+
+    playDrawer.open.mockClear();
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(secondClimb, { setAsCurrent: false, boardConfig: override });
+    });
+
+    expect(playDrawer.open).toHaveBeenCalledWith(secondClimb, { setAsCurrent: false });
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -815,16 +815,28 @@ describe('DrawerHostProvider play drawer board overrides', () => {
     const secondClimb = makeQueueItem('queue-y', 'same-override-2').climb as unknown as Climb;
 
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(firstClimb, { setAsCurrent: false, boardConfig: override });
+      hosts.at(-1)?.openPlayDrawer(firstClimb, {
+        previewQueueItem: makeQueueItem('preview-x', 'same-override-1'),
+        boardConfig: override,
+      });
     });
-    await waitFor(() => expect(playDrawer.open).toHaveBeenCalledWith(firstClimb, { setAsCurrent: false }));
+    await waitFor(() =>
+      expect(playDrawer.open).toHaveBeenCalledWith(firstClimb, {
+        previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'same-override-1' }) }),
+      }),
+    );
 
     playDrawer.open.mockClear();
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(secondClimb, { setAsCurrent: false, boardConfig: override });
+      hosts.at(-1)?.openPlayDrawer(secondClimb, {
+        previewQueueItem: makeQueueItem('preview-y', 'same-override-2'),
+        boardConfig: override,
+      });
     });
 
-    expect(playDrawer.open).toHaveBeenCalledWith(secondClimb, { setAsCurrent: false });
+    expect(playDrawer.open).toHaveBeenCalledWith(secondClimb, {
+      previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'same-override-2' }) }),
+    });
   });
 });
 

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -6,9 +6,9 @@
  *
  * Default board comes from `useActiveBoard()` (the user's stored pick); callers
  * can override via the second arg to `openPlayDrawer` if needed (e.g. opening a
- * climb from a different board context). The active boardConfig is exposed
- * through the context so consumers (like the persistent bar's log-ascent
- * button) don't have to resolve the active board independently.
+ * climb from a different board context). The stored active boardConfig is
+ * exposed through the context so consumers (like the persistent bar's
+ * log-ascent button) don't have to resolve the active board independently.
  */
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
@@ -98,8 +98,9 @@ export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
 };
 
 type DrawerHostValue = {
-  /** Currently resolved board config (override OR default board). Null while
-   *  the default board is still loading and no override is set. */
+  /** User's stored active board config. Temporary PlayDrawer overrides are not
+   *  reflected here, so persistent queue/log-ascent surfaces stay bound to the
+   *  selected board. Null while the stored board is still loading. */
   boardConfig: BoardConfig | null;
   openPlayDrawer: (climb: Climb, options?: OpenPlayDrawerOptions) => void;
   openLogAscent: (input: LogAscentInput) => void;
@@ -194,8 +195,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // matches the override.
   const pendingOverrideOpenRef = useRef<{ climb: Climb; options: PlayDrawerOpenOptions } | null>(null);
 
-  const activeBoardConfig: BoardConfig | null = useMemo(() => {
-    if (boardConfigOverride) return boardConfigOverride;
+  // The user's STORED active board as a BoardConfig (never the override). Used
+  // by non-drawer surfaces and to decide whether a climb opened with a board
+  // override is genuinely a different board (→ switch-board gate) or the same
+  // board (→ drop the override and render against the user's precise board).
+  const storedActiveBoardConfig = useMemo<BoardConfig | null>(() => {
     if (!activeBoard) return null;
     return {
       boardName: activeBoard.boardType,
@@ -204,7 +208,12 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       setIds: activeBoard.setIds,
       angle: activeBoard.angle,
     };
-  }, [boardConfigOverride, activeBoard]);
+  }, [activeBoard]);
+
+  const activeBoardConfig: BoardConfig | null = useMemo(
+    () => boardConfigOverride ?? storedActiveBoardConfig,
+    [boardConfigOverride, storedActiveBoardConfig],
+  );
 
   const selectedBoardPresenceBoard = useMemo<ResolveBoardUuidArgs | null>(() => {
     if (!activeBoard) return null;
@@ -220,25 +229,14 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     void resolveAndBindBoardByUuid(selectedBoardPresenceBoard);
   }, [boardPresenceEnabled, selectedBoardPresenceBoard, resolveAndBindBoardByUuid, resetPresence]);
 
-  // Keep a ref so the otherwise empty-dep `openClimbActions` callback can
-  // snapshot the current board config without churning its identity.
+  // Keep refs so otherwise empty-dep open callbacks can snapshot the relevant
+  // board config without churning their identity. `activeBoardConfigRef` is the
+  // drawer board (including a temporary override); `storedActiveBoardConfigRef`
+  // is the user's selected board and is what non-drawer surfaces use.
   const activeBoardConfigRef = useRef(activeBoardConfig);
   activeBoardConfigRef.current = activeBoardConfig;
-
-  // The user's STORED active board as a BoardConfig (never the override). Used
-  // to decide whether a climb opened with a board override is genuinely a
-  // different board (→ switch-board gate) or the same board (→ drop the override
-  // and render against the user's precise board).
-  const storedActiveBoardConfig = useMemo<BoardConfig | null>(() => {
-    if (!activeBoard) return null;
-    return {
-      boardName: activeBoard.boardType,
-      layoutId: activeBoard.layoutId,
-      sizeId: activeBoard.sizeId,
-      setIds: activeBoard.setIds,
-      angle: activeBoard.angle,
-    };
-  }, [activeBoard]);
+  const storedActiveBoardConfigRef = useRef(storedActiveBoardConfig);
+  storedActiveBoardConfigRef.current = storedActiveBoardConfig;
   const boardConfigOverrideRef = useRef(boardConfigOverride);
   boardConfigOverrideRef.current = boardConfigOverride;
   const myBoardsRef = useRef(myBoardsConn);
@@ -248,7 +246,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     // Pull `source` out alongside `boardConfig` so neither reaches PlayDrawer.open
     // — `source` is analytics-only and would otherwise leak into the drawer.
     const { boardConfig: override, source: openSource, ...openOptions } = options ?? {};
-    const boardConfig = override ?? activeBoardConfigRef.current;
+    const boardConfig = override ?? storedActiveBoardConfigRef.current;
     track(SHARED_EVENTS.PlayDrawerOpened, {
       climbUuid: climb.uuid,
       boardName: boardConfig?.boardName,
@@ -259,6 +257,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     });
     if (override) {
       pendingOverrideOpenRef.current = { climb, options: openOptions };
+      if (boardConfigsMatch(override, activeBoardConfigRef.current)) {
+        pendingOverrideOpenRef.current = null;
+        playDrawerRef.current?.open(climb, openOptions);
+        return;
+      }
       setBoardConfigOverride(override);
       return;
     }
@@ -334,7 +337,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // user switches their active board mid-interaction.
   const openClimbActions = useCallback(
     (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => {
-      const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
+      const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
       if (!boardConfig) return;
       setClimbActions({ climb, boardConfig, onEditEntry: options?.onEditEntry });
     },
@@ -346,7 +349,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const openAddToPlaylist = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
-    const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
+    const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
     if (!boardConfig) return;
     setPlaylistClimb({ climb, boardConfig });
   }, []);
@@ -399,15 +402,15 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   // The queue sheet renders climbs against the active board (thumbnails + tick).
   const queueBoard = useMemo<QueueItemRowBoard | null>(() => {
-    if (!activeBoardConfig) return null;
+    if (!storedActiveBoardConfig) return null;
     return {
-      boardName: activeBoardConfig.boardName as BoardName,
-      layoutId: activeBoardConfig.layoutId,
-      sizeId: activeBoardConfig.sizeId,
-      setIds: activeBoardConfig.setIds,
-      angle: activeBoardConfig.angle,
+      boardName: storedActiveBoardConfig.boardName as BoardName,
+      layoutId: storedActiveBoardConfig.layoutId,
+      sizeId: storedActiveBoardConfig.sizeId,
+      setIds: storedActiveBoardConfig.setIds,
+      angle: storedActiveBoardConfig.angle,
     };
-  }, [activeBoardConfig]);
+  }, [storedActiveBoardConfig]);
 
   // Tap a queue item → make it current (for the whole session, always-live) and
   // show it in the play drawer.
@@ -445,11 +448,11 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   // Tick a history climb → open the log-ascent sheet (stacks above the queue
   // sheet, which stays open beneath) pre-filled with the active session.
-  // Deps: only `sessionId` — `activeBoardConfigRef` is a stable ref read at call
+  // Deps: only `sessionId` — `storedActiveBoardConfigRef` is a stable ref read at call
   // time (intentionally not a dep). If that ref ever becomes state, add it here.
   const handleQueueTickHistory = useCallback(
     (item: ClimbQueueItem) => {
-      const boardConfig = activeBoardConfigRef.current;
+      const boardConfig = storedActiveBoardConfigRef.current;
       if (!boardConfig) return;
       setLogAscentInput({
         climbUuid: item.climb.uuid,
@@ -516,7 +519,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const handleBoardSheetClimbPress = useCallback(
     (action: BoardSheetClimbAction) => {
       const item = climbToQueueItem(action.climb, { uuid: action.queueItemUuid ?? undefined });
-      const boardConfigOverride = boardConfigsMatch(action.boardConfig, activeBoardConfigRef.current)
+      const boardConfigOverride = boardConfigsMatch(action.boardConfig, storedActiveBoardConfigRef.current)
         ? undefined
         : action.boardConfig;
       setCurrentClimb(item);
@@ -566,7 +569,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<DrawerHostValue>(
     () => ({
-      boardConfig: activeBoardConfig,
+      boardConfig: storedActiveBoardConfig,
       openPlayDrawer,
       openLogAscent,
       openClimbActions,
@@ -577,7 +580,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       openBoardSheet,
     }),
     [
-      activeBoardConfig,
+      storedActiveBoardConfig,
       openPlayDrawer,
       openLogAscent,
       openClimbActions,
@@ -657,7 +660,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       <BoardSheet
         ref={boardSheetRef}
         boardLabel={boardSheetLabel}
-        boardConfig={activeBoardConfig}
+        boardConfig={storedActiveBoardConfig}
         onClose={requestCloseBoardSheet}
         onSwitchBoard={handleSwitchBoardFromSheet}
         onClimbPress={handleBoardSheetClimbPress}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -360,8 +360,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
 
   // Single parameterized beta-video opener (mirrors openAddToPlaylist), used both by
   // the reaction menu's shared action list (useClimbActions) and by PlayDrawer.
+  // Falls back to the stored active board, not the override-inclusive one, so a
+  // temporary drawer board override can't leak into the beta-video surface.
   const openAddBetaVideo = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
-    const boardConfig = boardConfigOverride ?? activeBoardConfigRef.current;
+    const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
     if (!boardConfig) return;
     setBetaVideoClimb({ climb, boardConfig });
   }, []);

--- a/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
+++ b/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
@@ -6,6 +6,7 @@ import {
   findPreviousQueueItem,
   computeNavigationState,
   findNextQueueItemWithSuggestions,
+  findPreviousQueueItemWithSuggestions,
   computeNavigationStateWithSuggestions,
 } from '../queue-navigation';
 
@@ -225,6 +226,56 @@ describe('findNextQueueItemWithSuggestions', () => {
   });
 });
 
+describe('findPreviousQueueItemWithSuggestions', () => {
+  it('behaves like findPreviousQueueItem for a current item that IS in the queue', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    expect(findPreviousQueueItemWithSuggestions(items, items[2], null)).toBe(items[1]);
+    expect(findPreviousQueueItemWithSuggestions(items, items[0], null)).toBeNull();
+    expect(findPreviousQueueItemWithSuggestions(items, null, null)).toBeNull();
+  });
+
+  it('never peeks backward into the playlist while the current item is in the queue', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    // current is the queue head and there IS an earlier playlist climb, but the
+    // committed active-board path must stay queue-only (no backward peek).
+    const queue = [itemFor(y)];
+    const source = makeSource(x, [x, y]);
+    expect(findPreviousQueueItemWithSuggestions(queue, queue[0], source)).toBeNull();
+  });
+
+  it('falls through to the previous playlist climb for an orphan current (view-only preview)', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    const z = makeClimb('z');
+    const queue = [makeItem('a'), makeItem('b')];
+    const orphan = itemFor(y); // previewed climb, never committed to the queue
+    const source = makeSource(x, [x, y, z]);
+    const peek = findPreviousQueueItemWithSuggestions(queue, orphan, source);
+    // Diverges from findPreviousQueueItem (which would return null).
+    expect(peek?.climb.uuid).toBe('x');
+    expect(peek?.uuid).toBe(getPlaylistPeekQueueItemUuid('x'));
+    expect(peek?.suggested).toBe(true);
+    expect(peek?.addedBy).toBeNull();
+  });
+
+  it('returns null for an orphan current that is first in the playlist', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    const orphan = itemFor(x); // x is the first playlist climb → nothing before it
+    const source = makeSource(x, [x, y]);
+    expect(findPreviousQueueItemWithSuggestions([], orphan, source)).toBeNull();
+  });
+
+  it('returns null for an orphan current not in the playlist at all', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    const orphan = itemFor(makeClimb('not-in-playlist'));
+    const source = makeSource(x, [x, y]);
+    expect(findPreviousQueueItemWithSuggestions([], orphan, source)).toBeNull();
+  });
+});
+
 describe('computeNavigationStateWithSuggestions', () => {
   it('matches computeNavigationState when source is null', () => {
     const items = [makeItem('a'), makeItem('b'), makeItem('c')];
@@ -242,9 +293,24 @@ describe('computeNavigationStateWithSuggestions', () => {
     expect(state.canNext).toBe(true);
     expect(state.nextItem?.climb.uuid).toBe('y');
     expect(state.nextItem?.suggested).toBe(true);
-    // previous + remainingCount stay queue-based.
+    // For a queued current climb, previous + remainingCount stay queue-based.
     expect(state.canPrevious).toBe(false);
     expect(state.prevItem).toBeNull();
     expect(state.remainingCount).toBe(0);
+  });
+
+  it('lights up both directions for a view-only preview (orphan current in the playlist)', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    const z = makeClimb('z');
+    // The wrong-board preview shows `y` without committing it to the queue.
+    const orphan = itemFor(y);
+    const source = makeSource(x, [x, y, z]);
+    const state = computeNavigationStateWithSuggestions([], orphan, source);
+    expect(state.canNext).toBe(true);
+    expect(state.nextItem?.climb.uuid).toBe('z');
+    expect(state.canPrevious).toBe(true);
+    expect(state.prevItem?.climb.uuid).toBe('x');
+    expect(state.prevItem?.suggested).toBe(true);
   });
 });

--- a/packages/shared/play-view/src/queue-navigation.ts
+++ b/packages/shared/play-view/src/queue-navigation.ts
@@ -79,6 +79,18 @@ function getNextPlaylistClimb(
   return source.climbs[index + 1] ?? null;
 }
 
+/** The playlist climb immediately before `currentClimbUuid` in the source's
+ * ordered list, or null if the current climb isn't in the playlist or is first. */
+function getPreviousPlaylistClimb(
+  source: PlaylistSuggestionSource | null,
+  currentClimbUuid: string | undefined,
+): Climb | null {
+  if (!source || !currentClimbUuid) return null;
+  const index = source.climbs.findIndex((climb) => climb.uuid === currentClimbUuid);
+  if (index <= 0) return null;
+  return source.climbs[index - 1] ?? null;
+}
+
 /** Wrap a suggested climb as a transient "peek" queue item. */
 function toPeekItem(climb: Climb): ClimbQueueItem {
   return { climb, addedBy: null, uuid: getPlaylistPeekQueueItemUuid(climb.uuid), suggested: true };
@@ -121,9 +133,40 @@ export function findNextQueueItemWithSuggestions(
 }
 
 /**
+ * Like findPreviousQueueItem, but when the current item isn't in the queue at
+ * all, fall through to the PREVIOUS playlist climb (the one immediately before
+ * the current climb in the suggestion source's ordered list) as a transient
+ * "peek" item — the mirror of findNextQueueItemWithSuggestions.
+ *
+ * This only matters for the wrong-board view-only preview, where peeked climbs
+ * are shown but never committed to the queue, so they have no queue predecessor
+ * to walk back to. Queue-first: while the current item IS in the queue we return
+ * its queue predecessor (or null at the head) exactly like findPreviousQueueItem,
+ * so the committed active-board path never peeks backward into the playlist.
+ */
+export function findPreviousQueueItemWithSuggestions(
+  queue: ClimbQueue,
+  currentClimbQueueItem: ClimbQueueItem | null,
+  source: PlaylistSuggestionSource | null,
+): ClimbQueueItem | null {
+  if (!currentClimbQueueItem) return null;
+
+  const currentIndex = queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid);
+  if (currentIndex >= 0) {
+    return currentIndex > 0 ? queue[currentIndex - 1] : null;
+  }
+
+  const prevClimb = getPreviousPlaylistClimb(source, currentClimbQueueItem.climb?.uuid);
+  return prevClimb ? toPeekItem(prevClimb) : null;
+}
+
+/**
  * computeNavigationState that lights up canNext/nextItem from playlist
- * suggestions when the queue is exhausted. canPrevious/prevItem stay queue-only
- * (web has no backward suggestion fall-through). remainingCount stays
+ * suggestions when the queue is exhausted, and canPrevious/prevItem from
+ * suggestions when the current climb isn't in the queue at all (the wrong-board
+ * view-only preview, whose peeked climbs are never committed to the queue). For
+ * a current climb that IS in the queue, prev stays queue-only — the committed
+ * active-board path never peeks backward into the playlist. remainingCount stays
  * queue-based to match web's action-bar remaining count.
  */
 export function computeNavigationStateWithSuggestions(
@@ -132,7 +175,7 @@ export function computeNavigationStateWithSuggestions(
   source: PlaylistSuggestionSource | null,
 ): NavigationState {
   const nextItem = findNextQueueItemWithSuggestions(queue, currentClimbQueueItem, source);
-  const prevItem = findPreviousQueueItem(queue, currentClimbQueueItem);
+  const prevItem = findPreviousQueueItemWithSuggestions(queue, currentClimbQueueItem, source);
 
   const currentIndex = currentClimbQueueItem ? queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid) : -1;
   const remainingCount = currentIndex >= 0 ? queue.length - currentIndex - 1 : queue.length;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -400,6 +400,7 @@ export default defineConfig({
       },
       'typecheck:climb-filters': {
         command: 'bun run --filter=@boardsesh/climb-filters typecheck',
+        dependsOn: ['codegen'],
       },
       'typecheck:i18n': {
         command: 'bun run --filter=@boardsesh/i18n typecheck',


### PR DESCRIPTION
## Summary
- Opens wrong-board playlist climbs in the mobile play drawer with the playlist board renderer instead of routing straight to board switching.
- Keeps wrong-board taps view-only: no active queue mutation until the user switches boards.
- Uses the tapped climb angle for wrong-board view-only drawer overrides, so switching boards carries the right angle.
- Reopens the play drawer when the same board override is requested again after dismissing a wrong-board preview.
- Keeps previous/next navigation local in view-only preview mode.
- Makes playlist board mismatch detection use the stored active board instead of temporary drawer host overrides.
- Keeps temporary drawer board overrides out of the public drawer-host board, queue sheet, and board sheet surfaces.
- Adds regression coverage for view-only activation, row tap behavior, drawer-override mismatch lifecycle, provider override leakage, repeated override opens, tapped-angle overrides, and preview navigation.

## Root cause
Playlist detail rows already rendered against a compatible playlist board, but taps still activated through the active-board queue path. That could show wrong-board/incompatible messaging or mutate the queue with a climb for another board. The mismatch hook also read `DrawerHostProvider`'s current `boardConfig`, which includes temporary drawer overrides, so a wrong-board preview could make the playlist look compatible on the next render. The provider also exposed that temporary override to non-drawer surfaces.

Follow-up review found that repeated taps using the same override object could be ignored after dismissal, the view-only override used the active-board angle instead of the tapped climb angle, and previous navigation in view-only mode still fell through to shared queue navigation. Those paths are now covered directly.

## Validation
- `vp test run packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts`
- `vp run typecheck:mobile`
- `vp check packages/mobile/src/lib/playlists/use-playlist-render-board.ts packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx packages/mobile/src/lib/playlists/use-playlist-activation.ts packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx packages/mobile/src/providers/drawer-host-provider.tsx packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx packages/mobile/src/components/play-drawer/PlayDrawer.tsx packages/mobile/src/components/play-drawer/play-drawer-navigation.ts packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts`

Full `vp check` still reports formatter issues in unrelated files on `origin/main` (`CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend tick files, and db drizzle metadata). Those files are not touched in this PR.

---

## Rebase + review round (2026-06-18)

Rebased onto latest `main` and resolved conflicts where main's concurrent changes overlapped this PR:
- `use-playlist-activation.ts` — combined main's re-tap dedup (`useActiveClimbUuid`/`usePlaylistSuggestionSource`, pure-reopen path) with this PR's view-only board path; the view-only check runs first, then the active-board re-tap logic.
- Test files — kept both sides' new tests; aligned the re-tap test's `playlistUuid` with the production-format `playlist:` prefix (`createPlaylistSuggestionSource` uses `sourceId`).

Ran three code-review subagents (correctness, RN performance/architecture, tests/quality). Applied their findings:
- **Backward navigation in view-only preview** (medium): the wrong-board preview shows peeked climbs without committing them to the queue, so `findPreviousQueueItem` (queue-only) always returned `null` and the prev control stayed disabled while next worked. Added `findPreviousQueueItemWithSuggestions` — queue-first for committed climbs (active-board path unchanged), falling through to the previous playlist climb only for an orphan current (the preview) — and wired it into `computeNavigationStateWithSuggestions` (mobile-only caller). Covered by new `queue-navigation` tests.
- **Beta-video board leak** (low): `openAddBetaVideo` now falls back to the stored active board, matching `openClimbActions`/`openAddToPlaylist`, so a temporary drawer board override can't leak into that surface.
- **Duplicate test** (low): dropped a `playlist-detail-view` test that asserted the same row-activates-while-banner-shown behavior as the stronger `TENSION_CLIMB` case.

### Validation (rebase round)
- `vp run test:mobile` — 2467 passed
- `vp test run packages/shared/play-view` — 140 passed (incl. new backward-nav coverage)
- `vp run typecheck:mobile`, `vp run typecheck:shared`
- `vp check` on all changed files — clean
