### PR TITLE
fix(android): stop sideload APK versionCode from regressing below the live ceiling

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -134,16 +134,20 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: bunx expo prebuild --platform android --clean --no-install
 
-      # versionCode = max versionCode across Play tracks + 1, queried from Google
-      # Play via fastlane. Querying the live tracks keeps the result strictly
-      # above the Capacitor app's versionCode (an install upgrades in place).
-      # Falls back to offset + run_number (the previous deterministic scheme)
-      # when there's no Play service account yet or the query fails, so the build
-      # stays green before the Play bootstrap.
+      # versionCode = max(sideload floor, Play track ceiling + 1), resolved by
+      # `fastlane android next_version_code`. The sideload floor is the
+      # deterministic offset + run_number line below (VERSION_CODE_FALLBACK) — it
+      # is the versionCode every GitHub Release sideload APK has shipped, so it's
+      # the LIVE ceiling of the channel users sideload (~2_000_2xx). The Play
+      # internal track sits in the low hundreds, so it can only RAISE the number,
+      # never lower it: deriving from Play alone regressed the shared versionCode
+      # from 2_000_285 (build 285) to 190 (build 289), which Android rejects as
+      # INSTALL_FAILED_VERSION_DOWNGRADE on every sideload upgrade. See
+      # docs/android-sideload-build.md.
       # NOTE: github.run_number resets to 1 if this workflow file is renamed or
-      # recreated — if you do that AND the fallback is in use, bump
-      # version_code_offset past the current production ceiling via the
-      # workflow_dispatch input, or new builds will be un-installable.
+      # recreated — if you do that, bump version_code_offset past the current
+      # production ceiling via the workflow_dispatch input first, or the floor
+      # drops below installed builds and new APKs become un-installable.
       - name: Compute version code
         id: version_code
         working-directory: fastlane

--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -67,23 +67,45 @@ own signing.
 Both the Capacitor app (`mobile/`, `android-release.yml`) and the RN rewrite
 (`packages/mobile/`) ship the **same package `com.boardsesh.app`** signed with
 the **same key**, so an RN APK upgrades a Capacitor install in place. To keep
-that direction valid, the RN build sets:
+that direction valid, the RN build computes the versionCode as:
 
 ```
-versionCode = version_code_offset (default 2000000) + github.run_number
+versionCode = max(
+  version_code_offset (default 2000000) + github.run_number,  # sideload floor
+  max(Play track versionCodes) + 1                            # Play ceiling
+)
 ```
 
