### PR TITLE
Fix duplicate App Store screenshot; add session/playlist/logbook shots

### DIFF
--- a/app-stores/apple/app-store-metadata.md
+++ b/app-stores/apple/app-store-metadata.md
@@ -62,6 +62,23 @@ Requires Bluetooth Low Energy (BLE) for board connection. Works without a board 
 
 First release. Connect to your Kilter, Tension, or MoonBoard over Bluetooth. Browse and search climbs, build queues, track sends, and run shared sessions with Party Mode.
 
+## Screenshots
+
+iPhone 6.9" (1320×2868), captured + uploaded by `vp run mobile:screenshots` (Maestro → fastlane; see `packages/mobile/.maestro/README.md`). Ten slots, in store display order (the filename prefix sets the order):
+
+1. `00-home` — activity feed, your crew's sessions
+2. `01-climbs` — browse the board's climbs
+3. `02-board-view` — a climb with the holds lit (the signature view)
+4. `03-party` — a live, shared Party Mode session (filled by the party flow)
+5. `04-session-detail` — a session recap: stats, leaderboard, sends
+6. `05-workout-generator` — the Record tab's workout generator
+7. `06-discover` — the playlist library
+8. `07-playlist-detail` — a smart playlist (crowd favourites)
+9. `08-logbook` — your logged sends and progression
+10. `09-profile` — your stats and progression
+
+Apple allows up to 10 and this set fills all 10; the board-switcher sheet shot was retired to make room. Google Play caps phones at 8, so its set drops party, playlist detail, and logbook (see the Play metadata).
+
 ## Review Notes
 
 **Demo Account**

--- a/app-stores/google/play-store-metadata.md
+++ b/app-stores/google/play-store-metadata.md
@@ -77,15 +77,18 @@ Requires Bluetooth Low Energy (BLE) for board connection. Works without a board 
 - JPEG or PNG, 16:9 or 9:16 aspect ratio
 - Minimum 320px, maximum 3840px per side
 
-**Screens to capture:**
+**Screens to capture** (8 = the Play Store phone max; captured + uploaded by `vp run mobile:screenshots --platform android`, in store display order):
 
-1. Board selection screen (Kilter, Tension, MoonBoard options)
-2. Climb list with filters (grade range, rating, hold count)
-3. Climb detail view with holds lit up on the board image
-4. Queue panel with multiple climbs lined up
-5. Bluetooth scanning / device connection screen
-6. Party Mode session with shared queue and participants
-7. Logbook / profile with send history and grade progression
+1. `00-home` — activity feed, your crew's sessions
+2. `01-climbs` — browse the board's climbs
+3. `02-board-view` — a climb with the holds lit (the signature view)
+4. `03-discover` — the playlist library
+5. `04-workout-generator` — the Record tab's workout generator
+6. `05-profile` — your stats and progression
+7. `06-board-sheet` — the board switcher
+8. `07-session-detail` — a session recap: stats, leaderboard, sends
+
+(Party Mode, playlist detail, and the logbook are on the iOS 10-shot set but don't fit Android's 8-shot cap.)
 
 ## What's New (Version 1.0)
 

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -31,8 +31,11 @@ simulator keychain first so login authenticates cleanly against prod.
 - `login.yaml` — reusable subflow. Fills the test credentials, submits via the
   keyboard return key, and dismisses the iOS "Save Password" prompt. Only runs
   when the auth screen is showing (the Keychain token survives `clearState`).
-- `app-store.yaml` / `app-store-android.yaml` — log in, then capture Home,
-  Discover, Profile, Climbs, Record, board view, and board sheet.
+- `app-store.yaml` (iOS) — log in, then capture Home, Discover, Profile, Logbook,
+  session detail, Climbs, the workout generator, playlist detail, and the board view
+  (10 store slots; the `03` live-party slot is filled by the party flow, PR2).
+- `app-store-android.yaml` — the eight Play Store shots: Home, Discover, Profile,
+  session detail, Climbs, the workout generator, board view, and the board sheet.
 - `onboarding.yaml` / `onboarding-android.yaml` — capture app screens for
   onboarding-card illustrations (`--flow onboarding`).
 
