### PR TITLE
Compile out screenshot-mode branches from production mobile bundles

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -29,7 +29,7 @@ simulator keychain first so login authenticates cleanly against prod.
 ## Flows
 
 There is no login flow. The screenshot build auto-signs-in on boot — the auth provider's
-`SCREENSHOT_MODE` branch (`auth-provider.tsx`, fed by `screenshot-mode.ts` `SCREENSHOT_USER_*`)
+`EXPO_PUBLIC_SCREENSHOT_MODE` branch (`auth-provider.tsx`, fed by `screenshot-mode.ts` `SCREENSHOT_USER_*`)
 signs in during its initial auth check, before the loading gate clears, so the app renders
 straight into Home: no login screen ever mounts, no form is typed, and iOS never offers to
 save the password. The orchestrator launches the app and waits for the `$screen /home` log

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -58,7 +58,6 @@ import { getFilterSummary, buildClimbFilterSummary } from '../../../src/lib/filt
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName, visibleSearchTextNeedsSync } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
-import { SCREENSHOT_MODE } from '../../../src/lib/screenshot-mode';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
@@ -554,7 +553,7 @@ function ClimbListInner() {
   // board's results land, and at most once. Dead-strips in normal builds.
   const screenshotBoardViewOpenedRef = useRef(false);
   useEffect(() => {
-    if (!SCREENSHOT_MODE || !screenshotOpenFirst) return;
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1' || !screenshotOpenFirst) return;
     if (screenshotBoardViewOpenedRef.current) return;
     const firstClimb = visibleClimbs[0];
     if (!searchReady || !firstClimb) return;

--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -11,7 +11,6 @@ import { ProgressTab } from '../../../src/components/you/ProgressTab';
 import { SessionsTab } from '../../../src/components/you/SessionsTab';
 import { LogbookTab } from '../../../src/components/you/LogbookTab';
 import { SocialTab } from '../../../src/components/you/SocialTab';
-import { SCREENSHOT_MODE } from '../../../src/lib/screenshot-mode';
 
 // Screenshot mode selects the visible sub-tab via a `screenshotTab` deep-link
 // param so the logbook/sessions shots are deterministic.
@@ -30,13 +29,13 @@ export default function YouScreen() {
   const filterSheetRef = useRef<BottomSheet | null>(null);
   const { screenshotTab } = useLocalSearchParams<{ screenshotTab?: string }>();
   const [activeTab, setActiveTab] = useState<ProfileTabKey>(() =>
-    SCREENSHOT_MODE && isProfileTabKey(screenshotTab) ? screenshotTab : 'progress',
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && isProfileTabKey(screenshotTab) ? screenshotTab : 'progress',
   );
   // The profile tab stays mounted across screenshot shots, so re-sync the visible
   // sub-tab whenever the deep-link param changes (initial mount is covered by the
   // useState initialiser). Inert in normal builds — manual tab taps own the state.
   useEffect(() => {
-    if (!SCREENSHOT_MODE) return;
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1') return;
     setActiveTab(isProfileTabKey(screenshotTab) ? screenshotTab : 'progress');
   }, [screenshotTab]);
 

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -53,15 +53,14 @@ import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
-import { SCREENSHOT_MODE } from '../src/lib/screenshot-mode';
 
 void SplashScreen.preventAutoHideAsync();
 
 // The screenshots build is a Debug dev-client (__DEV__ true) so it can load its
 // JS from Metro; a stray warning would pop a LogBox toast into a captured
-// screenshot. Suppress all LogBox UI in screenshot mode. SCREENSHOT_MODE is a
-// build/bundle-time flag, so this dead-strips from every normal build.
-if (SCREENSHOT_MODE) {
+// screenshot. Suppress all LogBox UI in screenshot mode. EXPO_PUBLIC_SCREENSHOT_MODE
+// is inlined at build time, so this dead-strips from every normal build.
+if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') {
   LogBox.ignoreAllLogs(true);
 }
 

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -3,7 +3,6 @@ import { router, useSegments } from 'expo-router';
 import * as Linking from 'expo-linking';
 import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
 import { useProfile } from '../../lib/graphql/hooks';
-import { SCREENSHOT_MODE } from '../../lib/screenshot-mode';
 
 type OnboardingGateProps = {
   /** True once auth + fonts are resolved and the splash has hidden. */
@@ -54,7 +53,7 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
     if (!ready || decidedRef.current) return;
     // Screenshot builds never auto-present the tour: the app-store flow needs to
     // reach the tabs, and the onboarding-capture flow opens /onboarding itself.
-    if (SCREENSHOT_MODE) return;
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return;
     decidedRef.current = true;
 
     let cancelled = false;

--- a/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/PreSessionView.tsx
@@ -34,7 +34,7 @@ import {
   DEFAULT_VOLUME_OPTIONS,
 } from '@boardsesh/playlist-generator';
 import { assertNever } from '../../../lib/assert-never';
-import { SCREENSHOT_MODE, SCREENSHOT_WORKOUT } from '../../../lib/screenshot-mode';
+import { SCREENSHOT_WORKOUT } from '../../../lib/screenshot-mode';
 import { GeneratorPickerCard, type GeneratorSelection } from './GeneratorPickerCard';
 import { WorkoutPreviewRow } from './WorkoutPreviewRow';
 import { useWorkoutPreview } from './use-workout-preview';
@@ -47,7 +47,7 @@ import type { PreviewItem } from './workout-preview-pool';
 // The DEFAULT_*_OPTIONS omit `targetGrade` (see playlist-generator types), so each
 // branch adds a mid-grade default — mirroring buildDefaultOptions in GeneratorPickerCard.
 function initialGeneratorSelection(): GeneratorSelection {
-  if (!SCREENSHOT_MODE || !SCREENSHOT_WORKOUT) return { type: 'off' };
+  if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1' || !SCREENSHOT_WORKOUT) return { type: 'off' };
   const targetGrade = 15;
   switch (SCREENSHOT_WORKOUT) {
     case 'volume':

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -23,7 +23,6 @@ import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
-import { SCREENSHOT_MODE } from '../../lib/screenshot-mode';
 
 type FeedRow = { type: 'header'; bucket: FeedRecencyBucket } | { type: 'session'; item: SessionFeedItem };
 type CommentTarget = { entityId: string; entityType: SocialEntityType };
@@ -176,7 +175,7 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
   // deep-link param, so it never disturbs the default profile shot. Fires once.
   const screenshotSessionOpenedRef = useRef(false);
   useEffect(() => {
-    if (!SCREENSHOT_MODE || screenshotSessionOpenedRef.current) return;
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1' || screenshotSessionOpenedRef.current) return;
     const firstSession = sessions[0];
     if (!firstSession) return;
     screenshotSessionOpenedRef.current = true;

--- a/packages/mobile/src/lib/screenshot-mode.ts
+++ b/packages/mobile/src/lib/screenshot-mode.ts
@@ -7,15 +7,30 @@ import {
 
 /**
  * Build-time screenshot mode. The dedicated screenshots build (see
- * `scripts/mobile-screenshots.ts`) is compiled with
- * `EXPO_PUBLIC_SCREENSHOT_MODE=1`; every normal build leaves the var unset, so
- * `SCREENSHOT_MODE` is `false` and the branches that read it dead-strip. This is
- * the native analogue of the web app-store flow's `sessionStorage` flags
- * (`boardsesh:e2e-bluetooth-picker`, `boardsesh:e2e-suppress-install-card`): a
- * presentation-stability switch, not a data-mocking layer — the seeded backend
- * stays the source of truth.
+ * `scripts/mobile-screenshots.ts`) is compiled with `EXPO_PUBLIC_SCREENSHOT_MODE=1`;
+ * every normal build leaves the var unset. It's the native analogue of the web
+ * app-store flow's `sessionStorage` flags (`boardsesh:e2e-bluetooth-picker`,
+ * `boardsesh:e2e-suppress-install-card`): a presentation-stability switch, not a
+ * data-mocking layer — the seeded backend stays the source of truth.
+ *
+ * The boolean is intentionally NOT exported from here. Each consumer inlines the
+ * raw comparison directly in its guard / ternary condition:
+ *
+ *   if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') { … }
+ *   if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1') return;
+ *
+ * babel-preset-expo replaces `process.env.EXPO_PUBLIC_*` with a literal per
+ * module, so in a minified release build the condition folds in place
+ * (`undefined === '1'` → `false`) and terser dead-strips the branch — needing
+ * only literal folding, no cross-module or cross-statement constant propagation.
+ * Routing the flag through a shared export — or even a module-local
+ * `const SCREENSHOT_MODE = …` — makes the strip lean on the minifier's
+ * variable-propagation passes instead of plain literal folding. Keep the raw
+ * `process.env.EXPO_PUBLIC_SCREENSHOT_MODE` comparison at each call site.
+ *
+ * The typed override helpers below stay shared: they're only read inside the
+ * now-DCE-able branches, so they strip along with them.
  */
-export const SCREENSHOT_MODE = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
 
 /**
  * Theme the screenshots build locks to so a capture can't flip mid-run when

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -13,7 +13,7 @@ import {
   type CredentialsSignInResult,
   type OAuthSignInResult,
 } from '../lib/auth';
-import { SCREENSHOT_MODE, SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screenshot-mode';
+import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screenshot-mode';
 import { reset as resetAnalytics, track } from '../lib/analytics';
 import { reportError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
@@ -120,8 +120,10 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         // Screenshot build: sign in programmatically here, before the loading gate
         // clears, so the app renders straight into /home — the login screen never
         // mounts. No form is shown, so there's no Maestro timing race and no iOS
-        // "Save Password?" dialog. Inert in normal builds (SCREENSHOT_MODE === false).
-        if (SCREENSHOT_MODE && SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
+        // "Save Password?" dialog. Inert in normal builds (dead-strips when
+        // EXPO_PUBLIC_SCREENSHOT_MODE is unset — the comparison stays inlined here so the
+        // release minifier folds it in place rather than across a module boundary).
+        if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
           const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
           if (screenshotSignIn.success) {
             setIsAuthenticated(true);

--- a/packages/mobile/src/providers/theme-provider.tsx
+++ b/packages/mobile/src/providers/theme-provider.tsx
@@ -44,7 +44,7 @@ import {
 import { variantFeatures, type VariantFeatures } from '../theme/variants/variant-features';
 import { secureStorePreferences } from '../lib/preferences/secure-store-adapter';
 import { assertNever } from '../lib/assert-never';
-import { SCREENSHOT_MODE, SCREENSHOT_THEME_OVERRIDE, SCREENSHOT_VARIANT_PREFERENCE } from '../lib/screenshot-mode';
+import { SCREENSHOT_THEME_OVERRIDE, SCREENSHOT_VARIANT_PREFERENCE } from '../lib/screenshot-mode';
 
 type ColorScheme = 'light' | 'dark';
 
@@ -218,14 +218,14 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   // theme is locked to a fixed value (light by default) so captures can't flip
   // mid-run when the keychain read resolves.
   const [themeOverride, setThemeOverrideState] = useState<ThemeOverride>(
-    SCREENSHOT_MODE ? SCREENSHOT_THEME_OVERRIDE : 'system',
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? SCREENSHOT_THEME_OVERRIDE : 'system',
   );
   // `'auto'` until SecureStore hydrates — same value as a brand-new user, so the
   // first paint resolves to the platform default (Liquid Glass on iOS 26,
   // Material elsewhere) via the synchronous capability check, no flash. Locked
   // in screenshot mode for the same reason as the theme override.
   const [uiVariantPreference, setUiVariantPreferenceState] = useState<UiVariantPreference>(
-    SCREENSHOT_MODE ? SCREENSHOT_VARIANT_PREFERENCE : 'auto',
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? SCREENSHOT_VARIANT_PREFERENCE : 'auto',
   );
   // Guards the hydration effect against stomping a user choice that lands
   // before the SecureStore read resolves (a tap on a settings toggle can
@@ -237,7 +237,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     // Screenshot mode pins the theme + variant to fixed values, so skip the
     // SecureStore reads entirely — otherwise a saved override could flip the
     // look between the first paint and the capture.
-    if (SCREENSHOT_MODE) return;
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return;
     let cancelled = false;
     secureStorePreferences
       .get<ThemeOverride>(THEME_OVERRIDE_KEY)


### PR DESCRIPTION
## What

Make the React Native `SCREENSHOT_MODE` guards actually dead-strip from production bundles, instead of just being gated off at runtime.

## Why

The screenshot-mode call sites `import { SCREENSHOT_MODE }` from `screenshot-mode.ts`. `babel-preset-expo` correctly folds the env var to `false` *inside that file*, so screenshot code never **runs** in prod — but Metro does **not** fold a `const` across module boundaries. The release minifier can't prove the imported guard is `false`, so every screenshot branch (auto-sign-in on login, auto-join sessions, pre-selected workouts, pinned theme/variant, suppressed onboarding/LogBox) physically **ships** in the production bundle. (The old doc comment claiming the branches "dead-strip" was inaccurate for that reason.)

## How

Inline the raw env comparison **directly in each guard / ternary condition** — no shared export, no module-local const:

```ts
if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') { … }
if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1') return;
SCREENSHOT_MODE ? … → process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? …
```

`babel-preset-expo` replaces `process.env.EXPO_PUBLIC_*` with a literal per module, so in a minified release build the condition folds in place (`undefined === '1'` → `false`) and terser dead-strips the branch (and the now-unused aux imports like `SCREENSHOT_WORKOUT` / `SCREENSHOT_USER_EMAIL`). This needs only **literal folding** — no cross-module or cross-statement constant propagation, so it doesn't lean on the minifier's variable-propagation passes. The dedicated screenshots build keeps setting `EXPO_PUBLIC_SCREENSHOT_MODE=1`, so the branches are retained there.

Covers all eight call sites on `main`: `_layout`, `climbs`, `profile`, `auth/login`, `OnboardingGate`, `PreSessionView`, `SessionsTab`, `theme-provider`.

- Dropped the `SCREENSHOT_MODE` export from `screenshot-mode.ts`; kept the typed `SCREENSHOT_THEME_OVERRIDE` / `SCREENSHOT_VARIANT_PREFERENCE` / `SCREENSHOT_WORKOUT` / `SCREENSHOT_USER_*` helpers (they only run inside the now-DCE-able branches).
- Rewrote that file's doc to spell out that the comparison must stay inlined at each call site — routing it through a shared export *or even a module-local const* re-introduces the propagation dependency.
- **No change** to the env var name, `scripts/mobile-screenshots.ts`, the `.env`, or `.github/workflows/mobile-screenshots.yml`.

### Trade-off
The `process.env.EXPO_PUBLIC_SCREENSHOT_MODE` comparison is now repeated per call site instead of one shared const. That repetition is *required* for guaranteed-static DCE.

## Verification

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 2342 passed ✅
- `vp lint` + format on changed files — 0 warnings / 0 errors ✅
- **DCE proof** via production `expo export` (Hermes `.hbc`) with temporary sentinels in two screenshot branches:

  | Branch | prod (env unset) | screenshot (`EXPO_PUBLIC_SCREENSHOT_MODE=1`, `--clear`) |
  |---|---|---|
  | `_layout` LogBox | **0 — stripped** | 1 — retained |
  | `auth/login` auto-sign-in | **0 — stripped** | 1 — retained |

  (The `--clear` matters: `EXPO_PUBLIC_*` values aren't part of Metro's transform-cache key.) Sentinels removed after the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)