### PR TITLE
Document the filter-FAB glass tint and cover dark mode

### DIFF
--- a/packages/mobile/src/components/search/FilterButton.tsx
+++ b/packages/mobile/src/components/search/FilterButton.tsx
@@ -12,6 +12,15 @@ import { glassSize } from '../../theme/layout';
 
 export const FILTER_FAB_SIZE = glassSize.inlinePrimary;
 
+// Tint alpha for the floating Liquid Glass FAB. It sits between the subtle
+// active-state tint (0.18) and the opaque fill — vivid enough to spot outdoors,
+// translucent enough that the glass still lenses the background instead of
+// collapsing into a flat purple disc. Kept deliberately soft: on the iOS < 26
+// blur fallback (where GlassSurface paints only the tint, not the opaque
+// fallback) the white glyph can sit near the 3:1 floor over a light backdrop —
+// an accepted, non-blocking tradeoff. iOS 26 glass and the solid path stay clear.
+const FLOATING_GLASS_TINT_ALPHA = 0.6;
+
 type FilterButtonProps = {
   activeFilterCount: number;
   onPress: () => void;
@@ -31,9 +40,9 @@ export function FilterButton({ activeFilterCount, onPress, onLongPress, prominen
 
   if (floatingLiquidGlass) {
     iconColor = brandColors.onPrimary;
-    // Translucent violet so the Liquid Glass lenses through (purple GLASS, not a
+    // Translucent violet so the Liquid Glass lenses through (purple glass, not a
     // flat fill); the opaque fallback keeps Reduce Transparency / Android legible.
-    tintColor = withAlpha(brandColors.primaryFill, 0.6);
+    tintColor = withAlpha(brandColors.primaryFill, FLOATING_GLASS_TINT_ALPHA);
     fallbackColor = brandColors.primaryFill;
   } else if (active) {
     // Liquid Glass paints the active button on a violet glass tint, so a violet

--- a/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/filter-button.test.tsx
@@ -3,7 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement } from 'react';
 
-const cfg = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+const cfg = vi.hoisted(() => ({
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  // The provider hands components the already scheme-resolved brand fill; dark
+  // mode swaps this to #7C3AED. Tests vary it to prove the FAB tints from whatever
+  // fill it's given rather than a hardcoded hue.
+  primaryFill: '#6D28D9',
+}));
 
 // GlassIconButton → a <button> surfacing the props FilterButton forwards: the
 // badge count, the icon tint, the glass tint, and the accessibility label.
@@ -67,7 +73,7 @@ vi.mock('../../GlassIconButton', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { fill: '#EEE', secondaryLabel: '#999' },
-    brandColors: { primary: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF' },
+    brandColors: { primary: '#6D28D9', primaryFill: cfg.primaryFill, onPrimary: '#FFFFFF' },
     variant: cfg.variant,
   }),
 }));
@@ -96,6 +102,7 @@ const button = (root: HTMLElement) => root.querySelector('[data-icon="filter"]')
 describe('FilterButton', () => {
   beforeEach(() => {
     cfg.variant = 'liquidGlass';
+    cfg.primaryFill = '#6D28D9';
   });
 
   it('renders the filter glyph and fires onPress', () => {
@@ -150,6 +157,16 @@ describe('FilterButton', () => {
     // the fallback stays opaque so Reduce Transparency / Android read as a solid violet.
     expect(filterButton.getAttribute('data-tint')).toBe('#6D28D9@0.6');
     expect(filterButton.getAttribute('data-fallback')).toBe('#6D28D9');
+  });
+
+  it('tints the floating affordance from the scheme-resolved brand fill (dark mode)', () => {
+    // In dark mode the provider resolves brandColors.primaryFill to #7C3AED. The
+    // FAB must follow that fill (tint + opaque fallback), not a hardcoded violet.
+    cfg.primaryFill = '#7C3AED';
+    const { container } = render(<FilterButton activeFilterCount={0} onPress={() => {}} prominence="floating" />);
+    const filterButton = button(container);
+    expect(filterButton.getAttribute('data-tint')).toBe('#7C3AED@0.6');
+    expect(filterButton.getAttribute('data-fallback')).toBe('#7C3AED');
   });
 
   it('uses a white glyph on the violet glass tint when active (Liquid Glass)', () => {


### PR DESCRIPTION
Follow-up polish on #2968, addressing the review feedback there (that PR was already merged).

## Changes

- **Named constant** — pull the floating tint alpha into `FLOATING_GLASS_TINT_ALPHA` with a comment explaining the `0.6` value: it sits between the subtle active-state tint (`0.18`) and the opaque fill. (claude[bot]: "magic number")
- **Documented contrast tradeoff** — the comment records that `0.6` is a deliberate, accepted choice: on the iOS < 26 **blur** fallback `GlassSurface` paints only the tint (not the opaque fallback), so the white glyph sits near the 3:1 floor over a light backdrop. iOS 26 glass and the solid/Reduce-Transparency path stay well clear. (Codex P2 — kept the softer look intentionally.)
- **Comment reword** — dropped the all-caps `"purple GLASS"`. (claude[bot]: "comment style")
- **Dark-mode test** — asserts the floating tint follows the scheme-resolved brand fill (dark → `#7C3AED`), not a hardcoded violet. (claude[bot]: "missing dark-mode test")

## No behaviour change

The tint stays `0.6`; this is documentation + test coverage only.

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` (FilterButton suite) — 17/17 pass (new dark-mode case)
- lint/format — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)