@@ -49,8 +52,10 @@ simulator keychain first so login authenticates cleanly against prod.
   would land on the launcher. The orchestrator passes that env via `maestro test
 -e` (an `expo-development-client` deep link pointing at its Metro port, default
   8081, override with `BOARDSESH_METRO_PORT`), so the flow isn't pinned to a port.
-  Re-opening the deep link reloads the JS runtime (used to clear the play drawer
-  before the board-sheet shot). The orchestrator pre-warms the Metro bundle before
+  Re-opening the deep link reloads the JS runtime (clears the play drawer between
+  drawer-opening shots; iOS now shoots the board view last so it doesn't need it,
+  while Android relaunches before its board-sheet shot). The orchestrator pre-warms
+  the Metro bundle before
   Maestro runs, but the first load still waits up to 300s as a safety net for a
   cold bundle on a slow CI runner. The orchestrator uninstalls + reinstalls and
   resets the keychain, so the app cold-loads signed out with fresh app data (no
@@ -60,14 +65,25 @@ simulator keychain first so login authenticates cleanly against prod.
   data before capture.
 - Navigation uses custom-scheme deep links (`com.boardsesh.app://<route>`); Expo
   Router maps tab routes with the `(tabs)` group stripped (`://climbs`, `://home`,
-  `://boards`, …). Each `openLink` is followed by an optional `tapOn "Open"` to
-  clear iOS's "Open in 'Boardsesh'?" confirmation.
+  `://boards`, …). Each iOS `openLink` is followed by an optional `tapOn "Open"` to
+  clear iOS's "Open in 'Boardsesh'?" confirmation (Android has no such dialog).
+- Detail screens Maestro can't tap into are reached with screenshot-mode deep-link
+  params the build only honours when `EXPO_PUBLIC_SCREENSHOT_MODE=1`:
+  `://climbs?screenshotOpenFirst=1` auto-opens the first climb's board view (this
+  replaced a flaky `50%,26%` tap that was duplicating the climb-list shot),
+  `://profile?screenshotTab=logbook` opens the Logbook tab, and
+  `://profile?screenshotTab=sessions` opens the Sessions tab and auto-opens the
+  newest session's detail. For any screen shot twice, the plain visit runs before
+  the param visit so no stale param leaks in.
 - **Coordinate taps**: on this iOS 26 / RN Fabric build Maestro's accessibility
   tree only exposes native text inputs and system dialogs — plain Views, Text,
   reanimated pressables and gesture rows don't surface, so app buttons can't be
-  matched by id/text. The board pick and the climb tap (board view) therefore use
-  percentage `point:` taps **pinned to the iPhone 16 Pro Max**. Re-check them if
-  the device changes. Login works because it drives `TextInput`s (by testID) and
-  the keyboard return key, not buttons.
-- Screenshot mode (build-time flag) locks the theme to light + the platform
-  variant and stops the onboarding gate from auto-presenting the tour.
+  matched by id/text. After moving the board view to a deep link, iOS keeps just
+  **one** `point:` tap — the board pick (`24%,45%`) — **pinned to the iPhone 16 Pro
+  Max**; Android additionally keeps the board-switcher tap (`78%,10%`) for its
+  board-sheet shot. Re-check them if the device changes. Login works because it
+  drives `TextInput`s (by testID) and the keyboard return key, not buttons.
+- Screenshot mode (the build-time `EXPO_PUBLIC_SCREENSHOT_MODE=1` flag) locks the
+  theme to dark + the platform variant, pre-selects the Record-tab workout, drives
+  the deep-link params above, and stops the onboarding gate from auto-presenting the
+  tour. See `packages/mobile/src/lib/screenshot-mode.ts`.

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -1,14 +1,28 @@
 appId: com.boardsesh.app
 name: app-store screenshots android
 ---
-# Play Store screenshots from the standalone screenshot APK. Unlike iOS, this
-# APK already contains the screenshot-mode JS bundle, so launch the app directly
-# instead of opening an expo-development-client URL.
+# Play Store screenshots from the standalone screenshot APK. Unlike iOS, this APK already
+# contains the screenshot-mode JS bundle (the workflow builds it with
+# EXPO_PUBLIC_SCREENSHOT_MODE=1), so launch the app directly instead of opening an
+# expo-development-client URL, and there's no "Open in Boardsesh?" deep-link dialog.
 #
