### PR TITLE
feat(mobile): dedicated My Boards management UI

### DIFF
--- a/packages/mobile/app/boards/_layout.tsx
+++ b/packages/mobile/app/boards/_layout.tsx
@@ -33,6 +33,10 @@ export default function BoardsLayout() {
           nested sheet): a back chevron is the drill-in affordance and there's no
           dueling pan-to-dismiss over the already-modal picker. */}
       <Stack.Screen name="create" options={{ title: tBoards('mobile.create.screenTitle') }} />
+      {/* Manage your boards (edit / delete owned, unfollow followed) — distinct
+          from the index picker, which only switches the active board. */}
+      <Stack.Screen name="manage" options={{ title: t('myBoards.title') }} />
+      <Stack.Screen name="edit" options={{ title: tBoards('mobile.edit.screenTitle') }} />
     </Stack>
   );
 }

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -1,49 +1,17 @@
-import { useCallback, useEffect, useMemo, useState, type ComponentProps } from 'react';
-import {
-  View,
-  ScrollView,
-  TextInput,
-  StyleSheet,
-  Pressable,
-  KeyboardAvoidingView,
-  Platform,
-  useWindowDimensions,
-  type ViewStyle,
-} from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { SUPPORTED_BOARDS, toBoardName } from '@boardsesh/board-config';
-import type { BoardName } from '@boardsesh/shared-schema';
+import { toBoardName } from '@boardsesh/board-config';
 import { useMyBoards, useCreateBoard, useProfile } from '../../src/lib/graphql/hooks';
 import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useToast } from '../../src/providers/toast-provider';
-import { useTheme } from '../../src/providers/theme-provider';
 import { hapticSelection } from '../../src/lib/haptics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
-import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useDeviceLocation } from '../../src/lib/use-device-location';
 import { useBoardBuilder, type BoardBuilderSeed } from '../../src/components/board-discovery/use-board-builder';
-import { BoardConfigChips } from '../../src/components/board-discovery/BoardConfigChips';
-import {
-  boardTypeLabel,
-  cleanLayoutName,
-  formatSizeLabel,
-  formatDefaultBoardName,
-} from '../../src/components/board-discovery/board-builder-labels';
+import { BoardForm } from '../../src/components/board-discovery/BoardForm';
+import { formatDefaultBoardName } from '../../src/components/board-discovery/board-builder-labels';
 import { findOwnedBoardForConfig } from '../../src/components/board-discovery/board-items';
-import { BoardImageNative } from '../../src/components/BoardImageNative';
-import { getBoardRenderData } from '../../src/lib/board-details';
-import { AngleSlider } from '../../src/components/play-drawer/AngleSlider';
-import { AngleBoardDiagram } from '../../src/components/play-drawer/AngleBoardDiagram';
-import { SwitchRow } from '../../src/components/SwitchRow';
-import { Text } from '../../src/components/Text';
-import { Icon } from '../../src/components/Icon';
-import { Button } from '../../src/components/Button';
-import { spacing, borderRadius } from '../../src/theme/tokens';
-
-const PREVIEW_MAX_HEIGHT = 260;
 
 export default function CreateBoard() {
   const router = useRouter();
@@ -58,10 +26,6 @@ export default function CreateBoard() {
   const { isAuthenticated } = useAuth();
   const { t } = useTranslation('boards');
   const { showToast } = useToast();
-  const { systemColors } = useTheme();
-  const insets = useSafeAreaInsets();
-  const bottomChrome = useBottomChromeMetrics();
-  const { width: windowWidth } = useWindowDimensions();
 
   const setActiveBoard = useSetActiveBoard();
   const createBoard = useCreateBoard();
@@ -83,7 +47,6 @@ export default function CreateBoard() {
   }, [params.seedBoardName, params.seedLayoutId, params.seedSizeId, params.seedSetIds]);
 
   const builder = useBoardBuilder(seed);
-  const { setCoords } = builder;
 
   // Auto-generated default name, e.g. "Marco's Kilter Original 12×12", from the
   // user's display name + config. Used as the placeholder and the create-time
@@ -103,17 +66,7 @@ export default function CreateBoard() {
     [profile?.displayName, builder.boardName, builder.rawLayoutName, selectedSize],
   );
 
-  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-
-  const location = useDeviceLocation();
-  const requestLocation = location.request;
-  const onUseMyLocation = useCallback(() => void requestLocation(), [requestLocation]);
-  useEffect(() => {
-    // location.coords stays null until the user taps "Use my location" (request
-    // is explicit), so this only stamps coords once they've opted in.
-    if (location.coords) setCoords(location.coords);
-  }, [location.coords, setCoords]);
 
   const handleCreate = useCallback(async () => {
     if (submitting) return;
@@ -140,372 +93,13 @@ export default function CreateBoard() {
     }
   }, [submitting, builder, defaultName, myBoards, createBoard, setActiveBoard, router, boardReturnTo, showToast, t]);
 
-  // Chip options — memoised so the per-snap angle re-render doesn't rebuild them
-  // (they don't depend on angle), letting the memoised chip rows bail out.
-  const boardOptions = useMemo(
-    () =>
-      SUPPORTED_BOARDS.map((board) => ({
-        key: board,
-        label: boardTypeLabel(board),
-        value: board,
-        selected: board === builder.boardName,
-      })),
-    [builder.boardName],
-  );
-  const layoutOptions = useMemo(
-    () =>
-      builder.layouts.map((layout) => ({
-        key: layout.id,
-        label: cleanLayoutName(layout.name, builder.boardName),
-        value: layout.id,
-        selected: layout.id === builder.layoutId,
-      })),
-    [builder.layouts, builder.boardName, builder.layoutId],
-  );
-  const sizeOptions = useMemo(
-    () =>
-      builder.sizes.map((size) => ({
-        key: size.id,
-        label: formatSizeLabel(size),
-        value: size.id,
-        selected: size.id === builder.sizeId,
-      })),
-    [builder.sizes, builder.sizeId],
-  );
-  const setOptions = useMemo(
-    () =>
-      builder.sets.map((set) => ({
-        key: set.id,
-        label: set.name,
-        value: set.id,
-        selected: builder.setIds.includes(set.id),
-      })),
-    [builder.sets, builder.setIds],
-  );
-
-  const showPreview = builder.layoutId != null && builder.sizeId != null && builder.setIds.length > 0;
-  const setIdsWire = builder.setIds.join(',');
-  // Account for both the scroll content padding and the preview tile's padding.
-  const previewMaxWidth = windowWidth - (spacing[4] + spacing[3]) * 2;
-
   return (
-    <KeyboardAvoidingView style={styles.flex} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        contentContainerStyle={[styles.content, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[16] }]}
-        showsVerticalScrollIndicator={false}
-        keyboardShouldPersistTaps="handled"
-      >
-        {/* Live board art — turns layout/size/set IDs into a recognizable wall. */}
-        <View style={[styles.preview, { backgroundColor: systemColors.secondaryBackground }]}>
-          {showPreview ? (
-            <BoardConfigPreview
-              boardName={builder.boardName}
-              layoutId={builder.layoutId!}
-              sizeId={builder.sizeId!}
-              setIds={setIdsWire}
-              maxWidth={previewMaxWidth}
-            />
-          ) : (
-            <View style={styles.previewPlaceholder}>
-              <Icon name="boards" size={40} color={systemColors.tertiaryLabel} />
-              <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.previewHint}>
-                {t('mobile.create.previewHint')}
-              </Text>
-            </View>
-          )}
-        </View>
-
-        <SectionLabel>{t('mobile.custom.board')}</SectionLabel>
-        <BoardConfigChips groupLabel={t('mobile.custom.board')} options={boardOptions} onSelect={builder.selectBoard} />
-
-        <SectionLabel>{t('mobile.custom.layout')}</SectionLabel>
-        <BoardConfigChips
-          groupLabel={t('mobile.custom.layout')}
-          options={layoutOptions}
-          onSelect={builder.selectLayout}
-        />
-
-        {builder.sizes.length > 0 ? (
-          <>
-            <SectionLabel>{t('mobile.custom.size')}</SectionLabel>
-            <BoardConfigChips
-              groupLabel={t('mobile.custom.size')}
-              options={sizeOptions}
-              onSelect={builder.selectSize}
-            />
-          </>
-        ) : null}
-
-        {builder.angles.length > 0 ? (
-          <>
-            <SectionLabel>{t('mobile.custom.angle')}</SectionLabel>
-            {/* Teaching diagram: tilts the wall to the angle (+ degree readout),
-                reused from the play drawer. */}
-            <View style={styles.angleDiagram}>
-              <AngleBoardDiagram
-                angle={builder.angle}
-                size={140}
-                accessibilityLabel={t('mobile.create.anglePreview', { angle: builder.angle })}
-              />
-            </View>
-            {/* Reuse the play-drawer angle picker for a consistent feel. */}
-            <AngleSlider angles={builder.angles} value={builder.angle} onChange={builder.setAngle} />
-            {/* Adjustability is a separate capability from the default angle, so
-                it's a toggle (matching the other settings rows), not a chip. */}
-            <SwitchRow
-              label={t('mobile.create.adjustable')}
-              value={builder.isAngleAdjustable}
-              onValueChange={builder.setIsAngleAdjustable}
-            />
-          </>
-        ) : null}
-
-        {builder.layoutId != null ? (
-          <>
-            <SectionLabel>{t('mobile.custom.name')}</SectionLabel>
-            <BuilderTextInput
-              value={builder.name}
-              onChangeText={builder.setName}
-              placeholder={defaultName}
-              accessibilityLabel={t('mobile.custom.name')}
-              maxLength={100}
-              returnKeyType="done"
-            />
-          </>
-        ) : null}
-
-        {/* Advanced — hold sets (default all), visibility, location, serial. */}
-        <Pressable
-          onPress={() => setAdvancedOpen((open) => !open)}
-          accessibilityRole="button"
-          accessibilityState={{ expanded: advancedOpen }}
-          style={styles.advancedHeader}
-        >
-          <Text variant="headline">{t('mobile.create.moreOptions')}</Text>
-          <Icon name={advancedOpen ? 'chevron.up' : 'chevron.down'} size={18} color={systemColors.secondaryLabel} />
-        </Pressable>
-
-        {advancedOpen ? (
-          <View style={styles.advancedBody}>
-            {builder.sets.length > 0 ? (
-              <>
-                <SectionLabel>{t('mobile.custom.sets')}</SectionLabel>
-                <BoardConfigChips
-                  groupLabel={t('mobile.custom.sets')}
-                  options={setOptions}
-                  onSelect={builder.toggleSet}
-                />
-              </>
-            ) : null}
-
-            <SwitchRow label={t('mobile.create.ownBoard')} value={builder.isOwned} onValueChange={builder.setIsOwned} />
-            <SwitchRow
-              label={t('mobile.create.public')}
-              description={t('mobile.create.publicHint')}
-              value={builder.isPublic}
-              onValueChange={builder.setIsPublic}
-            />
-            <SwitchRow
-              label={t('mobile.create.unlisted')}
-              value={builder.isUnlisted}
-              onValueChange={builder.setIsUnlisted}
-            />
-            <SwitchRow
-              label={t('mobile.create.hideLocation')}
-              value={builder.hideLocation}
-              onValueChange={builder.setHideLocation}
-            />
-
-            <SectionLabel>{t('mobile.create.location')}</SectionLabel>
-            <BuilderTextInput
-              value={builder.locationName}
-              onChangeText={builder.setLocationName}
-              placeholder={t('mobile.create.locationPlaceholder')}
-              accessibilityLabel={t('mobile.create.location')}
-              maxLength={120}
-            />
-            <Button
-              title={builder.coords ? t('mobile.create.locationSet') : t('mobile.create.useMyLocation')}
-              variant="text"
-              onPress={onUseMyLocation}
-              disabled={builder.coords != null}
-            />
-
-            <SectionLabel>{t('mobile.create.serial')}</SectionLabel>
-            <BuilderTextInput
-              value={builder.serialNumber}
-              onChangeText={builder.setSerialNumber}
-              placeholder={t('mobile.create.serialPlaceholder')}
-              accessibilityLabel={t('mobile.create.serial')}
-              autoCapitalize="characters"
-              maxLength={100}
-            />
-            <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.serialHint}>
-              {t('mobile.create.serialHint')}
-            </Text>
-          </View>
-        ) : null}
-      </ScrollView>
-
-      {/* Pinned, safe-area-aware primary action. */}
-      <View
-        style={[
-          styles.footer,
-          {
-            backgroundColor: systemColors.secondaryBackground,
-            borderTopColor: systemColors.separator,
-            paddingBottom: insets.bottom + spacing[3],
-          },
-        ]}
-      >
-        <Button
-          title={t('mobile.create.save')}
-          onPress={() => void handleCreate()}
-          variant="filled"
-          size="large"
-          disabled={!builder.canCreate || submitting}
-          loading={submitting}
-        />
-      </View>
-    </KeyboardAvoidingView>
-  );
-}
-
-function SectionLabel({ children }: { children: string }) {
-  const { systemColors } = useTheme();
-  return (
-    <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
-      {children}
-    </Text>
-  );
-}
-
-/** Themed text input for the builder's form fields (name / location / serial). */
-function BuilderTextInput({ style, ...props }: ComponentProps<typeof TextInput>) {
-  const { systemColors } = useTheme();
-  return (
-    <TextInput
-      placeholderTextColor={systemColors.tertiaryLabel}
-      {...props}
-      style={[
-        styles.input,
-        {
-          color: systemColors.label,
-          borderColor: systemColors.separator,
-          backgroundColor: systemColors.secondaryBackground,
-        },
-        style,
-      ]}
+    <BoardForm
+      builder={builder}
+      defaultName={defaultName}
+      submitting={submitting}
+      onSubmit={() => void handleCreate()}
+      submitLabel={t('mobile.create.save')}
     />
   );
 }
