### PR TITLE
fix(mobile): server-composite Live Activity thumbnail for 2.0 (match Capacitor)

### DIFF
--- a/docs/live-activity-push-testing.md
+++ b/docs/live-activity-push-testing.md
@@ -414,17 +414,26 @@ If you see `0 sent, N failed`, check the [Common Issues](#common-issues) section
 
 ### Board-photo thumbnail compositing
 
-The thumbnail in the Live Activity is built in two layers, never as a single network fetch (the no-network-board-art rule — see `scripts/mobile-board-art-network-check.ts`):
+For the 2.0 release the thumbnail is the **server-composited** board image, matching the
+legacy Capacitor app (which renders correctly). `ThumbnailFetcher` fetches
+`/api/internal/board-render?...&thumbnail=1&include_background=1` — the server (`sharp`)
+draws the board photo behind this climb's holds overlay and returns a finished image,
+which `ThumbnailFetcher` writes straight to the App Group `thumbnails/` dir for the widget
+to display. No on-device webp decode or compositing.
 
-1. The **climb's holds overlay** is fetched from `/api/internal/board-render?...&thumbnail=1` (no `include_background`) — a transparent PNG of just this climb's holds.
-2. The **board background** is the bundled board art (the per-set hold renders, mostly transparent webp shipped in the IPA). JS resolves these in `use-live-activity.ts` (`resolveBoardBackgroundPaths`) and stages their file paths into the App Group (`SharedConstants.boardBackgroundPathsKey`) at `startSession`.
+This deliberately reverses the earlier "no-network-board-art" rule. The on-device
+bundled-art path (`resolveBoardBackgroundPaths` staging + `compositeWithBoardBackground`)
+never rendered the board reliably in production, so it's deferred. Re-adding offline board
+art (and the `server-rendered-background` guard rule in `scripts/mobile-board-art-network-check.ts`)
+is tracked in issue #2982.
 
-`ThumbnailFetcher.compositeWithBoardBackground` (main-app process) draws the background layer(s) under the overlay, downscales to the widget display size, and writes a transparent PNG to the App Group `thumbnails/` dir — what the widget renders.
+If the Live Activity shows only the climb's holds and no board behind them, the server
+fetch failed or returned the overlay only. Check:
 
-If the Live Activity shows only the climb's holds and no board behind them, the background layers didn't resolve or stage. Check:
-
-- `[background-image-cache] No bundled asset for "…"` warnings (a board added to the schema but its art not bundled — re-run `scripts/sync-mobile-board-backgrounds.sh`).
-- That `boardBackgroundPaths` is non-empty in the `startSession` payload for the active board.
+- `include_background=1` is present in the `boardRenderUrl` request and the server returns a
+  composited image (not a 4xx).
+- The cached thumbnail isn't a stale pre-2.0 image — `cacheVersion` (`ThumbnailFetcher`)
+  bumps to purge old overlay-only caches on update.
 
 ## Debugging
 

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -147,6 +147,8 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertTrue(url?.absoluteString.contains("board_name=kilter") ?? false)
         XCTAssertTrue(url?.absoluteString.contains("frames=p1r12p2r13") ?? false)
         XCTAssertTrue(url?.absoluteString.contains("thumbnail=1") ?? false)
-        XCTAssertFalse(url?.absoluteString.contains("include_background=1") ?? true)
+        // 2.0: the thumbnail is composited server-side (matches the Capacitor app);
+        // the on-device bundled-art compositing is deferred to the revisit issue.
+        XCTAssertTrue(url?.absoluteString.contains("include_background=1") ?? false)
     }
 }

