### PR TITLE
[codex] Expand App Store screenshot matrix

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -28,14 +28,18 @@ on:
         options:
           - app-store
           - onboarding
-      device:
-        description: 'iOS simulator device name'
+      devices:
+        description: 'iOS simulator devices: common, or a comma-separated list of simulator names'
         type: string
-        default: 'iPhone 16 Pro Max'
+        default: 'common'
       android_device:
         description: 'Android emulator device label used for screenshot output'
         type: string
         default: 'Pixel 2'
+      locales:
+        description: 'App locales: all, or a comma-separated list such as en-US,es,fr'
+        type: string
+        default: 'all'
       upload:
         description: 'Upload captured screenshots to App Store Connect and Google Play. Never runs on the nightly cron.'
         type: boolean
@@ -54,7 +58,7 @@ permissions:
 jobs:
   ios:
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 180
 
     env:
       # Marks an upload dispatch — gates the App Store Connect upload steps so the
@@ -137,7 +141,8 @@ jobs:
             --platform ios \
             --flow "${{ inputs.flow || 'app-store' }}" \
             --backend prod \
-            --device "${{ inputs.device || 'iPhone 16 Pro Max' }}" \
+            --devices "${{ inputs.devices || 'common' }}" \
+            --locales "${{ inputs.locales || 'all' }}" \
             --app-path packages/mobile/.app-cache/Boardsesh.app
 
       # On a capture failure, save Maestro's debug output (the failure screenshot +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,9 +241,10 @@ Use `vp run mobile:ios` for local `packages/mobile` iOS builds instead of raw `e
 
 ### App Store screenshots (cached dev-client + Metro)
 
-`vp run mobile:screenshots` (`scripts/mobile-screenshots.ts`) drives Maestro over an iOS simulator. The app it installs is a Debug **dev-client** that loads its JS from **Metro** at runtime — the screenshot behaviour (`EXPO_PUBLIC_SCREENSHOT_MODE`, theme, workout) is baked into the Metro JS bundle, **not** the native binary. So the native `.app` is reusable: only the JS regenerates per run.
+`vp run mobile:screenshots` (`scripts/mobile-screenshots.ts`) drives Maestro over iOS simulators. The app it installs is a Debug **dev-client** that loads its JS from **Metro** at runtime — the screenshot behaviour (`EXPO_PUBLIC_SCREENSHOT_MODE`, theme, locale, workout) is baked into the Metro JS bundle, **not** the native binary. So the native `.app` is reusable: only the JS regenerates per run.
 
 - Pass `--app-path <Boardsesh.app>` to install a prebuilt/cached app (CI's common path). Without it, the script builds one via `vp run mobile:build-sim-app` (`scripts/mobile-build-sim-app.ts` → `expo prebuild` + `pod install` + `xcodebuild build -sdk iphonesimulator -configuration Debug`; **not** `expo run:ios`, whose launch step hangs in CI). Use `--clean` for a deterministic from-scratch build.
+- The default Apple capture is `--devices common --locales all`: iPhone 16 Pro Max, iPhone 14 Plus, and iPhone 16 Pro for app locales `en-US`, `es`, and `fr`. The Spanish app locale is written to both App Store Connect folders, `es-ES` and `es-MX`.
 - `.github/workflows/mobile-screenshots.yml` caches the `.app` (`actions/cache`) keyed on **native inputs only**: `packages/mobile/app.config.ts`, `plugins/**`, `modules/**`, `package.json`, `patches/**`, and the root `package.json` (which pins `@expo/cli` / `react-native-screens`), plus `runner.os`/`runner.arch`. JS/TS-only and web-only changes (including `bun.lock` churn) are a cache hit and skip the ~30-min native build; any native-input change busts the key and rebuilds. Bump the `-v1-` salt to force a rebuild. A native-dep change must invalidate the key — when adding native config, confirm it's covered by one of those globs.
 
 ### OTA preview distribution (EAS Update)

--- a/app-stores/README.md
+++ b/app-stores/README.md
@@ -9,7 +9,7 @@ app-stores/
   apple/
     app-store-submission-guide.md   # how to submit to App Store Connect
     app-store-metadata.md           # listing copy: name, subtitle, keywords, description
-    screenshots/<device>/           # generated on demand, gitignored (not committed)
+    screenshots/<app-store-locale>/<device>/ # generated on demand, gitignored
   google/
     play-store-submission-guide.md
     play-store-metadata.md
@@ -21,13 +21,18 @@ app-stores/
 The screenshots are captured from the real native app by the Maestro pipeline:
 
 ```bash
-vp run mobile:screenshots -- --platform ios --backend prod --theme dark
+vp run mobile:screenshots -- --platform ios --backend prod --theme dark --devices common --locales all
 vp run mobile:screenshots -- --platform android --backend prod --theme dark --app-path /path/to/app.apk
 ```
 
-It writes to `app-stores/<store>/screenshots/<device>/` (`ios` → `apple`,
-`android` → `google`). Dark is the default; pass `--theme light` for a light set.
-See `packages/mobile/.maestro/README.md` for prerequisites and how it works.
+Apple screenshots are written to
+`app-stores/apple/screenshots/<app-store-locale>/<device>/`. `--locales all`
+captures the app locales `en-US`, `es`, and `fr`, then writes App Store Connect
+folders `en-US`, `es-ES`, `es-MX`, and `fr-FR`.
+
+Google Play screenshots are written to `app-stores/google/screenshots/<device>/`.
+Dark is the default; pass `--theme light` for a light set. See
+`packages/mobile/.maestro/README.md` for prerequisites and how it works.
 
 The captured PNGs are **gitignored** — they're regenerated on demand and uploaded
 to App Store Connect / Google Play by the `Mobile Screenshots (Native)` workflow

--- a/app-stores/apple/app-store-submission-guide.md
+++ b/app-stores/apple/app-store-submission-guide.md
@@ -35,22 +35,28 @@ Verify the generated assets look correct before proceeding.
 Automated native capture (the real RN app, dark theme) via Maestro:
 
 ```bash
-vp run mobile:screenshots -- --platform ios --backend prod --theme dark
+vp run mobile:screenshots -- --platform ios --backend prod --theme dark --devices common --locales all
 ```
 
-This drives an iPhone 16 Pro Max simulator against prod (signed in as the test
-user) and saves PNGs to `app-stores/apple/screenshots/<device>/` — e.g.
-`app-stores/apple/screenshots/iphone-16-pro-max/`. See
+This drives the common iPhone simulator set against prod (signed in as the test
+user) and saves PNGs to `app-stores/apple/screenshots/<app-store-locale>/<device>/`
+— e.g. `app-stores/apple/screenshots/en-US/iphone-16-pro-max/`. See
 `packages/mobile/.maestro/README.md` for prerequisites (Maestro, the
 `SCREENSHOT_USER_PASSWORD` env, etc.).
 
 ### Required screenshot sizes
 
-| Device                          | Resolution | Required?                                |
-| ------------------------------- | ---------- | ---------------------------------------- |
-| 6.9" iPhone (iPhone 16 Pro Max) | 1320x2868  | Yes — captured by the Maestro flow       |
-| 6.5" iPhone (iPhone 14 Plus)    | 1284x2778  | Optional (the 6.9" asset is accepted)    |
-| 13" iPad (iPad Pro)             | 2064x2752  | No, but recommended if iPad is supported |
+| Device                           | Resolution | Required?                             |
+| -------------------------------- | ---------- | ------------------------------------- |
+| 6.9" iPhone (iPhone 16 Pro Max)  | 1320x2868  | Yes — captured by the Maestro flow    |
+| 6.5/6.7" iPhone (iPhone 14 Plus) | 1284x2778  | Optional, captured for common devices |
+| 6.3" iPhone (iPhone 16 Pro)      | 1206x2622  | Optional, captured for common devices |
+| 13" iPad (iPad Pro)              | 2064x2752  | Not required while tablet is disabled |
+
+The app currently has `supportsTablet: false`, so iPad screenshots are not part
+of the automated set. `--locales all` captures `en-US`, `es`, and `fr`; the
+single Spanish app locale is uploaded to both App Store Connect Spanish locales:
+`es-ES` and `es-MX`.
 
 Dark is the canonical appearance; pass `--theme light` for a light set.
 
@@ -93,9 +99,9 @@ Store Connect.
 
 What it does:
 
-1. Captures the iPhone 16 Pro Max screenshots on a simulator, against **prod**
-   (signed in as the test user) — the canonical store recipe, with no local
-   backend needed.
+1. Captures common iPhone screenshots on simulators, against **prod** (signed in
+   as the test user) for every supported app locale — the canonical store
+   recipe, with no local backend needed.
 2. Runs `vp run check:screenshot-dimensions`, which fails the run if any PNG
    isn't an Apple-accepted size for its slot (so Apple can't reject the upload
    for a bad resolution).