-# Coordinate taps are pinned to the CI Pixel 2 emulator at 1080x1920:
+# Google Play caps phone screenshots at 8. This set is the seven hero screens plus the
+# session-detail recap (the one extra over iOS's 10-shot set; party/playlist/logbook are
+# iOS-only for now — no room here).
+#
+# Screenshot-mode deep-link params (honoured because the APK is built with
+# EXPO_PUBLIC_SCREENSHOT_MODE=1):
+#   ://climbs?screenshotOpenFirst=1    -> auto-opens the first climb's board view
+#   ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
+#
+# One coordinate tap survives, pinned to the CI Pixel 2 emulator at 1080x1920:
 #   board pick = '24%,45%' (first "Your boards" card on /boards)
 #   board sheet = '78%,10%' (board-switcher glyph in the climbs top chrome)
-#   board view  = '50%,26%' (first climb row in the list)
+# The old board-view '50%,26%' tap is gone — it mis-tapped and duplicated the climb-list
+# shot; the board view is now a deterministic deep link.
+#
+# Order: board-independent shots first (home/discover/profile/session); board-dependent
+# shots after the board is picked. Plain visits run before screenshot-param visits.
 - launchApp
 - extendedWaitUntil:
     visible:
@@ -20,44 +34,50 @@ name: app-store screenshots android
 - waitForAnimationToEnd
 - takeScreenshot: 00-home
 
-# Discover — playlists.
+# Discover — playlist library.
 - openLink: com.boardsesh.app://discover
 - waitForAnimationToEnd
 - takeScreenshot: 03-discover
 
-# Profile — stats, sessions, logbook.
+# Profile — progress tab (stats, sessions, logbook). Plain link FIRST so no stale
+# screenshotTab param carries over.
 - openLink: com.boardsesh.app://profile
 - waitForAnimationToEnd
 - takeScreenshot: 05-profile
 
-# Activate a board so Climbs / board-view / board-sheet / generator render real
-# content. Open the board picker and tap the first card under "Your boards".
+# Session detail — the Sessions sub-tab auto-opens the newest session's recap in
+# screenshot mode. Two settle-waits bracket the feed load and the detail push.
+- openLink: com.boardsesh.app://profile?screenshotTab=sessions
+- waitForAnimationToEnd
+- waitForAnimationToEnd
+- takeScreenshot: 07-session-detail
+
+# Activate a board so the board-backed shots render real content. Open the board picker
+# and tap the first card under "Your boards".
 - openLink: com.boardsesh.app://boards
 - waitForAnimationToEnd
 - tapOn:
     point: '24%,45%'
 - waitForAnimationToEnd
 
-# Climbs — the main browse surface.
+# Climbs — the main browse surface. Plain link FIRST (the list shot).
 - openLink: com.boardsesh.app://climbs
 - waitForAnimationToEnd
 - takeScreenshot: 01-climbs
 
-# Workout generator — the Record/session screen with a workout pre-selected.
+# Workout generator — the Record screen with a workout pre-selected.
 - openLink: com.boardsesh.app://record
 - waitForAnimationToEnd
 - takeScreenshot: 04-workout-generator
 
-# Board view — open the first climb.
-- openLink: com.boardsesh.app://climbs
+# Board view — open the first climb (wall with holds lit) via the screenshot-mode param.
+- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
 - waitForAnimationToEnd
-- tapOn:
-    point: '50%,26%'
 - waitForAnimationToEnd
 - takeScreenshot: 02-board-view
 
-# Board sheet — relaunch first so the play drawer from the board-view shot is
-# gone, then open Climbs and tap the board-switcher glyph.
+# Board sheet — relaunch first so the play drawer from the board-view shot is gone, then
+# open Climbs and tap the board-switcher glyph.
 - launchApp
 - waitForAnimationToEnd
 - openLink: com.boardsesh.app://climbs

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -1,39 +1,44 @@
 appId: com.boardsesh.app
 name: app-store screenshots
 ---
-# App Store / Play Store hero shots against the prod backend + curated test user.
+# App Store hero shots against the prod backend + curated test user.
 #