--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -218,6 +218,12 @@ enum SharedQueueState {
             URLQueryItem(name: "set_ids", value: setIds),
             URLQueryItem(name: "frames", value: item.frames),
             URLQueryItem(name: "thumbnail", value: "1"),
+            // 2.0: let the server composite the board photo behind the holds
+            // overlay (matches the legacy Capacitor app, which renders correctly).
+            // On-device bundled-board-art compositing is deferred — see the
+            // "offline board art" revisit issue. The widget then just displays the
+            // finished image; no local webp decode/composite needed.
+            URLQueryItem(name: "include_background", value: "1"),
         ]
 
         return components?.url

--- a/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
+++ b/packages/mobile/modules/live-activity/ios/ThumbnailFetcher.swift
@@ -27,16 +27,16 @@ actor ThumbnailFetcher {
     /// with new compositing logic discards thumbnails written by older builds
     /// instead of serving them stale. The App Group container survives app
     /// updates, so without this an upgrading user keeps seeing the previous
-    /// build's images. v1 = overlay-only (no board art); v2 = board background
-    /// composited behind the holds overlay — but v2 builds decoded the bundled
-    /// webp via Apple ImageIO (`UIImage(contentsOfFile:)`), which fails on the
-    /// lossy VP8 board art, so v2 actually cached overlay-only images while
-    /// recording version 2. v3 = backgrounds decoded via libwebp
-    /// (`SDImageWebPCoder`), so the board photo finally composites. The bump
-    /// forces v2 builds' stale overlay-only thumbnails to be purged on update.
-    /// Mirrors `RENDERER_VERSION` in use-native-climb-render.ts, which solved the
-    /// same transition in-app.
-    static let cacheVersion = 3
+    /// build's images. v1 = overlay-only (no board art); v2/v3 = on-device
+    /// compositing of the bundled board art behind the holds overlay, which never
+    /// rendered correctly in production (v2 decoded the bundled webp via Apple
+    /// ImageIO, which fails on the lossy VP8 art; v3 switched to libwebp but still
+    /// fell back to overlay-only). v4 = the server returns the fully composited
+    /// thumbnail (include_background=1), so the board photo always shows. The bump
+    /// purges v2/v3 builds' stale overlay-only thumbnails on update. Mirrors
+    /// `RENDERER_VERSION` in use-native-climb-render.ts, which solved the same
+    /// transition in-app.
+    static let cacheVersion = 4
 
     // MARK: - Dependencies
 
@@ -223,11 +223,12 @@ actor ThumbnailFetcher {
                 return nil
             }
 
-            // Composite the holds overlay over the bundled board background(s)
-            // when they're staged; otherwise persist the raw overlay (the
-            // graceful holds-only fallback for an unbundled board).
-            let imageData = compositeWithBoardBackground(overlayData: data) ?? data
-            try imageData.write(to: fileURL, options: .atomic)
+            // 2.0: the server returns the fully composited thumbnail (board photo
+            // behind the holds overlay, via include_background=1 in boardRenderUrl),
+            // matching the legacy Capacitor app. Persist it directly — no on-device
+            // webp decode/composite. The bundled-board-art compositing below is
+            // retained but unused, pending the "offline board art" revisit issue.
+            try data.write(to: fileURL, options: .atomic)
 
             // Evict after writing so we stay within the cache limit.
             // Note: called within the actor, so file I/O runs on the actor's

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -218,6 +218,12 @@ enum SharedQueueState {
             URLQueryItem(name: "set_ids", value: setIds),
             URLQueryItem(name: "frames", value: item.frames),
             URLQueryItem(name: "thumbnail", value: "1"),
+            // 2.0: let the server composite the board photo behind the holds
+            // overlay (matches the legacy Capacitor app, which renders correctly).
+            // On-device bundled-board-art compositing is deferred — see the
+            // "offline board art" revisit issue. The widget then just displays the
+            // finished image; no local webp decode/composite needed.
+            URLQueryItem(name: "include_background", value: "1"),
         ]
 
         return components?.url

--- a/scripts/__tests__/mobile-board-art-network-check.test.ts
+++ b/scripts/__tests__/mobile-board-art-network-check.test.ts
@@ -29,10 +29,12 @@ describe('mobile board-art network check', () => {
     );
   });
 