@@ -103,7 +109,7 @@ What it does:
    with `skip_binary_upload`, `skip_metadata`, and `submit_for_review: false`.
    deliver routes each image to its display slot by pixel dimensions
    (1320×2868 → the 6.9" iPhone slot); the `00-`/`01-` filename prefixes set the
-   display order.
+   display order inside each device slot.
 
 **Authentication** uses the App Store Connect API key already configured for the
 TestFlight workflows — no new secrets:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,20 +1,20 @@
 # Uploads native store screenshots to App Store Connect / Google Play.
 #
-# Screenshots only — no binary, no text metadata, no review submission. The
+# Screenshots only - no binary, no text metadata, no review submission. The
 # screenshots are captured fresh by `vp run mobile:screenshots` (see
-# scripts/mobile-screenshots.ts) into the canonical tree:
+# scripts/mobile-screenshots.ts) into the canonical trees:
 #
-#   app-stores/apple/screenshots/<device>/NN-name.png
+#   app-stores/apple/screenshots/<app-store-locale>/<device>/NN-name.png
+#   app-stores/google/screenshots/<device>/NN-name.png
 #
-# deliver wants <screenshots_path>/<locale>/NN-name.png, so we stage the device
-# PNGs into an en-US/ dir under a temp path (never mutating the canonical tree)
-# and hand that to upload_to_app_store. deliver routes each image to its display
-# slot by pixel dimensions (1320×2868 -> 6.9" iPhone); the NN- filename prefixes
-# set the display order.
+# App Store Connect wants <screenshots_path>/<locale>/NN-name.png, so we stage
+# each locale into a flat temp path and prefix each file with its device slug to
+# avoid cross-device filename collisions. deliver routes each image to its display
+# slot by pixel dimensions; the NN- filename prefixes still set display order
+# inside each slot.
 #
-# Auth is an App Store Connect API key, supplied as env vars by CI:
-#   APP_STORE_CONNECT_API_KEY_ID, APP_STORE_CONNECT_ISSUER_ID, ASC_KEY_PATH
-# (ASC_KEY_PATH points at the decoded .p8 — see the upload workflow.)
+# Google Play wants metadata_path/android/<locale>/images/phoneScreenshots/*.png,
+# so we stage the captured phone screenshots into that fastlane supply layout.
 
 require "fileutils"
 require "tmpdir"
@@ -23,9 +23,9 @@ opt_out_usage
 default_platform(:ios)
 
 REPO_ROOT = File.expand_path("..", __dir__)
-APPLE_SCREENSHOTS_DIR = File.join(REPO_ROOT, "app-stores", "apple", "screenshots", "iphone-16-pro-max")
+APPLE_SCREENSHOTS_ROOT = File.join(REPO_ROOT, "app-stores", "apple", "screenshots")
 GOOGLE_SCREENSHOTS_DIR = File.join(REPO_ROOT, "app-stores", "google", "screenshots", "pixel-2")
-DELIVER_LOCALE = "en-US"
+EXPECTED_DELIVER_LOCALES = ["en-US", "es-ES", "es-MX", "fr-FR"].freeze
 SUPPLY_LOCALE = "en-US"
 
 APP_IDENTIFIER = "com.boardsesh.app"
@@ -78,25 +78,80 @@ def emit_ci_output(value)
   File.open(github_output, "a") { |file| file.puts("value=#{value}") }
 end
 
+def pngs_for_locale(locale)
+  locale_dir = File.join(APPLE_SCREENSHOTS_ROOT, locale)
+  unless Dir.exist?(locale_dir)
+    UI.user_error!("Missing screenshots for App Store locale #{locale}. Run `vp run mobile:screenshots -- --locales all --devices common` first.")
+  end
+
+  device_dirs = Dir.children(locale_dir).select { |entry| File.directory?(File.join(locale_dir, entry)) }.sort
+  UI.user_error!("No device screenshot folders found for App Store locale #{locale}.") if device_dirs.empty?
+
+  device_dirs.to_h do |device_slug|
+    pngs = Dir.glob(File.join(locale_dir, device_slug, "*.png")).sort
+    UI.user_error!("No PNGs found for App Store locale #{locale}, device #{device_slug}.") if pngs.empty?
+    [device_slug, pngs]
+  end
+end
+
+def screenshot_manifest
+  UI.user_error!("No screenshots directory at #{APPLE_SCREENSHOTS_ROOT}. Run `vp run mobile:screenshots` first.") unless Dir.exist?(APPLE_SCREENSHOTS_ROOT)
+
+  unexpected_locales = Dir.children(APPLE_SCREENSHOTS_ROOT)
+    .select { |entry| File.directory?(File.join(APPLE_SCREENSHOTS_ROOT, entry)) }
+    .reject { |locale| EXPECTED_DELIVER_LOCALES.include?(locale) }
+    .sort
+  unless unexpected_locales.empty?
+    UI.user_error!("Unknown App Store screenshot locale folder(s): #{unexpected_locales.join(', ')}.")
+  end
+
+  manifest = EXPECTED_DELIVER_LOCALES.to_h { |locale| [locale, pngs_for_locale(locale)] }
+  reference_locale = EXPECTED_DELIVER_LOCALES.first
+  reference_devices = manifest.fetch(reference_locale).keys.sort
+
+  manifest.each do |locale, devices|
+    device_slugs = devices.keys.sort
+    if device_slugs != reference_devices
+      UI.user_error!("Device folders for #{locale} are #{device_slugs.join(', ')}, expected #{reference_devices.join(', ')}.")
+    end
+
+    reference_devices.each do |device_slug|
+      expected_names = manifest.fetch(reference_locale).fetch(device_slug).map { |path| File.basename(path) }
+      actual_names = devices.fetch(device_slug).map { |path| File.basename(path) }
+      if actual_names != expected_names
+        UI.user_error!("Screenshot files for #{locale}/#{device_slug} do not match #{reference_locale}/#{device_slug}.")
+      end
+    end
+  end
+
+  manifest
+end
+
+def staged_filename(device_slug, png_path)
+  basename = File.basename(png_path)
+  staged = basename.sub(/\A(\d+)-/, "\\1-#{device_slug}-")
+  staged == basename ? "#{device_slug}-#{basename}" : staged
+end
+
 platform :ios do
   desc "Upload App Store screenshots to App Store Connect (no binary, no metadata, no review)"
   lane :screenshots do
-    unless Dir.exist?(APPLE_SCREENSHOTS_DIR)
-      UI.user_error!("No screenshots directory at #{APPLE_SCREENSHOTS_DIR}. Run `vp run mobile:screenshots` first.")
-    end
-
-    pngs = Dir.glob(File.join(APPLE_SCREENSHOTS_DIR, "*.png")).sort
-    if pngs.empty?
-      # Guard against wiping the live screenshot set with an empty upload.
-      UI.user_error!("No PNGs found in #{APPLE_SCREENSHOTS_DIR}. Refusing to upload an empty screenshot set.")
-    end
+    manifest = screenshot_manifest
 
     staging_dir = Dir.mktmpdir("asc-screenshots-")
     begin
-      locale_dir = File.join(staging_dir, DELIVER_LOCALE)
-      FileUtils.mkdir_p(locale_dir)
-      pngs.each { |png| FileUtils.cp(png, File.join(locale_dir, File.basename(png))) }
-      UI.message("Staged #{pngs.length} screenshot(s) into #{locale_dir}")
+      manifest.each do |locale, devices|
+        locale_dir = File.join(staging_dir, locale)
+        FileUtils.mkdir_p(locale_dir)
+        staged_count = 0
+        devices.each do |device_slug, pngs|
+          pngs.each do |png|
+            FileUtils.cp(png, File.join(locale_dir, staged_filename(device_slug, png)))
+            staged_count += 1
+          end
+        end
+        UI.message("Staged #{staged_count} screenshot(s) into #{locale_dir}")
+      end
 
       api_key = app_store_connect_api_key(
         key_id: ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
@@ -118,7 +173,7 @@ platform :ios do
         sync_screenshots: true,
         submit_for_review: false,
         run_precheck_before_submit: false,
-        # force: true is mandatory in CI — without it deliver opens an HTML
+        # force: true is mandatory in CI: without it deliver opens an HTML
         # preview in a browser and blocks until timeout.
         force: true
       )

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -25,9 +25,16 @@ cd fastlane && bundle exec fastlane android next_version_code
 
 ## Screenshots — `ios screenshots`, `android screenshots`
 
-The iOS lane uploads PNGs in `app-stores/apple/screenshots/iphone-16-pro-max/`
-to App Store Connect as **screenshots only**. `deliver` routes each image to its
-display slot by pixel dimensions; the `NN-` filename prefixes set the order.
+The iOS lane uploads PNGs in
+`app-stores/apple/screenshots/<app-store-locale>/<device>/` (captured by
+`vp run mobile:screenshots -- --devices common --locales all`) as
+**screenshots only** — no binary, no text metadata, no review submission.
+deliver routes each image to its display slot by pixel dimensions; the `NN-`
+filename prefixes set the display order inside each slot.
+
+The upload expects the generated Apple locale folders `en-US`, `es-ES`, `es-MX`,
+and `fr-FR`. The app has one Spanish locale (`es`), so the capture pipeline
+writes the same Spanish screenshots to both App Store Connect Spanish locales.
 
 The Android lane uploads PNGs in `app-stores/google/screenshots/pixel-2/` to the
 Google Play phone screenshot slot as **screenshots only**, staged into

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -5,7 +5,9 @@ Driven by [Maestro](https://maestro.mobile.dev). Don't run these by hand — the
 orchestrator (`scripts/mobile-screenshots.ts`, exposed as `vp run
 mobile:screenshots`) prepares the simulator/emulator, applies a clean status bar,
 installs the native app artifact, captures each screen, and collects the PNGs
-into `app-stores/<apple|google>/screenshots/<device>/`.
+into the store screenshot folders. Apple captures go to
+`app-stores/apple/screenshots/<app-store-locale>/<device>/`; Google Play captures
+go to `app-stores/google/screenshots/<device>/`.
 
 On iOS, the artifact is a Debug **dev-client** `.app` (prebuilt/cached, or built
 on the fly when no `--app-path` is given). The flow starts **Metro** with
@@ -25,6 +27,11 @@ prod`), signed in as a curated test user (real feed, sessions, boards). The
 orchestrator builds with the prod `EXPO_PUBLIC_BACKEND_URL` and resets the
 simulator keychain first so login authenticates cleanly against prod.
 `--backend local` (the default) points at the seeded dev DB instead.
+
+By default the orchestrator captures the common Apple device matrix
+(`--devices common`: iPhone 16 Pro Max, iPhone 14 Plus, iPhone 16 Pro) and every
+app locale (`--locales all`: en-US, es, fr). Spanish is written to both App Store
+Connect Spanish folders (`es-ES` and `es-MX`).
 
 ## Flows
 
@@ -49,27 +56,34 @@ directly into its shots — no Maestro element races a transient auth screen.
 - `SCREENSHOT_USER_EMAIL` — test account email (default `test@boardsesh.com`).
 - `SCREENSHOT_USER_PASSWORD` — test account password. **Not committed** — pass it
   at runtime (prod differs from the local-DB `test`).
+- `MAESTRO_BOARD_PICK_POINT` — the percentage tap point for the board picker, passed
+  by the orchestrator per iOS device (the one surviving coordinate tap; everything
+  else the iOS flow needs is a deep link).
+- `EXPO_PUBLIC_SCREENSHOT_LOCALE` — the app locale baked into the bundle for the
+  current capture pass (the orchestrator reruns the flow once per locale; see
+  `screenshot-mode.ts`).
 
-The orchestrator bakes these into the bundle as `EXPO_PUBLIC_SCREENSHOT_USER_EMAIL` /
+The orchestrator bakes the credentials into the bundle as `EXPO_PUBLIC_SCREENSHOT_USER_EMAIL` /
 `_PASSWORD` (iOS via the Metro env, Android via the CI `.env`) so the app auto-signs-in
 on boot. They live only in screenshot-only builds; the separate prod-stripping of
 `EXPO_PUBLIC_SCREENSHOT_*` keeps them out of shipped bundles.
 
 ## Notes
 
-- The iOS app is a dev-client, so each iOS flow first loads its JS from Metro with
-  `openLink: ${MAESTRO_DEV_CLIENT_URL}` instead of `launchApp` — a bare launch
-  would land on the launcher. The orchestrator passes that env via `maestro test
--e` (an `expo-development-client` deep link pointing at its Metro port, default
-  8081, override with `BOARDSESH_METRO_PORT`), so the flow isn't pinned to a port.
-  Re-opening the deep link reloads the JS runtime (clears the play drawer between
-  drawer-opening shots; iOS now shoots the board view last so it doesn't need it,
-  while Android relaunches before its board-sheet shot). The orchestrator pre-warms
-  the Metro bundle, then (iOS) launches the app and waits for the `$screen /home`
-  log — up to 180s as a safety net for a cold bundle on a slow CI runner — before
-  running Maestro. The orchestrator uninstalls + reinstalls and resets the keychain,
-  so the app cold-loads with fresh app data and the auth provider re-signs-in (no
-  Maestro `clearState` needed).
+- The iOS app is a Debug dev-client that auto-loads Metro on a plain launch through the
+  screenshot build's `DEV_CLIENT_DEFAULT_LAUNCHER_URL` Info.plist value, so the
+  orchestrator just `simctl launch`es it — no `simctl openurl`, which on a fresh CI sim
+  raises an "Open in 'Boardsesh'?" confirmation Maestro can't reliably dismiss. The
+  build auto-signs-in on boot and lands straight on home: the orchestrator pre-warms the
+  Metro bundle (once per locale), then launches the app and waits for the `$screen /home`
+  log — up to 180s as a safety net for a cold bundle on a slow CI runner — before running
+  Maestro. It uninstalls + reinstalls and resets the keychain first, so the app cold-loads
+  with fresh app data and the auth provider re-signs-in (no Maestro `clearState` needed).
+  `MAESTRO_DEV_CLIENT_URL` (an `expo-development-client` deep link at the Metro port,
+  default 8081, override with `BOARDSESH_METRO_PORT`) is still passed for flows that need
+  to reload the JS runtime mid-run; the iOS app-store flow no longer does (the board view
+  is a deep link shot last, and the board-sheet shot is Android-only), while Android
+  relaunches before its board-sheet shot.
 - The Android app is a standalone screenshot APK, so Android flows use
   `launchApp`. The orchestrator uninstalls + reinstalls the APK and clears app
   data before capture.
@@ -89,12 +103,13 @@ on boot. They live only in screenshot-only builds; the separate prod-stripping o
   tree only exposes native text inputs and system dialogs — plain Views, Text,
   reanimated pressables and gesture rows don't surface, so app buttons can't be
   matched by id/text. After moving the board view to a deep link, iOS keeps just
-  **one** `point:` tap — the board pick (`24%,45%`) — **pinned to the iPhone 16 Pro
-  Max**; Android additionally keeps the board-switcher tap (`78%,10%`) for its
-  board-sheet shot. Re-check them if the device changes. There's no login step at all
+  **one** `point:` tap — the board pick — supplied per device by the orchestrator as
+  `MAESTRO_BOARD_PICK_POINT` (so a single flow captures the whole device matrix);
+  Android additionally keeps the board-switcher tap (`78%,10%`) for its board-sheet
+  shot. Re-check the points if a device's layout differs. There's no login step at all
   — the app auto-signs-in on boot and never shows a login screen.
 - Screenshot mode (the build-time `EXPO_PUBLIC_SCREENSHOT_MODE=1` flag) auto-signs-in
-  on boot with the baked `SCREENSHOT_USER_*` credentials, locks the theme to dark + the
-  platform variant, pre-selects the Record-tab workout, drives the deep-link params
-  above, and stops the onboarding gate from auto-presenting the tour. See
-  `packages/mobile/src/lib/screenshot-mode.ts`.
+  on boot with the baked `SCREENSHOT_USER_*` credentials, locks the theme to dark, the
+  locale to `EXPO_PUBLIC_SCREENSHOT_LOCALE`, and the platform variant, pre-selects the
+  Record-tab workout, drives the deep-link params above, and stops the onboarding gate
+  from auto-presenting the tour. See `packages/mobile/src/lib/screenshot-mode.ts`.

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -13,12 +13,18 @@ name: app-store screenshots
 #        ://climbs?screenshotOpenFirst=1    -> auto-opens the first climb's board view
 #        ://profile?screenshotTab=logbook   -> profile Logbook tab
 #        ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
-#   2. ONE coordinate tap that survives — the board picker (board pick = '24%,45%', the
-#      first "Your boards" card on /boards). Pinned to the orchestrator's device
-#      (iPhone 16 Pro Max); re-check it if you change the device.
+#   2. ONE coordinate tap that survives — the board picker (the first "Your boards" card
+#      on /boards). The orchestrator passes its percentage as MAESTRO_BOARD_PICK_POINT,
+#      per device, so this one flow captures the whole device matrix (see
+#      IOS_SCREENSHOT_DEVICES in scripts/mobile-screenshots.ts); re-check the point if a
+#      device's layout differs.
 #   The old board-view '50%,26%' and board-sheet '78%,10%' taps are GONE: the board view
 #   is now a deterministic deep link (it used to mis-tap and duplicate the climb-list
 #   shot), and the board-switcher sheet shot was retired.
+#
+# This flow is captured once per (device, locale) pair: the orchestrator bakes
+# EXPO_PUBLIC_SCREENSHOT_LOCALE into the Metro bundle per locale and reruns it on each
+# device in --devices, writing app-stores/apple/screenshots/<app-store-locale>/<device>/.
 #
 # Notes:
 # - The .app is a Debug dev-client that auto-loads Metro on launch, so the orchestrator
@@ -83,15 +89,15 @@ name: app-store screenshots
 - takeScreenshot: 04-session-detail
 
 # Activate a board so the board-backed shots render real content: open the board picker
-# and tap the first card under "Your boards" (the one surviving coordinate tap), which
-# activates it and dismisses back to Climbs.
+# and tap the first card under "Your boards" (the one surviving coordinate tap, supplied
+# per device as MAESTRO_BOARD_PICK_POINT), which activates it and dismisses back to Climbs.
 - openLink: com.boardsesh.app://boards
 - tapOn:
     text: 'Open'
     optional: true
 - waitForAnimationToEnd
 - tapOn:
-    point: '24%,45%'
+    point: ${MAESTRO_BOARD_PICK_POINT}
 - waitForAnimationToEnd
 
 # Climbs — the main browse surface (now board-backed). Plain link FIRST (the list shot),

--- a/packages/mobile/.maestro/onboarding.yaml
+++ b/packages/mobile/.maestro/onboarding.yaml
@@ -5,12 +5,13 @@ name: onboarding illustrations
 # fall back to SF Symbol / MDI glyphs when no image is present — see
 # onboarding-cards.ts).
 #
-# NOTE: the orchestrator writes these as raw, full-device PNGs to
-# app-stores/<store>/screenshots/<device>/ (same path as the app-store flow — it
-# does NOT crop). Turning them into card assets is a manual follow-up: crop to
-# the card content region, move into packages/mobile/assets/onboarding/, and wire
-# them up in onboarding-cards.ts. This flow is also unvalidated end-to-end (see
-# the a11y caveat in README.md re: matching `climb-list`).
+# NOTE: the orchestrator writes these as raw, full-device PNGs under
+# app-stores/<store>/screenshots/<app-store-locale>/<device>/ (same tree as the
+# app-store flow — it does NOT crop). Turning them into card assets is a manual
+# follow-up: crop to the card content region, move into packages/mobile/assets/
+# onboarding/, and wire them up in onboarding-cards.ts. This flow is also
+# unvalidated end-to-end (see the a11y caveat in README.md re: matching
+# `climb-list`).
 #
 # Card -> screen mapping (welcome/connect/find/play):
 #   welcome -> climbs list   (the browse hero)

--- a/packages/mobile/src/lib/i18n/__tests__/locale-preference.test.ts
+++ b/packages/mobile/src/lib/i18n/__tests__/locale-preference.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
 // detectDeviceLocale (reached via resolveLanguage and i18n init at import) reads
 // the device locales through expo-localization. Pin it to a French device so the
@@ -42,5 +42,45 @@ describe('resolveLanguage', () => {
   it('passes an explicit locale through unchanged', () => {
     expect(resolveLanguage('es')).toBe('es');
     expect(resolveLanguage('en-US')).toBe('en-US');
+  });
+});
+
+// The SCREENSHOT_LOCALE_OVERRIDE guard is a module-level const baked from env at
+// import, so re-import the module under a stubbed env to exercise both branches.
+describe('screenshot locale override', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('resolveLanguage returns the baked screenshot locale, ignoring the override arg', async () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '1');
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_LOCALE', 'es');
+
+    const { resolveLanguage: resolveUnderScreenshotMode } = await import('../locale-preference');
+
+    expect(resolveUnderScreenshotMode('system')).toBe('es');
+    expect(resolveUnderScreenshotMode('fr')).toBe('es');
+  });
+
+  it('getStoredLocaleOverride returns the baked screenshot locale without reading SecureStore', async () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '1');
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_LOCALE', 'es');
+
+    const secureStore = await import('expo-secure-store');
+    const { getStoredLocaleOverride } = await import('../locale-preference');
+
+    expect(await getStoredLocaleOverride()).toBe('es');
+    expect(secureStore.getItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('getStoredLocaleOverride falls back to "system" outside screenshot mode', async () => {
+    const { getStoredLocaleOverride } = await import('../locale-preference');
+
+    // The expo-secure-store mock returns null, so an absent override is "system".
+    expect(await getStoredLocaleOverride()).toBe('system');
   });
 });

--- a/packages/mobile/src/lib/i18n/__tests__/screenshot-locale.test.ts
+++ b/packages/mobile/src/lib/i18n/__tests__/screenshot-locale.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('expo-localization', () => ({
+  getLocales: () => [{ languageTag: 'fr-FR', languageCode: 'fr' }],
+}));
+
+describe('screenshot locale override', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the bundled screenshot locale in screenshot mode', async () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '1');
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_LOCALE', 'es');
+
+    const { detectDeviceLocale } = await import('../config');
+
+    expect(detectDeviceLocale()).toBe('es');
+  });
+
+  it('falls back to device locale when screenshot locale is absent', async () => {
+    const { detectDeviceLocale } = await import('../config');
+
+    expect(detectDeviceLocale()).toBe('fr');
+  });
+});

--- a/packages/mobile/src/lib/i18n/config.ts
+++ b/packages/mobile/src/lib/i18n/config.ts
@@ -8,6 +8,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import { getLocales } from 'expo-localization';
 import { SUPPORTED_LOCALES, DEFAULT_LOCALE, DEFAULT_NAMESPACE, MOBILE_NAMESPACES, type Locale } from '@boardsesh/i18n';
+import { SCREENSHOT_LOCALE_OVERRIDE } from '../screenshot-mode';
 
 // --- Locale catalogs from @boardsesh/i18n ---
 // Static imports so Metro bundles only the namespaces the mobile app uses;
@@ -113,6 +114,10 @@ const resources = {
  * to a concrete language without duplicating the matching logic.
  */
 export function detectDeviceLocale(): Locale {
+  if (SCREENSHOT_LOCALE_OVERRIDE) {
+    return SCREENSHOT_LOCALE_OVERRIDE;
+  }
+
   const deviceLocales = getLocales();
 
   for (const deviceLocale of deviceLocales) {
@@ -137,7 +142,7 @@ export function detectDeviceLocale(): Locale {
   return DEFAULT_LOCALE;
 }
 
-i18n.use(initReactI18next).init({
+void i18n.use(initReactI18next).init({
   compatibilityJSON: 'v4',
   resources,
   lng: detectDeviceLocale(),

--- a/packages/mobile/src/lib/i18n/locale-preference.ts
+++ b/packages/mobile/src/lib/i18n/locale-preference.ts
@@ -12,6 +12,7 @@
 
 import { SUPPORTED_LOCALES, type Locale } from '@boardsesh/i18n';
 import { secureStorePreferences } from '../preferences/secure-store-adapter';
+import { SCREENSHOT_LOCALE_OVERRIDE } from '../screenshot-mode';
 import { detectDeviceLocale } from './config';
 
 export const LOCALE_OVERRIDE_KEY = 'locale_override';
@@ -27,11 +28,17 @@ export function isLocaleOverride(value: unknown): value is LocaleOverride {
  * `'system'` follows the device; an explicit locale passes through.
  */
 export function resolveLanguage(override: LocaleOverride): Locale {
+  if (SCREENSHOT_LOCALE_OVERRIDE) {
+    return SCREENSHOT_LOCALE_OVERRIDE;
+  }
   return override === 'system' ? detectDeviceLocale() : override;
 }
 
 /** Read the persisted override, defaulting to `'system'` when absent/malformed. */
 export async function getStoredLocaleOverride(): Promise<LocaleOverride> {
+  if (SCREENSHOT_LOCALE_OVERRIDE) {
+    return SCREENSHOT_LOCALE_OVERRIDE;
+  }
   const stored = await secureStorePreferences.get<LocaleOverride>(LOCALE_OVERRIDE_KEY);
   return isLocaleOverride(stored) ? stored : 'system';
 }

--- a/packages/mobile/src/lib/screenshot-mode.ts
+++ b/packages/mobile/src/lib/screenshot-mode.ts
@@ -4,6 +4,7 @@ import {
   type ThemeOverride,
   type UiVariantPreference,
 } from '@boardsesh/key-value-storage';
+import { isSupportedLocale, type Locale } from '@boardsesh/i18n';
 
 /**
  * Build-time screenshot mode. The dedicated screenshots build (see
@@ -16,6 +17,16 @@ import {
  * stays the source of truth.
  */
 export const SCREENSHOT_MODE = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
+
+/**
+ * Language the screenshots build locks to. The capture orchestrator starts Metro
+ * once per app locale, so the override is baked into the bundle alongside theme
+ * and workout. Normal builds leave this unset and keep device/user language
+ * detection.
+ */
+const screenshotLocaleEnv = process.env.EXPO_PUBLIC_SCREENSHOT_LOCALE;
+export const SCREENSHOT_LOCALE_OVERRIDE: Locale | null =
+  SCREENSHOT_MODE && isSupportedLocale(screenshotLocaleEnv) ? screenshotLocaleEnv : null;
 
 /**
  * Theme the screenshots build locks to so a capture can't flip mid-run when

--- a/scripts/__tests__/assert-screenshot-dimensions.test.ts
+++ b/scripts/__tests__/assert-screenshot-dimensions.test.ts
@@ -134,6 +134,35 @@ describe('findScreenshotTreeOffenders', () => {
     expect(offenders.some((offender) => offender.file === 'fr-FR' && /missing/.test(offender.reason))).toBe(true);
   });
 
+  it('flags an unknown App Store locale directory', () => {
+    const tree = screenshotTree({
+      'de-DE': {
+        'iphone-16-pro-max': [
+          {
+            name: 'de-DE/iphone-16-pro-max/00-home.png',
+            buffer: pngHeader({ width: 1320, height: 2868 }),
+          },
+        ],
+        'iphone-14-plus': [
+          {
+            name: 'de-DE/iphone-14-plus/00-home.png',
+            buffer: pngHeader({ width: 1284, height: 2778 }),
+          },
+        ],
+        'iphone-16-pro': [
+          {
+            name: 'de-DE/iphone-16-pro/00-home.png',
+            buffer: pngHeader({ width: 1206, height: 2622 }),
+          },
+        ],
+      },
+    });
+    const offenders = findScreenshotTreeOffenders(tree);
+    expect(
+      offenders.some((offender) => offender.file === 'de-DE' && /unknown App Store locale/.test(offender.reason)),
+    ).toBe(true);
+  });
+
   it('flags inconsistent device sets across locales', () => {
     const tree = screenshotTree({
       'es-ES': {

--- a/scripts/__tests__/assert-screenshot-dimensions.test.ts
+++ b/scripts/__tests__/assert-screenshot-dimensions.test.ts
@@ -4,7 +4,9 @@ import {
   type Dimensions,
   findGooglePlayOffenders,
   findOffenders,
+  findScreenshotTreeOffenders,
   readPngDimensions,
+  type ScreenshotTree,
 } from '../assert-screenshot-dimensions';
 
 /** Build a minimal valid PNG header: signature + IHDR length + "IHDR" + width/height. */
@@ -52,6 +54,19 @@ describe('findOffenders', () => {
     expect(offenders).toEqual([]);
   });
 
+  it('accepts the common iPhone Plus and Pro sizes', () => {
+    expect(
+      findOffenders('iphone-14-plus', [
+        { name: 'iphone-14-plus/00-home.png', buffer: pngHeader({ width: 1284, height: 2778 }) },
+      ]),
+    ).toEqual([]);
+    expect(
+      findOffenders('iphone-16-pro', [
+        { name: 'iphone-16-pro/00-home.png', buffer: pngHeader({ width: 1206, height: 2622 }) },
+      ]),
+    ).toEqual([]);
+  });
+
   it('flags a wrong size, reporting both file and dimensions', () => {
     const offenders = findOffenders(slug, [
       { name: `${slug}/bad.png`, buffer: pngHeader({ width: 1284, height: 2778 }) },
@@ -72,6 +87,97 @@ describe('findOffenders', () => {
   it('reports a corrupt PNG as an offender rather than throwing', () => {
     const offenders = findOffenders(slug, [{ name: `${slug}/corrupt.png`, buffer: Buffer.alloc(4) }]);
     expect(offenders).toHaveLength(1);
+  });
+});
+
+describe('findScreenshotTreeOffenders', () => {
+  function screenshotTree(overrides: Partial<ScreenshotTree> = {}): ScreenshotTree {
+    const baseTree: ScreenshotTree = {};
+    for (const locale of ['en-US', 'es-ES', 'es-MX', 'fr-FR']) {
+      baseTree[locale] = {
+        'iphone-16-pro-max': [
+          {
+            name: `${locale}/iphone-16-pro-max/00-home.png`,
+            buffer: pngHeader({ width: 1320, height: 2868 }),
+          },
+        ],
+        'iphone-14-plus': [
+          {
+            name: `${locale}/iphone-14-plus/00-home.png`,
+            buffer: pngHeader({ width: 1284, height: 2778 }),
+          },
+        ],
+        'iphone-16-pro': [
+          {
+            name: `${locale}/iphone-16-pro/00-home.png`,
+            buffer: pngHeader({ width: 1206, height: 2622 }),
+          },
+        ],
+      };
+    }
+    for (const [locale, devices] of Object.entries(overrides)) {
+      if (devices) {
+        baseTree[locale] = devices;
+      }
+    }
+    return baseTree;
+  }
+
+  it('accepts a complete localized common-device tree', () => {
+    expect(findScreenshotTreeOffenders(screenshotTree())).toEqual([]);
+  });
+
+  it('flags missing App Store locales', () => {
+    const tree = screenshotTree();
+    delete tree['fr-FR'];
+    const offenders = findScreenshotTreeOffenders(tree);
+    expect(offenders.some((offender) => offender.file === 'fr-FR' && /missing/.test(offender.reason))).toBe(true);
+  });
+
+  it('flags inconsistent device sets across locales', () => {
+    const tree = screenshotTree({
+      'es-ES': {
+        'iphone-16-pro-max': [
+          {
+            name: 'es-ES/iphone-16-pro-max/00-home.png',
+            buffer: pngHeader({ width: 1320, height: 2868 }),
+          },
+        ],
+      },
+    });
+    const offenders = findScreenshotTreeOffenders(tree);
+    expect(offenders.some((offender) => offender.file === 'es-ES' && /device folders/.test(offender.reason))).toBe(
+      true,
+    );
+  });
+
+  it('flags inconsistent PNG sets across locales', () => {
+    const tree = screenshotTree({
+      'es-MX': {
+        'iphone-16-pro-max': [
+          {
+            name: 'es-MX/iphone-16-pro-max/01-climbs.png',
+            buffer: pngHeader({ width: 1320, height: 2868 }),
+          },
+        ],
+        'iphone-14-plus': [
+          {
+            name: 'es-MX/iphone-14-plus/00-home.png',
+            buffer: pngHeader({ width: 1284, height: 2778 }),
+          },
+        ],
+        'iphone-16-pro': [
+          {
+            name: 'es-MX/iphone-16-pro/00-home.png',
+            buffer: pngHeader({ width: 1206, height: 2622 }),
+          },
+        ],
+      },
+    });
+    const offenders = findScreenshotTreeOffenders(tree);
+    expect(
+      offenders.some((offender) => offender.file === 'es-MX/iphone-16-pro-max' && /PNG set/.test(offender.reason)),
+    ).toBe(true);
   });
 });
 

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -1,13 +1,24 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildScreenshotEnv, deviceSlug, parseArgs, type ScreenshotOptions } from '../mobile-screenshots';
+import {
+  buildScreenshotEnv,
+  deviceSlug,
+  parseArgs,
+  resolveAppStoreLocaleTargets,
+  type ScreenshotOptions,
+} from '../mobile-screenshots';
+
+const commonDevices = ['iPhone 16 Pro Max', 'iPhone 14 Plus', 'iPhone 16 Pro'];
+const allAppLocales: ScreenshotOptions['appLocales'] = ['en-US', 'es', 'fr'];
 
 function makeOptions(overrides: Partial<ScreenshotOptions> = {}): ScreenshotOptions {
   return {
     platform: 'ios',
     flow: 'app-store',
     backend: 'local',
-    device: 'iPhone 16 Pro Max',
+    devices: commonDevices,
+    androidDevice: 'Pixel 2',
+    appLocales: allAppLocales,
     variant: null,
     theme: 'dark',
     workout: 'volume',
@@ -37,7 +48,7 @@ describe('deviceSlug', () => {
 });
 
 describe('parseArgs', () => {
-  it('defaults to ios / app-store / local / dark when no flags are given', () => {
+  it('defaults to ios / app-store / local / common devices / all locales / dark when no flags are given', () => {
     expect(parseArgs([])).toEqual(makeOptions());
   });
 
@@ -58,8 +69,10 @@ describe('parseArgs', () => {
         'light',
         '--variant',
         'material',
-        '--device',
-        'Pixel 8',
+        '--devices',
+        'iPhone 16 Pro Max, iPhone 16 Pro',
+        '--locales',
+        'es,fr',
         '--workout',
         'ladder',
         '--app-path',
@@ -70,7 +83,9 @@ describe('parseArgs', () => {
       platform: 'android',
       flow: 'onboarding',
       backend: 'prod',
-      device: 'Pixel 8',
+      devices: ['iPhone 16 Pro Max', 'iPhone 16 Pro'],
+      androidDevice: 'Pixel 2',
+      appLocales: ['es', 'fr'],
       variant: 'material',
       theme: 'light',
       workout: 'ladder',
@@ -80,7 +95,13 @@ describe('parseArgs', () => {
   });
 
   it('defaults Android captures to the Play phone emulator device', () => {
-    expect(parseArgs(['--platform', 'android']).device).toBe('Pixel 2');
+    expect(parseArgs(['--platform', 'android']).androidDevice).toBe('Pixel 2');
+  });
+
+  it('uses --device as the Android label and a backwards-compatible single-iOS-device alias', () => {
+    const options = parseArgs(['--device', 'iPhone 16 Pro Max']);
+    expect(options.devices).toEqual(['iPhone 16 Pro Max']);
+    expect(options.androidDevice).toBe('iPhone 16 Pro Max');
   });
 
   it('maps --workout off to null', () => {
@@ -90,6 +111,15 @@ describe('parseArgs', () => {
   it('rejects an invalid enum value', () => {
     expect(() => parseArgs(['--theme', 'sepia'])).toThrow(/--theme must be one of/);
     expect(() => parseArgs(['--platform', 'windows'])).toThrow(/--platform must be one of/);
+  });
+
+  it('maps --devices common and --locales all to the defaults', () => {
+    expect(parseArgs(['--devices', 'common', '--locales', 'all'])).toEqual(makeOptions());
+  });
+
+  it('rejects invalid locales and empty comma lists', () => {
+    expect(() => parseArgs(['--locales', 'de'])).toThrow(/supported app locales/);
+    expect(() => parseArgs(['--devices', ','])).toThrow(/at least one device/);
   });
 
   it('rejects an unknown flag and a value-less flag', () => {
@@ -103,6 +133,11 @@ describe('buildScreenshotEnv', () => {
     const env = buildScreenshotEnv(makeOptions({ theme: 'dark' }), baseEnv());
     expect(env.EXPO_PUBLIC_SCREENSHOT_MODE).toBe('1');
     expect(env.EXPO_PUBLIC_SCREENSHOT_THEME).toBe('dark');
+  });
+
+  it('bakes the screenshot locale when a locale target is supplied', () => {
+    const env = buildScreenshotEnv(makeOptions(), baseEnv(), 'fr');
+    expect(env.EXPO_PUBLIC_SCREENSHOT_LOCALE).toBe('fr');
   });
 
   it('points a local build at the local backend defaults', () => {
@@ -153,5 +188,15 @@ describe('buildScreenshotEnv', () => {
     );
     expect(overridden.EXPO_PUBLIC_SCREENSHOT_USER_EMAIL).toBe('shots@boardsesh.com');
     expect(overridden.EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD).toBe('secret');
+  });
+});
+
+describe('resolveAppStoreLocaleTargets', () => {
+  it('maps app locales to App Store Connect locale directories', () => {
+    expect(resolveAppStoreLocaleTargets(['en-US', 'es', 'fr'])).toEqual([
+      { appLocale: 'en-US', appStoreLocales: ['en-US'] },
+      { appLocale: 'es', appStoreLocales: ['es-ES', 'es-MX'] },
+      { appLocale: 'fr', appStoreLocales: ['fr-FR'] },
+    ]);
   });
 });

--- a/scripts/assert-screenshot-dimensions.ts
+++ b/scripts/assert-screenshot-dimensions.ts
@@ -16,7 +16,9 @@
  *   vp run check:screenshot-dimensions -- --platform android
  *
  * The default platform is ios for backwards compatibility with the original
- * App Store-only gate.
+ * App Store-only gate. Exit code 0 means every PNG under
+ * app-stores/apple/screenshots/<app-store-locale>/<device>/ or
+ * app-stores/google/screenshots/<device>/ matches the selected store rules.
  */
 
 import { readFileSync, readdirSync } from 'node:fs';
@@ -36,6 +38,8 @@ export interface Dimensions {
   height: number;
 }
 
+export const EXPECTED_APP_STORE_LOCALES = ['en-US', 'es-ES', 'es-MX', 'fr-FR'] as const;
+
 /**
  * Portrait sizes App Store Connect accepts, keyed by the capture device slug
  * (see deviceSlug() in mobile-screenshots.ts). A device folder with no entry
@@ -49,6 +53,10 @@ export const ACCEPTED_SIZES: Record<string, readonly Dimensions[]> = {
     { width: 1320, height: 2868 },
     { width: 1290, height: 2796 },
   ],
+  // 6.5"/6.7" iPhone Plus slot.
+  'iphone-14-plus': [{ width: 1284, height: 2778 }],
+  // Current non-Max Pro slot.
+  'iphone-16-pro': [{ width: 1206, height: 2622 }],
 };
 
 /** Read width/height from a PNG buffer's IHDR. Throws on a non-PNG / truncated file. */
@@ -75,7 +83,9 @@ export interface Offender {
   reason: string;
 }
 
-/** Pure: validate one Apple device folder's PNGs against its accepted-size allow-list. */
+export type ScreenshotTree = Record<string, Record<string, PngFile[]>>;
+
+/** Pure: validate one App Store device folder's PNGs against its accepted-size allow-list. */
 export function findOffenders(deviceSlug: string, files: readonly PngFile[]): Offender[] {
   const accepted = ACCEPTED_SIZES[deviceSlug];
   if (!accepted) {
@@ -157,6 +167,80 @@ export function findGooglePlayOffenders(deviceSlug: string, files: readonly PngF
   return offenders;
 }
 
+function sortedKeys(record: Record<string, unknown>): string[] {
+  return Object.keys(record).sort();
+}
+
+function basenames(files: readonly PngFile[], deviceSlug: string): string[] {
+  return files.map((file) => file.name.split('/').at(-1) ?? file.name.replace(`${deviceSlug}/`, '')).sort();
+}
+
+function listsMatch(first: readonly string[], second: readonly string[]): boolean {
+  return first.length === second.length && first.every((item, index) => item === second[index]);
+}
+
+/** Pure: validate locale/device coverage plus per-device PNG dimensions. */
+export function findScreenshotTreeOffenders(tree: ScreenshotTree): Offender[] {
+  const offenders: Offender[] = [];
+  const localeNames = sortedKeys(tree);
+
+  for (const locale of localeNames) {
+    if (!(EXPECTED_APP_STORE_LOCALES as readonly string[]).includes(locale)) {
+      offenders.push({ file: locale, reason: 'unknown App Store locale directory' });
+    }
+  }
+
+  for (const expectedLocale of EXPECTED_APP_STORE_LOCALES) {
+    if (!tree[expectedLocale]) {
+      offenders.push({ file: expectedLocale, reason: 'missing App Store locale directory' });
+    }
+  }
+
+  const firstExpectedLocale = EXPECTED_APP_STORE_LOCALES.find((locale) => tree[locale]);
+  const referenceDevices = firstExpectedLocale ? sortedKeys(tree[firstExpectedLocale]) : [];
+  if (referenceDevices.length === 0 && firstExpectedLocale) {
+    offenders.push({ file: firstExpectedLocale, reason: 'contains no device screenshot folders' });
+  }
+
+  for (const expectedLocale of EXPECTED_APP_STORE_LOCALES) {
+    const devices = tree[expectedLocale];
+    if (!devices) continue;
+    const deviceNames = sortedKeys(devices);
+    if (deviceNames.length === 0) {
+      offenders.push({ file: expectedLocale, reason: 'contains no device screenshot folders' });
+      continue;
+    }
+    if (referenceDevices.length > 0 && !listsMatch(deviceNames, referenceDevices)) {
+      offenders.push({
+        file: expectedLocale,
+        reason: `device folders are ${deviceNames.join(', ')}, expected ${referenceDevices.join(', ')}`,
+      });
+    }
+
+    for (const deviceName of deviceNames) {
+      const files = devices[deviceName];
+      if (!files || files.length === 0) {
+        offenders.push({ file: `${expectedLocale}/${deviceName}`, reason: 'contains no PNG screenshots' });
+        continue;
+      }
+      if (referenceDevices.includes(deviceName) && firstExpectedLocale) {
+        const referenceFiles = tree[firstExpectedLocale]?.[deviceName] ?? [];
+        const expectedFiles = basenames(referenceFiles, deviceName);
+        const actualFiles = basenames(files, deviceName);
+        if (expectedFiles.length > 0 && !listsMatch(actualFiles, expectedFiles)) {
+          offenders.push({
+            file: `${expectedLocale}/${deviceName}`,
+            reason: `PNG set is ${actualFiles.join(', ')}, expected ${expectedFiles.join(', ')}`,
+          });
+        }
+      }
+      offenders.push(...findOffenders(deviceName, files));
+    }
+  }
+
+  return offenders;
+}
+
 type ScreenshotPlatform = 'ios' | 'android' | 'all';
 
 function parsePlatform(argv: readonly string[]): ScreenshotPlatform {
@@ -180,47 +264,100 @@ function parsePlatform(argv: readonly string[]): ScreenshotPlatform {
   return platform;
 }
 
-function validateScreenshotRoot(
-  rootDir: string,
-  platformName: string,
-  validator: (deviceSlug: string, files: readonly PngFile[]) => Offender[],
-): number {
-  let deviceDirs: string[];
+function readAppleScreenshotTree(): { tree: ScreenshotTree; pngCount: number } | null {
+  let localeDirs: string[];
   try {
-    deviceDirs = readdirSync(rootDir, { withFileTypes: true })
+    localeDirs = readdirSync(APPLE_SHOTS_DIR, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
   } catch {
-    console.error(`${LOG} FAILED: ${rootDir} not found - run \`vp run mobile:screenshots\` first.`);
-    return 1;
+    console.error(`${LOG} FAILED: ${APPLE_SHOTS_DIR} not found - run \`vp run mobile:screenshots\` first.`);
+    return null;
   }
 
