### PR TITLE
Harden board presence catch-up

### DIFF
--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -65,20 +65,33 @@ const connectionEvent = (seq: number, nextHolder: BoardConnectionHolder | null):
   seq,
 });
 
-type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void; resolved: boolean };
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (reason: unknown) => void;
+  resolve: (value: T) => void;
+  settled: boolean;
+};
 function deferred<T>(): Deferred<T> {
   const target: Deferred<T> = {
     promise: Promise.resolve(undefined as T),
+    reject: () => {},
     resolve: () => {},
-    resolved: false,
+    settled: false,
   };
-  const promise = new Promise<T>((res) => {
+  const promise = new Promise<T>((res, rej) => {
     target.resolve = (value) => {
-      if (target.resolved) {
+      if (target.settled) {
         return;
       }
-      target.resolved = true;
+      target.settled = true;
       res(value);
+    };
+    target.reject = (reason) => {
+      if (target.settled) {
+        return;
+      }
+      target.settled = true;
+      rej(reason);
     };
   });
   target.promise = promise;
@@ -97,7 +110,7 @@ function pushDeferred<T>(map: Map<number, Array<Deferred<T>>>, boardId: number):
 }
 
 function nextPendingDeferred<T>(map: Map<number, Array<Deferred<T>>>, boardId: number): Deferred<T> {
-  const existing = map.get(boardId)?.find((entry) => !entry.resolved);
+  const existing = map.get(boardId)?.find((entry) => !entry.settled);
   return existing ?? pushDeferred(map, boardId);
 }
 
@@ -166,14 +179,29 @@ function makeClient() {
       target.resolve(climbs);
       return target.promise;
     },
+    rejectRecent: (boardId: number, error: unknown) => {
+      const target = nextPendingDeferred(recentByBoard, boardId);
+      target.reject(error);
+      return target.promise;
+    },
     resolveStats: (boardId: number, stats: BoardPresenceStats) => {
       const target = nextPendingDeferred(statsByBoard, boardId);
       target.resolve(stats);
       return target.promise;
     },
+    rejectStats: (boardId: number, error: unknown) => {
+      const target = nextPendingDeferred(statsByBoard, boardId);
+      target.reject(error);
+      return target.promise;
+    },
     resolveConnection: (boardId: number, nextHolder: BoardConnectionHolder | null) => {
       const target = nextPendingDeferred(connectionByBoard, boardId);
       target.resolve(nextHolder);
+      return target.promise;
+    },
+    rejectConnection: (boardId: number, error: unknown) => {
+      const target = nextPendingDeferred(connectionByBoard, boardId);
+      target.reject(error);
       return target.promise;
     },
   };
@@ -408,6 +436,33 @@ describe('useBoardPresence — sequence gap recovery', () => {
     expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
     expect(harness.fetchStats).toHaveBeenCalledTimes(1);
     expect(harness.fetchConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('repairs history while keeping stale stats and holder when partial catch-up fetches fail', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed-holder' }));
+    });
+
+    act(() => {
+      harness.emit(setEvent(climb('live-newest', 4)));
+    });
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('live-newest', 4), climb('missed', 3), climb('first', 1)]);
+      await Promise.all([
+        harness.rejectStats(1, new Error('stats fetch failed')).catch(() => undefined),
+        harness.rejectConnection(1, new Error('connection fetch failed')).catch(() => undefined),
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.history.map((entry) => entry.seq)).toEqual([4, 3, 1]));
+    expect(result.current.stats?.climbsSentCount).toBe(1);
+    expect(result.current.holder?.userId).toBe('seed-holder');
   });
 
   it('coalesces multiple gaps while a catch-up is already in flight and reruns once', async () => {

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -147,6 +147,9 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     let isActive = true;
     let catchUpInFlight = false;
     let catchUpRequested = false;
+    // Once a baseline exists, a live gap may trigger catch-up even while the
+    // initial backfill is still resolving. That overlap is safe: both paths
+    // merge through BACKFILL_HISTORY, which dedups by (climbUuid, seq).
     let hasSequenceBaseline = false;
     // Identifies this effect run; late async results for a superseded board are
     // ignored by comparing against the ref, which the cleanup flips off.

--- a/packages/shared/board-presence/src/__tests__/reducer.test.ts
+++ b/packages/shared/board-presence/src/__tests__/reducer.test.ts
@@ -392,16 +392,16 @@ describe('REFRESH_STATS', () => {
     expect(result.lastStatsSeq).toBe(8);
   });
 
-  it('never regresses lastStatsSeq when an older catch-up snapshot resolves late', () => {
-    const state = makeState({ stats: makeStats({ climbsSentCount: 7 }), lastStatsSeq: 12 });
+  it('ignores an older catch-up snapshot so neither stats nor lastStatsSeq regress', () => {
+    const freshStats = makeStats({ climbsSentCount: 7 });
+    const state = makeState({ stats: freshStats, lastStatsSeq: 12 });
 
     const result = boardPresenceReducer(state, {
       type: 'REFRESH_STATS',
       payload: { stats: makeStats({ climbsSentCount: 8 }), upToSeq: 10 },
     });
 
-    expect(result.stats?.climbsSentCount).toBe(8);
-    expect(result.lastStatsSeq).toBe(12);
+    expect(result).toBe(state);
   });
 });
 
@@ -524,7 +524,7 @@ describe('REFRESH_CONNECTION', () => {
     expect(result.lastConnectionSeq).toBe(9);
   });
 
-  it('can refresh to a free board without regressing lastConnectionSeq', () => {
+  it('ignores an older catch-up snapshot so neither holder nor lastConnectionSeq regress', () => {
     const state = makeState({ holder: makeHolder({ userId: 'old' }), lastConnectionSeq: 12 });
 
     const result = boardPresenceReducer(state, {
@@ -532,8 +532,7 @@ describe('REFRESH_CONNECTION', () => {
       payload: { holder: null, upToSeq: 10 },
     });
 
-    expect(result.holder).toBeNull();
-    expect(result.lastConnectionSeq).toBe(12);
+    expect(result).toBe(state);
   });
 });
 

--- a/packages/shared/board-presence/src/reducer.ts
+++ b/packages/shared/board-presence/src/reducer.ts
@@ -144,10 +144,13 @@ export function boardPresenceReducer(state: BoardPresenceState, action: BoardPre
     }
 
     case 'REFRESH_STATS': {
+      if (action.payload.upToSeq < state.lastStatsSeq) {
+        return state;
+      }
       return {
         ...state,
         stats: action.payload.stats,
-        lastStatsSeq: Math.max(state.lastStatsSeq, action.payload.upToSeq),
+        lastStatsSeq: action.payload.upToSeq,
       };
     }
 
@@ -181,10 +184,13 @@ export function boardPresenceReducer(state: BoardPresenceState, action: BoardPre
     }
 
     case 'REFRESH_CONNECTION': {
+      if (action.payload.upToSeq < state.lastConnectionSeq) {
+        return state;
+      }
       return {
         ...state,
         holder: action.payload.holder,
-        lastConnectionSeq: Math.max(state.lastConnectionSeq, action.payload.upToSeq),
+        lastConnectionSeq: action.payload.upToSeq,
       };
     }
 


### PR DESCRIPTION
## Summary
- Ignore stale stats and connection snapshots so late catch-up responses cannot replace newer live state.
- Add coverage for partial catch-up failures where history repairs but stale stats and holder state remain intact.
- Document why initial backfill and live catch-up can overlap safely.

## Validation
- `vp test run --project board-presence`
- `vp test run --project board-presence-react`
- `vp run typecheck:board-presence`
- `vp run typecheck:board-presence-react`

Follow-up to #2950.