### PR TITLE
Fix Kilter BLE incompatible_climb: explicit preview, spill-skip, softer mismatch UX + diagnostics

### DIFF
--- a/packages/backend/src/__tests__/climb-queries.test.ts
+++ b/packages/backend/src/__tests__/climb-queries.test.ts
@@ -35,6 +35,14 @@ describe('Climb Query Functions', () => {
       expect(typeof result.hasMore).toBe('boolean');
       expect(result.totalCount).toBeDefined();
       expect(typeof result.totalCount).toBe('number');
+
+      // Each result carries the searched board + layout so a queued climb can be
+      // checked against a connected board (BLE spill guard). The search is scoped
+      // to testParams (kilter / layout 1) by its WHERE clause.
+      if (result.climbs.length > 0) {
+        expect(result.climbs[0].boardType).toBe('kilter');
+        expect(result.climbs[0].layoutId).toBe(1);
+      }
     });
 
     it('should enforce MAX_PAGE_SIZE limit', async () => {

--- a/packages/backend/src/__tests__/queue-sync-fixes.test.ts
+++ b/packages/backend/src/__tests__/queue-sync-fixes.test.ts
@@ -593,4 +593,32 @@ describe('setCurrentClimb - combined queue/current state publishing', () => {
       }),
     );
   });
+
+  it('round-trips boardType/layoutId through setCurrentClimb storage (party spill metadata)', async () => {
+    const sessionId = uuidv4();
+    const boardPath = '/tension/8/2/3/40';
+    await registerAndJoinSession('client-1', sessionId, boardPath, 'User1');
+
+    // A peer on tension / layout 8 sends a climb carrying its own board metadata.
+    const climb = createTestClimb();
+    climb.climb.boardType = 'tension';
+    climb.climb.layoutId = 8;
+
+    const ctx = {
+      connectionId: 'client-1',
+      sessionId,
+      rateLimitTokens: 60,
+      rateLimitLastReset: Date.now(),
+    };
+
+    await queueMutations.setCurrentClimb({}, { item: climb, shouldAddToQueue: true }, ctx);
+
+    // The stored state — what a FullSync / subscription serializes back to peers —
+    // must keep the metadata, so a peer on another board can skip the spill climb.
+    const state = await roomManager.getQueueState(sessionId);
+    expect(state.currentClimbQueueItem?.climb.boardType).toBe('tension');
+    expect(state.currentClimbQueueItem?.climb.layoutId).toBe(8);
+    expect(state.queue[0]?.climb.boardType).toBe('tension');
+    expect(state.queue[0]?.climb.layoutId).toBe(8);
+  });
 });

--- a/packages/backend/src/__tests__/search-climbs-frames.test.ts
+++ b/packages/backend/src/__tests__/search-climbs-frames.test.ts
@@ -102,3 +102,22 @@ describe('searchClimbs surfaces frames_count/frames_pace (issue #2690)', () => {
     expect(result.climbs[0].framesPace).toBe(1200);
   });
 });
+
+describe('searchClimbs stamps boardType/layoutId from the searched board', () => {
+  beforeEach(() => {
+    mockDb.select.mockReset();
+  });
+
+  // The search WHERE filters on board + layout, so every row belongs to the
+  // searched board. mapResultToClimbRow stamps them from params (like angle) so
+  // queued climbs carry the board metadata the BLE spill guard reads.
+  it('carries the route board/layout onto each result climb', async () => {
+    mockDb.select.mockReturnValue(makeChain([rawRow('c1'), rawRow('c2')]));
+
+    const searchParams: ClimbSearchParams = { page: 0, pageSize: 1 };
+    const result = await searchClimbs(params, searchParams);
+
+    expect(result.climbs[0].boardType).toBe('kilter');
+    expect(result.climbs[0].layoutId).toBe(1);
+  });
+});

--- a/packages/backend/src/db/queries/climbs/get-climb.ts
+++ b/packages/backend/src/db/queries/climbs/get-climb.ts
@@ -67,6 +67,10 @@ export const getClimbByUuid = async (params: GetClimbParams): Promise<Climb | nu
       name: row.name || '',
       description: row.description || '',
       frames: row.frames || '',
