### PR TITLE
fix(mobile): Live Activity thumbnail missing board art — decode webp via libwebp

### DIFF
--- a/packages/mobile/modules/live-activity/ios/LiveActivityModulePod.podspec
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModulePod.podspec
@@ -15,4 +15,9 @@ Pod::Spec.new do |s|
   s.source_files   = '*.swift'
   s.frameworks     = 'ActivityKit', 'CoreBluetooth', 'WidgetKit', 'AppIntents'
   s.dependency 'ExpoModulesCore'
+  # libwebp-backed coder for the bundled board-background webp(s) composited into
+  # Live Activity thumbnails. expo-image already pins SDWebImageWebPCoder, so this
+  # (left unpinned) unifies on the same resolved pod — no duplicate libwebp. Needed
+  # because Apple ImageIO (UIImage(contentsOfFile:)) can't decode the lossy VP8 webp.
+  s.dependency 'SDWebImageWebPCoder'
 end

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -1,6 +1,8 @@
 import Foundation
 import UIKit
 import os.log
+import SDWebImage
+import SDWebImageWebPCoder
 
 // MARK: - ThumbnailFetcher
 
@@ -244,11 +246,27 @@ actor ThumbnailFetcher {
     }
 
     /// Decoded background layer for a path, memoized in `backgroundLayerCache`.
+    ///
+    /// The bundled board art is lossy VP8 webp, which Apple's ImageIO
+    /// (`UIImage(contentsOfFile:)`) does not reliably decode — it returns nil, so
+    /// the composite was silently dropping the board photo and caching the
+    /// holds-only overlay. Decode webp through libwebp (`SDImageWebPCoder`, the
+    /// same coder expo-image falls back to for these files) instead. Call the
+    /// coder directly rather than via `SDImageCodersManager.shared`: expo-image's
+    /// registered webp coder defaults to Apple's ImageIO codec, which would fail
+    /// the same way. Non-webp paths (defensive) fall back to `UIImage(data:)`.
     private func backgroundLayer(at path: String) -> UIImage? {
         if let cached = backgroundLayerCache[path] { return cached }
-        guard let image = UIImage(contentsOfFile: path) else { return nil }
-        backgroundLayerCache[path] = image
-        return image
+        guard let data = fileManager.contents(atPath: path) else { return nil }
+        let image: UIImage?
+        if SDImageWebPCoder.shared.canDecode(from: data) {
+            image = SDImageWebPCoder.shared.decodedImage(with: data, options: nil)
+        } else {
+            image = UIImage(data: data)
+        }
+        guard let decoded = image else { return nil }
+        backgroundLayerCache[path] = decoded
+        return decoded
     }
 
     /// Drops all cached background layers. Called on a board/session change so