-The offset keeps the RN line strictly above the Capacitor line (which uses a raw
-`run_number` in the low thousands), so RN always supersedes. The trade-off is
-deliberate: **the RN rewrite is the successor.** A Capacitor release can no
-longer upgrade a device already on the RN build.
+The `offset + run_number` term is the **sideload floor** — the deterministic
+line that every GitHub Release APK has shipped on, and the channel users
+actually sideload. The offset keeps it strictly above the Capacitor line (which
+uses a raw `run_number` in the low thousands), so RN always supersedes. The
+trade-off is deliberate: **the RN rewrite is the successor.** A Capacitor
+release can no longer upgrade a device already on the RN build.
+
+`fastlane android next_version_code` (see `fastlane/Fastfile`) resolves the
+number. The Play query may only **raise** the result above the sideload floor,
+never lower it.
+
+> **Why the floor is a hard floor, not a fallback.** Build 285 shipped
+> versionCode `2000285`. Build 289 was the first to read the Play track and —
+> because that lane returned the Play ceiling **instead of** the floor — shipped
+> versionCode `190` (Play's internal track started fresh in the low hundreds).
+> `190 < 2000285`, so every sideloader hit `INSTALL_FAILED_VERSION_DOWNGRADE` and
+> could no longer install the new APK over their existing one. The fix takes the
+> **max** of the floor and the Play ceiling, so the sideload line can never
+> regress while still staying above whatever Play already has (the AAB uploads
+> cleanly too). Builds 289–298 are the affected range; build 299+ jumps back to
+> `2000299`, which supersedes both the last good sideload build (`2000285`) and
+> the broken `190` builds, so every device converges on one upgrade.
 
 Two invariants to respect:
 
 1. **Don't rename `android-apk-rn.yml`.** `github.run_number` resets to 1 on
-   rename/recreate. If you must, bump `version_code_offset` (the
-   `workflow_dispatch` input) past the current production ceiling first, or new
-   builds become un-installable over existing ones.
+   rename/recreate, which would drop the sideload floor below installed builds.
+   If you must, bump `version_code_offset` (the `workflow_dispatch` input) past
+   the current production ceiling first, or new builds become un-installable
+   over existing ones.
 2. **Capacitor publishing is already disabled.** `android-release.yml` still
    builds the Capacitor app for CI validation, but its GitHub-Release and
    Play-Store-upload steps were removed so it can't publish a lower-versionCode
@@ -198,11 +220,13 @@ these v2/v3-signed release APKs.
 
 No separate version source: the app version is read from
 `packages/mobile/app.config.ts`, and the AAB inherits the exact `versionCode`
-the "Set version code" step seds in (`offset + run_number`), shared with the
-APK. Play enforces strictly-increasing `versionCode` per track, which
-`run_number` monotonicity satisfies. `eas.json`'s `appVersionSource: remote`
-governs only `eas build`/`eas submit` — do **not** enable EAS auto-increment for
-Android, or it would fight the gradle version source.
+the "Set version code" step seds in (`max(offset + run_number, Play ceiling + 1)`
+— see [versionCode and coexistence](#versioncode-and-coexistence-with-the-capacitor-app)),
+shared with the APK. Play enforces strictly-increasing `versionCode` per track,
+which the floor's `run_number` monotonicity satisfies. `eas.json`'s
+`appVersionSource: remote` governs only `eas build`/`eas submit` — do **not**
+enable EAS auto-increment for Android, or it would fight the gradle version
+source.
 
 For production later, promote from internal and use Play's staged rollout (set
 `track: production` + `status: inProgress` + `userFraction` on the upload step).

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -257,13 +257,28 @@ platform :android do
     )
   end
 
-  desc "Print the next Android versionCode (max across release tracks + 1)"
+  desc "Print the next Android versionCode (sideload floor raised to the Play ceiling, never below it)"
   lane :next_version_code do
+    # VERSION_CODE_FALLBACK is the deterministic sideload line: offset (2_000_000)
+    # + github.run_number, set by android-apk-rn.yml. It is the versionCode that
+    # has shipped on every GitHub Release sideload APK, so it is the LIVE ceiling
+    # of the channel users actually sideload — currently ~2_000_2xx.
+    #
+    # It is a FLOOR, not a "fallback". The Google Play internal track sits in the
+    # low hundreds (it started fresh from the bootstrap upload), so deriving the
+    # shared versionCode from Play alone drags it far BELOW the sideload ceiling:
+    # build 285 shipped 2_000_285, then build 289 (which first read Play) shipped
+    # 190, and Android then rejects every sideload upgrade with
+    # INSTALL_FAILED_VERSION_DOWNGRADE (190 < 2_000_285). The Play query may only
+    # RAISE the number above this floor, never lower it. See
+    # docs/android-sideload-build.md.
     fallback = ENV["VERSION_CODE_FALLBACK"].to_s
+    floor = fallback.empty? ? nil : fallback.to_i
+
     json_key_data = ENV["GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"].to_s
-    code =
+    play_next =
       begin
-        # No service account yet (first-upload bootstrap) -> fall back below.
+        # No service account yet (first-upload bootstrap) -> floor only.
         UI.user_error!("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is empty.") if json_key_data.empty?
         codes = []
         %w[production beta alpha internal].each do |track|
@@ -283,14 +298,23 @@ platform :android do
           end
         end
         UI.user_error!("No version codes on any track.") if codes.empty?
-        # Querying the live tracks keeps the result above the legacy Capacitor ceiling.
         codes.map(&:to_i).max + 1
       rescue => error
         UI.important("google_play_track_version_codes failed: #{error.message}")
-        UI.user_error!("No version code from Google Play and VERSION_CODE_FALLBACK is unset.") if fallback.empty?
-        UI.important("Falling back to VERSION_CODE_FALLBACK=#{fallback}")
-        fallback.to_i
+        nil
       end
+
+    # max(sideload floor, Play ceiling + 1). Keeps every sideload upgrade valid
+    # while staying strictly above whatever Play already has, so the AAB uploads
+    # cleanly too. Errors only when BOTH inputs are missing.
+    code = [floor, play_next].compact.max
+    UI.user_error!("No version code: Google Play query returned nothing and VERSION_CODE_FALLBACK is unset.") if code.nil?
+
+    if floor && play_next && play_next > floor
+      UI.important("Play ceiling (#{play_next}) is above the sideload floor (#{floor}); using #{code}.")
+    elsif floor && play_next
+      UI.important("Play ceiling (#{play_next}) is at/below the sideload floor (#{floor}); holding the floor at #{code}.")
+    end
 
     UI.success("Android versionCode: #{code}")
     emit_ci_output(code)


### PR DESCRIPTION
## What users saw

Since **Android build 289**, sideloaders can no longer install the GitHub Release APK over their existing install — Android rejects it with `INSTALL_FAILED_VERSION_DOWNGRADE`.

## Root cause

Build 289 was the first build to resolve the Android `versionCode` from Google Play, via the `fastlane android next_version_code` lane added in `89b4959f9`. That lane returned `max(Play track codes) + 1` and only fell back to the deterministic `offset + run_number` line **on error**.

But the two channels have divergent version histories:

- The **sideload APK** (GitHub Release) had always shipped on the deterministic `offset + run_number` line — currently **~2,000,2xx**.
- The **Play internal track** started fresh from the bootstrap upload, sitting in the **low hundreds**.

So reading Play as the primary source collapsed the shared `versionCode`. Confirmed by parsing the `versionCode` out of the released APK manifests:

| Build | versionCode | source |
|-------|-------------|--------|
| 285 (last good) | `2000285` | `offset + run_number` |
| 289 | `190` | `max(Play) + 1` ← **190 < 2000285** |
| 294 | `190` | |
| 298 (latest) | `190` | |

`190 < 2000285`, so every sideload upgrade fails with `INSTALL_FAILED_VERSION_DOWNGRADE`. (289–298 are all stuck at 190 because the AAB at 190 never lands on Play, so the track ceiling never advances.)

## Fix

Treat `offset + run_number` (`VERSION_CODE_FALLBACK`) as a **hard floor**, not a fallback:

```
versionCode = max(offset + run_number, max(Play track codes) + 1)
```

The Play query can only **raise** the number above the sideload line, never lower it. This keeps every sideload upgrade valid while staying strictly above whatever Play already has, so the AAB still uploads cleanly. Errors only when *both* inputs are missing.

Build 299+ jumps back to ~`2000299`, which supersedes **both** the last good sideload (`2000285`) and the broken `190` builds — so every device, whether stuck on 2000285 or on a fresh 190 install, converges on a single upgrade.

## Changes

- `fastlane/Fastfile` — `next_version_code` now returns `max(floor, Play ceiling + 1)`.
- `.github/workflows/android-apk-rn.yml` — updated the "Compute version code" comment to the floor semantics.
- `docs/android-sideload-build.md` — documented the floor + the 289–298 incident.

## Verification

- Parsed the manifest `versionCode` from the actual released APKs (285/289/294/298) to confirm the regression (table above).
- Simulated the decision function across the regression, post-fix, Play-ahead, Play-query-failed, bootstrap, and both-missing cases — the floor invariant holds (no build regresses below `2000285`).
- `vp check` formatting passes for the changed files; the 3 pre-existing lint errors are in unrelated `packages/*` files and also present on `main`.

> No way to run the Android release build locally (it needs the production keystore + Play service account in CI). The change is confined to the version-code math; logic verified by simulation and by reading the real APK version codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)