-
-/** The empty board art (no lit holds) at the config's native aspect ratio. */
-function BoardConfigPreview({
-  boardName,
-  layoutId,
-  sizeId,
-  setIds,
-  maxWidth,
-}: {
-  boardName: BoardName;
-  layoutId: number;
-  sizeId: number;
-  setIds: string;
-  maxWidth: number;
-}) {
-  const renderData = useMemo(() => {
-    const setIdValues = setIds.split(',').map(Number).filter(Number.isFinite);
-    if (setIdValues.length === 0) return null;
-    return getBoardRenderData({ boardName, layoutId, sizeId, setIds: setIdValues });
-  }, [boardName, layoutId, sizeId, setIds]);
-
-  if (!renderData) return null;
-
-  const aspect = renderData.boardWidth / renderData.boardHeight;
-  let height = PREVIEW_MAX_HEIGHT;
-  let width = height * aspect;
-  if (width > maxWidth) {
-    width = maxWidth;
-    height = width / aspect;
-  }
-  const boardStyle: ViewStyle = { width, height, borderRadius: borderRadius.lg, overflow: 'hidden' };
-
-  return (
-    // Decorative — the config is already conveyed by the chips, so hide the art
-    // from screen readers rather than landing on an unlabeled image.
-    <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
-      <BoardImageNative
-        frames=""
-        boardName={boardName}
-        layoutId={layoutId}
-        sizeId={sizeId}
-        setIds={setIds}
-        boardWidth={renderData.boardWidth}
-        boardHeight={renderData.boardHeight}
-        renderWidth={Math.round(width)}
-        style={boardStyle}
-      />
-    </View>
-  );
-}
-
-const styles = StyleSheet.create({
-  flex: {
-    flex: 1,
-  },
-  content: {
-    padding: spacing[4],
-    gap: spacing[2],
-  },
-  preview: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: PREVIEW_MAX_HEIGHT,
-    borderRadius: borderRadius.lg,
-    padding: spacing[3],
-    marginBottom: spacing[2],
-  },
-  previewPlaceholder: {
-    alignItems: 'center',
-    gap: spacing[2],
-  },
-  previewHint: {
-    textAlign: 'center',
-  },
-  sectionLabel: {
-    marginTop: spacing[3],
-    marginBottom: spacing[1],
-    textTransform: 'uppercase',
-  },
-  angleDiagram: {
-    alignItems: 'center',
-    paddingVertical: spacing[2],
-  },
-  input: {
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[3],
-    borderRadius: borderRadius.lg,
-    borderWidth: StyleSheet.hairlineWidth,
-    fontSize: 17,
-  },
-  advancedHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: spacing[5],
-    paddingVertical: spacing[2],
-  },
-  advancedBody: {
-    gap: spacing[2],
-  },
-  serialHint: {
-    marginTop: spacing[1],
-  },
-  footer: {
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[3],
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-});

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useMemo, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { toBoardName } from '@boardsesh/board-config';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { useBoard, useProfile, useUpdateBoard } from '../../src/lib/graphql/hooks';
+import { useActiveBoard, useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useAuth } from '../../src/providers/auth-provider';
+import { useToast } from '../../src/providers/toast-provider';
+import { hapticSelection } from '../../src/lib/haptics';
+import { useBoardBuilder, type BoardBuilderSeed } from '../../src/components/board-discovery/use-board-builder';
+import { BoardForm } from '../../src/components/board-discovery/BoardForm';
+import { formatDefaultBoardName } from '../../src/components/board-discovery/board-builder-labels';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { useTheme } from '../../src/providers/theme-provider';
+import { iosSystemColors } from '../../src/theme/ios-colors';
+import { spacing } from '../../src/theme/tokens';
+
+export default function EditBoard() {
+  const router = useRouter();
+  const { boardUuid } = useLocalSearchParams<{ boardUuid?: string }>();
+  const { t } = useTranslation('boards');
+  const { systemColors } = useTheme();
+
+  const { data: board, isLoading } = useBoard(boardUuid ?? null);
+  const boardName = board ? toBoardName(board.boardType) : null;
+
+  if (isLoading) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  // Missing (deleted elsewhere / stale link) or an unrenderable board type:
+  // there's nothing to edit, so offer a way back rather than a broken form.
+  if (!board || !boardName) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <Icon name="error" size={40} color={iosSystemColors.systemGray} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('mobile.edit.notFound')}
+        </Text>
+        <Button
+          title={t('mobile.edit.back')}
+          variant="outlined"
+          onPress={() => router.back()}
+          style={styles.stateButton}
+        />
+      </View>
+    );
+  }
+
+  // Remount the form per board so the builder seeds (incl. the More-options meta,
+  // which only applies via the state initialisers) from a fully-loaded board.
+  return <EditBoardForm key={board.uuid} board={board} />;
+}
+
+function EditBoardForm({ board }: { board: UserBoard }) {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+  const { t } = useTranslation('boards');
+  const { showToast } = useToast();
+
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
+  const { data: activeBoard } = useActiveBoard();
+  const setActiveBoard = useSetActiveBoard();
+  const updateBoard = useUpdateBoard();
+
+  // Config edits are server-rejected once a board has ticks; lock the chips and
+  // omit the config from the update so we don't trip that guard.
+  const lockedConfig = board.totalAscents > 0;
+
+  const seed = useMemo<BoardBuilderSeed>(() => {
+    const seedBoardName = toBoardName(board.boardType)!;
+    return {
+      boardName: seedBoardName,
+      layoutId: board.layoutId,
+      sizeId: board.sizeId,
+      setIds: board.setIds,
+      angle: board.angle,
+      name: board.name,
+      isOwned: board.isOwned,
+      isPublic: board.isPublic,
+      isUnlisted: board.isUnlisted,
+      hideLocation: board.hideLocation,
+      isAngleAdjustable: board.isAngleAdjustable,
+      locationName: board.locationName ?? undefined,
+      latitude: board.latitude ?? undefined,
+      longitude: board.longitude ?? undefined,
+      serialNumber: board.serialNumber ?? undefined,
+    };
+  }, [board]);
+
+  const builder = useBoardBuilder(seed);
+
+  const selectedSize = useMemo(
+    () => builder.sizes.find((size) => size.id === builder.sizeId) ?? null,
+    [builder.sizes, builder.sizeId],
+  );
+  const defaultName = useMemo(
+    () =>
+      formatDefaultBoardName({
+        userName: profile?.displayName,
+        boardName: builder.boardName,
+        layoutName: builder.rawLayoutName,
+        size: selectedSize,
+      }),
+    [profile?.displayName, builder.boardName, builder.rawLayoutName, selectedSize],
+  );
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleUpdate = useCallback(async () => {
+    if (submitting) return;
+    const input = builder.buildUpdateInput(board.uuid, { lockedConfig, fallbackName: defaultName });
+    if (!input) return;
+    setSubmitting(true);
+    hapticSelection();
+    try {
+      const updated = await updateBoard.mutateAsync(input);
+      // The active board is a denormalised AsyncStorage copy — re-persist it so
+      // the rename / angle / visibility change reaches BLE + the play drawer.
+      if (activeBoard?.uuid === updated.uuid) await setActiveBoard(updated);
+      router.back();
+      // Navigated away on success — leave `submitting` set (unmounting).
+    } catch {
+      // Covers the config-locked race and the duplicate-config guard, both of
+      // which the server enforces authoritatively.
+      showToast(t('mobile.edit.updateError'), 'error');
+      setSubmitting(false);
+    }
+  }, [
+    submitting,
+    builder,
+    board.uuid,
+    lockedConfig,
+    defaultName,
+    updateBoard,
+    activeBoard?.uuid,
+    setActiveBoard,
+    router,
+    showToast,
+    t,
+  ]);
+
+  return (
+    <BoardForm
+      builder={builder}
+      defaultName={defaultName}
+      submitting={submitting}
+      onSubmit={() => void handleUpdate()}
+      submitLabel={t('mobile.edit.save')}
+      lockedConfig={lockedConfig}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[8],
+  },
+  stateTitle: {
+    marginTop: spacing[3],
+    textAlign: 'center',
+  },
+  stateButton: {
+    marginTop: spacing[4],
+  },
+});

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -28,9 +28,8 @@ export default function BoardSelection() {
   const { isAuthenticated, refreshAuthState } = useAuth();
   const bottomChrome = useBottomChromeMetrics();
   const router = useRouter();
-  const { returnTo, focus } = useLocalSearchParams<{ returnTo?: string; focus?: string }>();
+  const { returnTo } = useLocalSearchParams<{ returnTo?: string }>();
   const boardReturnTo = resolveBoardReturnTo(returnTo);
-  const shouldFocusMyBoards = focus === 'myBoards';
   const { t } = useTranslation('boards');
   const { showToast } = useToast();
 
@@ -260,8 +259,8 @@ export default function BoardSelection() {
           <BoardModeCard icon="plus" label={t('mobile.discovery.create')} onPress={onModeCreate} />
         </View>
 
-        {shouldFocusMyBoards ? myBoardsSection : nearbySection}
-        {shouldFocusMyBoards ? nearbySection : myBoardsSection}
+        {nearbySection}
+        {myBoardsSection}
 
         {popularItems.length > 0 ? (
           <Section title={t('mobile.discovery.popularTitle')}>

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { RefreshControl, StyleSheet, View } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { useMyBoards, useProfile, useDeleteBoard, useUnfollowBoard } from '../../src/lib/graphql/hooks';
+import { useActiveBoard, useClearActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useAuth } from '../../src/providers/auth-provider';
+import { useToast } from '../../src/providers/toast-provider';
+import { useConfirm } from '../../src/providers/dialog-provider';
+import { useTheme } from '../../src/providers/theme-provider';
+import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { BoardManageRow } from '../../src/components/board-discovery/BoardManageRow';
+import { iosSystemColors } from '../../src/theme/ios-colors';
+import { spacing } from '../../src/theme/tokens';
+
+const EMPTY_BOARDS: UserBoard[] = [];
+
+type ManageItem =
+  | { type: 'header'; key: string; title: string }
+  | { type: 'board'; key: string; board: UserBoard; isOwned: boolean; isActive: boolean };
+
+const keyExtractor = (item: ManageItem) => item.key;
+const getItemType = (item: ManageItem) => item.type;
+
+export default function ManageBoards() {
+  const router = useRouter();
+  const { t } = useTranslation('boards');
+  const { isAuthenticated, refreshAuthState } = useAuth();
+  const { systemColors, brandColors } = useTheme();
+  const { showToast } = useToast();
+  const confirm = useConfirm();
+  const bottomChrome = useBottomChromeMetrics();
+  const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
+
+  const { data: profile, isLoading: isProfileLoading } = useProfile({ enabled: isAuthenticated });
+  const currentUserId = profile?.id;
+  const { data: activeBoard } = useActiveBoard();
+  const activeUuid = activeBoard?.uuid;
+
+  const {
+    data: boardConnection,
+    isLoading,
+    isError,
+    refetch,
+    isRefetching,
+  } = useMyBoards(undefined, { enabled: isAuthenticated });
+  const myBoards = boardConnection?.boards ?? EMPTY_BOARDS;
+
+  const deleteBoard = useDeleteBoard();
+  const unfollowBoard = useUnfollowBoard();
+  const clearActiveBoard = useClearActiveBoard();
+
+  // See boards/index.tsx: a hard 401 clears tokens without flipping
+  // isAuthenticated, so re-validate on error to escape a stuck retry loop.
+  useEffect(() => {
+    if (isError) void refreshAuthState();
+  }, [isError, refreshAuthState]);
+
+  // myBoards returns owned-first; split into the two managed groups. Each board
+  // carries everything the row needs (no per-row lookups), and `isActive` is
+  // precomputed so a row never scans for the active board.
+  const items = useMemo<ManageItem[]>(() => {
+    const result: ManageItem[] = [];
+    const owned = myBoards.filter((board) => board.ownerId === currentUserId);
+    const followed = myBoards.filter((board) => board.ownerId !== currentUserId);
+    if (owned.length > 0) {
+      result.push({ type: 'header', key: 'header:owned', title: t('mobile.manage.ownedHeader') });
+      for (const board of owned) {
+        result.push({ type: 'board', key: board.uuid, board, isOwned: true, isActive: board.uuid === activeUuid });
+      }
+    }
+    if (followed.length > 0) {
+      result.push({ type: 'header', key: 'header:following', title: t('mobile.manage.followingHeader') });
+      for (const board of followed) {
+        result.push({ type: 'board', key: board.uuid, board, isOwned: false, isActive: board.uuid === activeUuid });
+      }
+    }
+    return result;
+  }, [myBoards, currentUserId, activeUuid, t]);
+
+  const onCreate = useCallback(() => {
+    router.push('/boards/create');
+  }, [router]);
+
+  const handleEdit = useCallback(
+    (board: UserBoard) => {
+      router.push({ pathname: '/boards/edit', params: { boardUuid: board.uuid } });
+    },
+    [router],
+  );
+
+  const handleDelete = useCallback(
+    async (board: UserBoard) => {
+      const confirmed = await confirm({
+        title: t('mobile.manage.deleteTitle'),
+        message: t('mobile.manage.deleteMessage', { name: board.name }),
+        confirmLabel: t('mobile.manage.deleteConfirm'),
+        cancelLabel: t('mobile.manage.cancel'),
+        destructive: true,
+      });
+      if (!confirmed) return;
+      try {
+        await deleteBoard.mutateAsync(board.uuid);
+        // The deleted board can't stay the active selection — drop it so the app
+        // routes to the picker instead of a board that no longer exists.
+        if (activeUuid === board.uuid) await clearActiveBoard();
+      } catch {
+        showToast(t('mobile.manage.deleteError'), 'error');
+      }
+    },
+    [confirm, t, deleteBoard, activeUuid, clearActiveBoard, showToast],
+  );
+
+  const handleUnfollow = useCallback(
+    async (board: UserBoard) => {
+      try {
+        await unfollowBoard.mutateAsync(board.uuid);
+        if (activeUuid === board.uuid) await clearActiveBoard();
+      } catch {
+        showToast(t('mobile.manage.unfollowError'), 'error');
+      }
+    },
+    [unfollowBoard, activeUuid, clearActiveBoard, showToast, t],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ManageItem }) => {
+      if (item.type === 'header') {
+        return (
+          <Text variant="title3" style={styles.sectionHeader}>
+            {item.title}
+          </Text>
+        );
+      }
+      const isMutating =
+        (deleteBoard.isPending && deleteBoard.variables === item.board.uuid) ||
+        (unfollowBoard.isPending && unfollowBoard.variables === item.board.uuid);
+      return (
+        <BoardManageRow
+          board={item.board}
+          isOwned={item.isOwned}
+          isActive={item.isActive}
+          isMutating={isMutating}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          onUnfollow={handleUnfollow}
+        />
+      );
+    },
+    [
+      deleteBoard.isPending,
+      deleteBoard.variables,
+      unfollowBoard.isPending,
+      unfollowBoard.variables,
+      handleEdit,
+      handleDelete,
+      handleUnfollow,
+    ],
+  );
+
+  if (!isAuthenticated) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <Icon name="person" size={40} color={iosSystemColors.systemGray} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('mobile.signInTitle')}
+        </Text>
+        <Text variant="subheadline" style={styles.stateSubtitle}>
+          {t('mobile.signInSubtitle')}
+        </Text>
+        <Button title={t('mobile.signInCta')} onPress={() => router.push('/auth/login')} style={styles.stateButton} />
+      </View>
+    );
+  }
+
+  // Wait for the profile too: owned-vs-followed is keyed on currentUserId, so
+  // rendering before it resolves would briefly file the user's own boards under
+  // "Following" (myBoards can win the race on a cold open / deep link).
+  if ((isLoading && myBoards.length === 0) || (!isError && isProfileLoading && !currentUserId)) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (isError && myBoards.length === 0) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <Icon name="error" size={40} color={iosSystemColors.systemRed} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('mobile.errorTitle')}
+        </Text>
+        <Button
+          title={t('mobile.errorRetry')}
+          variant="outlined"
+          loading={isRefetching}
+          onPress={() => void refetch()}
+          style={styles.stateButton}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
+      <FlashList
+        data={items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        getItemType={getItemType}
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={{ paddingBottom }}
+        ListHeaderComponent={
+          items.length > 0 ? (
+            <View style={styles.listHeader}>
+              <Button title={t('mobile.discovery.create')} variant="outlined" onPress={onCreate} />
+            </View>
+          ) : null
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyState}>
+            <Icon name="boards" size={48} color={systemColors.tertiaryLabel} />
+            <Text variant="headline" style={styles.emptyTitle}>
+              {t('mobile.emptyTitle')}
+            </Text>
+            <Text variant="subheadline" style={styles.emptySubtitle}>
+              {t('mobile.emptySubtitle')}
+            </Text>
+            <Button title={t('mobile.discovery.create')} onPress={onCreate} style={styles.emptyCta} />
+          </View>
+        }
+        refreshControl={
+          <RefreshControl refreshing={isRefetching} onRefresh={() => void refetch()} tintColor={brandColors.primary} />
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  listHeader: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  sectionHeader: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[5],
+    paddingBottom: spacing[2],
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[8],
+  },
+  stateTitle: {
+    marginTop: spacing[3],
+    textAlign: 'center',
+  },
+  stateSubtitle: {
+    marginTop: spacing[1],
+    textAlign: 'center',
+    opacity: 0.6,
+  },
+  stateButton: {
+    marginTop: spacing[4],
+  },
+  emptyState: {
+    alignItems: 'center',
+    paddingHorizontal: spacing[8],
+    paddingVertical: spacing[16],
+    gap: spacing[2],
+  },
+  emptyTitle: {
+    marginTop: spacing[3],
+    opacity: 0.6,
+  },
+  emptySubtitle: {
+    opacity: 0.4,
+    textAlign: 'center',
+  },
+  emptyCta: {
+    marginTop: spacing[5],
+  },
+});

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -16,14 +16,11 @@ import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { BoardManageRow } from '../../src/components/board-discovery/BoardManageRow';
+import { buildManageItems, type ManageItem } from '../../src/components/board-discovery/manage-items';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
 
 const EMPTY_BOARDS: UserBoard[] = [];