-# IMPORTANT — coordinate taps: on this iOS 26 / RN Fabric build, Maestro's
-# accessibility tree only exposes native text inputs and system dialogs; plain
-# Views, Text, reanimated pressables and gesture rows do NOT surface, so app
-# buttons can't be matched by id/text. Board-dependent interactions therefore use
-# percentage coordinate taps, pinned to the orchestrator's device (iPhone 16 Pro
-# Max). If you change the device, re-check the three `point:` taps below:
-#   board pick = '24%,45%' (first "Your boards" card on /boards)
-#   board sheet = '78%,10%' (board-switcher glyph in the climbs top chrome)
-#   board view  = '50%,26%' (first climb row in the list)
+# Capture mechanism on this iOS 26 / RN Fabric build: Maestro's accessibility tree only
+# exposes native text inputs + system dialogs — plain Views/Text/pressables and gesture
+# rows do NOT surface, so app controls can't be matched by id/text. We drive the app two
+# ways:
+#   1. Deep links (com.boardsesh.app://...), including screenshot-mode query params that
+#      the build only honours when EXPO_PUBLIC_SCREENSHOT_MODE=1 (see
+#      packages/mobile/src/lib/screenshot-mode.ts):
+#        ://climbs?screenshotOpenFirst=1    -> auto-opens the first climb's board view
+#        ://profile?screenshotTab=logbook   -> profile Logbook tab
+#        ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
+#   2. ONE coordinate tap that survives — the board picker (board pick = '24%,45%', the
+#      first "Your boards" card on /boards). Pinned to the orchestrator's device
+#      (iPhone 16 Pro Max); re-check it if you change the device.
+#   The old board-view '50%,26%' and board-sheet '78%,10%' taps are GONE: the board view
+#   is now a deterministic deep link (it used to mis-tap and duplicate the climb-list
+#   shot), and the board-switcher sheet shot was retired.
 #
-# Other notes:
-# - The .app is a Debug dev-client that auto-loads Metro on launch (the build bakes
-#   DEV_CLIENT_DEFAULT_LAUNCHER_URL into Info.plist), so the ORCHESTRATOR just
-#   `simctl launch`es it — no `simctl openurl`, which on a fresh CI sim raises an
-#   "Open in Boardsesh?" confirmation Maestro can't reliably dismiss. So this flow
-#   just waits for the auth screen.
-# - The orchestrator uninstalled + reinstalled the app (fresh AsyncStorage, so no
-#   stale active board — re-picked via the board picker below) and reset the
-#   simulator keychain, so this cold-loads signed out and login authenticates
-#   against the target backend.
+# Notes:
+# - The .app is a Debug dev-client that auto-loads Metro on launch, so the orchestrator
+#   just simctl-launches it; this flow waits for the signed-out auth screen, then logs in.
+# - Fresh install (orchestrator uninstalled/reinstalled + reset keychain): cold-loads
+#   signed out, no active board (re-picked below), login authenticates against the backend.
+# - iOS shows an "Open in 'Boardsesh'?" confirmation for the first in-flow route deep link
+#   on a fresh sim; each openLink is followed by an optional tapOn "Open".
+# - Order: board-INDEPENDENT shots (home/discover/profile/logbook/session) run first so a
+#   board-pick miss can't lose them; board-DEPENDENT shots (climbs/workout/playlist/board
+#   view) run after the board is active. For any screen visited twice, the PLAIN visit
+#   runs before the screenshot-param visit so no stale param leaks into it. Board view is
+#   LAST because the play drawer it opens overlays the whole app.
 # - The Record/session screen renders the WORKOUT GENERATOR because Metro bundles
-#   EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume) — its shelf is a
-#   gesture-handler ScrollView Maestro can't tap, so the selection is pre-seeded.
-# - iOS shows an "Open in 'Boardsesh'?" confirmation for the first in-flow route
-#   deep link on a fresh sim (until the scheme is trusted); each openLink is
-#   followed by an optional tapOn "Open".
-# - Board-independent captures (home/discover/profile) run first so a board-pick
-#   miss can't lose them.
+#   EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume).
+# - Filenames are numbered for store DISPLAY order (00..09), not capture order. 03 is the
+#   live-party shot, added by the party-session flow (see app-store-party.yaml / PR2).
 #
