### PR TITLE
docs: post-merge comment cleanup for the screenshot matrix (#2951)

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -29,7 +29,10 @@ on:
           - app-store
           - onboarding
       devices:
-        description: 'iOS simulator devices: common, or a comma-separated list of simulator names'
+        # A subset only makes sense for local iteration: the dimension gate and the
+        # App Store Connect upload both require the full common-device matrix, so a
+        # narrowed list here fails the "Assert screenshot dimensions" step in CI.
+        description: 'iOS simulator devices: common (required for upload), or a comma-separated list for local iteration'
         type: string
         default: 'common'
       android_device:
@@ -37,7 +40,9 @@ on:
         type: string
         default: 'Pixel 2'
       locales:
-        description: 'App locales: all, or a comma-separated list such as en-US,es,fr'
+        # Same as devices: the dimension gate + upload expect all four App Store
+        # locales (en-US, es-ES, es-MX, fr-FR), so a subset fails CI validation.
+        description: 'App locales: all (required for upload), or a comma-separated list such as en-US,es for local iteration'
         type: string
         default: 'all'
       upload:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,6 @@
 # Uploads native store screenshots to App Store Connect / Google Play.
 #
-# Screenshots only - no binary, no text metadata, no review submission. The
+# Screenshots only — no binary, no text metadata, no review submission. The
 # screenshots are captured fresh by `vp run mobile:screenshots` (see
 # scripts/mobile-screenshots.ts) into the canonical trees:
 #
@@ -173,7 +173,7 @@ platform :ios do
         sync_screenshots: true,
         submit_for_review: false,
         run_precheck_before_submit: false,
-        # force: true is mandatory in CI: without it deliver opens an HTML
+        # force: true is mandatory in CI — without it deliver opens an HTML
         # preview in a browser and blocks until timeout.
         force: true
       )

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -7,7 +7,7 @@ high-res icon / feature graphic). Nothing here uploads a binary, submits for
 review, or does a staged rollout.
 
 ```bash
-# screenshots (PNGs from app-stores/*/screenshots/<device>/)
+# screenshots (PNGs from app-stores/apple/screenshots/<locale>/<device>/ and app-stores/google/screenshots/<device>/)
 cd fastlane && bundle exec fastlane ios screenshots
 cd fastlane && bundle exec fastlane android screenshots
 

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -28,9 +28,11 @@ name: app-store screenshots
 #
 # Notes:
 # - The .app is a Debug dev-client that auto-loads Metro on launch, so the orchestrator
-#   just simctl-launches it; this flow waits for the signed-out auth screen, then logs in.
-# - Fresh install (orchestrator uninstalled/reinstalled + reset keychain): cold-loads
-#   signed out, no active board (re-picked below), login authenticates against the backend.
+#   just simctl-launches it; the build auto-signs-in on boot, so there's no login screen
+#   and this flow opens straight into the shots (the orchestrator gates on `$screen /home`).
+# - Fresh install (orchestrator uninstalled/reinstalled + reset keychain): cold-loads with
+#   no active board (re-picked below), and the keychain reset forces the auto-sign-in to
+#   re-authenticate against the target backend rather than reuse a stale token.
 # - iOS shows an "Open in 'Boardsesh'?" confirmation for the first in-flow route deep link
 #   on a fresh sim; each openLink is followed by an optional tapOn "Open".
 # - Order: board-INDEPENDENT shots (home/discover/profile/logbook/session) run first so a


### PR DESCRIPTION
## Summary

Follow-up to #2951 (App Store screenshot matrix). That PR was merged at `17f0556b`, just before the code-review fixes landed on the branch, so these doc/comment-only changes didn't make it into `main`. No functional code changes.

- **`packages/mobile/.maestro/app-store.yaml`** — rewrite the stale "waits for the signed-out auth screen, then logs in" Notes block. Both review passes flagged this as the one inaccuracy: the merged flow auto-signs-in on boot (the orchestrator gates on `$screen /home`), there is no login screen, and the header now says so consistently.
- **`.github/workflows/mobile-screenshots.yml`** — document that a non-default `devices`/`locales` subset is for local iteration only; the dimension gate and the App Store Connect upload both require the full common-device × four-locale matrix.
- **`fastlane/README.md` / `fastlane/Fastfile`** — correct the stale Apple screenshots path (now `<locale>/<device>/`) and restore em-dash punctuation for consistency.

## Validation

- `vp check` clean on all touched files.
- Comment/doc-only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)