### PR TITLE
fix(mobile): stop cold-start crash from undefined SCREENSHOT_MODE reference

### DIFF
--- a/packages/mobile/src/lib/__tests__/screenshot-mode.test.ts
+++ b/packages/mobile/src/lib/__tests__/screenshot-mode.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Regression guard for the cold-start crash where a merge between two PRs left a
+// bare `SCREENSHOT_MODE` reference in this module after the binding was deleted.
+// `screenshot-mode.ts` is imported by the auth + theme providers at the top of
+// the startup tree, so a top-level ReferenceError here aborts the app on launch
+// (expo-updates ErrorRecovery then crashes the process). These tests import the
+// module fresh under different env so any top-level throw fails loudly here
+// instead of only on a device.
+
+const SCREENSHOT_ENV_KEYS = [
+  'EXPO_PUBLIC_SCREENSHOT_MODE',
+  'EXPO_PUBLIC_SCREENSHOT_LOCALE',
+  'EXPO_PUBLIC_SCREENSHOT_THEME',
+  'EXPO_PUBLIC_SCREENSHOT_VARIANT',
+  'EXPO_PUBLIC_SCREENSHOT_WORKOUT',
+  'EXPO_PUBLIC_SCREENSHOT_USER_EMAIL',
+  'EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD',
+] as const;
+
+describe('screenshot-mode', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of SCREENSHOT_ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of SCREENSHOT_ENV_KEYS) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+  });
+
+  it('evaluates without throwing in a normal build (no screenshot env)', async () => {
+    const screenshotMode = await import('../screenshot-mode');
+    // The locale override line is exactly where the bare-`SCREENSHOT_MODE` bug
+    // lived. In a normal build the guard is false, so there is no override.
+    expect(screenshotMode.SCREENSHOT_LOCALE_OVERRIDE).toBeNull();
+    expect(screenshotMode.SCREENSHOT_THEME_OVERRIDE).toBe('dark');
+    expect(screenshotMode.SCREENSHOT_VARIANT_PREFERENCE).toBe('auto');
+    expect(screenshotMode.SCREENSHOT_WORKOUT).toBeNull();
+    expect(screenshotMode.SCREENSHOT_USER_EMAIL).toBe('');
+    expect(screenshotMode.SCREENSHOT_USER_PASSWORD).toBe('');
+  });
+
+  it('keeps the locale override null when screenshot mode is off, even with a locale set', async () => {
+    process.env.EXPO_PUBLIC_SCREENSHOT_LOCALE = 'fr';
+    const screenshotMode = await import('../screenshot-mode');
+    expect(screenshotMode.SCREENSHOT_LOCALE_OVERRIDE).toBeNull();
+  });
+
+  it('applies a supported locale override only when screenshot mode is on', async () => {
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE = '1';
+    process.env.EXPO_PUBLIC_SCREENSHOT_LOCALE = 'fr';
+    const screenshotMode = await import('../screenshot-mode');
+    expect(screenshotMode.SCREENSHOT_LOCALE_OVERRIDE).toBe('fr');
+  });
+
+  it('ignores an unsupported locale even in screenshot mode', async () => {
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE = '1';
+    process.env.EXPO_PUBLIC_SCREENSHOT_LOCALE = 'zz-not-a-locale';
+    const screenshotMode = await import('../screenshot-mode');
+    expect(screenshotMode.SCREENSHOT_LOCALE_OVERRIDE).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/screenshot-mode.ts
+++ b/packages/mobile/src/lib/screenshot-mode.ts
@@ -41,7 +41,9 @@ import { isSupportedLocale, type Locale } from '@boardsesh/i18n';
  */
 const screenshotLocaleEnv = process.env.EXPO_PUBLIC_SCREENSHOT_LOCALE;
 export const SCREENSHOT_LOCALE_OVERRIDE: Locale | null =
-  SCREENSHOT_MODE && isSupportedLocale(screenshotLocaleEnv) ? screenshotLocaleEnv : null;
+  process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && isSupportedLocale(screenshotLocaleEnv)
+    ? screenshotLocaleEnv
+    : null;
 
 /**
  * Theme the screenshots build locks to so a capture can't flip mid-run when


### PR DESCRIPTION
## The crash

TestFlight build **2.0.0 (100375)** aborts ~386 ms after launch, before any UI renders:

```
ErrorRecovery.crash() (ErrorRecovery.swift:277)
ErrorRecovery.runNextTask() (ErrorRecovery.swift:190)
ErrorRecovery.notify(newRemoteLoadStatus:) (ErrorRecovery.swift:149)
```

That frame is expo-updates' deliberate abort. It only fires when a **fatal RN/JS error** hits `RCTSetFatalExceptionHandler` at startup, the recovery pipeline can't roll back to a working update, and it rethrows the original exception. So the native frame is just the messenger — the real fault is a fatal during JS startup.

### How we pinned it without a device

- PostHog error tracking had **no** matching exception at the crash time. The crash is too early to flush.
- "Application Opened" telemetry: build **100375 produced zero events**, while the four builds immediately before it (100371–100374) each opened fine. So 100375 crashes on every cold start, before anything sends — a fresh regression.
- `vp run typecheck:mobile` **fails on `main` right now**:
  ```
  src/lib/screenshot-mode.ts:44:3 - error TS2304: Cannot find name 'SCREENSHOT_MODE'.
  ```

## Root cause — a clean merge of two PRs into broken code

Two PRs landed on `main` ~60 s apart today:

- **#2951** (`e577b2eac`) added `SCREENSHOT_LOCALE_OVERRIDE`, whose initializer reads `SCREENSHOT_MODE && isSupportedLocale(...)`.
- **#2959** (`5bee3f81a`) **deleted** `export const SCREENSHOT_MODE`, inlining `process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1'` at every other call site.

They don't conflict textually, so each branch was green individually, but the merged result left a bare `SCREENSHOT_MODE` at module top level — a `ReferenceError` the moment `screenshot-mode.ts` is evaluated. `auth-provider` and `theme-provider` import it near the top of the startup tree, so every cold start throws and the app never boots.

## The fix

Inline the env comparison the same way the other call sites (and this file's own docs) already do:

```ts
export const SCREENSHOT_LOCALE_OVERRIDE: Locale | null =
  process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && isSupportedLocale(screenshotLocaleEnv)
    ? screenshotLocaleEnv
    : null;
```

This removes the undefined reference and preserves the production dead-strip that #2959 was about: in a normal build `EXPO_PUBLIC_SCREENSHOT_MODE` folds to a literal, the guard folds false, and the override strips to `null`.

Also adds a `screenshot-mode` test that imports the module fresh under several env configs, so a future top-level throw fails in CI instead of only on a device.

## Validation

- `vp run typecheck:mobile` — passes (was failing on `main`)
- `vp run test:mobile` — 2369 passed (4 new)
- `vp check` — clean (changed files)
- `vp run check:mobile-bundle` — production Hermes bundle builds (10.9 MB)

## Follow-up worth considering

The release/TestFlight build path didn't gate on `typecheck` (or it built from the red `main` before CI caught it). Adding a typecheck gate before the native build would have caught this pre-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)