### PR TITLE
Address review feedback on the mobile sheet sticky footer

### DIFF
--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -96,6 +96,12 @@ export const ModalSheet = forwardRef<BottomSheetModal, ModalSheetProps>(function
     backgroundColor: systemColors.secondaryBackground,
   };
 
+  // FOLLOW-UP: this still renders the scrollable body and footer as flex siblings
+  // inside a single BottomSheetView — the anti-pattern Sheet.tsx moved away from
+  // (it now uses gorhom's native sticky footer via `footerComponent`). Nesting the
+  // scrollview inside a BottomSheetView breaks single-finger scrolling on Android
+  // and lets the body overflow the footer. PlaylistFormSheet hits this path with
+  // footer + scrollable. Port ModalSheet to the same `footerComponent` pattern.
   const footerNode = footer ? (
     <View
       style={[

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -1,5 +1,13 @@
-import { forwardRef, useCallback, useMemo, useState, type ReactNode } from 'react';
-import { Platform, StyleSheet, View, type LayoutChangeEvent, type StyleProp, type ViewStyle } from 'react-native';
+import { createContext, forwardRef, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import {
+  Platform,
+  StyleSheet,
+  View,
+  type ColorValue,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetFooter,
@@ -23,6 +31,45 @@ import { useTheme } from '../providers/theme-provider';
 // BottomSheetModal, so for the plain BottomSheet we wrap the element directly.
 const useOverlay = Platform.OS === 'ios';
 
+// Pre-seed the footer height so the scroll body reserves room on the very first
+// frame, before the footer's onLayout has measured it. Starting from 0 leaves
+// paddingBottom at just spacing[4], so the last content row briefly sits under
+// the sticky footer until layout settles. Roughly one button row plus padding;
+// handleFooterLayout corrects it to the real height on first layout.
+const ESTIMATED_FOOTER_HEIGHT = 80;
+
+// gorhom's BottomSheetFooterContainer is memoised on the *identity* of the
+// `footerComponent` we hand it. If that component is a fresh closure every parent
+// render (the inevitable result of capturing inline-JSX `footer` in a useCallback
+// dep list), gorhom remounts the whole footer subtree on each render — which
+// drops keyboard focus for an input that lives in the footer (CommentSheet's
+// composer) and refires onLayout. So `footerComponent` is a single stable
+// module-level component; the live footer content and chrome flow in through
+// context, letting dynamic content (a loading spinner, an enabled/disabled send
+// button) re-render without changing the component identity.
+type SheetFooterContextValue = {
+  footer: ReactNode;
+  onLayout: (event: LayoutChangeEvent) => void;
+  backgroundColor: ColorValue;
+  borderTopColor: ColorValue;
+  paddingBottom: number;
+};
+
+const SheetFooterContext = createContext<SheetFooterContextValue | null>(null);
+
+function SheetFooter(props: BottomSheetFooterProps) {
+  const footerContext = useContext(SheetFooterContext);
+  if (!footerContext) return null;
+  const { footer, onLayout, backgroundColor, borderTopColor, paddingBottom } = footerContext;
+  return (
+    <BottomSheetFooter {...props} bottomInset={0}>
+      <View onLayout={onLayout} style={[styles.footer, { backgroundColor, borderTopColor, paddingBottom }]}>
+        {footer}
+      </View>
+    </BottomSheetFooter>
+  );
+}
+
 type SheetProps = {
   children: ReactNode;
   snapPoints?: (string | number)[];
@@ -35,6 +82,11 @@ type SheetProps = {
   // your own BottomSheetScrollView in the children, as nesting it inside the
   // default BottomSheetView breaks gorhom's scroll gesture wiring.
   scrollable?: boolean;
+  // Extra style for the content/scroll container. NOTE: when a `footer` is set,
+  // the sheet computes its own `paddingBottom` (footer height + a gap) so the
+  // last row clears the sticky-footer overlay, and that value OVERRIDES any
+  // `paddingBottom` you pass here. Set other padding/margins freely — just don't
+  // rely on a custom `paddingBottom` alongside a footer.
   contentContainerStyle?: StyleProp<ViewStyle>;
   // Optional bottom action area. Rendered as a sibling below the content with
   // safe-area-aware bottom padding so the CTA sits comfortably above the home
@@ -103,74 +155,71 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
   // Footer height feeds the scroll content's bottom padding. gorhom's
   // BottomSheetFooter is an absolutely-positioned overlay pinned to the sheet's
   // bottom (and it rises with the keyboard), so the scrollable body sits *behind*
-  // it — without this padding the last rows would hide under the footer.
-  const [footerHeight, setFooterHeight] = useState(0);
+  // it — without this padding the last rows would hide under the footer. Seed
+  // with an estimate so the body reserves room on the first frame; the real
+  // height replaces it once the footer lays out.
+  const [footerHeight, setFooterHeight] = useState(ESTIMATED_FOOTER_HEIGHT);
   const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
     setFooterHeight(event.nativeEvent.layout.height);
   }, []);
 
-  // Use gorhom's native sticky footer instead of a flex sibling. This keeps the
-  // BottomSheetScrollView as the sheet's direct child, which is what preserves
-  // gorhom's scroll-gesture wiring — nesting the scrollview inside a
-  // BottomSheetView (the old footer path) broke single-finger scrolling on
-  // Android and let the body overflow, pushing the footer off-screen.
-  const renderFooter = useCallback(
-    (props: BottomSheetFooterProps) => (
-      <BottomSheetFooter {...props} bottomInset={0}>
-        <View
-          onLayout={handleFooterLayout}
-          style={[
-            styles.footer,
-            {
-              backgroundColor: systemColors.secondaryBackground,
-              borderTopColor: systemColors.separator,
-              paddingBottom: insets.bottom + spacing[3],
-            },
-          ]}
-        >
-          {footer}
-        </View>
-      </BottomSheetFooter>
-    ),
+  // Use gorhom's native sticky footer (the stable module-level SheetFooter)
+  // instead of a flex sibling. This keeps the BottomSheetScrollView as the
+  // sheet's direct child, which is what preserves gorhom's scroll-gesture wiring
+  // — nesting the scrollview inside a BottomSheetView (the old footer path) broke
+  // single-finger scrolling on Android and let the body overflow, pushing the
+  // footer off-screen. The live footer content + chrome reach SheetFooter through
+  // this context value (see the SheetFooterContext comment for why).
+  const footerContextValue = useMemo<SheetFooterContextValue>(
+    () => ({
+      footer,
+      onLayout: handleFooterLayout,
+      backgroundColor: systemColors.secondaryBackground,
+      borderTopColor: systemColors.separator,
+      paddingBottom: insets.bottom + spacing[3],
+    }),
     [footer, handleFooterLayout, systemColors.secondaryBackground, systemColors.separator, insets.bottom],
   );
 
   // When a sticky footer is present, reserve room below the content so it clears
-  // the overlay (footer height + a small gap). Overrides any paddingBottom the
-  // consumer set on contentContainerStyle.
+  // the overlay (footer height + a small gap). This is appended last to
+  // contentContainerStyle, so it overrides any paddingBottom the consumer set
+  // there (documented on the contentContainerStyle prop).
   const footerSpacing = footer ? { paddingBottom: footerHeight + spacing[4] } : null;
 
   const sheet = (
-    <BottomSheet
-      ref={ref}
-      index={-1}
-      snapPoints={enableDynamicSizing ? undefined : snapPoints}
-      enableDynamicSizing={enableDynamicSizing}
-      enablePanDownToClose={enablePanDownToClose}
-      keyboardBehavior={keyboardBehavior}
-      keyboardBlurBehavior={keyboardBlurBehavior}
-      android_keyboardInputMode={android_keyboardInputMode}
-      backdropComponent={renderBackdrop}
-      backgroundComponent={glass ? GlassSheetBackground : undefined}
-      backgroundStyle={glass ? undefined : backgroundStyle}
-      onChange={handleChange}
-      onClose={onClose}
-      handleIndicatorStyle={sheetChrome.handleStyle}
-      footerComponent={footer ? renderFooter : undefined}
-      style={styles.sheet}
-    >
-      {scrollable ? (
-        <BottomSheetScrollView
-          style={styles.content}
-          contentContainerStyle={[contentContainerStyle, footerSpacing]}
-          showsVerticalScrollIndicator={false}
-        >
-          {children}
-        </BottomSheetScrollView>
-      ) : (
-        <BottomSheetView style={[styles.content, footerSpacing]}>{children}</BottomSheetView>
-      )}
-    </BottomSheet>
+    <SheetFooterContext.Provider value={footerContextValue}>
+      <BottomSheet
+        ref={ref}
+        index={-1}
+        snapPoints={enableDynamicSizing ? undefined : snapPoints}
+        enableDynamicSizing={enableDynamicSizing}
+        enablePanDownToClose={enablePanDownToClose}
+        keyboardBehavior={keyboardBehavior}
+        keyboardBlurBehavior={keyboardBlurBehavior}
+        android_keyboardInputMode={android_keyboardInputMode}
+        backdropComponent={renderBackdrop}
+        backgroundComponent={glass ? GlassSheetBackground : undefined}
+        backgroundStyle={glass ? undefined : backgroundStyle}
+        onChange={handleChange}
+        onClose={onClose}
+        handleIndicatorStyle={sheetChrome.handleStyle}
+        footerComponent={footer ? SheetFooter : undefined}
+        style={styles.sheet}
+      >
+        {scrollable ? (
+          <BottomSheetScrollView
+            style={styles.content}
+            contentContainerStyle={[contentContainerStyle, footerSpacing]}
+            showsVerticalScrollIndicator={false}
+          >
+            {children}
+          </BottomSheetScrollView>
+        ) : (
+          <BottomSheetView style={[styles.content, footerSpacing]}>{children}</BottomSheetView>
+        )}
+      </BottomSheet>
+    </SheetFooterContext.Provider>
   );
 
   return fullWindowOverlay && useOverlay ? <FullWindowOverlay>{sheet}</FullWindowOverlay> : sheet;

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { createElement, createRef, forwardRef, type ComponentType, type ReactNode, type Ref } from 'react';
+
+// RN style arrays merge later-wins, so the effective paddingBottom is the last
+// layer that defines one (matching how Sheet appends footerSpacing last).
+function readPaddingBottom(style: unknown): number | undefined {
+  const layers = Array.isArray(style) ? style : [style];
+  let result: number | undefined;
+  for (const layer of layers) {
+    if (layer && typeof layer === 'object' && 'paddingBottom' in layer) {
+      result = (layer as { paddingBottom?: number }).paddingBottom;
+    }
+  }
+  return result;
+}
+
+// Captured across renders so tests can assert the footer's onLayout handler, the
+// scroll container's reserved paddingBottom, and the identity of the footer
+// component gorhom is handed each render.
+const captures = vi.hoisted(() => ({
+  footerOnLayout: null as null | ((event: { nativeEvent: { layout: { height: number } } }) => void),
+  scrollPaddingBottom: undefined as number | undefined,
+  viewPaddingBottom: undefined as number | undefined,
+  footerComponents: [] as Array<ComponentType<{ animatedFooterPosition?: unknown }> | undefined>,
+}));
+
+type ViewMockProps = {
+  children?: ReactNode;
+  style?: unknown;
+  onLayout?: (event: { nativeEvent: { layout: { height: number } } }) => void;
+};
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: { ios?: unknown; android?: unknown }) => options.ios },
+  View: ({ children, style, onLayout }: ViewMockProps) => {
+    // Only the footer's inner wrapper sets onLayout — capture it so a test can
+    // simulate the footer measuring and assert the body padding follows.
+    if (onLayout) {
+      captures.footerOnLayout = onLayout;
+      captures.viewPaddingBottom = readPaddingBottom(style);
+    }
+    return createElement('div', null, children);
+  },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+type FooterComponent = ComponentType<{ animatedFooterPosition?: unknown }>;
+type SheetMockProps = {
+  children?: ReactNode;
+  footerComponent?: FooterComponent;
+};
+type ScrollMockProps = { children?: ReactNode; contentContainerStyle?: unknown };
+vi.mock('@gorhom/bottom-sheet', () => ({
+  default: forwardRef(({ children, footerComponent }: SheetMockProps, ref: Ref<unknown>) => {
+    captures.footerComponents.push(footerComponent);
+    return createElement(
+      'div',
+      { 'data-sheet': 'true', ref },
+      children,
+      // Render the footer the way gorhom does, inside the sheet subtree (and
+      // therefore inside Sheet's footer context provider) so SheetFooter resolves.
+      footerComponent ? createElement(footerComponent, { animatedFooterPosition: { value: 0 } }) : null,
+    );
+  }),
+  BottomSheetScrollView: ({ children, contentContainerStyle }: ScrollMockProps) => {
+    captures.scrollPaddingBottom = readPaddingBottom(contentContainerStyle);
+    return createElement('div', { 'data-scroll': 'true' }, children);
+  },
+  BottomSheetView: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+  BottomSheetFooter: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-footer': 'true' }, children),
+  BottomSheetBackdrop: () => null,
+}));
+
+vi.mock('react-native-screens', () => ({
+  FullWindowOverlay: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
+vi.mock('../GlassSheetBackground', () => ({
+  GlassSheetBackground: () => null,
+}));
+
+vi.mock('../../lib/haptics', () => ({
+  hapticMedium: vi.fn(),
+}));
+
+vi.mock('../../theme/tokens', () => ({
+  spacing: { 2: 8, 3: 12, 4: 16, 6: 24 },
+  sheetStyles: { background: {} },
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#fff', separator: '#ccc' },
+    sheet: { scrimOpacity: 0.5, corners: {}, handleStyle: {} },
+  }),
+}));
+
+import { Sheet } from '../Sheet';
+
+const SPACING_4 = 16;
+const ESTIMATED_FOOTER_HEIGHT = 80;
+
+beforeEach(() => {
+  captures.footerOnLayout = null;
+  captures.scrollPaddingBottom = undefined;
+  captures.viewPaddingBottom = undefined;
+  captures.footerComponents = [];
+});
+
+describe('Sheet footer wiring', () => {
+  it('reserves room for the footer on first render using the estimated height', () => {
+    render(
+      <Sheet scrollable footer={<div data-testid="footer">save</div>}>
+        <div>body</div>
+      </Sheet>,
+    );
+
+    // Before the footer measures, the body padding is the estimate + gap — not a
+    // bare spacing[4], which would let the last row sit under the footer.
+    expect(captures.scrollPaddingBottom).toBe(ESTIMATED_FOOTER_HEIGHT + SPACING_4);
+  });
+
+  it('updates the reserved padding once the footer reports its real height', () => {
+    render(
+      <Sheet scrollable footer={<div data-testid="footer">save</div>}>
+        <div>body</div>
+      </Sheet>,
+    );
+
+    expect(captures.footerOnLayout).not.toBeNull();
+    act(() => {
+      captures.footerOnLayout?.({ nativeEvent: { layout: { height: 120 } } });
+    });
+
+    expect(captures.scrollPaddingBottom).toBe(120 + SPACING_4);
+  });
+
+  it('hands gorhom a stable footer component across re-renders with new inline footers', () => {
+    const ref = createRef<unknown>();
+    const { rerender } = render(
+      <Sheet ref={ref as never} scrollable footer={<div>first</div>}>
+        <div>body</div>
+      </Sheet>,
+    );
+
+    // A new inline footer on every render is the real-world case (consumers pass
+    // inline JSX). The component identity must not change, or gorhom remounts the
+    // footer subtree (dropping a composer's keyboard focus).
+    rerender(
+      <Sheet ref={ref as never} scrollable footer={<div>second</div>}>
+        <div>body</div>
+      </Sheet>,
+    );
+
+    const distinct = new Set(captures.footerComponents.filter(Boolean));
+    expect(distinct.size).toBe(1);
+  });
+
+  it('does not reserve footer padding when no footer is provided', () => {
+    render(
+      <Sheet scrollable>
+        <div>body</div>
+      </Sheet>,
+    );
+
+    expect(captures.scrollPaddingBottom).toBeUndefined();
+    expect(captures.footerComponents.every((component) => component === undefined)).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -58,7 +58,6 @@ export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClo
       scrollable
       fullWindowOverlay
       onClose={onClose}
-      contentContainerStyle={styles.content}
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
@@ -121,7 +120,6 @@ export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClo
 }
 
 const styles = StyleSheet.create({
-  content: { paddingBottom: spacing[6] },
   title: { paddingHorizontal: spacing[4], paddingTop: spacing[2], paddingBottom: spacing[3] },
   centered: { paddingVertical: spacing[10], alignItems: 'center' },
   empty: { paddingHorizontal: spacing[4], paddingVertical: spacing[6], opacity: 0.6 },

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -272,7 +272,6 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       scrollable
       fullWindowOverlay
       onClose={onClose}
-      contentContainerStyle={styles.content}
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
@@ -409,7 +408,6 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
 }
 
 const styles = StyleSheet.create({
-  content: { paddingBottom: spacing[6] },
   title: { paddingHorizontal: spacing[4], paddingTop: spacing[2] },
   field: { paddingHorizontal: spacing[4] },
   dateTimeButton: {

--- a/packages/mobile/src/components/you/YouFilterSheet.tsx
+++ b/packages/mobile/src/components/you/YouFilterSheet.tsx
@@ -51,7 +51,6 @@ export function YouFilterSheet({
       scrollable
       fullWindowOverlay
       footer={<Button title={t('mobile.filter.done')} onPress={() => sheetRef.current?.close()} />}
-      contentContainerStyle={styles.content}
     >
       <Text variant="title3" style={styles.title}>
         {t('mobile.filter.title')}
@@ -85,9 +84,6 @@ export function YouFilterSheet({
 }
 
 const styles = StyleSheet.create({
-  content: {
-    paddingBottom: spacing[6],
-  },
   title: {
     paddingHorizontal: spacing[4],
     paddingTop: spacing[2],


### PR DESCRIPTION
Follow-ups on the review of #2953 (`fix/mobile-sheet-sticky-footer`). Five points were raised; this PR resolves all five.

## 1. Initial layout jank on first open (`Sheet.tsx`)
`footerHeight` started at `0`, so the scroll body's `paddingBottom` was just `spacing[4]` (16px) until the footer's `onLayout` fired — the last content row briefly sat under the sticky footer on first render. Now pre-seeded with an `ESTIMATED_FOOTER_HEIGHT` of 80px (roughly one button row + padding); `handleFooterLayout` still corrects it to the real height on first layout.

## 2. `renderFooter` memoization was a no-op (and a latent focus bug)
gorhom's `BottomSheetFooterContainer` is `memo`'d on the **identity** of `footerComponent`. The old `renderFooter` `useCallback` captured the inline-JSX `footer` in its dep list, so it was a fresh closure on every parent render — gorhom remounted the entire footer subtree each time. For `CommentSheet`, whose footer **is** the text composer, that means the `BottomSheetTextInput` remounts (and drops keyboard focus) on every keystroke, not just a wasted optimization.

Fix: `footerComponent` is now a single module-level `SheetFooter`. The live footer content + chrome flow in through a small context, so dynamic footer content (a loading spinner, an enabled/disabled send button) still re-renders without changing the component identity → no remount.

## 3. Dead `paddingBottom` in consumers + undocumented override
`contentContainerStyle`'s `paddingBottom` is silently overridden by the sheet's footer spacing when a footer is present. Documented this on the `contentContainerStyle` prop JSDoc, and removed the now-dead `paddingBottom: spacing[6]` from `LogbookEditSheet`, `YouFilterSheet`, and `CommentSheet` (all three always pass a footer, so it never applied). `BoardDetailSheet` is left as-is — its footer can be null, so its padding is not dead.

## 4. `ModalSheet.tsx` still uses the old flex-sibling pattern
Out of scope to port here, as flagged in review. Added a `FOLLOW-UP` comment on `ModalSheet`'s footer pointing at the `footerComponent` pattern and naming `PlaylistFormSheet` as the affected consumer.

## 5. No tests for the footer wiring
Added `sheet.test.tsx` covering: the estimated-height pre-seed, `onLayout` updating the reserved padding, the stable `footerComponent` identity across re-renders with new inline footers, and the no-footer case.

## Validation
- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2352 passed (incl. 4 new)
- `vp run check:mobile-bundle` — OK
- `vp check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)