### PR TITLE
[codex] Render incompatible discover playlist rows correctly

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -121,10 +121,9 @@ export default function PlaylistDetail() {
     refreshErrorMessage: 'Failed to refresh playlist suggestions:',
   });
 
-  // Render the climbs against the playlist's own board. When it matches the
-  // active board this is the active board (tapping queues normally); when it
-  // differs (or there's no active board) rows render read-only against the
-  // playlist's board and `boardBanner` prompts a switch.
+  // Prefer the active board for row rendering; mixed-board climbs resolve their
+  // own board per row and dim when they do not fit the active board. The banner
+  // still prompts a switch for list-level board mismatches.
   const { renderBoard, banner: boardBanner } = usePlaylistRenderBoard(
     playlist ? { boardType: playlist.boardType, layoutId: playlist.layoutId } : null,
   );

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useRef, useState } from 'react';
 import {
   type ColorValue,
   type LayoutChangeEvent,
@@ -42,6 +42,7 @@ import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
 import { withAlpha } from '../../theme/colors';
 import { toQueueClimb, toSchemaClimb } from '../../lib/climb-types';
 import type { PlaylistRenderBoard, PlaylistBoardBanner } from '../../lib/playlists/use-playlist-render-board';
+import { resolvePlaylistClimbRenderBoard } from '../../lib/playlists/playlist-climb-render-board';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
@@ -94,14 +95,13 @@ export type PlaylistDetailHero = {
 export type PlaylistDetailViewProps = {
   hero: PlaylistDetailHero;
   climbs: Climb[];
-  /** Board the climb rows render against (resolved by `usePlaylistRenderBoard`).
-   *  Null while the active board is still loading, or when the playlist's board
-   *  can't be resolved — every row renders null in that case. */
+  /** Preferred active board for climb rows. Compatible rows render against it;
+   *  incompatible rows resolve their own board config and are dimmed. */
   renderBoard: PlaylistRenderBoard | null;
   /** Set when the playlist belongs to a board other than the active one (or
-   *  there is no active board). Rows render read-only against the playlist's own
-   *  board, a switch-board banner shows above the list, and queueing (row tap +
-   *  activate-all) is disabled. */
+   *  there is no active board). A switch-board banner shows above the list and
+   *  activate-all is disabled; row taps still open the drawer so it can explain
+   *  incompatibility. */
   boardBanner?: PlaylistBoardBanner | null;
   /** True while the first page loads (hero still renders; list shows a spinner). */
   isLoading: boolean;
@@ -138,14 +138,12 @@ const noopRemove = (_climbUuid: string) => {};
 /**
  * Shared hero + paginated climb list for the playlist-detail and
  * smart-playlist-detail screens. Renders the colour/emoji hero, then a FlashList
- * of `ClimbListRow`s rendered against `renderBoard`, paginating via
+ * of `ClimbListRow`s rendered from `renderBoard`, paginating via
  * `fetchNextPage` as the list nears its end.
  *
- * `renderBoard` is the user's active board for the common case. When a playlist
- * belongs to a different board, the caller passes the playlist's own board plus
- * a `boardBanner`: rows then render read-only against that board, a switch-board
- * banner shows above the list, and queueing is disabled (the queue / play drawer
- * / BLE LEDs follow the single active board).
+ * `renderBoard` is the user's active board for the common case. Rows whose
+ * climbs do not fit that board render against their own board config and are
+ * dimmed; the play drawer owns the incompatibility message when opened.
  *
  * Two presentations: the Liquid Glass variant keeps the full-bleed gradient hero
  * with white text and floating FABs; the Material 3 variant swaps in a Paper
@@ -231,27 +229,19 @@ export function PlaylistDetailView({
   // header `collapsed` flips during scroll) would otherwise re-render every row.
   const handleActivate = useCallback((tapped: SchemaClimb) => onActivateClimb(toQueueClimb(tapped)), [onActivateClimb]);
 
-  // Read-only mode (board mismatch): tapping a climb routes to the board
-  // switcher — the one action that lets the user actually climb it. Read the
-  // banner through a ref so this callback (and thus `renderItem`) stays stable
-  // even if `boardBanner`'s identity churns — otherwise every FlashList row
-  // would re-render on a banner recreation.
-  const boardBannerRef = useRef(boardBanner);
-  boardBannerRef.current = boardBanner;
-  const handleSwitchBoard = useCallback(() => boardBannerRef.current?.onPress(), []);
-
-  // `renderItem` depends on this boolean, not the `boardBanner` object, so a
-  // banner identity change doesn't invalidate the memoized rows.
-  const readOnly = !!boardBanner;
+  // Activate-all only needs to know whether the board-switch banner is present;
+  // row taps still open the drawer so it can explain incompatible climbs.
+  const disableActivateAll = !!boardBanner;
 
   // Activate-all: queue the playlist from the top. Reuses the same row-tap path
   // (which seeds the suggestion source from the whole list), so swiping the play
-  // drawer walks the playlist. No-op on an empty list or in read-only mode.
+  // drawer walks the playlist. No-op on an empty list or while the switch-board
+  // banner is shown.
   const handleActivateAll = useCallback(() => {
-    if (readOnly) return;
+    if (disableActivateAll) return;
     const first = climbs[0];
     if (first) onActivateClimb(first);
-  }, [readOnly, climbs, onActivateClimb]);
+  }, [disableActivateAll, climbs, onActivateClimb]);
 
   // List-level drag-to-reorder for edit mode. Always instantiated (hooks can't be
   // conditional); only the edit rows wire up its handles. `isDragging` locks the
@@ -261,30 +251,23 @@ export function PlaylistDetailView({
     itemCount: climbs.length,
   });
 
-  // Stable board object for the memoized edit rows (a fresh inline object each
-  // render would defeat their memoization).
-  const editBoard = useMemo(
-    () =>
-      renderBoard
-        ? {
-            boardName: renderBoard.boardName as BoardName,
-            layoutId: renderBoard.layoutId,
-            sizeId: renderBoard.sizeId,
-            setIds: renderBoard.setIds,
-            angle: renderBoard.angle,
-          }
-        : null,
-    [renderBoard],
-  );
-
   const renderItem = useCallback(
     ({ item, index }: { item: Climb; index: number }) => {
-      if (!renderBoard) return null;
-      if (editMode && editBoard) {
+      const resolvedBoard = resolvePlaylistClimbRenderBoard(item, renderBoard);
+      if (!resolvedBoard) return null;
+
+      if (editMode) {
+        const board = resolvedBoard.renderBoard;
         return (
           <PlaylistEditClimbRow
             climb={item}
-            board={editBoard}
+            board={{
+              boardName: board.boardName as BoardName,
+              layoutId: board.layoutId,
+              sizeId: board.sizeId,
+              setIds: board.setIds,
+              angle: board.angle,
+            }}
             rowIndex={index}
             drag={dragControls}
             onRemove={onRemoveClimb ?? noopRemove}
@@ -292,31 +275,21 @@ export function PlaylistDetailView({
           />
         );
       }
+
       return (
         <ClimbListRow
           climb={toSchemaClimb(item)}
-          boardName={renderBoard.boardName as BoardName}
-          layoutId={renderBoard.layoutId}
-          sizeId={renderBoard.sizeId}
-          setIds={renderBoard.setIds}
-          // Read-only rows render at each climb's own angle (the angle its grade
-          // was baked at); the matching case uses the active board's angle.
-          angle={readOnly ? item.angle : renderBoard.angle}
-          onPress={readOnly ? handleSwitchBoard : handleActivate}
+          boardName={resolvedBoard.renderBoard.boardName as BoardName}
+          layoutId={resolvedBoard.renderBoard.layoutId}
+          sizeId={resolvedBoard.renderBoard.sizeId}
+          setIds={resolvedBoard.renderBoard.setIds}
+          angle={resolvedBoard.renderBoard.angle}
+          onPress={handleActivate}
+          unsupported={resolvedBoard.incompatible}
         />
       );
     },
-    [
-      renderBoard,
-      editMode,
-      editBoard,
-      dragControls,
-      onRemoveClimb,
-      onReorderClimb,
-      readOnly,
-      handleActivate,
-      handleSwitchBoard,
-    ],
+    [renderBoard, editMode, dragControls, onRemoveClimb, onReorderClimb, handleActivate],
   );
 
   // Cog shown beside the playlist name only in edit mode — opens the
@@ -369,9 +342,8 @@ export function PlaylistDetailView({
     </View>
   ) : null;
 
-  // Switch-board banner shown above the read-only list when the playlist's board
-  // differs from the active one. Sits inside the list header so it scrolls with
-  // the hero in both variants.
+  // Switch-board banner shown when the playlist's board differs from the active
+  // one. Sits inside the list header so it scrolls with the hero in both variants.
   const bannerNode = boardBanner ? <BoardMismatchBanner banner={boardBanner} systemColors={systemColors} /> : null;
 
   // ── Material 3 branch ───────────────────────────────────────────────────────
@@ -666,9 +638,8 @@ function MaterialEmptyState({
   );
 }
 
-/** Switch-board banner for a read-only playlist whose board differs from the
- *  active one: a board glyph + the prompt, then a filled CTA into `/boards`.
- *  Lives above the (read-only) climb list in both variants. */
+/** Switch-board banner for a playlist whose board differs from the active one:
+ *  a board glyph + the prompt, then a filled CTA into `/boards`. */
 function BoardMismatchBanner({
   banner,
   systemColors,

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import {
   type ColorValue,
   type LayoutChangeEvent,
@@ -33,7 +33,7 @@ import { ClimbListRowSkeleton } from '../ClimbListRowSkeleton';
 import { GlassIconButton } from '../GlassIconButton';
 import { ProgressiveBlur } from '../ProgressiveBlur';
 import { Button } from '../Button';
-import { PlaylistEditClimbRow } from './PlaylistEditClimbRow';
+import { PlaylistEditClimbRow, type PlaylistEditRowBoard } from './PlaylistEditClimbRow';
 import { usePlaylistDrag } from './use-playlist-drag';
 import { PlaylistBoardBackdrop } from './PlaylistBoardBackdrop';
 import { buildHeroGradient } from './playlist-gradient';
@@ -134,6 +134,12 @@ export type PlaylistDetailViewProps = {
 
 const noopReorder = (_climbUuid: string, _newIndex: number) => {};
 const noopRemove = (_climbUuid: string) => {};
+
+type ResolvedPlaylistClimbRow = {
+  renderBoard: PlaylistRenderBoard;
+  editBoard: PlaylistEditRowBoard;
+  incompatible: boolean;
+};
 
 /**
  * Shared hero + paginated climb list for the playlist-detail and
@@ -251,23 +257,38 @@ export function PlaylistDetailView({
     itemCount: climbs.length,
   });
 
+  const resolvedRowsByClimbUuid = useMemo(() => {
+    const resolvedRows = new Map<string, ResolvedPlaylistClimbRow>();
+    for (const climb of climbs) {
+      const resolvedBoard = resolvePlaylistClimbRenderBoard(climb, renderBoard);
+      if (!resolvedBoard) continue;
+
+      const board = resolvedBoard.renderBoard;
+      resolvedRows.set(climb.uuid, {
+        renderBoard: board,
+        editBoard: {
+          boardName: board.boardName as BoardName,
+          layoutId: board.layoutId,
+          sizeId: board.sizeId,
+          setIds: board.setIds,
+          angle: board.angle,
+        },
+        incompatible: resolvedBoard.incompatible,
+      });
+    }
+    return resolvedRows;
+  }, [climbs, renderBoard]);
+
   const renderItem = useCallback(
     ({ item, index }: { item: Climb; index: number }) => {
-      const resolvedBoard = resolvePlaylistClimbRenderBoard(item, renderBoard);
-      if (!resolvedBoard) return null;
+      const resolvedRow = resolvedRowsByClimbUuid.get(item.uuid);
+      if (!resolvedRow) return null;
 
       if (editMode) {
-        const board = resolvedBoard.renderBoard;
         return (
           <PlaylistEditClimbRow
             climb={item}
-            board={{
-              boardName: board.boardName as BoardName,
-              layoutId: board.layoutId,
-              sizeId: board.sizeId,
-              setIds: board.setIds,
-              angle: board.angle,
-            }}
+            board={resolvedRow.editBoard}
             rowIndex={index}
             drag={dragControls}
             onRemove={onRemoveClimb ?? noopRemove}
@@ -279,17 +300,17 @@ export function PlaylistDetailView({
       return (
         <ClimbListRow
           climb={toSchemaClimb(item)}
-          boardName={resolvedBoard.renderBoard.boardName as BoardName}
-          layoutId={resolvedBoard.renderBoard.layoutId}
-          sizeId={resolvedBoard.renderBoard.sizeId}
-          setIds={resolvedBoard.renderBoard.setIds}
-          angle={resolvedBoard.renderBoard.angle}
+          boardName={resolvedRow.renderBoard.boardName as BoardName}
+          layoutId={resolvedRow.renderBoard.layoutId}
+          sizeId={resolvedRow.renderBoard.sizeId}
+          setIds={resolvedRow.renderBoard.setIds}
+          angle={resolvedRow.renderBoard.angle}
           onPress={handleActivate}
-          unsupported={resolvedBoard.incompatible}
+          unsupported={resolvedRow.incompatible}
         />
       );
     },
-    [renderBoard, editMode, dragControls, onRemoveClimb, onReorderClimb, handleActivate],
+    [resolvedRowsByClimbUuid, editMode, dragControls, onRemoveClimb, onReorderClimb, handleActivate],
   );
 
   // Cog shown beside the playlist name only in edit mode — opens the

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -6,6 +6,19 @@ import type { Climb } from '@boardsesh/queue';
 
 const ctrl = vi.hoisted(() => ({ back: vi.fn(), variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
 
+type CapturedClimbListRowProps = {
+  climb: { uuid: string; name: string };
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+  unsupported?: boolean;
+  onPress?: (climb: { uuid: string; name: string }) => void;
+};
+
+const capturedClimbRows = vi.hoisted(() => [] as CapturedClimbListRowProps[]);
+
 // ── React Native ──────────────────────────────────────────────────────────────
 vi.mock('react-native', () => ({
   View: ({
@@ -66,12 +79,14 @@ vi.mock('expo-linear-gradient', () => ({
 vi.mock('@shopify/flash-list', () => ({
   FlashList: ({
     data,
+    renderItem,
     ListHeaderComponent,
     ListEmptyComponent,
     ListFooterComponent,
     onEndReached,
   }: {
     data?: unknown[];
+    renderItem?: (info: { item: unknown; index: number }) => ReactNode;
     ListHeaderComponent?: ReactNode;
     ListEmptyComponent?: ReactNode;
     ListFooterComponent?: ReactNode;
@@ -81,7 +96,9 @@ vi.mock('@shopify/flash-list', () => ({
       'div',
       { 'data-list': 'true', onClick: onEndReached },
       ListHeaderComponent ?? null,
-      data?.length === 0 ? (ListEmptyComponent ?? null) : null,
+      data && data.length > 0 && renderItem
+        ? data.map((item, index) => createElement('div', { key: index }, renderItem({ item, index })))
+        : (ListEmptyComponent ?? null),
       ListFooterComponent ?? null,
     ),
 }));
@@ -151,7 +168,22 @@ vi.mock('../../ActivityIndicator', () => ({
   ActivityIndicator: ({ size }: { size?: string }) => createElement('div', { 'data-spinner': size ?? 'default' }),
 }));
 
-vi.mock('../../ClimbListRow', () => ({ ClimbListRow: () => null }));
+vi.mock('../../ClimbListRow', () => ({
+  ClimbListRow: (props: CapturedClimbListRowProps) => {
+    capturedClimbRows.push(props);
+    return createElement(
+      'button',
+      {
+        'data-climb-row': props.climb.uuid,
+        'data-board-name': props.boardName,
+        'data-layout-id': String(props.layoutId),
+        'data-unsupported': props.unsupported ? 'true' : 'false',
+        onClick: () => props.onPress?.(props.climb),
+      },
+      props.climb.name,
+    );
+  },
+}));
 
 // Button pulls in react-native-paper + expo-modules-core; stub it to a plain
 // button so the board-mismatch banner can render in jsdom.
@@ -243,6 +275,24 @@ const CLIMB: Climb = {
   benchmark_difficulty: null,
 };
 
+const KILTER_CLIMB: Climb = {
+  ...CLIMB,
+  uuid: 'kilter-row',
+  name: 'Kilter Row',
+  boardType: 'kilter',
+  layoutId: 1,
+  angle: 40,
+};
+
+const TENSION_CLIMB: Climb = {
+  ...CLIMB,
+  uuid: 'tension-row',
+  name: 'Tension Row',
+  boardType: 'tension',
+  layoutId: 9,
+  angle: 35,
+};
+
 function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDetailViewProps {
   return {
     hero: {
@@ -266,6 +316,7 @@ describe('PlaylistDetailView', () => {
   beforeEach(() => {
     ctrl.back.mockClear();
     ctrl.variant = 'liquidGlass';
+    capturedClimbRows.length = 0;
   });
 
   // ── Navigation ──────────────────────────────────────────────────────────────
@@ -363,6 +414,51 @@ describe('PlaylistDetailView', () => {
   it('shows no footer spinner when isFetchingNextPage=false', () => {
     const { container } = render(<PlaylistDetailView {...makeProps({ isFetchingNextPage: false, climbs: [CLIMB] })} />);
     expect(container.querySelector('[data-spinner="small"]')).toBeNull();
+  });
+
+  it('renders compatible rows against the active board', () => {
+    render(
+      <PlaylistDetailView
+        {...makeProps({
+          climbs: [KILTER_CLIMB],
+          renderBoard: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 45 },
+        })}
+      />,
+    );
+
+    expect(capturedClimbRows[0]).toMatchObject({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,20',
+      angle: 45,
+      unsupported: false,
+    });
+  });
+
+  it('renders incompatible mixed-board rows on their own board and dims them', () => {
+    render(
+      <PlaylistDetailView
+        {...makeProps({
+          climbs: [KILTER_CLIMB, TENSION_CLIMB],
+          renderBoard: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 45 },
+        })}
+      />,
+    );
+
+    expect(capturedClimbRows).toHaveLength(2);
+    expect(capturedClimbRows[0]).toMatchObject({
+      boardName: 'kilter',
+      layoutId: 1,
+      angle: 45,
+      unsupported: false,
+    });
+    expect(capturedClimbRows[1]).toMatchObject({
+      boardName: 'tension',
+      layoutId: 9,
+      angle: 35,
+      unsupported: true,
+    });
   });
 
   // ── Board backdrop ──────────────────────────────────────────────────────────
@@ -484,7 +580,7 @@ describe('PlaylistDetailView', () => {
     });
   });
 
-  // ── Board-mismatch banner (read-only) ───────────────────────────────────────
+  // ── Board-mismatch banner ──────────────────────────────────────────────────
   describe('board mismatch banner', () => {
     const banner = {
       title: 'Switch to Kilter to climb this playlist',
@@ -518,9 +614,27 @@ describe('PlaylistDetailView', () => {
     it('hides the Material activate-all action while the banner is shown', () => {
       ctrl.variant = 'material';
       const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [CLIMB], boardBanner: banner })} />);
-      // Queueing is blocked on a board mismatch, so the play-all action is gone
-      // even though the list has climbs.
+      // Playlist-level activate-all is blocked on a board mismatch, so the play
+      // action is gone even though the list has climbs.
       expect(container.querySelector('[data-appbar-action="play"]')).toBeNull();
+    });
+
+    it('still activates a row while the banner is shown', () => {
+      const onActivateClimb = vi.fn();
+      const { container } = render(
+        <PlaylistDetailView
+          {...makeProps({
+            climbs: [TENSION_CLIMB],
+            boardBanner: banner,
+            onActivateClimb,
+          })}
+        />,
+      );
+
+      fireEvent.click(container.querySelector('[data-climb-row="tension-row"]') as HTMLElement);
+
+      expect(onActivateClimb).toHaveBeenCalledWith(TENSION_CLIMB);
+      expect(banner.onPress).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -17,7 +17,19 @@ type CapturedClimbListRowProps = {
   onPress?: (climb: { uuid: string; name: string }) => void;
 };
 
+type CapturedPlaylistEditClimbRowProps = {
+  climb: Climb;
+  board: {
+    boardName: string;
+    layoutId: number;
+    sizeId: number;
+    setIds: string;
+    angle: number;
+  };
+};
+
 const capturedClimbRows = vi.hoisted(() => [] as CapturedClimbListRowProps[]);
+const capturedEditRows = vi.hoisted(() => [] as CapturedPlaylistEditClimbRowProps[]);
 
 // ── React Native ──────────────────────────────────────────────────────────────
 vi.mock('react-native', () => ({
@@ -252,7 +264,10 @@ vi.mock('../use-playlist-drag', () => ({
   }),
 }));
 vi.mock('../PlaylistEditClimbRow', () => ({
-  PlaylistEditClimbRow: () => null,
+  PlaylistEditClimbRow: (props: CapturedPlaylistEditClimbRowProps) => {
+    capturedEditRows.push(props);
+    return createElement('div', { 'data-edit-climb-row': props.climb.uuid });
+  },
 }));
 
 // Use real playlist-gradient and playlist-colors (pure TS, no RN imports).
@@ -317,6 +332,7 @@ describe('PlaylistDetailView', () => {
     ctrl.back.mockClear();
     ctrl.variant = 'liquidGlass';
     capturedClimbRows.length = 0;
+    capturedEditRows.length = 0;
   });
 
   // ── Navigation ──────────────────────────────────────────────────────────────
@@ -459,6 +475,17 @@ describe('PlaylistDetailView', () => {
       angle: 35,
       unsupported: true,
     });
+  });
+
+  it('keeps edit row board props stable across parent rerenders', () => {
+    const climbs = [KILTER_CLIMB];
+    const renderBoard = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 45 };
+    const { rerender } = render(<PlaylistDetailView {...makeProps({ climbs, renderBoard, editMode: true })} />);
+
+    rerender(<PlaylistDetailView {...makeProps({ climbs, renderBoard, editMode: true })} />);
+
+    expect(capturedEditRows).toHaveLength(2);
+    expect(capturedEditRows[1]?.board).toBe(capturedEditRows[0]?.board);
   });
 
   // ── Board backdrop ──────────────────────────────────────────────────────────

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { Climb } from '@boardsesh/queue';
+import { getBoardConfigForPlaylist } from '../board-details-for-playlist';
+import type { PlaylistRenderBoard } from '../use-playlist-render-board';
+import { resolvePlaylistClimbRenderBoard } from '../playlist-climb-render-board';
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'climb-1',
+    layoutId: 1,
+    boardType: 'kilter',
+    setter_username: 'setter',
+    name: 'Test Climb',
+    frames: '',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: 'V5',
+    quality_average: '0',
+    stars: 0,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+    ...overrides,
+  };
+}
+
+function getKnownBoard(boardType: string, layoutId: number, angle = 40): PlaylistRenderBoard {
+  const config = getBoardConfigForPlaylist(boardType, layoutId);
+  if (!config) throw new Error(`Missing board config for ${boardType}:${layoutId}`);
+  return {
+    boardName: config.boardName,
+    layoutId: config.layoutId,
+    sizeId: config.sizeId,
+    setIds: config.setIds.join(','),
+    angle,
+  };
+}
+
+describe('resolvePlaylistClimbRenderBoard', () => {
+  it('uses the active board when the climb is compatible with it', () => {
+    const activeBoard = getKnownBoard('kilter', 1, 45);
+    const result = resolvePlaylistClimbRenderBoard(makeClimb({ angle: 40 }), activeBoard);
+
+    expect(result).toEqual({
+      renderBoard: activeBoard,
+      fit: 'exact',
+      incompatible: false,
+    });
+  });
+
+  it('renders a different-board climb on its own board and marks it incompatible', () => {
+    const activeBoard = getKnownBoard('kilter', 1);
+    const result = resolvePlaylistClimbRenderBoard(
+      makeClimb({ boardType: 'tension', layoutId: 9, angle: 35 }),
+      activeBoard,
+    );
+
+    expect(result?.renderBoard.boardName).toBe('tension');
+    expect(result?.renderBoard.layoutId).toBe(9);
+    expect(result?.renderBoard.angle).toBe(35);
+    expect(result?.fit).toBe('incompatible');
+    expect(result?.incompatible).toBe(true);
+  });
+
+  it('does not mark a climb incompatible solely because there is no active board', () => {
+    const result = resolvePlaylistClimbRenderBoard(makeClimb({ boardType: 'tension', layoutId: 9, angle: 30 }), null);
+
+    expect(result?.renderBoard.boardName).toBe('tension');
+    expect(result?.renderBoard.layoutId).toBe(9);
+    expect(result?.renderBoard.angle).toBe(30);
+    expect(result?.fit).toBe('exact');
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('returns null when the climb board cannot be resolved', () => {
+    const result = resolvePlaylistClimbRenderBoard(makeClimb({ boardType: 'unknown-board', layoutId: 999 }), null);
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
@@ -47,6 +47,24 @@ describe('resolvePlaylistClimbRenderBoard', () => {
     });
   });
 
+  it('uses the smallest larger size when the climb needs more board than the active size', () => {
+    const activeBoard: PlaylistRenderBoard = {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 14,
+      setIds: '1,20',
+      angle: 40,
+    };
+    const result = resolvePlaylistClimbRenderBoard(makeClimb({ frames: 'p1073r42' }), activeBoard);
+
+    expect(result?.renderBoard.boardName).toBe('kilter');
+    expect(result?.renderBoard.layoutId).toBe(1);
+    expect(result?.renderBoard.sizeId).toBe(10);
+    expect(result?.renderBoard.setIds).toBe('1,20');
+    expect(result?.fit).toBe('upsized');
+    expect(result?.incompatible).toBe(true);
+  });
+
   it('renders a different-board climb on its own board and marks it incompatible', () => {
     const activeBoard = getKnownBoard('kilter', 1);
     const result = resolvePlaylistClimbRenderBoard(

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx
@@ -65,24 +65,20 @@ describe('usePlaylistRenderBoard', () => {
     expect(result.current.banner).toBeNull();
   });
 
-  it('resolves the playlist board read-only + banner on a board-name mismatch', () => {
+  it('keeps the active board and shows a banner on a board-name mismatch', () => {
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'tension', layoutId: 9 }));
-    expect(result.current.renderBoard).toEqual({
-      boardName: 'tension',
-      layoutId: 9,
-      sizeId: 5,
-      setIds: '1,2',
-      angle: 40,
-    });
+    expect(result.current.renderBoard).toBe(mocks.activeBoard);
     expect(result.current.banner?.title).toContain('Tension');
     expect(result.current.banner?.subtitle).toContain('Tension');
+    expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
   });
 
   it('treats a layout mismatch on the same board as a mismatch', () => {
     mocks.resolved = { boardName: 'kilter', layoutId: 8, sizeId: 7, setIds: [3] };
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'kilter', layoutId: 8 }));
     expect(result.current.banner).not.toBeNull();
-    expect(result.current.renderBoard).toMatchObject({ boardName: 'kilter', layoutId: 8, setIds: '3' });
+    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
   });
 
   it('resolves read-only + banner when there is no active board', () => {
@@ -93,7 +89,16 @@ describe('usePlaylistRenderBoard', () => {
     expect(result.current.renderBoard).toMatchObject({ boardName: 'tension', angle: 0 });
   });
 
-  it('shows the banner alone when the board cannot be resolved (e.g. MoonBoard)', () => {
+  it('keeps the active board when the playlist board cannot be resolved', () => {
+    mocks.resolved = null;
+    const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'moonboard', layoutId: 1 }));
+    expect(result.current.renderBoard).toBe(mocks.activeBoard);
+    expect(result.current.banner).not.toBeNull();
+    expect(mocks.getBoardConfigForPlaylist).not.toHaveBeenCalled();
+  });
+
+  it('shows the banner alone when there is no active board and the fallback cannot be resolved', () => {
+    mocks.activeBoard = null;
     mocks.resolved = null;
     const { result } = renderHook(() => usePlaylistRenderBoard({ boardType: 'moonboard', layoutId: 1 }));
     expect(result.current.renderBoard).toBeNull();

--- a/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
+++ b/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
@@ -1,0 +1,160 @@
+import type { BoardName } from '@boardsesh/shared-schema';
+import type { Climb } from '@boardsesh/queue';
+import { canAddClimbToBoard } from '@boardsesh/board-config';
+import { getProductSize, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
+import { getBoardRenderData } from '../board-details';
+import { getBoardConfigForPlaylist } from './board-details-for-playlist';
+import type { PlaylistRenderBoard } from './use-playlist-render-board';
+
+export type PlaylistClimbRenderBoardFit = 'exact' | 'upsized' | 'incompatible';
+
+export type PlaylistClimbRenderBoardResult = {
+  renderBoard: PlaylistRenderBoard;
+  fit: PlaylistClimbRenderBoardFit;
+  incompatible: boolean;
+};
+
+function parseSetIds(setIds: string): number[] {
+  return setIds
+    .split(',')
+    .map((setId) => Number(setId))
+    .filter((setId) => Number.isFinite(setId) && setId > 0);
+}
+
+function toRenderBoard(boardName: BoardName, layoutId: number, sizeId: number, setIds: number[], angle: number) {
+  return {
+    boardName,
+    layoutId,
+    sizeId,
+    setIds: setIds.join(','),
+    angle,
+  };
+}
+
+function getRenderBoardTarget(renderBoard: PlaylistRenderBoard) {
+  const boardName = renderBoard.boardName as BoardName;
+  const setIds = parseSetIds(renderBoard.setIds);
+  const renderData = getBoardRenderData({
+    boardName,
+    layoutId: renderBoard.layoutId,
+    sizeId: renderBoard.sizeId,
+    setIds,
+  });
+
+  return {
+    board_name: boardName,
+    layout_id: renderBoard.layoutId,
+    holdsData: renderData?.holdsData,
+  };
+}
+
+function resolveGenericRenderBoard(climb: Climb, fallbackBoardName?: BoardName): PlaylistClimbRenderBoardResult | null {
+  const boardType = climb.boardType ?? fallbackBoardName;
+  if (!boardType) return null;
+  const resolved = getBoardConfigForPlaylist(boardType, climb.layoutId);
+  if (!resolved) return null;
+  return {
+    renderBoard: toRenderBoard(resolved.boardName, resolved.layoutId, resolved.sizeId, resolved.setIds, climb.angle),
+    fit: 'exact',
+    incompatible: false,
+  };
+}
+
+function resolveIncompatibleRenderBoard(
+  climb: Climb,
+  fallbackBoardName: BoardName,
+): PlaylistClimbRenderBoardResult | null {
+  const resolved = getBoardConfigForPlaylist(climb.boardType ?? fallbackBoardName, climb.layoutId);
+  if (!resolved) return null;
+  return {
+    renderBoard: toRenderBoard(resolved.boardName, resolved.layoutId, resolved.sizeId, resolved.setIds, climb.angle),
+    fit: 'incompatible',
+    incompatible: true,
+  };
+}
+
+function resolveUpsizedRenderBoard(
+  climb: Climb,
+  activeBoard: PlaylistRenderBoard,
+): PlaylistClimbRenderBoardResult | null {
+  const boardName = activeBoard.boardName as BoardName;
+  const activeSize = getProductSize(boardName, activeBoard.sizeId);
+  if (!activeSize) return null;
+
+  const activeArea = (activeSize.edgeRight - activeSize.edgeLeft) * (activeSize.edgeTop - activeSize.edgeBottom);
+  const activeSetIds = parseSetIds(activeBoard.setIds);
+
+  const candidates = getSizesForLayoutId(boardName, activeBoard.layoutId)
+    .filter((size) => size.id !== activeBoard.sizeId)
+    .map((size) => ({
+      size,
+      area: (size.edgeRight - size.edgeLeft) * (size.edgeTop - size.edgeBottom),
+    }))
+    .filter(({ area }) => area > activeArea)
+    .sort((left, right) => left.area - right.area);
+
+  for (const { size } of candidates) {
+    const availableSets = getSetsForLayoutAndSize(boardName, activeBoard.layoutId, size.id);
+    if (availableSets.length === 0) continue;
+
+    const availableSetIds = new Set(availableSets.map((set) => set.id));
+    const preferredSetIds = activeSetIds.filter((setId) => availableSetIds.has(setId));
+    const candidateSetIds = preferredSetIds.length > 0 ? preferredSetIds : availableSets.map((set) => set.id);
+    const candidateRenderBoard = toRenderBoard(
+      boardName,
+      activeBoard.layoutId,
+      size.id,
+      candidateSetIds,
+      activeBoard.angle,
+    );
+    const fit = canAddClimbToBoard(climb, getRenderBoardTarget(candidateRenderBoard));
+
+    if (fit.ok) {
+      return {
+        renderBoard: candidateRenderBoard,
+        fit: 'upsized',
+        incompatible: true,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the board a playlist row should render on.
+ *
+ * The active board wins when it can actually render the climb. A climb from a
+ * different board/layout, or one that needs a larger wall, falls back to the
+ * climb's own renderable board and is marked incompatible so the row can be
+ * dimmed while still opening the drawer.
+ */
+export function resolvePlaylistClimbRenderBoard(
+  climb: Climb,
+  activeBoard: PlaylistRenderBoard | null,
+): PlaylistClimbRenderBoardResult | null {
+  if (!activeBoard) {
+    return resolveGenericRenderBoard(climb);
+  }
+
+  const activeBoardName = activeBoard.boardName as BoardName;
+  if (
+    !climb.boardType ||
+    climb.boardType !== activeBoard.boardName ||
+    climb.layoutId == null ||
+    climb.layoutId !== activeBoard.layoutId
+  ) {
+    return resolveIncompatibleRenderBoard(climb, activeBoardName);
+  }
+
+  const exactFit = canAddClimbToBoard(climb, getRenderBoardTarget(activeBoard));
+  if (exactFit.ok) {
+    return {
+      renderBoard: activeBoard,
+      fit: 'exact',
+      incompatible: false,
+    };
+  }
+
+  return resolveUpsizedRenderBoard(climb, activeBoard) ?? resolveIncompatibleRenderBoard(climb, activeBoardName);
+}

--- a/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-render-board.ts
@@ -1,13 +1,13 @@
-// Decides which board a playlist-detail screen renders its climbs against, and
-// whether to gate queueing behind a board switch.
+// Decides which board a playlist-detail screen should prefer for climb-row
+// rendering, and whether to show a board-switch prompt.
 //
 // Playlists carry only `boardType` + `layoutId`. When the active board matches,
 // rows render against the user's precise board (correct size/sets/angle) and
-// tapping queues normally. When it differs — or there is no active board — rows
-// render read-only against the playlist's own board (largest size + all sets,
-// via `getBoardConfigForPlaylist`, mirroring web's playlist rendering); a banner
-// prompts switching boards because the queue, play drawer, and BLE LEDs all
-// follow the single active board, so you genuinely must switch to climb it.
+// tapping queues normally. When it differs, rows still receive the active board
+// first; each row can then fall back to its own board and visually mark itself
+// incompatible. If there is no active board, we fall back to the playlist's own
+// board (largest size + all sets, via `getBoardConfigForPlaylist`) so the list
+// can still render.
 
 import { useMemo } from 'react';
 import { useRouter } from 'expo-router';
@@ -21,8 +21,8 @@ import { getBoardConfigForPlaylist } from './board-details-for-playlist';
  *  config; `setIds` is the comma-joined string `ClimbListRow` expects. */
 export type PlaylistRenderBoard = BoardConfig;
 
-/** Shown above a read-only playlist list when its board differs from the active
- *  board (or there is no active board). Strings are already translated. */
+/** Shown above a playlist list when its board differs from the active board (or
+ *  there is no active board). Strings are already translated. */
 export type PlaylistBoardBanner = {
   title: string;
   subtitle: string;
@@ -31,11 +31,11 @@ export type PlaylistBoardBanner = {
 };
 
 export type UsePlaylistRenderBoardResult = {
-  /** Board the climb rows render against, or null when it can't be resolved (no
-   *  active board for a smart playlist; an unbundled board such as MoonBoard —
-   *  the banner still shows in that case). */
+  /** Preferred board for climb rows, or null when no active/fallback board can
+   *  be resolved. Individual rows may choose a different board to render a
+   *  specific climb. */
   renderBoard: PlaylistRenderBoard | null;
-  /** Set when the list is read-only (board mismatch / no active board). */
+  /** Set when the board-switch banner should be shown. */
   banner: PlaylistBoardBanner | null;
 };
 
@@ -57,7 +57,7 @@ export function usePlaylistRenderBoard(
   const boardType = playlistBoard?.boardType ?? null;
   const layoutId = playlistBoard?.layoutId ?? null;
 
-  // Resolve the render board + read-only flag from the real board state only (no
+  // Resolve the preferred render board + mismatch flag from the real board state only (no
   // `t`/`router`), so `renderBoard`'s identity is stable across unrelated
   // re-renders and never churns the FlashList rows that depend on it.
   const { renderBoard, mismatch } = useMemo<{ renderBoard: PlaylistRenderBoard | null; mismatch: boolean }>(() => {
@@ -67,9 +67,14 @@ export function usePlaylistRenderBoard(
     const matchesActive = boardLooselyMatches({ boardName: boardType, layoutId }, activeBoard);
     if (matchesActive) return { renderBoard: activeBoard, mismatch: false };
 
-    // Mismatch or no active board → read-only against the playlist's own board
-    // (largest size + all sets). `null` when it can't resolve (e.g. MoonBoard),
-    // in which case the banner shows alone rather than a half-broken list.
+    // Mismatch with an active board: keep passing the active board into row
+    // rendering so each row can decide whether it fits, or fall back to its own
+    // board and mark itself incompatible.
+    if (activeBoard) return { renderBoard: activeBoard, mismatch: true };
+
+    // No active board → render against the playlist's own board (largest size +
+    // all sets). `null` when it can't resolve (e.g. MoonBoard), in which case
+    // the banner shows alone rather than a half-broken list.
     const resolved = getBoardConfigForPlaylist(boardType, layoutId);
     if (!resolved) return { renderBoard: null, mismatch: true };
     return {
@@ -78,9 +83,9 @@ export function usePlaylistRenderBoard(
         layoutId: resolved.layoutId,
         sizeId: resolved.sizeId,
         setIds: resolved.setIds.join(','),
-        // List-level angle is unused in the read-only branch — each row renders
-        // at its own climb's angle (the angle its grade was baked at).
-        angle: activeBoard?.angle ?? 0,
+        // List-level angle is unused in the no-active-board fallback — each row
+        // renders at its own climb's angle (the angle its grade was baked at).
+        angle: 0,
       },
       mismatch: true,
     };


### PR DESCRIPTION
## Summary

- Prefer the active board when discover playlist rows render, then resolve each climb against its own board when it does not fit.
- Mark incompatible mixed-board rows through the existing `unsupported` row styling so they grey out while still opening the drawer on tap.
- Keep the board-switch banner behavior for playlist-level mismatches, but stop routing row taps to the board switcher.
- Add focused tests for row board resolution, hook mismatch behavior, and banner-row interaction.

## Why

Discover playlists can contain climbs from boards other than the currently active board. The previous list-level render board made those rows render as though the whole playlist belonged to one board and blocked row activation on mismatch. This PR mirrors the web behavior more closely: compatible rows use the active board, incompatible rows render on the correct board and visually signal that state.

## Validation

- `vp test run packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts packages/mobile/src/lib/playlists/__tests__/use-playlist-render-board.test.tsx packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx --reporter=agent`
- `vp run typecheck:mobile`
- `git diff --check`

`vp check` still fails on unrelated pre-existing formatting issues outside this change, including `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend files, and drizzle metadata files.