-  it('flags server-rendered background compositing from mobile/native code', () => {
-    expect(check('URLQueryItem(name: "include_background", value: "1")')).toContainEqual(
-      expect.stringContaining('server-rendered-background'),
-    );
+  // 2.0: the Live Activity thumbnail fetches the server-composited board image
+  // (include_background=1), matching the legacy Capacitor app. The
+  // `server-rendered-background` rule was removed; re-adding offline board art is
+  // tracked in the revisit issue.
+  it('allows server-rendered background compositing (include_background)', () => {
+    expect(check('URLQueryItem(name: "include_background", value: "1")')).toEqual([]);
   });
 
   it('allows intended remote user media image sources', () => {

--- a/scripts/mobile-board-art-network-check.ts
+++ b/scripts/mobile-board-art-network-check.ts
@@ -73,11 +73,11 @@ const RULES: readonly Rule[] = [
     message: 'Do not render board backgrounds through react-native-svg Image href; use bundled file paths.',
     test: (lineText) => /\bSvgImage\b/.test(lineText),
   },
-  {
-    name: 'server-rendered-background',
-    message: 'Mobile/native board-render requests must not ask the server to composite background board art.',
-    test: (lineText) => lineText.includes('include_background') && /["']1["']/.test(lineText),
-  },
+  // NOTE: the `server-rendered-background` rule (forbidding include_background=1)
+  // was removed for the 2.0 release. The Live Activity thumbnail now fetches the
+  // server-composited board image, matching the legacy Capacitor app, because the
+  // on-device bundled-art compositing never rendered correctly in production.
+  // Re-adding offline board art (and this guard) is tracked in issue #2982.
 ] as const;
 
 function shouldScanPath(filePath: string): boolean {


### PR DESCRIPTION
## Problem

The iOS Live Activity climb thumbnail shows only the holds-highlight **circles**, not the board image. The on-device bundled-board-art compositing never rendered the board in production — even after switching the webp decode to libwebp (#2978) and bumping the cache version (#2980), a **clean install still failed**.

The legacy **Capacitor** app (`mobile/ios/App/`) renders correctly because its widget fetches the **fully composited** image from the server (`/api/internal/board-render?...&thumbnail=1&include_background=1`) and just displays it — no local image work.

## Fix (2.0)

Match the proven Capacitor approach in the RN app:

- **`SharedConstants.swift`** (both the live-activity module copy and the byte-identical widget-target copy): add `include_background=1` to `boardRenderUrl`, so the server (`sharp`) composites the board photo behind this climb's holds overlay.
- **`ThumbnailFetcher._fetchAndSave`**: write the server image straight to the App Group cache; drop the local `compositeWithBoardBackground` call. The bundled-art compositing code (and the `SDWebImageWebPCoder` dep from #2978) is left in place but **unused**, deferred to #2982.
- **`cacheVersion` 3 → 4**: purge pre-2.0 overlay-only thumbnails on update so the new server-composited image shows in place (not just on reinstall).
- **CI guard**: remove the `server-rendered-background` rule (it forbade `include_background=1`) and flip its unit test; the other no-network rules stay. Update `docs/live-activity-push-testing.md`.

This deliberately reverses the "no-network-board-art rule". Restoring offline board art is tracked in **#2982**.

## Validation

Linux-safe (all green):
- `vp run check:mobile-board-art-network` — passes (include_background now allowed)
- `vp run test:mobile` — 2352 passing incl. the widget-target drift test (both `SharedConstants.swift` copies byte-identical) and the flipped guard test
- `vp run typecheck:mobile`

Requires the merge-triggered native TestFlight build to verify on device: open a climb's Live Activity → the board photo shows behind the holds circles. An in-place update purges the stale cache (`Purged N stale thumbnail(s) (cache version 3 → 4)`).

Follow-up to #2978 and #2980. Revisit: #2982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)