### PR TITLE
[codex] Fix Kilter stats inflation

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -107,17 +107,17 @@ The direct command supports the Aurora boards that still use Aurora's API for lo
 `ascensionist_count` is the materialized count derived from per-source columns,
 each owned by a single writer:
 
-| Column                         | Owner                           | Updated by                                                                                                                    |
-| ------------------------------ | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `aurora_ascensionist_count`    | Aurora sync                     | `upsertClimbStats` (this file's daemon) — written verbatim from Aurora's payload                                              |
-| `kilter_ascensionist_count`    | Kilter Grips sync               | `packages/kilter-sync` catalog sync                                                                                           |
-| `boardsesh_ascensionist_count` | Boardsesh `recomputeClimbStats` | `packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts` — `COUNT(DISTINCT user_id)` over flash/send ticks     |
-| `ascensionist_count`           | All writers, kept in lockstep   | recomputed as `COALESCE(kilter_ascensionist_count, aurora_ascensionist_count, 0) + COALESCE(boardsesh_ascensionist_count, 0)` |
+| Column                         | Owner                           | Updated by                                                                                                                                           |
+| ------------------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aurora_ascensionist_count`    | Aurora sync                     | `upsertClimbStats` (this file's daemon) — written verbatim from Aurora's payload                                                                     |
+| `kilter_ascensionist_count`    | Kilter Grips sync               | `packages/kilter-sync` catalog sync                                                                                                                  |
+| `boardsesh_ascensionist_count` | Boardsesh `recomputeClimbStats` | `packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts` — `COUNT(DISTINCT user_id)` over flash/send ticks                            |
+| `ascensionist_count`           | All writers, kept in lockstep   | recomputed as `GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(aurora_ascensionist_count, 0)) + COALESCE(boardsesh_ascensionist_count, 0)` |
 
 `aurora_` and `kilter_` are **not summed**: for the Kilter board they are the
 same ascents from two backends across the Aurora→Kilter Grips split, so the sum
-takes Kilter (live) and falls back to aurora. For Aurora-only boards (Tension
-etc.) `kilter_` is NULL and it collapses to `aurora_`. See kilter-sync.md.
+takes the higher upstream count. For Aurora-only boards (Tension etc.)
+`kilter_` is NULL and it collapses to `aurora_`. See kilter-sync.md.
 
 The search hot path reads `ascensionist_count` through the covering index from
 migration 0067, so it stays a regular column (not `GENERATED`) — every writer

--- a/docs/kilter-sync.md
+++ b/docs/kilter-sync.md
@@ -227,6 +227,16 @@ ascensionist_count = GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(a
 
 For boards with only one catalog source (e.g. Tension, `kilter_` is NULL) this collapses to `aurora_ + boardsesh_` — behaviour unchanged. The same formula is used at all three writers: the catalog sync (`catalog-sync.ts`), aurora-sync (`shared-sync.ts`), and the Boardsesh-tick recompute (`recompute-climb-stats.ts`). `boardsesh_ascensionist_count` stays additive because Boardsesh-native ticks aren't (yet) pushed to Kilter; revisit when push-back lands.
 
+### Stats repair
+
+A single Boardsesh layout maps to several Grips `product_layout_uuid`s (size variants). Before the `(source climb UUID, angle)` dedup landed, the catalog sync folded each repeated source stat once per variant, so `kilter_ascensionist_count` (and thus `ascensionist_count`) was inflated by the number of variants a climb appeared in. The fix prevents new inflation; existing rows need a one-time `repair-stats` pass (`stats-repair.ts`).
+
+`repair-stats` re-fetches every listed Grips layout, dedupes stats the same way the live sync now does, and **overwrites** `kilter_ascensionist_count` from the deduped value (also re-asserting Grips `display_difficulty / difficulty_average / quality_average` on canonical rows). It is idempotent — re-running converges and the second run is a no-op.
+
+- **Dry-run is the default and is read-only.** It reports `changedKilterRows`, `maxKilterDrop` / `maxKilterRise` (largest per-row decrease/increase), `statsDeduped`, `statsUnresolved`, and a `topBefore` list. Review these before applying — a large `maxKilterDrop` can also signal a partial Grips fetch (delisted climbs, rate-limit truncation), so treat it as a stop-and-investigate signal rather than blindly applying.
+- **`--apply` writes inside a single transaction** (overwrite + materialized-total recompute are atomic) and prints `topAfter`. A fetch error aborts before any write, since writes only run after the full fetch loop completes.
+- Run it with the **daemon paused** so a concurrent catalog sync doesn't interleave, and run it **unscoped** (no `--layouts`) for the production cleanup — the materialized-total recompute pass touches all Kilter rows, so a scoped run can leave inconsistent state. Rows for climbs Grips no longer lists aren't re-fetched, so this tool does not correct delisted-climb inflation.
+
 ### Quality scale — every board on 1–5
 
 Kilter Grips reports `quality_average` on a 1–5 scale (MoonBoard too), but Aurora reports 1–3. To keep `board_climb_stats.quality_average` one scale the UI renders uniformly, every writer stores 1–5: aurora-sync normalises its writes via `normalizeQualityTo5` (`×5/3`, continuous — it's a stored average, so unlike `convertQuality` it isn't rounded to integer star steps); Kilter Grips and Boardsesh-tick quality are already 1–5 and stored as-is.
@@ -300,9 +310,14 @@ bunx kilter-sync list                # List all stored kilter credentials
 bunx kilter-sync user <userId>       # Force a sync for one user
 bunx kilter-sync daemon              # Run the daemon (one-user-per-cycle, quiet hours)
 bunx kilter-sync catalog --user <id> # Sync the public climb catalog (Flow A)
+bunx kilter-sync repair-stats --user <id>          # Dry-run: report deduped Kilter counts vs DB (no writes)
+bunx kilter-sync repair-stats --user <id> --apply  # Write the deduped counts + recompute totals
+bunx kilter-sync repair-stats --user <id> --layouts <uuid,uuid>  # Scope to specific Grips product_layout_uuids
 bunx kilter-sync locations --user <id> # Sync public Kilter gym/board locations
 bunx kilter-sync locations --skip-if-missing-credentials # No-op when no token source is configured
 ```
