### PR TITLE
fix(mobile): stop the "You" title leaking onto another climber's profile

### DIFF
--- a/packages/mobile/app/(tabs)/profile/index.tsx
+++ b/packages/mobile/app/(tabs)/profile/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLocalSearchParams } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import type BottomSheet from '@gorhom/bottom-sheet';
 import { useProfile, useYouProfileData } from '../../../src/lib/graphql/hooks';
 import { useTheme } from '../../../src/providers/theme-provider';
@@ -19,8 +20,13 @@ function isProfileTabKey(value: string | string[] | undefined): value is Profile
 }
 
 export default function YouScreen() {
+  const { t } = useTranslation('you');
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
+
+  // The own profile's identity title. The reused sub-tabs render it in-body
+  // (collapsing under the floating chrome); another climber's profile omits it.
+  const dashboardTitle = t('metadata.dashboard.title');
 
   const { data: profile } = useProfile();
   const userId = profile?.id;
@@ -55,10 +61,18 @@ export default function YouScreen() {
   return (
     <View style={[styles.container, { backgroundColor: systemColors.background }]}>
       <View style={styles.page}>
-        {activeTab === 'progress' ? <ProgressTab data={youData} topInset={chromeHeight} /> : null}
-        {activeTab === 'sessions' ? <SessionsTab userId={userId} topInset={chromeHeight} /> : null}
-        {activeTab === 'logbook' ? <LogbookTab userId={userId} topInset={chromeHeight} /> : null}
-        {activeTab === 'social' ? <SocialTab userId={userId} topInset={chromeHeight} /> : null}
+        {activeTab === 'progress' ? (
+          <ProgressTab data={youData} topInset={chromeHeight} screenTitle={dashboardTitle} />
+        ) : null}
+        {activeTab === 'sessions' ? (
+          <SessionsTab userId={userId} topInset={chromeHeight} screenTitle={dashboardTitle} />
+        ) : null}
+        {activeTab === 'logbook' ? (
+          <LogbookTab userId={userId} topInset={chromeHeight} screenTitle={dashboardTitle} />
+        ) : null}
+        {activeTab === 'social' ? (
+          <SocialTab userId={userId} topInset={chromeHeight} screenTitle={dashboardTitle} />
+        ) : null}
       </View>
 
       <ProfileTopChrome

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -33,9 +33,12 @@ type LogbookTabProps = {
    * read-only in the play drawer instead of the editable LogbookEditSheet.
    */
   viewerIsOwner?: boolean;
+  /** In-body identity title (the own "You" tab passes "You"). Omitted on another
+   *  climber's profile, where the name lives in the public-profile header. */
+  screenTitle?: string;
 };
 
-export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: LogbookTabProps) {
+export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenTitle }: LogbookTabProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
   const router = useRouter();
@@ -110,13 +113,13 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
     [handleActivate, handleOpenActions, handleEdit, viewerIsOwner],
   );
 
-  // The screen's identity, in-body under the floating chrome. Memoized so
-  // FlashList doesn't re-render the header on every LogbookTab render. Always
-  // present so it sits above the empty state too. ScreenTitle hides itself on
-  // Material (the M3 app bar owns the title).
+  // The screen's identity (when supplied), in-body under the floating chrome.
+  // Memoized so FlashList doesn't re-render the header on every LogbookTab render.
+  // ScreenTitle hides itself on Material (the M3 app bar owns the title); the
+  // whole header is omitted on another climber's profile (no title passed).
   const listHeader = useMemo(
-    () => <ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>,
-    [t],
+    () => (screenTitle ? <ScreenTitle style={styles.screenTitle}>{screenTitle}</ScreenTitle> : null),
+    [screenTitle],
   );
 
   if (!userId || feed.isPending) {

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -24,9 +24,12 @@ type ProgressTabProps = {
   /** Measured chrome height — the scroll content insets its top by this so the
    *  first card rests below the floating chrome and the rest scroll under it. */
   topInset: number;
+  /** In-body identity title (the own "You" tab passes "You"). Omitted on another
+   *  climber's profile, where the name lives in the public-profile header. */
+  screenTitle?: string;
 };
 
-export const ProgressTab = memo(function ProgressTab({ data, topInset }: ProgressTabProps) {
+export const ProgressTab = memo(function ProgressTab({ data, topInset, screenTitle }: ProgressTabProps) {
   const { t } = useTranslation('profile');
   const { t: tYou } = useTranslation('you');
   const { systemColors, colorScheme, brandColors } = useTheme();
@@ -35,7 +38,6 @@ export const ProgressTab = memo(function ProgressTab({ data, topInset }: Progres
 
   const totalAscents = data.statisticsSummary.totalAscents;
   const noAscentData = t('empty.noAscentData');
-  const dashboardTitle = tYou('metadata.dashboard.title');
 
   // Legends so the layout-colored grade-distribution bars and the
   // flash-vs-redpoint pairs can be decoded (charts are color-only otherwise).
@@ -74,10 +76,11 @@ export const ProgressTab = memo(function ProgressTab({ data, topInset }: Progres
         <RefreshControl refreshing={data.refreshing} onRefresh={data.refetch} tintColor={brandColors.primary} />
       }
     >
-      {/* The screen's identity, in-body under the floating chrome — collapses into
-          the header capsule as it scrolls up behind the glass. ScreenTitle hides
-          itself on Material (the M3 app bar owns the title). */}
-      <ScreenTitle style={styles.screenTitle}>{dashboardTitle}</ScreenTitle>
+      {/* The screen's identity (when supplied), in-body under the floating chrome —
+          collapses into the header capsule as it scrolls up behind the glass.
+          ScreenTitle hides itself on Material (the M3 app bar owns the title).
+          Omitted on another climber's profile, where the name lives in the header. */}
+      {screenTitle ? <ScreenTitle style={styles.screenTitle}>{screenTitle}</ScreenTitle> : null}
 
       {totalAscents === 0 ? (
         <View style={styles.empty}>

--- a/packages/mobile/src/components/you/SessionsTab.tsx
+++ b/packages/mobile/src/components/you/SessionsTab.tsx
@@ -35,6 +35,9 @@ type SessionsTabProps = {
   /** Measured chrome height — the list insets its top by this so the first row
    *  rests below the floating chrome and the rest scroll under it. */
   topInset?: number;
+  /** In-body identity title (the own "You" tab passes "You"). Omitted on another
+   *  climber's profile, where the name lives in the public-profile header. */
+  screenTitle?: string;
 };
 
 // String-literal `t(...)` per call so the catalog keys stay statically greppable.
@@ -87,7 +90,7 @@ function SessionCardSkeleton() {
   );
 }
 
-export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
+export function SessionsTab({ userId, topInset = 0, screenTitle }: SessionsTabProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
   const router = useRouter();
@@ -207,17 +210,17 @@ export function SessionsTab({ userId, topInset = 0 }: SessionsTabProps) {
   // The screen's identity, in-body under the floating chrome, plus the feed
   // rollup when there are sessions. Memoized so FlashList doesn't re-measure /
   // re-render the header on every SessionsTab render — only when the rollup data
-  // (sessions/now) changes. The large title always renders so it sits above the
-  // empty state too.
+  // (sessions/now) changes. The title renders above the empty state too when
+  // supplied; it's omitted on another climber's profile.
   const listHeader = useMemo(
     () => (
       <>
-        {/* ScreenTitle hides itself on Material (the M3 app bar owns the title). */}
-        <ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>
+        {/* ScreenTitle hides itself on Material; omitted on another climber's profile. */}
+        {screenTitle ? <ScreenTitle style={styles.screenTitle}>{screenTitle}</ScreenTitle> : null}
         {sessions.length > 0 ? <SessionsFeedHeader sessions={sessions} now={now} /> : null}
       </>
     ),
-    [t, sessions, now],
+    [screenTitle, sessions, now],
   );
 
   if (!userId) {

--- a/packages/mobile/src/components/you/SocialTab.tsx
+++ b/packages/mobile/src/components/you/SocialTab.tsx
@@ -42,11 +42,14 @@ type SocialTabProps = {
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   topInset?: number;
   registerScrollToTop?: (scrollToTop: (() => void) | null) => void;
+  /** In-body identity title (the own "You" tab passes "You"). Omitted when the
+   *  surrounding screen supplies its own identity. */
+  screenTitle?: string;
 };
 
 const EMPTY_PEOPLE: SocialPerson[] = [];
 
-export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop }: SocialTabProps) {
+export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop, screenTitle }: SocialTabProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
   const bottomChrome = useBottomChromeMetrics();
@@ -140,7 +143,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
   const header = useMemo(
     () => (
       <View>
-        <ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>
+        {screenTitle ? <ScreenTitle style={styles.screenTitle}>{screenTitle}</ScreenTitle> : null}
 
         <View style={styles.summaryRow}>
           <SocialStatCard
@@ -176,7 +179,7 @@ export function SocialTab({ userId, onScroll, topInset = 0, registerScrollToTop 
         ) : null}
       </View>
     ),
-    [followerCount, followingCount, mode, searchQuery, segmentOptions, systemColors.fill, t],
+    [followerCount, followingCount, mode, searchQuery, segmentOptions, systemColors.fill, t, screenTitle],
   );
 
   if (!userId) {

--- a/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/social-tab.test.tsx
@@ -295,6 +295,19 @@ describe('SocialTab', () => {
     expect(getByText('1 follower · 2 following')).toBeTruthy();
   });
 
+  it('renders the in-body identity title only when a screenTitle is supplied', () => {
+    // The own "You" tab passes a title; another climber's profile reuses the same
+    // tab without one and must not surface the owner's "You" heading. Probe with a
+    // distinctive string so it can't collide with any other catalog copy.
+    const probe = 'Profile identity probe';
+
+    const { queryByText, rerender } = render(<SocialTab userId="me" />);
+    expect(queryByText(probe)).toBeNull();
+
+    rerender(<SocialTab userId="me" screenTitle={probe} />);
+    expect(queryByText(probe)).not.toBeNull();
+  });
+
   it('debounces climber search and follows a result from the Find segment', () => {
     const { getByText, getByPlaceholderText } = render(<SocialTab userId="me" />);
 


### PR DESCRIPTION
## Problem

Viewing **another climber's profile** on mobile (`/users/[userId]`) showed the word **"You"** directly under the Progress / Sessions / Logbook / Climbs segmented control on iOS. It's someone else's profile, so "You" is wrong.

## Root cause

The public profile screen reuses the same sub-tab components as the own-profile "You" tab — `ProgressTab`, `SessionsTab`, `LogbookTab`. Those components hardcoded an in-body large title:

```tsx
<ScreenTitle style={styles.screenTitle}>{t('metadata.dashboard.title')}</ScreenTitle>
```

`metadata.dashboard.title` resolves to **"You"**. `ScreenTitle` renders the large in-body title on the iOS Liquid Glass variant (and `null` on Android Material, where "You" lives in the app bar *above* the tabs instead), which is why the leak only showed on iOS, under the segmented control.

## Fix

Make the in-body title a `screenTitle?: string` prop the *screen* supplies, rendered only when provided (default off):

- The own **"You" tab** (`app/(tabs)/profile/index.tsx`) passes the dashboard title → behaviour unchanged on both platforms.
- The **public profile** omits it → no stray "You". The climber's name already appears in `PublicProfileHeaderBlock` and the native nav bar.
- `SocialTab` takes the same prop for a consistent API (it's own-profile-only, so its title is unchanged).

Passing the title (rather than a `hideTitle` flag) removes the own-profile assumption baked into the shared components — any future reuse is safe by construction.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2370 pass, incl. a new regression test in `social-tab.test.tsx` asserting the in-body title renders only when `screenTitle` is supplied
- `vp run check:mobile-bundle` — OK
- Manual (iOS): another climber's profile no longer shows "You" under the segmented control; own "You" tab still shows its large "You" title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
