### PR TITLE
Mobile playlists: live icon refresh, free emoji entry, dark colours

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -346,6 +346,16 @@ export default function PlaylistDetail() {
           isPublic: values.isPublic,
         });
         queryClient.setQueryData(['playlist', playlistUuid], updated);
+        // The list surfaces don't share this detail cache: the Add-to-Playlist
+        // picker reads the react-query ['userPlaylists'] list (5-min staleTime),
+        // so patch the edited row there too — otherwise the name/icon/colour
+        // stays stale in the picker until the staleTime lapses (matching how the
+        // create flow and bumpPlaylistClimbCount keep that cache honest). The
+        // Discover hub's owned/pinned shelves and the "My Playlists" list refetch
+        // on focus return.
+        queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) =>
+          prev?.map((entry) => (entry.uuid === updated.uuid || entry.id === updated.id ? updated : entry)),
+        );
         setEditVisible(false);
         showToast(t('edit.messages.updated'), 'success');
       } catch (err) {

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -346,13 +346,8 @@ export default function PlaylistDetail() {
           isPublic: values.isPublic,
         });
         queryClient.setQueryData(['playlist', playlistUuid], updated);
-        // The list surfaces don't share this detail cache: the Add-to-Playlist
-        // picker reads the react-query ['userPlaylists'] list (5-min staleTime),
-        // so patch the edited row there too — otherwise the name/icon/colour
-        // stays stale in the picker until the staleTime lapses (matching how the
-        // create flow and bumpPlaylistClimbCount keep that cache honest). The
-        // Discover hub's owned/pinned shelves and the "My Playlists" list refetch
-        // on focus return.
+        // Also patch the Add-to-Playlist picker's react-query list (the shelves
+        // refetch on focus, but this cache wouldn't until its staleTime lapses).
         queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) =>
           prev?.map((entry) => (entry.uuid === updated.uuid || entry.id === updated.id ? updated : entry)),
         );

--- a/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
@@ -19,9 +19,18 @@ const hook = vi.hoisted(() => ({
   refetch: vi.fn(),
 }));
 