+
+`repair-stats` is a one-time cleanup for the catalog-stats inflation (see [Stats repair](#stats-repair)). It defaults to a read-only dry-run; nothing is written without `--apply`.
 
 Run with 1Password like aurora-sync:
 

--- a/docs/kilter-sync.md
+++ b/docs/kilter-sync.md
@@ -214,14 +214,14 @@ Kilter's catalog has duplicate climbs at different UUIDs with identical hold lay
 2. **Fingerprint hit** — a new UUID whose `(layout_id, fingerprint)` matches an existing or already-seen-this-run canonical becomes an alias (`board_climb_aliases`), not a new row.
 3. **Miss** — insert a new canonical row + a self-alias.
 
-**Stats accumulation (worked example).** Two listed climbs `A` (count 18) and `B` (count 5) with identical holds collapse onto one canonical: `A` is canonical with `kilter_ascensionist_count = 18`, `B` aliases to `A` and its 5 ascents accumulate → 23. The accumulation is computed **in memory per `(canonical, angle)` and written as an overwrite** (not `+=`), so re-running recomputes the same 23 — idempotent. Display fields (`difficulty/quality/fa`) come only from the canonical climb's own stat row.
+**Stats accumulation (worked example).** Two listed climbs `A` (count 18) and `B` (count 5) with identical holds collapse onto one canonical: `A` is canonical with `kilter_ascensionist_count = 18`, `B` aliases to `A` and its 5 ascents accumulate → 23. The accumulation is computed **in memory per `(canonical, angle)` and written as an overwrite** (not `+=`), so re-running recomputes the same 23 — idempotent. If the same source climb stat appears through multiple Grips `product_layout_uuid`s that collapse to one Boardsesh layout, it is counted once by `(source climb UUID, angle)`. Display fields (`difficulty/quality/fa`) come only from the canonical climb's own stat row.
 
 ### `ascensionist_count` — aurora/kilter are aliased, not summed
 
-`board_climb_stats.ascensionist_count` is the materialized count the search hot path reads. There are three owned columns (`aurora_`, `kilter_`, `boardsesh_`), but for the **Kilter board `aurora_` and `kilter_` are the SAME ascents**: the legacy column was filled from the pre-split `kilterboardapp.com` and `kilter_` is filled from `kiltergrips.com`, which Kilter migrated the same logs into. They match within snapshot noise (median ratio 1.0). **Summing them double-counts** — every Kilter benchmark would read ~2× its real ascents — so the formula takes Kilter (the live source) and falls back to aurora, then adds the independent Boardsesh contribution:
+`board_climb_stats.ascensionist_count` is the materialized count the search hot path reads. There are three owned columns (`aurora_`, `kilter_`, `boardsesh_`), but for the **Kilter board `aurora_` and `kilter_` are the SAME ascents**: the legacy column was filled from the pre-split `kilterboardapp.com` and `kilter_` is filled from `kiltergrips.com`, which Kilter migrated the same logs into. They match within snapshot noise (median ratio 1.0). **Summing them double-counts** — every Kilter benchmark would read ~2× its real ascents — so the formula takes the higher upstream count, then adds the independent Boardsesh contribution:
 
 ```
-ascensionist_count = COALESCE(kilter_ascensionist_count, aurora_ascensionist_count, 0)
+ascensionist_count = GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(aurora_ascensionist_count, 0))
                    + COALESCE(boardsesh_ascensionist_count, 0)
 ```
 

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -459,12 +459,10 @@ async function upsertClimbStats(db: DrizzleDb, board: AuroraBoardName, data: Cli
           displayDifficulty: sql`excluded.display_difficulty`,
           benchmarkDifficulty: sql`excluded.benchmark_difficulty`,
           auroraAscensionistCount: sql`excluded.aurora_ascensionist_count`,
-          // aurora_ and kilter_ are the SAME ascents for the Kilter board (two
-          // backends across the Aurora→Kilter Grips split), so they are NOT
-          // summed — Kilter (the live source) wins, aurora is the fallback.
-          // For Aurora-only boards (Tension etc.) kilter_ is NULL so this
-          // collapses to aurora_ — behaviour unchanged. See kilter-sync.md.
-          ascensionistCount: sql`COALESCE(${climbStatsSchema.kilterAscensionistCount}, excluded.aurora_ascensionist_count, 0) + COALESCE(${climbStatsSchema.boardseshAscensionistCount}, 0)`,
+          // aurora_ and kilter_ are alternate upstream snapshots for Kilter,
+          // not independent sources. Use the higher upstream count so stale
+          // snapshots do not lower a climb, then add Boardsesh's local count.
+          ascensionistCount: sql`GREATEST(COALESCE(${climbStatsSchema.kilterAscensionistCount}, 0), COALESCE(excluded.aurora_ascensionist_count, 0)) + COALESCE(${climbStatsSchema.boardseshAscensionistCount}, 0)`,
           difficultyAverage: sql`excluded.difficulty_average`,
           qualityAverage: sql`excluded.quality_average`,
           qualityNormalized: sql`true`,

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { logger } from '../utils/logger';
 
-// Captured SQL fragments per call to tx.execute.
-const executedSql: string[] = [];
-
 const { mockDb } = vi.hoisted(() => {
   // The `sql` template returns an object whose `.queryChunks` array holds the
   // alternating raw SQL strings and parameter sentinels. For assertion
@@ -22,26 +19,8 @@ vi.mock('../db/client', () => ({
 
 import { recomputeClimbStats } from '../graphql/resolvers/ticks/recompute-climb-stats';
 
-function chainStub(): { insert: ReturnType<typeof vi.fn>; execute: ReturnType<typeof vi.fn> } {
-  const chain: Record<string, unknown> = {};
-  for (const method of ['values', 'onConflictDoNothing']) {
-    chain[method] = vi.fn(() => chain);
-  }
-  return {
-    insert: vi.fn(() => chain),
-    execute: vi.fn(async (query: unknown) => {
-      // Drizzle's sql template exposes `queryChunks` or `.toSQL()`. Use a
-      // best-effort serialize that walks the object's string-like fields.
-      const stringified = JSON.stringify(query);
-      executedSql.push(stringified);
-      return [];
-    }),
-  };
-}
-
 describe('recomputeClimbStats', () => {
   beforeEach(() => {
-    executedSql.length = 0;
     vi.clearAllMocks();
   });
 

--- a/packages/backend/src/__tests__/recompute-climb-stats.test.ts
+++ b/packages/backend/src/__tests__/recompute-climb-stats.test.ts
@@ -142,13 +142,12 @@ describe('recomputeClimbStats', () => {
     // Hard invariants the delete-last-tick path depends on:
     // 1. boardsesh_ascensionist_count defaults to 0 when no senders remain.
     expect(sql).toMatch(/boardsesh_ascensionist_count\s*=\s*COALESCE\(agg\.distinct_senders,\s*0\)/);
-    // 2. ascensionist_count is Kilter's count plus Boardsesh's. Aurora and
-    //    Kilter are the SAME upstream Kilter ascents pulled from two backends
-    //    (legacy kilterboardapp.com vs Kilter Grips), so they must NOT be
-    //    summed — we COALESCE to whichever backend reported (preferring the
-    //    newer Kilter Grips column), default 0, then add Boardsesh's distinct
-    //    senders. Each defaulted to 0 so the result never NULLs out.
-    expect(sql).toContain('COALESCE(s.kilter_ascensionist_count, s.aurora_ascensionist_count, 0)');
+    // 2. ascensionist_count is the higher upstream count plus Boardsesh's.
+    //    Aurora and Kilter are the SAME upstream Kilter ascents pulled from
+    //    two backends, so they must NOT be summed.
+    expect(sql).toContain(
+      'GREATEST(COALESCE(s.kilter_ascensionist_count, 0), COALESCE(s.aurora_ascensionist_count, 0))',
+    );
     expect(sql).toContain('COALESCE(agg.distinct_senders, 0)');
     // 3. The ticks filter is sargable — predicate on WHERE, not FILTER.
     expect(sql).toMatch(/WHERE[\s\S]*bt\.status IN \('flash','send'\)/);

--- a/packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/recompute-climb-stats.ts
@@ -10,7 +10,7 @@ import { logger } from '../../../utils/logger';
  *
  * What this writes:
  *   - boardsesh_ascensionist_count = COUNT(DISTINCT user_id) over flash/send ticks
- *   - ascensionist_count = COALESCE(kilter_ascensionist_count, aurora_ascensionist_count, 0)
+ *   - ascensionist_count = GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(aurora_ascensionist_count, 0))
  *                         + COALESCE(boardsesh_ascensionist_count, 0)
  *     (the materialized count the search hot path reads through the covering
  *     index from migration 0067)
@@ -18,8 +18,8 @@ import { logger } from '../../../utils/logger';
  *     aurora_ and kilter_ are NOT summed: for the Kilter board they are the
  *     SAME ascents from two backends (the pre-split kilterboardapp.com vs
  *     kiltergrips.com — Kilter migrated the logs, so the counts match within
- *     snapshot noise; summing would double them). Kilter (the live source)
- *     wins; aurora is a fallback for climbs Kilter Grips no longer carries.
+ *     snapshot noise; summing would double them). The higher upstream count
+ *     wins so one stale snapshot does not lower a climb.
  *     For boards with only one source (e.g. Tension) the other column is NULL
  *     so COALESCE collapses to that single value — behaviour is unchanged.
  *   - fa_username / fa_at:
@@ -85,7 +85,7 @@ export async function recomputeClimbStats(boardType: string, climbUuid: string, 
 
   await db.transaction(async (tx) => {
     // Defensive seed: set aurora_/kilter_ascensionist_count to 0 explicitly so
-    // the subsequent recompute (COALESCE(kilter, aurora, 0) + boardsesh) and any
+    // the subsequent recompute (GREATEST(kilter, aurora) + boardsesh) and any
     // later Aurora/Kilter upsert both see a sensible baseline. Without it,
     // freshly seeded rows would carry NULL counts until those syncs first ran.
     await tx
@@ -148,7 +148,7 @@ export async function recomputeClimbStats(boardType: string, climbUuid: string, 
       updated AS (
         UPDATE board_climb_stats s
            SET boardsesh_ascensionist_count = COALESCE(agg.distinct_senders, 0),
-               ascensionist_count           = COALESCE(s.kilter_ascensionist_count, s.aurora_ascensionist_count, 0)
+               ascensionist_count           = GREATEST(COALESCE(s.kilter_ascensionist_count, 0), COALESCE(s.aurora_ascensionist_count, 0))
                                             + COALESCE(agg.distinct_senders, 0),
                fa_username = CASE
                  WHEN COALESCE((SELECT boardsesh_owned FROM owner), FALSE)

--- a/packages/db/src/schema/boards/unified.ts
+++ b/packages/db/src/schema/boards/unified.ts
@@ -557,11 +557,13 @@ export const boardClimbStats = pgTable(
     angle: integer('angle').notNull(),
     displayDifficulty: doublePrecision('display_difficulty'),
     benchmarkDifficulty: doublePrecision('benchmark_difficulty'),
-    // ascensionistCount is the materialized sum kept in sync by three writers:
+    // ascensionistCount is the materialized total kept in sync by three writers:
     // Aurora sync updates aurora_ascensionist_count + ascensionist_count in one
     // statement; Kilter sync updates kilter_ascensionist_count +
     // ascensionist_count in one statement; the Boardsesh tick recompute updates
-    // boardsesh_ascensionist_count + ascensionist_count in one statement.
+    // boardsesh_ascensionist_count + ascensionist_count in one statement. Kilter
+    // and Aurora are alternate upstream snapshots, so totals use the higher of
+    // those two plus Boardsesh, not their sum.
     // Keep it as a regular column (not GENERATED) so the custom covering indexes
     // (board_climb_stats_ascents_covering_idx, migration 0068; the v2 variant with
     // climb_uuid as a trailing key column, migration 0122) keep working.

--- a/packages/kilter-sync/package.json
+++ b/packages/kilter-sync/package.json
@@ -41,6 +41,7 @@
     "sync:catalog": "tsx src/cli/index.ts catalog",
     "sync:daemon": "tsx src/cli/index.ts daemon",
     "sync:locations": "tsx src/cli/index.ts locations --skip-if-missing-credentials",
+    "sync:repair-stats": "tsx src/cli/index.ts repair-stats",
     "sync:user": "tsx src/cli/index.ts user"
   },
   "dependencies": {

--- a/packages/kilter-sync/src/cli/index.ts
+++ b/packages/kilter-sync/src/cli/index.ts
@@ -13,15 +13,29 @@ import { KILTER_BOARD_TYPE } from '../api/types';
 const program = new Command();
 program.name('kilter-sync').description('Kilter Grips sync utility (Keycloak + PowerSync + REST)').version('1.0.0');
 
+function getDatabaseUrl(): string {
+  const connectionString = process.env.DATABASE_URL || process.env.DB_URL;
+  if (!connectionString) {
+    console.error('DATABASE_URL or DB_URL is required');
+    process.exit(1);
+  }
+  return connectionString;
+}
+
+function parseLayoutUuids(layouts: string | undefined): string[] | undefined {
+  return layouts
+    ? layouts
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+    : undefined;
+}
+
 program
   .command('list')
   .description('List all users with kilter credentials')
   .action(async () => {
-    const connectionString = process.env.DATABASE_URL;
-    if (!connectionString) {
-      console.error('DATABASE_URL is required');
-      process.exit(1);
-    }
+    const connectionString = getDatabaseUrl();
     const client = postgres(connectionString, { max: 1, prepare: false });
     try {
       const db = drizzle(client);
@@ -108,12 +122,7 @@ program
           process.exitCode = 1;
           return;
         }
-        const layoutUuids = opts.layouts
-          ? opts.layouts
-              .split(',')
-              .map((value) => value.trim())
-              .filter(Boolean)
-          : undefined;
+        const layoutUuids = parseLayoutUuids(opts.layouts);
         const summary = await runner.runCatalogSync(tokenProvider, {
           applyDeletions: opts.applyDeletions,
           layoutUuids,
@@ -128,6 +137,30 @@ program
       }
     },
   );
+
+program
+  .command('repair-stats')
+  .description('Repair Kilter catalog stats after deduping repeated Grips layout stat rows')
+  .requiredOption('--user <userId>', 'use this linked user’s stored Kilter credential (refresh grant)')
+  .option('--layouts <uuids>', 'comma-separated product_layout_uuids to repair (default: all listed)')
+  .option('--apply', 'write repaired kilter_ascensionist_count and ascensionist_count values (default: dry-run)')
+  .action(async (opts: { user: string; layouts?: string; apply?: boolean }) => {
+    const runner = new SyncRunner({ onLog: (message) => console.info(message) });
+    try {
+      const tokenProvider = await runner.buildUserTokenProvider(opts.user);
+      const summary = await runner.repairCatalogStats(tokenProvider, {
+        apply: opts.apply,
+        layoutUuids: parseLayoutUuids(opts.layouts),
+      });
+      const mode = opts.apply ? 'applied' : 'dry-run';
+      console.log(`✓ Kilter stats repair ${mode}:`, JSON.stringify(summary, null, 2));
+    } catch (err) {
+      console.error('✗ Kilter stats repair failed:', err instanceof Error ? err.message : err);
+      process.exitCode = 1;
+    } finally {
+      await runner.stop();
+    }
+  });
 
 program
   .command('locations')

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -19,6 +19,7 @@ import { refreshAccessToken, type KeycloakClientConfig } from '../api/keycloak';
 import { passwordTokenProvider, refreshTokenProvider, type KilterTokenProvider } from '../api/token-provider';
 import { syncKilterUserData } from '../sync/user-sync';
 import { syncKilterCatalog, type KilterCatalogSummary } from '../sync/catalog-sync';
+import { repairKilterCatalogStats, type KilterStatsRepairSummary } from '../sync/stats-repair';
 import { buildLayoutResolver } from '../sync/layout-resolver';
 import { syncKilterLocations, pullKilterReference } from '../sync';
 import type { RunnerClient, RunnerDb, SyncRunnerConfig, SyncSummary, KilterCredentialRecord } from './types';
@@ -46,9 +47,9 @@ export class SyncRunner {
 
   private getClient(): { client: RunnerClient; db: RunnerDb } {
     if (!this.client || !this.db) {
-      const connectionString = process.env.DATABASE_URL;
+      const connectionString = process.env.DATABASE_URL || process.env.DB_URL;
       if (!connectionString) {
-        throw new Error('DATABASE_URL is required');
+        throw new Error('DATABASE_URL or DB_URL is required');
       }
       // prepare: false matches aurora-sync — Railway's pooled URL uses
       // PgBouncer in transaction mode, which is incompatible with prepared
@@ -270,6 +271,20 @@ export class SyncRunner {
     const reference = await pullKilterReference({ accessToken, log: (message) => this.log(message) });
     const resolver = await buildLayoutResolver(db);
     return syncKilterLocations({ db, reference, resolver, log: (message) => this.log(message) });
+  }
+
+  async repairCatalogStats(
+    tokenProvider: KilterTokenProvider,
+    opts: { apply?: boolean; layoutUuids?: string[] } = {},
+  ): Promise<KilterStatsRepairSummary> {
+    const { db } = this.getClient();
+    return repairKilterCatalogStats({
+      db,
+      tokenProvider,
+      apply: opts.apply,
+      layoutUuids: opts.layoutUuids,
+      log: (message) => this.log(message),
+    });
   }
 
   /** Build a refresh-grant token provider from a linked user's stored credential. */

--- a/packages/kilter-sync/src/sync/catalog-stats.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-stats.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { foldCatalogStat } from './catalog-sync';
+import { foldCatalogStat, foldCatalogStatOnce } from './catalog-sync';
 import type { KilterCatalogStat } from '../api/kilter-rest';
 import type { StatAccum } from './catalog-sync';
 
@@ -149,6 +149,38 @@ describe('foldCatalogStat — kilter catalog stat accumulation', () => {
     expect(accum.displayDifficulty).toBe(17); // first merged with a value wins
     expect(accum.qualityAverage).toBe(3.5); // m1 had null quality, m2 fills it
     expect(accum.hasOwnRowStats).toBe(false);
+  });
+
+  it('counts the same source climb stat only once across repeated Grips layouts', () => {
+    const map = new Map<string, StatAccum>();
+    const seen = new Set<string>();
+    const first = foldCatalogStatOnce(
+      map,
+      seen,
+      stat({ climbUuid: CANON, angle: 40, ascentCount: 12, currentDifficultyId: 20 }),
+      CANON,
+    );
+    const second = foldCatalogStatOnce(
+      map,
+      seen,
+      stat({ climbUuid: CANON, angle: 40, ascentCount: 12, currentDifficultyId: 20 }),
+      CANON,
+    );
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    const [accum] = [...map.values()];
+    expect(accum.kilterCount).toBe(12);
+  });
+
+  it('still sums distinct source UUIDs that resolve to the same canonical', () => {
+    const map = new Map<string, StatAccum>();
+    const seen = new Set<string>();
+    foldCatalogStatOnce(map, seen, stat({ climbUuid: 'alias-a', angle: 40, ascentCount: 12 }), CANON);
+    foldCatalogStatOnce(map, seen, stat({ climbUuid: 'alias-b', angle: 40, ascentCount: 5 }), CANON);
+
+    const [accum] = [...map.values()];
+    expect(accum.kilterCount).toBe(17);
   });
 
   it('#3: quality 0 or negative is stored as NULL (never a literal 0 rating); Grips 1-5 kept as-is', () => {

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -132,6 +132,10 @@ export type StatAccum = {
   hasOwnRowStats: boolean;
 };
 
+export function catalogStatSourceKey(stat: KilterCatalogStat): string {
+  return `${stat.climbUuid.toLowerCase()}|${stat.angle}`;
+}
+
 /**
  * Fold one Grips (climb, angle) stat row into the per-(canonical, angle)
  * accumulator. `kilterCount` sums ascents across every source UUID that
@@ -188,6 +192,21 @@ export function foldCatalogStat(
     if (accum.faUsername == null) accum.faUsername = stat.faUsername;
     if (accum.faAt == null) accum.faAt = stat.faAt;
   }
+}
+
+export function foldCatalogStatOnce(
+  accumByKey: Map<string, StatAccum>,
+  seenSourceStats: Set<string>,
+  stat: KilterCatalogStat,
+  canonicalUuid: string,
+): boolean {
+  const sourceKey = catalogStatSourceKey(stat);
+  if (seenSourceStats.has(sourceKey)) {
+    return false;
+  }
+  seenSourceStats.add(sourceKey);
+  foldCatalogStat(accumByKey, stat, canonicalUuid);
+  return true;
 }
 
 /**
@@ -376,12 +395,13 @@ async function syncBoardLayoutGroup(
 
   // Stats for the whole group (after every climb is in climbUuidToCanonical).
   const statsByCanonicalAngle = new Map<string, StatAccum>();
+  const seenSourceStats = new Set<string>();
   for (const gripsLayoutUuid of gripsLayoutUuids) {
     const stats = await withToken(state, (token) => fetchLayoutClimbStats(token, gripsLayoutUuid));
     for (const stat of stats) {
       const canonicalUuid = climbUuidToCanonical.get(stat.climbUuid.toLowerCase());
       if (!canonicalUuid) continue; // stat for a filtered/unknown climb
-      foldCatalogStat(statsByCanonicalAngle, stat, canonicalUuid);
+      foldCatalogStatOnce(statsByCanonicalAngle, seenSourceStats, stat, canonicalUuid);
     }
   }
 
@@ -408,11 +428,10 @@ async function syncBoardLayoutGroup(
           target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
           set: {
             kilterAscensionistCount: sql`excluded.kilter_ascensionist_count`,
-            // aurora_ and kilter_ are the SAME ascents for the Kilter board (the
-            // pre-split kilterboardapp.com vs kiltergrips.com — Kilter migrated
-            // the logs). Take Kilter (the live source) and fall back to aurora,
-            // never sum, or every Kilter climb would show ~2× its real ascents.
-            ascensionistCount: sql`COALESCE(excluded.kilter_ascensionist_count, ${boardClimbStats.auroraAscensionistCount}, 0) + COALESCE(${boardClimbStats.boardseshAscensionistCount}, 0)`,
+            // Kilter and Aurora are alternate upstream snapshots of the same
+            // Kilter ascents, so take the higher upstream count and add the
+            // independent Boardsesh count.
+            ascensionistCount: sql`GREATEST(COALESCE(excluded.kilter_ascensionist_count, 0), COALESCE(${boardClimbStats.auroraAscensionistCount}, 0)) + COALESCE(${boardClimbStats.boardseshAscensionistCount}, 0)`,
             // Kilter-origin canonicals: clobber with Grips values. Aurora-origin
             // canonicals (no Grips display row): excluded is null → keep existing.
             displayDifficulty: sql`COALESCE(excluded.display_difficulty, ${boardClimbStats.displayDifficulty})`,

--- a/packages/kilter-sync/src/sync/index.ts
+++ b/packages/kilter-sync/src/sync/index.ts
@@ -7,6 +7,12 @@ export { pushKilterUserData, type PushBackArgs } from './push-back';
 // catalog by UUID then hold fingerprint, and reconciled into board_climbs /
 // board_climb_stats. Reference tables come over PowerSync (reference-pull).
 export { syncKilterCatalog, type SyncKilterCatalogArgs, type KilterCatalogSummary } from './catalog-sync';
+export {
+  repairKilterCatalogStats,
+  type KilterStatsRepairArgs,
+  type KilterStatsRepairSummary,
+  type KilterStatsRepairTopRow,
+} from './stats-repair';
 export { pullKilterReference, type KilterReferencePull } from './reference-pull';
 export { buildLayoutResolver, type LayoutResolver } from './layout-resolver';
 export {

--- a/packages/kilter-sync/src/sync/stats-repair.test.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { KilterCatalogStat } from '../api/kilter-rest';
+import type { KilterReferencePull } from './reference-pull';
+
+const { mockFetchLayoutClimbStats, mockBuildLayoutResolver } = vi.hoisted(() => ({
+  mockFetchLayoutClimbStats: vi.fn(),
+  mockBuildLayoutResolver: vi.fn(),
+}));
+
+vi.mock('../api/kilter-rest', async () => {
+  const actual = await vi.importActual<typeof import('../api/kilter-rest')>('../api/kilter-rest');
+  return {
+    ...actual,
+    fetchLayoutClimbStats: mockFetchLayoutClimbStats,
+  };
+});
+
+vi.mock('./layout-resolver', () => ({
+  buildLayoutResolver: mockBuildLayoutResolver,
+}));
+
+import { repairKilterCatalogStats } from './stats-repair';
+
+type SelectResult = Array<Record<string, unknown>>;
+type ExecuteResult = unknown;
+
+function stat(overrides: Partial<KilterCatalogStat> & { climbUuid: string; angle: number; ascentCount: number }) {
+  return {
+    currentDifficultyId: null,
+    difficultyAverage: null,
+    qualityAverage: null,
+    faUsername: null,
+    faAt: null,
+    ...overrides,
+  };
+}
+
+function reference(): KilterReferencePull {
+  return {
+    products: [],
+    holds: [],
+    difficultyGrades: [],
+    gyms: [],
+    walls: [],
+    productLayouts: [
+      {
+        productLayoutUuid: 'layout-a',
+        productName: 'Kilter Board Original',
+        isListed: true,
+        edgeLeft: 0,
+        edgeRight: 0,
+        edgeBottom: 0,
+        edgeTop: 0,
+      },
+      {
+        productLayoutUuid: 'layout-b',
+        productName: 'Kilter Board Original',
+        isListed: true,
+        edgeLeft: 0,
+        edgeRight: 0,
+        edgeBottom: 0,
+        edgeTop: 0,
+      },
+    ],
+  };
+}
+
+function createDbShim(args: { selectResults: SelectResult[]; executeResults: ExecuteResult[] }) {
+  const insertValues: unknown[] = [];
+  const execute = vi.fn(async () => args.executeResults.shift() ?? []);
+  const select = vi.fn(() => ({
+    from: () => ({
+      where: () => Promise.resolve(args.selectResults.shift() ?? []),
+      innerJoin: () => ({
+        where: () => Promise.resolve(args.selectResults.shift() ?? []),
+      }),
+    }),
+  }));
+  const insert = vi.fn(() => ({
+    values: vi.fn((values: unknown) => {
+      insertValues.push(values);
+      return {
+        onConflictDoUpdate: vi.fn(async () => undefined),
+      };
+    }),
+  }));
+
+  return {
+    db: { select, execute, insert },
+    insertValues,
+  };
+}
+
+describe('repairKilterCatalogStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildLayoutResolver.mockResolvedValue({
+      resolve: vi.fn(() => 1),
+    });
+    mockFetchLayoutClimbStats.mockImplementation((_token: string, layoutUuid: string) => {
+      if (layoutUuid === 'layout-a') {
+        return Promise.resolve([
+          stat({ climbUuid: 'canon', angle: 40, ascentCount: 12, currentDifficultyId: 20 }),
+          stat({ climbUuid: 'alias-b', angle: 40, ascentCount: 5, currentDifficultyId: 20 }),
+        ]);
+      }
+      return Promise.resolve([stat({ climbUuid: 'canon', angle: 40, ascentCount: 12, currentDifficultyId: 20 })]);
+    });
+  });
+
+  it('dry-runs deduped Kilter counts without writing', async () => {
+    const { db, insertValues } = createDbShim({
+      selectResults: [[{ uuid: 'canon' }], [{ aliasUuid: 'alias-b', canonicalUuid: 'canon' }]],
+      executeResults: [[], [{ changed_rows: '1', max_drop: '12' }], [{ rows_to_recompute: '2' }]],
+    });
+
+    const summary = await repairKilterCatalogStats({
+      db: db as never,
+      tokenProvider: async () => 'token',
+      reference: reference(),
+    });
+
+    expect(summary.applied).toBe(false);
+    expect(summary.statsSeen).toBe(3);
+    expect(summary.statsDeduped).toBe(1);
+    expect(summary.statsUnresolved).toBe(0);
+    expect(summary.canonicalStatsComputed).toBe(1);
+    expect(summary.changedKilterRows).toBe(1);
+    expect(summary.formulaRowsRecomputed).toBe(2);
+    expect(summary.maxKilterDrop).toBe(12);
+    expect(insertValues).toHaveLength(0);
+  });
+
+  it('applies repaired counts and recomputes materialized totals', async () => {
+    const { db, insertValues } = createDbShim({
+      selectResults: [[{ uuid: 'canon' }], [{ aliasUuid: 'alias-b', canonicalUuid: 'canon' }]],
+      executeResults: [[], [{ changed_rows: '1', max_drop: '12' }], [{ rows_to_recompute: '2' }], { count: 2 }, []],
+    });
+
+    const summary = await repairKilterCatalogStats({
+      db: db as never,
+      tokenProvider: async () => 'token',
+      reference: reference(),
+      apply: true,
+    });
+
+    expect(summary.applied).toBe(true);
+    expect(summary.formulaRowsRecomputed).toBe(2);
+    expect(insertValues).toHaveLength(1);
+    expect(insertValues[0]).toMatchObject([
+      {
+        boardType: 'kilter',
+        climbUuid: 'canon',
+        angle: 40,
+        kilterAscensionistCount: 17,
+        ascensionistCount: 17,
+      },
+    ]);
+  });
+});

--- a/packages/kilter-sync/src/sync/stats-repair.test.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.test.ts
@@ -85,8 +85,11 @@ function createDbShim(args: { selectResults: SelectResult[]; executeResults: Exe
     }),
   }));
 
+  const db = { select, execute, insert, transaction: vi.fn() };
+  db.transaction.mockImplementation(async (cb: (tx: typeof db) => Promise<unknown>) => cb(db));
+
   return {
-    db: { select, execute, insert },
+    db,
     insertValues,
   };
 }
@@ -111,7 +114,7 @@ describe('repairKilterCatalogStats', () => {
   it('dry-runs deduped Kilter counts without writing', async () => {
     const { db, insertValues } = createDbShim({
       selectResults: [[{ uuid: 'canon' }], [{ aliasUuid: 'alias-b', canonicalUuid: 'canon' }]],
-      executeResults: [[], [{ changed_rows: '1', max_drop: '12' }], [{ rows_to_recompute: '2' }]],
+      executeResults: [[], [{ changed_rows: '1', max_drop: '12', max_rise: '4' }], [{ rows_to_recompute: '2' }]],
     });
 
     const summary = await repairKilterCatalogStats({
@@ -128,6 +131,7 @@ describe('repairKilterCatalogStats', () => {
     expect(summary.changedKilterRows).toBe(1);
     expect(summary.formulaRowsRecomputed).toBe(2);
     expect(summary.maxKilterDrop).toBe(12);
+    expect(summary.maxKilterRise).toBe(4);
     expect(insertValues).toHaveLength(0);
   });
 

--- a/packages/kilter-sync/src/sync/stats-repair.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.ts
@@ -1,0 +1,367 @@
+import { and, eq, sql } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import { boardClimbAliases, boardClimbs, boardClimbStats } from '@boardsesh/db/schema';
+import { commandCountFromResult } from '@boardsesh/db/client';
+
+import type { KilterTokenProvider } from '../api/token-provider';
+import { fetchLayoutClimbStats } from '../api/kilter-rest';
+import { KilterApiError } from '../api/errors';
+import { pullKilterReference, type KilterReferencePull } from './reference-pull';
+import { buildLayoutResolver } from './layout-resolver';
+import { catalogStatSourceKey, foldCatalogStat, type StatAccum } from './catalog-sync';
+
+type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+const KILTER = 'kilter';
+const BATCH = 1000;
+const TOP_LIMIT = 10;
+
+type TokenState = { provider: KilterTokenProvider; token: string };
+
+export type KilterStatsRepairArgs = {
+  db: DrizzleDb;
+  tokenProvider: KilterTokenProvider;
+  apply?: boolean;
+  log?: (message: string) => void;
+  reference?: KilterReferencePull;
+  layoutUuids?: string[];
+};
+
+export type KilterStatsRepairTopRow = {
+  name: string | null;
+  climbUuid: string;
+  angle: number;
+  ascensionistCount: number;
+  auroraAscensionistCount: number | null;
+  kilterAscensionistCount: number | null;
+  boardseshAscensionistCount: number | null;
+};
+
+export type KilterStatsRepairSummary = {
+  applied: boolean;
+  gripsLayoutsProcessed: number;
+  layoutsUnmapped: number;
+  statsSeen: number;
+  statsDeduped: number;
+  statsUnresolved: number;
+  canonicalStatsComputed: number;
+  changedKilterRows: number;
+  formulaRowsRecomputed: number;
+  maxKilterDrop: number;
+  topBefore: KilterStatsRepairTopRow[];
+  topAfter: KilterStatsRepairTopRow[] | null;
+};
+
+type RepairStatValue = {
+  boardType: string;
+  climbUuid: string;
+  angle: number;
+  displayDifficulty: number | null;
+  difficultyAverage: number | null;
+  qualityAverage: number | null;
+  qualityNormalized: boolean;
+  faUsername: string | null;
+  faAt: string | null;
+  kilterAscensionistCount: number;
+  ascensionistCount: number;
+};
+
+type CompareRow = {
+  changed_rows: number | string | null;
+  max_drop: number | string | null;
+};
+
+type FormulaCountRow = {
+  rows_to_recompute: number | string | null;
+};
+
+type TopRow = {
+  name: string | null;
+  climb_uuid: string;
+  angle: number | string;
+  ascensionist_count: number | string | null;
+  aurora_ascensionist_count: number | string | null;
+  kilter_ascensionist_count: number | string | null;
+  boardsesh_ascensionist_count: number | string | null;
+};
+
+function rowsFromResult<T>(result: unknown): T[] {
+  return Array.isArray(result) ? (result as T[]) : [];
+}
+
+async function processBatches<T>(rows: T[], fn: (chunk: T[]) => Promise<void>): Promise<void> {
+  for (let i = 0; i < rows.length; i += BATCH) {
+    await fn(rows.slice(i, i + BATCH));
+  }
+}
+
+async function withToken<T>(state: TokenState, call: (token: string) => Promise<T>): Promise<T> {
+  try {
+    return await call(state.token);
+  } catch (error) {
+    if (error instanceof KilterApiError && error.code === 'unauthorized') {
+      state.token = await state.provider();
+      return await call(state.token);
+    }
+    throw error;
+  }
+}
+
+function mapTopRow(row: TopRow): KilterStatsRepairTopRow {
+  return {
+    name: row.name,
+    climbUuid: row.climb_uuid,
+    angle: Number(row.angle),
+    ascensionistCount: Number(row.ascensionist_count ?? 0),
+    auroraAscensionistCount: row.aurora_ascensionist_count === null ? null : Number(row.aurora_ascensionist_count),
+    kilterAscensionistCount: row.kilter_ascensionist_count === null ? null : Number(row.kilter_ascensionist_count),
+    boardseshAscensionistCount:
+      row.boardsesh_ascensionist_count === null ? null : Number(row.boardsesh_ascensionist_count),
+  };
+}
+
+async function loadTopStats(db: DrizzleDb): Promise<KilterStatsRepairTopRow[]> {
+  const rows = rowsFromResult<TopRow>(
+    await db.execute(sql`
+      SELECT bc.name,
+             bcs.climb_uuid,
+             bcs.angle,
+             bcs.ascensionist_count,
+             bcs.aurora_ascensionist_count,
+             bcs.kilter_ascensionist_count,
+             bcs.boardsesh_ascensionist_count
+        FROM board_climb_stats bcs
+        JOIN board_climbs bc
+          ON bc.uuid = bcs.climb_uuid
+         AND bc.board_type = bcs.board_type
+       WHERE bcs.board_type = ${KILTER}
+       ORDER BY bcs.ascensionist_count DESC NULLS LAST
+       LIMIT ${TOP_LIMIT}
+    `),
+  );
+  return rows.map(mapTopRow);
+}
+
+async function loadCanonicalMap(db: DrizzleDb, layoutId: number): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const climbRows = await db
+    .select({ uuid: boardClimbs.uuid })
+    .from(boardClimbs)
+    .where(and(eq(boardClimbs.boardType, KILTER), eq(boardClimbs.layoutId, layoutId)));
+
+  for (const row of climbRows) {
+    map.set(row.uuid.toLowerCase(), row.uuid);
+  }
+
+  const aliasRows = await db
+    .select({
+      aliasUuid: boardClimbAliases.aliasUuid,
+      canonicalUuid: boardClimbAliases.canonicalUuid,
+    })
+    .from(boardClimbAliases)
+    .innerJoin(
+      boardClimbs,
+      and(
+        eq(boardClimbs.boardType, boardClimbAliases.boardType),
+        eq(boardClimbs.uuid, boardClimbAliases.canonicalUuid),
+      ),
+    )
+    .where(and(eq(boardClimbAliases.boardType, KILTER), eq(boardClimbs.layoutId, layoutId)));
+
+  for (const row of aliasRows) {
+    map.set(row.aliasUuid.toLowerCase(), row.canonicalUuid);
+  }
+
+  return map;
+}
+
+function statValueFromAccum(accum: StatAccum): RepairStatValue {
+  return {
+    boardType: KILTER,
+    climbUuid: accum.canonicalUuid,
+    angle: accum.angle,
+    displayDifficulty: accum.displayDifficulty,
+    difficultyAverage: accum.difficultyAverage,
+    qualityAverage: accum.qualityAverage,
+    qualityNormalized: true,
+    faUsername: accum.faUsername,
+    faAt: accum.faAt,
+    kilterAscensionistCount: accum.kilterCount,
+    ascensionistCount: accum.kilterCount,
+  };
+}
+
+async function compareExistingStats(
+  db: DrizzleDb,
+  statValues: RepairStatValue[],
+): Promise<{ changedRows: number; maxKilterDrop: number }> {
+  let changedRows = 0;
+  let maxKilterDrop = 0;
+
+  await processBatches(statValues, async (chunk) => {
+    const incoming = chunk.map((statValue) => ({
+      climb_uuid: statValue.climbUuid,
+      angle: statValue.angle,
+      kilter_count: statValue.kilterAscensionistCount,
+    }));
+    const rows = rowsFromResult<CompareRow>(
+      await db.execute(sql`
+        WITH incoming AS (
+          SELECT *
+            FROM jsonb_to_recordset(${JSON.stringify(incoming)}::jsonb)
+              AS i(climb_uuid text, angle integer, kilter_count bigint)
+        )
+        SELECT COUNT(*) FILTER (
+                 WHERE s.kilter_ascensionist_count IS DISTINCT FROM i.kilter_count
+               ) AS changed_rows,
+               MAX(COALESCE(s.kilter_ascensionist_count, 0) - i.kilter_count) FILTER (
+                 WHERE COALESCE(s.kilter_ascensionist_count, 0) > i.kilter_count
+               ) AS max_drop
+          FROM incoming i
+     LEFT JOIN board_climb_stats s
+            ON s.board_type = ${KILTER}
+           AND s.climb_uuid = i.climb_uuid
+           AND s.angle = i.angle
+      `),
+    );
+    const row = rows[0];
+    changedRows += Number(row?.changed_rows ?? 0);
+    maxKilterDrop = Math.max(maxKilterDrop, Number(row?.max_drop ?? 0));
+  });
+
+  return { changedRows, maxKilterDrop };
+}
+
+async function countFormulaMismatches(db: DrizzleDb): Promise<number> {
+  const rows = rowsFromResult<FormulaCountRow>(
+    await db.execute(sql`
+      SELECT COUNT(*) AS rows_to_recompute
+        FROM board_climb_stats
+       WHERE board_type = ${KILTER}
+         AND ascensionist_count IS DISTINCT FROM (
+           GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(aurora_ascensionist_count, 0))
+           + COALESCE(boardsesh_ascensionist_count, 0)
+         )
+    `),
+  );
+  return Number(rows[0]?.rows_to_recompute ?? 0);
+}
+
+async function upsertRepairedStats(db: DrizzleDb, statValues: RepairStatValue[]): Promise<void> {
+  await processBatches(statValues, async (chunk) => {
+    await db
+      .insert(boardClimbStats)
+      .values(chunk)
+      .onConflictDoUpdate({
+        target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
+        set: {
+          kilterAscensionistCount: sql`excluded.kilter_ascensionist_count`,
+          ascensionistCount: sql`GREATEST(COALESCE(excluded.kilter_ascensionist_count, 0), COALESCE(${boardClimbStats.auroraAscensionistCount}, 0)) + COALESCE(${boardClimbStats.boardseshAscensionistCount}, 0)`,
+          displayDifficulty: sql`COALESCE(excluded.display_difficulty, ${boardClimbStats.displayDifficulty})`,
+          difficultyAverage: sql`COALESCE(excluded.difficulty_average, ${boardClimbStats.difficultyAverage})`,
+          qualityAverage: sql`COALESCE(excluded.quality_average, ${boardClimbStats.qualityAverage})`,
+          qualityNormalized: sql`true`,
+          faUsername: sql`COALESCE(excluded.fa_username, ${boardClimbStats.faUsername})`,
+          faAt: sql`COALESCE(excluded.fa_at, ${boardClimbStats.faAt})`,
+        },
+      });
+  });
+}
+
+async function recomputeMaterializedTotals(db: DrizzleDb): Promise<number> {
+  const result = await db.execute(sql`
+    UPDATE board_climb_stats
+       SET ascensionist_count = (
+         GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(aurora_ascensionist_count, 0))
+         + COALESCE(boardsesh_ascensionist_count, 0)
+       )
+     WHERE board_type = ${KILTER}
+       AND ascensionist_count IS DISTINCT FROM (
+         GREATEST(COALESCE(kilter_ascensionist_count, 0), COALESCE(aurora_ascensionist_count, 0))
+         + COALESCE(boardsesh_ascensionist_count, 0)
+       )
+  `);
+  return commandCountFromResult(result) ?? 0;
+}
+
+export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Promise<KilterStatsRepairSummary> {
+  const log = args.log ?? (() => {});
+  const state: TokenState = { provider: args.tokenProvider, token: await args.tokenProvider() };
+  const reference = args.reference ?? (await pullKilterReference({ accessToken: state.token, log }));
+  const resolver = await buildLayoutResolver(args.db);
+  const wantedLayoutUuids = args.layoutUuids ? new Set(args.layoutUuids) : null;
+
+  const byBoardLayout = new Map<number, string[]>();
+  let layoutsUnmapped = 0;
+  for (const layout of reference.productLayouts) {
+    if (!layout.isListed) continue;
+    if (wantedLayoutUuids && !wantedLayoutUuids.has(layout.productLayoutUuid)) continue;
+    const layoutId = resolver.resolve(layout.productLayoutUuid, layout.productName);
+    if (layoutId === null) {
+      layoutsUnmapped += 1;
+      continue;
+    }
+    const group = byBoardLayout.get(layoutId) ?? [];
+    group.push(layout.productLayoutUuid);
+    byBoardLayout.set(layoutId, group);
+  }
+
+  const topBefore = await loadTopStats(args.db);
+  const statsByCanonicalAngle = new Map<string, StatAccum>();
+  const seenSourceStats = new Set<string>();
+  let statsSeen = 0;
+  let statsDeduped = 0;
+  let statsUnresolved = 0;
+  let gripsLayoutsProcessed = 0;
+
+  for (const [boardLayoutId, gripsLayoutUuids] of byBoardLayout) {
+    const canonicalBySourceUuid = await loadCanonicalMap(args.db, boardLayoutId);
+    gripsLayoutsProcessed += gripsLayoutUuids.length;
+    for (const gripsLayoutUuid of gripsLayoutUuids) {
+      const stats = await withToken(state, (token) => fetchLayoutClimbStats(token, gripsLayoutUuid));
+      for (const stat of stats) {
+        statsSeen += 1;
+        const sourceKey = catalogStatSourceKey(stat);
+        if (seenSourceStats.has(sourceKey)) {
+          statsDeduped += 1;
+          continue;
+        }
+        seenSourceStats.add(sourceKey);
+
+        const canonicalUuid = canonicalBySourceUuid.get(stat.climbUuid.toLowerCase());
+        if (!canonicalUuid) {
+          statsUnresolved += 1;
+          continue;
+        }
+        foldCatalogStat(statsByCanonicalAngle, stat, canonicalUuid);
+      }
+    }
+  }
+
+  const statValues = [...statsByCanonicalAngle.values()].map(statValueFromAccum);
+  const { changedRows, maxKilterDrop } = await compareExistingStats(args.db, statValues);
+  const formulaRowsBeforeApply = await countFormulaMismatches(args.db);
+
+  let formulaRowsRecomputed = 0;
+  let topAfter: KilterStatsRepairTopRow[] | null = null;
+  if (args.apply) {
+    await upsertRepairedStats(args.db, statValues);
+    formulaRowsRecomputed = await recomputeMaterializedTotals(args.db);
+    topAfter = await loadTopStats(args.db);
+  }
+
+  return {
+    applied: args.apply ?? false,
+    gripsLayoutsProcessed,
+    layoutsUnmapped,
+    statsSeen,
+    statsDeduped,
+    statsUnresolved,
+    canonicalStatsComputed: statValues.length,
+    changedKilterRows: changedRows,
+    formulaRowsRecomputed: args.apply ? formulaRowsRecomputed : formulaRowsBeforeApply,
+    maxKilterDrop,
+    topBefore,
+    topAfter,
+  };
+}

--- a/packages/kilter-sync/src/sync/stats-repair.ts
+++ b/packages/kilter-sync/src/sync/stats-repair.ts
@@ -1,7 +1,7 @@
 import { and, eq, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { boardClimbAliases, boardClimbs, boardClimbStats } from '@boardsesh/db/schema';
-import { commandCountFromResult } from '@boardsesh/db/client';
+import { commandCountFromResult, rowsFromResult } from '@boardsesh/db/client';
 
 import type { KilterTokenProvider } from '../api/token-provider';
 import { fetchLayoutClimbStats } from '../api/kilter-rest';
@@ -48,6 +48,7 @@ export type KilterStatsRepairSummary = {
   changedKilterRows: number;
   formulaRowsRecomputed: number;
   maxKilterDrop: number;
+  maxKilterRise: number;
   topBefore: KilterStatsRepairTopRow[];
   topAfter: KilterStatsRepairTopRow[] | null;
 };
@@ -69,6 +70,7 @@ type RepairStatValue = {
 type CompareRow = {
   changed_rows: number | string | null;
   max_drop: number | string | null;
+  max_rise: number | string | null;
 };
 
 type FormulaCountRow = {
@@ -84,10 +86,6 @@ type TopRow = {
   kilter_ascensionist_count: number | string | null;
   boardsesh_ascensionist_count: number | string | null;
 };
-
-function rowsFromResult<T>(result: unknown): T[] {
-  return Array.isArray(result) ? (result as T[]) : [];
-}
 
 async function processBatches<T>(rows: T[], fn: (chunk: T[]) => Promise<void>): Promise<void> {
   for (let i = 0; i < rows.length; i += BATCH) {
@@ -142,6 +140,11 @@ async function loadTopStats(db: DrizzleDb): Promise<KilterStatsRepairTopRow[]> {
   return rows.map(mapTopRow);
 }
 
+// Maps every source climb UUID (lowercased) to its canonical UUID for one board
+// layout, from board_climbs self-rows + persisted board_climb_aliases. Precondition:
+// run after a catalog sync has persisted this run's fingerprint aliases — the repair
+// reads only persisted aliases, it does not re-derive fingerprints. A source UUID
+// with no mapping here is counted in summary.statsUnresolved (observable, not silent).
 async function loadCanonicalMap(db: DrizzleDb, layoutId: number): Promise<Map<string, string>> {
   const map = new Map<string, string>();
   const climbRows = await db
@@ -194,9 +197,10 @@ function statValueFromAccum(accum: StatAccum): RepairStatValue {
 async function compareExistingStats(
   db: DrizzleDb,
   statValues: RepairStatValue[],
-): Promise<{ changedRows: number; maxKilterDrop: number }> {
+): Promise<{ changedRows: number; maxKilterDrop: number; maxKilterRise: number }> {
   let changedRows = 0;
   let maxKilterDrop = 0;
+  let maxKilterRise = 0;
 
   await processBatches(statValues, async (chunk) => {
     const incoming = chunk.map((statValue) => ({
@@ -216,7 +220,10 @@ async function compareExistingStats(
                ) AS changed_rows,
                MAX(COALESCE(s.kilter_ascensionist_count, 0) - i.kilter_count) FILTER (
                  WHERE COALESCE(s.kilter_ascensionist_count, 0) > i.kilter_count
-               ) AS max_drop
+               ) AS max_drop,
+               MAX(i.kilter_count - COALESCE(s.kilter_ascensionist_count, 0)) FILTER (
+                 WHERE i.kilter_count > COALESCE(s.kilter_ascensionist_count, 0)
+               ) AS max_rise
           FROM incoming i
      LEFT JOIN board_climb_stats s
             ON s.board_type = ${KILTER}
@@ -227,9 +234,10 @@ async function compareExistingStats(
     const row = rows[0];
     changedRows += Number(row?.changed_rows ?? 0);
     maxKilterDrop = Math.max(maxKilterDrop, Number(row?.max_drop ?? 0));
+    maxKilterRise = Math.max(maxKilterRise, Number(row?.max_rise ?? 0));
   });
 
-  return { changedRows, maxKilterDrop };
+  return { changedRows, maxKilterDrop, maxKilterRise };
 }
 
 async function countFormulaMismatches(db: DrizzleDb): Promise<number> {
@@ -339,14 +347,18 @@ export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Pro
   }
 
   const statValues = [...statsByCanonicalAngle.values()].map(statValueFromAccum);
-  const { changedRows, maxKilterDrop } = await compareExistingStats(args.db, statValues);
+  const { changedRows, maxKilterDrop, maxKilterRise } = await compareExistingStats(args.db, statValues);
   const formulaRowsBeforeApply = await countFormulaMismatches(args.db);
 
   let formulaRowsRecomputed = 0;
   let topAfter: KilterStatsRepairTopRow[] | null = null;
   if (args.apply) {
-    await upsertRepairedStats(args.db, statValues);
-    formulaRowsRecomputed = await recomputeMaterializedTotals(args.db);
+    // Atomic: a crash between the kilter-count overwrite and the materialized
+    // recompute would otherwise leave ascensionist_count stale until re-run.
+    await args.db.transaction(async (tx) => {
+      await upsertRepairedStats(tx, statValues);
+      formulaRowsRecomputed = await recomputeMaterializedTotals(tx);
+    });
     topAfter = await loadTopStats(args.db);
   }
 
@@ -361,6 +373,7 @@ export async function repairKilterCatalogStats(args: KilterStatsRepairArgs): Pro
     changedKilterRows: changedRows,
     formulaRowsRecomputed: args.apply ? formulaRowsRecomputed : formulaRowsBeforeApply,
     maxKilterDrop,
+    maxKilterRise,
     topBefore,
     topAfter,
   };


### PR DESCRIPTION
## Summary

Fixes inflated Kilter ascent totals introduced by the new Kilter catalog sync.

The Kilter catalog can return the same source climb stat through multiple Grips `product_layout_uuid`s that collapse to one Boardsesh layout. The sync was adding each repeated source stat into the canonical `(climb, angle)` bucket, which inflated `kilter_ascensionist_count` for affected climbs.

## Changes

- Dedupe Kilter catalog stats by `(source climb UUID, angle)` before folding into canonical stats.
- Preserve intentional accumulation for distinct duplicate/alias climb UUIDs that resolve to one canonical climb.
- Change all materialized ascent-total writers to use `max(Kilter, Aurora) + Boardsesh` instead of Kilter-first fallback.
- Add `kilter-sync repair-stats --user <userId> [--layouts ...] [--apply]` for dry-run/apply production repair.
- Update sync docs and tests around the count model.

## Validation

- `vp test run --project kilter-sync`
- `vp test run --project aurora-sync`
- `vp test run --project backend packages/backend/src/__tests__/recompute-climb-stats.test.ts`
- `vp run typecheck:kilter`
- `vp run typecheck:aurora`
- `vp run typecheck:backend`
- `git diff --check`

`vp check` still reports unrelated pre-existing formatting issues outside this diff: `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend tick files, and db drizzle metadata snapshots.