### PR TITLE
fix(ci): run iOS TestFlight signing ruby under bundle exec (xcodeproj)

### DIFF
--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -262,8 +262,15 @@ jobs:
           install_profile SHARE_EXTENSION_PROFILE_BASE64 share-extension IOS_SHARE_EXTENSION_PROFILE_NAME IOS_SHARE_EXTENSION_PROFILE_BUNDLE_ID com.boardsesh.app.share-extension
 
       - name: Configure per-target code signing
+        # `ruby/setup-ruby` makes its freshly-installed Ruby the active one, and
+        # that Ruby has no global xcodeproj gem (the macOS runner's system Ruby
+        # did). xcodeproj is a fastlane dependency, so run under `bundle exec`
+        # with the fastlane Gemfile while keeping the repo root as cwd so the
+        # relative project path below still resolves.
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/fastlane/Gemfile
         run: |
-          ruby <<'RUBY'
+          bundle exec ruby <<'RUBY'
           require 'xcodeproj'
           project = Xcodeproj::Project.open('packages/mobile/ios/Boardsesh.xcodeproj')
 


### PR DESCRIPTION
## Problem

Every `iOS TestFlight Deploy (React Native)` run on `main` has been failing at the **Configure per-target code signing** step:

```
cannot load such file -- xcodeproj (LoadError)
```

([example run](https://github.com/boardsesh/boardsesh/actions/runs/27674996772))

## Root cause

Commit `89b4959f9` ("Add fastlane metadata sync, store-derived build numbers…") added a **Setup Ruby and fastlane** step using `ruby/setup-ruby@v1` (Ruby 3.4) so the build number can be queried from App Store Connect via fastlane.

`ruby/setup-ruby` makes its freshly-installed Ruby the active interpreter for the rest of the job. That Ruby has no global `xcodeproj` gem — the macOS runner's *system* Ruby did, which is why the signing step worked before. The signing step runs plain `ruby` and `require 'xcodeproj'`, so it now blows up and no TestFlight upload ever happens.

## Fix

`xcodeproj` is already a fastlane dependency pinned in `fastlane/Gemfile.lock` (`xcodeproj (1.27.0)`), so the gem is installed in the bundle — it's just not on the global load path. Run the signing script under `bundle exec ruby` with `BUNDLE_GEMFILE` pointed at the fastlane Gemfile. Keeping the repo root as the working directory preserves the relative project path the script opens (`packages/mobile/ios/Boardsesh.xcodeproj`).

One-line behavioural change to the workflow; no secrets, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)