### PR TITLE
Gate screenshots on the auth field with a delayed auto sign-in

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -29,12 +29,12 @@ simulator keychain first so login authenticates cleanly against prod.
 ## Flows
 
 - `login.yaml` — reusable subflow. The screenshot build auto-signs-in on boot (see
-  `screenshot-mode.ts` `SCREENSHOT_USER_*` + `app/auth/login.tsx`), so this no longer
-  types credentials — it waits for the app to land on the home tab (the native tab
-  bar's "Discover" label, which only appears once signed in; not "Climbs" — that tab
-  is a search glyph with no text). It deliberately does NOT wait on the auth form:
-  auto sign-in redirects faster than Maestro can catch the field, and typing the form
-  would pop iOS's "Save Password?" dialog over every shot.
+  `screenshot-mode.ts` `SCREENSHOT_USER_*` + `app/auth/login.tsx`), so it never types
+  into the form (which would pop iOS's "Save Password?" dialog over every shot). It waits
+  for the auth field (`auth-email-input`) to appear — the one element that reliably
+  surfaces to Maestro on this build (native tab-bar labels don't) — then for the auto
+  sign-in to redirect out of it. `login.tsx` delays that sign-in ~3.5s so the field stays
+  on screen long enough to catch.
 - `app-store.yaml` (iOS) — log in, then capture Home, Discover, Profile, Logbook,
   session detail, Climbs, the workout generator, playlist detail, and the board view
   (10 store slots; the `03` live-party slot is filled by the party flow, PR2).

--- a/packages/mobile/.maestro/login.yaml
+++ b/packages/mobile/.maestro/login.yaml
@@ -1,26 +1,32 @@
 appId: com.boardsesh.app
-name: ready (subflow — waits for the screenshot-mode auto sign-in to land on a tab)
+name: ready (subflow — waits for the screenshot-mode auto sign-in)
 ---
 # The screenshot build auto-signs-in on boot (packages/mobile/src/lib/screenshot-mode.ts
-# SCREENSHOT_USER_* + app/auth/login.tsx), so there's no login form to drive. This subflow
-# just waits for the app to finish loading the (pre-warmed) Metro bundle and land on the
-# home tab — detected by the native tab bar, which is only present once signed in.
+# SCREENSHOT_USER_* + app/auth/login.tsx) — programmatically, so the flow never types into
+# the form and iOS never offers to save the password. This subflow waits for the (pre-warmed)
+# Metro bundle to load and for that auto sign-in to redirect into the app.
 #
-# We deliberately do NOT wait on the auth form: auto sign-in redirects within the network
-# round-trip, so the form flashes faster than Maestro polls and a `visible: auth-email-input`
-# wait times out (the field is already gone — this is the bug this replaced). The native
-# tab bar is a UIKit element, so it surfaces to Maestro (unlike plain RN views).
+# Why gate on the auth field: on this iOS 26 / RN Fabric build Maestro's a11y tree only
+# exposes native text inputs and system dialogs — native tab-bar LABELS do NOT surface
+# (`text: Climbs` and `text: Discover` both miss on a fully-loaded home). `auth-email-input`
+# is a native text input with a testID, so it's the one element reliably visible during boot.
+# app/auth/login.tsx delays the auto sign-in ~3.5s so the auth screen stays up long enough
+# for the `visible` gate below to catch it before it redirects.
 #
 # A "Sign in to your Apple Account" system alert can linger from a prior Apple-auth attempt
 # and cover the screen; dismiss it if present.
 - tapOn:
     text: 'Close'
     optional: true
-# The "Discover" tab label appears only once auto sign-in lands on a tab — a reliable
-# "loaded + authenticated" signal. (NOT "Climbs": that tab uses role="search", so iOS 26
-# renders it as a magnifying-glass glyph with no text label.) Generous timeout covers a
-# cold Metro bundle on a slow runner.
+# Cold-bundle gate: wait for the auth screen. Generous timeout covers a cold Metro bundle on
+# a slow runner; the delayed auto sign-in keeps the field on screen long enough to catch.
 - extendedWaitUntil:
     visible:
-      text: 'Discover'
+      id: 'auth-email-input'
     timeout: 300000
+# Auto sign-in has fired by now; wait for it to redirect out of auth before the first shot,
+# so screenshots capture the app, not the (briefly held) login screen.
+- extendedWaitUntil:
+    notVisible:
+      id: 'auth-email-input'
+    timeout: 60000

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -46,12 +46,22 @@ export default function LoginScreen() {
   // type into the login form — typing makes iOS pop a "Save Password?" dialog that
   // covers every captured screen and blocks the board picker. Fires once; inert in
   // normal builds (dead-strips with SCREENSHOT_MODE).
+  //
+  // The sign-in is deliberately delayed: the Maestro flow's cold-bundle gate waits for
+  // the auth screen (`auth-email-input`) to appear — the only element that reliably
+  // surfaces to Maestro's a11y tree on this build (native tab-bar labels don't). An
+  // immediate sign-in redirects within the network round-trip, so the auth field flashes
+  // faster than Maestro polls and the gate times out. The delay keeps the auth screen up
+  // long enough to catch; then it redirects to home.
   const screenshotSignInRef = useRef(false);
   useEffect(() => {
     if (!SCREENSHOT_MODE || screenshotSignInRef.current) return;
     if (!SCREENSHOT_USER_EMAIL || !SCREENSHOT_USER_PASSWORD) return;
     screenshotSignInRef.current = true;
-    void signInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
+    const timer = setTimeout(() => {
+      void signInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
+    }, 3500);
+    return () => clearTimeout(timer);
   }, [signInWithCredentials]);
 
   const trimmedEmail = email.trim();


### PR DESCRIPTION
Third attempt at the screenshot login gate — this one uses the only element Maestro can actually see.

**Problem:** after the auto-login fix (#2960/#2962/#2964), the flow must wait for the app to be loaded + signed-in before the first screenshot. Two native-tab-bar gates (`text: 'Climbs'`, then `text: 'Discover'`) both timed out on a fully-loaded home screen — debug artifacts confirmed the app was on Home with no Save-Password popup, but the tab labels aren't in Maestro's accessibility tree. On this iOS 26 / RN Fabric build Maestro only exposes native text inputs + system dialogs (the README's own a11y caveat).

**Fix:** gate on `auth-email-input` (a native text input with a testID — proven to surface; we used to type into it), and **delay the screenshot-mode auto sign-in ~3.5s** in `login.tsx` so the auth screen stays up long enough for the `visible` gate to catch it. Then `login.yaml` waits for the redirect (`notVisible`) before the first shot.

Auto sign-in stays programmatic — no form typing, so no iOS "Save Password?" dialog (the bug this whole effort set out to fix).

Validated: `typecheck:mobile`, lint, `check:mobile-bundle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)