### PR TITLE
Fix Android store-metadata upload path; auto-sync listing on change

### DIFF
--- a/.github/workflows/mobile-store-metadata.yml
+++ b/.github/workflows/mobile-store-metadata.yml
@@ -6,8 +6,12 @@ name: Mobile Store Metadata
 # (fastlane/metadata/android/en-US/). Listing text only — no binary, no
 # screenshots, no review submission, no staged rollout. The text lands on the
 # editable App Store version / Play draft listing, so a wrong value is fixed by
-# editing the .txt and re-running. Manual dispatch only (the listing copy
-# changes far less often than screenshots or builds).
+# editing the .txt and re-running.
+#
+# Runs automatically when the committed listing copy changes on main
+# (fastlane/metadata/** or the Fastfile lane logic), pushing to both stores. Also
+# dispatchable by hand to push a single store on demand. A push build always
+# targets `all`; a manual build uses the chosen platform input.
 #
 # iOS "What's New" (release_notes.txt) is part of the deliver text and IS pushed
 # here. The Android "What's new", by contrast, is NOT pushed here: it ships with
@@ -15,6 +19,11 @@ name: Mobile Store Metadata
 # the same changelogs/default.txt.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'fastlane/metadata/**'
+      - 'fastlane/Fastfile'
   workflow_dispatch:
     inputs:
       platform:
@@ -39,6 +48,10 @@ jobs:
     # App Store Connect / Google Play credentials (same secrets as the
     # screenshot upload job in mobile-screenshots.yml).
     environment: Production
+    # Manual runs honour the chosen platform input; automatic push runs have no
+    # input, so default to pushing both stores.
+    env:
+      PLATFORM: ${{ github.event.inputs.platform || 'all' }}
 
     steps:
       - name: Checkout repository
@@ -52,7 +65,7 @@ jobs:
           working-directory: fastlane
 
       - name: Decode App Store Connect API key
-        if: ${{ inputs.platform == 'ios' || inputs.platform == 'all' }}
+        if: ${{ env.PLATFORM == 'ios' || env.PLATFORM == 'all' }}
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
@@ -67,7 +80,7 @@ jobs:
           echo "ASC_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Upload App Store listing text
-        if: ${{ inputs.platform == 'ios' || inputs.platform == 'all' }}
+        if: ${{ env.PLATFORM == 'ios' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -84,7 +97,7 @@ jobs:
         run: rm -f "$HOME/.private_keys/AuthKey_"*.p8 2>/dev/null || true
 
       - name: Upload Play Store listing text
-        if: ${{ inputs.platform == 'android' || inputs.platform == 'all' }}
+        if: ${{ env.PLATFORM == 'android' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -96,7 +109,7 @@ jobs:
           bundle exec fastlane android metadata
 
       - name: Upload Play Store listing images
-        if: ${{ inputs.platform == 'android' || inputs.platform == 'all' }}
+        if: ${{ env.PLATFORM == 'android' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,8 +35,16 @@ APP_IDENTIFIER = "com.boardsesh.app"
 # truth for the listing copy — see app-stores/apple|google/*.md for the pointers
 # and the operational material (review notes, privacy labels) that can't be
 # uploaded.
-APPLE_METADATA_DIR = File.join(__dir__, "metadata")
-ANDROID_METADATA_DIR = File.join(__dir__, "metadata", "android")
+#
+# Anchor to REPO_ROOT (an absolute path), NOT __dir__. fastlane evaluates the
+# Fastfile through instance_eval, where __dir__ resolves to "." rather than this
+# file's directory — so File.join(__dir__, ...) yields a *relative* path like
+# "./metadata/android". deliver runs from fastlane/ so "./metadata" happens to
+# resolve, but supply runs from the repo root, where "./metadata/android" does
+# not exist ("Could not find folder ./metadata/android"). REPO_ROOT is already
+# absolutised via File.expand_path, so these paths resolve from any CWD.
+APPLE_METADATA_DIR = File.join(REPO_ROOT, "fastlane", "metadata")
+ANDROID_METADATA_DIR = File.join(REPO_ROOT, "fastlane", "metadata", "android")
 
 # Marketing version, read from the Expo app config. Anchored to a top-level
 # `version:` line whose value starts with a digit (semver), so a nested plugin


### PR DESCRIPTION
## What & why

We added the fastlane store-metadata sync but the listings never updated. Two problems, found by dispatching the `Mobile Store Metadata` workflow (run [27670987500](https://github.com/boardsesh/boardsesh/actions/runs/27670987500)) — it had **never run** before (`workflow_dispatch`-only, 0 runs):

### 1. Android upload was broken (real bug)
`supply` failed with `Could not find folder ./metadata/android` even though that folder is committed on `main`. Root cause: the `metadata`/`images` lanes built `metadata_path` from `__dir__`, which fastlane evaluates as `"."` inside its Fastfile `instance_eval`, so the path was the **relative** string `./metadata/android`. `deliver` (iOS) runs from `fastlane/` so `./metadata` happened to resolve, but `supply` (Android) runs from the **repo root**, where `./metadata/android` doesn't exist.

Fix: anchor both metadata dirs to `REPO_ROOT` (already absolutised via `File.expand_path`, same as the screenshot dirs), so they resolve regardless of which CWD the tool uses.

### 2. Nothing triggered it
It was manual-dispatch only, so the "automatic" listing sync never happened. Added a `push` trigger on `main` scoped to `fastlane/metadata/**` and `fastlane/Fastfile`, defaulting to both stores. Per-store manual dispatch still works (the step conditions now read a `PLATFORM` env that falls back to `all` for push events).

## iOS was already fine
The iOS step succeeded and uploaded to the **editable 2.0 ("Prepare for Submission") version** in App Store Connect — not the live listing, by design (`skip_app_version_update: true`). That's why the public App Store still shows old copy; it goes public when 2.0 is submitted and released.

## Validation
- iOS `deliver`: confirmed green in the dispatch above.
- Android `supply`: validated by dispatching this branch (see PR checks / linked run).
- Pre-commit (`vp check --fix`) passed.

## Note
After merge, the `push` trigger will fire on this change (it touches the Fastfile) and sync both stores automatically — the intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)