### PR TITLE
fix(mobile): resolve 5 session-detail regressions

### DIFF
--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -16,7 +16,7 @@ import { SessionAnalyticsSection } from './SessionAnalyticsSection';
 import { SessionBetaCarousel } from './SessionBetaCarousel';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionTickRow } from './SessionTickRow';
-import { useSessionDetail } from '../../lib/graphql/hooks';
+import { useSessionDetail, useBulkVoteSummaries } from '../../lib/graphql/hooks';
 import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
@@ -47,6 +47,8 @@ export default function SessionDetailScreen() {
   const paddingBottom = bottomChrome.floatingControlBottom + spacing[6];
 
   const { data: session, isPending } = useSessionDetail(sessionId);
+  const { data: voteSummaries } = useBulkVoteSummaries('session', sessionId ? [sessionId] : [], !!sessionId);
+  const sessionVoteSummary = voteSummaries?.[0];
 
   const commentSheetRef = useRef<BottomSheet | null>(null);
   const [commentTarget, setCommentTarget] = useState<{ entityId: string; entityType: SocialEntityType } | null>(null);
@@ -126,6 +128,7 @@ export default function SessionDetailScreen() {
         title={title}
         titleIsDate={!session.sessionName}
         onOpenComments={handleOpenSessionComments}
+        voteSummary={sessionVoteSummary}
       />
 
       <SessionAnalyticsSection gradeDistribution={session.gradeDistribution} />

--- a/packages/mobile/src/components/session/SessionSummaryCard.tsx
+++ b/packages/mobile/src/components/session/SessionSummaryCard.tsx
@@ -30,6 +30,7 @@ type SessionSummaryCardProps = {
    *  human "Sunday morning" instead of repeating the date. */
   titleIsDate: boolean;
   onOpenComments: (entityId: string) => void;
+  voteSummary?: { upvotes: number; userVote: number | null };
 };
 
 /**
@@ -39,7 +40,7 @@ type SessionSummaryCardProps = {
  * separate hero, a tiles card, and a standalone social row. Only the hardest-grade
  * tile carries colour, so the grade stays the one accent.
  */
-export function SessionSummaryCard({ session, title, titleIsDate, onOpenComments }: SessionSummaryCardProps) {
+export function SessionSummaryCard({ session, title, titleIsDate, onOpenComments, voteSummary }: SessionSummaryCardProps) {
   const { systemColors } = useTheme();
   const { t } = useTranslation('you');
   const { t: tSession } = useTranslation('session');
@@ -109,8 +110,8 @@ export function SessionSummaryCard({ session, title, titleIsDate, onOpenComments
       <View style={styles.social}>
         <FeedSocialRow
           entityId={session.sessionId}
-          upvotes={session.upvotes}
-          userVote={null}
+          upvotes={voteSummary?.upvotes ?? session.upvotes}
+          userVote={voteSummary?.userVote ?? null}
           commentCount={session.commentCount}
           onOpenComments={onOpenComments}
         />

--- a/packages/mobile/src/components/session/SessionTickRow.tsx
+++ b/packages/mobile/src/components/session/SessionTickRow.tsx
@@ -5,7 +5,7 @@ import type { SessionDetailTick, SessionFeedParticipant } from '@boardsesh/share
 import { getGradeTextColor } from '@boardsesh/play-view';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import type { IconName } from '../icon-map';
+import { type IconName } from '../icon-map';
 import { ListRow } from '../ListRow';
 import { PressableAvatar } from '../PressableAvatar';
 import { PressableSurface } from '../PressableSurface';
@@ -100,7 +100,9 @@ export const SessionTickRow = memo(function SessionTickRow({
   // fallbackSubtitle is used only by the ListRow path (climb/boardConfig missing).
   // In the ClimbListItemContent path, participant name is surfaced via
   // primarySubtitleOverride and attempt/comment/setter via subtitleDetailParts.
-  const fallbackSubtitle = detailParts.join(' · ') || undefined;
+  // ListRow has no detail line, so setterText is excluded here to avoid it
+  // appearing in the only subtitle slot alongside the attempt/comment text.
+  const fallbackSubtitle = [attemptText, tick.comment ?? null].filter((part): part is string => !!part).join(' · ') || undefined;
 
   const handlePress = useCallback(() => {
     hapticSelection();

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -178,6 +178,25 @@ describe('SessionSummaryCard', () => {
     expect(mockFeedSocialRow).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'sess-42' }));
   });
 
+  it('wires onOpenComments through to FeedSocialRow', () => {
+    const onOpenComments = vi.fn();
+    render(
+      createElement(SessionSummaryCard, {
+        session: session({ sessionId: 'sess-42' }),
+        title: 'Sesh',
+        titleIsDate: false,
+        onOpenComments,
+      }),
+    );
+    const capturedProps = mockFeedSocialRow.mock.calls[0][0] as {
+      entityId: string;
+      onOpenComments: (id: string) => void;
+    };
+    expect(typeof capturedProps.onOpenComments).toBe('function');
+    capturedProps.onOpenComments('sess-42');
+    expect(onOpenComments).toHaveBeenCalledWith('sess-42');
+  });
+
   it('passes participants to AvatarGroup', () => {
     const participants = [{ userId: 'u1', displayName: 'Alice', avatarUrl: null, sends: 3, flashes: 1, attempts: 7 }];
     render_(session({ participants }), 'Party', false);

--- a/packages/mobile/test/theme-animations-stub.ts
+++ b/packages/mobile/test/theme-animations-stub.ts
@@ -37,3 +37,14 @@ export const motionByVariant = {
     emphasized: { duration: 350, easingBezier: [0.05, 0.7, 0.1, 1] },
   },
 };
+
+export type SpringPreset = 'snappy' | 'interactive' | 'gentle' | 'bouncy';
+export type TimingPreset = 'instant' | 'fast' | 'normal' | 'slow';
+export type MotionConfig = {
+  duration: number;
+  easingBezier?: readonly [number, number, number, number];
+};
+export type Motion = {
+  standard: MotionConfig;
+  emphasized: MotionConfig;
+};


### PR DESCRIPTION
## Summary

- **userVote always null**: `SessionDetailScreen` now calls `useBulkVoteSummaries` for the open session and passes the result down as `voteSummary` to `SessionSummaryCard`, which forwards it to `FeedSocialRow`. The heart now reflects the user's real vote state instead of always showing un-voted.
- **Double-setter in ListRow fallback**: `fallbackSubtitle` in `SessionTickRow` is now built from `[attemptText, comment]` only — `setterText` is excluded from the fallback path since `ListRow` has no separate detail line. `detailParts` (passed as `subtitleDetailParts` to `ClimbListItemContent`) is unchanged.
- **import type lint violation**: `SessionTickRow.tsx` line 8 changed from `import type { IconName }` to `import { type IconName }` to satisfy the project's `inline-type-imports` rule.
- **Missing onOpenComments test**: Added a test case in `SessionSummaryCard.test.tsx` that captures the `onOpenComments` prop passed to `FeedSocialRow` via the mock spy and asserts it calls back with the correct `entityId`.
- **theme-animations-stub missing types**: Added `SpringPreset`, `TimingPreset`, `MotionConfig`, and `Motion` type exports to the stub, matching the real `animations.ts` exactly. No `keyof typeof` syntax — safe for Rolldown.

## Test plan

- [ ] `vp run typecheck:mobile` — no new type errors
- [ ] `vp run test:mobile` — all 15 `SessionSummaryCard` tests pass (14 existing + 1 new)
- [ ] Open a session you previously upvoted — heart should render filled
- [ ] Open a session on a board with an unknown layout — tick rows with missing board config should show attempt + comment in subtitle, no "Set by" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnDdr5KtVsAvbpgWbhk9xW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDdr5KtVsAvbpgWbhk9xW)_