### PR TITLE
Polish the mobile sheet footer per #2972 review

### DIFF
--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -36,7 +36,7 @@ const useOverlay = Platform.OS === 'ios';
 // paddingBottom at just spacing[4], so the last content row briefly sits under
 // the sticky footer until layout settles. Roughly one button row plus padding;
 // handleFooterLayout corrects it to the real height on first layout.
-const ESTIMATED_FOOTER_HEIGHT = 80;
+export const ESTIMATED_FOOTER_HEIGHT = 80;
 
 // gorhom's BottomSheetFooterContainer is memoised on the *identity* of the
 // `footerComponent` we hand it. If that component is a fresh closure every parent
@@ -170,14 +170,17 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
   // single-finger scrolling on Android and let the body overflow, pushing the
   // footer off-screen. The live footer content + chrome reach SheetFooter through
   // this context value (see the SheetFooterContext comment for why).
-  const footerContextValue = useMemo<SheetFooterContextValue>(
-    () => ({
-      footer,
-      onLayout: handleFooterLayout,
-      backgroundColor: systemColors.secondaryBackground,
-      borderTopColor: systemColors.separator,
-      paddingBottom: insets.bottom + spacing[3],
-    }),
+  const footerContextValue = useMemo<SheetFooterContextValue | null>(
+    () =>
+      footer
+        ? {
+            footer,
+            onLayout: handleFooterLayout,
+            backgroundColor: systemColors.secondaryBackground,
+            borderTopColor: systemColors.separator,
+            paddingBottom: insets.bottom + spacing[3],
+          }
+        : null,
     [footer, handleFooterLayout, systemColors.secondaryBackground, systemColors.separator, insets.bottom],
   );
 
@@ -187,6 +190,9 @@ export const Sheet = forwardRef<BottomSheet, SheetProps>(function Sheet(
   // there (documented on the contentContainerStyle prop).
   const footerSpacing = footer ? { paddingBottom: footerHeight + spacing[4] } : null;
 
+  // The provider wraps the sheet unconditionally (its value is null when there is
+  // no footer) so that toggling a footer on/off never changes the tree depth above
+  // BottomSheet — a conditional wrapper would remount the sheet and close it.
   const sheet = (
     <SheetFooterContext.Provider value={footerContextValue}>
       <BottomSheet

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -22,7 +22,8 @@ function readPaddingBottom(style: unknown): number | undefined {
 const captures = vi.hoisted(() => ({
   footerOnLayout: null as null | ((event: { nativeEvent: { layout: { height: number } } }) => void),
   scrollPaddingBottom: undefined as number | undefined,
-  viewPaddingBottom: undefined as number | undefined,
+  bodyPaddingBottom: undefined as number | undefined,
+  footerChromePaddingBottom: undefined as number | undefined,
   footerComponents: [] as Array<ComponentType<{ animatedFooterPosition?: unknown }> | undefined>,
 }));
 
@@ -38,7 +39,7 @@ vi.mock('react-native', () => ({
     // simulate the footer measuring and assert the body padding follows.
     if (onLayout) {
       captures.footerOnLayout = onLayout;
-      captures.viewPaddingBottom = readPaddingBottom(style);
+      captures.footerChromePaddingBottom = readPaddingBottom(style);
     }
     return createElement('div', null, children);
   },
@@ -67,7 +68,11 @@ vi.mock('@gorhom/bottom-sheet', () => ({
     captures.scrollPaddingBottom = readPaddingBottom(contentContainerStyle);
     return createElement('div', { 'data-scroll': 'true' }, children);
   },
-  BottomSheetView: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+  BottomSheetView: ({ children, style }: { children?: ReactNode; style?: unknown }) => {
+    // The non-scrollable branch reserves footer room on this view's style.
+    captures.bodyPaddingBottom = readPaddingBottom(style);
+    return createElement('div', { 'data-view': 'true' }, children);
+  },
   BottomSheetFooter: ({ children }: { children?: ReactNode }) =>
     createElement('div', { 'data-footer': 'true' }, children),
   BottomSheetBackdrop: () => null,
@@ -101,15 +106,18 @@ vi.mock('../../providers/theme-provider', () => ({
   }),
 }));
 
-import { Sheet } from '../Sheet';
+import { ESTIMATED_FOOTER_HEIGHT, Sheet } from '../Sheet';
 
+// Mirror the values the theme/token mocks above feed into the footer chrome.
+const SPACING_3 = 12;
 const SPACING_4 = 16;
-const ESTIMATED_FOOTER_HEIGHT = 80;
+const INSET_BOTTOM = 34;
 
 beforeEach(() => {
   captures.footerOnLayout = null;
   captures.scrollPaddingBottom = undefined;
-  captures.viewPaddingBottom = undefined;
+  captures.bodyPaddingBottom = undefined;
+  captures.footerChromePaddingBottom = undefined;
   captures.footerComponents = [];
 });
 
@@ -124,6 +132,22 @@ describe('Sheet footer wiring', () => {
     // Before the footer measures, the body padding is the estimate + gap — not a
     // bare spacing[4], which would let the last row sit under the footer.
     expect(captures.scrollPaddingBottom).toBe(ESTIMATED_FOOTER_HEIGHT + SPACING_4);
+    // The footer wrapper itself carries safe-area-aware bottom padding so the CTA
+    // clears the home indicator.
+    expect(captures.footerChromePaddingBottom).toBe(INSET_BOTTOM + SPACING_3);
+  });
+
+  it('reserves footer room on the non-scrollable body too', () => {
+    render(
+      <Sheet footer={<div data-testid="footer">save</div>}>
+        <div>body</div>
+      </Sheet>,
+    );
+
+    // The BottomSheetView branch (non-scrollable) must reserve the same room as
+    // the scrollable branch, or its last row hides under the sticky footer.
+    expect(captures.bodyPaddingBottom).toBe(ESTIMATED_FOOTER_HEIGHT + SPACING_4);
+    expect(captures.footerComponents.filter(Boolean).length).toBeGreaterThan(0);
   });
 
   it('updates the reserved padding once the footer reports its real height', () => {


### PR DESCRIPTION
Follow-up to the now-merged #2972, addressing the leftover review nits from the Claude review (which had marked #2972 "ready to merge — minor test quality issues only").

## Changes

**Export `ESTIMATED_FOOTER_HEIGHT`** — the 80px estimate was duplicated as a magic number in both `Sheet.tsx` and `sheet.test.tsx`. Now exported from `Sheet.tsx` and imported in the test.

**Null footer context on the no-footer path** — `footerContextValue` now returns `null` when there's no footer, so the no-footer render path no longer allocates the memoised context object. The provider still wraps the sheet **unconditionally** (with a comment explaining why): a conditional wrapper would change the tree depth above `BottomSheet` and remount/close the sheet when a footer toggles on or off.

**Test coverage** —
- Assert the footer wrapper's safe-area `paddingBottom` (`insets.bottom + spacing[3]`). This was a captured-but-never-asserted value before (dead capture).
- Cover the non-scrollable `BottomSheetView` branch with a footer — previously all tests only exercised the `scrollable` path.

## Validation
- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2353 passed (5 in `sheet.test.tsx`)
- `vp run check:mobile-bundle` — OK
- `vp check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)