### PR TITLE
Gate screenshot flows on the native tab bar (fix auto-login wait)

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -30,8 +30,10 @@ simulator keychain first so login authenticates cleanly against prod.
 
 - `login.yaml` — reusable subflow. The screenshot build auto-signs-in on boot (see
   `screenshot-mode.ts` `SCREENSHOT_USER_*` + `app/auth/login.tsx`), so this no longer
-  types credentials — it just waits for the auto sign-in to redirect out of the auth
-  screen. Typing the form would pop iOS's "Save Password?" dialog over every shot.
+  types credentials — it waits for the app to land on the home tab (the native tab
+  bar's "Climbs" item, which only appears once signed in). It deliberately does NOT
+  wait on the auth form: auto sign-in redirects faster than Maestro can catch the
+  field, and typing the form would pop iOS's "Save Password?" dialog over every shot.
 - `app-store.yaml` (iOS) — log in, then capture Home, Discover, Profile, Logbook,
   session detail, Climbs, the workout generator, playlist detail, and the board view
   (10 store slots; the `03` live-party slot is filled by the party flow, PR2).

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -24,10 +24,7 @@ name: app-store screenshots android
 # Order: board-independent shots first (home/discover/profile/session); board-dependent
 # shots after the board is picked. Plain visits run before screenshot-param visits.
 - launchApp
-- extendedWaitUntil:
-    visible:
-      id: 'auth-email-input'
-    timeout: 180000
+# Auto-signs-in on boot; login.yaml waits for the home tab (no login form is shown).
 - runFlow: login.yaml
 
 # Home — feed populated by the prod test user's follows.

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -37,12 +37,8 @@ name: app-store screenshots
 # - Filenames are numbered for store DISPLAY order (00..09), not capture order. 03 is the
 #   live-party shot, added by the party-session flow (see app-store-party.yaml / PR2).
 #
-# Cold Metro bundle on the first load can take a while; wait for the signed-out auth
-# screen, then log in.
-- extendedWaitUntil:
-    visible:
-      id: 'auth-email-input'
-    timeout: 300000
+# Cold Metro bundle on the first load can take a while; the screenshot build auto-signs-in
+# on boot, so login.yaml just waits for it to land on the home tab (no login form is shown).
 - runFlow: login.yaml
 
 # Home — feed populated by the prod test user's follows.

--- a/packages/mobile/.maestro/login.yaml
+++ b/packages/mobile/.maestro/login.yaml
@@ -1,26 +1,24 @@
 appId: com.boardsesh.app
-name: login (subflow — waits for screenshot-mode auto sign-in)
+name: ready (subflow — waits for the screenshot-mode auto sign-in to land on a tab)
 ---
-# The screenshot build signs in automatically on boot (see
-# packages/mobile/src/lib/screenshot-mode.ts SCREENSHOT_USER_* + app/auth/login.tsx),
-# so this subflow no longer types credentials — it just waits for the auto sign-in
-# to redirect out of the auth screen. The caller has already waited for the auth
-# screen to render (the cold Metro bundle gate).
+# The screenshot build auto-signs-in on boot (packages/mobile/src/lib/screenshot-mode.ts
+# SCREENSHOT_USER_* + app/auth/login.tsx), so there's no login form to drive. This subflow
+# just waits for the app to finish loading the (pre-warmed) Metro bundle and land on the
+# home tab — detected by the native tab bar, which is only present once signed in.
 #
-# Why not type the form: filling the password field makes iOS offer to save the
-# password, and that "Save Password?" system dialog then covers every captured
-# screen AND sits over the board picker so the board-pick tap misses (leaving the
-# climbs / board-view shots in the no-board state). Auto sign-in avoids the form
-# entirely, so the dialog never appears.
+# We deliberately do NOT wait on the auth form: auto sign-in redirects within the network
+# round-trip, so the form flashes faster than Maestro polls and a `visible: auth-email-input`
+# wait times out (the field is already gone — this is the bug this replaced). The native
+# tab bar is a UIKit element, so it surfaces to Maestro (unlike plain RN views).
 #
-# A "Sign in to your Apple Account" system alert can linger on the simulator from a
-# prior Apple-auth attempt and cover the auth screen; dismiss it if present.
+# A "Sign in to your Apple Account" system alert can linger from a prior Apple-auth attempt
+# and cover the screen; dismiss it if present.
 - tapOn:
     text: 'Close'
     optional: true
-# The email field disappearing is the reliable "auto sign-in succeeded +
-# redirected" signal — more robust than racing a specific tab's content load.
+# The "Climbs" tab item appears only once auto sign-in lands on a tab — a reliable
+# "loaded + authenticated" signal. Generous timeout covers a cold Metro bundle on a slow runner.
 - extendedWaitUntil:
-    notVisible:
-      id: 'auth-email-input'
-    timeout: 60000
+    visible:
+      text: 'Climbs'
+    timeout: 300000

--- a/packages/mobile/.maestro/onboarding-android.yaml
+++ b/packages/mobile/.maestro/onboarding-android.yaml
@@ -3,10 +3,6 @@ name: onboarding illustrations android
 ---
 # Android version of onboarding.yaml for the standalone screenshot APK.
 - launchApp
-- extendedWaitUntil:
-    visible:
-      id: 'auth-email-input'
-    timeout: 180000
 - runFlow: login.yaml
 
 - openLink: com.boardsesh.app://climbs

--- a/packages/mobile/.maestro/onboarding.yaml
+++ b/packages/mobile/.maestro/onboarding.yaml
@@ -25,10 +25,6 @@ name: onboarding illustrations
 # no openurl, no "Open in Boardsesh?" dialog on a fresh CI sim. This flow just waits
 # for the auth screen. The orchestrator uninstalled + reinstalled and reset the
 # keychain, so this cold-loads signed out.
-- extendedWaitUntil:
-    visible:
-      id: 'auth-email-input'
-    timeout: 300000
 - runFlow: login.yaml
 
 - openLink: com.boardsesh.app://climbs


### PR DESCRIPTION
Follow-up to #2960. That auto-login fix kept a `visible: auth-email-input` cold-bundle gate, which is self-contradictory — we auto-login, so the auth form barely renders. Auto sign-in redirects within the network round-trip, so the field flashes faster than Maestro polls and the wait timed out (the failed verification run logged `$screen /home` *before* the assertion failed).

This drops the auth-form waits from all four flows and instead waits (in `login.yaml`) for the native tab bar's **"Climbs"** item, which only appears once auto sign-in lands on a tab. It's a UIKit element, so it surfaces to Maestro (unlike plain RN views).

No app-code change — Maestro flows + docs only.

Verify by running the screenshots workflow on this branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)