### PR TITLE
Fix board presence gap recovery

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -321,6 +321,8 @@ Mobile resolves the feed board id in this order:
 
 Each resolver stamps short-lived proof-of-presence for the authenticated user before `reportBoardClimb` will accept a wall-feed report. On the mobile client, starting a newer UUID/config/serial resolve clears the previous board id and stale async results are ignored by a resolve-generation guard, so the sheet does not temporarily show another selected board's feed.
 
+Every board-presence event carries the board's shared `seq`. The client subscribes before its initial hot-feed backfill, then uses that backfill to establish the first sequence baseline. After that, any live event with `seq > lastObservedSeq + 1` is treated as a missed event: the client applies the live event immediately, then runs a coalesced hot-feed catch-up (`boardRecentClimbs`, `boardPresenceStats`, and `boardConnection`) for the active board. This intentionally uses the Redis-backed recent feed rather than durable `boardHistory`, because `boardHistory` is authenticated and dwell-gated while the board sheet must repair anonymous and short-dwell sends too.
+
 ---
 
 ## Backend URL Resolution
@@ -1824,12 +1826,14 @@ The push token as the credential keeps the widget extension out of the user-auth
 ### Validation
 
 **navigate**
+
 - `sessionId`: non-empty string
 - `action`: `"next"` or `"previous"`
 - `currentIndex`: integer, `>= 0`
 - Request body capped at 4 KB
 
 **take-control**
+
 - `sessionId`: non-empty string
 - Request body capped at 2 KB
 

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -65,13 +65,40 @@ const connectionEvent = (seq: number, nextHolder: BoardConnectionHolder | null):
   seq,
 });
 
-type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void };
+type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void; resolved: boolean };
 function deferred<T>(): Deferred<T> {
-  let resolve: (value: T) => void = () => {};
+  const target: Deferred<T> = {
+    promise: Promise.resolve(undefined as T),
+    resolve: () => {},
+    resolved: false,
+  };
   const promise = new Promise<T>((res) => {
-    resolve = res;
+    target.resolve = (value) => {
+      if (target.resolved) {
+        return;
+      }
+      target.resolved = true;
+      res(value);
+    };
   });
-  return { promise, resolve };
+  target.promise = promise;
+  return target;
+}
+
+function pushDeferred<T>(map: Map<number, Array<Deferred<T>>>, boardId: number): Deferred<T> {
+  const next = deferred<T>();
+  const entries = map.get(boardId);
+  if (entries) {
+    entries.push(next);
+  } else {
+    map.set(boardId, [next]);
+  }
+  return next;
+}
+
+function nextPendingDeferred<T>(map: Map<number, Array<Deferred<T>>>, boardId: number): Deferred<T> {
+  const existing = map.get(boardId)?.find((entry) => !entry.resolved);
+  return existing ?? pushDeferred(map, boardId);
 }
 
 // A controllable fake client. `emit` pushes a live event to the current
