### PR TITLE
fix(mobile): bump Live Activity thumbnail cacheVersion to 3 (purge stale overlay-only cache)

### DIFF
--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -28,9 +28,15 @@ actor ThumbnailFetcher {
     /// instead of serving them stale. The App Group container survives app
     /// updates, so without this an upgrading user keeps seeing the previous
     /// build's images. v1 = overlay-only (no board art); v2 = board background
-    /// composited behind the holds overlay. Mirrors `RENDERER_VERSION` in
-    /// use-native-climb-render.ts, which solved the same transition in-app.
-    static let cacheVersion = 2
+    /// composited behind the holds overlay — but v2 builds decoded the bundled
+    /// webp via Apple ImageIO (`UIImage(contentsOfFile:)`), which fails on the
+    /// lossy VP8 board art, so v2 actually cached overlay-only images while
+    /// recording version 2. v3 = backgrounds decoded via libwebp
+    /// (`SDImageWebPCoder`), so the board photo finally composites. The bump
+    /// forces v2 builds' stale overlay-only thumbnails to be purged on update.
+    /// Mirrors `RENDERER_VERSION` in use-native-climb-render.ts, which solved the
+    /// same transition in-app.
+    static let cacheVersion = 3
 
     // MARK: - Dependencies
 


### PR DESCRIPTION
## Problem

PR #2978 fixed the Live Activity board art by decoding the bundled webp via libwebp (`SDImageWebPCoder`) instead of Apple ImageIO. That shipped in build **100372** (confirmed: the build links `SDWebImageWebPCoder` and compiled the Swift change). But an in-place updater **still saw holds-only circles**.

## Root cause

The cache-version purge (`purgeStaleCacheIfNeeded`, `cacheVersion = 2`) was already present in the **previous** build (100371). That build:
1. Failed to decode the webp (ImageIO) → cached **overlay-only** thumbnails.
2. Wrote `thumbnailCacheVersion = 2` into the App Group container (which survives app updates).

PR #2978 left `cacheVersion = 2`. So on update 100371 → 100372, `purgeStaleCacheIfNeeded` saw stored `2 == 2` and **did not purge**. `fetchThumbnail` returns the cached file before ever re-compositing, so the stale overlay-only images persisted.

A fresh install (delete + reinstall) clears the container and shows the fix working — confirming the decode fix is correct and stale cache was masking it.

## Fix

Bump `cacheVersion` 2 → 3. Per the constant's own contract ("Bumped when the cached thumbnail's content contract changes"), the decode fix changed the output (overlay-only → composited) and must bump the version. v3 forces the v2 builds' stale overlay-only thumbnails to be purged on update, so the board photo re-composites with the working libwebp decoder. Comment updated to record that v2 silently cached overlay-only due to the ImageIO decode failure.

## Validation

- Pre-commit no-network board-art guard: green.
- One-line constant change in `ThumbnailFetcher.swift`; no JS/type impact.
- Verify on device after this lands in a new native TestFlight build: updating in place (no reinstall) shows the board holds under the highlight circles, and Console.app logs `Purged N stale thumbnail(s) (cache version 2 → 3)` then `composite: N/N background layer(s) under overlay`.

Follow-up to #2978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)