-# Cold Metro bundle on the first load can take a while; wait for the signed-out
-# auth screen (the orchestrator guarantees a logged-out start), then log in.
+# Cold Metro bundle on the first load can take a while; wait for the signed-out auth
+# screen, then log in.
 - extendedWaitUntil:
     visible:
       id: 'auth-email-input'
@@ -44,25 +49,46 @@ name: app-store screenshots
 - waitForAnimationToEnd
 - takeScreenshot: 00-home
 
-# Discover — playlists.
+# Discover — the playlist library (smart "Your Picks" + saved playlists).
 - openLink: com.boardsesh.app://discover
 - tapOn:
     text: 'Open'
     optional: true
 - waitForAnimationToEnd
-- takeScreenshot: 03-discover
+- takeScreenshot: 06-discover
 
-# Profile — stats, sessions, logbook.
+# Profile — progress tab (stats charts). Plain link FIRST so no stale screenshotTab
+# param carries over to it.
 - openLink: com.boardsesh.app://profile
 - tapOn:
     text: 'Open'
     optional: true
 - waitForAnimationToEnd
-- takeScreenshot: 05-profile
+- takeScreenshot: 09-profile
 
-# Activate a board so Climbs / board-view / board-sheet / generator render real
-# content. Open the board picker and tap the first card under "Your boards"
-# (top-left), which activates it and dismisses back to Climbs.
+# Logbook — the climbing history, every logged send. The screenshot-mode param selects
+# the Logbook sub-tab.
+- openLink: com.boardsesh.app://profile?screenshotTab=logbook
+- tapOn:
+    text: 'Open'
+    optional: true
+- waitForAnimationToEnd
+- takeScreenshot: 08-logbook
+
+# Session detail — the Sessions sub-tab auto-opens the newest session's recap in
+# screenshot mode (summary + grade chart + leaderboard + ticks). Two settle-waits bracket
+# the feed load and the detail push (Maestro has no sleep; tune if a capture lands early).
+- openLink: com.boardsesh.app://profile?screenshotTab=sessions
+- tapOn:
+    text: 'Open'
+    optional: true
+- waitForAnimationToEnd
+- waitForAnimationToEnd
+- takeScreenshot: 04-session-detail
+
+# Activate a board so the board-backed shots render real content: open the board picker
+# and tap the first card under "Your boards" (the one surviving coordinate tap), which
+# activates it and dismisses back to Climbs.
 - openLink: com.boardsesh.app://boards
 - tapOn:
     text: 'Open'
@@ -72,7 +98,8 @@ name: app-store screenshots
     point: '24%,45%'
 - waitForAnimationToEnd
 
-# Climbs — the main browse surface (now board-backed).
+# Climbs — the main browse surface (now board-backed). Plain link FIRST (the list shot),
+# before the board-view param visit below.
 - openLink: com.boardsesh.app://climbs
 - tapOn:
     text: 'Open'
@@ -80,42 +107,32 @@ name: app-store screenshots
 - waitForAnimationToEnd
 - takeScreenshot: 01-climbs
 
-# Workout generator — the Record/session screen with a workout pre-selected
-# (volume): target grade, warm-up, set config + the generated preview queue.
+# Workout generator — the Record screen with a workout pre-selected (volume): target
+# grade, warm-up, set config + the generated preview queue.
 - openLink: com.boardsesh.app://record
 - tapOn:
     text: 'Open'
     optional: true
 - waitForAnimationToEnd
-- takeScreenshot: 04-workout-generator
+- takeScreenshot: 05-workout-generator
 
-# Board view — open the first climb (the signature feature: wall with holds lit).
-- openLink: com.boardsesh.app://climbs
+# Playlist detail — a smart playlist (crowd favourites): full-bleed gradient hero + climb
+# grid. Computed relative to the active board, so it needs the board picked above.
+- openLink: com.boardsesh.app://discover/smart/RECOMMENDED_CROWD_FAVORITES
 - tapOn:
     text: 'Open'
     optional: true
 - waitForAnimationToEnd