-  const offenders: Offender[] = [];
+  const tree: ScreenshotTree = {};
   let pngCount = 0;
-  for (const slug of deviceDirs) {
-    const dir = join(rootDir, slug);
-    const pngNames = readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.png'));
-    const files: PngFile[] = pngNames.map((name) => ({
-      name: `${slug}/${name}`,
-      buffer: readFileSync(join(dir, name)),
-    }));
-    pngCount += files.length;
-    offenders.push(...validator(slug, files));
+  for (const locale of localeDirs) {
+    const localeDir = join(APPLE_SHOTS_DIR, locale);
+    tree[locale] = {};
+    const nestedDeviceDirs = readdirSync(localeDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+    for (const slug of nestedDeviceDirs) {
+      const dir = join(localeDir, slug);
+      const pngNames = readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.png'));
+      const files: PngFile[] = pngNames.map((name) => ({
+        name: `${locale}/${slug}/${name}`,
+        buffer: readFileSync(join(dir, name)),
+      }));
+      pngCount += files.length;
+      tree[locale][slug] = files;
+    }
   }
 
-  if (pngCount === 0) {
-    console.error(`${LOG} FAILED: no screenshots found under ${rootDir}.`);
+  return { tree, pngCount };
+}
+
+function validateAppleScreenshots(): number {
+  const screenshotTree = readAppleScreenshotTree();
+  if (!screenshotTree) return 1;
+
+  if (screenshotTree.pngCount === 0) {
+    console.error(`${LOG} FAILED: no screenshots found under ${APPLE_SHOTS_DIR}.`);
     return 1;
   }
+  const offenders = findScreenshotTreeOffenders(screenshotTree.tree);
   if (offenders.length > 0) {
-    console.error(`${LOG} FAILED: ${offenders.length} ${platformName} screenshot issue(s):`);
+    console.error(`${LOG} FAILED: ${offenders.length} App Store screenshot issue(s):`);
     for (const offender of offenders) {
       console.error(`  - ${offender.file}: ${offender.reason}`);
     }
     return 1;
   }
 
-  console.log(`${LOG} OK: ${pngCount} ${platformName} screenshot(s) match accepted dimensions.`);
+  console.log(`${LOG} OK: ${screenshotTree.pngCount} App Store screenshot(s) match accepted dimensions.`);
+  return 0;
+}
+
+function validateGooglePlayScreenshots(): number {
+  let deviceDirs: string[];
+  try {
+    deviceDirs = readdirSync(GOOGLE_SHOTS_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    console.error(
+      `${LOG} FAILED: ${GOOGLE_SHOTS_DIR} not found - run \`vp run mobile:screenshots -- --platform android\` first.`,
+    );
+    return 1;
+  }
+
+  const offenders: Offender[] = [];
+  let pngCount = 0;
+  for (const slug of deviceDirs) {
+    const dir = join(GOOGLE_SHOTS_DIR, slug);
+    const pngNames = readdirSync(dir).filter((name) => name.toLowerCase().endsWith('.png'));
+    const files: PngFile[] = pngNames.map((name) => ({
+      name: `${slug}/${name}`,
+      buffer: readFileSync(join(dir, name)),
+    }));
+    pngCount += files.length;
+    offenders.push(...findGooglePlayOffenders(slug, files));
+  }
+
+  if (pngCount === 0) {
+    console.error(`${LOG} FAILED: no screenshots found under ${GOOGLE_SHOTS_DIR}.`);
+    return 1;
+  }
+  if (offenders.length > 0) {
+    console.error(`${LOG} FAILED: ${offenders.length} Google Play screenshot issue(s):`);
+    for (const offender of offenders) {
+      console.error(`  - ${offender.file}: ${offender.reason}`);
+    }
+    return 1;
+  }
+
+  console.log(`${LOG} OK: ${pngCount} Google Play screenshot(s) match accepted dimensions.`);
   return 0;
 }
 
@@ -235,10 +372,7 @@ function main(argv: readonly string[] = process.argv.slice(2)): number {
 
   const platforms: Array<'ios' | 'android'> = platform === 'all' ? ['ios', 'android'] : [platform];
   for (const selectedPlatform of platforms) {
-    const status =
-      selectedPlatform === 'ios'
-        ? validateScreenshotRoot(APPLE_SHOTS_DIR, 'App Store', findOffenders)
-        : validateScreenshotRoot(GOOGLE_SHOTS_DIR, 'Google Play', findGooglePlayOffenders);
+    const status = selectedPlatform === 'ios' ? validateAppleScreenshots() : validateGooglePlayScreenshots();
     if (status !== 0) return status;
   }
   return 0;

--- a/scripts/assert-screenshot-dimensions.ts
+++ b/scripts/assert-screenshot-dimensions.ts
@@ -171,8 +171,13 @@ function sortedKeys(record: Record<string, unknown>): string[] {
   return Object.keys(record).sort();
 }
 
-function basenames(files: readonly PngFile[], deviceSlug: string): string[] {
-  return files.map((file) => file.name.split('/').at(-1) ?? file.name.replace(`${deviceSlug}/`, '')).sort();
+function basenames(files: readonly PngFile[]): string[] {
+  // file.name is "<locale>/<device>/<file>.png" (Apple) or "<device>/<file>.png"
+  // (Play), so the last path segment is the bare filename used to compare coverage
+  // across locales/devices. split() always returns at least one element, so the
+  // `?? file.name` fallback only satisfies `.at(-1)`'s `string | undefined` type —
+  // it never actually runs.
+  return files.map((file) => file.name.split('/').at(-1) ?? file.name).sort();
 }
 
 function listsMatch(first: readonly string[], second: readonly string[]): boolean {
@@ -225,8 +230,8 @@ export function findScreenshotTreeOffenders(tree: ScreenshotTree): Offender[] {
       }
       if (referenceDevices.includes(deviceName) && firstExpectedLocale) {
         const referenceFiles = tree[firstExpectedLocale]?.[deviceName] ?? [];
-        const expectedFiles = basenames(referenceFiles, deviceName);
-        const actualFiles = basenames(files, deviceName);
+        const expectedFiles = basenames(referenceFiles);
+        const actualFiles = basenames(files);
         if (expectedFiles.length > 0 && !listsMatch(actualFiles, expectedFiles)) {
           offenders.push({
             file: `${expectedLocale}/${deviceName}`,

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1015,9 +1015,14 @@ function waitForMetro(): boolean {
   return false;
 }
 
-/** Wait for a just-stopped Metro process group to release its listening port. */
+/**
+ * Wait for a just-stopped Metro process group to release its listening port.
+ * Capped at 60s: on a loaded CI runner the TCP stack can take a while to free the
+ * port between locale runs, and failing the next locale here would throw away the
+ * 60+ minutes already spent on earlier locales.
+ */
 function waitForPortToClose(port: number): boolean {
-  for (let attempt = 0; attempt < 30; attempt++) {
+  for (let attempt = 0; attempt < 60; attempt++) {
     if (!portInUse(port)) return true;
     sleepSeconds(1);
   }
@@ -1078,6 +1083,20 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   } catch (error) {
     console.error(`${LOG} ${error instanceof Error ? error.message : String(error)}`);
     return 1;
+  }
+
+  // --devices (the iOS device matrix) and --locales (the iOS locale matrix) only
+  // feed runIos; runAndroid captures the single --device into one en-US tree. Warn
+  // if they were passed for an android-only run so they don't look silently
+  // honoured. (`--platform all` still runs iOS, which does consume them.)
+  if (options.platform === 'android') {
+    const ignoredIosFlags = ['--devices', '--locales'].filter((flag) => argv.includes(flag));
+    if (ignoredIosFlags.length > 0) {
+      console.warn(
+        `${LOG} ${ignoredIosFlags.join(' and ')} only affect iOS captures and are ignored for --platform android; ` +
+          `use --device to pick the Android device.`,
+      );
+    }
   }
 
   const platforms: Array<'ios' | 'android'> = options.platform === 'all' ? ['ios', 'android'] : [options.platform];

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -16,12 +16,13 @@
  *
  * Flow: prepare a simulator/emulator, apply a clean status bar, install the app
  * artifact, run a Maestro flow that deep-links to each screen and captures it.
- * PNGs land in app-stores/<store>/screenshots/<device>/ (ios -> apple, android
- * -> google).
+ * iOS PNGs land in app-stores/apple/screenshots/<app-store-locale>/<device>/;
+ * Android PNGs land in app-stores/google/screenshots/<device>/.
  *
  * Usage:
  *   vp run mobile:screenshots -- [--platform ios] [--flow app-store|onboarding]
- *                                 [--backend local|prod] [--device "iPhone 16 Pro Max"]
+ *                                 [--backend local|prod] [--devices common|<comma-list>]
+ *                                 [--locales all|<comma-list>] [--device "iPhone 16 Pro Max"]
  *                                 [--variant material|liquidGlass] [--shutdown]
  *                                 [--app-path <path/to/Boardsesh.app|app.apk>]
  *
@@ -38,6 +39,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, 
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { SUPPORTED_LOCALES, isSupportedLocale, type Locale } from '../packages/shared/i18n/src/config';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
@@ -59,9 +61,7 @@ const STORE_BY_PLATFORM: Record<'ios' | 'android', string> = { ios: 'apple', and
 const LOG = '[mobile:screenshots]';
 
 const APP_ID = 'com.boardsesh.app';
-const DEFAULT_IOS_DEVICE = 'iPhone 16 Pro Max';
 const DEFAULT_ANDROID_DEVICE = 'Pixel 2';
-const IOS_DEVICE_TYPE_ID = 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max';
 const DEFAULT_ANDROID_APK = resolve(
   MOBILE_DIR,
   'android',
@@ -86,11 +86,55 @@ export type ScreenshotBackend = 'local' | 'prod';
 
 export type ScreenshotTheme = 'light' | 'dark';
 
+export interface IosScreenshotDevice {
+  name: string;
+  typeId: string;
+  // The one surviving coordinate tap (the board picker), passed to the flow as
+  // MAESTRO_BOARD_PICK_POINT. Everything else the flow needs is a deep link, so
+  // there's no per-device board-view / board-sheet tap any more.
+  boardPickPoint: string;
+}
+
+export const IOS_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
+  {
+    name: 'iPhone 16 Pro Max',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
+    boardPickPoint: '24%,45%',
+  },
+  {
+    name: 'iPhone 14 Plus',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-14-Plus',
+    boardPickPoint: '24%,45%',
+  },
+  {
+    name: 'iPhone 16 Pro',
+    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro',
+    boardPickPoint: '24%,45%',
+  },
+];
+
+const COMMON_IOS_DEVICE_NAMES = IOS_SCREENSHOT_DEVICES.map((device) => device.name);
+const DEFAULT_IOS_DEVICES_ARGUMENT = 'common';
+const DEFAULT_LOCALES_ARGUMENT = 'all';
+
+export interface AppStoreLocaleTarget {
+  appLocale: Locale;
+  appStoreLocales: readonly string[];
+}
+
+const APP_STORE_LOCALES_BY_APP_LOCALE: Record<Locale, readonly string[]> = {
+  'en-US': ['en-US'],
+  es: ['es-ES', 'es-MX'],
+  fr: ['fr-FR'],
+};
+
 export interface ScreenshotOptions {
   platform: ScreenshotPlatform;
   flow: ScreenshotFlow;
   backend: ScreenshotBackend;
-  device: string;
+  devices: string[];
+  androidDevice: string;
+  appLocales: Locale[];
   variant: string | null;
   theme: ScreenshotTheme;
   /** Workout type the Record/session screen pre-selects (generator screenshot); null = Off. */
@@ -102,12 +146,13 @@ export interface ScreenshotOptions {
 
 export function parseArgs(argv: readonly string[]): ScreenshotOptions {
   const args = argv.filter((argument) => argument !== '--');
-  let deviceProvided = false;
   const options: ScreenshotOptions = {
     platform: 'ios',
     flow: 'app-store',
     backend: 'local',
-    device: DEFAULT_IOS_DEVICE,
+    devices: [...COMMON_IOS_DEVICE_NAMES],
+    androidDevice: DEFAULT_ANDROID_DEVICE,
+    appLocales: [...SUPPORTED_LOCALES],
     variant: null,
     // Dark is the canonical store appearance (the app defaults to dark).
     theme: 'dark',
@@ -135,9 +180,19 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
         options.backend = expectEnum(flag, value, ['local', 'prod']) as ScreenshotBackend;
         index++;
         break;
-      case '--device':
-        options.device = expectValue(flag, value);
-        deviceProvided = true;
+      case '--device': {
+        const deviceName = expectValue(flag, value);
+        options.devices = [deviceName];
+        options.androidDevice = deviceName;
+        index++;
+        break;
+      }
+      case '--devices':
+        options.devices = parseDevicesArgument(expectValue(flag, value));
+        index++;
+        break;
+      case '--locales':
+        options.appLocales = parseLocalesArgument(expectValue(flag, value));
         index++;
         break;
       case '--variant':
@@ -166,11 +221,41 @@ export function parseArgs(argv: readonly string[]): ScreenshotOptions {
     }
   }
 
-  if (!deviceProvided && options.platform === 'android') {
-    options.device = DEFAULT_ANDROID_DEVICE;
-  }
-
   return options;
+}
+
+function parseDevicesArgument(value: string): string[] {
+  if (value === DEFAULT_IOS_DEVICES_ARGUMENT) {
+    return [...COMMON_IOS_DEVICE_NAMES];
+  }
+  const devices = value
+    .split(',')
+    .map((deviceName) => deviceName.trim())
+    .filter((deviceName) => deviceName.length > 0);
+  if (devices.length === 0) {
+    throw new Error('--devices requires at least one device name');
+  }
+  return devices;
+}
+
+function parseLocalesArgument(value: string): Locale[] {
+  if (value === DEFAULT_LOCALES_ARGUMENT) {
+    return [...SUPPORTED_LOCALES];
+  }
+  const locales = value
+    .split(',')
+    .map((locale) => locale.trim())
+    .filter((locale) => locale.length > 0);
+  if (locales.length === 0) {
+    throw new Error('--locales requires at least one locale');
+  }
+  const invalidLocales = locales.filter((locale) => !isSupportedLocale(locale));
+  if (invalidLocales.length > 0) {
+    throw new Error(
+      `--locales must contain supported app locales (${SUPPORTED_LOCALES.join(', ')}) or "all" (got ${invalidLocales.join(', ')})`,
+    );
+  }
+  return Array.from(new Set(locales)) as Locale[];
 }
 
 function expectValue(flag: string, value: string | undefined): string {
@@ -206,6 +291,7 @@ export function deviceSlug(deviceName: string): string {
 export function buildScreenshotEnv(
   options: ScreenshotOptions,
   baseEnv: NodeJS.ProcessEnv = process.env,
+  appLocale: Locale | null = null,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     ...baseEnv,
@@ -218,6 +304,9 @@ export function buildScreenshotEnv(
     EXPO_PUBLIC_SCREENSHOT_USER_EMAIL: baseEnv.SCREENSHOT_USER_EMAIL ?? DEFAULT_USER_EMAIL,
     EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD: baseEnv.SCREENSHOT_USER_PASSWORD ?? DEFAULT_USER_PASSWORD,
   };
+  if (appLocale) {
+    env.EXPO_PUBLIC_SCREENSHOT_LOCALE = appLocale;
+  }
   if (options.variant) {
     env.EXPO_PUBLIC_SCREENSHOT_VARIANT = options.variant;
   }
@@ -296,26 +385,54 @@ function newestIosRuntime(): string | null {
   return ios.length > 0 ? ios[ios.length - 1].identifier : null;
 }
 
-function findOrCreateIosDevice(deviceName: string): DeviceInfo {
+function resolveIosScreenshotDevices(deviceNames: readonly string[]): IosScreenshotDevice[] {
+  return deviceNames.map((deviceName) => {
+    const knownDevice = IOS_SCREENSHOT_DEVICES.find((device) => device.name === deviceName);
+    if (knownDevice) return knownDevice;
+    // An unlisted device name: usable only if a simulator by that name already
+    // exists (typeId: '' tells findOrCreateIosDevice it can't auto-create one, so
+    // it errors with a clear message instead). It gets the shared default
+    // board-pick point — add an IOS_SCREENSHOT_DEVICES entry to tune it per device.
+    return {
+      name: deviceName,
+      typeId: '',
+      boardPickPoint: '24%,45%',
+    };
+  });
+}
+
+export function resolveAppStoreLocaleTargets(appLocales: readonly Locale[]): AppStoreLocaleTarget[] {
+  return appLocales.map((appLocale) => ({
+    appLocale,
+    appStoreLocales: APP_STORE_LOCALES_BY_APP_LOCALE[appLocale],
+  }));
+}
+
+function findOrCreateIosDevice(screenshotDevice: IosScreenshotDevice): DeviceInfo {
   const devices = listSimulatorDevices();
-  const booted = devices.find((device) => device.name === deviceName && device.state === 'Booted');
+  const booted = devices.find((device) => device.name === screenshotDevice.name && device.state === 'Booted');
   if (booted) return booted;
-  const existing = devices.find((device) => device.name === deviceName);
+  const existing = devices.find((device) => device.name === screenshotDevice.name);
   if (existing) return existing;
+  if (screenshotDevice.typeId.length === 0) {
+    throw new Error(
+      `No "${screenshotDevice.name}" simulator found. Create it in Xcode or use one of: ${COMMON_IOS_DEVICE_NAMES.join(', ')}.`,
+    );
+  }
 
   const runtime = newestIosRuntime();
   if (!runtime) {
     throw new Error(
-      `No "${deviceName}" simulator found and no iOS runtime available to create one. Open Xcode > Settings > Components to install a simulator runtime, or create the device in Xcode.`,
+      `No "${screenshotDevice.name}" simulator found and no iOS runtime available to create one. Open Xcode > Settings > Components to install a simulator runtime, or create the device in Xcode.`,
     );
   }
-  console.log(`${LOG} Creating simulator "${deviceName}" (${runtime})...`);
-  const { status } = runCapture('xcrun', ['simctl', 'create', deviceName, IOS_DEVICE_TYPE_ID, runtime]);
+  console.log(`${LOG} Creating simulator "${screenshotDevice.name}" (${runtime})...`);
+  const { status } = runCapture('xcrun', ['simctl', 'create', screenshotDevice.name, screenshotDevice.typeId, runtime]);
   if (status !== 0) {
-    throw new Error(`Failed to create simulator "${deviceName}". Create it manually in Xcode and rerun.`);
+    throw new Error(`Failed to create simulator "${screenshotDevice.name}". Create it manually in Xcode and rerun.`);
   }
-  const created = listSimulatorDevices().find((device) => device.name === deviceName);
-  if (!created) throw new Error(`Created "${deviceName}" but could not locate it afterwards.`);
+  const created = listSimulatorDevices().find((device) => device.name === screenshotDevice.name);
+  if (!created) throw new Error(`Created "${screenshotDevice.name}" but could not locate it afterwards.`);
   return created;
 }
 
@@ -355,14 +472,46 @@ function clearStatusBar(udid: string): void {
   runCapture('xcrun', ['simctl', 'status_bar', udid, 'clear']);
 }
 
-function collectScreenshots(captureDir: string, platform: 'ios' | 'android', deviceName: string): string[] {
-  const outputDir = join(OUTPUT_ROOT, STORE_BY_PLATFORM[platform], 'screenshots', deviceSlug(deviceName));
-  mkdirSync(outputDir, { recursive: true });
+function collectScreenshots(
+  captureDir: string,
+  platform: 'ios' | 'android',
+  deviceName: string,
+  appStoreLocales: readonly string[] | null = null,
+): string[] {
   const pngs = readdirSync(captureDir).filter((file) => file.toLowerCase().endsWith('.png'));
-  for (const png of pngs) {
-    cpSync(join(captureDir, png), join(outputDir, png));
+  const saved: string[] = [];
+  if (!appStoreLocales) {
+    const outputDir = join(OUTPUT_ROOT, STORE_BY_PLATFORM[platform], 'screenshots', deviceSlug(deviceName));
+    mkdirSync(outputDir, { recursive: true });
+    for (const png of pngs) {
+      const outputFile = join(outputDir, png);
+      cpSync(join(captureDir, png), outputFile);
+      saved.push(outputFile);
+    }
+    return saved;
   }
-  return pngs.map((png) => join(outputDir, png));
+
+  for (const appStoreLocale of appStoreLocales) {
+    const outputDir = join(
+      OUTPUT_ROOT,
+      STORE_BY_PLATFORM[platform],
+      'screenshots',
+      appStoreLocale,
+      deviceSlug(deviceName),
+    );
+    mkdirSync(outputDir, { recursive: true });
+    for (const existingFile of readdirSync(outputDir)) {
+      if (existingFile.toLowerCase().endsWith('.png')) {
+        rmSync(join(outputDir, existingFile), { force: true });
+      }
+    }
+    for (const png of pngs) {
+      const outputFile = join(outputDir, png);
+      cpSync(join(captureDir, png), outputFile);
+      saved.push(outputFile);
+    }
+  }
+  return saved;
 }
 
 function flowFileForPlatform(options: ScreenshotOptions, platform: 'ios' | 'android'): string {
@@ -371,25 +520,17 @@ function flowFileForPlatform(options: ScreenshotOptions, platform: 'ios' | 'andr
   return join(MAESTRO_DIR, `${options.flow}.yaml`);
 }
 
-function runIos(options: ScreenshotOptions): number {
-  if (!commandExists('xcrun') || runCapture('xcrun', ['simctl', 'help']).status !== 0) {
-    console.log(`${LOG} Skipped: iOS simulator tooling (xcrun simctl) not available.`);
-    return 0;
-  }
-  if (!commandExists('maestro')) {
-    console.error(`${LOG} FAILED: Maestro not found on PATH. ${MAESTRO_INSTALL_HINT}`);
-    return 1;
-  }
-
-  const device = findOrCreateIosDevice(options.device);
+function captureIosDevice(
+  options: ScreenshotOptions,
+  screenshotDevice: IosScreenshotDevice,
+  appPath: string,
+  localeTarget: AppStoreLocaleTarget,
+): number {
+  const device = findOrCreateIosDevice(screenshotDevice);
   bootDevice(device);
   applyCleanStatusBar(device.udid);
 
-  // Resolve the dev-client .app: a cached/prebuilt one (--app-path, the CI common
-  // path) or build one now (slow; local convenience). The .app loads its JS from
-  // Metro, so it's reusable across JS changes.
-  const appPath = resolveAppPath(options);
-  console.log(`${LOG} Installing ${appPath} on ${device.name}...`);
+  console.log(`${LOG} Installing ${appPath} on ${device.name} for ${localeTarget.appLocale}...`);
   // Uninstall first so the run starts from a clean container (fresh AsyncStorage,
   // so no stale active board). The dev-client + Metro path drops Maestro's
   // `clearState`, which can't run before the bundle has loaded — the uninstall +
@@ -401,44 +542,26 @@ function runIos(options: ScreenshotOptions): number {
     return install.status;
   }
 
-  // Reset the simulator keychain so the app launches signed out and login runs
+  // Reset the simulator keychain so the app's auto-sign-in re-authenticates
   // against the target backend. The auth token lives in a shared keychain access
   // group (group.com.boardsesh.app) that survives both an app uninstall and the
   // fresh install above — so without this a stale token (e.g. from a previous
-  // --backend local run) makes login skip and the app talk to the wrong backend
-  // with an invalid session. The login subflow re-authenticates from a clean slate.
+  // --backend local run) is reused and the app talks to the wrong backend with an
+  // invalid session. A clean keychain forces a fresh sign-in with the baked creds.
   console.log(`${LOG} Resetting simulator keychain (clears any stale auth token)...`);
   runCapture('xcrun', ['simctl', 'keychain', device.udid, 'reset']);
 
-  // Start Metro so the dev-client can load its JS bundle. EXPO_PUBLIC_SCREENSHOT_*
-  // + the backend URLs are inlined here, at bundle time — that's what makes the
-  // native .app reusable. Killed in the finally below.
-  // Abort if the port is already taken: expo would silently skip starting our
-  // dev server (non-interactive), and the flow would then load whatever foreign
-  // Metro is on the port — capturing the wrong app's bundle. Fail loud instead.
-  if (portInUse(METRO_PORT)) {
-    console.error(
-      `${LOG} FAILED: port ${METRO_PORT} is already in use; another Metro would serve the wrong bundle. ` +
-        `Stop it, or set BOARDSESH_METRO_PORT to a free port.`,
-    );
-    return 1;
-  }
-
-  const metroEnv = buildScreenshotEnv(options);
-  console.log(
-    `${LOG} Starting Metro on ${METRO_PORT} (backend=${options.backend}, theme=${options.theme}, flow=${options.flow}${options.variant ? `, variant=${options.variant}` : ''})...`,
-  );
-  const metro = startMetro(metroEnv);
   const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-shots-'));
   try {
-    if (!waitForMetro()) {
-      console.error(`${LOG} FAILED: Metro did not become ready on port ${METRO_PORT}.`);
-      return 1;
-    }
-
-    // Compile the bundle now so the dev-client launch below isn't a cold bundle
-    // when we wait for the app to reach home (the slow-CI-runner case this guards).
-    prewarmMetroBundle();
+    // Metro is already up and pre-warmed by runIos (once per locale, before this
+    // per-device loop), so this goes straight to launching the app.
+    //
+    // Every device in a locale shares one Metro log, and startMetro only truncates
+    // it when Metro starts — so a `$screen /home` line from the previous device is
+    // still in the log. Snapshot the current marker count and wait for it to
+    // INCREASE (not merely be present), or device 2+ would skip the readiness wait
+    // on a stale marker and capture a blank/loading frame.
+    const homeReadyBaseline = homeReadyMarkerCount();
 
     // Just launch the app — no `simctl openurl`. The screenshots build bakes
     // DEV_CLIENT_DEFAULT_LAUNCHER_URL=http://localhost:8081 into Info.plist (see
@@ -456,7 +579,7 @@ function runIos(options: ScreenshotOptions): number {
     // there before Maestro runs — this is what login.yaml's readiness wait used to
     // do (now deleted; there's no login screen to gate on).
     console.log(`${LOG} Waiting for the app to auto-sign-in and reach home...`);
-    if (!waitForHomeReady()) {
+    if (!waitForHomeReady(homeReadyBaseline)) {
       console.error(`${LOG} FAILED: app did not reach the home screen (auto sign-in / bundle load).`);
       return 1;
     }
@@ -490,6 +613,8 @@ function runIos(options: ScreenshotOptions): number {
         `SCREENSHOT_USER_EMAIL=${email}`,
         '-e',
         `SCREENSHOT_USER_PASSWORD=${password}`,
+        '-e',
+        `MAESTRO_BOARD_PICK_POINT=${screenshotDevice.boardPickPoint}`,
       ],
       process.env,
       captureDir,
@@ -499,17 +624,16 @@ function runIos(options: ScreenshotOptions): number {
       return maestroStatus;
     }
 
-    const saved = collectScreenshots(captureDir, 'ios', device.name);
+    const saved = collectScreenshots(captureDir, 'ios', device.name, localeTarget.appStoreLocales);
     if (saved.length === 0) {
       console.error(`${LOG} WARNING: flow completed but no PNGs were captured.`);
       return 1;
     }
     console.log(
-      `${LOG} Saved ${saved.length} screenshot(s) to app-stores/${STORE_BY_PLATFORM.ios}/screenshots/${deviceSlug(device.name)}/`,
+      `${LOG} Saved ${saved.length} screenshot(s) to app-stores/${STORE_BY_PLATFORM.ios}/screenshots/{${localeTarget.appStoreLocales.join(',')}}/${deviceSlug(device.name)}/`,
     );
     for (const file of saved) console.log(`${LOG}   ${file}`);
   } finally {
-    stopMetro(metro);
     rmSync(captureDir, { force: true, recursive: true });
     clearStatusBar(device.udid);
     if (options.shutdown) {
@@ -620,7 +744,7 @@ function resolveAndroidDeviceId(): string | null {
 }
 
 function androidDeviceName(options: ScreenshotOptions): string {
-  return options.device === DEFAULT_IOS_DEVICE ? DEFAULT_ANDROID_DEVICE : options.device;
+  return options.androidDevice;
 }
 
 function resolveAndroidAppPath(options: ScreenshotOptions): string {
@@ -733,6 +857,60 @@ function clearAndroidStatusBar(deviceId: string): void {
   ]);
 }
 
+function runIos(options: ScreenshotOptions): number {
+  if (!commandExists('xcrun') || runCapture('xcrun', ['simctl', 'help']).status !== 0) {
+    console.log(`${LOG} Skipped: iOS simulator tooling (xcrun simctl) not available.`);
+    return 0;
+  }
+  if (!commandExists('maestro')) {
+    console.error(`${LOG} FAILED: Maestro not found on PATH. ${MAESTRO_INSTALL_HINT}`);
+    return 1;
+  }
+
+  // Abort if the port is already taken: expo would silently skip starting our
+  // dev server (non-interactive), and the flow would then load whatever foreign
+  // Metro is on the port — capturing the wrong app's bundle. Fail loud instead.
+  if (portInUse(METRO_PORT)) {
+    console.error(
+      `${LOG} FAILED: port ${METRO_PORT} is already in use; another Metro would serve the wrong bundle. ` +
+        `Stop it, or set BOARDSESH_METRO_PORT to a free port.`,
+    );
+    return 1;
+  }
+
+  const appPath = resolveAppPath(options);
+  const screenshotDevices = resolveIosScreenshotDevices(options.devices);
+  const localeTargets = resolveAppStoreLocaleTargets(options.appLocales);
+
+  for (let localeIndex = 0; localeIndex < localeTargets.length; localeIndex++) {
+    if (localeIndex > 0 && !waitForPortToClose(METRO_PORT)) {
+      console.error(`${LOG} FAILED: Metro port ${METRO_PORT} did not close after the previous locale run.`);
+      return 1;
+    }
+    const localeTarget = localeTargets[localeIndex];
+    const metroEnv = buildScreenshotEnv(options, process.env, localeTarget.appLocale);
+    console.log(
+      `${LOG} Starting Metro on ${METRO_PORT} (backend=${options.backend}, theme=${options.theme}, flow=${options.flow}, locale=${localeTarget.appLocale}${options.variant ? `, variant=${options.variant}` : ''})...`,
+    );
+    const metro = startMetro(metroEnv);
+    try {
+      if (!waitForMetro()) {
+        console.error(`${LOG} FAILED: Metro did not become ready on port ${METRO_PORT}.`);
+        return 1;
+      }
+      prewarmMetroBundle();
+      for (const screenshotDevice of screenshotDevices) {
+        const status = captureIosDevice(options, screenshotDevice, appPath, localeTarget);
+        if (status !== 0) return status;
+      }
+    } finally {
+      stopMetro(metro);
+    }
+  }
+
+  return 0;
+}
+
 /**
  * Resolve the Boardsesh.app to install: a prebuilt/cached one (--app-path, the CI
  * common path) or a freshly built Debug simulator app (local one-command DX).
@@ -837,6 +1015,15 @@ function waitForMetro(): boolean {
   return false;
 }
 
+/** Wait for a just-stopped Metro process group to release its listening port. */
+function waitForPortToClose(port: number): boolean {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    if (!portInUse(port)) return true;
+    sleepSeconds(1);
+  }
+  return false;
+}
+
 function stopMetro(metro: ChildProcess | null): void {
   if (!metro || metro.pid === undefined) return;
   console.log(`${LOG} Stopping Metro...`);
@@ -858,18 +1045,27 @@ function sleepSeconds(seconds: number): void {
 }
 
 /**
+ * How many times the app has logged it reached home so far. The `$screen /home`
+ * analytics line lands in Metro's stdout (NOT the device's unified log), which
+ * startMetro tee's to METRO_LOG_PATH — so count occurrences in that file.
+ */
+function homeReadyMarkerCount(): number {
+  const metroLog = existsSync(METRO_LOG_PATH) ? readFileSync(METRO_LOG_PATH, 'utf8') : '';
+  return metroLog.split('$screen /home').length - 1;
+}
+
+/**
  * After launch, wait until the app reaches the home screen, so the first
  * screenshot isn't a blank/loading frame. The screenshot build auto-signs-in and
  * boots straight to home (no login screen), so this replaces the old Maestro
- * login.yaml readiness gate. The app's `$screen /home` analytics line lands in
- * Metro's stdout (NOT the device's unified log), which startMetro tee's to
- * METRO_LOG_PATH — so poll that file.
+ * login.yaml readiness gate. Several devices share one Metro log within a locale,
+ * so wait for a NEW marker past `baselineCount` rather than any marker — the log
+ * still holds the previous device's `$screen /home`.
  */
-function waitForHomeReady(timeoutSeconds = 180): boolean {
+function waitForHomeReady(baselineCount = 0, timeoutSeconds = 180): boolean {
   const deadline = Date.now() + timeoutSeconds * 1000;
   while (Date.now() < deadline) {
-    const metroLog = existsSync(METRO_LOG_PATH) ? readFileSync(METRO_LOG_PATH, 'utf8') : '';
-    if (metroLog.includes('$screen /home')) return true;
+    if (homeReadyMarkerCount() > baselineCount) return true;
     sleepSeconds(2);
   }
   return false;


### PR DESCRIPTION
## Summary

- expand the native App Store screenshot pipeline to generate common iPhone sizes via `--devices common`
- generate screenshots for all supported app locales and map `es` to both `es-ES` and `es-MX`
- harden screenshot dimension validation and fastlane staging so partial localized uploads fail before touching App Store Connect
- update the GitHub workflow and screenshot/fastlane docs for the new localized tree

## Validation

- `vp test run --project scripts`
- `vp test run --project mobile packages/mobile/src/lib/i18n/__tests__/screenshot-locale.test.ts`
- `vp run test:mobile`
- `vp run typecheck:mobile`
- `vp run typecheck`
- `vp run check:mobile-bundle`
- `ruby -c fastlane/Fastfile`
- `git diff --check`

`vp check` was also run; it still fails only on pre-existing formatting issues in untouched files (`POSTHOG_INVENTORY.md`, `docs/websocket-implementation.md`, backend tick files, and db drizzle metadata snapshots).