### PR TITLE
Make the floating filter FAB read as purple glass, not a solid disc

### DIFF
--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -31,7 +31,9 @@ export function FilterButton({ activeFilterCount, onPress, onLongPress, prominen
 
   if (floatingLiquidGlass) {
     iconColor = brandColors.onPrimary;
-    tintColor = brandColors.primaryFill;
+    // Translucent violet so the Liquid Glass lenses through (purple GLASS, not a
+    // flat fill); the opaque fallback keeps Reduce Transparency / Android legible.
+    tintColor = withAlpha(brandColors.primaryFill, 0.6);
     fallbackColor = brandColors.primaryFill;
   } else if (active) {
     // Liquid Glass paints the active button on a violet glass tint, so a violet

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -142,11 +142,13 @@ describe('FilterButton', () => {
     expect(filterButton.getAttribute('data-fallback')).toBe('#EEE');
   });
 
-  it('uses a filled brand surface for the floating Liquid Glass affordance', () => {
+  it('uses a translucent violet glass tint over an opaque fallback for the floating Liquid Glass affordance', () => {
     const { container } = render(<FilterButton activeFilterCount={0} onPress={() => {}} prominence="floating" />);
     const filterButton = button(container);
     expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
-    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9');
+    // Translucent tint so the Liquid Glass lenses through (purple glass, not a flat fill);
+    // the fallback stays opaque so Reduce Transparency / Android read as a solid violet.
+    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9@0.6');
     expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9');
   });
 
@@ -164,7 +166,7 @@ describe('FilterButton', () => {
     const { container } = render(<FilterButton activeFilterCount={2} onPress={() => {}} prominence="floating" />);
     const filterButton = button(container);
     expect(filterButton.getAttribute('data-icon-color')).toBe('#FFFFFF');
-    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9');
+    expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9@0.6');
     expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9');
     expect(filterButton.getAttribute('data-badge-bg')).toBe('#FFFFFF');
     expect(filterButton.getAttribute('data-badge-color')).toBe('#6D28D9');


### PR DESCRIPTION
## What

The floating filter FAB on the mobile climb search screen reads as a flat purple disc instead of Liquid Glass. This makes it a translucent **purple glass** FAB while keeping it easy to spot.

## Why

The daylight-contrast change (#2944) set the floating FAB's Liquid Glass `tintColor` to the fully opaque brand violet (`brandColors.primaryFill` = `#6D28D9`). That tint is handed straight to the native iOS 26 `GlassView` (`GlassSurface.tsx`), and an opaque tint collapses the glass into a flat fill — so it rendered as a solid purple disc, "not very liquid glass."

## Change

One line in `FilterButton.tsx`, the `floatingLiquidGlass` branch:

```ts
tintColor = withAlpha(brandColors.primaryFill, 0.6); // was: brandColors.primaryFill (opaque)
```

- **glass** (iOS 26): the translucent violet now lenses the background through the Liquid Glass = the fix.
- **blur** (iOS < 26): frosted blur with a violet wash.
- **solid** (Reduce Transparency / Android on Liquid Glass): `fallbackColor` stays the **opaque** violet, so the surface stays solid and accessible (a see-through surface would defeat Reduce Transparency).

`withAlpha` resolves per color-scheme via the themed `brandColors`, so dark mode (`#7C3AED`) is handled for free. Material variant and the standard (non-floating) FilterButton are untouched.

## Tests

Updated the two floating-prominence assertions in `filter-button.test.tsx` to expect the translucent tint (`#6D28D9@0.6`); fallback/icon/badge assertions unchanged.

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` (FilterButton suite) — 16/16 pass
- `vp run check:mobile-bundle` — OK

Visual confirmation needs iOS 26 hardware/sim (Liquid Glass + blur don't render on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)