+// Capture the focus callback so a test can replay focus events and assert the
+// skip-first-focus refetch guard (the real useFocusEffect runs it on focus).
+const focusEffect = vi.hoisted(() => ({ cb: null as null | (() => void) }));
+
 vi.mock('@boardsesh/playlists-react', () => ({ useUserPlaylists: () => hook }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('expo-router', () => ({ router: { push: vi.fn() }, useFocusEffect: () => undefined }));
+vi.mock('expo-router', () => ({
+  router: { push: vi.fn() },
+  useFocusEffect: (cb: () => void) => {
+    focusEffect.cb = cb;
+  },
+}));
 
 // react-native primitives → DOM. FlatList renders its data (or the empty
 // component) plus the footer so the error/retry affordances are assertable.
@@ -124,6 +133,7 @@ beforeEach(() => {
   hook.loadMore.mockClear();
   hook.retryLoadMore.mockClear();
   hook.refetch.mockClear();
+  focusEffect.cb = null;
 });
 
 describe('AllPlaylistsScreen', () => {
@@ -155,5 +165,21 @@ describe('AllPlaylistsScreen', () => {
     const retryButton = getByLabelText('library.allPlaylists.loadMoreError library.errors.tryAgain');
     fireEvent.click(retryButton);
     expect(hook.retryLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the first focus but refetches on a return focus (e.g. after a detail edit)', () => {
+    hook.playlists = [{ uuid: 'a', name: 'Alpha', climbCount: 1 }];
+    render(<AllPlaylistsScreen />);
+
+    // The component registered a focus callback; the mount load already ran, so
+    // the first focus must NOT refetch.
+    expect(focusEffect.cb).toBeTypeOf('function');
+    focusEffect.cb?.();
+    expect(hook.refetch).not.toHaveBeenCalled();
+
+    // A later focus (returning from a pushed detail screen) refetches so an edit
+    // there lands here.
+    focusEffect.cb?.();
+    expect(hook.refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/all.test.tsx
@@ -21,7 +21,7 @@ const hook = vi.hoisted(() => ({
 
 vi.mock('@boardsesh/playlists-react', () => ({ useUserPlaylists: () => hook }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('expo-router', () => ({ router: { push: vi.fn() } }));
+vi.mock('expo-router', () => ({ router: { push: vi.fn() }, useFocusEffect: () => undefined }));
 
 // react-native primitives → DOM. FlatList renders its data (or the empty
 // component) plus the footer so the error/retry affordances are assertable.

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../../../src/lib/graphql/client', () => ({
 // usePlaylistClimbs: the climbs infinite query. The detail screen only reads
 // query.refetch (for the retry) and allClimbs here.
 const climbsRefetch = vi.hoisted(() => vi.fn());
+const updatePlaylistMock = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/playlists-react', () => ({
   usePlaylistClimbs: () => ({
     query: {
@@ -26,7 +27,7 @@ vi.mock('@boardsesh/playlists-react', () => ({
     allClimbs: [],
   }),
   usePlaylistMutations: () => ({
-    updatePlaylist: vi.fn(),
+    updatePlaylist: updatePlaylistMock,
     deletePlaylist: vi.fn(),
     pinPlaylist: vi.fn(),
     unpinPlaylist: vi.fn(),
@@ -95,7 +96,18 @@ vi.mock('../../../../src/components/playlist', () => ({
   PlaylistDetailView: ({ hero }: { hero: { name: string } }) =>
     createElement('div', { 'data-detail-view': 'true', 'data-hero-name': hero.name }),
   SKELETON_PLACEHOLDERS: ['a', 'b'],
-  PlaylistFormSheet: () => null,
+  // Surface the edit submit so the cache-patch test can drive handleEditSubmit
+  // without the real gorhom sheet.
+  PlaylistFormSheet: ({ onSubmit }: { onSubmit?: (values: unknown) => void }) =>
+    createElement(
+      'button',
+      {
+        'data-form-submit': 'true',
+        onClick: () =>
+          onSubmit?.({ name: 'Bad climbs', description: '', color: '#1F2937', icon: '💀', isPublic: false }),
+      },
+      'form-submit',
+    ),
   PlaylistActionsMenu: () => null,
   PlaylistFollowButton: () => null,
   PlaylistEditDoneButton: () => null,
@@ -105,18 +117,21 @@ vi.mock('../../../../src/components/playlist', () => ({
 
 import PlaylistDetail from '../[playlist_uuid]';
 
-function renderDetail() {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <PlaylistDetail />
-    </QueryClientProvider>,
-  );
+function renderDetail(queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })) {
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <PlaylistDetail />
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 beforeEach(() => {
   requestMock.mockReset();
   climbsRefetch.mockClear();
+  updatePlaylistMock.mockReset();
 });
 
 describe('PlaylistDetail metadata error handling', () => {
@@ -155,5 +170,47 @@ describe('PlaylistDetail metadata error handling', () => {
 
     expect(await findByText('detail.errors.notFoundTitle')).toBeTruthy();
     expect(queryByText('detail.errors.loadTitle')).toBeNull();
+  });
+});
+
+describe('PlaylistDetail edit cache propagation', () => {
+  const basePlaylist = {
+    uuid: 'p-1',
+    id: 'p-1',
+    name: 'Old name',
+    icon: '🔥',
+    color: '#6D28D9',
+    description: '',
+    climbCount: 3,
+    boardType: 'kilter',
+    layoutId: 1,
+    isPublic: false,
+    userRole: 'owner',
+    isPinnedByMe: false,
+    isFollowedByMe: false,
+    followerCount: 0,
+  };
+
+  it("patches the ['userPlaylists'] cache after an edit so the Add-to-Playlist picker is not stale", async () => {
+    requestMock.mockResolvedValue({ playlist: basePlaylist });
+    const updated = { ...basePlaylist, name: 'Bad climbs', icon: '💀', color: '#1F2937' };
+    updatePlaylistMock.mockResolvedValue(updated);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // The picker's cached list still holds the pre-edit row (matched by uuid).
+    queryClient.setQueryData(['userPlaylists'], [{ uuid: 'p-1', id: 'p-1', name: 'Old name', icon: '🔥' }]);
+
+    const { findByText } = renderDetail(queryClient);
+
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<Array<{ icon: string; name: string }>>(['userPlaylists']);
+      expect(cached?.[0].icon).toBe('💀');
+      expect(cached?.[0].name).toBe('Bad climbs');
+    });
+    // The detail hero cache is updated to the full server response.
+    expect(queryClient.getQueryData(['playlist', 'p-1'])).toEqual(updated);
   });
 });

--- a/packages/mobile/app/(tabs)/discover/all.tsx
+++ b/packages/mobile/app/(tabs)/discover/all.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, StyleSheet, TextInput, View } from 'react-native';
-import { router } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useUserPlaylists } from '@boardsesh/playlists-react';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
@@ -49,6 +49,21 @@ export default function AllPlaylistsScreen() {
   // Drain every page so the alphabetical sort + title filter see the whole
   // library, not just the first page.
   useDrainAllPages({ hasMore, isLoading, isLoadingMore, loadMore });
+
+  // Refresh on return so an edit/delete made on a pushed detail screen lands here
+  // (this list uses its own useState store, not the react-query cache the picker
+  // reads). Skip the first focus so we don't double-fetch the mount load. Mirrors
+  // the Discover hub's focus refetch. useDrainAllPages re-drains after refetch.
+  const hasFocusedRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!hasFocusedRef.current) {
+        hasFocusedRef.current = true;
+        return;
+      }
+      refetch();
+    }, [refetch]),
+  );
 
   const [query, setQuery] = useState('');
 

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -17,10 +17,14 @@ import { buildPlaylistFormValues, NAME_MAX, DESCRIPTION_MAX, type PlaylistFormVa
 
 export type { PlaylistFormValues };
 
-// Preset emoji palette for the icon picker. Mobile has no emoji-mart equivalent
-// (it's DOM-only on web); a tap-to-pick row keeps the picker native and the
-// value controlled.
-const PRESET_ICONS = ['🔥', '💪', '🎯', '⭐', '🧗', '🪨', '📈', '❄️', '🌙', '⚡', '🏆', '🎸'] as const;
+// Quick-pick emoji suggestions shown under the free-entry slot. The slot itself
+// takes any emoji via the system keyboard (mobile has no emoji-mart equivalent —
+// it's DOM-only on web); these are one-tap shortcuts for the common ones.
+const SUGGESTED_ICONS = ['🔥', '💪', '🎯', '⭐', '🧗', '🪨', '🏆'] as const;
+
+// Long enough to hold one ZWJ/variation-selector emoji (e.g. 🧗‍♀️) while keeping
+// the slot to a single glyph in practice.
+const ICON_MAX = 8;
 
 type PlaylistFormSheetProps = {
   mode: 'create' | 'edit';
@@ -175,7 +179,18 @@ export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmi
                 onPress={() => setColor(selected ? undefined : swatch)}
                 accessibilityRole="button"
                 accessibilityState={{ selected }}
-                style={[styles.swatch, { backgroundColor: swatch }, selected && styles.swatchSelected]}
+                style={[
+                  styles.swatch,
+                  // Hairline outline (theme-aware, so it can't live in the
+                  // StyleSheet) keeps the dark swatches visible on the dark sheet.
+                  // The selected style's 3px white border overrides it.
+                  {
+                    backgroundColor: swatch,
+                    borderWidth: StyleSheet.hairlineWidth,
+                    borderColor: systemColors.separator,
+                  },
+                  selected && styles.swatchSelected,
+                ]}
               >
                 {selected ? <Icon name="check.small" size={18} color={iosSystemColors.white} /> : null}
               </Pressable>
@@ -183,13 +198,50 @@ export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmi
           })}
         </View>
 
-        {/* Emoji picker — shown for create + edit (visibility stays edit-only,
-            since new playlists are always created private). */}
+        {/* Emoji icon — a free-entry slot (system keyboard → any emoji) with a
+            row of quick-pick suggestions. Shown for create + edit. */}
         <Text variant="footnote" style={styles.label}>
           {t('edit.fields.icon')}
         </Text>
+        <View style={styles.iconRow}>
+          <BottomSheetTextInput
+            value={icon ?? ''}
+            // Store the trimmed value (capped to a single glyph by maxLength); the
+            // header preview mirrors it live. Empty clears back to the generic tag.
+            onChangeText={(text) => {
+              const trimmed = text.trim();
+              setIcon(trimmed.length > 0 ? trimmed : undefined);
+            }}
+            placeholder="🙂"
+            placeholderTextColor={systemColors.tertiaryLabel}
+            maxLength={ICON_MAX}
+            textAlign="center"
+            autoCorrect={false}
+            autoCapitalize="none"
+            returnKeyType="done"
+            accessibilityLabel={t('edit.fields.icon')}
+            style={[
+              styles.emojiInput,
+              { backgroundColor: systemColors.fill, borderColor: systemColors.separator, color: systemColors.label },
+            ]}
+          />
+          {icon ? (
+            <Pressable
+              onPress={() => setIcon(undefined)}
+              accessibilityRole="button"
+              style={[styles.removeChip, { borderColor: systemColors.separator }]}
+            >
+              <Text variant="footnote" color={iosSystemColors.systemRed}>
+                {t('edit.fields.removeIcon')}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+        <Text variant="caption1" style={styles.iconHint}>
+          {t('edit.fields.iconHint')}
+        </Text>
         <View style={styles.swatchRow}>
-          {PRESET_ICONS.map((preset) => {
+          {SUGGESTED_ICONS.map((preset) => {
             const selected = icon === preset;
             return (
               <Pressable
@@ -211,17 +263,6 @@ export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmi
               </Pressable>
             );
           })}
-          {icon ? (
-            <Pressable
-              onPress={() => setIcon(undefined)}
-              accessibilityRole="button"
-              style={[styles.removeChip, { borderColor: systemColors.separator }]}
-            >
-              <Text variant="footnote" color={iosSystemColors.systemRed}>
-                {t('edit.fields.removeIcon')}
-              </Text>
-            </Pressable>
-          ) : null}
         </View>
 
         {isEdit ? (
@@ -283,6 +324,24 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: spacing[3],
     marginTop: spacing[1],
+  },
+  iconRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginTop: spacing[1],
+  },
+  emojiInput: {
+    width: 56,
+    height: 56,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 28,
+    paddingVertical: 0,
+  },
+  iconHint: {
+    opacity: 0.5,
+    marginTop: spacing[2],
   },
   swatch: {
     width: 36,

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -22,9 +22,11 @@ export type { PlaylistFormValues };
 // it's DOM-only on web); these are one-tap shortcuts for the common ones.
 const SUGGESTED_ICONS = ['🔥', '💪', '🎯', '⭐', '🧗', '🪨', '🏆'] as const;
 
-// Long enough to hold one ZWJ/variation-selector emoji (e.g. 🧗‍♀️) while keeping
-// the slot to a single glyph in practice.
-const ICON_MAX = 8;
+// Generous enough to hold a single multi-codepoint emoji whole — including long
+// ZWJ sequences like a family emoji (👨‍👩‍👧‍👦, 11 UTF-16 units) — so the cap never
+// truncates one mid-sequence into a broken glyph. Still well under the backend's
+// 50-char limit.
+const ICON_MAX = 16;
 
 type PlaylistFormSheetProps = {
   mode: 'create' | 'edit';

--- a/packages/mobile/src/components/playlist/playlist-colors.ts
+++ b/packages/mobile/src/components/playlist/playlist-colors.ts
@@ -2,7 +2,9 @@
 // has no valid `color`, and as the swatch options in the create/edit form. Leads
 // with the violet brand + amber accent, then a varied set so playlists stay
 // distinguishable. Mobile-specific (intentionally diverges from web's list, which
-// keeps the old maroon-led order).
+// keeps the old maroon-led order). Trails with two dark options (dark grey +
+// near-black) for "bad climbs"-style lists; the form gives swatches a hairline
+// outline so they stay visible on the dark sheet.
 export const PLAYLIST_COLORS = [
   '#6D28D9', // brand violet
   '#FF8A3D', // amber accent
@@ -12,6 +14,8 @@ export const PLAYLIST_COLORS = [
   '#0891B2', // cyan
   '#CA8A04', // gold
   '#DC2626', // red
+  '#374151', // dark grey
+  '#1F2937', // near-black
 ] as const;
 
 const HEX_PATTERN = /^#([0-9A-Fa-f]{3}){1,2}$/;

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -169,6 +169,7 @@
       "descriptionPlaceholder": "Optional description for your playlist...",
       "color": "Color",
       "icon": "Icon",
+      "iconHint": "Type any emoji, or pick one below",
       "removeIcon": "Remove",
       "visibility": "Visibility",
       "publicHint": "Public playlists can be viewed by anyone with the link",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -169,6 +169,7 @@
       "descriptionPlaceholder": "Descripción opcional para tu lista...",
       "color": "Color",
       "icon": "Icono",
+      "iconHint": "Escribe cualquier emoji o elige uno abajo",
       "removeIcon": "Quitar",
       "visibility": "Visibilidad",
       "publicHint": "Las listas públicas pueden ser vistas por cualquiera con el enlace",

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -169,6 +169,7 @@
       "descriptionPlaceholder": "Description facultative pour votre playlist...",
       "color": "Couleur",
       "icon": "Icône",
+      "iconHint": "Saisissez n'importe quel emoji, ou choisissez-en un ci-dessous",
       "removeIcon": "Retirer",
       "visibility": "Visibilité",
       "publicHint": "Les playlists publiques sont visibles par toute personne ayant le lien",


### PR DESCRIPTION
## What & why

Three pieces of feedback on **mobile** playlist editing (all mobile-only — web already has a full emoji picker and any-hex colour input).

### 1. Icon doesn't update in lists until you re-open Discover
Editing a playlist only wrote the detail cache (`['playlist', uuid]`). The list surfaces are fed differently and never saw the edit:
- The **Add-to-Playlist picker** reads the react-query `['userPlaylists']` list (5-min staleTime).
- The **My Playlists** (`all.tsx`) screen uses a local-`useState` store with no focus refetch.

Fix: `handleEditSubmit` now also patches `['userPlaylists']` (uuid/id match, like the create flow + `bumpPlaylistClimbCount`), and `all.tsx` gets a skip-first-focus `useFocusEffect(refetch)` mirroring the Discover hub (which already refetched owned/pinned on focus).

### 2. Free emoji entry instead of a fixed list
`PlaylistFormSheet` now has a centered emoji slot (`BottomSheetTextInput` → system keyboard → any emoji), with the previous emoji set kept as a **quick-pick suggestions row** (`🔥 💪 🎯 ⭐ 🧗 🪨 🏆`) plus the existing Remove button. Storage already holds raw emoji — no backend change.

### 3. Black/dark grey colour
Added `#374151` (dark grey) and `#1F2937` (near-black) to the mobile palette, plus a theme-aware hairline outline on all swatches so the dark ones stay visible on the dark sheet.

Added `edit.fields.iconHint` to en-US/es/fr.

## Testing
- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — 2318 passed, incl. a new regression test proving an edit patches `['userPlaylists']` (and fixed the `all.test.tsx` expo-router mock to expose `useFocusEffect`)
- `vp run check:mobile-bundle` ✓

⚠️ Not run: simulator / screenshot QA (macOS-only; authored on Linux). Please eyeball the emoji keyboard flow and the dark swatches in light/dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)