### PR TITLE
Fix Android screenshot capture: dash has no pipefail

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -347,7 +347,10 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            set -euo pipefail
+            # android-emulator-runner runs this script under `sh` (dash), which has no
+            # `pipefail` — `set -euo pipefail` aborts the step before anything runs. No
+            # pipes here, so `set -eu` is equivalent.
+            set -eu
             adb shell wm size 1080x1920
             adb shell wm density 420
             vp run mobile:screenshots -- \


### PR DESCRIPTION
The **iOS** screenshot run now works end-to-end (captured + uploaded to App Store Connect). But the **Android** job fails at the "Capture Android screenshots" step before it runs anything:

```
/usr/bin/sh -c set -euo pipefail
/usr/bin/sh: 1: set: Illegal option -o pipefail
```

That step's `script:` runs inside `reactivecircus/android-emulator-runner`, which executes under `sh` (dash). dash has no `pipefail`, so `set -euo pipefail` aborts the step immediately — before the emulator, app, or Maestro run. (Pre-existing; unrelated to the iOS auth/readiness fixes. The other `set -euo pipefail` lines are fine — they're in plain `run:` blocks that default to bash.)

The script has no pipes, so `set -eu` is equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)