### PR TITLE
[codex] Fix playlist render board fallback

### DIFF
--- a/packages/mobile/src/components/ClimbListThumbnail.tsx
+++ b/packages/mobile/src/components/ClimbListThumbnail.tsx
@@ -4,6 +4,7 @@ import type { BoardName } from '@boardsesh/shared-schema';
 import { useNativeClimbRender } from '../hooks/use-native-climb-render';
 import { borderRadius } from '../theme/tokens';
 import { LayeredClimbImage } from './LayeredClimbImage';
+import { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH } from './climb-list-thumbnail-metrics';
 
 /**
  * Portrait dimensions of the list thumbnail cell. Exported so ClimbListRow
@@ -11,8 +12,7 @@ import { LayeredClimbImage } from './LayeredClimbImage';
  * edge from a single source of truth. Portrait (not square) so the portrait
  * board image fills the cell instead of letterboxing to ~40px wide.
  */
-export const THUMBNAIL_WIDTH = 76;
-export const THUMBNAIL_HEIGHT = 96;
+export { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH };
 
 type ClimbListThumbnailProps = {
   frames: string;

--- a/packages/mobile/src/components/climb-list-thumbnail-metrics.ts
+++ b/packages/mobile/src/components/climb-list-thumbnail-metrics.ts
@@ -1,0 +1,8 @@
+/**
+ * Portrait dimensions of the shared climb-list thumbnail cell.
+ *
+ * Kept separate from `ClimbListThumbnail` so list-adjacent components can align
+ * placeholders and separators without importing the native image renderer.
+ */
+export const THUMBNAIL_WIDTH = 76;
+export const THUMBNAIL_HEIGHT = 96;

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
 import {
   type ColorValue,
   type LayoutChangeEvent,
@@ -30,6 +30,7 @@ import { type IconName } from '../icon-map';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { ClimbListRow } from '../ClimbListRow';
 import { ClimbListRowSkeleton } from '../ClimbListRowSkeleton';
+import { THUMBNAIL_HEIGHT, THUMBNAIL_WIDTH } from '../climb-list-thumbnail-metrics';
 import { GlassIconButton } from '../GlassIconButton';
 import { ProgressiveBlur } from '../ProgressiveBlur';
 import { Button } from '../Button';
@@ -42,7 +43,10 @@ import { PLAYLIST_COLORS, isValidHexColor } from './playlist-colors';
 import { withAlpha } from '../../theme/colors';
 import { toQueueClimb, toSchemaClimb } from '../../lib/climb-types';
 import type { PlaylistRenderBoard, PlaylistBoardBanner } from '../../lib/playlists/use-playlist-render-board';
-import { resolvePlaylistClimbRenderBoard } from '../../lib/playlists/playlist-climb-render-board';
+import {
+  getPlaylistRenderBoardTarget,
+  resolvePlaylistClimbRenderBoard,
+} from '../../lib/playlists/playlist-climb-render-board';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
@@ -135,11 +139,16 @@ export type PlaylistDetailViewProps = {
 const noopReorder = (_climbUuid: string, _newIndex: number) => {};
 const noopRemove = (_climbUuid: string) => {};
 
-type ResolvedPlaylistClimbRow = {
-  renderBoard: PlaylistRenderBoard;
-  editBoard: PlaylistEditRowBoard;
-  incompatible: boolean;
-};
+type ResolvedPlaylistClimbRow =
+  | {
+      kind: 'renderable';
+      renderBoard: PlaylistRenderBoard;
+      editBoard: PlaylistEditRowBoard;
+      incompatible: boolean;
+    }
+  | {
+      kind: 'unrenderable';
+    };
 
 /**
  * Shared hero + paginated climb list for the playlist-detail and
@@ -259,12 +268,18 @@ export function PlaylistDetailView({
 
   const resolvedRowsByClimbUuid = useMemo(() => {
     const resolvedRows = new Map<string, ResolvedPlaylistClimbRow>();
+    const activeBoardTarget = renderBoard ? getPlaylistRenderBoardTarget(renderBoard) : undefined;
+
     for (const climb of climbs) {
-      const resolvedBoard = resolvePlaylistClimbRenderBoard(climb, renderBoard);
-      if (!resolvedBoard) continue;
+      const resolvedBoard = resolvePlaylistClimbRenderBoard(climb, renderBoard, activeBoardTarget);
+      if (!resolvedBoard) {
+        resolvedRows.set(climb.uuid, { kind: 'unrenderable' });
+        continue;
+      }
 
       const board = resolvedBoard.renderBoard;
       resolvedRows.set(climb.uuid, {
+        kind: 'renderable',
         renderBoard: board,
         editBoard: {
           boardName: board.boardName as BoardName,
@@ -283,6 +298,10 @@ export function PlaylistDetailView({
     ({ item, index }: { item: Climb; index: number }) => {
       const resolvedRow = resolvedRowsByClimbUuid.get(item.uuid);
       if (!resolvedRow) return null;
+
+      if (resolvedRow.kind === 'unrenderable') {
+        return <UnrenderablePlaylistClimbRow climb={item} editMode={editMode} onRemove={onRemoveClimb ?? noopRemove} />;
+      }
 
       if (editMode) {
         return (
@@ -696,6 +715,65 @@ function BoardMismatchBanner({
   );
 }
 
+function UnrenderablePlaylistClimbRow({
+  climb,
+  editMode,
+  onRemove,
+}: {
+  climb: Climb;
+  editMode: boolean;
+  onRemove: (climbUuid: string) => void;
+}) {
+  const { t } = useTranslation('playlists');
+  const { systemColors } = useTheme();
+  const subtitle = t('detail.unrenderableClimb.subtitle');
+  const accessibilityLabel = `${climb.name}. ${subtitle}`;
+
+  const handleRemove = useCallback(() => {
+    onRemove(climb.uuid);
+  }, [onRemove, climb.uuid]);
+
+  return (
+    <View style={styles.unrenderableOuter}>
+      <View
+        style={[styles.unrenderableRow, { backgroundColor: systemColors.background }]}
+        accessible={!editMode}
+        accessibilityRole={editMode ? undefined : 'text'}
+        accessibilityLabel={editMode ? undefined : accessibilityLabel}
+      >
+        <View
+          style={[
+            styles.unrenderableThumbnail,
+            { backgroundColor: systemColors.secondaryBackground, borderColor: systemColors.separator },
+          ]}
+        >
+          <Icon name="warning" size={24} color={systemColors.secondaryLabel} />
+        </View>
+        <View style={styles.unrenderableText}>
+          <Text variant="body" numberOfLines={1} color={systemColors.label} style={styles.unrenderableTitle}>
+            {climb.name}
+          </Text>
+          <Text variant="footnote" numberOfLines={2} color={systemColors.secondaryLabel}>
+            {subtitle}
+          </Text>
+        </View>
+        {editMode ? (
+          <Pressable
+            onPress={handleRemove}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('editClimbs.removeAria', { name: climb.name })}
+            style={({ pressed }) => [styles.unrenderableRemove, pressed && styles.unrenderablePressed]}
+          >
+            <Icon name="minus.circle" size={24} color={iosSystemColors.systemRed} />
+          </Pressable>
+        ) : null}
+      </View>
+      <View style={[styles.unrenderableSeparator, { backgroundColor: systemColors.separator }]} />
+    </View>
+  );
+}
+
 function keyExtractor(item: Climb) {
   return item.uuid;
 }
@@ -905,5 +983,48 @@ const styles = StyleSheet.create({
   emptyText: {
     opacity: 0.5,
     textAlign: 'center',
+  },
+  unrenderableOuter: {
+    position: 'relative',
+    overflow: 'hidden',
+    opacity: 0.72,
+  },
+  unrenderableRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[2],
+    gap: spacing[3],
+  },
+  unrenderableThumbnail: {
+    width: THUMBNAIL_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    borderRadius: borderRadius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  unrenderableText: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  unrenderableTitle: {
+    fontWeight: '600',
+  },
+  unrenderableRemove: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  unrenderablePressed: {
+    opacity: 0.6,
+  },
+  unrenderableSeparator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: THUMBNAIL_WIDTH + spacing[2] + spacing[3],
   },
 });

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -734,28 +734,30 @@ function UnrenderablePlaylistClimbRow({
   }, [onRemove, climb.uuid]);
 
   return (
-    <View style={[styles.unrenderableOuter, { opacity: opacity.disabled }]}>
+    <View style={styles.unrenderableOuter}>
       <View
         style={[styles.unrenderableRow, { backgroundColor: systemColors.background }]}
         accessible={!editMode}
         accessibilityRole={editMode ? undefined : 'text'}
         accessibilityLabel={editMode ? undefined : accessibilityLabel}
       >
-        <View
-          style={[
-            styles.unrenderableThumbnail,
-            { backgroundColor: systemColors.secondaryBackground, borderColor: systemColors.separator },
-          ]}
-        >
-          <Icon name="warning" size={24} color={systemColors.secondaryLabel} />
-        </View>
-        <View style={styles.unrenderableText}>
-          <Text variant="body" numberOfLines={1} color={systemColors.label} style={styles.unrenderableTitle}>
-            {climb.name}
-          </Text>
-          <Text variant="footnote" numberOfLines={2} color={systemColors.secondaryLabel}>
-            {subtitle}
-          </Text>
+        <View style={[styles.unrenderableContent, { opacity: opacity.disabled }]}>
+          <View
+            style={[
+              styles.unrenderableThumbnail,
+              { backgroundColor: systemColors.secondaryBackground, borderColor: systemColors.separator },
+            ]}
+          >
+            <Icon name="warning" size={24} color={systemColors.secondaryLabel} />
+          </View>
+          <View style={styles.unrenderableText}>
+            <Text variant="body" numberOfLines={1} color={systemColors.label} style={styles.unrenderableTitle}>
+              {climb.name}
+            </Text>
+            <Text variant="footnote" numberOfLines={2} color={systemColors.secondaryLabel}>
+              {subtitle}
+            </Text>
+          </View>
         </View>
         {editMode ? (
           <Pressable
@@ -993,6 +995,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: spacing[2],
     paddingVertical: spacing[2],
+    gap: spacing[2],
+  },
+  unrenderableContent: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: spacing[3],
   },
   unrenderableThumbnail: {

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -725,7 +725,7 @@ function UnrenderablePlaylistClimbRow({
   onRemove: (climbUuid: string) => void;
 }) {
   const { t } = useTranslation('playlists');
-  const { systemColors } = useTheme();
+  const { systemColors, opacity } = useTheme();
   const subtitle = t('detail.unrenderableClimb.subtitle');
   const accessibilityLabel = `${climb.name}. ${subtitle}`;
 
@@ -734,7 +734,7 @@ function UnrenderablePlaylistClimbRow({
   }, [onRemove, climb.uuid]);
 
   return (
-    <View style={styles.unrenderableOuter}>
+    <View style={[styles.unrenderableOuter, { opacity: opacity.disabled }]}>
       <View
         style={[styles.unrenderableRow, { backgroundColor: systemColors.background }]}
         accessible={!editMode}
@@ -987,7 +987,6 @@ const styles = StyleSheet.create({
   unrenderableOuter: {
     position: 'relative',
     overflow: 'hidden',
-    opacity: 0.72,
   },
   unrenderableRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -36,17 +36,18 @@ vi.mock('react-native', () => ({
   View: ({
     children,
     pointerEvents,
-    style,
     onLayout,
+    accessibilityLabel,
   }: {
     children?: ReactNode;
     pointerEvents?: string;
-    style?: unknown;
     onLayout?: (e: unknown) => void;
+    accessibilityLabel?: string;
   }) => {
     const attrs: Record<string, unknown> = {};
     if (pointerEvents) attrs['data-pointer-events'] = pointerEvents;
     if (onLayout) attrs['data-has-layout'] = 'true';
+    if (accessibilityLabel) attrs['aria-label'] = accessibilityLabel;
     return createElement('div', attrs, children);
   },
   Pressable: ({
@@ -68,7 +69,7 @@ vi.mock('react-native', () => ({
 // ── Reanimated ────────────────────────────────────────────────────────────────
 vi.mock('react-native-reanimated', () => ({
   default: {
-    View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    View: ({ children }: { children?: ReactNode; style?: unknown }) =>
       createElement('div', { 'data-animated-view': 'true' }, children),
   },
   useAnimatedStyle: () => ({}),
@@ -122,7 +123,7 @@ vi.mock('react-native-safe-area-context', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string, opts?: Record<string, unknown>) => key }),
+  useTranslation: () => ({ t: (key: string, _opts?: Record<string, unknown>) => key }),
 }));
 
 // ── Theme / providers ─────────────────────────────────────────────────────────
@@ -308,6 +309,15 @@ const TENSION_CLIMB: Climb = {
   angle: 35,
 };
 
+const UNKNOWN_BOARD_CLIMB: Climb = {
+  ...CLIMB,
+  uuid: 'unknown-board-row',
+  name: 'Unknown Board Row',
+  boardType: 'unknown-board',
+  layoutId: 999,
+  angle: 40,
+};
+
 function makeProps(overrides: Partial<PlaylistDetailViewProps> = {}): PlaylistDetailViewProps {
   return {
     hero: {
@@ -475,6 +485,44 @@ describe('PlaylistDetailView', () => {
       angle: 35,
       unsupported: true,
     });
+  });
+
+  it('shows an indicator for climbs whose render board cannot be resolved', () => {
+    const onActivateClimb = vi.fn();
+    const { getByText, container } = render(
+      <PlaylistDetailView
+        {...makeProps({
+          climbs: [UNKNOWN_BOARD_CLIMB],
+          onActivateClimb,
+        })}
+      />,
+    );
+
+    expect(getByText('Unknown Board Row')).not.toBeNull();
+    expect(getByText('detail.unrenderableClimb.subtitle')).not.toBeNull();
+    expect(capturedClimbRows).toHaveLength(0);
+
+    fireEvent.click(
+      container.querySelector('[aria-label="Unknown Board Row. detail.unrenderableClimb.subtitle"]') as HTMLElement,
+    );
+    expect(onActivateClimb).not.toHaveBeenCalled();
+  });
+
+  it('lets owners remove unresolved climbs in edit mode', () => {
+    const onRemoveClimb = vi.fn();
+    const { container } = render(
+      <PlaylistDetailView
+        {...makeProps({
+          climbs: [UNKNOWN_BOARD_CLIMB],
+          editMode: true,
+          onRemoveClimb,
+        })}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[aria-label="editClimbs.removeAria"]') as HTMLElement);
+
+    expect(onRemoveClimb).toHaveBeenCalledWith('unknown-board-row');
   });
 
   it('keeps edit row board props stable across parent rerenders', () => {

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -123,7 +123,14 @@ vi.mock('react-native-safe-area-context', () => ({
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string, _opts?: Record<string, unknown>) => key }),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'editClimbs.removeAria' && typeof opts?.name === 'string') {
+        return `${key}:${opts.name}`;
+      }
+      return key;
+    },
+  }),
 }));
 
 // ── Theme / providers ─────────────────────────────────────────────────────────
@@ -140,6 +147,7 @@ vi.mock('../../../providers/theme-provider', () => ({
       tertiaryBackground: '#e5e5e5',
     },
     brandColors: { primary: '#6D28D9' },
+    opacity: { disabled: 0.5 },
   }),
 }));
 
@@ -489,7 +497,7 @@ describe('PlaylistDetailView', () => {
 
   it('shows an indicator for climbs whose render board cannot be resolved', () => {
     const onActivateClimb = vi.fn();
-    const { getByText, getByLabelText } = render(
+    const { getByText } = render(
       <PlaylistDetailView
         {...makeProps({
           climbs: [UNKNOWN_BOARD_CLIMB],
@@ -501,8 +509,6 @@ describe('PlaylistDetailView', () => {
     expect(getByText('Unknown Board Row')).not.toBeNull();
     expect(getByText('detail.unrenderableClimb.subtitle')).not.toBeNull();
     expect(capturedClimbRows).toHaveLength(0);
-
-    fireEvent.click(getByLabelText('Unknown Board Row. detail.unrenderableClimb.subtitle'));
     expect(onActivateClimb).not.toHaveBeenCalled();
   });
 
@@ -518,7 +524,7 @@ describe('PlaylistDetailView', () => {
       />,
     );
 
-    fireEvent.click(getByLabelText('editClimbs.removeAria'));
+    fireEvent.click(getByLabelText('editClimbs.removeAria:Unknown Board Row'));
 
     expect(onRemoveClimb).toHaveBeenCalledWith('unknown-board-row');
   });

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -489,7 +489,7 @@ describe('PlaylistDetailView', () => {
 
   it('shows an indicator for climbs whose render board cannot be resolved', () => {
     const onActivateClimb = vi.fn();
-    const { getByText, container } = render(
+    const { getByText, getByLabelText } = render(
       <PlaylistDetailView
         {...makeProps({
           climbs: [UNKNOWN_BOARD_CLIMB],
@@ -502,15 +502,13 @@ describe('PlaylistDetailView', () => {
     expect(getByText('detail.unrenderableClimb.subtitle')).not.toBeNull();
     expect(capturedClimbRows).toHaveLength(0);
 
-    fireEvent.click(
-      container.querySelector('[aria-label="Unknown Board Row. detail.unrenderableClimb.subtitle"]') as HTMLElement,
-    );
+    fireEvent.click(getByLabelText('Unknown Board Row. detail.unrenderableClimb.subtitle'));
     expect(onActivateClimb).not.toHaveBeenCalled();
   });
 
   it('lets owners remove unresolved climbs in edit mode', () => {
     const onRemoveClimb = vi.fn();
-    const { container } = render(
+    const { getByLabelText } = render(
       <PlaylistDetailView
         {...makeProps({
           climbs: [UNKNOWN_BOARD_CLIMB],
@@ -520,7 +518,7 @@ describe('PlaylistDetailView', () => {
       />,
     );
 
-    fireEvent.click(container.querySelector('[aria-label="editClimbs.removeAria"]') as HTMLElement);
+    fireEvent.click(getByLabelText('editClimbs.removeAria'));
 
     expect(onRemoveClimb).toHaveBeenCalledWith('unknown-board-row');
   });

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
+import { getProductSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
 import { getBoardConfigForPlaylist } from '../board-details-for-playlist';
 import type { PlaylistRenderBoard } from '../use-playlist-render-board';
 import { getPlaylistRenderBoardTarget, resolvePlaylistClimbRenderBoard } from '../playlist-climb-render-board';
@@ -56,14 +57,33 @@ describe('resolvePlaylistClimbRenderBoard', () => {
       throw new Error('Expected kilter layout 1 to expose renderable holds');
     }
 
-    const result = resolvePlaylistClimbRenderBoard(makeClimb({ frames: `p${firstHoldId}r42` }), activeBoard, {
+    const activeSize = getProductSize(activeBoard.boardName as BoardName, activeBoard.sizeId);
+    if (!activeSize) {
+      throw new Error('Expected kilter layout 1 active size to resolve');
+    }
+    const activeArea = (activeSize.edgeRight - activeSize.edgeLeft) * (activeSize.edgeTop - activeSize.edgeBottom);
+    const largerSizes = getSizesForLayoutId(activeBoard.boardName as BoardName, activeBoard.layoutId).filter((size) => {
+      const sizeArea = (size.edgeRight - size.edgeLeft) * (size.edgeTop - size.edgeBottom);
+      return sizeArea > activeArea;
+    });
+    expect(largerSizes).toHaveLength(0);
+
+    const climb = makeClimb({ frames: `p${firstHoldId}r42` });
+    const resultWithActualTarget = resolvePlaylistClimbRenderBoard(climb, activeBoard, actualTarget);
+    expect(resultWithActualTarget).toEqual({
+      renderBoard: activeBoard,
+      fit: 'exact',
+      incompatible: false,
+    });
+
+    const resultWithPrecomputedTarget = resolvePlaylistClimbRenderBoard(climb, activeBoard, {
       board_name: activeBoard.boardName as BoardName,
       layout_id: activeBoard.layoutId,
       holdsData: [{ id: -1 }],
     });
 
-    expect(result?.fit).not.toBe('exact');
-    expect(result?.incompatible).toBe(true);
+    expect(resultWithPrecomputedTarget?.fit).toBe('incompatible');
+    expect(resultWithPrecomputedTarget?.incompatible).toBe(true);
   });
 
   it('uses the smallest larger size when the climb needs more board than the active size', () => {

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
 import { getBoardConfigForPlaylist } from '../board-details-for-playlist';
 import type { PlaylistRenderBoard } from '../use-playlist-render-board';
-import { resolvePlaylistClimbRenderBoard } from '../playlist-climb-render-board';
+import { getPlaylistRenderBoardTarget, resolvePlaylistClimbRenderBoard } from '../playlist-climb-render-board';
 
 function makeClimb(overrides: Partial<Climb> = {}): Climb {
   return {
@@ -45,6 +46,24 @@ describe('resolvePlaylistClimbRenderBoard', () => {
       fit: 'exact',
       incompatible: false,
     });
+  });
+
+  it('honors a precomputed active-board compatibility target', () => {
+    const activeBoard = getKnownBoard('kilter', 1, 45);
+    const actualTarget = getPlaylistRenderBoardTarget(activeBoard);
+    const firstHoldId = actualTarget.holdsData?.[0]?.id;
+    if (firstHoldId == null) {
+      throw new Error('Expected kilter layout 1 to expose renderable holds');
+    }
+
+    const result = resolvePlaylistClimbRenderBoard(makeClimb({ frames: `p${firstHoldId}r42` }), activeBoard, {
+      board_name: activeBoard.boardName as BoardName,
+      layout_id: activeBoard.layoutId,
+      holdsData: [{ id: -1 }],
+    });
+
+    expect(result?.fit).not.toBe('exact');
+    expect(result?.incompatible).toBe(true);
   });
 
   it('uses the smallest larger size when the climb needs more board than the active size', () => {

--- a/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
+++ b/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
@@ -1,6 +1,6 @@
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { Climb } from '@boardsesh/queue';
-import { canAddClimbToBoard } from '@boardsesh/board-config';
+import { canAddClimbToBoard, type BoardCompatibilityTarget } from '@boardsesh/board-config';
 import { getProductSize, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
 import { getBoardRenderData } from '../board-details';
 import { getBoardConfigForPlaylist } from './board-details-for-playlist';
@@ -31,7 +31,7 @@ function toRenderBoard(boardName: BoardName, layoutId: number, sizeId: number, s
   };
 }
 
-function getRenderBoardTarget(renderBoard: PlaylistRenderBoard) {
+export function getPlaylistRenderBoardTarget(renderBoard: PlaylistRenderBoard): BoardCompatibilityTarget {
   const boardName = renderBoard.boardName as BoardName;
   const setIds = parseSetIds(renderBoard.setIds);
   const renderData = getBoardRenderData({
@@ -107,7 +107,7 @@ function resolveUpsizedRenderBoard(
       candidateSetIds,
       activeBoard.angle,
     );
-    const fit = canAddClimbToBoard(climb, getRenderBoardTarget(candidateRenderBoard));
+    const fit = canAddClimbToBoard(climb, getPlaylistRenderBoardTarget(candidateRenderBoard));
 
     if (fit.ok) {
       return {
@@ -132,6 +132,7 @@ function resolveUpsizedRenderBoard(
 export function resolvePlaylistClimbRenderBoard(
   climb: Climb,
   activeBoard: PlaylistRenderBoard | null,
+  activeBoardTarget?: BoardCompatibilityTarget,
 ): PlaylistClimbRenderBoardResult | null {
   if (!activeBoard) {
     return resolveGenericRenderBoard(climb);
@@ -147,7 +148,7 @@ export function resolvePlaylistClimbRenderBoard(
     return resolveIncompatibleRenderBoard(climb, activeBoardName);
   }
 
-  const exactFit = canAddClimbToBoard(climb, getRenderBoardTarget(activeBoard));
+  const exactFit = canAddClimbToBoard(climb, activeBoardTarget ?? getPlaylistRenderBoardTarget(activeBoard));
   if (exactFit.ok) {
     return {
       renderBoard: activeBoard,

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -109,6 +109,9 @@
       "subtitle": "These are {{board}} climbs. Switch boards to queue them.",
       "cta": "Switch board"
     },
+    "unrenderableClimb": {
+      "subtitle": "Board data is missing for this climb."
+    },
     "menu": {
       "generate": "Generate",
       "editClimbs": "Edit climbs",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -109,6 +109,9 @@
       "subtitle": "Estos son bloques de {{board}}. Cambia de tablero para ponerlos en cola.",
       "cta": "Cambiar de tablero"
     },
+    "unrenderableClimb": {
+      "subtitle": "Faltan datos del tablero para este bloque."
+    },
     "menu": {
       "generate": "Generar",
       "editClimbs": "Editar bloques",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -109,6 +109,9 @@
       "subtitle": "Ce sont des voies {{board}}. Changez de planche pour les mettre en file.",
       "cta": "Changer de planche"
     },
+    "unrenderableClimb": {
+      "subtitle": "Les données de planche manquent pour cette voie."
+    },
     "menu": {
       "generate": "Générer",
       "editClimbs": "Modifier les blocs",


### PR DESCRIPTION
## Summary

- Precompute the active playlist render-board compatibility target once per playlist detail render pass instead of once per compatible climb.
- Keep playlist climbs with unknown or unresolvable board data visible as a disabled warning row instead of silently omitting them.
- Allow owners to remove those unresolved rows in playlist edit mode.

## Root Cause

`resolvePlaylistClimbRenderBoard` built the active board compatibility target inside the per-climb resolution path. When a climb could not resolve to any board config, `PlaylistDetailView` stored no row data and `renderItem` returned `null`, making the climb disappear from the list with no indicator.

## Validation

- `vp test run --project mobile packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx`
- `vp run typecheck:mobile`
- `vp run check:i18n:orphans`
- `vp check --fix` on the touched files

Full `vp check` still reports pre-existing formatting issues in unrelated files: `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts`, `packages/backend/src/graphql/resolvers/ticks/mutations.ts`, and several `packages/db/drizzle/meta/*` files.