+- waitForAnimationToEnd
+- takeScreenshot: 07-playlist-detail
+
+# Board view — the signature feature: the wall with holds lit. The screenshot-mode param
+# auto-opens the first climb's play drawer (no coordinate tap). LAST, because the play
+# drawer overlays the app and would bleed into later shots.
+- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
 - tapOn:
-    point: '50%,26%'
+    text: 'Open'
+    optional: true
+- waitForAnimationToEnd
 - waitForAnimationToEnd
 - takeScreenshot: 02-board-view
-
-# Board sheet — LAST, because the drawer-host overlays (board sheet, play drawer)
-# persist across deep-link tab switches. Reload the bundle first (a fresh JS
-# runtime; the Keychain login + active board survive it) to clear the play drawer
-# left open by the board-view step, then open Climbs and tap the board-switcher
-# glyph. The bundle is warm by now, so the reload is quick.
-- openLink: ${MAESTRO_DEV_CLIENT_URL}
-- tapOn:
-    text: 'Open'
-    optional: true
-- waitForAnimationToEnd
-- openLink: com.boardsesh.app://climbs
-- tapOn:
-    text: 'Open'
-    optional: true
-- waitForAnimationToEnd
-- tapOn:
-    point: '78%,10%'
-- waitForAnimationToEnd
-- takeScreenshot: 06-board-sheet

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -68,6 +68,7 @@ vi.mock('react-native-safe-area-context', () => ({
 vi.mock('expo-router', () => ({
   Stack: { Screen: () => null },
   useRouter: () => ({ push: vi.fn() }),
+  useLocalSearchParams: () => ({}),
 }));
 
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'queue-item-1' }));

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet, RefreshControl, Keyboard } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Stack, useRouter } from 'expo-router';
+import { Stack, useRouter, useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { Climb, BoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -58,6 +58,7 @@ import { getFilterSummary, buildClimbFilterSummary } from '../../../src/lib/filt
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName, visibleSearchTextNeedsSync } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
+import { SCREENSHOT_MODE } from '../../../src/lib/screenshot-mode';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
@@ -122,6 +123,9 @@ const ActiveAwareClimbListRow = memo(function ActiveAwareClimbListRow(
 
 function ClimbListInner() {
   const router = useRouter();
+  // Screenshot mode opens the first climb's board view via this deep-link param
+  // (see the auto-open effect below). Absent on the plain `/climbs` list shot.
+  const { screenshotOpenFirst } = useLocalSearchParams<{ screenshotOpenFirst?: string }>();
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist, openBoardSheet } = useDrawerHost();
   // The board capsule opens the wall's "now on the wall" sheet (the board
@@ -542,6 +546,21 @@ function ClimbListInner() {
     },
     [activateClimbListClimb, blurSearchInputs],
   );
+
+  // Screenshot mode: deterministically open the first climb's play drawer (the
+  // board-view shot) instead of a Maestro coordinate tap, which can't match RN
+  // rows on this iOS build and was capturing the climb list twice. Gated on the
+  // deep-link param so the plain `/climbs` list shot is untouched; fires once the
+  // board's results land, and at most once. Dead-strips in normal builds.
+  const screenshotBoardViewOpenedRef = useRef(false);
+  useEffect(() => {
+    if (!SCREENSHOT_MODE || !screenshotOpenFirst) return;
+    if (screenshotBoardViewOpenedRef.current) return;
+    const firstClimb = visibleClimbs[0];
+    if (!searchReady || !firstClimb) return;
+    screenshotBoardViewOpenedRef.current = true;
+    handleClimbPress(firstClimb);
+  }, [screenshotOpenFirst, searchReady, visibleClimbs, handleClimbPress]);
 
   const handleAddToQueue = useCallback(
     (climb: Climb) => {

--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useLocalSearchParams } from 'expo-router';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import { useProfile, useYouProfileData } from '../../../src/lib/graphql/hooks';
 import { useTheme } from '../../../src/providers/theme-provider';
@@ -10,6 +11,13 @@ import { ProgressTab } from '../../../src/components/you/ProgressTab';
 import { SessionsTab } from '../../../src/components/you/SessionsTab';
 import { LogbookTab } from '../../../src/components/you/LogbookTab';
 import { SocialTab } from '../../../src/components/you/SocialTab';
+import { SCREENSHOT_MODE } from '../../../src/lib/screenshot-mode';
+
+// Screenshot mode selects the visible sub-tab via a `screenshotTab` deep-link
+// param so the logbook/sessions shots are deterministic.
+function isProfileTabKey(value: string | string[] | undefined): value is ProfileTabKey {
+  return value === 'progress' || value === 'sessions' || value === 'logbook' || value === 'social';
+}
 
 export default function YouScreen() {
   const { systemColors } = useTheme();
@@ -20,7 +28,17 @@ export default function YouScreen() {
   const youData = useYouProfileData(userId);
 
   const filterSheetRef = useRef<BottomSheet | null>(null);
-  const [activeTab, setActiveTab] = useState<ProfileTabKey>('progress');
+  const { screenshotTab } = useLocalSearchParams<{ screenshotTab?: string }>();
+  const [activeTab, setActiveTab] = useState<ProfileTabKey>(() =>
+    SCREENSHOT_MODE && isProfileTabKey(screenshotTab) ? screenshotTab : 'progress',
+  );
+  // The profile tab stays mounted across screenshot shots, so re-sync the visible
+  // sub-tab whenever the deep-link param changes (initial mount is covered by the
+  // useState initialiser). Inert in normal builds — manual tab taps own the state.
+  useEffect(() => {
+    if (!SCREENSHOT_MODE) return;
+    setActiveTab(isProfileTabKey(screenshotTab) ? screenshotTab : 'progress');
+  }, [screenshotTab]);
 
   // The measured chrome height insets each sub-tab's scroll content; seed it to
   // the safe-area top plus the islands row + segmented control so the first paint

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, RefreshControl, StyleSheet } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useRouter, useFocusEffect } from 'expo-router';
@@ -23,6 +23,7 @@ import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { SCREENSHOT_MODE } from '../../lib/screenshot-mode';
 
 type FeedRow = { type: 'header'; bucket: FeedRecencyBucket } | { type: 'session'; item: SessionFeedItem };
 type CommentTarget = { entityId: string; entityType: SocialEntityType };
@@ -168,6 +169,19 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
     },
     [router],
   );
+
+  // Screenshot mode: open the most recent session's detail once the feed lands,
+  // so the session-detail shot is deterministic (Maestro can't tap a session card
+  // on this iOS build). This tab only mounts via the `screenshotTab=sessions`
+  // deep-link param, so it never disturbs the default profile shot. Fires once.
+  const screenshotSessionOpenedRef = useRef(false);
+  useEffect(() => {
+    if (!SCREENSHOT_MODE || screenshotSessionOpenedRef.current) return;
+    const firstSession = sessions[0];
+    if (!firstSession) return;
+    screenshotSessionOpenedRef.current = true;
+    handleOpenSession(firstSession);
+  }, [sessions, handleOpenSession]);
 
   const handleEndReached = useCallback(() => {
     if (feed.hasNextPage && !feed.isFetchingNextPage) void feed.fetchNextPage();


### PR DESCRIPTION
The board-view (play-drawer) shot relied on a Maestro coordinate tap ('50%,26%') that mis-fired on the iOS Fabric build and re-captured the climb list, so store slots #2 and #3 rendered identical — and the lost shot is the single most-used feature (52 mobile DAU). Replace the tap with a SCREENSHOT_MODE deep-link param that auto-opens the first climb's board view.

Grow the set to the store maximums (iOS 10, Android 8), prioritising the highest-traffic screens not yet shown (PostHog): playlist detail (124 views/2wk), session detail (~57), and the logbook. New shots are driven by SCREENSHOT_MODE-gated deep-link params, since Maestro can't match RN views by id/text on this build:
- ://climbs?screenshotOpenFirst=1   -> first climb's board view
- ://profile?screenshotTab=logbook  -> Logbook tab
- ://profile?screenshotTab=sessions -> Sessions tab, auto-opens newest session
Playlist detail deep-links a stable smart-playlist route (no app code).

Drop the iOS board-switcher sheet shot to fit 10; Android keeps it and adds only session detail (8-shot cap). Every new branch dead-strips in normal builds. The live-party shot (iOS slot 03) lands in a follow-up that needs a backend screenshot-session fixture.