### PR TITLE
feat(mobile): dismissable active-climb accessory bar

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -19,6 +19,7 @@ const cfg = vi.hoisted(() => ({
   glassCapable: true,
   platformOS: 'ios' as 'ios' | 'android',
   materialScreens: [] as Array<{ name: string; options?: { lazy?: boolean } }>,
+  accessoryDismissed: false,
 }));
 
 vi.mock('react-native', () => ({
@@ -54,6 +55,11 @@ vi.mock('../../../src/hooks/use-sticky-accessory-presence', () => ({
 // real hook; the route-segment split is unit-tested in route-segments.test.
 vi.mock('../../../src/hooks/use-inside-tabs', () => ({
   useInsideTabs: () => cfg.insideTabs,
+}));
+
+// User-dismissed (and not actively climbing): the native accessory host unmounts.
+vi.mock('../../../src/hooks/use-accessory-dismissed', () => ({
+  useAccessoryDismissed: () => cfg.accessoryDismissed,
 }));
 
 vi.mock('../../../src/components/queue-control/QueueBottomAccessory', () => ({
@@ -164,6 +170,7 @@ describe('TabLayout', () => {
     cfg.glassCapable = true;
     cfg.platformOS = 'ios';
     cfg.materialScreens = [];
+    cfg.accessoryDismissed = false;
   });
 
   it('lands on the home tab by default', () => {
@@ -257,6 +264,16 @@ describe('TabLayout', () => {
   it('skips the empty native bottom accessory when no climb is current', () => {
     cfg.nativeAccessoryActive = true;
     cfg.hasCurrentClimb = false;
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-bottom-accessory="true"]')).toBeNull();
+  });
+
+  it('skips the native bottom accessory when the user has tucked the bar away', () => {
+    cfg.nativeAccessoryActive = true;
+    cfg.hasCurrentClimb = true;
+    cfg.accessoryDismissed = true;
 
     const { container } = render(<TabLayout />);
 

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { brandColors } from '../../src/theme/colors';
 import { useNativeAccessoryActive, useNativeTabBar } from '../../src/hooks/use-bottom-accessory';
 import { useInsideTabs } from '../../src/hooks/use-inside-tabs';
+import { useAccessoryDismissed } from '../../src/hooks/use-accessory-dismissed';
 
 // Cold-start on Home: the leftmost tab carries the beta shelf and followed
 // activity feed, while Climbs remains the search surface one tab over. Drives
@@ -72,6 +73,11 @@ export default function TabLayout() {
   // makes the real mount match. `isTabsRoute` keys on segments[0] only, so intra-tab
   // navigation doesn't toggle it.
   const insideTabs = useInsideTabs();
+  // Tucked away by the user (and not actively climbing): unmount the UIKit
+  // accessory host entirely — a clean unmount that stays unmounted, like an empty
+  // queue, so no orphaned glass-platter snapshot. Applied outside the sticky
+  // presence grace so a deliberate hide takes effect immediately, not after 500ms.
+  const accessoryDismissed = useAccessoryDismissed();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
 
@@ -126,7 +132,7 @@ export default function TabLayout() {
       labelStyle={{ default: { color: systemColors.secondaryLabel }, selected: { color: systemColors.label } }}
       tintColor={systemColors.label}
     >
-      {insideTabs && nativeAccessoryActive && hasCurrentClimb ? (
+      {insideTabs && nativeAccessoryActive && hasCurrentClimb && !accessoryDismissed ? (
         <NativeTabs.BottomAccessory key="queue-bottom-accessory">
           <QueueBottomAccessory />
         </NativeTabs.BottomAccessory>

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -39,6 +39,8 @@ import { PlaylistsAdapterWrapper } from '../src/providers/playlists-adapter';
 import { BoardProvider } from '@boardsesh/board-react';
 import { toBoardName } from '@boardsesh/board-config';
 import { PersistentQueueBar } from '../src/components/queue-control/persistent-queue-bar';
+import { AccessoryDismissResets } from '../src/components/queue-control/AccessoryDismissResets';
+import { AccessoryDismissHint } from '../src/components/queue-control/AccessoryDismissHint';
 import { UserDrawerProvider } from '../src/components/user-drawer/UserDrawerProvider';
 import { useMobileClimbActionsData } from '../src/lib/graphql/hooks';
 import { useActiveBoard } from '../src/lib/graphql/use-active-board';
@@ -397,6 +399,8 @@ function RootLayout() {
                                                           </Stack>
                                                         </ThemedNavigation>
                                                         <PersistentQueueBar />
+                                                        <AccessoryDismissResets />
+                                                        <AccessoryDismissHint />
                                                         <OnboardingGate ready={authReady && fontsReady} />
                                                       </UserDrawerProvider>
                                                     </TabBarHeightProvider>

--- a/packages/mobile/src/components/queue-control/AccessoryDismissHint.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryDismissHint.tsx
@@ -1,0 +1,131 @@
+// One-time coachmark teaching that the active-climb strip can be tucked away.
+// Shown once, only while the bar is in the dismissible state (a current climb,
+// inside the tabs, and no climbing signal), then never again. It teaches the
+// affordance without prescribing the exact gesture — the swipe (JS bar) and the
+// hide chevron (native platter) are both discoverable from here.
+
+import { useEffect, useRef, useState } from 'react';
+import { AccessibilityInfo, Pressable, StyleSheet, View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { useReduceMotion } from '../../hooks/use-reduce-motion';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useHasActiveClimb } from '../../providers/queue-provider';
+import { useIsActivelyClimbing } from '../../hooks/use-actively-climbing';
+import { useAccessoryDismissed } from '../../hooks/use-accessory-dismissed';
+import { useAccessoryDismissHintSeen } from '../../lib/accessory-dismiss-hint-store';
+import { borderRadius, shadows, spacing } from '../../theme/tokens';
+import { timing } from '../../theme/animations';
+
+// Auto-retire the hint if the user neither acts on it nor taps "Got it"; one
+// exposure is enough and it should never linger.
+const HINT_AUTO_RETIRE_MS = 8000;
+
+export function AccessoryDismissHint() {
+  const { t } = useTranslation('common');
+  const { systemColors } = useTheme();
+  const reduceMotion = useReduceMotion();
+  const bottomChrome = useBottomChromeMetrics();
+  const hasClimb = useHasActiveClimb();
+  const isActivelyClimbing = useIsActivelyClimbing();
+  const dismissed = useAccessoryDismissed();
+  const { seen, loaded, markSeen } = useAccessoryDismissHintSeen();
+
+  // The bar is currently visible AND in the dismissible (no-signal) state.
+  const barDismissibleNow = bottomChrome.insideTabs && hasClimb && !isActivelyClimbing && !dismissed;
+  const shouldOffer = loaded && !seen && barDismissibleNow;
+
+  const [showing, setShowing] = useState(false);
+  const offeredRef = useRef(false);
+
+  // Offer the hint exactly once, ever. Persist "seen" immediately (so it never
+  // returns across launches) and latch local visibility so marking it seen — which
+  // flips `shouldOffer` false on the same tick — doesn't yank it off screen.
+  useEffect(() => {
+    if (offeredRef.current || !shouldOffer) return;
+    offeredRef.current = true;
+    markSeen();
+    setShowing(true);
+  }, [shouldOffer, markSeen]);
+
+  // Auto-retire so it never lingers; the timer is tied to `showing`, not the
+  // offer condition, so it isn't cleared the instant "seen" is persisted.
+  useEffect(() => {
+    if (!showing) return undefined;
+    const timer = setTimeout(() => setShowing(false), HINT_AUTO_RETIRE_MS);
+    return () => clearTimeout(timer);
+  }, [showing]);
+
+  // Retire the moment the user acts on it (dismisses) or starts climbing.
+  useEffect(() => {
+    if (showing && (dismissed || isActivelyClimbing)) setShowing(false);
+  }, [showing, dismissed, isActivelyClimbing]);
+
+  // The hint is a passive, time-limited overlay, so screen-reader users would
+  // otherwise never hear it — announce the copy when it appears.
+  useEffect(() => {
+    if (showing) AccessibilityInfo.announceForAccessibility(t('mobile.accessoryBar.coachmarkHint'));
+  }, [showing, t]);
+
+  // Only paint while latched AND the bar is genuinely on screen beneath it (so it
+  // can't float over a pushed root screen or after the bar is gone).
+  if (!showing || !barDismissibleNow) return null;
+
+  return (
+    <Animated.View
+      pointerEvents="box-none"
+      entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}
+      exiting={reduceMotion ? undefined : FadeOut.duration(timing.fast)}
+      style={[styles.wrap, { bottom: bottomChrome.floatingControlBottom + spacing[2] }]}
+    >
+      <View
+        style={[
+          styles.bubble,
+          shadows.md,
+          { backgroundColor: systemColors.elevatedSurface, borderColor: systemColors.separator },
+        ]}
+      >
+        <Text variant="footnote" color={systemColors.label} numberOfLines={2} style={styles.label}>
+          {t('mobile.accessoryBar.coachmarkHint')}
+        </Text>
+        <Pressable
+          onPress={() => setShowing(false)}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.accessoryBar.coachmarkGotIt')}
+          hitSlop={spacing[2]}
+        >
+          <Text variant="footnote" color={systemColors.accent} style={styles.action}>
+            {t('mobile.accessoryBar.coachmarkGotIt')}
+          </Text>
+        </Pressable>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: 'absolute',
+    left: spacing[4],
+    right: spacing[4],
+    alignItems: 'center',
+  },
+  bubble: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    maxWidth: 420,
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[4],
+    borderRadius: borderRadius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  label: {
+    flexShrink: 1,
+  },
+  action: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/queue-control/AccessoryDismissResets.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryDismissResets.tsx
@@ -1,0 +1,11 @@
+import { useAccessoryDismissResets } from '../../hooks/use-accessory-dismiss-resets';
+
+/**
+ * Null-rendering host for {@link useAccessoryDismissResets}. Mounted near the app
+ * root so the board-connect / board-switch reset wiring runs for the whole session
+ * regardless of whether the accessory bar itself is currently visible.
+ */
+export function AccessoryDismissResets(): null {
+  useAccessoryDismissResets();
+  return null;
+}

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -6,7 +6,8 @@
 
 import { useMemo, type ReactNode } from 'react';
 import { View, StyleSheet, type ColorValue } from 'react-native';
-import { GestureDetector } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { Climb } from '@boardsesh/queue';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
@@ -76,10 +77,18 @@ export function ClimbCapsule({
   endActionSize = 0,
   surfaceTreatment = 'floating',
 }: ClimbCapsuleProps) {
+  const { t } = useTranslation('common');
   const { systemColors } = useTheme();
   const { boardConfig } = useDrawerHost();
   const { formatGrade } = useGradeFormat();
-  const { openGesture, currentItem } = useAccessoryClimbTap();
+  const { openGesture, dismissGesture, dismiss, canDismiss, currentItem } = useAccessoryClimbTap();
+  // Swipe down to tuck the bar away; a quick tap still opens. The pan only
+  // activates on a downward drag, so it never steals a tap. Exclusive gives the
+  // dismiss priority so a deliberate drag never registers as an accidental open.
+  const gesture = useMemo(
+    () => (canDismiss ? Gesture.Exclusive(dismissGesture, openGesture) : openGesture),
+    [canDismiss, dismissGesture, openGesture],
+  );
 
   // Source-of-truth flip: show the wall's lit climb when a board feed is live
   // (flag-gated), else the local queue head.
@@ -124,11 +133,21 @@ export function ClimbCapsule({
           style={[styles.gradeAccent, { backgroundColor: grades.currentColor }]}
         />
       ) : null}
-      <GestureDetector gesture={openGesture}>
+      <GestureDetector gesture={gesture}>
         <View
           style={[styles.tapArea, { height, borderRadius: capsuleRadius }]}
           accessibilityRole="button"
           accessibilityLabel={currentClimb.name}
+          accessibilityActions={
+            canDismiss ? [{ name: 'dismiss', label: t('mobile.accessoryBar.hideControlAria') }] : undefined
+          }
+          onAccessibilityAction={
+            canDismiss
+              ? (event) => {
+                  if (event.nativeEvent.actionName === 'dismiss') dismiss();
+                }
+              : undefined
+          }
         >
           <View style={[styles.labelSlot, { right: labelRight }]}>
             <ClimbLabel

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -5,22 +5,28 @@
 // behaviour is shared with the native accessory via useAccessoryClimbTap.
 
 import { useMemo, type ReactNode } from 'react';
-import { View, StyleSheet, type ColorValue } from 'react-native';
+import { Pressable, View, StyleSheet, type ColorValue } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { Climb } from '@boardsesh/queue';
-import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
+import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH, glassSize } from '../../theme/layout';
 import { spacing } from '../../theme/tokens';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
+import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
 import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './AccessoryBarSurface';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
+
+// Visible hide control on the JS bar (Android / iOS < 26 / Material) — parity with
+// the iOS 26 native platter chevron, so the dismiss is discoverable everywhere, not
+// just swipe-only. Matches the inline tick's touch size.
+const HIDE_CONTROL_SIZE = glassSize.inline;
 
 type ClimbLabelProps = {
   climb: Climb;
@@ -109,9 +115,13 @@ export function ClimbCapsule({
   if (!currentClimb) return null;
 
   const capsuleRadius = surfaceTreatment === 'docked' ? 0 : height / 2;
-  // Reserve room on the right so the name/grade never slide under the inline tick.
+  // Reserve room on the right so the name/grade never slide under the inline tick
+  // or the (optional) hide control.
   const endActionReservedWidth = endAction ? endActionSize + spacing[2] : 0;
-  const labelRight = spacing[4] + endActionReservedWidth;
+  const hideReservedWidth = canDismiss ? HIDE_CONTROL_SIZE + spacing[2] : 0;
+  const labelRight = spacing[4] + endActionReservedWidth + hideReservedWidth;
+  // The hide control sits just inboard of the tick (or at the edge when there's none).
+  const hideControlRight = spacing[2] + endActionReservedWidth;
 
   // The docked Material bar stays on a neutral M3 surface (a step above the tab bar
   // via elevation) and marks the grade with a vivid leading colour stripe — distinct
@@ -138,16 +148,6 @@ export function ClimbCapsule({
           style={[styles.tapArea, { height, borderRadius: capsuleRadius }]}
           accessibilityRole="button"
           accessibilityLabel={currentClimb.name}
-          accessibilityActions={
-            canDismiss ? [{ name: 'dismiss', label: t('mobile.accessoryBar.hideControlAria') }] : undefined
-          }
-          onAccessibilityAction={
-            canDismiss
-              ? (event) => {
-                  if (event.nativeEvent.actionName === 'dismiss') dismiss();
-                }
-              : undefined
-          }
         >
           <View style={[styles.labelSlot, { right: labelRight }]}>
             <ClimbLabel
@@ -161,6 +161,18 @@ export function ClimbCapsule({
           </View>
         </View>
       </GestureDetector>
+      {canDismiss ? (
+        <Pressable
+          onPress={dismiss}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.accessoryBar.hideControlAria')}
+          accessibilityHint={t('mobile.accessoryBar.hideControlHint')}
+          hitSlop={spacing[1]}
+          style={[styles.hideSlot, { right: hideControlRight, width: HIDE_CONTROL_SIZE, height }]}
+        >
+          <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
+        </Pressable>
+      ) : null}
       {endAction ? <View style={[styles.endActionSlot, { width: endActionSize, height }]}>{endAction}</View> : null}
     </AccessoryBarSurface>
   );
@@ -200,6 +212,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     right: spacing[2],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Hide control: absolutely placed just inboard of the tick (its `right` is set
+  // inline), outside the tap-to-open gesture target so it never opens the drawer.
+  hideSlot: {
+    position: 'absolute',
+    top: 0,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -1,5 +1,6 @@
-import { StyleSheet, View, type ColorValue } from 'react-native';
+import { Pressable, StyleSheet, View, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
+import { useTranslation } from 'react-i18next';
 import type { Climb } from '@boardsesh/queue';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
@@ -8,6 +9,7 @@ import { spacing } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
+import { Icon } from '../Icon';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
@@ -71,10 +73,11 @@ function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardCon
  * capsule's colorized grade.
  */
 export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAccessoryClimbRowProps) {
+  const { t } = useTranslation('common');
   const { boardConfig } = useDrawerHost();
   const { systemColors } = useTheme();
   const { formatGrade } = useGradeFormat();
-  const { openGesture } = useAccessoryClimbTap();
+  const { openGesture, dismiss, canDismiss } = useAccessoryClimbTap();
 
   const showThumbnail = placement === 'regular' && boardConfig !== null;
   const rowHeight = placement === 'inline' ? glassSize.inline : glassSize.standard;
@@ -95,6 +98,18 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
           </View>
         </View>
       </GestureDetector>
+      {canDismiss ? (
+        <Pressable
+          onPress={dismiss}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.accessoryBar.hideControlAria')}
+          accessibilityHint={t('mobile.accessoryBar.hideControlHint')}
+          hitSlop={spacing[1]}
+          style={[styles.hideSlot, { width: glassSize.inline, height: rowHeight }]}
+        >
+          <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
+        </Pressable>
+      ) : null}
       <View style={[styles.tickSlot, { width: glassSize.inline, height: rowHeight }]}>
         <LogAscentToolbarButton climb={climb} size={glassSize.inline} iconSize={24} />
       </View>
@@ -138,6 +153,14 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     minWidth: spacing[10],
     textAlign: 'right',
+  },
+  // Separated from the tick by a gap so the hide control is never mistaken for —
+  // or fat-fingered into — logging an ascent.
+  hideSlot: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    marginRight: spacing[1],
   },
   tickSlot: {
     alignItems: 'center',

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -66,7 +66,7 @@ vi.mock('react-native-gesture-handler', () => {
   return {
     GestureDetector: ({ children }: { children?: ReactNode }) =>
       createElement('div', { 'data-gesture': 'true' }, children),
-    Gesture: { Tap: () => builder },
+    Gesture: { Tap: () => builder, Pan: () => builder, Exclusive: () => builder },
   };
 });
 
@@ -120,7 +120,11 @@ vi.mock('../../../providers/theme-provider', () => ({
 
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
+  useActiveClimbQueueItemUuid: () => queue.state.currentClimbQueueItem?.uuid ?? null,
 }));
+
+vi.mock('../../../hooks/use-actively-climbing', () => ({ useIsActivelyClimbing: () => false }));
+vi.mock('../../../lib/accessory-dismiss-store', () => ({ dismissAccessory: vi.fn() }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer, boardConfig: null }),
@@ -137,6 +141,8 @@ vi.mock('../../../hooks/use-grade-format', () => ({
     formatGrade: (difficulty: string | null | undefined) => (difficulty ? `${difficulty} 6C` : null),
   }),
 }));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -46,11 +46,30 @@ vi.mock('react-native', () => ({
     }, [onLayout]);
     return createElement('div', { 'data-testid': testID, 'data-bg': backgroundOf(style) }, children);
   },
+  Pressable: ({
+    children,
+    accessibilityLabel,
+    onPress,
+  }: {
+    children?: ReactNode;
+    accessibilityRole?: string;
+    accessibilityLabel?: string;
+    onPress?: () => void;
+  }) =>
+    createElement(
+      'button',
+      { 'data-hide-control': 'true', 'data-label': accessibilityLabel ?? '', onClick: onPress },
+      children,
+    ),
   StyleSheet: {
     create: (styles: Record<string, unknown>) => styles,
     absoluteFill: {},
     hairlineWidth: 1,
   },
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon-name': name }),
 }));
 
 // The tap hook wraps its open handler in runOnJS — return it as-is.
@@ -114,7 +133,7 @@ vi.mock('../../GlassSurface', () => ({
 
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
-    systemColors: { label: '#111111', separator: '#cccccc', elevatedSurface: '#f0f0f0' },
+    systemColors: { label: '#111111', secondaryLabel: '#888888', separator: '#cccccc', elevatedSurface: '#f0f0f0' },
   }),
 }));
 
@@ -142,12 +161,14 @@ vi.mock('../../../hooks/use-grade-format', () => ({
   }),
 }));
 
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 
 vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => `${color}29` }));
-vi.mock('../../../theme/layout', () => ({ TOOLBAR_CAPSULE_HEIGHT: 52, TOOLBAR_CAPSULE_MAX_WIDTH: 260 }));
+vi.mock('../../../theme/layout', () => ({
+  TOOLBAR_CAPSULE_HEIGHT: 52,
+  TOOLBAR_CAPSULE_MAX_WIDTH: 260,
+  glassSize: { inline: 44 },
+}));
 vi.mock('../../../theme/tokens', () => ({
   shadows: { sm: {} },
   spacing: { 1: 4, 2: 8, 4: 16 },

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -100,6 +100,21 @@ vi.mock('react-native', () => ({
       children,
     );
   },
+  Pressable: ({
+    children,
+    accessibilityLabel,
+    onPress,
+  }: {
+    children?: ReactNode;
+    accessibilityRole?: string;
+    accessibilityLabel?: string;
+    onPress?: () => void;
+  }) =>
+    createElement(
+      'button',
+      { 'data-hide-control': 'true', 'data-label': accessibilityLabel ?? '', onClick: onPress },
+      children,
+    ),
   StyleSheet: {
     create: (styles: Record<string, unknown>) => styles,
   },
@@ -116,11 +131,17 @@ vi.mock('react-native-gesture-handler', () => {
   return {
     GestureDetector: ({ children }: { children?: ReactNode }) =>
       createElement('div', { 'data-gesture': 'true' }, children),
-    Gesture: { Tap: () => builder },
+    Gesture: { Tap: () => builder, Pan: () => builder, Exclusive: () => builder },
   };
 });
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon-name': name }),
+}));
+vi.mock('../../../hooks/use-actively-climbing', () => ({ useIsActivelyClimbing: () => false }));
+vi.mock('../../../lib/accessory-dismiss-store', () => ({ dismissAccessory: vi.fn() }));
 
 type TextMockProps = {
   children?: ReactNode;
@@ -170,6 +191,7 @@ vi.mock('../../../providers/queue-provider', () => ({
     nextClimb: queue.nextClimb,
     previousClimb: queue.previousClimb,
   }),
+  useActiveClimbQueueItemUuid: () => queue.state.currentClimbQueueItem?.uuid ?? null,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -14,6 +14,7 @@ const cfg = vi.hoisted(() => ({
   measuredTabBarHeight: null as number | null,
   nativeAccessoryActive: false,
   nativeTabBar: false,
+  dismissed: false,
 }));
 
 // useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
@@ -48,6 +49,11 @@ vi.mock('../../../lib/route-segments', () => ({
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
   useHasActiveClimb: () => cfg.currentClimbQueueItem?.climb != null,
+}));
+// The bar (and use-bottom-chrome-metrics) consult this to hide a user-dismissed
+// climb; default to visible and flip per-test.
+vi.mock('../../../hooks/use-accessory-dismissed', () => ({
+  useAccessoryDismissed: () => cfg.dismissed,
 }));
 vi.mock('../../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => true }));
 vi.mock('../../../theme/animations', () => ({ timing: { fast: 150, normal: 250 } }));
@@ -134,6 +140,14 @@ describe('PersistentQueueBar', () => {
     cfg.measuredTabBarHeight = null;
     cfg.nativeAccessoryActive = false;
     cfg.nativeTabBar = false;
+    cfg.dismissed = false;
+  });
+
+  it('renders nothing when the user has tucked the bar away', () => {
+    cfg.dismissed = true;
+    const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
   });
 
   it('renders nothing when no climb is current', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
@@ -19,6 +19,7 @@ const tap = vi.hoisted(() => ({ onEnd: null as ((...args: unknown[]) => unknown)
 
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state }),
+  useActiveClimbQueueItemUuid: () => queue.state.currentClimbQueueItem?.uuid ?? null,
 }));
 
 vi.mock('../../../providers/drawer-host-provider', () => ({
@@ -29,6 +30,9 @@ vi.mock('../use-wall-or-queue-climb', () => ({
   useWallOrQueueCurrentClimb: (localClimb: Climb | null) => wall.climb ?? localClimb,
 }));
 
+vi.mock('../../../hooks/use-actively-climbing', () => ({ useIsActivelyClimbing: () => false }));
+vi.mock('../../../lib/accessory-dismiss-store', () => ({ dismissAccessory: vi.fn() }));
+
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
@@ -38,14 +42,26 @@ vi.mock('react-native-reanimated', () => ({
 }));
 
 vi.mock('react-native-gesture-handler', () => {
-  const builder = {
-    maxDuration: () => builder,
+  const tapBuilder = {
+    maxDuration: () => tapBuilder,
     onEnd: (cb: (...args: unknown[]) => unknown) => {
       tap.onEnd = cb;
-      return builder;
+      return tapBuilder;
     },
   };
-  return { Gesture: { Tap: () => builder } };
+  const panBuilder = {
+    enabled: () => panBuilder,
+    activeOffsetY: () => panBuilder,
+    failOffsetY: () => panBuilder,
+    onEnd: () => panBuilder,
+  };
+  return {
+    Gesture: {
+      Tap: () => tapBuilder,
+      Pan: () => panBuilder,
+      Exclusive: (...gestures: unknown[]) => gestures[0],
+    },
+  };
 });
 
 import { useAccessoryClimbTap } from '../use-accessory-climb-tap';
@@ -86,7 +102,7 @@ describe('useAccessoryClimbTap', () => {
 
   it('opens the local queue head active on tap (it already is current)', () => {
     renderHook(() => useAccessoryClimbTap());
-    tap.onEnd?.();
+    tap.onEnd?.(undefined, true);
     // The bar shows the current climb, so it opens active — no preview.
     expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-head' }), {
       source: 'current_queue_item',
@@ -96,7 +112,7 @@ describe('useAccessoryClimbTap', () => {
   it('opens a peer-driven wall climb as a preview when a board feed is live', () => {
     wall.climb = makeClimb('wall');
     renderHook(() => useAccessoryClimbTap());
-    tap.onEnd?.();
+    tap.onEnd?.(undefined, true);
     // The wall climb isn't the local current, so it opens view-only (badged).
     expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-wall' }), {
       previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-wall' }) }),
@@ -108,7 +124,7 @@ describe('useAccessoryClimbTap', () => {
     queue.state.currentClimbQueueItem = null;
     wall.climb = null;
     renderHook(() => useAccessoryClimbTap());
-    tap.onEnd?.();
+    tap.onEnd?.(undefined, true);
     expect(drawer.openPlayDrawer).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,6 +21,7 @@ import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useAccessoryDismissed } from '../../hooks/use-accessory-dismissed';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
@@ -37,8 +38,12 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  // Tucked away by the user (and not actively climbing) — hide the JS bar. The
+  // native iOS 26 platter is gated the same way at its mount in (tabs)/_layout.
+  const hidden = useAccessoryDismissed();
 
   if (!currentClimb) return null;
+  if (hidden) return null;
   if (!bottomChrome.jsQueueToolbarVisible && bottomChrome.nativeAccessoryMounted) return null;
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });

--- a/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
@@ -2,11 +2,17 @@ import { useCallback, useMemo } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
 import type { ClimbQueueItem } from '@boardsesh/queue';
-import { useQueue } from '../../providers/queue-provider';
+import { useQueue, useActiveClimbQueueItemUuid } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import { hapticLight } from '../../lib/haptics';
+import { dismissAccessory } from '../../lib/accessory-dismiss-store';
+import { useIsActivelyClimbing } from '../../hooks/use-actively-climbing';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
+
+// A downward drag past this distance (or a firm downward flick) tucks the bar away.
+const DISMISS_TRANSLATION_THRESHOLD = 40;
+const DISMISS_VELOCITY_THRESHOLD = 600;
 
 /**
  * Tap-to-open behind the bottom accessory bar (`ClimbCapsule` and the iOS 26
@@ -18,6 +24,12 @@ import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 export type AccessoryClimbTap = {
   /** Tap → open the play drawer for the displayed climb. */
   openGesture: GestureType;
+  /** Downward swipe → tuck the bar away (JS bar composes this with `openGesture`). */
+  dismissGesture: GestureType;
+  /** Imperative dismiss for the native platter's explicit hide control. */
+  dismiss: () => void;
+  /** Whether the bar may be dismissed right now (false while actively climbing). */
+  canDismiss: boolean;
   /** Local queue head; the wrappers re-apply `useWallOrQueueCurrentClimb` for display. */
   currentItem: ClimbQueueItem | null | undefined;
 };
@@ -26,6 +38,11 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
   const { state } = useQueue();
   const { openPlayDrawer } = useDrawerHost();
   const { currentClimbQueueItem } = state;
+  const activeQueueItemUuid = useActiveClimbQueueItemUuid();
+  const isActivelyClimbing = useIsActivelyClimbing();
+  // The bar is dismissible only when there's a climb to dismiss and no climbing
+  // signal — an active climber keeps one-tap return / tick, so no hide affordance.
+  const canDismiss = !isActivelyClimbing && activeQueueItemUuid !== null;
 
   // Open whatever the accessory is showing: the wall's lit climb when a feed is
   // live, else the local queue head — useWallOrQueueCurrentClimb already folds the
@@ -52,16 +69,43 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
     }
   }, [openPlayDrawer, accessoryClimb, currentClimbQueueItem]);
 
+  const dismiss = useCallback(() => {
+    if (!activeQueueItemUuid) return;
+    hapticLight();
+    // UI-only: tuck the strip away for this queue item. Never mutates the queue.
+    dismissAccessory(activeQueueItemUuid);
+  }, [activeQueueItemUuid]);
+
   const openGesture = useMemo(
     () =>
       Gesture.Tap()
         .maxDuration(250)
-        .onEnd(() => {
+        .onEnd((_event, success) => {
           'worklet';
+          // Only open on a recognized tap — never on a cancelled one (the tap loses
+          // to the dismiss Pan under Gesture.Exclusive on the JS bar).
+          if (!success) return;
           runOnJS(handleOpenPlay)();
         }),
     [handleOpenPlay],
   );
 
-  return { openGesture, currentItem: currentClimbQueueItem };
+  // Activates only on a downward drag (and bails on an upward one), so it never
+  // competes with the tap for a quick press. Disabled entirely while climbing.
+  const dismissGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(canDismiss)
+        .activeOffsetY(12)
+        .failOffsetY(-12)
+        .onEnd((event) => {
+          'worklet';
+          if (event.translationY > DISMISS_TRANSLATION_THRESHOLD || event.velocityY > DISMISS_VELOCITY_THRESHOLD) {
+            runOnJS(dismiss)();
+          }
+        }),
+    [canDismiss, dismiss],
+  );
+
+  return { openGesture, dismissGesture, dismiss, canDismiss, currentItem: currentClimbQueueItem };
 }

--- a/packages/mobile/src/hooks/__tests__/use-accessory-dismissed.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-accessory-dismissed.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cfg = vi.hoisted(() => ({
+  dismissedUuid: null as string | null,
+  activeUuid: null as string | null,
+  climbing: false,
+}));
+
+vi.mock('../../providers/queue-provider', () => ({
+  useActiveClimbQueueItemUuid: () => cfg.activeUuid,
+}));
+vi.mock('../../lib/accessory-dismiss-store', () => ({
+  useDismissedAccessoryUuid: () => cfg.dismissedUuid,
+}));
+vi.mock('../use-actively-climbing', () => ({
+  useIsActivelyClimbing: () => cfg.climbing,
+}));
+
+import { useAccessoryDismissed } from '../use-accessory-dismissed';
+
+describe('useAccessoryDismissed', () => {
+  beforeEach(() => {
+    cfg.dismissedUuid = null;
+    cfg.activeUuid = null;
+    cfg.climbing = false;
+  });
+
+  it('is false when there is no current climb', () => {
+    cfg.dismissedUuid = 'climb-1';
+    expect(renderHook(() => useAccessoryDismissed()).result.current).toBe(false);
+  });
+
+  it('is false when the current climb was never dismissed', () => {
+    cfg.activeUuid = 'climb-1';
+    expect(renderHook(() => useAccessoryDismissed()).result.current).toBe(false);
+  });
+
+  it('is true when the current climb is the dismissed one and not climbing', () => {
+    cfg.activeUuid = 'climb-1';
+    cfg.dismissedUuid = 'climb-1';
+    expect(renderHook(() => useAccessoryDismissed()).result.current).toBe(true);
+  });
+
+  it('is false when actively climbing, even if the current climb was dismissed', () => {
+    cfg.activeUuid = 'climb-1';
+    cfg.dismissedUuid = 'climb-1';
+    cfg.climbing = true;
+    expect(renderHook(() => useAccessoryDismissed()).result.current).toBe(false);
+  });
+
+  it('is false when a different climb was the one dismissed', () => {
+    cfg.activeUuid = 'climb-2';
+    cfg.dismissedUuid = 'climb-1';
+    expect(renderHook(() => useAccessoryDismissed()).result.current).toBe(false);
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-actively-climbing.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-actively-climbing.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cfg = vi.hoisted(() => ({ ble: false, wall: false, sessionId: null as string | null }));
+
+vi.mock('../../lib/ble/bluetooth-status-store', () => ({
+  useBluetoothConnectedStatus: () => cfg.ble,
+}));
+vi.mock('../../components/queue-control/use-wall-or-queue-climb', () => ({
+  useHasWallClimb: () => cfg.wall,
+}));
+vi.mock('../../providers/queue-provider', () => ({
+  useQueueSessionId: () => ({ sessionId: cfg.sessionId }),
+}));
+
+import { useIsActivelyClimbing } from '../use-actively-climbing';
+
+describe('useIsActivelyClimbing', () => {
+  beforeEach(() => {
+    cfg.ble = false;
+    cfg.wall = false;
+    cfg.sessionId = null;
+  });
+
+  it('is false with no climbing signal', () => {
+    expect(renderHook(() => useIsActivelyClimbing()).result.current).toBe(false);
+  });
+
+  it('is true when a board is connected over Bluetooth', () => {
+    cfg.ble = true;
+    expect(renderHook(() => useIsActivelyClimbing()).result.current).toBe(true);
+  });
+
+  it('is true when a live wall climb is present', () => {
+    cfg.wall = true;
+    expect(renderHook(() => useIsActivelyClimbing()).result.current).toBe(true);
+  });
+
+  it('is true during a session', () => {
+    cfg.sessionId = 'session-1';
+    expect(renderHook(() => useIsActivelyClimbing()).result.current).toBe(true);
+  });
+});

--- a/packages/mobile/src/hooks/use-accessory-dismiss-resets.ts
+++ b/packages/mobile/src/hooks/use-accessory-dismiss-resets.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+import { useBluetoothConnectedStatus } from '../lib/ble/bluetooth-status-store';
+import { useActiveBoard } from '../lib/graphql/use-active-board';
+import { resetAccessoryDismiss } from '../lib/accessory-dismiss-store';
+
+/**
+ * Brings a tucked-away accessory bar back when the user CONNECTS to a board (BLE
+ * goes disconnected → connected) or SWITCHES the active board. The dismissed state
+ * otherwise survives app launches (it is keyed to the climb and persisted), so
+ * these board events are the explicit "I'm at the wall now" signals that clear it.
+ *
+ * Mount once near the app root (see {@link import('../components/queue-control/AccessoryDismissResets')}).
+ */
+export function useAccessoryDismissResets(): void {
+  const bluetoothConnected = useBluetoothConnectedStatus();
+  const { data: activeBoard } = useActiveBoard();
+
+  const prevConnectedRef = useRef(bluetoothConnected);
+  useEffect(() => {
+    if (bluetoothConnected && !prevConnectedRef.current) resetAccessoryDismiss();
+    prevConnectedRef.current = bluetoothConnected;
+  }, [bluetoothConnected]);
+
+  // `activeBoard` is `undefined` until the query first settles. That initial settle
+  // (undefined → board | null) is cold-start hydration, NOT a switch, so it must not
+  // clear a dismissal that should survive the launch — only a later change does.
+  const boardUuid = activeBoard?.uuid ?? null;
+  const prevBoardUuidRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (activeBoard === undefined) return;
+    if (prevBoardUuidRef.current === undefined) {
+      prevBoardUuidRef.current = boardUuid;
+      return;
+    }
+    if (boardUuid !== prevBoardUuidRef.current) {
+      prevBoardUuidRef.current = boardUuid;
+      resetAccessoryDismiss();
+    }
+  }, [activeBoard, boardUuid]);
+}

--- a/packages/mobile/src/hooks/use-accessory-dismissed.ts
+++ b/packages/mobile/src/hooks/use-accessory-dismissed.ts
@@ -1,0 +1,19 @@
+import { useActiveClimbQueueItemUuid } from '../providers/queue-provider';
+import { useDismissedAccessoryUuid } from '../lib/accessory-dismiss-store';
+import { useIsActivelyClimbing } from './use-actively-climbing';
+
+/**
+ * Whether the active-climb accessory bar should be hidden right now.
+ *
+ * Hidden only when the user explicitly dismissed THIS climb — the persisted
+ * dismissed uuid still matches the current queue-item uuid — AND there is no live
+ * climbing signal. Any climbing signal forces the bar back (see
+ * {@link useIsActivelyClimbing}); a new climb becoming current changes the uuid and
+ * clears the match for free, so a stale dismiss can never suppress a fresh climb.
+ */
+export function useAccessoryDismissed(): boolean {
+  const dismissedUuid = useDismissedAccessoryUuid();
+  const activeQueueItemUuid = useActiveClimbQueueItemUuid();
+  const isActivelyClimbing = useIsActivelyClimbing();
+  return !isActivelyClimbing && activeQueueItemUuid !== null && dismissedUuid === activeQueueItemUuid;
+}

--- a/packages/mobile/src/hooks/use-actively-climbing.ts
+++ b/packages/mobile/src/hooks/use-actively-climbing.ts
@@ -1,0 +1,21 @@
+import { useBluetoothConnectedStatus } from '../lib/ble/bluetooth-status-store';
+import { useHasWallClimb } from '../components/queue-control/use-wall-or-queue-climb';
+import { useQueueSessionId } from '../providers/queue-provider';
+
+/**
+ * Single source of truth for "the user is actively climbing right now": a board is
+ * connected over Bluetooth, a live wall feed is showing a climb, or a session is in
+ * progress. While any of these holds, the active-climb accessory bar asserts itself
+ * and cannot be dismissed (the dismiss affordance does not even render), so an
+ * active climber can never hide a live control or lose one-tap return / tick.
+ *
+ * Keep this the ONE definition — it is read by the native mount gate, the JS bar,
+ * the dismiss affordances, and the coachmark, so a second copy would drift.
+ * All three inputs are cheap presence / rare-change selectors.
+ */
+export function useIsActivelyClimbing(): boolean {
+  const bluetoothConnected = useBluetoothConnectedStatus();
+  const hasWallClimb = useHasWallClimb();
+  const { sessionId } = useQueueSessionId();
+  return bluetoothConnected || hasWallClimb || sessionId !== null;
+}

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -5,6 +5,7 @@ import { useTheme } from '../providers/theme-provider';
 import { isTabsRoute } from '../lib/route-segments';
 import { useStickyAccessoryPresence } from './use-sticky-accessory-presence';
 import { useNativeAccessoryActive, useNativeTabBar } from './use-bottom-accessory';
+import { useAccessoryDismissed } from './use-accessory-dismissed';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 
 /**
@@ -22,7 +23,11 @@ export function useBottomChromeMetrics() {
   // board-presence ("on the wall") climb counts too. Use the same sticky wrapper
   // as the accessory mount gate so the JS-vs-native arbitration tracks what the
   // accessory host actually shows (incl. its brief presence-blip hold).
-  const hasCurrentClimb = useStickyAccessoryPresence();
+  // When the user has tucked the bar away (and isn't actively climbing) it claims
+  // no space — list/scroll padding and floating-control offsets reclaim it. Applied
+  // OUTSIDE the sticky presence grace so a deliberate hide is reflected immediately.
+  const accessoryDismissed = useAccessoryDismissed();
+  const hasCurrentClimb = useStickyAccessoryPresence() && !accessoryDismissed;
   const { variant } = useTheme();
   const insideTabs = isTabsRoute(segments);
   const nativeAccessoryActive = useNativeAccessoryActive();

--- a/packages/mobile/src/lib/__tests__/accessory-dismiss-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/accessory-dismiss-store.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getMock = vi.fn();
+const setMock = vi.fn();
+vi.mock('../preference-store', () => ({
+  getPreference: (key: string) => getMock(key),
+  setPreference: (key: string, value: unknown) => setMock(key, value),
+  removePreference: vi.fn(),
+}));
+
+import {
+  dismissAccessory,
+  resetAccessoryDismiss,
+  useDismissedAccessoryUuid,
+  __resetAccessoryDismissStoreForTests,
+} from '../accessory-dismiss-store';
+
+const STORAGE_KEY = 'boardsesh_accessory_dismiss_v1';
+
+describe('accessory-dismiss-store', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    setMock.mockReset();
+    __resetAccessoryDismissStoreForTests();
+  });
+
+  it('starts null and hydrates a persisted dismissed uuid from storage', async () => {
+    getMock.mockResolvedValue({ dismissedQueueItemUuid: 'climb-1' });
+    const { result } = renderHook(() => useDismissedAccessoryUuid());
+    expect(result.current).toBeNull();
+    await waitFor(() => expect(result.current).toBe('climb-1'));
+    expect(getMock).toHaveBeenCalledWith(STORAGE_KEY);
+  });
+
+  it('hydrates to null when nothing is stored', async () => {
+    getMock.mockResolvedValue(null);
+    const { result } = renderHook(() => useDismissedAccessoryUuid());
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  it('dismissAccessory sets the uuid and persists it', async () => {
+    getMock.mockResolvedValue(null);
+    const { result } = renderHook(() => useDismissedAccessoryUuid());
+    await waitFor(() => expect(result.current).toBeNull());
+    act(() => dismissAccessory('climb-2'));
+    expect(result.current).toBe('climb-2');
+    expect(setMock).toHaveBeenCalledWith(STORAGE_KEY, { dismissedQueueItemUuid: 'climb-2' });
+  });
+
+  it('resetAccessoryDismiss clears the uuid and persists null', async () => {
+    getMock.mockResolvedValue({ dismissedQueueItemUuid: 'climb-3' });
+    const { result } = renderHook(() => useDismissedAccessoryUuid());
+    await waitFor(() => expect(result.current).toBe('climb-3'));
+    act(() => resetAccessoryDismiss());
+    expect(result.current).toBeNull();
+    expect(setMock).toHaveBeenCalledWith(STORAGE_KEY, { dismissedQueueItemUuid: null });
+  });
+
+  it('a dismiss before hydration wins over the stale persisted value', async () => {
+    // Storage holds an old dismissal, but the user dismisses a new climb before
+    // the async read resolves — the explicit choice must not be clobbered.
+    let resolveStored: (value: { dismissedQueueItemUuid: string } | null) => void = () => {};
+    getMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStored = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useDismissedAccessoryUuid());
+    act(() => dismissAccessory('fresh'));
+    expect(result.current).toBe('fresh');
+    await act(async () => {
+      resolveStored({ dismissedQueueItemUuid: 'stale' });
+    });
+    expect(result.current).toBe('fresh');
+  });
+});

--- a/packages/mobile/src/lib/accessory-dismiss-hint-store.ts
+++ b/packages/mobile/src/lib/accessory-dismiss-hint-store.ts
@@ -1,0 +1,72 @@
+// "Has the one-time dismiss coachmark been seen?" — a single persisted boolean,
+// shown once while the bar is in the dismissible (no climbing-signal) state to
+// teach that the strip can be tucked away. Same module-store pattern as
+// grade-format-preference.ts; persisted via AsyncStorage (non-secret).
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+const STORAGE_KEY = 'boardsesh_accessory_dismiss_hint_seen_v1';
+
+type HintSnapshot = { seen: boolean; loaded: boolean };
+
+let seen = false;
+let hasLoaded = false;
+let snapshot: HintSnapshot = { seen, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: HintSnapshot = { seen: false, loaded: false };
+
+function notify(): void {
+  snapshot = { seen, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+async function load(): Promise<void> {
+  if (hasLoaded) return;
+  const stored = await getPreference<boolean>(STORAGE_KEY);
+  if (hasLoaded) return;
+  seen = stored === true;
+  hasLoaded = true;
+  notify();
+}
+
+export function markAccessoryDismissHintSeen(): void {
+  if (hasLoaded && seen) return;
+  seen = true;
+  hasLoaded = true;
+  notify();
+  void setPreference<boolean>(STORAGE_KEY, true);
+}
+
+let loadPromise: Promise<void> | null = null;
+function ensureLoaded(): Promise<void> {
+  if (!loadPromise) loadPromise = load();
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): HintSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): HintSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useAccessoryDismissHintSeen(): { seen: boolean; loaded: boolean; markSeen: () => void } {
+  const { seen: seenValue, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  useEffect(() => {
+    void ensureLoaded();
+  }, []);
+  const markSeen = useCallback(() => {
+    markAccessoryDismissHintSeen();
+  }, []);
+  return { seen: seenValue, loaded, markSeen };
+}

--- a/packages/mobile/src/lib/accessory-dismiss-store.ts
+++ b/packages/mobile/src/lib/accessory-dismiss-store.ts
@@ -1,0 +1,108 @@
+// Local, persisted state for "the user tucked away the active-climb accessory
+// bar." It holds the queue-item uuid of the climb that was dismissed — NOT a bare
+// boolean — so a dismiss attaches to one specific stale climb and stops applying
+// the moment a different climb becomes current (its uuid no longer matches).
+//
+// Crucially this is a UI-only flag: dismissing the bar must NEVER mutate the queue
+// (no DELTA_UPDATE_CURRENT_CLIMB / DELTA_REMOVE_QUEUE_ITEM / CLEAR_QUEUE) and never
+// release a board hold. The climb stays current and reachable from Record / the
+// queue sheet; only the strip is hidden.
+//
+// Persisted via AsyncStorage (non-secret) so the choice survives a cold start —
+// the bar stays tucked away across launches until the user connects to / switches
+// boards (see use-accessory-dismiss-resets) or the current climb changes.
+//
+// Module-store shape mirrors grade-format-preference.ts: `current`/`hasLoaded` are
+// canonical; `snapshot` is the referentially-stable compound value consumers read,
+// rebuilt ONLY in notify() so useSyncExternalStore never trips its changed-snapshot
+// loop. Bump the key suffix if the persisted shape changes.
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+const STORAGE_KEY = 'boardsesh_accessory_dismiss_v1';
+
+type DismissSnapshot = { dismissedQueueItemUuid: string | null; loaded: boolean };
+type StoredDismiss = { dismissedQueueItemUuid: string | null };
+
+let current: string | null = null;
+let hasLoaded = false;
+let snapshot: DismissSnapshot = { dismissedQueueItemUuid: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: DismissSnapshot = { dismissedQueueItemUuid: null, loaded: false };
+
+function notify(): void {
+  snapshot = { dismissedQueueItemUuid: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+export async function loadAccessoryDismiss(): Promise<void> {
+  if (hasLoaded) return;
+  const stored = await getPreference<StoredDismiss>(STORAGE_KEY);
+  // A dismiss/reset may have raced in while we awaited storage — honour it over
+  // the (now stale) persisted value.
+  if (hasLoaded) return;
+  current = stored && typeof stored.dismissedQueueItemUuid === 'string' ? stored.dismissedQueueItemUuid : null;
+  hasLoaded = true;
+  notify();
+}
+
+/** Tuck the bar away for this specific climb (queue-item uuid). */
+export function dismissAccessory(queueItemUuid: string): void {
+  if (hasLoaded && current === queueItemUuid) return;
+  current = queueItemUuid;
+  hasLoaded = true;
+  notify();
+  void setPreference<StoredDismiss>(STORAGE_KEY, { dismissedQueueItemUuid: queueItemUuid });
+}
+
+/** Bring the bar back (board connect/switch, ticking the climb, etc.). */
+export function resetAccessoryDismiss(): void {
+  if (hasLoaded && current === null) return;
+  current = null;
+  hasLoaded = true;
+  notify();
+  void setPreference<StoredDismiss>(STORAGE_KEY, { dismissedQueueItemUuid: null });
+}
+
+// One-time load, memoized as a promise singleton so it fires exactly once no
+// matter how many consumers mount (or how often StrictMode re-invokes effects).
+let loadPromise: Promise<void> | null = null;
+function ensureLoaded(): Promise<void> {
+  if (!loadPromise) loadPromise = loadAccessoryDismiss();
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): DismissSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): DismissSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useDismissedAccessoryUuid(): string | null {
+  const { dismissedQueueItemUuid } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  // Kick the one-time AsyncStorage hydrate from an effect (not render/subscribe).
+  useEffect(() => {
+    void ensureLoaded();
+  }, []);
+  return dismissedQueueItemUuid;
+}
+
+// Test-only: reset module state between cases. Not for app use.
+export function __resetAccessoryDismissStoreForTests(): void {
+  current = null;
+  hasLoaded = false;
+  snapshot = { dismissedQueueItemUuid: null, loaded: false };
+  loadPromise = null;
+  listeners.clear();
+}

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -273,12 +273,16 @@ type QueueLiveStatsContextValue = {
 const QueueLiveStatsContext = createContext<QueueLiveStatsContextValue | null>(null);
 
 /**
- * Active-climb selector context. Changes identity ONLY when the active climb's
- * uuid changes, so the climb list (which highlights the active row) stops
- * re-rendering on every unrelated queue mutation or party push.
+ * Active-climb selector context. Carries both the active climb's uuid (for the
+ * climb list, which highlights the matching row regardless of which queue item it
+ * came from) and the active queue-ITEM uuid (unique per enqueue, for features that
+ * must distinguish a re-added climb as a fresh activation — e.g. the accessory
+ * dismiss). Identity changes only when one of these changes, so it stays off the
+ * hot path of unrelated queue mutations / party pushes.
  */
 type QueueActiveClimbContextValue = {
   activeClimbUuid: string | null;
+  activeClimbQueueItemUuid: string | null;
 };
 
 const QueueActiveClimbContext = createContext<QueueActiveClimbContextValue | null>(null);
@@ -349,6 +353,18 @@ export function useActiveClimbUuid(): string | null {
   const context = useContext(QueueActiveClimbContext);
   if (!context) throw new Error('useActiveClimbUuid must be used within QueueProvider');
   return context.activeClimbUuid;
+}
+
+/**
+ * The active queue-ITEM uuid (unique per enqueue), not the climb uuid. The same
+ * climb re-added from search / a playlist / a peer broadcast is a distinct item,
+ * so this changes where {@link useActiveClimbUuid} would not — exactly the
+ * granularity the accessory dismiss keys on so a fresh activation un-hides the bar.
+ */
+export function useActiveClimbQueueItemUuid(): string | null {
+  const context = useContext(QueueActiveClimbContext);
+  if (!context) throw new Error('useActiveClimbQueueItemUuid must be used within QueueProvider');
+  return context.activeClimbQueueItemUuid;
 }
 
 export function useHasActiveClimb(): boolean {
@@ -1674,7 +1690,11 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // changes (memoized on the uuid string), so highlight-only consumers like the
   // climb list don't re-render on unrelated queue mutations or party pushes.
   const activeClimbUuid = state.currentClimbQueueItem?.climb?.uuid ?? null;
-  const activeClimbValue = useMemo<QueueActiveClimbContextValue>(() => ({ activeClimbUuid }), [activeClimbUuid]);
+  const activeClimbQueueItemUuid = state.currentClimbQueueItem?.uuid ?? null;
+  const activeClimbValue = useMemo<QueueActiveClimbContextValue>(
+    () => ({ activeClimbUuid, activeClimbQueueItemUuid }),
+    [activeClimbUuid, activeClimbQueueItemUuid],
+  );
 
   // Presence-only selector: flips solely when a climb appears/disappears, so
   // bottom-chrome consumers (whole tab screens) don't re-render on climb-to-climb

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -10,6 +10,12 @@
       "viewProfile": "View {{name}}'s profile",
       "thisClimber": "this climber"
     },
+    "accessoryBar": {
+      "coachmarkHint": "Not climbing right now? You can tuck this away.",
+      "coachmarkGotIt": "Got it",
+      "hideControlAria": "Hide the current climb",
+      "hideControlHint": "Keeps it in your queue"
+    },
     "more": {
       "title": "More",
       "library": "Library",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -208,6 +208,12 @@
       "viewProfile": "Ver el perfil de {{name}}",
       "thisClimber": "este escalador"
     },
+    "accessoryBar": {
+      "coachmarkHint": "¿No estás escalando ahora? Puedes ocultarlo.",
+      "coachmarkGotIt": "Entendido",
+      "hideControlAria": "Ocultar el bloque actual",
+      "hideControlHint": "Lo mantiene en tu cola"
+    },
     "more": {
       "title": "Más",
       "library": "Biblioteca",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -10,6 +10,12 @@
       "viewProfile": "Voir le profil de {{name}}",
       "thisClimber": "ce grimpeur"
     },
+    "accessoryBar": {
+      "coachmarkHint": "Pas en train de grimper ? Tu peux le masquer.",
+      "coachmarkGotIt": "Compris",
+      "hideControlAria": "Masquer le bloc actuel",
+      "hideControlHint": "Le garde dans ta file d'attente"
+    },
     "more": {
       "title": "Plus",
       "library": "Bibliothèque",


### PR DESCRIPTION
## Why

The persistent "now playing" strip (current climb + grade + tick, above the tab bar) showed on **every** tab whenever a climb was current — including the social Home/Discover/Profile tabs. The visibility rule conflated *"a climb is queued"* with *"the user is climbing right now,"* so casually previewing a climb pinned the strip indefinitely (the solo queue even persists across launches), with no way to tuck it away. Users complained it's always there even when they're not at the gym.

## What

The strip now behaves like a music mini-player: present and useful while you climb, dismissable when you're not — without eroding its strengths.

- **Hide-only, never destructive.** Dismissing writes a local, persisted `{ dismissedQueueItemUuid }` and dispatches **no** queue action. The queue and current climb are untouched and still reachable from Record / the queue sheet. Party-mode safe (local store, no peer desync).
- **Climbing-signal gated (root-cause fix).** `useIsActivelyClimbing = bluetoothConnected || liveWallClimb || inSession` (one shared hook). While any holds, the bar asserts itself, is non-dismissible, and the hide affordance does not render — an active climber never loses one-tap return or quick-tick.
- **Keyed to the queue item**, not the climb, so re-adding the same climb is a fresh activation that un-hides for free. Persists across launches; clears when the user **connects to** or **switches** boards.
- **Affordances.** JS bar: swipe down (plus a VoiceOver "Hide" action since a swipe isn't screen-reader-reachable). iOS 26 Liquid Glass platter: an explicit hide chevron, visually separated from the tick (fat-finger guard). The native UIKit host unmounts cleanly when hidden (no doubled-snapshot regression). A one-time coachmark teaches it.

Design was worked through a UX panel; product decisions (native affordance, BLE = climbing, persist-until-board-change, coachmark) confirmed with the requester.

## Files

New: `accessory-dismiss-store.ts`, `accessory-dismiss-hint-store.ts`, `use-actively-climbing.ts`, `use-accessory-dismissed.ts`, `use-accessory-dismiss-resets.ts`, `AccessoryDismissResets.tsx`, `AccessoryDismissHint.tsx`.
Wired through: `use-accessory-climb-tap.ts`, `ClimbCapsule.tsx`, `NativeAccessoryClimbRow.tsx`, `persistent-queue-bar.tsx`, `use-bottom-chrome-metrics.ts`, `app/(tabs)/_layout.tsx`, `app/_layout.tsx`, `queue-provider.tsx` (new `useActiveClimbQueueItemUuid` selector). i18n added to en/es/fr.

## Testing

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` ✓ (2385 tests; new unit tests for the store + `useIsActivelyClimbing` + `useAccessoryDismissed`, plus dismiss-coverage tests in the tab-layout and persistent-bar suites)
- `vp run check:mobile-bundle` ✓ (Android 10.9 MB)
- i18n catalog-completeness ✓
- Adversarial multi-agent review pass applied (queue-item-uuid keying fix + a11y improvements).

⚠️ **Needs on-device (macOS) QA:** the iOS 26 native platter chevron + clean-unmount-on-hide (no doubled-text snapshot) can't be exercised on the Linux bundle check. QA plan in `.boardsesh/qa-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)