### PR TITLE
Gate on the "Discover" tab label, not "Climbs" (search glyph has no t…

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -31,9 +31,10 @@ simulator keychain first so login authenticates cleanly against prod.
 - `login.yaml` — reusable subflow. The screenshot build auto-signs-in on boot (see
   `screenshot-mode.ts` `SCREENSHOT_USER_*` + `app/auth/login.tsx`), so this no longer
   types credentials — it waits for the app to land on the home tab (the native tab
-  bar's "Climbs" item, which only appears once signed in). It deliberately does NOT
-  wait on the auth form: auto sign-in redirects faster than Maestro can catch the
-  field, and typing the form would pop iOS's "Save Password?" dialog over every shot.
+  bar's "Discover" label, which only appears once signed in; not "Climbs" — that tab
+  is a search glyph with no text). It deliberately does NOT wait on the auth form:
+  auto sign-in redirects faster than Maestro can catch the field, and typing the form
+  would pop iOS's "Save Password?" dialog over every shot.
 - `app-store.yaml` (iOS) — log in, then capture Home, Discover, Profile, Logbook,
   session detail, Climbs, the workout generator, playlist detail, and the board view
   (10 store slots; the `03` live-party slot is filled by the party flow, PR2).

--- a/packages/mobile/.maestro/login.yaml
+++ b/packages/mobile/.maestro/login.yaml
@@ -16,9 +16,11 @@ name: ready (subflow — waits for the screenshot-mode auto sign-in to land on a
 - tapOn:
     text: 'Close'
     optional: true
-# The "Climbs" tab item appears only once auto sign-in lands on a tab — a reliable
-# "loaded + authenticated" signal. Generous timeout covers a cold Metro bundle on a slow runner.
+# The "Discover" tab label appears only once auto sign-in lands on a tab — a reliable
+# "loaded + authenticated" signal. (NOT "Climbs": that tab uses role="search", so iOS 26
+# renders it as a magnifying-glass glyph with no text label.) Generous timeout covers a
+# cold Metro bundle on a slow runner.
 - extendedWaitUntil:
     visible:
-      text: 'Climbs'
+      text: 'Discover'
     timeout: 300000


### PR DESCRIPTION
…ext)

The tab-bar gate failed on a fully-loaded home screen: the Climbs tab uses role="search", so iOS 26 renders it as a magnifying-glass icon with no "Climbs" text — the assertion timed out. The failure screenshot confirmed auto-login works and the Save-Password popup is gone. Switch the gate to "Discover", a real tab label.