@@ -280,10 +298,10 @@ actor ThumbnailFetcher {
     /// transparent pixels), not an opaque board photo, and the server overlay is
     /// likewise transparent. The composite must keep its alpha so the widget's
     /// dark `activityBackgroundTint` shows through; flattening to JPEG would turn
-    /// the transparent board into a solid black block. iOS ImageIO can't encode
-    /// the smaller webp (decode-only — no runtime encoder without libwebp), so
-    /// PNG + the downscale above is the alpha-preserving, dependency-free option;
-    /// the cache also stays bounded to `maxCachedThumbnails`.
+    /// the transparent board into a solid black block. PNG + the downscale above
+    /// is the simplest alpha-preserving output (we could now re-encode webp via the
+    /// linked `SDImageWebPCoder`, but the downscaled PNG is already tiny), and the
+    /// cache also stays bounded to `maxCachedThumbnails`.
     private func compositeWithBoardBackground(overlayData: Data) -> Data? {
         let paths = stagedBackgroundPaths()
         // Evict cached layers for boards we've navigated away from (and clear
@@ -304,7 +322,7 @@ actor ThumbnailFetcher {
 
         let backgroundLayers = paths.compactMap { backgroundLayer(at: $0) }
         guard !backgroundLayers.isEmpty else {
-            logger.error("composite skipped: \(paths.count, privacy: .public) staged path(s) but 0 decoded via UIImage(contentsOfFile:) — first: \(paths.first ?? "?", privacy: .public)")
+            logger.error("composite skipped: \(paths.count, privacy: .public) staged path(s) but 0 decoded via SDImageWebPCoder — first: \(paths.first ?? "?", privacy: .public)")
             return nil
         }
         logger.notice("composite: \(backgroundLayers.count, privacy: .public)/\(paths.count, privacy: .public) background layer(s) under overlay")


### PR DESCRIPTION
## Problem

The iOS Live Activity climb thumbnail (lock screen / Dynamic Island) showed only the coloured hold-highlight **circles**, with the board image (the actual holds) missing. In-app board art (play screen, climb cards, playlist backdrops) rendered fine — only the Live Activity was affected, and the bug reproduced on latest `main` (after all of today's Live Activity fixes).

## Root cause

The thumbnail is a native composite (`ThumbnailFetcher.compositeWithBoardBackground`, main-app process): the server returns a holds-only overlay (the circles), and the bundled board-background webp(s) are drawn underneath. `backgroundLayer(at:)` decoded those webps with `UIImage(contentsOfFile:)` (Apple **ImageIO**), which does not reliably decode the bundled **lossy VP8** webp board art (`file` → `Web/P image, VP8 encoding, YUV color`). It returned `nil` → background layers empty → composite skipped → the holds-only overlay was cached (circles only).

In-app art is unaffected because it renders via React Native `<Image>` / **expo-image**, whose webp coder falls back to **libwebp** (`SDImageWebPCoder`) when Apple's codec fails. The widget composite had no such fallback.

## Fix

Decode the background layers through `SDImageWebPCoder` (libwebp) directly — the same coder expo-image relies on for these files.

- `ThumbnailFetcher.backgroundLayer(at:)`: read the file into `Data` and decode via `SDImageWebPCoder.shared.decodedImage(with:options:)`. Called **directly**, not through `SDImageCodersManager.shared`, whose expo-image-registered webp coder defaults back to Apple's ImageIO codec (same failure). Non-webp paths fall back to `UIImage(data:)`. Memoization (`backgroundLayerCache`) and the graceful `nil` → overlay-only fallback are unchanged.
- `LiveActivityModulePod.podspec`: add `SDWebImageWebPCoder` (unpinned). expo-image already pins `SDWebImageWebPCoder ~> 0.14.6`, so CocoaPods unifies on one shared pod — no duplicate libwebp / duplicate-symbol risk.
- Updated the `0 decoded` diagnostic log wording to reference `SDImageWebPCoder`.

Compositing runs only in the main-app process (the widget extension has no `ThumbnailFetcher`), so only this module needs the decoder. Ships via a **new native build**, not OTA.

## Validation

Linux-safe (all green):
- `vp run typecheck:mobile`
- `vp run test:mobile` — 2348 passed
- `vp run check:mobile-bundle` — iOS + Android bundles export OK
- `vp run check:mobile-board-art-network` — no-network guard stays green

Requires macOS to verify the native change (could not run from this environment):
1. `expo prebuild` + `pod install` resolve `SDWebImageWebPCoder` once at `0.14.6`; Xcode compiles `ThumbnailFetcher.swift` against the new imports.
2. Start a session, open the Live Activity, and confirm Console.app (subsystem `com.boardsesh.app`, category `ThumbnailFetcher`) logs `composite: N/N background layer(s) under overlay` (was `composite skipped: ... 0 decoded`), and the thumbnail shows the board holds under the highlight circles.

Follow-up (optional): a macOS-only regression test in `LiveActivityWidgetTests.swift` asserting `SDImageWebPCoder.shared.decodedImage(with:)` decodes a bundled VP8 webp while `UIImage(contentsOfFile:)` returns nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)