### PR TITLE
fix(mobile): tap a participant avatar to open their profile

### DIFF
--- a/packages/mobile/src/components/session-screen/in-session/SessionPresenceRow.tsx
+++ b/packages/mobile/src/components/session-screen/in-session/SessionPresenceRow.tsx
@@ -30,7 +30,10 @@ export function SessionPresenceRow({ users }: SessionPresenceRowProps) {
   const participants = useMemo(
     () =>
       ordered.map((user) => ({
-        userId: user.id,
+        // user.id is the connection id; user.userId is the stable DB user id the
+        // profile route expects. Unauthenticated connections have no userId, so
+        // their avatar stays non-tappable rather than linking to a dead profile.
+        userId: user.userId,
         displayName: user.username,
         avatarUrl: user.avatarUrl,
       })),

--- a/packages/mobile/src/components/you/AvatarGroup.tsx
+++ b/packages/mobile/src/components/you/AvatarGroup.tsx
@@ -5,7 +5,10 @@ import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { useTheme } from '../../providers/theme-provider';
 
-type Participant = { userId: string; displayName?: string | null; avatarUrl?: string | null };
+// userId is the profile to open on tap; it's nullable because some rosters
+// include unauthenticated connections (e.g. session presence), which have no
+// linked profile. PressableAvatar degrades those to a plain, non-tappable avatar.
+type Participant = { userId?: string | null; displayName?: string | null; avatarUrl?: string | null };
 
 type AvatarGroupProps = {
   participants: Participant[];
@@ -30,7 +33,7 @@ export function AvatarGroup({ participants, size = 32, max = 3 }: AvatarGroupPro
     <View style={styles.row}>
       {shown.map((participant, index) => (
         <View
-          key={participant.userId}
+          key={participant.userId ?? `anon-${index}`}
           style={[
             styles.ring,
             {

--- a/packages/mobile/src/components/you/AvatarGroup.tsx
+++ b/packages/mobile/src/components/you/AvatarGroup.tsx
@@ -1,5 +1,5 @@
 import { View, StyleSheet } from 'react-native';
-import { Avatar } from '../Avatar';
+import { PressableAvatar } from '../PressableAvatar';
 import { Text } from '../Text';
 import { brandColors } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -19,7 +19,7 @@ export function AvatarGroup({ participants, size = 32, max = 3 }: AvatarGroupPro
 
   if (participants.length <= 1) {
     const only = participants[0];
-    return <Avatar uri={only?.avatarUrl} name={only?.displayName} size={size} />;
+    return <PressableAvatar userId={only?.userId} uri={only?.avatarUrl} name={only?.displayName} size={size} />;
   }
 
   const shown = participants.slice(0, max);
@@ -40,7 +40,12 @@ export function AvatarGroup({ participants, size = 32, max = 3 }: AvatarGroupPro
             },
           ]}
         >
-          <Avatar uri={participant.avatarUrl} name={participant.displayName} size={size} />
+          <PressableAvatar
+            userId={participant.userId}
+            uri={participant.avatarUrl}
+            name={participant.displayName}
+            size={size}
+          />
         </View>
       ))}
       {overflow > 0 && (

--- a/packages/mobile/src/components/you/CommentSheet.tsx
+++ b/packages/mobile/src/components/you/CommentSheet.tsx
@@ -4,7 +4,7 @@ import BottomSheet, { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { SocialEntityType } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
-import { Avatar } from '../Avatar';
+import { PressableAvatar } from '../PressableAvatar';
 import { Icon } from '../Icon';
 import { Sheet } from '../Sheet';
 import { ActivityIndicator } from '../ActivityIndicator';
@@ -100,7 +100,12 @@ export function CommentSheet({ sheetRef, entityId, entityType = 'session', onClo
       ) : (
         comments.map((comment) => (
           <View key={comment.uuid} style={styles.commentRow}>
-            <Avatar uri={comment.userAvatarUrl} name={comment.userDisplayName} size={32} />
+            <PressableAvatar
+              userId={comment.userId}
+              uri={comment.userAvatarUrl}
+              name={comment.userDisplayName}
+              size={32}
+            />
             <View style={styles.commentBody}>
               <View style={styles.commentMeta}>
                 <Text variant="subheadline" style={styles.commentName}>

--- a/packages/mobile/src/components/you/__tests__/AvatarGroup.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/AvatarGroup.test.tsx
@@ -15,7 +15,7 @@ vi.mock('react-native', () => ({
 vi.mock('../../PressableAvatar', () => ({
   PressableAvatar: (props: Record<string, unknown>) => {
     mockPressableAvatar(props);
-    return createElement('div', { 'data-testid': 'pressable-avatar', 'data-user': String(props.userId ?? '') });
+    return createElement('div', { 'data-testid': 'pressable-avatar' });
   },
 }));
 vi.mock('../../Text', () => ({
@@ -51,6 +51,47 @@ describe('AvatarGroup', () => {
     expect(mockPressableAvatar).toHaveBeenCalledTimes(3);
     const userIds = mockPressableAvatar.mock.calls.map((call) => (call[0] as Participant).userId);
     expect(userIds).toEqual(['u1', 'u2', 'u3']);
+  });
+
+  it('forwards uri and name to each avatar', () => {
+    render(
+      createElement(AvatarGroup, {
+        participants: [
+          { userId: 'u1', displayName: 'Alice', avatarUrl: 'https://example.test/a.png' },
+          { userId: 'u2', displayName: 'Bob', avatarUrl: null },
+        ],
+      }),
+    );
+    expect(mockPressableAvatar).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u1', name: 'Alice', uri: 'https://example.test/a.png' }),
+    );
+  });
+
+  it('honours a custom max, collapsing the rest into the overflow tile', () => {
+    const { container } = render(createElement(AvatarGroup, { participants: ['u1', 'u2'].map(participant), max: 1 }));
+    expect(mockPressableAvatar).toHaveBeenCalledTimes(1);
+    expect(mockPressableAvatar).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u1' }));
+    expect(container.textContent).toContain('+1');
+  });
+
+  it('renders a non-interactive avatar for a participant without a userId (e.g. an anonymous guest)', () => {
+    // A null userId (unauthenticated session connection) must not crash the keyed
+    // list and must not become a tappable link to a non-existent profile.
+    render(
+      createElement(AvatarGroup, {
+        participants: [
+          { userId: 'u1', displayName: 'Alice', avatarUrl: null },
+          { userId: null, displayName: 'Guest', avatarUrl: null },
+        ],
+      }),
+    );
+    const userIds = mockPressableAvatar.mock.calls.map((call) => (call[0] as Participant).userId);
+    expect(userIds).toEqual(['u1', null]);
+  });
+
+  it('renders without throwing when the participant list is empty', () => {
+    expect(() => render(createElement(AvatarGroup, { participants: [] }))).not.toThrow();
+    expect(mockPressableAvatar).toHaveBeenCalledWith(expect.objectContaining({ userId: undefined }));
   });
 
   it('caps shown avatars at max and renders the +N overflow tile as non-interactive', () => {

--- a/packages/mobile/src/components/you/__tests__/AvatarGroup.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/AvatarGroup.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPressableAvatar = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+// AvatarGroup's whole job is to delegate each avatar to PressableAvatar with the
+// right userId; PressableAvatar's own test covers that a tap navigates. So here we
+// capture the props handed to each PressableAvatar.
+vi.mock('../../PressableAvatar', () => ({
+  PressableAvatar: (props: Record<string, unknown>) => {
+    mockPressableAvatar(props);
+    return createElement('div', { 'data-testid': 'pressable-avatar', 'data-user': String(props.userId ?? '') });
+  },
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#000' } }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { white: '#fff' } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#eee' } }),
+}));
+
+import { AvatarGroup } from '../AvatarGroup';
+
+type Participant = { userId: string; displayName?: string | null; avatarUrl?: string | null };
+
+function participant(userId: string): Participant {
+  return { userId, displayName: userId.toUpperCase(), avatarUrl: null };
+}
+
+beforeEach(() => {
+  mockPressableAvatar.mockClear();
+});
+
+describe('AvatarGroup', () => {
+  it('renders a single pressable avatar carrying the participant userId', () => {
+    render(createElement(AvatarGroup, { participants: [participant('u1')] }));
+    expect(mockPressableAvatar).toHaveBeenCalledTimes(1);
+    expect(mockPressableAvatar).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u1' }));
+  });
+
+  it('renders one pressable avatar per shown participant with its own userId', () => {
+    render(createElement(AvatarGroup, { participants: ['u1', 'u2', 'u3'].map(participant) }));
+    expect(mockPressableAvatar).toHaveBeenCalledTimes(3);
+    const userIds = mockPressableAvatar.mock.calls.map((call) => (call[0] as Participant).userId);
+    expect(userIds).toEqual(['u1', 'u2', 'u3']);
+  });
+
+  it('caps shown avatars at max and renders the +N overflow tile as non-interactive', () => {
+    const { container } = render(
+      createElement(AvatarGroup, { participants: ['u1', 'u2', 'u3', 'u4', 'u5'].map(participant) }),
+    );
+    // Default max is 3: only the first three become pressable; the rest collapse
+    // into a "+N" tile that is NOT a PressableAvatar (it isn't a single user).
+    expect(mockPressableAvatar).toHaveBeenCalledTimes(3);
+    expect(container.querySelectorAll('[data-testid="pressable-avatar"]').length).toBe(3);
+    expect(container.textContent).toContain('+2');
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/comment-sheet-error.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/comment-sheet-error.test.tsx
@@ -66,7 +66,7 @@ vi.mock('@gorhom/bottom-sheet', () => ({
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../Avatar', () => ({ Avatar: () => createElement('div', null) }));
+vi.mock('../../PressableAvatar', () => ({ PressableAvatar: () => createElement('div', null) }));
 vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
 vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => createElement('div', null) }));
 


### PR DESCRIPTION
## Problem

On mobile, tapping a user's avatar should open their profile (`/users/[userId]`). It already does in the leaderboard, per-climb tick rows, climber search, and board presence — but **on session feed cards and on the session-detail hero header, tapping an avatar did nothing.**

## Root cause

Both surfaces render their participant avatars through the shared `AvatarGroup`, which rendered plain, non-interactive `Avatar`s instead of the app's `PressableAvatar` (the navigation wrapper that pushes `/users/[userId]`). One component was the cause for both.

## Changes

- **`AvatarGroup.tsx`** — render `PressableAvatar` for the single and grouped cases, passing each participant's `userId`. The `+N` overflow tile stays non-interactive. This also fixes the third consumer, the in-session presence row.
- **`CommentSheet.tsx`** — comment-author avatars now use `PressableAvatar` too (comments carry `userId`; authors with no linked id fall back to a plain avatar).
- **`AvatarGroup.test.tsx`** (new) — asserts each shown participant gets a `PressableAvatar` with the right `userId`, and the `+N` tile isn't pressable.
- **`comment-sheet-error.test.tsx`** — its avatar mock updated to `PressableAvatar` (the import swap otherwise pulled in unmocked `expo-router`).

No tap-conflict handling needed: in the feed card the avatars sit inside the card's outer `PressableSurface`, and RN's responder system lets the inner avatar win a direct tap while taps elsewhere still open the session.

Web is unaffected — its session-card avatars already navigate via `LocaleLink`.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2355 passed
- `vp run check:mobile-bundle` — bundle OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)