+      // Scoped by the WHERE clause to this board + layout — carry them so the
+      // queue's BLE spill guard can tell a climb set for another board apart.
+      boardType: params.board_name,
+      layoutId: params.layout_id,
       angle: Number(params.angle),
       ascensionist_count: Number(row.ascensionist_count || 0),
       difficulty: getGradeLabel(row.difficulty_id),

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -13,6 +13,11 @@ const MAX_HOLD_FILTER_ENTRIES = 300;
  */
 export const ClimbInputSchema = z.object({
   uuid: ExternalUUIDSchema,
+  // Board the climb belongs to. Round-tripped through the queue so a connected
+  // board can skip a climb set for a different board/layout. Nullish: older
+  // clients and pre-metadata queue items omit it.
+  boardType: z.string().max(50).nullish(),
+  layoutId: z.number().int().positive().nullish(),
   setter_username: z
     .string()
     .max(100)

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -47,6 +47,11 @@ function mapResultToClimbRow(result: RawSelectResult, params: BoardRouteParams):
     userId: result.userId ?? null,
     name: result.name || '',
     frames: result.frames || '',
+    // The search is scoped to one board + layout (the WHERE filter), so every
+    // row belongs to it — stamp from the route params like `angle`. Lets the
+    // queue's BLE spill guard tell a climb set for another board apart.
+    boardType: params.board_name,
+    layoutId: params.layout_id,
     angle: params.angle,
     ascensionist_count: Number(result.ascensionist_count || 0),
     difficulty: getGradeLabel(toIntegerOrNull(result.difficulty_id)),

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -182,6 +182,10 @@ export type ClimbRow = {
   name: string;
   description: string;
   frames: string;
+  /** Board the climb belongs to (the searched board). Carried so the queue's BLE
+   *  spill guard can skip a climb set for a different board/layout. */
+  boardType: string;
+  layoutId: number;
   angle: number;
   ascensionist_count: number;
   difficulty: string;

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -21,6 +21,7 @@ import { BoardRenderUnavailable } from './BoardRenderUnavailable';
 import { PlaybackControls } from './PlaybackControls';
 import { useMobilePlayback } from './use-mobile-playback';
 import { PlayDrawerHeader } from './PlayDrawerHeader';
+import { PlayDrawerPreviewBanner } from './PlayDrawerPreviewBanner';
 import { PlayDrawerActionBar } from './PlayDrawerActionBar';
 import { SwitchBoardOverlay } from './SwitchBoardOverlay';
 import { LogAscentSheet } from '../LogAscentSheet';
@@ -61,26 +62,28 @@ type BoardConfig = {
 
 export type PlayDrawerOpenOptions = {
   /**
-   * When `true` (default), the opened climb is dispatched through
-   * `setCurrentClimb`, which both makes it the active climb and appends
-   * it to the queue. Pass `false` when the drawer is being opened for a
-   * climb that's already current (e.g. from the persistent queue bar),
-   * to avoid duplicating that climb at the end of the queue — the queue
-   * item wrapper carries a fresh uuid, so the reducer's idempotency
-   * guards key off uuid and don't catch the duplicate.
+   * The caller already dispatched `setCurrentClimb` for this climb (the
+   * drawer-host queue / suggestion / board-sheet taps and playlist activation
+   * do this). The drawer renders from `currentClimbQueueItem` and skips its own
+   * commit so the item isn't dispatched twice. No Preview badge — the shown
+   * climb IS the active climb.
    */
-  setAsCurrent?: boolean;
+  committedExternally?: boolean;
   /**
-   * Playlist source that seeds the drawer's next/previous suggestions when a
-   * climb is opened with `setAsCurrent: false` (the suggestion source the
-   * activation builds isn't on the queue yet). Drives swipe-through-playlist in
-   * the drawer without re-dispatching.
+   * View-only preview: show this item in the drawer WITHOUT committing it to the
+   * queue. The drawer renders a "Preview" badge + a "Set active" button so the
+   * user can promote it. Used by genuinely view-only surfaces — the workout
+   * builder, logbook / feed / climb-view browse, and the peer-driven wall climb
+   * behind the accessory bar. The lightbulb keeps acting on the active climb,
+   * not this preview.
    */
-  previewPlaylistSuggestionSource?: PlaylistSuggestionSource | null;
-  /** Queue item to display as the drawer's navigation anchor without
-   * re-dispatching it (used with `setAsCurrent: false` so prev/next anchor on
-   * the right queue entry). */
   previewQueueItem?: ClimbQueueItem | null;
+  /**
+   * Playlist source that seeds the drawer's next/previous suggestions for a
+   * preview open (the suggestion source isn't on the queue yet). Drives
+   * swipe-through-playlist in the drawer without re-dispatching.
+   */
+  playlistSuggestionSource?: PlaylistSuggestionSource | null;
 };
 
 export type PlayDrawerHandle = {
@@ -189,6 +192,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const displayedQueueItem = drawerPreviewItem ?? state.currentClimbQueueItem;
   const displayedClimb = displayedQueueItem?.climb;
+  // A view-only preview is showing (not the active/wall climb). Commit paths
+  // never set `drawerPreviewItem`, so this is true only for genuine previews
+  // (workout builder, logbook/cross-board, the peer-driven accessory wall climb).
+  const isPreview = drawerPreviewItem != null;
 
   // Real favorite status for the heart, keyed on (boardName, climbUuid, angle).
   // Gated on the sheet being open so it doesn't fetch while the drawer is closed.
@@ -280,18 +287,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const openDrawer = useCallback(
     (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
-      const previewPlaylistSuggestionSource = options?.previewPlaylistSuggestionSource ?? null;
-      const shouldShowCurrentQueueItem =
-        options?.setAsCurrent === false &&
-        options.previewQueueItem == null &&
-        previewPlaylistSuggestionSource === null &&
-        state.currentClimbQueueItem?.climb.uuid === selectedClimb.uuid;
-      const selectedItem = shouldShowCurrentQueueItem
-        ? null
-        : (options?.previewQueueItem ??
-          climbToQueueItem(selectedClimb, { suggested: previewPlaylistSuggestionSource !== null }));
-      setDrawerPreviewSuggestionSource(previewPlaylistSuggestionSource);
-      setDrawerPreviewItem(selectedItem);
+      const previewItem = options?.previewQueueItem ?? null;
+      const playlistSuggestionSource = options?.playlistSuggestionSource ?? null;
+      // A view-only preview is shown without committing; the badge keys off this.
+      // Commit paths (committedExternally) and fresh active opens leave it null so
+      // the drawer renders the real currentClimbQueueItem.
+      setDrawerPreviewItem(previewItem);
+      setDrawerPreviewSuggestionSource(previewItem ? playlistSuggestionSource : null);
       setIsMirrored(false);
       // Drop any stale optimistic heart so the opened climb shows its real
       // (server) favorite status rather than a leftover from the last climb.
@@ -299,10 +301,15 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       setIsTickBarActive(false);
       setIsSheetOpen(true);
       setActiveSubDrawer('none');
-      if (selectedItem && (options?.setAsCurrent ?? true)) {
-        // Fresh activation from the list/search clears any playlist suggestion
-        // source (web passes the same null option on every non-playlist set).
-        setCurrentClimb(selectedItem, { playlistSuggestionSource: null });
+      if (!previewItem && !options?.committedExternally) {
+        // Fresh active open (search / list / LogbookTab / accessory-of-current):
+        // make it current unless it already is, so re-opening the current climb
+        // doesn't re-append it. A fresh-uuid item on a genuinely new selection is
+        // intentional (re-tapping starts a fresh pass — see queue setCurrentClimb).
+        const isAlreadyCurrent = state.currentClimbQueueItem?.climb.uuid === selectedClimb.uuid;
+        if (!isAlreadyCurrent) {
+          setCurrentClimb(climbToQueueItem(selectedClimb), { playlistSuggestionSource: null });
+        }
       }
       sheetRef.current?.present();
     },
@@ -367,6 +374,16 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setIsMirrored(false);
     // The favorite override is cleared by the climb-change effect.
   }, [nextClimb]);
+
+  // Promote the previewed climb to the active/current queue item. The Preview
+  // badge clears and the lightbulb (which acts on the current climb) now drives
+  // this climb.
+  const handleSetActive = useCallback(() => {
+    if (!drawerPreviewItem) return;
+    setCurrentClimb(drawerPreviewItem, { playlistSuggestionSource: drawerPreviewSuggestionSource });
+    setDrawerPreviewItem(null);
+    setDrawerPreviewSuggestionSource(null);
+  }, [drawerPreviewItem, drawerPreviewSuggestionSource, setCurrentClimb]);
 
   const handleMirror = useCallback(() => {
     const nextMirrored = !isMirrored;
@@ -495,7 +512,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const handleSimilarClimbPress = useCallback(
     (similarClimb: Climb) => {
       const queueItem = climbToQueueItem(similarClimb);
-      setDrawerPreviewItem(queueItem);
+      // Tapping a similar climb activates it (commit), so it's never a preview —
+      // clear any preview that was showing.
+      setDrawerPreviewItem(null);
       setDrawerPreviewSuggestionSource(null);
       setIsMirrored(false);
       // The favorite override is cleared by the climb-change effect.
@@ -584,6 +603,13 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                   isNoMatch={displayedClimb.is_no_match}
                   benchmarkDifficulty={displayedClimb.benchmark_difficulty}
                 />
+
+                {isPreview ? (
+                  // Cross-board previews use the switch-board overlay instead, so
+                  // hide "Set active" there — promoting a foreign-board climb would
+                  // only spill it into the queue.
+                  <PlayDrawerPreviewBanner showSetActive={!boardMismatch} onSetActive={handleSetActive} />
+                ) : null}
 
                 <View style={styles.boardSection}>
                   {boardRenderData ? (

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPreviewBanner.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPreviewBanner.tsx
@@ -1,0 +1,82 @@
+import { memo } from 'react';
+import { StyleSheet, View, Pressable } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+type PlayDrawerPreviewBannerProps = {
+  /** Whether to show the "Set active" affordance. Hidden when the climb is on a
+   *  board the user isn't on (the switch-board overlay is the right action there). */
+  showSetActive: boolean;
+  /** Promote the previewed climb to the current queue item. */
+  onSetActive: () => void;
+};
+
+/**
+ * Banner shown in the play drawer when the displayed climb is a *preview* — a
+ * climb the user is browsing (workout builder, logbook/cross-board, the
+ * peer-driven wall climb) that is NOT their active/wall climb. The lightbulb acts
+ * on the active climb, not this preview, so the banner makes that explicit and
+ * offers a one-tap "Set active" to promote it.
+ */
+export const PlayDrawerPreviewBanner = memo(function PlayDrawerPreviewBanner({
+  showSetActive,
+  onSetActive,
+}: PlayDrawerPreviewBannerProps) {
+  const { t } = useTranslation('session');
+  const { systemColors } = useTheme();
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.chip}>
+        <Text variant="caption1" color={iosSystemColors.white} style={styles.chipLabel}>
+          {t('playView.previewBadge')}
+        </Text>
+      </View>
+      {showSetActive ? (
+        <Pressable
+          onPress={onSetActive}
+          accessibilityRole="button"
+          accessibilityLabel={t('playView.setActive')}
+          hitSlop={8}
+          style={styles.setActive}
+        >
+          <Text variant="subheadline" color={systemColors.accent} style={styles.setActiveLabel}>
+            {t('playView.setActive')}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginHorizontal: spacing[4],
+    marginTop: spacing[1],
+    marginBottom: spacing[2],
+  },
+  chip: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[1] / 2,
+    borderRadius: borderRadius.sm,
+    backgroundColor: iosSystemColors.systemOrange,
+  },
+  chipLabel: {
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  setActive: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[1],
+  },
+  setActiveLabel: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-preview-banner.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-preview-banner.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type PressableMockProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress, accessibilityLabel }: PressableMockProps) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// t echoes the key so the badge + button copy is assertable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { accent: '#007AFF' } }),
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { white: '#FFFFFF', systemOrange: '#FF9500' },
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 4: 16 },
+  borderRadius: { sm: 4 },
+}));
+
+import { PlayDrawerPreviewBanner } from '../PlayDrawerPreviewBanner';
+
+describe('PlayDrawerPreviewBanner', () => {
+  it('renders the Preview badge and a Set active button', () => {
+    const { container } = render(createElement(PlayDrawerPreviewBanner, { showSetActive: true, onSetActive: vi.fn() }));
+    expect(container.textContent).toContain('playView.previewBadge');
+    expect(container.querySelector('button')).toBeTruthy();
+    expect(container.textContent).toContain('playView.setActive');
+  });
+
+  it('promotes the climb when Set active is pressed', () => {
+    const onSetActive = vi.fn();
+    const { container } = render(createElement(PlayDrawerPreviewBanner, { showSetActive: true, onSetActive }));
+    (container.querySelector('button') as HTMLButtonElement).click();
+    expect(onSetActive).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides Set active when showSetActive is false (cross-board uses the switch-board overlay)', () => {
+    const { container } = render(
+      createElement(PlayDrawerPreviewBanner, { showSetActive: false, onSetActive: vi.fn() }),
+    );
+    expect(container.textContent).toContain('playView.previewBadge');
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -72,6 +72,10 @@ vi.mock('react-native-gesture-handler', () => {
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
+// useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
+// pulls expo-crypto's randomUUID — stub it so the native module isn't loaded.
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
 // getGradeColor returns a distinct hue for V6 so we can assert the grade text
 // carries the grade colour (not a generic white-on-pill style).
 vi.mock('@boardsesh/board-constants/grade-colors', () => ({
@@ -249,11 +253,10 @@ describe('ClimbCapsule', () => {
     expect(container.querySelector('[data-glass]')?.getAttribute('data-tint')).toBe('');
   });
 
-  it('wires openPlayDrawer with setAsCurrent:false (drawer-open behavior; tap worklet not driven in jsdom)', () => {
-    // We cannot fire the RNGH Tap worklet under jsdom, so reach the wired
-    // callback directly by spying on Gesture.Tap().onEnd's handler is not
-    // exposed; instead assert the render path is healthy and that the only
-    // openPlayDrawer call shape the component can make carries setAsCurrent:false.
+  it('wires openPlayDrawer for tap-to-open (drawer-open behavior; tap worklet not driven in jsdom)', () => {
+    // We cannot fire the RNGH Tap worklet under jsdom, so the wired callback can't
+    // be reached here; instead assert the render path is healthy and that no
+    // openPlayDrawer call fires without a tap.
     const item = makeItem(makeClimb());
     queue.state.currentClimbQueueItem = item;
     queue.state.queue = [item];

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -32,6 +32,10 @@ function styleDataValue(styleValue: unknown): string {
   return JSON.stringify(styleValue);
 }
 
+// useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
+// pulls expo-crypto's randomUUID — stub it so the native module isn't loaded.
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   PlatformColor: (name: string) => name,

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -16,6 +16,10 @@ const cfg = vi.hoisted(() => ({
   nativeTabBar: false,
 }));
 
+// useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
+// pulls expo-crypto's randomUUID — stub it so the native module isn't loaded.
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),

--- a/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
@@ -31,6 +31,8 @@ vi.mock('../use-wall-or-queue-climb', () => ({
 
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
 vi.mock('react-native-reanimated', () => ({
   runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
 }));
@@ -82,20 +84,23 @@ describe('useAccessoryClimbTap', () => {
     expect(result.current.currentItem?.uuid).toBe('head');
   });
 
-  it('opens the local queue head on tap (setAsCurrent false)', () => {
+  it('opens the local queue head active on tap (it already is current)', () => {
     renderHook(() => useAccessoryClimbTap());
     tap.onEnd?.();
+    // The bar shows the current climb, so it opens active — no preview.
     expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-head' }), {
-      setAsCurrent: false,
+      source: 'current_queue_item',
     });
   });
 
-  it('opens the wall climb on tap when a board feed is live', () => {
+  it('opens a peer-driven wall climb as a preview when a board feed is live', () => {
     wall.climb = makeClimb('wall');
     renderHook(() => useAccessoryClimbTap());
     tap.onEnd?.();
+    // The wall climb isn't the local current, so it opens view-only (badged).
     expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-wall' }), {
-      setAsCurrent: false,
+      previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-wall' }) }),
+      source: 'current_queue_item',
     });
   });
 

--- a/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
@@ -4,6 +4,7 @@ import { runOnJS } from 'react-native-reanimated';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useQueue } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import { hapticLight } from '../../lib/haptics';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 
@@ -29,15 +30,27 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
   // Open whatever the accessory is showing: the wall's lit climb when a feed is
   // live, else the local queue head — useWallOrQueueCurrentClimb already folds the
   // local head in as its fallback, so this is the single source of truth for the
-  // open target. setAsCurrent stays false so opening the head doesn't duplicate it
-  // at the end of the queue.
+  // open target.
   const accessoryClimb = useWallOrQueueCurrentClimb(currentClimbQueueItem?.climb ?? null);
 
   const handleOpenPlay = useCallback(() => {
     if (!accessoryClimb) return;
     hapticLight();
-    openPlayDrawer(accessoryClimb, { setAsCurrent: false });
-  }, [openPlayDrawer, accessoryClimb]);
+    // When the bar mirrors the local queue head, open it active (it already IS
+    // current, so openDrawer won't re-append it). When a live feed makes the bar
+    // show a peer-driven WALL climb that isn't your current, open it as a
+    // view-only preview (badged) — you're looking at someone else's wall, not
+    // taking it over until you choose to. Both are queue-bar opens, so keep the
+    // `current_queue_item` analytics source.
+    if (accessoryClimb.uuid === currentClimbQueueItem?.climb.uuid) {
+      openPlayDrawer(accessoryClimb, { source: 'current_queue_item' });
+    } else {
+      openPlayDrawer(accessoryClimb, {
+        previewQueueItem: climbToQueueItem(accessoryClimb),
+        source: 'current_queue_item',
+      });
+    }
+  }, [openPlayDrawer, accessoryClimb, currentClimbQueueItem]);
 
   const openGesture = useMemo(
     () =>

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -149,7 +149,7 @@ export function PreSessionView({ showChrome = false }: PreSessionViewProps) {
   const handlePreviewPress = useCallback(
     (item: ClimbQueueItem) => {
       setActivePreviewUuid(item.uuid);
-      openPlayDrawer(item.climb as Climb, { setAsCurrent: false, previewQueueItem: item });
+      openPlayDrawer(item.climb as Climb, { previewQueueItem: item });
     },
     [openPlayDrawer],
   );

--- a/packages/mobile/src/components/you/__tests__/sessions-tab-clock.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/sessions-tab-clock.test.tsx
@@ -50,6 +50,10 @@ const feed = vi.hoisted(() => ({
   fetchNextPage: vi.fn(),
 }));
 
+// openClimbInPlayDrawer builds a preview queue item via climbToQueueItem, which
+// pulls expo-crypto's randomUUID — stub it so the native module isn't loaded.
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   // Expose onRefresh so the test can fire a pull-to-refresh without a real list.

--- a/packages/mobile/src/lib/__tests__/open-climb-in-play-drawer.test.ts
+++ b/packages/mobile/src/lib/__tests__/open-climb-in-play-drawer.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Climb } from '@boardsesh/shared-schema';
 
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
 vi.mock('../playlists/board-details-for-playlist', () => ({
   getBoardConfigForPlaylist: vi.fn(),
 }));
@@ -40,30 +42,42 @@ beforeEach(() => {
 });
 
 describe('openClimbInPlayDrawer', () => {
-  it('kind:climb opens the drawer directly with the given board config, tagged as a climb-view', () => {
+  it('kind:climb opens the drawer as a view-only preview with the given board config, tagged as a climb-view', () => {
     const deps = makeDeps();
     const climb = { uuid: 'c-1', name: 'X' } as Climb;
     const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 40 };
+    // Default (setAsCurrent omitted) is a view-only preview.
     openClimbInPlayDrawer({ kind: 'climb', climb, boardConfig }, deps);
     expect(deps.openPlayDrawer).toHaveBeenCalledWith(climb, {
-      setAsCurrent: false,
+      previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'c-1' }) }),
       boardConfig,
       source: 'climb_view',
     });
     expect(deps.router.push).not.toHaveBeenCalled();
   });
 
-  it('kind:tick with frames opens the drawer with a resolved board config (no route push)', () => {
+  it('kind:climb with setAsCurrent opens active (no preview)', () => {
+    const deps = makeDeps();
+    const climb = { uuid: 'c-1', name: 'X' } as Climb;
+    const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 40 };
+    openClimbInPlayDrawer({ kind: 'climb', climb, boardConfig }, deps, { setAsCurrent: true });
+    expect(deps.openPlayDrawer).toHaveBeenCalledWith(climb, {
+      boardConfig,
+      source: 'climb_view',
+    });
+  });
+
+  it('kind:tick with frames opens a view-only preview with a resolved board config (no route push)', () => {
     mockedGetBoardConfig.mockReturnValue(KILTER_CONFIG);
     const deps = makeDeps();
     openClimbInPlayDrawer({ kind: 'tick', tick: makeTick({ angle: 50 }) }, deps);
     expect(deps.openPlayDrawer).toHaveBeenCalledTimes(1);
     const [, options] = deps.openPlayDrawer.mock.calls[0];
-    expect(options).toEqual({
-      setAsCurrent: false,
+    expect(options).toMatchObject({
       boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 50 },
       source: 'climb_view',
     });
+    expect(options.previewQueueItem?.climb?.uuid).toBe('climb-1');
     expect(deps.router.push).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-conversion.test.ts
@@ -23,6 +23,8 @@ function makeSubscriptionItem(overrides: Partial<SubscriptionQueueItem['climb']>
       stars: 3,
       difficulty_error: '0.5',
       benchmark_difficulty: null,
+      boardType: 'kilter',
+      layoutId: 1,
       mirrored: true,
       is_no_match: true,
       framesCount: 4,
@@ -57,5 +59,20 @@ describe('toClimbQueueItem (SEED-2 fields)', () => {
     expect(result.climb.is_no_match).toBeNull();
     expect(result.climb.framesCount).toBeNull();
     expect(result.climb.framesPace).toBeNull();
+  });
+
+  it('carries boardType/layoutId so a peer-synced spill climb can be skipped on another board', () => {
+    const result = toClimbQueueItem(makeSubscriptionItem({ boardType: 'tension', layoutId: 8 }));
+
+    expect(result.climb.boardType).toBe('tension');
+    expect(result.climb.layoutId).toBe(8);
+  });
+
+  it('leaves board metadata undefined when a pre-metadata peer omits it (treated as sendable)', () => {
+    const result = toClimbQueueItem(makeSubscriptionItem({ boardType: undefined, layoutId: undefined }));
+
+    expect(result.climb.boardType).toBeUndefined();
+    // layoutId falls through as undefined; the spill guard reads nullish as "unknown".
+    expect(result.climb.layoutId).toBeUndefined();
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/board-config-match.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/board-config-match.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import type { UserBoard } from '@boardsesh/shared-schema';
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { ResolvedBoardEntry } from '../resolve-serials';
-import { configFromResolvedEntry, decideBlePickerSelection, type BleBoardConfig } from '../board-config-match';
+import {
+  configFromResolvedEntry,
+  decideBlePickerSelection,
+  classifyClimbBoardCompatibility,
+  findNextCompatibleQueueItem,
+  type BleBoardConfig,
+} from '../board-config-match';
 
 function makeCurrentConfig(overrides: Partial<BleBoardConfig> = {}): BleBoardConfig {
   return {
@@ -150,5 +157,121 @@ describe('decideBlePickerSelection', () => {
     expect(decision.entry.kind).toBe('recorded');
     if (decision.entry.kind !== 'recorded') throw new Error('expected recorded entry');
     expect(decision.entry.config.boardUuid).toBe('recorded-board-uuid');
+  });
+});
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'climb-1',
+    name: 'Climb',
+    frames: 'p1r12',
+    setter_username: 'setter',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: 'V3',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0.3',
+    benchmark_difficulty: null,
+    ...overrides,
+  };
+}
+
+function makeItem(uuid: string, climb: Partial<Climb> = {}): ClimbQueueItem {
+  return { uuid, climb: makeClimb({ uuid: `c-${uuid}`, ...climb }) };
+}
+
+const KILTER_L1: BleBoardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20' };
+
+describe('classifyClimbBoardCompatibility', () => {
+  it('returns unknown when the active config is missing', () => {
+    expect(classifyClimbBoardCompatibility(undefined, makeClimb({ boardType: 'kilter', layoutId: 1 }))).toBe('unknown');
+  });
+
+  it('returns unknown when the climb carries no board metadata', () => {
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: undefined, layoutId: undefined }))).toBe(
+      'unknown',
+    );
+  });
+
+  it('returns compatible when known boardType and layoutId match', () => {
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: 'kilter', layoutId: 1 }))).toBe(
+      'compatible',
+    );
+  });
+
+  it('returns incompatible on a different boardType', () => {
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: 'tension', layoutId: 1 }))).toBe(
+      'incompatible',
+    );
+  });
+
+  it('returns incompatible on a different layoutId', () => {
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: 'kilter', layoutId: 8 }))).toBe(
+      'incompatible',
+    );
+  });
+
+  it('falls through to the layout check when boardType is unrecognised', () => {
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: 'mystery', layoutId: 1 }))).toBe(
+      'compatible',
+    );
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: 'mystery', layoutId: 8 }))).toBe(
+      'incompatible',
+    );
+  });
+
+  it('judges on layout alone when only layoutId is known', () => {
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: undefined, layoutId: 1 }))).toBe(
+      'compatible',
+    );
+    expect(classifyClimbBoardCompatibility(KILTER_L1, makeClimb({ boardType: undefined, layoutId: 8 }))).toBe(
+      'incompatible',
+    );
+  });
+});
+
+describe('findNextCompatibleQueueItem', () => {
+  it('skips a run of spill climbs and returns the next compatible one with the count', () => {
+    const queue = [
+      makeItem('q0', { boardType: 'kilter', layoutId: 1 }), // current, incompatible? no — compatible
+      makeItem('q1', { boardType: 'tension', layoutId: 1 }), // spill
+      makeItem('q2', { boardType: 'kilter', layoutId: 8 }), // spill (layout)
+      makeItem('q3', { boardType: 'kilter', layoutId: 1 }), // compatible
+    ];
+    // Start at the spill at q1.
+    const result = findNextCompatibleQueueItem(queue, 'q1', KILTER_L1);
+    expect(result.item?.uuid).toBe('q3');
+    expect(result.skippedCount).toBe(2);
+  });
+
+  it('returns the current item with skippedCount 0 when it is already compatible', () => {
+    const queue = [
+      makeItem('q0', { boardType: 'kilter', layoutId: 1 }),
+      makeItem('q1', { boardType: 'kilter', layoutId: 1 }),
+    ];
+    const result = findNextCompatibleQueueItem(queue, 'q0', KILTER_L1);
+    expect(result.item?.uuid).toBe('q0');
+    expect(result.skippedCount).toBe(0);
+  });
+
+  it('returns null when every remaining climb is incompatible', () => {
+    const queue = [
+      makeItem('q0', { boardType: 'tension', layoutId: 1 }),
+      makeItem('q1', { boardType: 'kilter', layoutId: 8 }),
+    ];
+    const result = findNextCompatibleQueueItem(queue, 'q0', KILTER_L1);
+    expect(result.item).toBeNull();
+    expect(result.skippedCount).toBe(2);
+  });
+
+  it('treats unknown-metadata climbs as sendable (not skipped)', () => {
+    const queue = [
+      makeItem('q0', { boardType: 'tension', layoutId: 1 }), // spill
+      makeItem('q1', { boardType: undefined, layoutId: undefined }), // unknown → stop here
+    ];
+    const result = findNextCompatibleQueueItem(queue, 'q0', KILTER_L1);
+    expect(result.item?.uuid).toBe('q1');
+    expect(result.skippedCount).toBe(1);
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -328,7 +328,7 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(sendResult).toBe(false);
-    expect(Alert.alert).toHaveBeenCalledWith('ble.notAvailable', 'ble.errorIncompatible');
+    expect(Alert.alert).toHaveBeenCalledWith('ble.sendFailedTitle', 'ble.errorIncompatible');
     // The board must never receive the original (un-mirrored) frames.
     expect(fakeAdapter.write).not.toHaveBeenCalled();
     const failureCall = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -475,6 +475,77 @@ describe('useBoardBluetooth', () => {
     expect(result.current.isConnected).toBe(false);
   });
 
+  it('tracks incompatible_climb with skip counts and the provided send context', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    mockGetLedPlacements.mockReturnValue({ 100: 7 });
+    // Empty packet + skipped placements = every placement was dropped → incompatible.
+    mockGetAuroraBluetoothPacket.mockReturnValue({
+      packet: new Uint8Array([]),
+      skippedPositionCount: 3,
+      skippedRoleCount: 1,
+      totalPlacements: 4,
+    });
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 1,
+        getConnectedViaMismatchOverride: () => true,
+      }),
+    );
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let sendResult: boolean | undefined;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p100r12', false, undefined, {
+        sendSource: 'auto',
+        targetQueueItemUuid: 'q-1',
+        climbUuid: 'c-1',
+        climbBoardType: 'tension',
+        climbLayoutId: 1,
+      });
+    });
+
+    expect(sendResult).toBe(false);
+    expect(Alert.alert).toHaveBeenCalledWith('ble.sendFailedTitle', 'ble.errorIncompatible');
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Climb Sent to Board Failure');
+    expect(failure?.[1]).toMatchObject({
+      failureReason: 'incompatible_climb',
+      skippedPositionCount: 3,
+      skippedRoleCount: 1,
+      totalPlacements: 4,
+      sendSource: 'auto',
+      targetQueueItemUuid: 'q-1',
+      climbUuid: 'c-1',
+      climbBoardType: 'tension',
+      climbLayoutId: 1,
+      connectedViaMismatchOverride: true,
+    });
+  });
+
+  it('attaches connectedViaMismatchOverride to the connection-success event', async () => {
+    const fakeAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, getConnectedViaMismatchOverride: () => true }),
+    );
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const successCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
+    expect(successCall?.[1]).toMatchObject({ connectedViaMismatchOverride: true });
+  });
+
   it('emits apiLevel and deviceNamePresent on the connection-success event', async () => {
     const fakeAdapter = makeFakeAdapter({
       requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'dev-1', deviceName: 'Kilter A1#0042@3' }),

--- a/packages/mobile/src/lib/ble/board-config-match.ts
+++ b/packages/mobile/src/lib/ble/board-config-match.ts
@@ -1,6 +1,7 @@
 import { normaliseSetIds, toBoardName } from '@boardsesh/board-config';
 import { parseSerialNumber } from '@boardsesh/ble-protocol';
 import type { BoardName } from '@boardsesh/shared-schema';
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import type { DiscoveredDevice } from './types';
 import type { ResolvedBoardEntry } from './resolve-serials';
 
@@ -48,6 +49,64 @@ export function matchesBleBoardConfig(config: BleBoardConfig, currentConfig: Ble
     config.sizeId === currentConfig.sizeId &&
     normaliseSetIds(config.setIds) === normaliseSetIds(currentConfig.setIds)
   );
+}
+
+export type ClimbBoardCompatibility = 'compatible' | 'incompatible' | 'unknown';
+
+/** The active-board fields needed to judge whether a climb belongs to this board. */
+export type ActiveBoardForCompatibility = Pick<BleBoardConfig, 'boardName' | 'layoutId'>;
+
+/**
+ * Decide whether a queued climb can be lit on the connected board.
+ *
+ * - `unknown` — the climb carries no board metadata (older items, or party-synced
+ *   items from before the metadata round-trip). Never block on this; send as today.
+ * - `incompatible` — a KNOWN `boardType` or `layoutId` clearly differs from the
+ *   active board. A "spill" climb (party peer on another board, or a queue left
+ *   over from a board switch) — skip it instead of dark-firing the wall.
+ * - `compatible` — the known metadata matches the active board.
+ *
+ * An unrecognised `boardType` string is treated as no board signal (we can't
+ * judge it), falling through to the layout check.
+ */
+export function classifyClimbBoardCompatibility(
+  activeConfig: ActiveBoardForCompatibility | undefined,
+  climb: Pick<Climb, 'boardType' | 'layoutId'>,
+): ClimbBoardCompatibility {
+  if (!activeConfig) return 'unknown';
+  const climbBoardName = climb.boardType ? toBoardName(climb.boardType) : undefined;
+  const hasLayoutSignal = climb.layoutId != null;
+  if (climbBoardName == null && !hasLayoutSignal) return 'unknown';
+  if (climbBoardName != null && climbBoardName !== activeConfig.boardName) return 'incompatible';
+  if (hasLayoutSignal && climb.layoutId !== activeConfig.layoutId) return 'incompatible';
+  return 'compatible';
+}
+
+/**
+ * Scan the queue forward from the current item for the first climb that isn't
+ * `incompatible` with the active board, returning it plus how many incompatible
+ * climbs were skipped to reach it (the current item counts as skipped when it is
+ * itself incompatible). Returns `{ item: null }` when every remaining climb is
+ * incompatible. When `activeConfig` is unknown, nothing is incompatible, so the
+ * current item is returned with `skippedCount: 0`.
+ */
+export function findNextCompatibleQueueItem(
+  queue: ReadonlyArray<ClimbQueueItem>,
+  currentUuid: string | null,
+  activeConfig: ActiveBoardForCompatibility | undefined,
+): { item: ClimbQueueItem | null; skippedCount: number } {
+  const foundIndex = currentUuid ? queue.findIndex((entry) => entry.uuid === currentUuid) : -1;
+  const startIndex = foundIndex >= 0 ? foundIndex : 0;
+  let skippedCount = 0;
+  for (let index = startIndex; index < queue.length; index++) {
+    const item = queue[index];
+    if (classifyClimbBoardCompatibility(activeConfig, item.climb) === 'incompatible') {
+      skippedCount++;
+      continue;
+    }
+    return { item, skippedCount };
+  }
+  return { item: null, skippedCount };
 }
 
 export function decideBlePickerSelection({

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -149,6 +149,28 @@ export const convertToMirroredFramesString = (frames: string, holdsData: HoldPla
     .join('');
 };
 
+/**
+ * Diagnostic context attached to Climb Sent to Board Success/Failure so PostHog
+ * can tell WHAT was sent and WHY apart. Optional — callers that don't have it
+ * (e.g. a manual mirror re-send) just omit it.
+ */
+export type BleSendContext = {
+  /** Where the send came from: the queue auto-sender, an undo, or a clear. */
+  sendSource: 'auto' | 'undo' | 'clear';
+  targetQueueItemUuid?: string;
+  climbUuid?: string;
+  /** The climb's own board metadata, when known — lets a board/climb mismatch be seen. */
+  climbBoardType?: string;
+  climbLayoutId?: number | null;
+};
+
+export type SendFramesToBoard = (
+  frames: string,
+  mirrored?: boolean,
+  signal?: AbortSignal,
+  sendContext?: BleSendContext,
+) => Promise<boolean | undefined>;
+
 type UseBoardBluetoothOptions = {
   boardName?: string;
   layoutId?: number;
@@ -162,6 +184,9 @@ type UseBoardBluetoothOptions = {
   analyticsBoardId?: number | null;
   onConnectionChange?: (connected: boolean) => void;
   onConnectSuccess?: (serial: string | null) => void;
+  /** Reads whether this connection was made via the mismatch "Connect anyway"
+   *  override, attached to connection + send analytics. */
+  getConnectedViaMismatchOverride?: () => boolean;
 };
 
 const KEEP_AWAKE_TAG = 'boardsesh-ble';
@@ -216,6 +241,7 @@ export function useBoardBluetooth({
   analyticsBoardId,
   onConnectionChange,
   onConnectSuccess,
+  getConnectedViaMismatchOverride,
 }: UseBoardBluetoothOptions) {
   const { t } = useTranslation('settings');
   // Connect-failure copy lives in the shared `common.bluetooth.*` keys so web
@@ -359,7 +385,7 @@ export function useBoardBluetooth({
   }, [clearConnectionAfterDrop]);
 
   const sendFramesToBoard = useCallback(
-    async (frames: string, mirrored: boolean = false, signal?: AbortSignal) => {
+    async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
       if (!adapterRef.current || !boardName || layoutId === undefined || sizeId === undefined) return;
       const boardAnalyticsProperties = {
         boardName,
@@ -367,6 +393,8 @@ export function useBoardBluetooth({
         sizeId,
         mirrored,
         boardId: analyticsBoardId ?? undefined,
+        connectedViaMismatchOverride: getConnectedViaMismatchOverride?.() ?? false,
+        ...sendContext,
       };
 
       // Lazily create the per-connection-generation controller so connect()
@@ -475,6 +503,9 @@ export function useBoardBluetooth({
             track(SHARED_EVENTS.ClimbSentToBoardFailure, {
               ...boardAnalyticsProperties,
               failureReason: 'incompatible_climb',
+              skippedPositionCount: result.skippedPositionCount,
+              skippedRoleCount: result.skippedRoleCount,
+              totalPlacements: result.totalPlacements,
             });
             return false;
           }
@@ -540,7 +571,17 @@ export function useBoardBluetooth({
       );
       return queuedSend;
     },
-    [boardName, layoutId, sizeId, holdsData, ledColorOverrides, analyticsBoardId, handleDisconnection, t],
+    [
+      boardName,
+      layoutId,
+      sizeId,
+      holdsData,
+      ledColorOverrides,
+      analyticsBoardId,
+      handleDisconnection,
+      getConnectedViaMismatchOverride,
+      t,
+    ],
   );
 
   const connect = useCallback(
@@ -691,6 +732,7 @@ export function useBoardBluetooth({
           apiLevel: apiLevelRef.current,
           deviceNamePresent: !!connection.deviceName,
           boardId: analyticsBoardId ?? undefined,
+          connectedViaMismatchOverride: getConnectedViaMismatchOverride?.() ?? false,
         });
         return true;
       } catch (error) {
@@ -759,6 +801,7 @@ export function useBoardBluetooth({
       analyticsBoardId,
       onConnectionChange,
       onConnectSuccess,
+      getConnectedViaMismatchOverride,
       sendFramesToBoard,
       sanitizedColorOverrides,
       colorSignature,

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -400,7 +400,7 @@ export function useBoardBluetooth({
             // letting the AutoSender buzz success on a dark board.
             if (sent === false) {
               console.warn('[BLE] All MoonBoard placements skipped — climb has unrecognised hold data');
-              Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
+              Alert.alert(t('ble.sendFailedTitle'), t('ble.errorIncompatible'));
               track(SHARED_EVENTS.ClimbSentToBoardFailure, {
                 ...boardAnalyticsProperties,
                 failureReason: 'incompatible_climb',
@@ -430,7 +430,7 @@ export function useBoardBluetooth({
               console.error(
                 `[BLE] Cannot mirror frames: holdsData is missing or empty for ${boardName} layout=${layoutId}`,
               );
-              Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
+              Alert.alert(t('ble.sendFailedTitle'), t('ble.errorIncompatible'));
               track(SHARED_EVENTS.ClimbSentToBoardFailure, {
                 ...boardAnalyticsProperties,
                 failureReason: 'missing_mirror_data',
@@ -451,7 +451,7 @@ export function useBoardBluetooth({
             console.error(
               `[BLE] LED placement map is empty for ${boardName} layout=${layoutId} size=${sizeId}. Board configuration may be incorrect or LED data may need regeneration.`,
             );
-            Alert.alert(t('ble.notAvailable'), t('ble.errorLedMissing'));
+            Alert.alert(t('ble.sendFailedTitle'), t('ble.errorLedMissing'));
             track(SHARED_EVENTS.ClimbSentToBoardFailure, {
               ...boardAnalyticsProperties,
               failureReason: 'missing_led_placements',
@@ -471,7 +471,7 @@ export function useBoardBluetooth({
 
           if (skippedCount > 0 && result.packet.length === 0) {
             console.warn(`[BLE] All ${result.totalPlacements} placements skipped — climb incompatible with board`);
-            Alert.alert(t('ble.notAvailable'), t('ble.errorIncompatible'));
+            Alert.alert(t('ble.sendFailedTitle'), t('ble.errorIncompatible'));
             track(SHARED_EVENTS.ClimbSentToBoardFailure, {
               ...boardAnalyticsProperties,
               failureReason: 'incompatible_climb',

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -16,6 +16,12 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 export function toClimbInput(climb: Climb): ClimbInput {
   return {
     uuid: climb.uuid,
+    // Board the climb belongs to. Round-tripped through the queue so a connected
+    // board can skip a climb set for a different board/layout (a "spill" climb
+    // from a party peer on another board, or a queue left over from a board
+    // switch) instead of dark-firing the wall.
+    boardType: climb.boardType,
+    layoutId: climb.layoutId,
     setter_username: climb.setter_username,
     userId: climb.userId,
     name: climb.name,
@@ -53,6 +59,10 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
     suggested: options?.suggested,
     climb: {
       uuid: climb.uuid,
+      // Board metadata so the BLE auto-sender can detect a board/layout mismatch
+      // before writing (see toClimbInput above).
+      layoutId: climb.layoutId,
+      boardType: climb.boardType,
       name: climb.name,
       frames: climb.frames,
       setter_username: climb.setter_username,

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -71,6 +71,8 @@ const BOARD_FIELDS = `
 
 const CLIMB_SEARCH_FIELDS = `
   uuid
+  boardType
+  layoutId
   setter_username
   userId
   name
@@ -94,6 +96,8 @@ const CLIMB_SEARCH_FIELDS = `
 
 const CLIMB_DETAIL_FIELDS = `
   uuid
+  boardType
+  layoutId
   setter_username
   userId
   name
@@ -1093,6 +1097,8 @@ export type SessionUpdateEvent = {
 // re-opened drawer can't render the grade.
 const SUBSCRIPTION_CLIMB_FIELDS = `
   uuid
+  boardType
+  layoutId
   name
   frames
   setter_username

--- a/packages/mobile/src/lib/open-climb-in-play-drawer.ts
+++ b/packages/mobile/src/lib/open-climb-in-play-drawer.ts
@@ -1,6 +1,7 @@
 import { type useRouter } from 'expo-router';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { BoardConfig, OpenPlayDrawerOptions } from '../providers/drawer-host-provider';
+import { climbToQueueItem } from './climb-to-queue-item';
 import { getBoardConfigForPlaylist } from './playlists/board-details-for-playlist';
 import { tickToClimb, type TickLike } from './tick-to-climb';
 
@@ -38,12 +39,23 @@ export type OpenClimbArgs =
 export type OpenClimbOptions = {
   /**
    * When `true`, the opened climb is set as the current climb (and appended to
-   * the queue) — a tap-to-activate. Defaults to `false` (view-only), preserving
-   * the original behaviour for every existing caller. Ignored on the `ref`
-   * fallback, which routes through the climb page and opens with its own default.
+   * the queue) — a tap-to-activate. Defaults to `false` (view-only preview: the
+   * drawer shows it with a "Preview" badge + "Set active" and leaves the queue
+   * untouched), preserving the original behaviour for every existing caller.
+   * Ignored on the `ref` fallback, which routes through the climb page and opens
+   * with its own default.
    */
   setAsCurrent?: boolean;
 };
+
+/**
+ * Build the play-drawer open options for a climb that is either activated
+ * (commit) or shown view-only (preview). A preview anchors navigation on a fresh
+ * queue item without committing it; an active open lets the drawer commit.
+ */
+function openModeOptions(climb: Climb, setAsCurrent: boolean): Pick<OpenPlayDrawerOptions, 'previewQueueItem'> {
+  return setAsCurrent ? {} : { previewQueueItem: climbToQueueItem(climb) };
+}
 
 /**
  * The single entry point for opening a climb anywhere in the app. Every former
@@ -58,7 +70,11 @@ export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, 
   const setAsCurrent = options?.setAsCurrent ?? false;
 
   if (args.kind === 'climb') {
-    openPlayDrawer(args.climb, { setAsCurrent, boardConfig: args.boardConfig, source: 'climb_view' });
+    openPlayDrawer(args.climb, {
+      ...openModeOptions(args.climb, setAsCurrent),
+      boardConfig: args.boardConfig,
+      source: 'climb_view',
+    });
     return;
   }
 
@@ -67,7 +83,7 @@ export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, 
     const config = getBoardConfigForPlaylist(args.tick.boardType, args.tick.layoutId);
     if (climb && config) {
       openPlayDrawer(climb, {
-        setAsCurrent,
+        ...openModeOptions(climb, setAsCurrent),
         boardConfig: {
           boardName: config.boardName,
           layoutId: config.layoutId,

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -117,52 +117,44 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     await result.current(climb);
     // The drawer opens FIRST — before the shared activation's setCurrentClimb +
     // suggestion-source work — so BottomSheetModal.present() fires on the same
-    // frame as the tap. setAsCurrent:false stops the drawer re-dispatching and
-    // wiping the suggestion source the activation builds. previewQueueItem is
-    // the navigation anchor the queue dispatch will reuse.
-    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
-      setAsCurrent: false,
-      previewQueueItem: expect.objectContaining({ climb }),
-    });
-    // The shared activation still runs (suggestion source + the queue dispatch,
-    // which is wrapped in startTransition).
+    // frame as the tap. `committedExternally` tells the drawer the caller already
+    // dispatches the climb, so it renders from currentClimbQueueItem (no preview)
+    // and doesn't re-dispatch.
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
+    // The shared activation still runs (suggestion source + the synchronous queue
+    // dispatch).
     expect(mocks.activate).toHaveBeenCalledWith(climb);
   });
 
-  it('dispatches the exact previewQueueItem instance the drawer pinned', async () => {
+  it('dispatches the exact item the activation pinned', async () => {
     const { result } = renderActivation();
     const climb = makeClimb('a');
     await result.current(climb);
-    const previewItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
 
+    // The first dispatch reuses the item pinned during activate (same climb uuid),
+    // so the drawer's nav anchor and the queue entry share one uuid.
     const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
-    // Same instance, not a second item with a fresh uuid — otherwise the drawer
-    // anchors prev/remaining-count on an orphan uuid that is never in the queue.
-    expect(mocks.setCurrentClimb.mock.calls[0][0]).toBe(previewItem);
-    expect(item).toBe(previewItem);
+    expect(mocks.setCurrentClimb.mock.calls[0][0]).toBe(item);
+    expect(item?.climb).toEqual(climb);
   });
 
   it('reuses the pinned item once — a second dispatch builds a fresh item', async () => {
     const { result } = renderActivation();
     const climb = makeClimb('a');
     await result.current(climb);
-    const previewItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
 
     const first = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
     const second = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
-    expect(first).toBe(previewItem);
-    expect(second).not.toBe(previewItem);
-    expect(second?.uuid).not.toBe(previewItem.uuid);
+    expect(second).not.toBe(first);
+    expect(second?.uuid).not.toBe(first?.uuid);
   });
 
   it('ignores the pinned item when the dispatched climb differs', async () => {
     const { result } = renderActivation();
     await result.current(makeClimb('a'));
-    const previewItem = mocks.openPlayDrawer.mock.calls[0][1].previewQueueItem;
 
     const climbB = makeClimb('b');
     const item = await captured().queueApi!.setCurrentClimb(climbB, { playlistSuggestionSource: null });
-    expect(item).not.toBe(previewItem);
     expect(item?.climb).toEqual(climbB);
   });
 
@@ -174,10 +166,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     // Every tap drives the shared activation — there is no non-driver preview
     // branch that skips it anymore.
     expect(mocks.activate).toHaveBeenCalledWith(climb);
-    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
-      setAsCurrent: false,
-      previewQueueItem: expect.objectContaining({ climb }),
-    });
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
   });
 
   it('fetchClimbsForBoard pages the playlist via the injected fetchPage', async () => {

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -10,7 +10,7 @@
 // swaps in a richer suggestion source so swiping through the play drawer walks
 // the whole playlist.
 
-import { useCallback, useMemo, useRef, startTransition } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
 import { getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
 import { useQueueActions } from '../../providers/queue-provider';
@@ -57,12 +57,11 @@ export function usePlaylistActivation({
   const { openPlayDrawer } = useDrawerHost();
   const activeBoard = useActiveBoard().data ?? null;
 
-  // The queue item the returned callback already pinned in the drawer as
-  // previewQueueItem. queueApi.setCurrentClimb dispatches that exact item so
-  // the drawer's navigation anchor and the queue entry share one uuid —
-  // otherwise prev/remaining-count anchor on an orphan uuid that's never in
-  // the queue. Single-use; the climb-uuid match guards against a stale ref
-  // from an earlier tap whose activation never reached setCurrentClimb.
+  // The queue item the returned callback built for this tap. queueApi.setCurrentClimb
+  // dispatches that exact instance so the drawer's navigation anchor and the queue
+  // entry share one uuid — otherwise prev/remaining-count anchor on an orphan uuid
+  // that's never in the queue. Single-use; the climb-uuid match guards against a
+  // stale ref from an earlier tap whose activation never reached setCurrentClimb.
   const pendingQueueItemRef = useRef<ClimbQueueItem | null>(null);
 
   // The shared hook expects setCurrentClimb to return the activated item (so it
@@ -76,11 +75,11 @@ export function usePlaylistActivation({
         pendingQueueItemRef.current = null;
         const item =
           pendingItem && pendingItem.climb.uuid === climb.uuid ? pendingItem : climbToQueueItem(toSchemaClimb(climb));
-        // Mark as a non-urgent transition so React can flush the drawer's
-        // opening animation frame before processing the queue re-renders.
-        startTransition(() => {
-          setCurrentClimb(item, options);
-        });
+        // Commit synchronously: the drawer now renders from currentClimbQueueItem
+        // (no preview render-ahead), so this dispatch must land in the same batch
+        // as the open — under startTransition it would defer and the drawer would
+        // paint a stale first frame.
+        setCurrentClimb(item, options);
         return item;
       },
       refreshPlaylistSuggestionSource,
@@ -139,22 +138,21 @@ export function usePlaylistActivation({
     refreshErrorMessage,
   });
 
-  // Open the drawer immediately, then let the shared hook do its state work.
-  // The drawer receives the climb directly via open() and renders correctly
-  // before DELTA_UPDATE_CURRENT_CLIMB propagates (setAsCurrent:false prevents
-  // the drawer from re-dispatching and wiping the suggestion source).
-  // The queue dispatch inside queueApi.setCurrentClimb is wrapped in
-  // startTransition so React processes those re-renders at low priority after
-  // the animation frame runs.
+  // Open the drawer immediately, then let the shared hook commit the climb. The
+  // open and the synchronous setCurrentClimb dispatch land in the same React
+  // batch, so the drawer (rendering from currentClimbQueueItem) paints the
+  // activated climb on the first frame. `committedExternally` tells the drawer
+  // the caller already dispatched, so it doesn't re-commit or treat this as a
+  // preview.
   return useCallback(
     (climb: Climb) => {
       // Always-live: every tap activates the climb for the whole session (no
       // driver/preview gate). The drawer opens first (same frame as the tap),
-      // then the shared activation builds the suggestion source and dispatches
-      // the queue update under startTransition.
+      // then the shared activation builds the suggestion source and commits the
+      // queue update.
       const item = climbToQueueItem(toSchemaClimb(climb));
       pendingQueueItemRef.current = item;
-      openPlayDrawer(toSchemaClimb(climb), { setAsCurrent: false, previewQueueItem: item });
+      openPlayDrawer(toSchemaClimb(climb), { committedExternally: true });
       return activate(climb).catch((error: unknown) => {
         console.error('Playlist climb activation failed:', error);
         reportHandledError(error, { tags: { source: 'playlist', op: 'activate-climb' } });

--- a/packages/mobile/src/lib/queue-conversion.ts
+++ b/packages/mobile/src/lib/queue-conversion.ts
@@ -14,6 +14,11 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
  */
 export type SubscriptionClimb = {
   uuid: string;
+  // Board the climb belongs to — round-tripped so a peer on a different board can
+  // skip a "spill" climb instead of dark-firing its wall. Nullish from older
+  // peers / pre-metadata items (then the spill guard treats it as sendable).
+  boardType?: string | null;
+  layoutId?: number | null;
   name: string;
   frames: string;
   setter_username: string;
@@ -49,6 +54,8 @@ export function toClimbQueueItem(subscriptionItem: SubscriptionQueueItem): Climb
     uuid: subscriptionItem.uuid,
     climb: {
       uuid: subscriptionItem.climb.uuid,
+      boardType: subscriptionItem.climb.boardType ?? undefined,
+      layoutId: subscriptionItem.climb.layoutId,
       name: subscriptionItem.climb.name,
       frames: subscriptionItem.climb.frames,
       setter_username: subscriptionItem.climb.setter_username,

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -357,8 +357,25 @@ describe('BluetoothProvider mismatch switch', () => {
     const buttons = lastAlertButtons();
     expect(buttons).toHaveLength(3);
     expect(buttons[0]?.style).toBe('cancel');
-    expect(buttons[1]?.style).toBe('destructive');
+    // "Connect anyway" is a warning now, not a destructive (red) action.
+    expect(buttons[1]?.style).toBeUndefined();
     expect(buttons[2]?.text).toBeTruthy();
+  });
+
+  it('tracks the mismatch dialog shown, and resolved with the action taken', () => {
+    bluetooth.state.pickerState = makeMismatchingPickerState();
+    resolvedBoards.value = new Map([['SN-2', { kind: 'saved', board: makeBoard() }]]);
+
+    renderProvider(KILTER_PROPS);
+    pickerSheet.props?.onSelect('device-2');
+
+    const shown = analytics.track.mock.calls.find(([name]) => name === 'BLE Board Config Mismatch Shown');
+    expect(shown?.[1]).toMatchObject({ serial: 'SN-2', canSwitch: true, recordedEntryKind: 'saved' });
+
+    // Connect anyway → resolved:connect_anyway, no destructive styling, proceeds.
+    lastAlertButtons()[1]?.onPress?.();
+    const resolved = analytics.track.mock.calls.find(([name]) => name === 'BLE Board Config Mismatch Resolved');
+    expect(resolved?.[1]).toMatchObject({ action: 'connect_anyway', serial: 'SN-2' });
   });
 
   it('switches the active board and silently auto-connects once after the config matches', async () => {
@@ -373,6 +390,10 @@ describe('BluetoothProvider mismatch switch', () => {
     const switchButton = lastAlertButtons()[2];
     expect(switchButton).toBeDefined();
     switchButton?.onPress?.();
+
+    expect(
+      analytics.track.mock.calls.find(([name]) => name === 'BLE Board Config Mismatch Resolved')?.[1],
+    ).toMatchObject({ action: 'switch_setup' });
 
     await waitFor(() => {
       expect(activeBoard.setActiveBoard).toHaveBeenCalledWith(savedBoard);

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -23,12 +23,16 @@ const alert = vi.hoisted(() => ({
 
 const queue = vi.hoisted(() => ({
   currentClimbQueueItem: null as ClimbQueueItem | null,
+  queue: [] as ClimbQueueItem[],
   sessionId: null as string | null,
   lastConnectedBoardSerial: null as string | null,
   confirmClimbOnWall: vi.fn(async () => {}),
   reportWallDisconnect: vi.fn(async () => {}),
   setSessionBoardSerial: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(),
 }));
+
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 
 const bluetooth = vi.hoisted(() => {
   const mock = {
@@ -129,7 +133,10 @@ vi.mock('../../components/ble/DevicePickerSheet', () => ({
 
 vi.mock('../queue-provider', () => ({
   useQueue: () => ({
-    state: { currentClimbQueueItem: queue.currentClimbQueueItem },
+    state: { currentClimbQueueItem: queue.currentClimbQueueItem, queue: queue.queue },
+  }),
+  useQueueActions: () => ({
+    setCurrentClimb: queue.setCurrentClimb,
   }),
   useQueueSessionControls: () => ({
     sessionId: queue.sessionId,
@@ -138,6 +145,10 @@ vi.mock('../queue-provider', () => ({
     reportWallDisconnect: queue.reportWallDisconnect,
     setSessionBoardSerial: queue.setSessionBoardSerial,
   }),
+}));
+
+vi.mock('../toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
 }));
 
 vi.mock('../../lib/board-details', () => ({
@@ -600,5 +611,140 @@ describe('BluetoothProvider mismatch switch', () => {
     // The picker is only cancelled once the switch goes through — on failure it
     // stays open so the user can still pick a device or use Connect anyway.
     expect(pickerState.handleCancel).not.toHaveBeenCalled();
+  });
+});
+
+function makeBoardItem(uuid: string, boardType: string | undefined, layoutId: number | undefined): ClimbQueueItem {
+  return {
+    uuid: `queue-${uuid}`,
+    climb: {
+      uuid,
+      name: `Climb ${uuid}`,
+      frames: `frames-${uuid}`,
+      boardType,
+      layoutId,
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+describe('BluetoothProvider spill skip', () => {
+  beforeEach(() => {
+    queue.currentClimbQueueItem = null;
+    queue.queue = [];
+    queue.sessionId = null;
+    queue.setCurrentClimb.mockClear();
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    bluetooth.state.isConnected = true;
+    bluetooth.state.sendFramesToBoard.mockClear();
+    bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    bluetooth.state.isConnected = false;
+  });
+
+  it('skips an incompatible current climb, advances to the next compatible one, and toasts + tracks', async () => {
+    // Active board is kilter / layout 1 (KILTER_PROPS). The current is a tension
+    // spill; the next compatible kilter climb follows.
+    const spill = makeBoardItem('spill', 'tension', 1);
+    const compatible = makeBoardItem('ok', 'kilter', 1);
+    queue.currentClimbQueueItem = spill;
+    queue.queue = [spill, compatible];
+
+    renderProvider(KILTER_PROPS);
+    await act(async () => {});
+
+    // The spill frames were never written to the board.
+    expect(bluetooth.state.sendFramesToBoard).not.toHaveBeenCalledWith(
+      'frames-spill',
+      expect.anything(),
+      expect.anything(),
+    );
+    // The queue advanced to the compatible climb and the user was told.
+    expect(queue.setCurrentClimb).toHaveBeenCalledWith(compatible);
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
+    const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
+    expect(skipCall).toBeDefined();
+    expect(skipCall?.[1]).toMatchObject({
+      skippedClimbUuid: 'spill',
+      skippedCount: 1,
+      advancedToClimbUuid: 'ok',
+    });
+  });
+
+  it('clears the board (no advance) when no compatible climb remains', async () => {
+    const spill = makeBoardItem('spill', 'tension', 1);
+    queue.currentClimbQueueItem = spill;
+    queue.queue = [spill];
+
+    renderProvider(KILTER_PROPS);
+    await act(async () => {});
+
+    expect(queue.setCurrentClimb).not.toHaveBeenCalled();
+    // clearBoard sends empty frames to dark the wall.
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('');
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
+    const skipCall = analytics.track.mock.calls.find(([name]) => name === 'BLE Queue Climb Skipped');
+    expect(skipCall?.[1]).toMatchObject({ skippedClimbUuid: 'spill', advancedToClimbUuid: null });
+  });
+
+  it('sends a compatible current climb normally (no skip)', async () => {
+    const compatible = makeBoardItem('ok', 'kilter', 1);
+    queue.currentClimbQueueItem = compatible;
+    queue.queue = [compatible];
+
+    renderProvider(KILTER_PROPS);
+    await act(async () => {});
+
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('frames-ok', false, expect.anything());
+    expect(queue.setCurrentClimb).not.toHaveBeenCalled();
+    expect(toast.showToast).not.toHaveBeenCalled();
+  });
+
+  it('re-reports a spill if the user returns to it after advancing away', async () => {
+    const spill = makeBoardItem('spill', 'tension', 1);
+    const compatible = makeBoardItem('ok', 'kilter', 1);
+    queue.currentClimbQueueItem = spill;
+    queue.queue = [spill, compatible];
+
+    const { rerender } = renderProvider(KILTER_PROPS);
+    await act(async () => {});
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
+
+    // The advance lands: the compatible climb becomes current and is sent, which
+    // clears the spill dedup.
+    queue.currentClimbQueueItem = compatible;
+    rerender(createElement(BluetoothProvider, { ...KILTER_PROPS, children: createElement('div', null) }));
+    await act(async () => {});
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('frames-ok', false, expect.anything());
+
+    // Navigating back to the spill skips + toasts again — not a silent stick.
+    queue.currentClimbQueueItem = spill;
+    rerender(createElement(BluetoothProvider, { ...KILTER_PROPS, children: createElement('div', null) }));
+    await act(async () => {});
+    expect(toast.showToast).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not skip a climb with unknown board metadata', async () => {
+    const unknown = makeBoardItem('unknown', undefined, undefined);
+    queue.currentClimbQueueItem = unknown;
+    queue.queue = [unknown];
+
+    renderProvider(KILTER_PROPS);
+    await act(async () => {});
+
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('frames-unknown', false, expect.anything());
+    expect(queue.setCurrentClimb).not.toHaveBeenCalled();
+    expect(toast.showToast).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -727,7 +727,12 @@ describe('BluetoothProvider spill skip', () => {
     renderProvider(KILTER_PROPS);
     await act(async () => {});
 
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('frames-ok', false, expect.anything());
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+      'frames-ok',
+      false,
+      expect.anything(),
+      expect.objectContaining({ sendSource: 'auto', climbUuid: 'ok' }),
+    );
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
     expect(toast.showToast).not.toHaveBeenCalled();
   });
@@ -747,7 +752,12 @@ describe('BluetoothProvider spill skip', () => {
     queue.currentClimbQueueItem = compatible;
     rerender(createElement(BluetoothProvider, { ...KILTER_PROPS, children: createElement('div', null) }));
     await act(async () => {});
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('frames-ok', false, expect.anything());
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+      'frames-ok',
+      false,
+      expect.anything(),
+      expect.objectContaining({ sendSource: 'auto', climbUuid: 'ok' }),
+    );
 
     // Navigating back to the spill skips + toasts again — not a silent stick.
     queue.currentClimbQueueItem = spill;
@@ -764,7 +774,12 @@ describe('BluetoothProvider spill skip', () => {
     renderProvider(KILTER_PROPS);
     await act(async () => {});
 
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('frames-unknown', false, expect.anything());
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+      'frames-unknown',
+      false,
+      expect.anything(),
+      expect.objectContaining({ sendSource: 'auto', climbUuid: 'unknown' }),
+    );
     expect(queue.setCurrentClimb).not.toHaveBeenCalled();
     expect(toast.showToast).not.toHaveBeenCalled();
   });

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -15,7 +15,12 @@ type BluetoothHookOptions = {
   onConnectSuccess?: (serial: string | null) => void;
   holdsData?: unknown;
 };
-type SendFramesToBoard = (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
+type SendFramesToBoard = (
+  frames: string,
+  mirrored?: boolean,
+  signal?: AbortSignal,
+  sendContext?: unknown,
+) => Promise<boolean | undefined>;
 
 const wallConfirm = vi.hoisted(() => ({
   emitWallConfirm: vi.fn(),
@@ -165,8 +170,9 @@ vi.mock('../../components/ble/DevicePickerSheet', () => ({
 
 vi.mock('../queue-provider', () => ({
   useQueue: () => ({
-    state: { currentClimbQueueItem: queue.currentClimbQueueItem },
+    state: { currentClimbQueueItem: queue.currentClimbQueueItem, queue: [] },
   }),
+  useQueueActions: () => ({ setCurrentClimb: vi.fn() }),
   useQueueSessionControls: () => ({
     sessionId: queue.sessionId,
     participantId: queue.participantId,
@@ -175,6 +181,10 @@ vi.mock('../queue-provider', () => ({
     reportWallDisconnect: queue.reportWallDisconnect,
     setSessionBoardSerial: queue.setSessionBoardSerial,
   }),
+}));
+
+vi.mock('../toast-provider', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
 }));
 
 const boardDetails = vi.hoisted(() => ({
@@ -306,7 +316,12 @@ describe('BluetoothProvider wall-confirm integration', () => {
     renderProvider();
 
     await waitFor(() => {
-      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('p1r12', false, expect.any(AbortSignal));
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+        'p1r12',
+        false,
+        expect.any(AbortSignal),
+        expect.objectContaining({ sendSource: 'auto' }),
+      );
     });
 
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
@@ -338,7 +353,12 @@ describe('BluetoothProvider wall-confirm integration', () => {
     renderProvider();
 
     await waitFor(() => {
-      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('p1r12', false, expect.any(AbortSignal));
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+        'p1r12',
+        false,
+        expect.any(AbortSignal),
+        expect.objectContaining({ sendSource: 'auto' }),
+      );
     });
     expect(bluetooth.state.connectInitialSendRef.current).toBeNull();
   });
@@ -365,7 +385,12 @@ describe('BluetoothProvider wall-confirm integration', () => {
     renderProvider();
 
     await waitFor(() => {
-      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('p1r12', false, expect.any(AbortSignal));
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+        'p1r12',
+        false,
+        expect.any(AbortSignal),
+        expect.objectContaining({ sendSource: 'auto' }),
+      );
     });
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
@@ -400,7 +425,13 @@ describe('BluetoothProvider wall-confirm integration', () => {
     await waitFor(() => {
       expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(2);
     });
-    expect(bluetooth.state.sendFramesToBoard).toHaveBeenNthCalledWith(2, 'p1r12', false, expect.any(AbortSignal));
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenNthCalledWith(
+      2,
+      'p1r12',
+      false,
+      expect.any(AbortSignal),
+      expect.objectContaining({ sendSource: 'auto' }),
+    );
   });
 
   it('keeps auto-sending while a restored session is waiting for JOIN to resolve identity', async () => {
@@ -414,7 +445,12 @@ describe('BluetoothProvider wall-confirm integration', () => {
     renderProvider();
 
     await waitFor(() => {
-      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith('p1r12', false, expect.any(AbortSignal));
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+        'p1r12',
+        false,
+        expect.any(AbortSignal),
+        expect.objectContaining({ sendSource: 'auto' }),
+      );
     });
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
@@ -1023,7 +1059,13 @@ describe('BluetoothProvider wall-confirm integration', () => {
       const undoResult = await capturedBluetooth?.undoWallChange();
 
       expect(undoResult).toBe(true);
-      expect(bluetooth.state.sendFramesToBoard).toHaveBeenNthCalledWith(2, 'previous-frames', false);
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenNthCalledWith(
+        2,
+        'previous-frames',
+        false,
+        undefined,
+        expect.objectContaining({ sendSource: 'undo' }),
+      );
       expect(presence.reportClimbForBoard).toHaveBeenNthCalledWith(
         2,
         99,

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -450,7 +450,7 @@ describe('DrawerHostProvider queue sheet (always-live, no driver gate)', () => {
     });
 
     expect(queue.setCurrentClimb).toHaveBeenCalledWith(item);
-    expect(playDrawer.open).toHaveBeenCalledWith(item.climb, { setAsCurrent: false, previewQueueItem: item });
+    expect(playDrawer.open).toHaveBeenCalledWith(item.climb, { committedExternally: true });
   });
 
   it('broadcasts suggestion selection for every session member while anchoring drawer navigation to that item', async () => {
@@ -485,8 +485,7 @@ describe('DrawerHostProvider queue sheet (always-live, no driver gate)', () => {
       playlistSuggestionSource,
     });
     expect(playDrawer.open).toHaveBeenCalledWith(suggestion, {
-      setAsCurrent: false,
-      previewQueueItem: suggestedItem,
+      committedExternally: true,
     });
   });
 });
@@ -519,8 +518,7 @@ describe('DrawerHostProvider board sheet climb actions', () => {
     expect(queue.setCurrentClimb).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'wall-queue-x', climb }));
     await waitFor(() =>
       expect(playDrawer.open).toHaveBeenCalledWith(climb, {
-        setAsCurrent: false,
-        previewQueueItem: expect.objectContaining({ uuid: 'wall-queue-x', climb }),
+        committedExternally: true,
       }),
     );
     await waitFor(() =>
@@ -742,8 +740,9 @@ describe('DrawerHostProvider play drawer open analytics source', () => {
     await waitFor(() => expect(hosts.at(-1)).toBeDefined());
 
     const climb = makeQueueItem('queue-x', 'climb-view-1').climb as unknown as Climb;
+    const previewItem = makeQueueItem('queue-preview-1', 'climb-view-1');
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { setAsCurrent: false, source: 'climb_view' });
+      hosts.at(-1)?.openPlayDrawer(climb, { previewQueueItem: previewItem, source: 'climb_view' });
     });
 
     expect(analytics.track).toHaveBeenCalledWith(
@@ -752,14 +751,14 @@ describe('DrawerHostProvider play drawer open analytics source', () => {
     );
   });
 
-  it('defaults a queue-nav open (setAsCurrent:false, no source) to current_queue_item', async () => {
+  it('defaults a queue-nav open (committedExternally, no source) to current_queue_item', async () => {
     const hosts: Array<ReturnType<typeof useDrawerHost>> = [];
     renderHost((host) => hosts.push(host));
     await waitFor(() => expect(hosts.at(-1)).toBeDefined());
 
     const climb = makeQueueItem('queue-x', 'queue-nav-1').climb as unknown as Climb;
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { setAsCurrent: false });
+      hosts.at(-1)?.openPlayDrawer(climb, { committedExternally: true });
     });
 
     expect(analytics.track).toHaveBeenCalledWith(
@@ -775,12 +774,12 @@ describe('DrawerHostProvider play drawer open analytics source', () => {
 
     const climb = makeQueueItem('queue-x', 'climb-view-2').climb as unknown as Climb;
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { setAsCurrent: false, source: 'climb_view' });
+      hosts.at(-1)?.openPlayDrawer(climb, { committedExternally: true, source: 'climb_view' });
     });
 
     // No board override → the drawer opens synchronously with only the queue
     // options; `source` was pulled out and must not reach PlayDrawer.open.
-    expect(playDrawer.open).toHaveBeenCalledWith(climb, { setAsCurrent: false });
+    expect(playDrawer.open).toHaveBeenCalledWith(climb, { committedExternally: true });
   });
 });
 
@@ -829,7 +828,7 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
       angle: 55,
     };
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { setAsCurrent: false, boardConfig: override });
+      hosts.at(-1)?.openPlayDrawer(climb, { boardConfig: override });
     });
     await waitFor(() => expect(playDrawer.props?.onSwitchBoard).toBeDefined());
 
@@ -866,7 +865,7 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
       angle: 55,
     };
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { setAsCurrent: false, boardConfig: override });
+      hosts.at(-1)?.openPlayDrawer(climb, { boardConfig: override });
     });
     await waitFor(() => expect(playDrawer.props?.onSwitchBoard).toBeDefined());
 
@@ -896,7 +895,7 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
       angle: 55,
     };
     act(() => {
-      hosts.at(-1)?.openPlayDrawer(climb, { setAsCurrent: false, boardConfig: override });
+      hosts.at(-1)?.openPlayDrawer(climb, { boardConfig: override });
     });
     await waitFor(() => expect(playDrawer.props?.onSwitchBoard).toBeDefined());
 

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -460,6 +460,11 @@ export function BluetoothProvider({
   const previousPresenceBoardIdRef = useRef<number | null>(presenceBoardId);
   const boardConfigIdentity = `${boardName ?? ''}:${layoutId ?? ''}:${sizeId ?? ''}:${setIds ?? ''}`;
   const previousBoardConfigIdentityRef = useRef(boardConfigIdentity);
+  // True while this connection was made via "Connect anyway" on the board-config
+  // mismatch dialog (our records say this controller belongs to another setup).
+  // Cleared on disconnect/drop and on board-config change. Attached to connection
+  // + send analytics so override sessions are filterable.
+  const connectedViaMismatchOverrideRef = useRef(false);
   const undoWallChangeToastArmIdRef = useRef<number | null>(null);
   const nextUndoWallChangeToastArmIdRef = useRef(0);
   const undoWallChangeToastArmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -509,6 +514,7 @@ export function BluetoothProvider({
     previousBoardConfigIdentityRef.current = boardConfigIdentity;
     if (previousBoardConfigIdentity !== boardConfigIdentity) {
       clearPendingWallReportAndUndoToastArm();
+      connectedViaMismatchOverrideRef.current = false;
     }
   }, [boardConfigIdentity, clearPendingWallReportAndUndoToastArm]);
 
@@ -875,6 +881,17 @@ export function BluetoothProvider({
       } catch (error) {
         console.error('Failed to switch to correct board config:', error);
         reportHandledError(error, { tags: { source: 'board-config', op: 'switch' } });
+        track(SHARED_EVENTS.BleBoardConfigMismatchResolved, {
+          serial: decision.serial,
+          currentBoardName: currentBoardConfigRef.current?.boardName,
+          currentLayoutId: currentBoardConfigRef.current?.layoutId,
+          recordedBoardName: decision.config.boardName,
+          recordedLayoutId: decision.config.layoutId,
+          recordedEntryKind: decision.entry.kind,
+          // Reaching this catch means the switch button was offered (and tapped).
+          canSwitch: true,
+          action: 'switch_failed',
+        });
         Alert.alert(t('boardConfigMismatch.title'), t('boardConfigMismatch.mobileSwitchFailed'));
       }
     },
@@ -904,18 +921,43 @@ export function BluetoothProvider({
       const canSwitch =
         decision.entry.kind === 'saved' ||
         (decision.entry.kind === 'recorded' && decision.entry.config.boardUuid != null);
+
+      const mismatchAnalytics = {
+        serial: decision.serial,
+        currentBoardName: activeBoardConfig?.boardName,
+        currentLayoutId: activeBoardConfig?.layoutId,
+        recordedBoardName: decision.config.boardName,
+        recordedLayoutId: decision.config.layoutId,
+        recordedEntryKind: decision.entry.kind,
+        canSwitch,
+      };
+      track(SHARED_EVENTS.BleBoardConfigMismatchShown, mismatchAnalytics);
+      const trackResolved = (action: 'cancel' | 'connect_anyway' | 'switch_setup') =>
+        track(SHARED_EVENTS.BleBoardConfigMismatchResolved, { ...mismatchAnalytics, action });
+
+      // "Connect anyway" is a warning, not a destructive action — connecting to a
+      // working board the user owns isn't dangerous, just possibly mis-mapped.
       const buttons = [
-        { text: t('boardConfigMismatch.cancel'), style: 'cancel' as const },
+        { text: t('boardConfigMismatch.cancel'), style: 'cancel' as const, onPress: () => trackResolved('cancel') },
         {
-          text: t('boardConfigMismatch.connectAnyway'),
-          style: 'destructive' as const,
-          onPress: () => activePickerState.handleSelect(deviceId),
+          text: t('boardConfigMismatch.mobileConnectAnyway'),
+          onPress: () => {
+            trackResolved('connect_anyway');
+            connectedViaMismatchOverrideRef.current = true;
+            activePickerState.handleSelect(deviceId);
+          },
         },
         ...(canSwitch
           ? [
               {
-                text: t('boardConfigMismatch.switchToCorrect'),
-                onPress: () => void handleMismatchSwitch(decision),
+                text:
+                  decision.entry.kind === 'saved'
+                    ? t('boardConfigMismatch.mobileSwitchSetup')
+                    : t('boardConfigMismatch.mobileUseRecordedSetup'),
+                onPress: () => {
+                  trackResolved('switch_setup');
+                  void handleMismatchSwitch(decision);
+                },
               },
             ]
           : []),
@@ -923,7 +965,7 @@ export function BluetoothProvider({
       Alert.alert(
         t('boardConfigMismatch.title'),
         [
-          t('boardConfigMismatch.intro'),
+          t('boardConfigMismatch.mobileConnectAnywayWarning'),
           t('boardConfigMismatch.mobileCurrentLabel', { config: currentLabel }),
           t('boardConfigMismatch.mobileRecordedLabel', { config: recordedLabel }),
         ].join('\n\n'),
@@ -1043,6 +1085,7 @@ export function BluetoothProvider({
   const wrappedDisconnect = useCallback(async () => {
     clearPendingWallReportAndUndoToastArm();
     releaseBoardHolder();
+    connectedViaMismatchOverrideRef.current = false;
     isUserDisconnectRef.current = true;
     track(SHARED_EVENTS.BluetoothDisconnected, { boardName, reason: 'user', inSession: sessionIdRef.current != null });
     try {
@@ -1079,6 +1122,7 @@ export function BluetoothProvider({
   useEffect(() => {
     if (wasConnectedRef.current && !isConnected && !isUserDisconnectRef.current) {
       clearPendingWallReportAndUndoToastArm();
+      connectedViaMismatchOverrideRef.current = false;
       // An unexpected drop also frees our board hold (the booted phone is no
       // longer writing the wall). Compare-and-delete server-side, so if another
       // phone already took over this is a no-op.

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -9,7 +9,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
 import type { BoardPresenceClimb, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import { emitWallConfirm } from '@boardsesh/play-view';
-import { useBoardBluetooth, boardConfigKey } from '../lib/ble/use-board-bluetooth';
+import { useBoardBluetooth, boardConfigKey, type SendFramesToBoard } from '../lib/ble/use-board-bluetooth';
 import { useResolvedBleDeviceBoards } from '../lib/ble/resolve-serials';
 import {
   decideBlePickerSelection,
@@ -42,7 +42,7 @@ type BluetoothContextValue = {
   loading: boolean;
   connect: (initialFrames?: string, mirrored?: boolean, targetSerial?: string) => Promise<boolean>;
   disconnect: () => Promise<void>;
-  sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
+  sendFramesToBoard: SendFramesToBoard;
   clearBoard: () => Promise<boolean | undefined>;
   /**
    * Force the auto-sender to re-push the current climb to the wall once, even
@@ -145,7 +145,7 @@ function BluetoothAutoSender({
   activeConfig,
   onSkipSpillClimb,
 }: {
-  sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
+  sendFramesToBoard: SendFramesToBoard;
   /**
    * Fired once a climb is on the wall (a fresh write or a deduped re-broadcast).
    * Receives the full lit queue item so consumers can both emit the local
@@ -169,7 +169,7 @@ function BluetoothAutoSender({
 }) {
   type AutoSendRequest = {
     item: ClimbQueueItem;
-    sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
+    sendFramesToBoard: SendFramesToBoard;
     colorSignature: string;
   };
 
@@ -328,7 +328,13 @@ function BluetoothAutoSender({
           }
 
           try {
-            const result = await requestSendFramesToBoard(item.climb.frames, !!item.climb.mirrored, signal);
+            const result = await requestSendFramesToBoard(item.climb.frames, !!item.climb.mirrored, signal, {
+              sendSource: 'auto',
+              targetQueueItemUuid: item.uuid,
+              climbUuid: item.climb.uuid,
+              climbBoardType: item.climb.boardType,
+              climbLayoutId: item.climb.layoutId,
+            });
 
             // After the await, the AutoSender may have unmounted — skip
             // post-send side effects.
@@ -723,6 +729,10 @@ export function BluetoothProvider({
     );
   }, [boardName, layoutId, sizeId, setIds]);
 
+  // Stable reader for the override flag, so the hook can attach it to connection
+  // and send analytics without re-creating its callbacks when the flag flips.
+  const getConnectedViaMismatchOverride = useCallback(() => connectedViaMismatchOverrideRef.current, []);
+
   const {
     isConnected,
     loading,
@@ -742,6 +752,7 @@ export function BluetoothProvider({
     analyticsBoardId: presenceBoardId,
     ledColorOverrides: bluetoothColorOverrides,
     onConnectSuccess: handleConnectSuccess,
+    getConnectedViaMismatchOverride,
   });
 
   const resolvedPickerBoards = useResolvedBleDeviceBoards(pickerState?.devices ?? EMPTY_PICKER_DEVICES);
@@ -984,7 +995,10 @@ export function BluetoothProvider({
     }
 
     lastAcceptedReportSignatureRef.current = null;
-    const writeSucceeded = await sendFramesToBoard(frames, false).catch((error: unknown) => {
+    const writeSucceeded = await sendFramesToBoard(frames, false, undefined, {
+      sendSource: 'undo',
+      climbUuid: undoTarget.climbUuid,
+    }).catch((error: unknown) => {
       console.warn('[board-presence] undo BLE resend failed', error);
       return false;
     });

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -13,7 +13,10 @@ import { useBoardBluetooth, boardConfigKey } from '../lib/ble/use-board-bluetoot
 import { useResolvedBleDeviceBoards } from '../lib/ble/resolve-serials';
 import {
   decideBlePickerSelection,
+  classifyClimbBoardCompatibility,
+  findNextCompatibleQueueItem,
   type BleBoardConfig,
+  type ActiveBoardForCompatibility,
   type PickerSelectionDecision,
 } from '../lib/ble/board-config-match';
 import { summarizePickerResolution, type PickerResolutionStats } from '../lib/ble/picker-resolution-stats';
@@ -24,9 +27,10 @@ import type { GetBoardQueryResponse } from '../lib/graphql/operations';
 import { getBoardRenderData } from '../lib/board-details';
 import { registerBluetoothConnection } from '../lib/ble/bluetooth-status-store';
 import { reportHandledError } from '../lib/error-reporting';
-import { useQueue, useQueueSessionControls } from './queue-provider';
+import { useQueue, useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useBoardPresenceControls } from './board-presence-provider';
 import { useQueueSnackbar } from './queue-snackbar-provider';
+import { useToast } from './toast-provider';
 import { toClimbInput } from '../lib/climb-to-queue-item';
 import { hapticSuccess } from '../lib/haptics';
 import { DevicePickerSheet } from '../components/ble/DevicePickerSheet';
@@ -138,6 +142,8 @@ function BluetoothAutoSender({
   reassertNonce,
   connectInitialSendRef,
   colorSignature,
+  activeConfig,
+  onSkipSpillClimb,
 }: {
   sendFramesToBoard: (frames: string, mirrored?: boolean, signal?: AbortSignal) => Promise<boolean | undefined>;
   /**
@@ -151,6 +157,15 @@ function BluetoothAutoSender({
   // freshly mounted AutoSender doesn't repeat a byte-identical first send.
   connectInitialSendRef: React.MutableRefObject<{ frames: string; mirrored: boolean; colorSignature: string } | null>;
   colorSignature: string;
+  // Active board (name + layout) so a climb set for a different board can be
+  // detected and skipped before it dark-fires the wall. Undefined until the board
+  // config resolves — then everything classifies as "unknown" (sent as today).
+  activeConfig: ActiveBoardForCompatibility | undefined;
+  // Called when the current climb is a "spill" (belongs to another board). Hands
+  // the provider the next compatible queue item to advance to (or null) plus the
+  // skip count, so it can re-point the queue + toast without the AutoSender
+  // owning queue actions or i18n.
+  onSkipSpillClimb: (args: { skipped: ClimbQueueItem; next: ClimbQueueItem | null; skippedCount: number }) => void;
 }) {
   type AutoSendRequest = {
     item: ClimbQueueItem;
@@ -164,6 +179,25 @@ function BluetoothAutoSender({
   useEffect(() => {
     onWallConfirmedRef.current = onWallConfirmed;
   }, [onWallConfirmed]);
+
+  // Live refs so the drain loop reads the latest board config + skip handler +
+  // queue without listing them as effect deps (which would re-run the loop on
+  // every queue keystroke). A board change re-creates sendFramesToBoard, which
+  // IS a dep, so the loop still re-evaluates compatibility when the board flips.
+  const activeConfigRef = useRef(activeConfig);
+  activeConfigRef.current = activeConfig;
+  const onSkipSpillClimbRef = useRef(onSkipSpillClimb);
+  useEffect(() => {
+    onSkipSpillClimbRef.current = onSkipSpillClimb;
+  }, [onSkipSpillClimb]);
+  const queueRef = useRef(state.queue);
+  queueRef.current = state.queue;
+  // Dedup spill reports: the async drain can re-enter for the same incompatible
+  // current before the advance lands (a colour/reassert re-render races the
+  // setCurrentClimb). Report a given spill uuid once, then clear the moment a
+  // compatible/unknown climb is processed — so deliberately navigating BACK to a
+  // skipped spill re-advances and re-toasts instead of silently sticking.
+  const lastSkipReportedUuidRef = useRef<string | null>(null);
 
   const isWritingRef = useRef(false);
   const pendingSendRef = useRef<AutoSendRequest | null>(null);
@@ -228,6 +262,31 @@ function BluetoothAutoSender({
         while (toSend) {
           if (signal?.aborted) return;
           const { item, sendFramesToBoard: requestSendFramesToBoard, colorSignature: requestColorSignature } = toSend;
+
+          // Spill guard: a climb set for a DIFFERENT board/layout than the
+          // connected board would skip every LED placement and dark-fire the
+          // wall (surfacing as the incompatible_climb failure). Don't write it —
+          // hand the provider the next compatible queue item to advance to (the
+          // queue snapshot + active config live in refs so this stays off the
+          // effect deps). Only a KNOWN mismatch is skipped; unknown/missing
+          // metadata is sent as today.
+          if (classifyClimbBoardCompatibility(activeConfigRef.current, item.climb) === 'incompatible') {
+            if (lastSkipReportedUuidRef.current !== item.uuid) {
+              lastSkipReportedUuidRef.current = item.uuid;
+              const { item: nextItem, skippedCount } = findNextCompatibleQueueItem(
+                queueRef.current,
+                item.uuid,
+                activeConfigRef.current,
+              );
+              onSkipSpillClimbRef.current({ skipped: item, next: nextItem, skippedCount });
+            }
+            toSend = pendingSendRef.current;
+            pendingSendRef.current = null;
+            continue;
+          }
+          // Reaching here means the item is compatible/unknown and will be sent —
+          // clear the spill dedup so a later return to a skipped spill re-reports.
+          lastSkipReportedUuidRef.current = null;
 
           // connect() may have just written these exact frames as its
           // initialFrames (connect-and-light flows like the play drawer).
@@ -337,6 +396,10 @@ export function BluetoothProvider({
   } = useBoardPresenceControls();
   const { currentClimb: wallCurrentClimb } = useBoardPresenceCurrent();
   const { showUndoWallChangeSnackbar } = useQueueSnackbar();
+  // Queue actions (no state subscription, so the provider doesn't re-render on
+  // queue changes) + toast, for advancing past a spill climb and telling the user.
+  const { setCurrentClimb } = useQueueActions();
+  const { showToast } = useToast();
   const { overrides: holdColorOverrides, signature: holdColorSignature } = useHoldColorOverrides();
   const bluetoothColorOverrides = useMemo(
     () => getBluetoothColorOverrides(holdColorOverrides),
@@ -909,6 +972,48 @@ export function BluetoothProvider({
 
   const clearBoard = useCallback(() => sendFramesToBoard(''), [sendFramesToBoard]);
 
+  // Advance the queue past a "spill" climb (one set for a different board/layout
+  // than the connected board) instead of dark-firing the wall, and tell the user.
+  // The auto-sender detects the mismatch (and dedups repeat reports for the same
+  // spill), computes the next compatible item, and calls this once; here we
+  // re-point the queue so the auto-sender lights the next climb, or clear the wall
+  // when nothing compatible remains.
+  const handleSkipSpillClimb = useCallback(
+    ({
+      skipped,
+      next,
+      skippedCount,
+    }: {
+      skipped: ClimbQueueItem;
+      next: ClimbQueueItem | null;
+      skippedCount: number;
+    }) => {
+      track(SHARED_EVENTS.BleQueueClimbSkipped, {
+        boardName: boardNameRef.current,
+        layoutId: layoutIdRef.current,
+        sizeId: sizeIdRef.current,
+        skippedClimbUuid: skipped.climb.uuid,
+        skippedClimbBoardType: skipped.climb.boardType,
+        skippedClimbLayoutId: skipped.climb.layoutId ?? undefined,
+        skippedCount,
+        advancedToClimbUuid: next?.climb.uuid ?? null,
+        inSession: sessionIdRef.current != null,
+      });
+
+      showToast(
+        t('boardConfigMismatch.mobileSkippedSpillToast', { count: skippedCount, name: skipped.climb.name }),
+        'info',
+      );
+
+      if (next) {
+        setCurrentClimb(next);
+      } else {
+        void clearBoard();
+      }
+    },
+    [setCurrentClimb, showToast, clearBoard, t],
+  );
+
   // Bumped by `reassertWall()` to force the auto-sender to re-push the current
   // climb once, bypassing the byte-identical dedup.
   const [reassertNonce, setReassertNonce] = useState(0);
@@ -1026,6 +1131,8 @@ export function BluetoothProvider({
           reassertNonce={reassertNonce}
           connectInitialSendRef={connectInitialSendRef}
           colorSignature={holdColorSignature}
+          activeConfig={currentBoardConfig}
+          onSkipSpillClimb={handleSkipSpillClimb}
         />
       )}
       {children}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -91,10 +91,10 @@ export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
   boardConfig?: BoardConfig;
   /** Analytics-only tag for the `Play Drawer Opened` event's `source`. Lets a
    *  real climb-view (feed/session/beta/playlist) be distinguished from a
-   *  queue-nav / accessory tap — both pass `setAsCurrent: false`, so the
-   *  default `current_queue_item`/`mobile` heuristic can't tell them apart.
-   *  Pulled out before the rest of the options reach `PlayDrawer.open`, so it
-   *  never leaks into the drawer itself. */
+   *  queue-nav / accessory tap — the latter open `committedExternally` or with a
+   *  `previewQueueItem`, so the default `current_queue_item`/`mobile` heuristic
+   *  can't tell them apart. Pulled out before the rest of the options reach
+   *  `PlayDrawer.open`, so it never leaks into the drawer itself. */
   source?: 'climb_view' | 'current_queue_item' | 'mobile';
 };
 
@@ -243,7 +243,9 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       climbUuid: climb.uuid,
       boardName: boardConfig?.boardName,
       layoutId: boardConfig?.layoutId,
-      source: openSource ?? (openOptions.setAsCurrent === false ? 'current_queue_item' : 'mobile'),
+      source:
+        openSource ??
+        (openOptions.committedExternally || openOptions.previewQueueItem != null ? 'current_queue_item' : 'mobile'),
     });
     if (override) {
       pendingOverrideOpenRef.current = { climb, options: openOptions };
@@ -453,7 +455,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const handleQueueClimbPress = useCallback(
     (item: ClimbQueueItem) => {
       setCurrentClimb(item);
-      openPlayDrawer(item.climb, { setAsCurrent: false, previewQueueItem: item });
+      openPlayDrawer(item.climb, { committedExternally: true });
       requestCloseQueueSheet();
     },
     [setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
@@ -467,7 +469,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       const item = climbToQueueItem(climb, { suggested: true });
       const schemaClimb = item.climb as Climb;
       setCurrentClimb(item, { playlistSuggestionSource: source });
-      openPlayDrawer(schemaClimb, { setAsCurrent: false, previewQueueItem: item });
+      openPlayDrawer(schemaClimb, { committedExternally: true });
       requestCloseQueueSheet();
     },
     [setCurrentClimb, openPlayDrawer, requestCloseQueueSheet],
@@ -551,8 +553,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         : action.boardConfig;
       setCurrentClimb(item);
       openPlayDrawer(action.climb, {
-        setAsCurrent: false,
-        previewQueueItem: item,
+        committedExternally: true,
         boardConfig: boardConfigOverride,
       });
     },

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -63,6 +63,10 @@ Input type for creating or updating a climb.
 """
 input ClimbInput {
   uuid: ID!
+  "Board type the climb belongs to (kilter / tension). Round-tripped so a connected board can skip a climb set for another board."
+  boardType: String
+  "Layout the climb belongs to. Round-tripped so a connected board can skip a climb set for another layout."
+  layoutId: Int
   setter_username: String!
   "Boardsesh user ID of the climb owner (null for Aurora-synced climbs)."
   userId: ID

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -703,6 +703,8 @@ export type ClimbInput = {
   angle: Scalars['Int']['input'];
   ascensionist_count: Scalars['Int']['input'];
   benchmark_difficulty?: InputMaybe<Scalars['String']['input']>;
+  /** Board type the climb belongs to (kilter / tension). Round-tripped so a connected board can skip a climb set for another board. */
+  boardType?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   difficulty: Scalars['String']['input'];
   difficulty_error: Scalars['String']['input'];
@@ -714,6 +716,8 @@ export type ClimbInput = {
   /** Whether this climb is still a draft. */
   is_draft?: InputMaybe<Scalars['Boolean']['input']>;
   is_no_match?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Layout the climb belongs to. Round-tripped so a connected board can skip a climb set for another layout. */
+  layoutId?: InputMaybe<Scalars['Int']['input']>;
   mirrored?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
   /** ISO timestamp of when this climb was first published. */

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -59,6 +59,10 @@ export const climbTypeDefs = /* GraphQL */ `
   """
   input ClimbInput {
     uuid: ID!
+    "Board type the climb belongs to (kilter / tension). Round-tripped so a connected board can skip a climb set for another board."
+    boardType: String
+    "Layout the climb belongs to. Round-tripped so a connected board can skip a climb set for another layout."
+    layoutId: Int
     setter_username: String!
     "Boardsesh user ID of the climb owner (null for Aurora-synced climbs)."
     userId: ID

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -55,6 +55,11 @@ export type Climb = {
 // Input type for Climb (matches GraphQL ClimbInput)
 export type ClimbInput = {
   uuid: string;
+  // Board the climb belongs to. Round-tripped through the queue so a connected
+  // board can skip a climb set for a different board/layout instead of
+  // dark-firing the wall.
+  boardType?: string;
+  layoutId?: number | null;
   setter_username: string;
   // Boardsesh user ID of the climb owner; nullable for Aurora-synced climbs.
   userId?: string | null;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -72,6 +72,12 @@ export const SHARED_EVENTS = {
   // skippedCount, advancedToClimbUuid (null when no compatible climb remained),
   // active board config, and the skipped climb's board config.
   BleQueueClimbSkipped: 'BLE Queue Climb Skipped',
+  // The "this controller belongs to another board setup" dialog was shown when a
+  // scanned serial resolved to a different board config than the active one, and
+  // how the user resolved it. Resolved `action`: 'cancel' | 'connect_anyway' |
+  // 'switch_setup' | 'switch_failed'.
+  BleBoardConfigMismatchShown: 'BLE Board Config Mismatch Shown',
+  BleBoardConfigMismatchResolved: 'BLE Board Config Mismatch Resolved',
   // Search
   ClimbSearchPerformed: 'Climb Search Performed',
   SearchHoldFilterChanged: 'Search Hold Filter Changed',

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -67,6 +67,11 @@ export const SHARED_EVENTS = {
   BlePickerDevicesResolved: 'BLE Picker Devices Resolved',
   ClimbSentToBoardSuccess: 'Climb Sent to Board Success',
   ClimbSentToBoardFailure: 'Climb Sent to Board Failure',
+  // A queued climb set for a DIFFERENT board/layout than the connected board was
+  // skipped instead of dark-firing the wall. Props: skippedClimbUuid,
+  // skippedCount, advancedToClimbUuid (null when no compatible climb remained),
+  // active board config, and the skipped climb's board config.
+  BleQueueClimbSkipped: 'BLE Queue Climb Skipped',
   // Search
   ClimbSearchPerformed: 'Climb Search Performed',
   SearchHoldFilterChanged: 'Search Hold Filter Changed',

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -700,6 +700,8 @@ export type ClimbInput = {
   angle: Scalars['Int']['input'];
   ascensionist_count: Scalars['Int']['input'];
   benchmark_difficulty?: InputMaybe<Scalars['String']['input']>;
+  /** Board type the climb belongs to (kilter / tension). Round-tripped so a connected board can skip a climb set for another board. */
+  boardType?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   difficulty: Scalars['String']['input'];
   difficulty_error: Scalars['String']['input'];
@@ -711,6 +713,8 @@ export type ClimbInput = {
   /** Whether this climb is still a draft. */
   is_draft?: InputMaybe<Scalars['Boolean']['input']>;
   is_no_match?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Layout the climb belongs to. Round-tripped so a connected board can skip a climb set for another layout. */
+  layoutId?: InputMaybe<Scalars['Int']['input']>;
   mirrored?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
   /** ISO timestamp of when this climb was first published. */

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -4,6 +4,8 @@
 // Fragment for reusable climb fields
 const CLIMB_FIELDS = `
   uuid
+  boardType
+  layoutId
   setter_username
   name
   frames

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -483,6 +483,8 @@
     }
   },
   "playView": {
+    "previewBadge": "Preview",
+    "setActive": "Set active",
     "previousFrame": "Previous frame",
     "nextFrame": "Next frame",
     "play": "Play",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -370,6 +370,8 @@
     "mobileRecordedLabel": "Recorded for this controller: {{config}}",
     "mobileConfigValue": "{{board}} layout {{layoutId}}, size {{sizeId}}, sets {{setIds}}",
     "mobileUnknownConfig": "Unknown board config",
+    "mobileSkippedSpillToast_one": "Skipped {{name}} — it's set for a different board",
+    "mobileSkippedSpillToast_other": "Skipped {{count}} climbs set for a different board",
     "mobileSwitchFailed": "Couldn't switch to that board's config. Try Connect anyway.",
     "cancel": "Cancel",
     "connectAnyway": "Connect anyway",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -375,7 +375,11 @@
     "mobileSwitchFailed": "Couldn't switch to that board's config. Try Connect anyway.",
     "cancel": "Cancel",
     "connectAnyway": "Connect anyway",
-    "switchToCorrect": "Switch to correct config"
+    "switchToCorrect": "Switch to correct config",
+    "mobileConnectAnyway": "Connect anyway",
+    "mobileConnectAnywayWarning": "Our records show this controller belongs to another board setup. Connecting anyway may light climbs incorrectly.",
+    "mobileSwitchSetup": "Switch board setup",
+    "mobileUseRecordedSetup": "Use recorded setup"
   },
   "devicePicker": {
     "title": "Select your board",
@@ -404,7 +408,7 @@
     "relightBoard": "Re-light board",
     "turnOff": "Turn off the board",
     "holdForControls": "Hold for board controls",
-    "notAvailable": "Bluetooth is not available",
+    "sendFailedTitle": "Couldn't light board",
     "connectionFailedTitle": "Couldn't connect",
     "permissionRequired": "Bluetooth permission required",
     "errorPermissionDenied": "Allow Bluetooth permissions to connect a board.",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -483,6 +483,8 @@
     }
   },
   "playView": {
+    "previewBadge": "Vista previa",
+    "setActive": "Activar",
     "previousFrame": "Fotograma anterior",
     "nextFrame": "Fotograma siguiente",
     "play": "Reproducir",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -375,7 +375,11 @@
     "mobileSwitchFailed": "No se pudo cambiar a la configuración de ese tablero. Prueba Conectar igualmente.",
     "cancel": "Cancelar",
     "connectAnyway": "Conectar igualmente",
-    "switchToCorrect": "Cambiar a la configuración correcta"
+    "switchToCorrect": "Cambiar a la configuración correcta",
+    "mobileConnectAnyway": "Conectar igualmente",
+    "mobileConnectAnywayWarning": "Nuestros registros muestran que este controlador pertenece a otra configuración de tablero. Conectar igualmente podría iluminar las vías de forma incorrecta.",
+    "mobileSwitchSetup": "Cambiar de tablero",
+    "mobileUseRecordedSetup": "Usar la configuración registrada"
   },
   "devicePicker": {
     "title": "Selecciona tu tablero",
@@ -404,7 +408,7 @@
     "relightBoard": "Reiluminar tablero",
     "turnOff": "Apagar el tablero",
     "holdForControls": "Mantén pulsado para los controles",
-    "notAvailable": "Bluetooth no está disponible",
+    "sendFailedTitle": "No se pudo iluminar el tablero",
     "connectionFailedTitle": "No se pudo conectar",
     "permissionRequired": "Permiso de Bluetooth necesario",
     "errorPermissionDenied": "Permite los permisos de Bluetooth para conectar un tablero.",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -370,6 +370,8 @@
     "mobileRecordedLabel": "Registrado para este controlador: {{config}}",
     "mobileConfigValue": "{{board}} diseño {{layoutId}}, tamaño {{sizeId}}, sets {{setIds}}",
     "mobileUnknownConfig": "Configuración de tablero desconocida",
+    "mobileSkippedSpillToast_one": "Se omitió {{name}} — es de otro tablero",
+    "mobileSkippedSpillToast_other": "Se omitieron {{count}} vías de otro tablero",
     "mobileSwitchFailed": "No se pudo cambiar a la configuración de ese tablero. Prueba Conectar igualmente.",
     "cancel": "Cancelar",
     "connectAnyway": "Conectar igualmente",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -483,6 +483,8 @@
     }
   },
   "playView": {
+    "previewBadge": "Aperçu",
+    "setActive": "Activer",
     "previousFrame": "Image précédente",
     "nextFrame": "Image suivante",
     "play": "Lire",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -375,7 +375,11 @@
     "mobileSwitchFailed": "Impossible de passer à la configuration de ce board. Essayez Connecter quand même.",
     "cancel": "Annuler",
     "connectAnyway": "Connecter quand même",
-    "switchToCorrect": "Passer à la bonne configuration"
+    "switchToCorrect": "Passer à la bonne configuration",
+    "mobileConnectAnyway": "Connecter quand même",
+    "mobileConnectAnywayWarning": "D'après nos enregistrements, ce contrôleur appartient à une autre configuration de board. Connecter quand même pourrait allumer les voies de façon incorrecte.",
+    "mobileSwitchSetup": "Changer de board",
+    "mobileUseRecordedSetup": "Utiliser la configuration enregistrée"
   },
   "devicePicker": {
     "title": "Sélectionnez votre board",
@@ -404,7 +408,7 @@
     "relightBoard": "Rallumer le panneau",
     "turnOff": "Éteindre le panneau",
     "holdForControls": "Maintenir pour les commandes",
-    "notAvailable": "Le Bluetooth n'est pas disponible",
+    "sendFailedTitle": "Impossible d'allumer le board",
     "connectionFailedTitle": "Connexion impossible",
     "permissionRequired": "Autorisation Bluetooth requise",
     "errorPermissionDenied": "Autorisez le Bluetooth pour connecter un panneau.",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -370,6 +370,8 @@
     "mobileRecordedLabel": "Enregistré pour ce contrôleur : {{config}}",
     "mobileConfigValue": "{{board}} layout {{layoutId}}, taille {{sizeId}}, sets {{setIds}}",
     "mobileUnknownConfig": "Configuration du board inconnue",
+    "mobileSkippedSpillToast_one": "{{name}} ignorée — elle est pour un autre board",
+    "mobileSkippedSpillToast_other": "{{count}} voies ignorées, prévues pour un autre board",
     "mobileSwitchFailed": "Impossible de passer à la configuration de ce board. Essayez Connecter quand même.",
     "cancel": "Annuler",
     "connectAnyway": "Connecter quand même",


### PR DESCRIPTION
## Why

PostHog + DB telemetry for a Beest Kilter (serial `751521`) showed a clean BLE connect — the controller resolved correctly to the saved board (kilter / layout 1 / size 10 / sets 1,20) — immediately followed by `Climb Sent to Board Failure` with `failureReason = incompatible_climb`. The controller→board mapping was fine; the **wrong climb** reached the board, every LED placement was skipped, and the wall dark-fired. Two mobile root causes, plus the telemetry was too thin to tell them apart.

## What (5 reviewed parts, mobile only + one additive `ClimbInput` field)

**A — Preview is now explicit.** The play drawer could show a view-only "preview" climb while the BLE auto-sender lit `currentClimbQueueItem` — a different climb. Preview stays for the surfaces that need it (workout builder, logbook/feed/cross-board browse, the peer-driven accessory wall climb) but is now shown with a **"Preview" badge + a "Set active" button**, and the overloaded `setAsCurrent:false` open option is split into `committedExternally` (render-ahead) vs `previewQueueItem` (view-only). The lightbulb/auto-sender are unchanged.

**B — Spill-skip.** Queue items now carry `boardType`/`layoutId` (preserved in `climbToQueueItem`/`toClimbInput` and added to the GraphQL `ClimbInput` so they round-trip through party sync). When the connected board's current climb belongs to a *different* board/layout, the auto-sender skips it instead of dark-firing — advancing to the next compatible climb (or clearing the wall) and toasting. Only a **known** mismatch is skipped; unknown/missing metadata sends as before.

**C — Mismatch dialog UX.** "Connect anyway" is a warning, not a destructive (red) action. New mobile-only copy ("our records show this controller belongs to another board setup; connecting anyway may light climbs incorrectly", "Switch board setup" / "Use recorded setup"); web's shared dialog is untouched.

**D — Send-failure copy.** Send failures stop using "Bluetooth is not available" as the title — a send-specific "Couldn't light board" replaces it.

**E — Diagnostics.** Thread send context (`sendSource`, `targetQueueItemUuid`, `climbUuid`, the climb's own board config) into `Climb Sent to Board Success/Failure`; incompatible failures now carry `skippedPositionCount`/`skippedRoleCount`/`totalPlacements`. `Bluetooth Connection Success` + every send carry `connectedViaMismatchOverride`. New events: `BLE Queue Climb Skipped`, `BLE Board Config Mismatch Shown/Resolved`.

## Testing

- `vp run typecheck` (mobile, shared, backend, web, db) — pass.
- Full mobile suite: **2330 tests** pass (incl. new board-config-compat, spill-skip, preview-banner, mismatch-dialog, send-context tests).
- Web climb/queue (1005) + backend queue/climb (79) pass — validates the `ClimbInput` round-trip.
- i18n catalog parity + orphan checks pass; `vp run check:mobile-bundle` OK.
- Each part was reviewed by an independent agent and its feedback addressed before the next.

## Notes

- Party mode: advancing past a spill changes the shared current climb for peers — acceptable since a session is normally one physical board.
- Manual QA still recommended on a dev client (preview badge + Set active; spill-skip toast; mismatch dialog wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