@@ -85,44 +112,17 @@ function makeClient() {
   const unsubscribe = vi.fn();
   let subscribedBoardId: number | null = null;
 
-  const recentByBoard = new Map<number, Deferred<BoardPresenceClimb[]>>();
-  const statsByBoard = new Map<number, Deferred<BoardPresenceStats>>();
-  const connectionByBoard = new Map<number, Deferred<BoardConnectionHolder | null>>();
-  const recentFor = (boardId: number) => {
-    const existing = recentByBoard.get(boardId);
-    if (existing) {
-      return existing;
-    }
-    const next = deferred<BoardPresenceClimb[]>();
-    recentByBoard.set(boardId, next);
-    return next;
-  };
-  const statsFor = (boardId: number) => {
-    const existing = statsByBoard.get(boardId);
-    if (existing) {
-      return existing;
-    }
-    const next = deferred<BoardPresenceStats>();
-    statsByBoard.set(boardId, next);
-    return next;
-  };
-  const connectionFor = (boardId: number) => {
-    const existing = connectionByBoard.get(boardId);
-    if (existing) {
-      return existing;
-    }
-    const next = deferred<BoardConnectionHolder | null>();
-    connectionByBoard.set(boardId, next);
-    return next;
-  };
+  const recentByBoard = new Map<number, Array<Deferred<BoardPresenceClimb[]>>>();
+  const statsByBoard = new Map<number, Array<Deferred<BoardPresenceStats>>>();
+  const connectionByBoard = new Map<number, Array<Deferred<BoardConnectionHolder | null>>>();
 
   const reportClimb = vi.fn(async () => true);
   const reportDisconnect = vi.fn(async () => true);
   // Captured separately so assertions reference the bound mock directly
   // (referencing `client.fetchX` trips the unbound-method lint).
-  const fetchRecentClimbs = vi.fn((boardId: number) => recentFor(boardId).promise);
-  const fetchStats = vi.fn((boardId: number) => statsFor(boardId).promise);
-  const fetchConnection = vi.fn((boardId: number) => connectionFor(boardId).promise);
+  const fetchRecentClimbs = vi.fn((boardId: number) => pushDeferred(recentByBoard, boardId).promise);
+  const fetchStats = vi.fn((boardId: number) => pushDeferred(statsByBoard, boardId).promise);
+  const fetchConnection = vi.fn((boardId: number) => pushDeferred(connectionByBoard, boardId).promise);
   const subscribeNowPlaying = vi.fn(
     (
       boardId: number,
@@ -162,17 +162,17 @@ function makeClient() {
     emitComplete: () => onComplete?.(),
     getSubscribedBoardId: () => subscribedBoardId,
     resolveRecent: (boardId: number, climbs: BoardPresenceClimb[]) => {
-      const target = recentFor(boardId);
+      const target = nextPendingDeferred(recentByBoard, boardId);
       target.resolve(climbs);
       return target.promise;
     },
     resolveStats: (boardId: number, stats: BoardPresenceStats) => {
-      const target = statsFor(boardId);
+      const target = nextPendingDeferred(statsByBoard, boardId);
       target.resolve(stats);
       return target.promise;
     },
     resolveConnection: (boardId: number, nextHolder: BoardConnectionHolder | null) => {
-      const target = connectionFor(boardId);
+      const target = nextPendingDeferred(connectionByBoard, boardId);
       target.resolve(nextHolder);
       return target.promise;
     },
@@ -342,6 +342,112 @@ describe('useBoardPresence — subscribe before backfill', () => {
   });
 });
 
+describe('useBoardPresence — sequence gap recovery', () => {
+  it('does not run gap catch-up before the initial recent-climbs fetch establishes a sequence baseline', () => {
+    const harness = makeClient();
+    renderHook(() => useBoardPresence(1, harness.client));
+
+    act(() => {
+      harness.emit(statsEvent(7, { climbsSentCount: 3 }));
+    });
+
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+    expect(harness.fetchStats).toHaveBeenCalledTimes(1);
+    expect(harness.fetchConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('repairs a missed live sequence with a hot-feed catch-up', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed-holder' }));
+    });
+
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+    expect(result.current.history.map((entry) => entry.seq)).toEqual([1]);
+
+    act(() => {
+      harness.emit(setEvent(climb('live-newest', 4)));
+    });
+
+    expect(result.current.currentClimb?.climbUuid).toBe('live-newest');
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+    expect(harness.fetchStats).toHaveBeenCalledTimes(2);
+    expect(harness.fetchConnection).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('live-newest', 4), climb('missed', 3), climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 2, hardestGrade: 'V8' });
+      await harness.resolveConnection(1, holder({ userId: 'catch-up-holder' }));
+    });
+
+    await waitFor(() => expect(result.current.history.map((entry) => entry.seq)).toEqual([4, 3, 1]));
+    expect(result.current.currentClimb?.climbUuid).toBe('live-newest');
+    expect(result.current.stats?.climbsSentCount).toBe(2);
+    expect(result.current.stats?.hardestGrade).toBe('V8');
+    expect(result.current.holder?.userId).toBe('catch-up-holder');
+  });
+
+  it('does not catch up for duplicate or out-of-order events', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('current', 5)]);
+    });
+    expect(result.current.history.map((entry) => entry.seq)).toEqual([5]);
+
+    act(() => {
+      harness.emit(setEvent(climb('older', 4)));
+      harness.emit(setEvent(climb('current', 5)));
+    });
+
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+    expect(harness.fetchStats).toHaveBeenCalledTimes(1);
+    expect(harness.fetchConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces multiple gaps while a catch-up is already in flight and reruns once', async () => {
+    const harness = makeClient();
+    renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed-holder' }));
+    });
+
+    act(() => {
+      harness.emit(statsEvent(3, { climbsSentCount: 2 }));
+    });
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      harness.emit(connectionEvent(5, holder({ userId: 'second-gap' })));
+    });
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 2 });
+      await harness.resolveConnection(1, holder({ userId: 'first-catch-up' }));
+    });
+
+    await waitFor(() => expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 2 });
+      await harness.resolveConnection(1, holder({ userId: 'second-catch-up' }));
+    });
+
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(3);
+  });
+});
+
 describe('useBoardPresence — switching boards', () => {
   it('resets state, resubscribes, and ignores the old board’s late async', async () => {
     const harness = makeClient();
@@ -404,6 +510,39 @@ describe('useBoardPresence — switching boards', () => {
       await harness.resolveStats(2, { ...emptyStats, climbsSentCount: 1 });
     });
     expect(result.current.stats?.climbsSentCount).toBe(1);
+  });
+
+  it('ignores a late gap catch-up from the previous board after switching boards', async () => {
+    const harness = makeClient();
+    const { result, rerender } = renderHook(({ boardId }) => useBoardPresence(boardId, harness.client), {
+      initialProps: { boardId: 1 },
+    });
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('board1-current', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'board1-holder' }));
+    });
+
+    act(() => {
+      harness.emit(setEvent(climb('board1-gap', 4)));
+    });
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+
+    rerender({ boardId: 2 });
+    expect(result.current.currentClimb).toBeNull();
+    expect(result.current.history).toEqual([]);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('board1-gap', 4), climb('board1-missed', 3)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 2 });
+      await harness.resolveConnection(1, holder({ userId: 'late-board1-holder' }));
+    });
+
+    expect(result.current.currentClimb).toBeNull();
+    expect(result.current.history).toEqual([]);
+    expect(result.current.stats).toBeNull();
+    expect(result.current.holder).toBeNull();
   });
 
   it('unsubscribes on unmount', () => {

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -24,6 +24,7 @@ import {
 import type {
   BoardConnectionHolder,
   BoardPresenceClimb,
+  BoardPresenceEvent,
   BoardPresenceStats,
   ClimbQueueItemInput,
 } from '@boardsesh/shared-schema';
@@ -92,6 +93,23 @@ export type BoardPresenceActions = {
   getUndoTarget: () => BoardPresenceClimb | null;
 };
 
+function boardPresenceEventSeq(event: BoardPresenceEvent): number | null {
+  switch (event.__typename) {
+    case 'BoardClimbSet':
+      return event.climb.seq;
+    case 'BoardClimbCleared':
+    case 'BoardStatsUpdated':
+    case 'BoardConnectionChanged':
+      return event.seq;
+    default:
+      return null;
+  }
+}
+
+function highestClimbSeq(climbs: BoardPresenceClimb[]): number {
+  return climbs.reduce((highestSeq, climb) => Math.max(highestSeq, climb.seq), 0);
+}
+
 export function useBoardPresence(boardId: number | null, client: BoardPresenceClient | null): UseBoardPresenceResult {
   const [state, dispatch] = useReducer(boardPresenceReducer, initialBoardPresenceState);
   const [isLive, setIsLive] = useState(false);
@@ -107,6 +125,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   currentClimbRef.current = state.currentClimb;
   const undoTargetRef = useRef<BoardPresenceClimb | null>(undoTarget);
   undoTargetRef.current = undoTarget;
+  const observedSeqRef = useRef(0);
 
   useEffect(() => {
     // No board or no transport: collapse to the initial state and stay inert.
@@ -115,6 +134,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       dispatch({ type: 'RESET' });
       setIsLive(false);
       setUndoTarget(null);
+      observedSeqRef.current = 0;
       return;
     }
 
@@ -122,11 +142,76 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     // history/current/stats never bleed into this one.
     dispatch({ type: 'RESET' });
     setUndoTarget(null);
+    observedSeqRef.current = 0;
 
     let isActive = true;
+    let catchUpInFlight = false;
+    let catchUpRequested = false;
+    let hasSequenceBaseline = false;
     // Identifies this effect run; late async results for a superseded board are
     // ignored by comparing against the ref, which the cleanup flips off.
     const subscribedBoardId = boardId;
+
+    const runCatchUp = () => {
+      if (!isActive || boardIdRef.current !== subscribedBoardId) {
+        return;
+      }
+      if (catchUpInFlight) {
+        catchUpRequested = true;
+        return;
+      }
+
+      catchUpInFlight = true;
+      const startedAtSeq = observedSeqRef.current;
+      const connectionFetch = client.fetchConnection;
+      const connectionPromise =
+        connectionFetch === undefined
+          ? Promise.resolve<BoardConnectionHolder | null | undefined>(undefined)
+          : connectionFetch(boardId);
+
+      void Promise.allSettled([
+        client.fetchRecentClimbs(boardId),
+        client.fetchStats(boardId),
+        connectionPromise,
+      ] as const)
+        .then(([recentResult, statsResult, connectionResult]) => {
+          if (!isActive || boardIdRef.current !== subscribedBoardId) {
+            return;
+          }
+
+          let repairedThroughSeq = startedAtSeq;
+          if (recentResult.status === 'fulfilled') {
+            const recentClimbs = recentResult.value;
+            repairedThroughSeq = Math.max(repairedThroughSeq, highestClimbSeq(recentClimbs));
+            observedSeqRef.current = Math.max(observedSeqRef.current, repairedThroughSeq);
+            dispatch({ type: 'BACKFILL_HISTORY', payload: recentClimbs });
+          }
+
+          if (statsResult.status === 'fulfilled') {
+            dispatch({
+              type: 'REFRESH_STATS',
+              payload: { stats: statsResult.value, upToSeq: repairedThroughSeq },
+            });
+          }
+
+          if (connectionFetch !== undefined && connectionResult.status === 'fulfilled') {
+            dispatch({
+              type: 'REFRESH_CONNECTION',
+              payload: { holder: connectionResult.value ?? null, upToSeq: repairedThroughSeq },
+            });
+          }
+        })
+        .finally(() => {
+          if (!isActive) {
+            return;
+          }
+          catchUpInFlight = false;
+          if (catchUpRequested) {
+            catchUpRequested = false;
+            runCatchUp();
+          }
+        });
+    };
 
     // 1) Subscribe FIRST. Events arriving during the catch-up fetches below are
     //    buffered straight into the reducer; the reducer's seq-dedup then keeps
@@ -136,6 +221,15 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       (event) => {
         if (!isActive) {
           return;
+        }
+        const eventSeq = boardPresenceEventSeq(event);
+        if (eventSeq !== null) {
+          const previousObservedSeq = observedSeqRef.current;
+          observedSeqRef.current = Math.max(previousObservedSeq, eventSeq);
+          if (hasSequenceBaseline && eventSeq > previousObservedSeq + 1) {
+            runCatchUp();
+          }
+          hasSequenceBaseline = true;
         }
         const action = mapBoardPresenceEnvelopeToAction(event);
         if (action) {
@@ -166,11 +260,14 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       .fetchRecentClimbs(boardId)
       .then((recentClimbs) => {
         if (isActive && boardIdRef.current === subscribedBoardId) {
+          observedSeqRef.current = Math.max(observedSeqRef.current, highestClimbSeq(recentClimbs));
+          hasSequenceBaseline = true;
           dispatch({ type: 'BACKFILL_HISTORY', payload: recentClimbs });
         }
       })
       .catch(() => {
         // Backfill is best-effort; the live stream still drives the wall.
+        hasSequenceBaseline = observedSeqRef.current > 0;
       });
 
     void client

--- a/packages/shared/board-presence/src/__tests__/reducer.test.ts
+++ b/packages/shared/board-presence/src/__tests__/reducer.test.ts
@@ -378,6 +378,33 @@ describe('SEED_STATS', () => {
   });
 });
 
+describe('REFRESH_STATS', () => {
+  it('overwrites stale stats from a catch-up snapshot and advances lastStatsSeq through the repaired seq', () => {
+    const state = makeState({ stats: makeStats({ climbsSentCount: 1 }), lastStatsSeq: 3 });
+    const refreshed = makeStats({ climbsSentCount: 9, hardestGrade: 'V10' });
+
+    const result = boardPresenceReducer(state, {
+      type: 'REFRESH_STATS',
+      payload: { stats: refreshed, upToSeq: 8 },
+    });
+
+    expect(result.stats).toEqual(refreshed);
+    expect(result.lastStatsSeq).toBe(8);
+  });
+
+  it('never regresses lastStatsSeq when an older catch-up snapshot resolves late', () => {
+    const state = makeState({ stats: makeStats({ climbsSentCount: 7 }), lastStatsSeq: 12 });
+
+    const result = boardPresenceReducer(state, {
+      type: 'REFRESH_STATS',
+      payload: { stats: makeStats({ climbsSentCount: 8 }), upToSeq: 10 },
+    });
+
+    expect(result.stats?.climbsSentCount).toBe(8);
+    expect(result.lastStatsSeq).toBe(12);
+  });
+});
+
 describe('APPLY_CONNECTION_CHANGED', () => {
   it('sets the holder and advances lastConnectionSeq', () => {
     const holder = makeHolder({ userId: 'alice', displayName: 'Alice' });
@@ -480,6 +507,33 @@ describe('SEED_CONNECTION', () => {
 
     const result = boardPresenceReducer(state, { type: 'SEED_CONNECTION', payload: makeHolder({ userId: 'alice' }) });
     expect(result).toBe(state);
+  });
+});
+
+describe('REFRESH_CONNECTION', () => {
+  it('overwrites stale holder state from a catch-up snapshot and advances lastConnectionSeq through the repaired seq', () => {
+    const state = makeState({ holder: makeHolder({ userId: 'old' }), lastConnectionSeq: 2 });
+    const refreshed = makeHolder({ userId: 'new' });
+
+    const result = boardPresenceReducer(state, {
+      type: 'REFRESH_CONNECTION',
+      payload: { holder: refreshed, upToSeq: 9 },
+    });
+
+    expect(result.holder).toEqual(refreshed);
+    expect(result.lastConnectionSeq).toBe(9);
+  });
+
+  it('can refresh to a free board without regressing lastConnectionSeq', () => {
+    const state = makeState({ holder: makeHolder({ userId: 'old' }), lastConnectionSeq: 12 });
+
+    const result = boardPresenceReducer(state, {
+      type: 'REFRESH_CONNECTION',
+      payload: { holder: null, upToSeq: 10 },
+    });
+
+    expect(result.holder).toBeNull();
+    expect(result.lastConnectionSeq).toBe(12);
   });
 });
 

--- a/packages/shared/board-presence/src/reducer.ts
+++ b/packages/shared/board-presence/src/reducer.ts
@@ -143,6 +143,14 @@ export function boardPresenceReducer(state: BoardPresenceState, action: BoardPre
       };
     }
 
+    case 'REFRESH_STATS': {
+      return {
+        ...state,
+        stats: action.payload.stats,
+        lastStatsSeq: Math.max(state.lastStatsSeq, action.payload.upToSeq),
+      };
+    }
+
     case 'APPLY_CONNECTION_CHANGED': {
       // Live connection push. Connection events share the per-board seq counter
       // with climb + stats events, so a stale/duplicate push (out-of-order Redis
@@ -169,6 +177,14 @@ export function boardPresenceReducer(state: BoardPresenceState, action: BoardPre
       return {
         ...state,
         holder: action.payload,
+      };
+    }
+
+    case 'REFRESH_CONNECTION': {
+      return {
+        ...state,
+        holder: action.payload.holder,
+        lastConnectionSeq: Math.max(state.lastConnectionSeq, action.payload.upToSeq),
       };
     }
 

--- a/packages/shared/board-presence/src/types.ts
+++ b/packages/shared/board-presence/src/types.ts
@@ -64,8 +64,15 @@ export type BoardPresenceAction =
   | { type: 'APPLY_STATS_UPDATED'; payload: { stats: BoardPresenceStats; seq: number } }
   // One-time initial fetch seed; only fills the tiles before any live push.
   | { type: 'SEED_STATS'; payload: BoardPresenceStats }
+  // Full-feed catch-up after a detected sequence gap. This is a snapshot, so it
+  // replaces stale tiles and advances the stats cursor through the repaired seq.
+  | { type: 'REFRESH_STATS'; payload: { stats: BoardPresenceStats; upToSeq: number } }
   // Live connection push from the subscription (holder, or null when freed).
   | { type: 'APPLY_CONNECTION_CHANGED'; payload: { holder: BoardConnectionHolder | null; seq: number } }
   // One-time initial fetch seed; only fills the holder before any live push.
   | { type: 'SEED_CONNECTION'; payload: BoardConnectionHolder | null }
+  // Full-feed catch-up after a detected sequence gap. This is a snapshot, so it
+  // replaces stale holder state and advances the connection cursor through the
+  // repaired seq.
+  | { type: 'REFRESH_CONNECTION'; payload: { holder: BoardConnectionHolder | null; upToSeq: number } }
   | { type: 'RESET' };


### PR DESCRIPTION
## Summary
- detect gaps in board-presence live `seq` after the initial hot-feed baseline
- repair missed events with a coalesced hot-feed catch-up for recent climbs, stats, and holder state
- add reducer snapshot refresh actions and document the board-presence recovery model

## Validation
- `vp test run --project board-presence`
- `vp test run --project board-presence-react`
- `vp run typecheck:board-presence`
- `vp run typecheck:board-presence-react`
- `vp check` currently fails on pre-existing formatting issues outside this change: `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts`, `packages/backend/src/graphql/resolvers/ticks/mutations.ts`, and db drizzle meta files `0129`-`0132` plus `_journal.json`.