-
-type ManageItem =
-  | { type: 'header'; key: string; title: string }
-  | { type: 'board'; key: string; board: UserBoard; isOwned: boolean; isActive: boolean };
 
 const keyExtractor = (item: ManageItem) => item.key;
 const getItemType = (item: ManageItem) => item.type;
@@ -38,7 +35,12 @@ export default function ManageBoards() {
   const bottomChrome = useBottomChromeMetrics();
   const paddingBottom = bottomChrome.scrollBottomPadding + spacing[4];
 
-  const { data: profile, isLoading: isProfileLoading } = useProfile({ enabled: isAuthenticated });
+  const {
+    data: profile,
+    isLoading: isProfileLoading,
+    isError: isProfileError,
+    refetch: refetchProfile,
+  } = useProfile({ enabled: isAuthenticated });
   const currentUserId = profile?.id;
   const { data: activeBoard } = useActiveBoard();
   const activeUuid = activeBoard?.uuid;
@@ -62,27 +64,16 @@ export default function ManageBoards() {
     if (isError) void refreshAuthState();
   }, [isError, refreshAuthState]);
 
-  // myBoards returns owned-first; split into the two managed groups. Each board
-  // carries everything the row needs (no per-row lookups), and `isActive` is
-  // precomputed so a row never scans for the active board.
-  const items = useMemo<ManageItem[]>(() => {
-    const result: ManageItem[] = [];
-    const owned = myBoards.filter((board) => board.ownerId === currentUserId);
-    const followed = myBoards.filter((board) => board.ownerId !== currentUserId);
-    if (owned.length > 0) {
-      result.push({ type: 'header', key: 'header:owned', title: t('mobile.manage.ownedHeader') });
-      for (const board of owned) {
-        result.push({ type: 'board', key: board.uuid, board, isOwned: true, isActive: board.uuid === activeUuid });
-      }
-    }
-    if (followed.length > 0) {
-      result.push({ type: 'header', key: 'header:following', title: t('mobile.manage.followingHeader') });
-      for (const board of followed) {
-        result.push({ type: 'board', key: board.uuid, board, isOwned: false, isActive: board.uuid === activeUuid });
-      }
-    }
-    return result;
-  }, [myBoards, currentUserId, activeUuid, t]);
+  // Split into owned + followed groups (pure helper, unit-tested). Each board
+  // carries precomputed isOwned/isActive so a row never scans for them.
+  const items = useMemo(
+    () =>
+      buildManageItems(myBoards, currentUserId, activeUuid, {
+        ownedHeader: t('mobile.manage.ownedHeader'),
+        followingHeader: t('mobile.manage.followingHeader'),
+      }),
+    [myBoards, currentUserId, activeUuid, t],
+  );
 
   const onCreate = useCallback(() => {
     router.push('/boards/create');
@@ -180,9 +171,9 @@ export default function ManageBoards() {
   }
 
   // Wait for the profile too: owned-vs-followed is keyed on currentUserId, so
-  // rendering before it resolves would briefly file the user's own boards under
+  // rendering before it resolves would file the user's own boards under
   // "Following" (myBoards can win the race on a cold open / deep link).
-  if ((isLoading && myBoards.length === 0) || (!isError && isProfileLoading && !currentUserId)) {
+  if ((isLoading && myBoards.length === 0) || (isProfileLoading && !currentUserId)) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
         <ActivityIndicator size="large" />
@@ -190,7 +181,10 @@ export default function ManageBoards() {
     );
   }
 
-  if (isError && myBoards.length === 0) {
+  // Boards failed with nothing cached, OR the profile settled without an id —
+  // without currentUserId we can't classify owned vs followed, so never render
+  // the list; offer a retry that refetches both.
+  if ((isError && myBoards.length === 0) || !currentUserId) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
         <Icon name="error" size={40} color={iosSystemColors.systemRed} />
@@ -201,7 +195,10 @@ export default function ManageBoards() {
           title={t('mobile.errorRetry')}
           variant="outlined"
           loading={isRefetching}
-          onPress={() => void refetch()}
+          onPress={() => {
+            void refetch();
+            if (isProfileError || !currentUserId) void refetchProfile();
+          }}
           style={styles.stateButton}
         />
       </View>

--- a/packages/mobile/src/components/SwipeableRow.tsx
+++ b/packages/mobile/src/components/SwipeableRow.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
-import { Pressable, View, StyleSheet } from 'react-native';
+import { Pressable, View, StyleSheet, type AccessibilityActionEvent } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import {
   Gesture,
@@ -30,6 +30,12 @@ type SwipeableRowProps = {
   pressAccessibilityLabel?: string;
   /** When false, the swipe is disabled and any open swipe snaps shut. */
   enabled?: boolean;
+  /**
+   * Identity of the row's current data. FlashList recycles this component onto a
+   * new item; when `resetKey` changes the swipe snaps shut so an open swipe can't
+   * leak onto the recycled row.
+   */
+  resetKey?: string | number;
 };
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -53,6 +59,7 @@ function SwipeableRowComponent({
   onPress,
   pressAccessibilityLabel,
   enabled = true,
+  resetKey,
 }: SwipeableRowProps) {
   const translateX = useSharedValue(0);
   const isSwipeOpen = useSharedValue(false);
@@ -71,6 +78,13 @@ function SwipeableRowComponent({
       isSwipeOpen.value = false;
     }
   }, [enabled, translateX, isSwipeOpen]);
+
+  // Instant reset when this cell is recycled onto a different row (FlashList
+  // reuses the instance), so an open swipe doesn't carry over to the new data.
+  useEffect(() => {
+    translateX.value = 0;
+    isSwipeOpen.value = false;
+  }, [resetKey, translateX, isSwipeOpen]);
 
   const panGesture = useMemo(
     () =>
@@ -123,11 +137,20 @@ function SwipeableRowComponent({
     onActionRef.current?.();
   }, [translateX, isSwipeOpen]);
 
+  // The pan gesture is unreachable for VoiceOver/TalkBack, so expose the action
+  // as an accessibility action on the row (the only way AT users can delete /
+  // unfollow). Gated on `enabled` so it isn't offered mid-mutation.
+  const handleAccessibilityAction = useCallback((event: AccessibilityActionEvent) => {
+    if (event.nativeEvent.actionName === 'rowAction') onActionRef.current?.();
+  }, []);
+
   const rowContent = (
     <AnimatedPressable
       onPress={handlePress}
       accessibilityRole={onPress ? 'button' : undefined}
       accessibilityLabel={pressAccessibilityLabel}
+      accessibilityActions={enabled ? [{ name: 'rowAction', label: actionLabel }] : undefined}
+      onAccessibilityAction={enabled ? handleAccessibilityAction : undefined}
       style={[styles.row, rowAnimatedStyle]}
     >
       {children}

--- a/packages/mobile/src/components/SwipeableRow.tsx
+++ b/packages/mobile/src/components/SwipeableRow.tsx
@@ -1,0 +1,182 @@
+import { memo, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { Pressable, View, StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import {
+  Gesture,
+  GestureDetector,
+  type GestureUpdateEvent,
+  type PanGestureHandlerEventPayload,
+} from 'react-native-gesture-handler';
+import { Icon } from './Icon';
+import type { IconName } from './icon-map';
+import { iosSystemColors } from '../theme/ios-colors';
+import { hapticMedium } from '../lib/haptics';
+
+const SWIPE_OPEN_THRESHOLD = -80;
+const ACTION_BUTTON_WIDTH = 80;
+const CLOSE_SPRING = { damping: 20, stiffness: 200 };
+
+type SwipeableRowProps = {
+  /** The row body. Its own press target should call through `onPress`. */
+  children: ReactNode;
+  /** Reveal-and-tap action (e.g. delete / unfollow). */
+  onAction: () => void;
+  actionLabel: string;
+  /** Background colour of the revealed action (defaults to the system red). */
+  actionColor?: string;
+  actionIcon?: IconName;
+  /** Tap on the row body (ignored while the swipe is open — that tap closes it). */
+  onPress?: () => void;
+  pressAccessibilityLabel?: string;
+  /** When false, the swipe is disabled and any open swipe snaps shut. */
+  enabled?: boolean;
+};
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+/**
+ * A horizontally-swipeable row that reveals a single trailing destructive
+ * action — the iOS swipe-to-delete idiom, distilled from `QueueItemRow` so list
+ * screens can reuse it without re-deriving the gesture maths. Unlike
+ * `QueueItemRow` it does NOT animate itself out on action: callers often gate the
+ * action behind a confirm dialog, so the row must survive a cancel. On action it
+ * snaps the swipe shut and fires `onAction`; the row disappears when the caller's
+ * data refetch drops it. Callbacks are read through refs and the gesture is
+ * memoised so the row can be wrapped in `React.memo` and skip list re-renders.
+ */
+function SwipeableRowComponent({
+  children,
+  onAction,
+  actionLabel,
+  actionColor = iosSystemColors.systemRed,
+  actionIcon = 'delete',
+  onPress,
+  pressAccessibilityLabel,
+  enabled = true,
+}: SwipeableRowProps) {
+  const translateX = useSharedValue(0);
+  const isSwipeOpen = useSharedValue(false);
+
+  // Read the volatile callbacks through refs so a parent re-render that hands us
+  // fresh `onAction`/`onPress` identities doesn't churn the memoised gesture.
+  const onActionRef = useRef(onAction);
+  onActionRef.current = onAction;
+  const onPressRef = useRef(onPress);
+  onPressRef.current = onPress;
+
+  // Snap shut when the swipe is disabled (e.g. a mutation starts on this row).
+  useEffect(() => {
+    if (!enabled) {
+      translateX.value = withSpring(0, CLOSE_SPRING);
+      isSwipeOpen.value = false;
+    }
+  }, [enabled, translateX, isSwipeOpen]);
+
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(enabled)
+        .activeOffsetX([-10, 10])
+        .failOffsetY([-5, 5])
+        .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
+          // Only allow swiping left.
+          if (event.translationX > 0) {
+            translateX.value = 0;
+            return;
+          }
+          translateX.value = Math.max(event.translationX, -ACTION_BUTTON_WIDTH - 20);
+        })
+        .onEnd(() => {
+          if (translateX.value < SWIPE_OPEN_THRESHOLD) {
+            translateX.value = withSpring(-ACTION_BUTTON_WIDTH, CLOSE_SPRING);
+            isSwipeOpen.value = true;
+          } else {
+            translateX.value = withSpring(0, CLOSE_SPRING);
+            isSwipeOpen.value = false;
+          }
+        }),
+    [enabled, translateX, isSwipeOpen],
+  );
+
+  const rowAnimatedStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
+  const actionButtonStyle = useAnimatedStyle(() => {
+    const width = Math.min(Math.abs(translateX.value), ACTION_BUTTON_WIDTH);
+    return { width, opacity: width / ACTION_BUTTON_WIDTH };
+  });
+
+  const handlePress = useCallback(() => {
+    // A tap with the action revealed closes it instead of activating the row.
+    if (isSwipeOpen.value) {
+      translateX.value = withSpring(0, CLOSE_SPRING);
+      isSwipeOpen.value = false;
+      return;
+    }
+    onPressRef.current?.();
+  }, [translateX, isSwipeOpen]);
+
+  const handleActionPress = useCallback(() => {
+    hapticMedium();
+    // Snap shut so a cancelled confirm leaves the row at rest; the caller's
+    // refetch removes the row when the action actually commits.
+    translateX.value = withSpring(0, CLOSE_SPRING);
+    isSwipeOpen.value = false;
+    onActionRef.current?.();
+  }, [translateX, isSwipeOpen]);
+
+  const rowContent = (
+    <AnimatedPressable
+      onPress={handlePress}
+      accessibilityRole={onPress ? 'button' : undefined}
+      accessibilityLabel={pressAccessibilityLabel}
+      style={[styles.row, rowAnimatedStyle]}
+    >
+      {children}
+    </AnimatedPressable>
+  );
+
+  return (
+    <View style={styles.swipeContainer}>
+      {enabled ? (
+        <Animated.View style={[styles.action, { backgroundColor: actionColor }, actionButtonStyle]}>
+          <Pressable
+            onPress={handleActionPress}
+            accessibilityRole="button"
+            accessibilityLabel={actionLabel}
+            style={styles.actionButton}
+          >
+            <Icon name={actionIcon} size={22} color={iosSystemColors.white} />
+          </Pressable>
+        </Animated.View>
+      ) : null}
+
+      {enabled ? <GestureDetector gesture={panGesture}>{rowContent}</GestureDetector> : rowContent}
+    </View>
+  );
+}
+
+export const SwipeableRow = memo(SwipeableRowComponent);
+
+const styles = StyleSheet.create({
+  swipeContainer: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    overflow: 'hidden',
+  },
+  row: {
+    flex: 1,
+  },
+  action: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  actionButton: {
+    flex: 1,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/packages/mobile/src/components/board-discovery/BoardConfigChips.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardConfigChips.tsx
@@ -18,6 +18,8 @@ type BoardConfigChipsProps<T> = {
   groupLabel: string;
   options: ChipOption<T>[];
   onSelect: (value: T) => void;
+  /** Read-only: chips render dimmed and ignore taps (e.g. locked config on edit). */
+  disabled?: boolean;
 };
 
 /**
@@ -26,20 +28,22 @@ type BoardConfigChipsProps<T> = {
  * `accessibilityState.selected` (not colour alone), and `hitSlop` keeps the
  * touch target ≥44pt even though the chip is visually compact.
  */
-function BoardConfigChipsInner<T>({ groupLabel, options, onSelect }: BoardConfigChipsProps<T>) {
+function BoardConfigChipsInner<T>({ groupLabel, options, onSelect, disabled = false }: BoardConfigChipsProps<T>) {
   const { systemColors, brandColors: themeBrandColors } = useTheme();
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.row}>
       {options.map((option) => (
         <Pressable
           key={option.key}
-          onPress={() => onSelect(option.value)}
+          onPress={disabled ? undefined : () => onSelect(option.value)}
+          disabled={disabled}
           accessibilityRole="button"
-          accessibilityState={{ selected: option.selected }}
+          accessibilityState={{ selected: option.selected, disabled }}
           accessibilityLabel={`${groupLabel}: ${option.label}`}
           hitSlop={8}
           style={[
             styles.chip,
+            disabled && styles.chipDisabled,
             {
               // Border is a foreground accent → scheme-aware. Fill stays static:
               // the selected label turns white and must sit on the brand fill.
@@ -72,5 +76,8 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     borderRadius: borderRadius.full,
     borderWidth: StyleSheet.hairlineWidth,
+  },
+  chipDisabled: {
+    opacity: 0.4,
   },
 });

--- a/packages/mobile/src/components/board-discovery/BoardForm.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardForm.tsx
@@ -1,0 +1,478 @@
+import { useCallback, useEffect, useMemo, useState, type ComponentProps } from 'react';
+import {
+  View,
+  ScrollView,
+  TextInput,
+  StyleSheet,
+  Pressable,
+  KeyboardAvoidingView,
+  Platform,
+  useWindowDimensions,
+  type ViewStyle,
+} from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { SUPPORTED_BOARDS } from '@boardsesh/board-config';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { useTheme } from '../../providers/theme-provider';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useDeviceLocation } from '../../lib/use-device-location';
+import type { useBoardBuilder } from './use-board-builder';
+import { BoardConfigChips } from './BoardConfigChips';
+import { boardTypeLabel, cleanLayoutName, formatSizeLabel } from './board-builder-labels';
+import { BoardImageNative } from '../BoardImageNative';
+import { getBoardRenderData } from '../../lib/board-details';
+import { AngleSlider } from '../play-drawer/AngleSlider';
+import { AngleBoardDiagram } from '../play-drawer/AngleBoardDiagram';
+import { SwitchRow } from '../SwitchRow';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+const PREVIEW_MAX_HEIGHT = 260;
+
+type BoardBuilder = ReturnType<typeof useBoardBuilder>;
+
+type BoardFormProps = {
+  builder: BoardBuilder;
+  /** Auto-generated name, used as the name placeholder + create/update fallback. */
+  defaultName: string;
+  submitting: boolean;
+  onSubmit: () => void;
+  submitLabel: string;
+  /**
+   * Lock the board/layout/size/set chips (editing a board that already has
+   * ticks — the server rejects config changes on those). Shows a hint.
+   */
+  lockedConfig?: boolean;
+};
+
+/**
+ * The board builder form — preview art, the board → layout → size → sets cascade,
+ * angle picker, name, and a "More options" section (ownership, visibility,
+ * location, serial), with a pinned primary action. Shared by the create and edit
+ * screens; the only difference between them is the submit handler/label and
+ * whether the config chips are locked. Owns its own location-permission flow.
+ */
+export function BoardForm({
+  builder,
+  defaultName,
+  submitting,
+  onSubmit,
+  submitLabel,
+  lockedConfig = false,
+}: BoardFormProps) {
+  const { t } = useTranslation('boards');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const bottomChrome = useBottomChromeMetrics();
+  const { width: windowWidth } = useWindowDimensions();
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const { setCoords } = builder;
+  const location = useDeviceLocation();
+  const requestLocation = location.request;
+  const onUseMyLocation = useCallback(() => void requestLocation(), [requestLocation]);
+  useEffect(() => {
+    // location.coords stays null until the user taps "Use my location" (request
+    // is explicit), so this only stamps coords once they've opted in.
+    if (location.coords) setCoords(location.coords);
+  }, [location.coords, setCoords]);
+
+  // Chip options — memoised so the per-snap angle re-render doesn't rebuild them
+  // (they don't depend on angle), letting the memoised chip rows bail out.
+  const boardOptions = useMemo(
+    () =>
+      SUPPORTED_BOARDS.map((board) => ({
+        key: board,
+        label: boardTypeLabel(board),
+        value: board,
+        selected: board === builder.boardName,
+      })),
+    [builder.boardName],
+  );
+  const layoutOptions = useMemo(
+    () =>
+      builder.layouts.map((layout) => ({
+        key: layout.id,
+        label: cleanLayoutName(layout.name, builder.boardName),
+        value: layout.id,
+        selected: layout.id === builder.layoutId,
+      })),
+    [builder.layouts, builder.boardName, builder.layoutId],
+  );
+  const sizeOptions = useMemo(
+    () =>
+      builder.sizes.map((size) => ({
+        key: size.id,
+        label: formatSizeLabel(size),
+        value: size.id,
+        selected: size.id === builder.sizeId,
+      })),
+    [builder.sizes, builder.sizeId],
+  );
+  const setOptions = useMemo(
+    () =>
+      builder.sets.map((set) => ({
+        key: set.id,
+        label: set.name,
+        value: set.id,
+        selected: builder.setIds.includes(set.id),
+      })),
+    [builder.sets, builder.setIds],
+  );
+
+  const showPreview = builder.layoutId != null && builder.sizeId != null && builder.setIds.length > 0;
+  const setIdsWire = builder.setIds.join(',');
+  // Account for both the scroll content padding and the preview tile's padding.
+  const previewMaxWidth = windowWidth - (spacing[4] + spacing[3]) * 2;
+
+  return (
+    <KeyboardAvoidingView style={styles.flex} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[styles.content, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[16] }]}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Live board art — turns layout/size/set IDs into a recognizable wall. */}
+        <View style={[styles.preview, { backgroundColor: systemColors.secondaryBackground }]}>
+          {showPreview ? (
+            <BoardConfigPreview
+              boardName={builder.boardName}
+              layoutId={builder.layoutId!}
+              sizeId={builder.sizeId!}
+              setIds={setIdsWire}
+              maxWidth={previewMaxWidth}
+            />
+          ) : (
+            <View style={styles.previewPlaceholder}>
+              <Icon name="boards" size={40} color={systemColors.tertiaryLabel} />
+              <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.previewHint}>
+                {t('mobile.create.previewHint')}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        {lockedConfig ? (
+          <View style={[styles.lockedHint, { backgroundColor: systemColors.secondaryBackground }]}>
+            <Icon name="info" size={16} color={systemColors.secondaryLabel} />
+            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.lockedHintText}>
+              {t('mobile.edit.configLockedHint')}
+            </Text>
+          </View>
+        ) : null}
+
+        <SectionLabel>{t('mobile.custom.board')}</SectionLabel>
+        <BoardConfigChips
+          groupLabel={t('mobile.custom.board')}
+          options={boardOptions}
+          onSelect={builder.selectBoard}
+          disabled={lockedConfig}
+        />
+
+        <SectionLabel>{t('mobile.custom.layout')}</SectionLabel>
+        <BoardConfigChips
+          groupLabel={t('mobile.custom.layout')}
+          options={layoutOptions}
+          onSelect={builder.selectLayout}
+          disabled={lockedConfig}
+        />
+
+        {builder.sizes.length > 0 ? (
+          <>
+            <SectionLabel>{t('mobile.custom.size')}</SectionLabel>
+            <BoardConfigChips
+              groupLabel={t('mobile.custom.size')}
+              options={sizeOptions}
+              onSelect={builder.selectSize}
+              disabled={lockedConfig}
+            />
+          </>
+        ) : null}
+
+        {builder.angles.length > 0 ? (
+          <>
+            <SectionLabel>{t('mobile.custom.angle')}</SectionLabel>
+            {/* Teaching diagram: tilts the wall to the angle (+ degree readout),
+                reused from the play drawer. */}
+            <View style={styles.angleDiagram}>
+              <AngleBoardDiagram
+                angle={builder.angle}
+                size={140}
+                accessibilityLabel={t('mobile.create.anglePreview', { angle: builder.angle })}
+              />
+            </View>
+            {/* Reuse the play-drawer angle picker for a consistent feel. */}
+            <AngleSlider angles={builder.angles} value={builder.angle} onChange={builder.setAngle} />
+            {/* Adjustability is a separate capability from the default angle, so
+                it's a toggle (matching the other settings rows), not a chip. */}
+            <SwitchRow
+              label={t('mobile.create.adjustable')}
+              value={builder.isAngleAdjustable}
+              onValueChange={builder.setIsAngleAdjustable}
+            />
+          </>
+        ) : null}
+
+        {builder.layoutId != null ? (
+          <>
+            <SectionLabel>{t('mobile.custom.name')}</SectionLabel>
+            <BuilderTextInput
+              value={builder.name}
+              onChangeText={builder.setName}
+              placeholder={defaultName}
+              accessibilityLabel={t('mobile.custom.name')}
+              maxLength={100}
+              returnKeyType="done"
+            />
+          </>
+        ) : null}
+
+        {/* Advanced — hold sets (default all), visibility, location, serial. */}
+        <Pressable
+          onPress={() => setAdvancedOpen((open) => !open)}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: advancedOpen }}
+          style={styles.advancedHeader}
+        >
+          <Text variant="headline">{t('mobile.create.moreOptions')}</Text>
+          <Icon name={advancedOpen ? 'chevron.up' : 'chevron.down'} size={18} color={systemColors.secondaryLabel} />
+        </Pressable>
+
+        {advancedOpen ? (
+          <View style={styles.advancedBody}>
+            {builder.sets.length > 0 ? (
+              <>
+                <SectionLabel>{t('mobile.custom.sets')}</SectionLabel>
+                <BoardConfigChips
+                  groupLabel={t('mobile.custom.sets')}
+                  options={setOptions}
+                  onSelect={builder.toggleSet}
+                  disabled={lockedConfig}
+                />
+              </>
+            ) : null}
+
+            <SwitchRow label={t('mobile.create.ownBoard')} value={builder.isOwned} onValueChange={builder.setIsOwned} />
+            <SwitchRow
+              label={t('mobile.create.public')}
+              description={t('mobile.create.publicHint')}
+              value={builder.isPublic}
+              onValueChange={builder.setIsPublic}
+            />
+            <SwitchRow
+              label={t('mobile.create.unlisted')}
+              value={builder.isUnlisted}
+              onValueChange={builder.setIsUnlisted}
+            />
+            <SwitchRow
+              label={t('mobile.create.hideLocation')}
+              value={builder.hideLocation}
+              onValueChange={builder.setHideLocation}
+            />
+
+            <SectionLabel>{t('mobile.create.location')}</SectionLabel>
+            <BuilderTextInput
+              value={builder.locationName}
+              onChangeText={builder.setLocationName}
+              placeholder={t('mobile.create.locationPlaceholder')}
+              accessibilityLabel={t('mobile.create.location')}
+              maxLength={120}
+            />
+            <Button
+              title={builder.coords ? t('mobile.create.locationSet') : t('mobile.create.useMyLocation')}
+              variant="text"
+              onPress={onUseMyLocation}
+              disabled={builder.coords != null}
+            />
+
+            <SectionLabel>{t('mobile.create.serial')}</SectionLabel>
+            <BuilderTextInput
+              value={builder.serialNumber}
+              onChangeText={builder.setSerialNumber}
+              placeholder={t('mobile.create.serialPlaceholder')}
+              accessibilityLabel={t('mobile.create.serial')}
+              autoCapitalize="characters"
+              maxLength={100}
+            />
+            <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.serialHint}>
+              {t('mobile.create.serialHint')}
+            </Text>
+          </View>
+        ) : null}
+      </ScrollView>
+
+      {/* Pinned, safe-area-aware primary action. */}
+      <View
+        style={[
+          styles.footer,
+          {
+            backgroundColor: systemColors.secondaryBackground,
+            borderTopColor: systemColors.separator,
+            paddingBottom: insets.bottom + spacing[3],
+          },
+        ]}
+      >
+        <Button
+          title={submitLabel}
+          onPress={onSubmit}
+          variant="filled"
+          size="large"
+          disabled={!builder.canCreate || submitting}
+          loading={submitting}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  const { systemColors } = useTheme();
+  return (
+    <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
+      {children}
+    </Text>
+  );
+}
+
+/** Themed text input for the builder's form fields (name / location / serial). */
+function BuilderTextInput({ style, ...props }: ComponentProps<typeof TextInput>) {
+  const { systemColors } = useTheme();
+  return (
+    <TextInput
+      placeholderTextColor={systemColors.tertiaryLabel}
+      {...props}
+      style={[
+        styles.input,
+        {
+          color: systemColors.label,
+          borderColor: systemColors.separator,
+          backgroundColor: systemColors.secondaryBackground,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+/** The empty board art (no lit holds) at the config's native aspect ratio. */
+function BoardConfigPreview({
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  maxWidth,
+}: {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  maxWidth: number;
+}) {
+  const renderData = useMemo(() => {
+    const setIdValues = setIds.split(',').map(Number).filter(Number.isFinite);
+    if (setIdValues.length === 0) return null;
+    return getBoardRenderData({ boardName, layoutId, sizeId, setIds: setIdValues });
+  }, [boardName, layoutId, sizeId, setIds]);
+
+  if (!renderData) return null;
+
+  const aspect = renderData.boardWidth / renderData.boardHeight;
+  let height = PREVIEW_MAX_HEIGHT;
+  let width = height * aspect;
+  if (width > maxWidth) {
+    width = maxWidth;
+    height = width / aspect;
+  }
+  const boardStyle: ViewStyle = { width, height, borderRadius: borderRadius.lg, overflow: 'hidden' };
+
+  return (
+    // Decorative — the config is already conveyed by the chips, so hide the art
+    // from screen readers rather than landing on an unlabeled image.
+    <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+      <BoardImageNative
+        frames=""
+        boardName={boardName}
+        layoutId={layoutId}
+        sizeId={sizeId}
+        setIds={setIds}
+        boardWidth={renderData.boardWidth}
+        boardHeight={renderData.boardHeight}
+        renderWidth={Math.round(width)}
+        style={boardStyle}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing[4],
+    gap: spacing[2],
+  },
+  preview: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: PREVIEW_MAX_HEIGHT,
+    borderRadius: borderRadius.lg,
+    padding: spacing[3],
+    marginBottom: spacing[2],
+  },
+  previewPlaceholder: {
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  previewHint: {
+    textAlign: 'center',
+  },
+  lockedHint: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    padding: spacing[3],
+    borderRadius: borderRadius.md,
+  },
+  lockedHintText: {
+    flex: 1,
+  },
+  sectionLabel: {
+    marginTop: spacing[3],
+    marginBottom: spacing[1],
+    textTransform: 'uppercase',
+  },
+  angleDiagram: {
+    alignItems: 'center',
+    paddingVertical: spacing[2],
+  },
+  input: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 17,
+  },
+  advancedHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: spacing[5],
+    paddingVertical: spacing[2],
+  },
+  advancedBody: {
+    gap: spacing[2],
+  },
+  serialHint: {
+    marginTop: spacing[1],
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -1,0 +1,170 @@
+import { memo, useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { toBoardName } from '@boardsesh/board-config';
+import { SwipeableRow } from '../SwipeableRow';
+import { BoardImageNative } from '../BoardImageNative';
+import { getBoardRenderData } from '../../lib/board-details';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+const THUMB_SIZE = 56;
+
+type BoardManageRowProps = {
+  board: UserBoard;
+  /** True when the user owns this board (edit/delete); false for followed boards (unfollow). */
+  isOwned: boolean;
+  isActive: boolean;
+  /** A mutation targeting this row is in flight — show a spinner and disable the swipe. */
+  isMutating: boolean;
+  onEdit: (board: UserBoard) => void;
+  onDelete: (board: UserBoard) => void;
+  onUnfollow: (board: UserBoard) => void;
+};
+
+/**
+ * One board in the management list. Owned boards open the edit form on tap and
+ * reveal Delete on swipe; followed boards reveal Unfollow on swipe (no tap
+ * target — switching/activating lives on the board picker, not here). Memoised;
+ * its props are referentially stable from the screen except `board` (rebuilt on
+ * refetch), so it re-renders only when its own board data changes.
+ */
+function BoardManageRowComponent({
+  board,
+  isOwned,
+  isActive,
+  isMutating,
+  onEdit,
+  onDelete,
+  onUnfollow,
+}: BoardManageRowProps) {
+  const { t } = useTranslation('boards');
+  const { systemColors, brandColors } = useTheme();
+
+  const boardName = toBoardName(board.boardType);
+  const renderData = useMemo(() => {
+    if (!boardName) return null;
+    const setIdValues = board.setIds.split(',').map(Number).filter(Number.isFinite);
+    if (setIdValues.length === 0) return null;
+    return getBoardRenderData({ boardName, layoutId: board.layoutId, sizeId: board.sizeId, setIds: setIdValues });
+  }, [boardName, board.layoutId, board.sizeId, board.setIds]);
+
+  // Owned: size / location tells one of your walls apart. Followed: whose board it is.
+  const subtitle = isOwned
+    ? (board.sizeName ?? board.locationName ?? board.boardType)
+    : (board.ownerDisplayName ?? board.boardType);
+
+  const content = (
+    <View style={[styles.row, { backgroundColor: systemColors.background, borderBottomColor: systemColors.separator }]}>
+      <View
+        style={[
+          styles.thumb,
+          {
+            backgroundColor: systemColors.tertiaryBackground,
+            borderColor: isActive ? brandColors.primary : systemColors.separator,
+            borderWidth: isActive ? 2 : StyleSheet.hairlineWidth,
+          },
+        ]}
+      >
+        {renderData && boardName ? (
+          // 400px source matches the discovery cards / climb thumbnails so the
+          // board-art cache entry is shared across surfaces.
+          <BoardImageNative
+            frames=""
+            boardName={boardName}
+            layoutId={board.layoutId}
+            sizeId={board.sizeId}
+            setIds={board.setIds}
+            boardWidth={renderData.boardWidth}
+            boardHeight={renderData.boardHeight}
+            renderWidth={400}
+            style={styles.thumbImage}
+          />
+        ) : (
+          <Icon name="boards" size={26} color={systemColors.tertiaryLabel} />
+        )}
+      </View>
+
+      <View style={styles.textCol}>
+        <Text variant="body" numberOfLines={1}>
+          {board.name}
+        </Text>
+        <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
+          {subtitle}
+        </Text>
+      </View>
+
+      {isActive ? (
+        <View style={styles.activeBadge}>
+          <Icon name="tick" size={14} color={brandColors.primary} />
+          <Text variant="caption1" color={brandColors.primary}>
+            {t('mobile.boardDetail.alreadyActive')}
+          </Text>
+        </View>
+      ) : null}
+
+      {isMutating ? (
+        <ActivityIndicator size="small" />
+      ) : isOwned ? (
+        <Icon name="chevron.right" size={14} color={iosSystemColors.systemGray4} />
+      ) : null}
+    </View>
+  );
+
+  return (
+    <SwipeableRow
+      onPress={isOwned ? () => onEdit(board) : undefined}
+      pressAccessibilityLabel={isOwned ? t('mobile.manage.editAria', { name: board.name }) : undefined}
+      onAction={isOwned ? () => onDelete(board) : () => onUnfollow(board)}
+      actionLabel={
+        isOwned
+          ? t('mobile.manage.deleteAria', { name: board.name })
+          : t('mobile.manage.unfollowAria', { name: board.name })
+      }
+      actionIcon={isOwned ? 'delete' : 'minus.circle'}
+      actionColor={isOwned ? iosSystemColors.systemRed : iosSystemColors.systemOrange}
+      enabled={!isMutating}
+    >
+      {content}
+    </SwipeableRow>
+  );
+}
+
+export const BoardManageRow = memo(BoardManageRowComponent);
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing[3],
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[4],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  thumb: {
+    width: THUMB_SIZE,
+    height: THUMB_SIZE,
+    borderRadius: borderRadius.md,
+    overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbImage: {
+    width: '100%',
+    height: '100%',
+  },
+  textCol: {
+    flex: 1,
+    minWidth: 0,
+  },
+  activeBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -5,6 +5,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import { toBoardName } from '@boardsesh/board-config';
 import { SwipeableRow } from '../SwipeableRow';
 import { BoardImageNative } from '../BoardImageNative';
+import { boardTypeLabel } from './board-builder-labels';
 import { getBoardRenderData } from '../../lib/board-details';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -54,10 +55,22 @@ function BoardManageRowComponent({
     return getBoardRenderData({ boardName, layoutId: board.layoutId, sizeId: board.sizeId, setIds: setIdValues });
   }, [boardName, board.layoutId, board.sizeId, board.setIds]);
 
+  // Board art isn't square; fit it inside the square thumb at its native aspect
+  // (passing height:'100%' would override BoardImageNative's aspectRatio and stretch it).
+  const thumbFit = useMemo(() => {
+    if (!renderData) return null;
+    const aspect = renderData.boardWidth / renderData.boardHeight;
+    return aspect >= 1
+      ? { width: THUMB_SIZE, height: THUMB_SIZE / aspect }
+      : { width: THUMB_SIZE * aspect, height: THUMB_SIZE };
+  }, [renderData]);
+
+  // Proper-cased board name for trademark correctness when used as a fallback.
+  const boardTypeText = boardName ? boardTypeLabel(boardName) : board.boardType;
   // Owned: size / location tells one of your walls apart. Followed: whose board it is.
   const subtitle = isOwned
-    ? (board.sizeName ?? board.locationName ?? board.boardType)
-    : (board.ownerDisplayName ?? board.boardType);
+    ? (board.sizeName ?? board.locationName ?? boardTypeText)
+    : (board.ownerDisplayName ?? boardTypeText);
 
   const content = (
     <View style={[styles.row, { backgroundColor: systemColors.background, borderBottomColor: systemColors.separator }]}>
@@ -71,7 +84,7 @@ function BoardManageRowComponent({
           },
         ]}
       >
-        {renderData && boardName ? (
+        {renderData && boardName && thumbFit ? (
           // 400px source matches the discovery cards / climb thumbnails so the
           // board-art cache entry is shared across surfaces.
           <BoardImageNative
@@ -83,7 +96,7 @@ function BoardManageRowComponent({
             boardWidth={renderData.boardWidth}
             boardHeight={renderData.boardHeight}
             renderWidth={400}
-            style={styles.thumbImage}
+            style={thumbFit}
           />
         ) : (
           <Icon name="boards" size={26} color={systemColors.tertiaryLabel} />
@@ -129,6 +142,7 @@ function BoardManageRowComponent({
       actionIcon={isOwned ? 'delete' : 'minus.circle'}
       actionColor={isOwned ? iosSystemColors.systemRed : iosSystemColors.systemOrange}
       enabled={!isMutating}
+      resetKey={board.uuid}
     >
       {content}
     </SwipeableRow>
@@ -153,10 +167,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  thumbImage: {
-    width: '100%',
-    height: '100%',
   },
   textCol: {
     flex: 1,

--- a/packages/mobile/src/components/board-discovery/__tests__/manage-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/manage-items.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { buildManageItems, type ManageItem } from '../manage-items';
+
+// buildManageItems only reads uuid + ownerId, so a minimal cast is enough.
+const board = (uuid: string, ownerId: string): UserBoard => ({ uuid, ownerId }) as unknown as UserBoard;
+const labels = { ownedHeader: 'Your boards', followingHeader: 'Following' };
+
+function boardItem(items: ManageItem[], key: string) {
+  const found = items.find((item) => item.type === 'board' && item.key === key);
+  if (!found || found.type !== 'board') throw new Error(`board item not found: ${key}`);
+  return found;
+}
+
+describe('buildManageItems', () => {
+  it('splits owned vs followed by ownerId, each under its own header (owned first)', () => {
+    const items = buildManageItems(
+      [board('o1', 'me'), board('o2', 'me'), board('f1', 'other')],
+      'me',
+      undefined,
+      labels,
+    );
+    expect(items.map((item) => (item.type === 'header' ? `#${item.title}` : item.key))).toEqual([
+      '#Your boards',
+      'o1',
+      'o2',
+      '#Following',
+      'f1',
+    ]);
+    expect(boardItem(items, 'o1').isOwned).toBe(true);
+    expect(boardItem(items, 'f1').isOwned).toBe(false);
+  });
+
+  it('omits a section header when that group is empty', () => {
+    const ownedOnly = buildManageItems([board('o1', 'me')], 'me', undefined, labels);
+    expect(ownedOnly.some((item) => item.type === 'header' && item.title === 'Following')).toBe(false);
+    expect(ownedOnly.some((item) => item.type === 'header' && item.title === 'Your boards')).toBe(true);
+
+    const followedOnly = buildManageItems([board('f1', 'other')], 'me', undefined, labels);
+    expect(followedOnly.some((item) => item.type === 'header' && item.title === 'Your boards')).toBe(false);
+    expect(followedOnly.some((item) => item.type === 'header' && item.title === 'Following')).toBe(true);
+  });
+
+  it('returns an empty array for no boards', () => {
+    expect(buildManageItems([], 'me', undefined, labels)).toEqual([]);
+  });
+
+  it('flags only the active board', () => {
+    const items = buildManageItems([board('o1', 'me'), board('o2', 'me')], 'me', 'o2', labels);
+    expect(boardItem(items, 'o1').isActive).toBe(false);
+    expect(boardItem(items, 'o2').isActive).toBe(true);
+  });
+
+  it('classifies every board as followed when currentUserId is undefined', () => {
+    // The manage screen must NOT render in this state — this documents why
+    // (an undefined id would file owned boards under "Following").
+    const items = buildManageItems([board('o1', 'me')], undefined, undefined, labels);
+    expect(items[0]).toEqual({ type: 'header', key: 'header:following', title: 'Following' });
+    expect(boardItem(items, 'o1').isOwned).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/__tests__/use-board-builder.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/use-board-builder.test.tsx
@@ -117,4 +117,72 @@ describe('useBoardBuilder', () => {
     act(() => result.current.setName('Garage'));
     expect(result.current.buildCreateInput("Marco's Kilter")?.name).toBe('Garage');
   });
+
+  it('pre-fills the More-options meta from a full (edit) seed', () => {
+    const { result } = renderHook(() =>
+      useBoardBuilder({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '20,1',
+        name: 'Garage Wall',
+        isPublic: false,
+        isUnlisted: true,
+        isOwned: false,
+        isAngleAdjustable: false,
+        locationName: 'Garage',
+        serialNumber: 'SN-9',
+        latitude: 1.5,
+        longitude: -2.5,
+      }),
+    );
+    expect(result.current.name).toBe('Garage Wall');
+    expect(result.current.isPublic).toBe(false);
+    expect(result.current.isUnlisted).toBe(true);
+    expect(result.current.isOwned).toBe(false);
+    expect(result.current.isAngleAdjustable).toBe(false);
+    expect(result.current.locationName).toBe('Garage');
+    expect(result.current.serialNumber).toBe('SN-9');
+    expect(result.current.coords).toEqual({ latitude: 1.5, longitude: -2.5 });
+  });
+
+  it('builds an update input carrying the uuid, meta, and normalised config', () => {
+    const { result } = renderHook(() =>
+      useBoardBuilder({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '20,1',
+        name: 'Garage',
+        isPublic: false,
+      }),
+    );
+    const input = result.current.buildUpdateInput('board-uuid-1');
+    expect(input?.boardUuid).toBe('board-uuid-1');
+    expect(input?.name).toBe('Garage');
+    expect(input?.isPublic).toBe(false);
+    // Config is sent (not locked) and numerically normalised.
+    expect(input?.layoutId).toBe(1);
+    expect(input?.sizeId).toBe(10);
+    expect(input?.setIds).toBe('1,20');
+  });
+
+  it('omits the config from the update input when locked (board has ticks)', () => {
+    const { result } = renderHook(() =>
+      useBoardBuilder({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '20,1' }),
+    );
+    const input = result.current.buildUpdateInput('board-uuid-1', { lockedConfig: true });
+    expect(input?.boardUuid).toBe('board-uuid-1');
+    // Editable meta still present...
+    expect(input?.name).toBeDefined();
+    // ...but the config keys are omitted so the server's tick guard isn't tripped.
+    expect(input?.layoutId).toBeUndefined();
+    expect(input?.sizeId).toBeUndefined();
+    expect(input?.setIds).toBeUndefined();
+  });
+
+  it('returns a null update input before the config is complete', () => {
+    const { result } = renderHook(() => useBoardBuilder());
+    expect(result.current.buildUpdateInput('board-uuid-1')).toBeNull();
+  });
 });

--- a/packages/mobile/src/components/board-discovery/manage-items.ts
+++ b/packages/mobile/src/components/board-discovery/manage-items.ts
@@ -1,0 +1,41 @@
+// Pure builder for the My Boards management list. Kept out of the screen so the
+// owned/followed split (the trickiest bit) is unit-testable without rendering.
+
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+/** A row in the management list: a section header or a board. */
+export type ManageItem =
+  | { type: 'header'; key: string; title: string }
+  | { type: 'board'; key: string; board: UserBoard; isOwned: boolean; isActive: boolean };
+
+/**
+ * Split `boards` (owned + followed, as `myBoards` returns them) into a flat item
+ * array: an owned group then a followed group, each preceded by a header that's
+ * omitted when the group is empty. Owned = `board.ownerId === currentUserId`.
+ * `myBoards` already orders owned-first, so this is a single pass; the caller
+ * supplies the localized header titles. Each board carries precomputed
+ * `isOwned`/`isActive` so the row never scans for them.
+ */
+export function buildManageItems(
+  boards: UserBoard[],
+  currentUserId: string | undefined,
+  activeUuid: string | undefined,
+  labels: { ownedHeader: string; followingHeader: string },
+): ManageItem[] {
+  const items: ManageItem[] = [];
+  const owned = boards.filter((board) => board.ownerId === currentUserId);
+  const followed = boards.filter((board) => board.ownerId !== currentUserId);
+  if (owned.length > 0) {
+    items.push({ type: 'header', key: 'header:owned', title: labels.ownedHeader });
+    for (const board of owned) {
+      items.push({ type: 'board', key: board.uuid, board, isOwned: true, isActive: board.uuid === activeUuid });
+    }
+  }
+  if (followed.length > 0) {
+    items.push({ type: 'header', key: 'header:following', title: labels.followingHeader });
+    for (const board of followed) {
+      items.push({ type: 'board', key: board.uuid, board, isOwned: false, isActive: board.uuid === activeUuid });
+    }
+  }
+  return items;
+}

--- a/packages/mobile/src/components/board-discovery/use-board-builder.ts
+++ b/packages/mobile/src/components/board-discovery/use-board-builder.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { BoardName, CreateBoardInput } from '@boardsesh/shared-schema';
+import type { BoardName, CreateBoardInput, UpdateBoardInput } from '@boardsesh/shared-schema';
 import { SUPPORTED_BOARDS, ANGLES, normaliseSetIds } from '@boardsesh/board-config';
 import {
   getBoardLayouts,
@@ -9,7 +9,14 @@ import {
 } from '../../lib/custom-board-options';
 import { cleanLayoutName } from './board-builder-labels';
 
-/** A board config to pre-fill the builder with (e.g. a tapped Popular setup). */
+/**
+ * A board to pre-fill the builder with. The config fields (board/layout/size/
+ * sets) drive the cascade and, when their VALUES change, re-seed it (see
+ * `seedKey`). The optional meta fields pre-fill the "More options" form when
+ * EDITING an existing board; they're seeded once via the `useState` initializers
+ * (never re-seeded), so a render can't wipe the user's edits. The create flow
+ * and the Popular-config seed omit them and fall back to the home-board defaults.
+ */
 export type BoardBuilderSeed = {
   boardName: BoardName;
   layoutId: number;
@@ -17,6 +24,17 @@ export type BoardBuilderSeed = {
   /** Comma-separated set ids. */
   setIds: string;
   angle?: number;
+  // Meta (edit only):
+  name?: string;
+  isOwned?: boolean;
+  isPublic?: boolean;
+  isUnlisted?: boolean;
+  hideLocation?: boolean;
+  isAngleAdjustable?: boolean;
+  locationName?: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  serialNumber?: string;
 };
 
 function defaultAngle(boardName: BoardName): number {
@@ -43,18 +61,22 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
   const [sizeId, setSizeId] = useState<number | null>(seed?.sizeId ?? null);
   const [setIds, setSetIds] = useState<number[]>(seed ? parseSetIds(seed.setIds) : []);
   const [angle, setAngle] = useState<number>(seed?.angle ?? defaultAngle(initialBoard));
-  const [name, setName] = useState('');
+  // Meta seeds (edit) run once here — NOT in the re-seed effect — so re-renders
+  // can't clobber edits. Create / Popular omit them, so the home-board defaults apply.
+  const [name, setName] = useState(seed?.name ?? '');
 
   // "More options" / advanced. Owned + public default to the home-board case.
-  const [isOwned, setIsOwned] = useState(true);
-  const [isPublic, setIsPublic] = useState(true);
-  const [isUnlisted, setIsUnlisted] = useState(false);
-  const [hideLocation, setHideLocation] = useState(false);
+  const [isOwned, setIsOwned] = useState(seed?.isOwned ?? true);
+  const [isPublic, setIsPublic] = useState(seed?.isPublic ?? true);
+  const [isUnlisted, setIsUnlisted] = useState(seed?.isUnlisted ?? false);
+  const [hideLocation, setHideLocation] = useState(seed?.hideLocation ?? false);
   // Most home boards with a kicker tilt are adjustable; default on.
-  const [isAngleAdjustable, setIsAngleAdjustable] = useState(true);
-  const [locationName, setLocationName] = useState('');
-  const [coords, setCoords] = useState<{ latitude: number; longitude: number } | null>(null);
-  const [serialNumber, setSerialNumber] = useState('');
+  const [isAngleAdjustable, setIsAngleAdjustable] = useState(seed?.isAngleAdjustable ?? true);
+  const [locationName, setLocationName] = useState(seed?.locationName ?? '');
+  const [coords, setCoords] = useState<{ latitude: number; longitude: number } | null>(
+    seed?.latitude != null && seed?.longitude != null ? { latitude: seed.latitude, longitude: seed.longitude } : null,
+  );
+  const [serialNumber, setSerialNumber] = useState(seed?.serialNumber ?? '');
 
   // Re-seed when the seed's VALUES change (opened from a different Popular
   // config). Keyed on the serialized seed, not its object identity, so an
@@ -150,6 +172,44 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
     };
   };
 
+  /**
+   * The validated UpdateBoardInput for `boardUuid`, or null when the config is
+   * incomplete. Name/angle/visibility/location/serial are always editable. The
+   * config (layout/size/sets) is sent only when `lockedConfig` is false — the
+   * server rejects config changes on boards that already have ticks, and an
+   * unchanged config would still trip its duplicate-config guard, so we omit it.
+   * Emptied location/serial are sent as `null` so editing them to blank clears
+   * the stored value (vs `buildCreateInput`, which has nothing to clear).
+   */
+  const buildUpdateInput = (
+    boardUuid: string,
+    options?: { lockedConfig?: boolean; fallbackName?: string },
+  ): UpdateBoardInput | null => {
+    if (layoutId == null || sizeId == null || setIds.length === 0) return null;
+    const input: UpdateBoardInput = {
+      boardUuid,
+      name: name.trim() || options?.fallbackName?.trim() || cleanLayoutName(rawLayoutName, boardName),
+      angle,
+      isOwned,
+      isPublic,
+      isUnlisted,
+      hideLocation,
+      isAngleAdjustable,
+      // null (not undefined) so emptying a previously-set field clears it on the
+      // server — undefined would leave the old value in place (see UpdateBoardInput).
+      serialNumber: serialNumber.trim() || null,
+      locationName: locationName.trim() || null,
+      latitude: coords?.latitude,
+      longitude: coords?.longitude,
+    };
+    if (!options?.lockedConfig) {
+      input.layoutId = layoutId;
+      input.sizeId = sizeId;
+      input.setIds = normaliseSetIds(setIds.join(','));
+    }
+    return input;
+  };
+
   return {
     // config
     boardName,
@@ -190,5 +250,6 @@ export function useBoardBuilder(seed?: BoardBuilderSeed | null) {
     setCoords,
     setSerialNumber,
     buildCreateInput,
+    buildUpdateInput,
   };
 }

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -95,17 +95,18 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     transform: [{ translateX: -drawerWidth + drawerWidth * drawerProgress.value }],
   }));
 
-  const openBoards = useCallback(
-    (focus?: 'myBoards') => {
-      closeUserDrawer();
-      const returnTo = currentBoardReturnTo(segments);
-      router.push({
-        pathname: '/boards',
-        params: focus ? { returnTo, focus } : { returnTo },
-      });
-    },
-    [closeUserDrawer, segments],
-  );
+  const openBoards = useCallback(() => {
+    closeUserDrawer();
+    const returnTo = currentBoardReturnTo(segments);
+    router.push({ pathname: '/boards', params: { returnTo } });
+  }, [closeUserDrawer, segments]);
+
+  // "My Boards" is now a management screen (edit / delete owned, unfollow
+  // followed), distinct from the board picker that "Change Board" opens.
+  const openManageBoards = useCallback(() => {
+    closeUserDrawer();
+    router.push('/boards/manage');
+  }, [closeUserDrawer]);
 
   const openProfileSettings = useCallback(() => {
     closeUserDrawer();
@@ -190,8 +191,8 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
               </View>
 
               <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
-                <DrawerRow icon="boards" title={t('userDrawer.changeBoard')} onPress={() => openBoards()} />
-                <DrawerRow icon="boards.fill" title={t('myBoards.title')} onPress={() => openBoards('myBoards')} />
+                <DrawerRow icon="boards" title={t('userDrawer.changeBoard')} onPress={openBoards} />
+                <DrawerRow icon="boards.fill" title={t('myBoards.title')} onPress={openManageBoards} />
               </View>
 
               <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -10,6 +10,7 @@ import type {
   SearchBoardsInput,
   PopularBoardConfigsInput,
   CreateBoardInput,
+  UpdateBoardInput,
   SetterStatsInput,
   UserProfile,
   SessionSummary,
@@ -33,6 +34,14 @@ import {
   type DeleteDraftClimbMutationResponse,
 } from '@boardsesh/graphql/operations/new-climb-feed';
 import { SEARCH_GYMS, type SearchGymsQueryResponse } from '@boardsesh/graphql/operations/gyms';
+import {
+  UPDATE_BOARD,
+  DELETE_BOARD,
+  UNFOLLOW_BOARD,
+  type UpdateBoardMutationResponse,
+  type DeleteBoardMutationResponse,
+  type UnfollowBoardMutationResponse,
+} from '@boardsesh/graphql/operations/boards';
 import { getHttpClient } from '../client';
 import {
   GET_PROFILE,
@@ -193,6 +202,66 @@ export function useCreateBoard() {
     },
     onSuccess: () => {
       // A freshly created board should appear in the user's board list.
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+    },
+  });
+}
+
+/**
+ * Edit a board the user owns (name, visibility, angle, location, serial — and
+ * layout/size/sets only when the board has zero ticks; the server enforces the
+ * latter). Invalidate-only: `myBoards` carries enriched fields (counts, sizeName)
+ * that can't be rebuilt client-side. Re-syncing the active board's denormalised
+ * AsyncStorage copy is the edit screen's job — see `useSetActiveBoard`.
+ */
+export function useUpdateBoard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpdateBoardInput) => {
+      const response = await getHttpClient().request<UpdateBoardMutationResponse>(UPDATE_BOARD, { input });
+      return response.updateBoard;
+    },
+    onSuccess: (updated) => {
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['board', updated.uuid] });
+    },
+  });
+}
+
+/**
+ * Soft-delete a board the user owns. `deleteBoard` takes a BARE `boardUuid`
+ * (unlike `unfollowBoard`, which wraps it in `{ input }`). Clearing the active
+ * board when the deleted one was active is the screen's responsibility.
+ */
+export function useDeleteBoard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (boardUuid: string) => {
+      const response = await getHttpClient().request<DeleteBoardMutationResponse>(DELETE_BOARD, { boardUuid });
+      return response.deleteBoard;
+    },
+    onSuccess: (_deleted, boardUuid) => {
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['board', boardUuid] });
+    },
+  });
+}
+
+/**
+ * Stop following someone else's board. `unfollowBoard` wraps the uuid in
+ * `{ input: { boardUuid } }` (a FollowBoardInput) — NOT the bare arg shape that
+ * `deleteBoard` uses. Reversible, so callers skip the confirm dialog.
+ */
+export function useUnfollowBoard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (boardUuid: string) => {
+      const response = await getHttpClient().request<UnfollowBoardMutationResponse>(UNFOLLOW_BOARD, {
+        input: { boardUuid },
+      });
+      return response.unfollowBoard;
+    },
+    onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
     },
   });

--- a/packages/mobile/src/lib/graphql/use-active-board.ts
+++ b/packages/mobile/src/lib/graphql/use-active-board.ts
@@ -13,7 +13,7 @@
 import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { getStoredActiveBoard, setStoredActiveBoard } from '../active-board-store';
+import { getStoredActiveBoard, setStoredActiveBoard, clearStoredActiveBoard } from '../active-board-store';
 
 export const ACTIVE_BOARD_QUERY_KEY = ['activeBoard'] as const;
 
@@ -46,4 +46,18 @@ export function useSetActiveBoard() {
     },
     [queryClient],
   );
+}
+
+/**
+ * Returns a clearer that drops the active board: removed from storage and the
+ * `['activeBoard']` cache set to `null`. Used when the active board is deleted
+ * or unfollowed — the app's contract is "no active board → route to the picker"
+ * (see this module's header), so we never auto-pick a replacement.
+ */
+export function useClearActiveBoard() {
+  const queryClient = useQueryClient();
+  return useCallback(async () => {
+    await clearStoredActiveBoard();
+    queryClient.setQueryData<UserBoard | null>(ACTIVE_BOARD_QUERY_KEY, null);
+  }, [queryClient]);
 }

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -88,10 +88,14 @@ export type UpdateBoardInput = {
   boardUuid: string;
   name?: string;
   slug?: string;
-  description?: string;
-  locationName?: string;
-  latitude?: number;
-  longitude?: number;
+  // Nullable clearable fields: `undefined` leaves the value unchanged, `null`
+  // clears it server-side (the resolver applies any value that isn't undefined,
+  // and the Zod schema accepts null). The edit form sends null for an emptied
+  // field that previously had a value.
+  description?: string | null;
+  locationName?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
   isPublic?: boolean;
   isUnlisted?: boolean;
   hideLocation?: boolean;
@@ -101,7 +105,7 @@ export type UpdateBoardInput = {
   layoutId?: number;
   sizeId?: number;
   setIds?: string;
-  serialNumber?: string;
+  serialNumber?: string | null;
 };
 
 export type BoardLeaderboardInput = {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -30,6 +30,27 @@
     }
   },
   "mobile": {
+    "edit": {
+      "screenTitle": "Edit board",
+      "save": "Save changes",
+      "updateError": "Couldn't save your changes. Try again.",
+      "notFound": "We couldn't find that board",
+      "back": "Go back",
+      "configLockedHint": "This board has logged climbs, so its layout, size, and sets are locked."
+    },
+    "manage": {
+      "ownedHeader": "Your boards",
+      "followingHeader": "Following",
+      "deleteTitle": "Delete board?",
+      "deleteMessage": "Remove \"{{name}}\" from your boards? This can't be undone.",
+      "deleteConfirm": "Delete",
+      "cancel": "Cancel",
+      "deleteError": "Couldn't delete that board. Try again.",
+      "unfollowError": "Couldn't unfollow that board. Try again.",
+      "editAria": "Edit {{name}}",
+      "deleteAria": "Delete {{name}}",
+      "unfollowAria": "Unfollow {{name}}"
+    },
     "emptyTitle": "No boards yet",
     "emptySubtitle": "Search for a board to get started",
     "signInTitle": "Sign in to see your boards",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -30,6 +30,27 @@
     }
   },
   "mobile": {
+    "edit": {
+      "screenTitle": "Editar board",
+      "save": "Guardar cambios",
+      "updateError": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
+      "notFound": "No encontramos ese board",
+      "back": "Volver",
+      "configLockedHint": "Este board tiene ascensos registrados, así que su layout, tamaño y sets están bloqueados."
+    },
+    "manage": {
+      "ownedHeader": "Tus boards",
+      "followingHeader": "Siguiendo",
+      "deleteTitle": "¿Eliminar board?",
+      "deleteMessage": "¿Quitar \"{{name}}\" de tus boards? No se puede deshacer.",
+      "deleteConfirm": "Eliminar",
+      "cancel": "Cancelar",
+      "deleteError": "No se pudo eliminar ese board. Inténtalo de nuevo.",
+      "unfollowError": "No se pudo dejar de seguir ese board. Inténtalo de nuevo.",
+      "editAria": "Editar {{name}}",
+      "deleteAria": "Eliminar {{name}}",
+      "unfollowAria": "Dejar de seguir {{name}}"
+    },
     "emptyTitle": "Aún no tienes boards",
     "emptySubtitle": "Busca un board para empezar",
     "signInTitle": "Inicia sesión para ver tus boards",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -30,6 +30,27 @@
     }
   },
   "mobile": {
+    "edit": {
+      "screenTitle": "Modifier le board",
+      "save": "Enregistrer",
+      "updateError": "Impossible d'enregistrer les modifications. Réessaie.",
+      "notFound": "Board introuvable",
+      "back": "Retour",
+      "configLockedHint": "Ce board a des voies enregistrées : son layout, sa taille et ses sets sont verrouillés."
+    },
+    "manage": {
+      "ownedHeader": "Tes boards",
+      "followingHeader": "Abonnements",
+      "deleteTitle": "Supprimer le board ?",
+      "deleteMessage": "Retirer \"{{name}}\" de tes boards ? C'est définitif.",
+      "deleteConfirm": "Supprimer",
+      "cancel": "Annuler",
+      "deleteError": "Impossible de supprimer ce board. Réessaie.",
+      "unfollowError": "Impossible de te désabonner de ce board. Réessaie.",
+      "editAria": "Modifier {{name}}",
+      "deleteAria": "Supprimer {{name}}",
+      "unfollowAria": "Se désabonner de {{name}}"
+    },
     "emptyTitle": "Aucun board pour le moment",
     "emptySubtitle": "Cherche un board pour commencer",
     "signInTitle": "Connecte-toi pour voir tes boards",


### PR DESCRIPTION
## What

In the mobile app, the drawer's **My Boards** entry opened the *same* screen as **Change Board** — the board picker — where the only action was to *activate* a board on tap. There was no way to edit, delete, or unfollow a board.

This makes **My Boards** a dedicated management screen:

- **Boards you own** → **edit** (tap a row) and **delete** (swipe), plus **create**.
- **Boards you follow** → **unfollow** (swipe).

**Change Board** is unchanged — it still opens the picker for switching the active board.

> Note on scope: "boards of others you've climbed on" maps to **followed** boards. Climbing on a board does **not** auto-follow it (verified: `boardFollows` is only written by the follow/unfollow resolvers), so the follow relationship is the only "others' boards" the app tracks. No backend change was needed — `createBoard`/`updateBoard`/`deleteBoard`/`followBoard`/`unfollowBoard` and `myBoards` (owned + followed) already exist.

## How

- **New screens**: `app/boards/manage.tsx` (a `FlashList` split into *Your boards* / *Following*) and `app/boards/edit.tsx`.
- **Shared form**: extracted `BoardForm` from `create.tsx` (create + edit now share it); extended `useBoardBuilder` with a meta seed + `buildUpdateInput`. Config (layout/size/sets) is **locked** once a board has logged climbs (server rejects those edits), and emptying location/serial now **clears** them server-side.
- **New hooks**: `useUpdateBoard` / `useDeleteBoard` / `useUnfollowBoard`, plus `useClearActiveBoard`. The active board is a denormalised AsyncStorage copy, so editing it **re-persists**, and deleting/unfollowing it **clears** the active selection (the app then routes to the picker).
- **Reusable** `SwipeableRow` (swipe-to-reveal destructive action, modeled on `QueueItemRow`) + memoized `BoardManageRow`.
- **Drawer** rewired: *My Boards* → `/boards/manage`; removed the now-dead `focus` reorder from the picker.
- **i18n**: `mobile.edit.*` / `mobile.manage.*` added to en-US, es, fr (at parity).

## Behaviour

- Owned row: tap → edit form; swipe → Delete (with confirm dialog).
- Followed row: swipe → Unfollow (reversible, no confirm).
- Deleting/unfollowing the active board clears it; editing the active board propagates to BLE / play drawer.
- Mutations are invalidate-only with per-row pending state.

## Validation

- `vp run typecheck` (full monorepo) ✓
- `vp run test:mobile` — 2356 tests ✓ (incl. new `buildUpdateInput` + meta-seed cases)
- `vp run check:mobile-bundle` ✓
- `vp check` — 0 lint errors
- Adversarial multi-agent review of the diff (correctness / RN-perf / wiring / i18n / a11y); both confirmed findings fixed (clear-on-edit, profile-load race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)