### PR TITLE
Fix unreadable x-axis on Profile Activity & V-Points charts

### DIFF
--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -60,6 +60,7 @@
     "flashVsRedpoint": "Flash vs Redpoint",
     "vPoints": "V-Points",
     "vPointsTotal": "{{value}} total",
+    "weekAxisLabel": "Week",
     "chartTooltipTotal": "Total",
     "gradeDistributionAria": "Grade distribution across boards",
     "weeklyAttemptsAria": "Weekly attempts by difficulty",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -60,6 +60,7 @@
     "flashVsRedpoint": "Flash vs Trabajado",
     "vPoints": "V-Points",
     "vPointsTotal": "{{value}} en total",
+    "weekAxisLabel": "Semana",
     "chartTooltipTotal": "Total",
     "gradeDistributionAria": "Distribución por grados en todas las tablas de escalada",
     "weeklyAttemptsAria": "Intentos semanales por dificultad",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -60,6 +60,7 @@
     "flashVsRedpoint": "Flash vs après-travail",
     "vPoints": "V-Points",
     "vPointsTotal": "{{value}} au total",
+    "weekAxisLabel": "Semaine",
     "chartTooltipTotal": "Total",
     "gradeDistributionAria": "Répartition par cotation sur tous les boards",
     "weeklyAttemptsAria": "Essais hebdo par difficulté",

--- a/packages/web/app/components/charts/css-bar-chart.tsx
+++ b/packages/web/app/components/charts/css-bar-chart.tsx
@@ -26,8 +26,6 @@ type CssBarChartProps = {
   ariaLabel?: string;
   /** Max number of x-axis labels to display; surplus labels are hidden. */
   maxLabels?: number;
-  /** Render x-axis labels at a -45° angle (useful for dense charts). */
-  angledLabels?: boolean;
 };
 
 export const CssBarChart = React.memo(function CssBarChart({
@@ -37,7 +35,6 @@ export const CssBarChart = React.memo(function CssBarChart({
   showLegend = true,
   ariaLabel = 'Bar chart',
   maxLabels,
-  angledLabels = false,
 }: CssBarChartProps) {
   // Pivot data: bars have segments, MUI wants series (one per unique segment label/color)
   const { series, categories } = useMemo(() => {
@@ -89,7 +86,7 @@ export const CssBarChart = React.memo(function CssBarChart({
 
   let bottomMargin = 4;
   if (showLegend) {
-    bottomMargin = angledLabels ? 40 : 24;
+    bottomMargin = 24;
   }
 
   return (
@@ -103,6 +100,9 @@ export const CssBarChart = React.memo(function CssBarChart({
         },
       }}
     >
+      {/* No explicit height: the chart fills the responsive Box above so it
+          matches the box on mobile too (a fixed height would overflow and clip
+          the x-axis labels). */}
       <BarChart
         series={series}
         xAxis={[
@@ -110,10 +110,9 @@ export const CssBarChart = React.memo(function CssBarChart({
             data: categories,
             scaleType: 'band' as const,
             ...(tickInterval ? { tickInterval } : {}),
-            tickLabelStyle: angledLabels ? { angle: -45, textAnchor: 'end', fontSize: 9 } : { fontSize: 9 },
+            tickLabelStyle: { fontSize: 11 },
           },
         ]}
-        height={height}
         margin={{ top: 4, bottom: bottomMargin, left: 0, right: 0 }}
         yAxis={[{ position: 'none' }]}
         hideLegend
@@ -189,16 +188,16 @@ export const GroupedBarChart = React.memo(function GroupedBarChart({
         },
       }}
     >
+      {/* No explicit height: fills the responsive Box above (see CssBarChart). */}
       <BarChart
         series={series}
         xAxis={[
           {
             data: categories,
             scaleType: 'band' as const,
-            tickLabelStyle: { fontSize: 9 },
+            tickLabelStyle: { fontSize: 11 },
           },
         ]}
-        height={height}
         margin={{ top: 4, bottom: 24, left: 0, right: 0 }}
         yAxis={[{ position: 'none' }]}
         hideLegend

--- a/packages/web/app/profile/[user_id]/components/stats-summary.tsx
+++ b/packages/web/app/profile/[user_id]/components/stats-summary.tsx
@@ -226,11 +226,10 @@ export default function StatsSummary({
             </Typography>
             <CssBarChart
               bars={weeklyBars}
-              height={180}
-              mobileHeight={120}
+              height={200}
+              mobileHeight={150}
               gap={3}
               ariaLabel={t('stats.weeklyAttemptsAria')}
-              angledLabels
               maxLabels={12}
             />
           </div>

--- a/packages/web/app/profile/[user_id]/components/v-points-chart.tsx
+++ b/packages/web/app/profile/[user_id]/components/v-points-chart.tsx
@@ -54,7 +54,9 @@ export default function VPointsChart({ data }: VPointsChartProps) {
           {
             data: weekLabels,
             scaleType: 'band' as const,
-            tickLabelStyle: { fontSize: 10 },
+            label: t('stats.weekAxisLabel'),
+            labelStyle: { fontSize: 11 },
+            tickLabelStyle: { fontSize: 11 },
             tickInterval: (_value: string, index: number) => index % labelInterval === 0,
           },
         ]}
@@ -70,7 +72,7 @@ export default function VPointsChart({ data }: VPointsChartProps) {
           },
         ]}
         height={160}
-        margin={{ top: 5, bottom: 30, left: 30, right: 5 }}
+        margin={{ top: 5, bottom: 48, left: 30, right: 5 }}
         hideLegend
         sx={{ width: '100%' }}
       />


### PR DESCRIPTION
## Problem

On the Profile / You page (`/you`), two charts had broken x-axes:

- **Activity**: x-axis labels were clipped — only "half a W" was visible.
- **V-Points**: the x-axis showed bare week numbers with no indication it was a time axis.

## Root causes

1. **Activity (`CssBarChart`)** — the `<BarChart>` was given a fixed pixel `height`, but its wrapper `<Box>` resizes via a CSS media query (smaller on mobile). MUI X renders the SVG at the fixed height, so on mobile the chart overflowed its box and the bottom label band was clipped. The labels were also angled at -45° at a 9px font; MUI X collapses overlapping rotated labels to **empty strings**, leaving only a clipped fragment.
2. **V-Points** — week-number ticks at 10px with **no axis title**.

## Changes

- `CssBarChart` / `GroupedBarChart` now **fill their responsive container** (no fixed height) so they match the box on mobile, and use horizontal **11px** tick labels.
- Activity chart switched to **horizontal, downsampled** week labels (the approach V-Points already uses) — they degrade gracefully (MUI hides overlaps) instead of collapsing to empty.
- V-Points chart gains a **"Week"** x-axis title (i18n: `en-US` / `es` / `fr`) plus larger ticks and a taller bottom margin.
- Removed the now-dead `angledLabels` prop.

Week-number labels were kept (per request); they now read like `W25 '25 … W14 '26` and are fully legible.

## Verification

- `vp run typecheck:web` ✓, lint ✓, `vp run check:i18n` ✓
- Full web suite (**4736 tests**) ✓ including i18n catalog-completeness; `css-bar-chart` unit tests ✓
- Drove the real app signed in as the seeded test user and captured `/you` at desktop and mobile widths — labels render fully on both, downsampling to ~5 on mobile, no clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)