### PR TITLE
fix(mobile): accessory-bar "On the wall" status + tap-a-climb sets it active

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
+++ b/packages/mobile/app/(tabs)/climbs/[climbUuid].tsx
@@ -56,7 +56,9 @@ export default function ClimbDetail() {
     if (firedRef.current) return;
     if (!climb || !hasRequiredParams) return;
     firedRef.current = true;
-    // setAsCurrent:false so a deep-linked climb doesn't disturb the queue.
+    // preview:true so a deep-linked climb doesn't disturb the queue (in a session
+    // it would change the shared current climb for everyone). The drawer shows it
+    // with a "Preview" badge + "Set active" to opt into playing it.
     openClimbInPlayDrawer(
       {
         kind: 'climb',
@@ -70,6 +72,7 @@ export default function ClimbDetail() {
         },
       },
       { openPlayDrawer, router },
+      { preview: true },
     );
     if (router.canGoBack()) {
       router.back();

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -29,6 +29,9 @@ type ClimbActionsSheetProps = {
   angle: number;
   /** Current signed-in user id — gates the owner-only Edit row. */
   currentUserId?: string | null;
+  /** When provided, shows a "Preview" row that opens the climb view-only (a
+   *  "Preview" badge + "Set active") instead of the default tap-to-activate. */
+  onPreview?: () => void;
   onAddToQueue?: () => void;
   onOpenPlaylist?: () => void;
   onToggleFavorite?: () => void;
@@ -58,6 +61,7 @@ function ClimbActionsSheet({
   setIds,
   angle,
   currentUserId,
+  onPreview,
   onAddToQueue,
   onOpenPlaylist,
   onToggleFavorite,
@@ -86,6 +90,11 @@ function ClimbActionsSheet({
       isPresentedRef.current = false;
     }
   }, [visible, climb]);
+
+  const handlePreview = useCallback(() => {
+    onPreview?.();
+    onClose();
+  }, [onPreview, onClose]);
 
   const handleAddToQueue = useCallback(() => {
     onAddToQueue?.();
@@ -220,6 +229,14 @@ function ClimbActionsSheet({
         />
       )}
       <View style={styles.content}>
+        {onPreview && (
+          <ListRow
+            title={t('mobile.climbActions.preview')}
+            leading={<Icon name="visibility" size={22} color={accentActionIconColor} />}
+            onPress={handlePreview}
+            showSeparator
+          />
+        )}
         {onAddToQueue && (
           <ListRow
             title={t('mobile.climbRow.addToQueue')}

--- a/packages/mobile/src/components/DrawerHeader.tsx
+++ b/packages/mobile/src/components/DrawerHeader.tsx
@@ -10,21 +10,26 @@ type DrawerHeaderProps = {
   /** Centered column content (e.g. title + subtitle, or a name input + counts). */
   center: ReactNode;
   /** Left-aligned element on the same row as `center`/`trailing` (e.g. an on-wall
-   *  status). When provided it REPLACES the auto-width spacer, so `center` is no
-   *  longer mirror-centered against `trailing` — pass it only when an off-centre
-   *  name is acceptable. Omit it (the default) to keep `center` optically centered. */
+   *  status). When provided, BOTH flanks take the wider of the two natural widths
+   *  so `center` stays optically screen-centered (the leading element sits left,
+   *  the trailing element right, the centered name between them). Omit it (the
+   *  default) to keep the original behaviour: an auto-width spacer mirroring
+   *  `trailing`. */
   leading?: ReactNode;
   /** Right-aligned element (e.g. a grade, an angle, a validity check). Its width
-   *  is measured at runtime and mirrored into the leading spacer so `center`
+   *  is measured at runtime and mirrored into the leading slot so `center`
    *  stays centered regardless of the trailing element's width. */
   trailing?: ReactNode;
   trailingMinWidth?: number;
 };
 
 /**
- * Shared drawer header chassis: a centered column flanked by a measured-width
- * trailing slot and a matching leading spacer. Used by the Play Drawer (name +
- * stats + grade) and the Create Drawer (name input + start/finish + validity).
+ * Shared drawer header chassis: a centered column flanked by measured-width
+ * leading/trailing slots. With no `leading`, an auto-width spacer mirrors the
+ * trailing element (Create Drawer; ordinary Play Drawer headers). With a
+ * `leading` element, both flanks size to the wider of the two so the title stays
+ * centered. Used by the Play Drawer (name + stats + grade, plus an optional
+ * on-wall status on the left).
  */
 export const DrawerHeader = memo(function DrawerHeader({
   center,
@@ -33,24 +38,49 @@ export const DrawerHeader = memo(function DrawerHeader({
   trailingMinWidth = DEFAULT_TRAILING_MIN_WIDTH,
 }: DrawerHeaderProps) {
   const [trailingWidth, setTrailingWidth] = useState(trailingMinWidth);
+  const [leadingWidth, setLeadingWidth] = useState(0);
 
   const handleTrailingLayout = useCallback((event: LayoutChangeEvent) => {
     const measured = Math.ceil(event.nativeEvent.layout.width);
     setTrailingWidth((previous) => (previous === measured ? previous : measured));
   }, []);
 
+  const handleLeadingLayout = useCallback((event: LayoutChangeEvent) => {
+    const measured = Math.ceil(event.nativeEvent.layout.width);
+    setLeadingWidth((previous) => (previous === measured ? previous : measured));
+  }, []);
+
+  // With a leading element both flanks share the wider natural width, so the
+  // centered name stays screen-centered instead of drifting toward the narrower
+  // (grade) side. The inner measure views size to their content (flexShrink 0),
+  // so the onLayout widths are intrinsic — not the constrained slot width.
+  const hasLeading = leading != null;
+  const sideWidth = Math.max(leadingWidth, trailingWidth);
+
   return (
     <View style={styles.container}>
       <View style={styles.headerRow}>
-        {leading != null ? (
-          <View style={styles.leading}>{leading}</View>
+        {hasLeading ? (
+          <View style={[styles.side, { width: sideWidth }]}>
+            <View style={styles.sideMeasure} onLayout={handleLeadingLayout}>
+              {leading}
+            </View>
+          </View>
         ) : (
           <View style={[styles.leadingSpacer, { width: trailingWidth }]} />
         )}
         <View style={styles.centerColumn}>{center}</View>
-        <View style={[styles.trailing, { minWidth: trailingMinWidth }]} onLayout={handleTrailingLayout}>
-          {trailing}
-        </View>
+        {hasLeading ? (
+          <View style={[styles.side, styles.sideTrailing, { width: sideWidth }]}>
+            <View style={styles.sideMeasure} onLayout={handleTrailingLayout}>
+              {trailing}
+            </View>
+          </View>
+        ) : (
+          <View style={[styles.trailing, { minWidth: trailingMinWidth }]} onLayout={handleTrailingLayout}>
+            {trailing}
+          </View>
+        )}
       </View>
     </View>
   );
@@ -71,10 +101,6 @@ const styles = StyleSheet.create({
   leadingSpacer: {
     flexShrink: 0,
   },
-  leading: {
-    flexShrink: 1,
-    alignItems: 'flex-start',
-  },
   centerColumn: {
     flex: 1,
     minWidth: 0,
@@ -83,5 +109,16 @@ const styles = StyleSheet.create({
   trailing: {
     flexShrink: 0,
     alignItems: 'flex-end',
+  },
+  // Equal-width flanks used when a leading element is present.
+  side: {
+    flexShrink: 0,
+    alignItems: 'flex-start',
+  },
+  sideTrailing: {
+    alignItems: 'flex-end',
+  },
+  sideMeasure: {
+    flexShrink: 0,
   },
 });

--- a/packages/mobile/src/components/DrawerHeader.tsx
+++ b/packages/mobile/src/components/DrawerHeader.tsx
@@ -53,9 +53,10 @@ export const DrawerHeader = memo(function DrawerHeader({
   // With a leading element both flanks share the wider natural width, so the
   // centered name stays screen-centered instead of drifting toward the narrower
   // (grade) side. The inner measure views size to their content (flexShrink 0),
-  // so the onLayout widths are intrinsic — not the constrained slot width.
+  // so the onLayout widths are intrinsic — not the constrained slot width. The
+  // `trailingMinWidth` floor matches the no-leading branch's trailing minWidth.
   const hasLeading = leading != null;
-  const sideWidth = Math.max(leadingWidth, trailingWidth);
+  const sideWidth = Math.max(leadingWidth, trailingWidth, trailingMinWidth);
 
   return (
     <View style={styles.container}>

--- a/packages/mobile/src/components/DrawerHeader.tsx
+++ b/packages/mobile/src/components/DrawerHeader.tsx
@@ -9,6 +9,11 @@ const DEFAULT_TRAILING_MIN_WIDTH: number = spacing[12];
 type DrawerHeaderProps = {
   /** Centered column content (e.g. title + subtitle, or a name input + counts). */
   center: ReactNode;
+  /** Left-aligned element on the same row as `center`/`trailing` (e.g. an on-wall
+   *  status). When provided it REPLACES the auto-width spacer, so `center` is no
+   *  longer mirror-centered against `trailing` — pass it only when an off-centre
+   *  name is acceptable. Omit it (the default) to keep `center` optically centered. */
+  leading?: ReactNode;
   /** Right-aligned element (e.g. a grade, an angle, a validity check). Its width
    *  is measured at runtime and mirrored into the leading spacer so `center`
    *  stays centered regardless of the trailing element's width. */
@@ -23,6 +28,7 @@ type DrawerHeaderProps = {
  */
 export const DrawerHeader = memo(function DrawerHeader({
   center,
+  leading,
   trailing,
   trailingMinWidth = DEFAULT_TRAILING_MIN_WIDTH,
 }: DrawerHeaderProps) {
@@ -36,7 +42,11 @@ export const DrawerHeader = memo(function DrawerHeader({
   return (
     <View style={styles.container}>
       <View style={styles.headerRow}>
-        <View style={[styles.leadingSpacer, { width: trailingWidth }]} />
+        {leading != null ? (
+          <View style={styles.leading}>{leading}</View>
+        ) : (
+          <View style={[styles.leadingSpacer, { width: trailingWidth }]} />
+        )}
         <View style={styles.centerColumn}>{center}</View>
         <View style={[styles.trailing, { minWidth: trailingMinWidth }]} onLayout={handleTrailingLayout}>
           {trailing}
@@ -60,6 +70,10 @@ const styles = StyleSheet.create({
   },
   leadingSpacer: {
     flexShrink: 0,
+  },
+  leading: {
+    flexShrink: 1,
+    alignItems: 'flex-start',
   },
   centerColumn: {
     flex: 1,

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -234,4 +234,20 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
     expect(onEditEntry).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it('hides the Preview row unless onPreview is provided', () => {
+    render(<ClimbActionsSheet visible={true} {...baseProps} />);
+    expect(screen.queryByText('mobile.climbActions.preview')).toBeNull();
+  });
+
+  it('fires onPreview then onClose from the Preview row (view-only open)', () => {
+    const onPreview = vi.fn();
+    const onClose = vi.fn();
+    render(<ClimbActionsSheet visible={true} {...baseProps} onClose={onClose} onPreview={onPreview} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.preview'));
+
+    expect(onPreview).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -22,6 +22,7 @@ import { PlaybackControls } from './PlaybackControls';
 import { useMobilePlayback } from './use-mobile-playback';
 import { PlayDrawerHeader } from './PlayDrawerHeader';
 import { PlayDrawerPreviewBanner } from './PlayDrawerPreviewBanner';
+import { PlayDrawerOnWallBanner } from './PlayDrawerOnWallBanner';
 import { PlayDrawerActionBar } from './PlayDrawerActionBar';
 import { SwitchBoardOverlay } from './SwitchBoardOverlay';
 import { LogAscentSheet } from '../LogAscentSheet';
@@ -75,9 +76,18 @@ export type PlayDrawerOpenOptions = {
    * user can promote it. Used by genuinely view-only surfaces — the workout
    * builder, logbook / feed / climb-view browse, and the peer-driven wall climb
    * behind the accessory bar. The lightbulb keeps acting on the active climb,
-   * not this preview.
+   * not this preview. (The wall climb opts into `previewIsWallClimb` below, which
+   * swaps the "Preview / Set active" banner for a read-only "Now on the wall".)
    */
   previewQueueItem?: ClimbQueueItem | null;
+  /**
+   * The preview is the live wall climb behind the accessory bar — a peer (or
+   * another climber on this board) is driving the wall and this climb is lit
+   * right now. Renders the read-only "Now on the wall" status banner instead of
+   * "Preview / Set active": it isn't a browse preview to promote, it's already
+   * on the wall. Only meaningful alongside `previewQueueItem`.
+   */
+  previewIsWallClimb?: boolean;
   /**
    * Playlist source that seeds the drawer's next/previous suggestions for a
    * preview open (the suggestion source isn't on the queue yet). Drives
@@ -139,6 +149,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [drawerPreviewSuggestionSource, setDrawerPreviewSuggestionSource] = useState<PlaylistSuggestionSource | null>(
     null,
   );
+  // True when the preview is the live wall climb (accessory bar). Swaps the
+  // "Preview / Set active" banner for the read-only "Now on the wall" status.
+  const [drawerPreviewIsWallClimb, setDrawerPreviewIsWallClimb] = useState(false);
   const [isMirrored, setIsMirrored] = useState(false);
   // Local optimistic override for the heart. `null` means "no local change —
   // show the server's favorite status". A tap sets it optimistically, the
@@ -294,6 +307,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
       // the drawer renders the real currentClimbQueueItem.
       setDrawerPreviewItem(previewItem);
       setDrawerPreviewSuggestionSource(previewItem ? playlistSuggestionSource : null);
+      setDrawerPreviewIsWallClimb(previewItem ? (options?.previewIsWallClimb ?? false) : false);
       setIsMirrored(false);
       // Drop any stale optimistic heart so the opened climb shows its real
       // (server) favorite status rather than a leftover from the last climb.
@@ -350,6 +364,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const handleClose = useCallback(() => {
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
+    setDrawerPreviewIsWallClimb(false);
     setIsMirrored(false);
     setIsTickBarActive(false);
     setIsSheetOpen(false);
@@ -362,6 +377,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const handlePrev = useCallback(() => {
     // Always-live: navigation commits the shared current climb for everyone.
     setDrawerPreviewItem(null);
+    setDrawerPreviewIsWallClimb(false);
     previousClimb();
     setIsMirrored(false);
     // The favorite override is cleared by the climb-change effect.
@@ -370,6 +386,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const handleNext = useCallback(() => {
     // Always-live: navigation commits the shared current climb for everyone.
     setDrawerPreviewItem(null);
+    setDrawerPreviewIsWallClimb(false);
     nextClimb();
     setIsMirrored(false);
     // The favorite override is cleared by the climb-change effect.
@@ -383,6 +400,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     setCurrentClimb(drawerPreviewItem, { playlistSuggestionSource: drawerPreviewSuggestionSource });
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
+    setDrawerPreviewIsWallClimb(false);
   }, [drawerPreviewItem, drawerPreviewSuggestionSource, setCurrentClimb]);
 
   const handleMirror = useCallback(() => {
@@ -605,10 +623,16 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                 />
 
                 {isPreview ? (
-                  // Cross-board previews use the switch-board overlay instead, so
-                  // hide "Set active" there — promoting a foreign-board climb would
-                  // only spill it into the queue.
-                  <PlayDrawerPreviewBanner showSetActive={!boardMismatch} onSetActive={handleSetActive} />
+                  drawerPreviewIsWallClimb ? (
+                    // The accessory-bar wall climb is physically lit right now, so
+                    // it's a read-only status, not a promotable preview — no button.
+                    <PlayDrawerOnWallBanner />
+                  ) : (
+                    // Cross-board previews use the switch-board overlay instead, so
+                    // hide "Set active" there — promoting a foreign-board climb would
+                    // only spill it into the queue.
+                    <PlayDrawerPreviewBanner showSetActive={!boardMismatch} onSetActive={handleSetActive} />
+                  )
                 ) : null}
 
                 <View style={styles.boardSection}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -73,17 +73,18 @@ export type PlayDrawerOpenOptions = {
   /**
    * View-only preview: show this item in the drawer WITHOUT committing it to the
    * queue. The drawer renders a "Preview" badge + a "Set active" button so the
-   * user can promote it. Used by genuinely view-only surfaces — the workout
-   * builder, logbook / feed / climb-view browse, and the peer-driven wall climb
-   * behind the accessory bar. The lightbulb keeps acting on the active climb,
-   * not this preview. (The wall climb opts into `previewIsWallClimb` below, which
-   * swaps the "Preview / Set active" banner for a read-only "Now on the wall".)
+   * user can promote it. Used by the explicit "Preview" climb action, the
+   * deep-link / standalone climb-page route, the workout builder, and the
+   * peer-driven wall climb behind the accessory bar. The lightbulb keeps acting
+   * on the active climb, not this preview. (The wall climb opts into
+   * `previewIsWallClimb` below, which swaps the "Preview / Set active" banner for
+   * the read-only "On the wall" status.)
    */
   previewQueueItem?: ClimbQueueItem | null;
   /**
    * The preview is the live wall climb behind the accessory bar — a peer (or
    * another climber on this board) is driving the wall and this climb is lit
-   * right now. Renders the read-only "Now on the wall" status banner instead of
+   * right now. Renders the read-only "On the wall" status banner instead of
    * "Preview / Set active": it isn't a browse preview to promote, it's already
    * on the wall. Only meaningful alongside `previewQueueItem`.
    */
@@ -150,7 +151,7 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
     null,
   );
   // True when the preview is the live wall climb (accessory bar). Swaps the
-  // "Preview / Set active" banner for the read-only "Now on the wall" status.
+  // "Preview / Set active" banner for the read-only "On the wall" status.
   const [drawerPreviewIsWallClimb, setDrawerPreviewIsWallClimb] = useState(false);
   const [isMirrored, setIsMirrored] = useState(false);
   // Local optimistic override for the heart. `null` means "no local change —

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -620,19 +620,17 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
                   setterUsername={displayedClimb.setter_username}
                   isNoMatch={displayedClimb.is_no_match}
                   benchmarkDifficulty={displayedClimb.benchmark_difficulty}
+                  // The accessory-bar wall climb is physically lit right now, so its
+                  // read-only "on the wall" status rides in the header's leading slot
+                  // (left of the name, opposite the grade) rather than as a banner.
+                  leading={isPreview && drawerPreviewIsWallClimb ? <PlayDrawerOnWallBanner /> : undefined}
                 />
 
-                {isPreview ? (
-                  drawerPreviewIsWallClimb ? (
-                    // The accessory-bar wall climb is physically lit right now, so
-                    // it's a read-only status, not a promotable preview — no button.
-                    <PlayDrawerOnWallBanner />
-                  ) : (
-                    // Cross-board previews use the switch-board overlay instead, so
-                    // hide "Set active" there — promoting a foreign-board climb would
-                    // only spill it into the queue.
-                    <PlayDrawerPreviewBanner showSetActive={!boardMismatch} onSetActive={handleSetActive} />
-                  )
+                {isPreview && !drawerPreviewIsWallClimb ? (
+                  // Cross-board previews use the switch-board overlay instead, so
+                  // hide "Set active" there — promoting a foreign-board climb would
+                  // only spill it into the queue.
+                  <PlayDrawerPreviewBanner showSetActive={!boardMismatch} onSetActive={handleSetActive} />
                 ) : null}
 
                 <View style={styles.boardSection}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, type ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
@@ -21,6 +21,9 @@ type PlayDrawerHeaderProps = {
   /** Intrinsic attributes shown as grey glyphs after the name. */
   isNoMatch?: boolean | null;
   benchmarkDifficulty?: string | null;
+  /** Left-aligned element on the name's row (e.g. the on-wall status). Shifts the
+   *  centered name right — pass only when that's acceptable. */
+  leading?: ReactNode;
 };
 
 export const PlayDrawerHeader = memo(function PlayDrawerHeader({
@@ -32,6 +35,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   setterUsername,
   isNoMatch,
   benchmarkDifficulty,
+  leading,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
   const gradeColor = useMemo(
@@ -47,6 +51,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
 
   return (
     <DrawerHeader
+      leading={leading}
       center={
         <>
           <View style={styles.nameRow}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -21,8 +21,8 @@ type PlayDrawerHeaderProps = {
   /** Intrinsic attributes shown as grey glyphs after the name. */
   isNoMatch?: boolean | null;
   benchmarkDifficulty?: string | null;
-  /** Left-aligned element on the name's row (e.g. the on-wall status). Shifts the
-   *  centered name right — pass only when that's acceptable. */
+  /** Left-aligned element on the name's row (e.g. the on-wall status). The header
+   *  balances both flanks so the name stays centered. */
   leading?: ReactNode;
 };
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawerOnWallBanner.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerOnWallBanner.tsx
@@ -1,0 +1,49 @@
+import { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+/**
+ * Status banner shown in the play drawer when the displayed climb is the live
+ * wall climb behind the accessory bar — a peer (or another climber on this
+ * board) is driving the wall over BLE and this climb is physically lit right
+ * now. Unlike {@link PlayDrawerPreviewBanner}, there's no "Set active": the
+ * climb isn't a browse preview to promote, it's already on the wall. So this is
+ * a read-only status chip, no affordance.
+ */
+export const PlayDrawerOnWallBanner = memo(function PlayDrawerOnWallBanner() {
+  const { t } = useTranslation('session');
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.chip}>
+        <Text variant="caption1" color={iosSystemColors.white} style={styles.chipLabel}>
+          {t('playView.onWallBadge')}
+        </Text>
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: spacing[4],
+    marginTop: spacing[1],
+    marginBottom: spacing[2],
+  },
+  chip: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[1] / 2,
+    borderRadius: borderRadius.sm,
+    backgroundColor: iosSystemColors.systemGreen,
+  },
+  chipLabel: {
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawerOnWallBanner.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerOnWallBanner.tsx
@@ -1,29 +1,44 @@
-import { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { memo, useContext } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
+import { BoardPresenceCurrentContext } from '@boardsesh/board-presence-react';
 import { Text } from '../Text';
-import { iosSystemColors } from '../../theme/ios-colors';
-import { spacing, borderRadius } from '../../theme/tokens';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
 
 /**
- * Status banner shown in the play drawer when the displayed climb is the live
- * wall climb behind the accessory bar — a peer (or another climber on this
- * board) is driving the wall over BLE and this climb is physically lit right
- * now. Unlike {@link PlayDrawerPreviewBanner}, there's no "Set active": the
- * climb isn't a browse preview to promote, it's already on the wall. So this is
- * a read-only status chip, no affordance.
+ * Status line shown in the play drawer when the displayed climb is the live wall
+ * climb behind the accessory bar — a peer (or another climber on this board) is
+ * driving the wall over BLE and this climb is physically lit right now.
+ *
+ * Unlike {@link PlayDrawerPreviewBanner}, this is *read-only* ambient status, not
+ * a promotable preview, so it deliberately sits a tier quieter: no filled chip,
+ * just a broadcast glyph + an amber footnote line. It speaks the same vocabulary
+ * as the BoardSheet "Now on the wall" hero (amber accent + the holder's "Lit by
+ * {name}" identity), so the drawer and the sheet read as one system.
  */
 export const PlayDrawerOnWallBanner = memo(function PlayDrawerOnWallBanner() {
   const { t } = useTranslation('session');
+  const { brandColors } = useTheme();
+
+  // Read the presence context directly (non-throwing): gorhom portals the play
+  // drawer to a modal host, so this can render outside the provider subtree —
+  // degrade to the anonymous "On the wall" label instead of crashing, exactly as
+  // BoardConnectionBadge does. The holder IS the sender, so identity comes from
+  // the live current climb, falling back to the holder record for a late joiner.
+  const current = useContext(BoardPresenceCurrentContext);
+  const litByName = (current?.currentClimb?.sentByDisplayName ?? current?.holder?.displayName ?? null)?.trim() || null;
+  const label = litByName ? t('mobile.boardPresence.litByLine', { name: litByName }) : t('playView.onWallBadge');
 
   return (
-    <View style={styles.row}>
-      <View style={styles.chip}>
-        <Text variant="caption1" color={iosSystemColors.white} style={styles.chipLabel}>
-          {t('playView.onWallBadge')}
-        </Text>
-      </View>
-    </View>
+    <Animated.View entering={FadeIn.springify().damping(15).stiffness(200)} style={styles.row}>
+      <Icon name="bluetooth.connected" size={13} color={brandColors.warning} />
+      <Text variant="footnote" color={brandColors.warning} numberOfLines={1} style={styles.label}>
+        {label}
+      </Text>
+    </Animated.View>
   );
 });
 
@@ -31,19 +46,12 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
+    gap: spacing[1],
     marginHorizontal: spacing[4],
     marginTop: spacing[1],
     marginBottom: spacing[2],
   },
-  chip: {
-    paddingHorizontal: spacing[2],
-    paddingVertical: spacing[1] / 2,
-    borderRadius: borderRadius.sm,
-    backgroundColor: iosSystemColors.systemGreen,
-  },
-  chipLabel: {
-    fontWeight: '700',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+  label: {
+    flexShrink: 1,
   },
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawerOnWallBanner.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerOnWallBanner.tsx
@@ -18,6 +18,11 @@ import { spacing } from '../../theme/tokens';
  * just a broadcast glyph + an amber footnote line. It speaks the same vocabulary
  * as the BoardSheet "Now on the wall" hero (amber accent + the holder's "Lit by
  * {name}" identity), so the drawer and the sheet read as one system.
+ *
+ * Renders inline in the DrawerHeader's leading slot — to the left of the climb
+ * name, opposite the grade — so it reads as chrome in the corner rather than a
+ * banner pushing the board down. The header supplies the row padding, so this
+ * component carries no outer margins.
  */
 export const PlayDrawerOnWallBanner = memo(function PlayDrawerOnWallBanner() {
   const { t } = useTranslation('session');
@@ -43,13 +48,12 @@ export const PlayDrawerOnWallBanner = memo(function PlayDrawerOnWallBanner() {
 });
 
 const styles = StyleSheet.create({
+  // Margin-free: this renders inline in the DrawerHeader leading slot, which
+  // supplies the row's padding/gap. The grade sits in the trailing slot opposite.
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],
-    marginHorizontal: spacing[4],
-    marginTop: spacing[1],
-    marginBottom: spacing[2],
   },
   label: {
     flexShrink: 1,

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPreviewBanner.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPreviewBanner.tsx
@@ -16,10 +16,12 @@ type PlayDrawerPreviewBannerProps = {
 
 /**
  * Banner shown in the play drawer when the displayed climb is a *preview* — a
- * climb the user is browsing (workout builder, logbook/cross-board, the
- * peer-driven wall climb) that is NOT their active/wall climb. The lightbulb acts
- * on the active climb, not this preview, so the banner makes that explicit and
- * offers a one-tap "Set active" to promote it.
+ * climb the user is browsing (workout builder, logbook/cross-board) that is NOT
+ * their active/wall climb. The lightbulb acts on the active climb, not this
+ * preview, so the banner makes that explicit and offers a one-tap "Set active"
+ * to promote it. The peer-driven accessory-bar wall climb is *not* a preview in
+ * this sense — it's physically lit — so it renders {@link PlayDrawerOnWallBanner}
+ * (read-only, no "Set active") instead.
  */
 export const PlayDrawerPreviewBanner = memo(function PlayDrawerPreviewBanner({
   showSetActive,

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-on-wall-banner.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-on-wall-banner.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// t echoes the key so the badge copy is assertable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { white: '#FFFFFF', systemGreen: '#34C759' },
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 4: 16 },
+  borderRadius: { sm: 4 },
+}));
+
+import { PlayDrawerOnWallBanner } from '../PlayDrawerOnWallBanner';
+
+describe('PlayDrawerOnWallBanner', () => {
+  it('renders the "Now on the wall" badge', () => {
+    const { container } = render(createElement(PlayDrawerOnWallBanner));
+    expect(container.textContent).toContain('playView.onWallBadge');
+  });
+
+  it('renders no button — the wall climb is a read-only status, not a promotable preview', () => {
+    const { container } = render(createElement(PlayDrawerOnWallBanner));
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.textContent).not.toContain('playView.setActive');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-on-wall-banner.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-on-wall-banner.test.tsx
@@ -1,40 +1,86 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, type ContextType, type ReactNode } from 'react';
 
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
 
-// t echoes the key so the badge copy is assertable.
+// Animated.View just renders children; FadeIn is a no-op chainable.
+vi.mock('react-native-reanimated', () => {
+  const chain: Record<string, () => unknown> = {};
+  chain.springify = () => chain;
+  chain.damping = () => chain;
+  chain.stiffness = () => chain;
+  return {
+    default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+    FadeIn: chain,
+  };
+});
+
+// t interpolates the holder name so "Lit by {name}" is assertable.
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, opts?: { name?: string }) => {
+      if (key === 'mobile.boardPresence.litByLine') return `Lit by ${opts?.name}`;
+      if (key === 'playView.onWallBadge') return 'On the wall';
+      return key;
+    },
+  }),
 }));
 
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 
-vi.mock('../../../theme/ios-colors', () => ({
-  iosSystemColors: { white: '#FFFFFF', systemGreen: '#34C759' },
+// Icon renders an identifiable marker so the glyph name is assertable.
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { warning: '#B45309' } }),
 }));
 
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 4: 16 },
-  borderRadius: { sm: 4 },
 }));
 
+// A real context (created inside the hoisted factory) so the test can inject a
+// holder via its Provider; imported back below to reach the same instance.
+vi.mock('@boardsesh/board-presence-react', async () => {
+  const React = await import('react');
+  return { BoardPresenceCurrentContext: React.createContext<unknown>(null) };
+});
+
+import { BoardPresenceCurrentContext } from '@boardsesh/board-presence-react';
 import { PlayDrawerOnWallBanner } from '../PlayDrawerOnWallBanner';
 
 describe('PlayDrawerOnWallBanner', () => {
-  it('renders the "Now on the wall" badge', () => {
+  it('shows the broadcast glyph and a quiet "On the wall" line for an anonymous holder', () => {
     const { container } = render(createElement(PlayDrawerOnWallBanner));
-    expect(container.textContent).toContain('playView.onWallBadge');
+    expect(container.textContent).toContain('On the wall');
+    expect(container.querySelector('[data-icon="bluetooth.connected"]')).toBeTruthy();
   });
 
-  it('renders no button — the wall climb is a read-only status, not a promotable preview', () => {
+  it('attributes the climb to the holder when their name is known', () => {
+    // Runtime uses the mocked context; the cast only satisfies the real type.
+    const presenceValue = { currentClimb: { sentByDisplayName: 'Marco' }, holder: null } as unknown as ContextType<
+      typeof BoardPresenceCurrentContext
+    >;
+    const { container } = render(
+      createElement(
+        BoardPresenceCurrentContext.Provider,
+        { value: presenceValue },
+        createElement(PlayDrawerOnWallBanner),
+      ),
+    );
+    expect(container.textContent).toContain('Lit by Marco');
+    expect(container.textContent).not.toContain('On the wall');
+  });
+
+  it('renders no button and no "Set active" — it is read-only status, not a promotable preview', () => {
     const { container } = render(createElement(PlayDrawerOnWallBanner));
     expect(container.querySelector('button')).toBeNull();
     expect(container.textContent).not.toContain('playView.setActive');

--- a/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
@@ -93,13 +93,15 @@ describe('useAccessoryClimbTap', () => {
     });
   });
 
-  it('opens a peer-driven wall climb as a preview when a board feed is live', () => {
+  it('opens a peer-driven wall climb as a read-only "Now on the wall" view when a board feed is live', () => {
     wall.climb = makeClimb('wall');
     renderHook(() => useAccessoryClimbTap());
     tap.onEnd?.();
-    // The wall climb isn't the local current, so it opens view-only (badged).
+    // The wall climb isn't the local current and is physically lit, so it opens
+    // view-only with `previewIsWallClimb` (no "Set active" takeover).
     expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-wall' }), {
       previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-wall' }) }),
+      previewIsWallClimb: true,
       source: 'current_queue_item',
     });
   });

--- a/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
@@ -39,14 +39,16 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
     // When the bar mirrors the local queue head, open it active (it already IS
     // current, so openDrawer won't re-append it). When a live feed makes the bar
     // show a peer-driven WALL climb that isn't your current, open it as a
-    // view-only preview (badged) — you're looking at someone else's wall, not
-    // taking it over until you choose to. Both are queue-bar opens, so keep the
+    // read-only "Now on the wall" view (`previewIsWallClimb`) — it's physically
+    // lit right now, so there's no "Set active" takeover; you're just looking at
+    // someone else's wall. Both are queue-bar opens, so keep the
     // `current_queue_item` analytics source.
     if (accessoryClimb.uuid === currentClimbQueueItem?.climb.uuid) {
       openPlayDrawer(accessoryClimb, { source: 'current_queue_item' });
     } else {
       openPlayDrawer(accessoryClimb, {
         previewQueueItem: climbToQueueItem(accessoryClimb),
+        previewIsWallClimb: true,
         source: 'current_queue_item',
       });
     }

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -59,7 +59,8 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
   const handleActivate = useCallback(
     (ascent: AscentFeedItem) => {
       track(SHARED_EVENTS.LogbookRowClicked, { climbUuid: ascent.climbUuid });
-      openClimbInPlayDrawer({ kind: 'tick', tick: ascent }, { openPlayDrawer, router }, { setAsCurrent: true });
+      // Default open mode is now "set active", so no option is needed here.
+      openClimbInPlayDrawer({ kind: 'tick', tick: ascent }, { openPlayDrawer, router });
     },
     [openPlayDrawer, router],
   );

--- a/packages/mobile/src/lib/__tests__/open-climb-in-play-drawer.test.ts
+++ b/packages/mobile/src/lib/__tests__/open-climb-in-play-drawer.test.ts
@@ -42,32 +42,32 @@ beforeEach(() => {
 });
 
 describe('openClimbInPlayDrawer', () => {
-  it('kind:climb opens the drawer as a view-only preview with the given board config, tagged as a climb-view', () => {
+  it('kind:climb opens active by default (no preview), tagged as a climb-view', () => {
     const deps = makeDeps();
     const climb = { uuid: 'c-1', name: 'X' } as Climb;
     const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 40 };
-    // Default (setAsCurrent omitted) is a view-only preview.
+    // Default is now "set active": no previewQueueItem (pressing a climb plays it).
     openClimbInPlayDrawer({ kind: 'climb', climb, boardConfig }, deps);
     expect(deps.openPlayDrawer).toHaveBeenCalledWith(climb, {
-      previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'c-1' }) }),
       boardConfig,
       source: 'climb_view',
     });
     expect(deps.router.push).not.toHaveBeenCalled();
   });
 
-  it('kind:climb with setAsCurrent opens active (no preview)', () => {
+  it('kind:climb with preview:true opens a view-only preview (previewQueueItem set)', () => {
     const deps = makeDeps();
     const climb = { uuid: 'c-1', name: 'X' } as Climb;
     const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 40 };
-    openClimbInPlayDrawer({ kind: 'climb', climb, boardConfig }, deps, { setAsCurrent: true });
+    openClimbInPlayDrawer({ kind: 'climb', climb, boardConfig }, deps, { preview: true });
     expect(deps.openPlayDrawer).toHaveBeenCalledWith(climb, {
+      previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'c-1' }) }),
       boardConfig,
       source: 'climb_view',
     });
   });
 
-  it('kind:tick with frames opens a view-only preview with a resolved board config (no route push)', () => {
+  it('kind:tick with frames opens active by default with a resolved board config (no route push)', () => {
     mockedGetBoardConfig.mockReturnValue(KILTER_CONFIG);
     const deps = makeDeps();
     openClimbInPlayDrawer({ kind: 'tick', tick: makeTick({ angle: 50 }) }, deps);
@@ -77,8 +77,16 @@ describe('openClimbInPlayDrawer', () => {
       boardConfig: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20,33', angle: 50 },
       source: 'climb_view',
     });
-    expect(options.previewQueueItem?.climb?.uuid).toBe('climb-1');
+    expect(options.previewQueueItem).toBeUndefined();
     expect(deps.router.push).not.toHaveBeenCalled();
+  });
+
+  it('kind:tick with preview:true opens a view-only preview', () => {
+    mockedGetBoardConfig.mockReturnValue(KILTER_CONFIG);
+    const deps = makeDeps();
+    openClimbInPlayDrawer({ kind: 'tick', tick: makeTick({ angle: 50 }) }, deps, { preview: true });
+    const [, options] = deps.openPlayDrawer.mock.calls[0];
+    expect(options.previewQueueItem?.climb?.uuid).toBe('climb-1');
   });
 
   it('kind:tick without frames falls back to the climb route', () => {

--- a/packages/mobile/src/lib/open-climb-in-play-drawer.ts
+++ b/packages/mobile/src/lib/open-climb-in-play-drawer.ts
@@ -38,14 +38,15 @@ export type OpenClimbArgs =
 
 export type OpenClimbOptions = {
   /**
-   * When `true`, the opened climb is set as the current climb (and appended to
-   * the queue) — a tap-to-activate. Defaults to `false` (view-only preview: the
-   * drawer shows it with a "Preview" badge + "Set active" and leaves the queue
-   * untouched), preserving the original behaviour for every existing caller.
-   * Ignored on the `ref` fallback, which routes through the climb page and opens
-   * with its own default.
+   * When `true`, the climb opens **view-only**: the drawer shows it with a
+   * "Preview" badge + a "Set active" button and leaves the queue untouched.
+   * Defaults to `false` — the climb is set as the current climb (and appended to
+   * the queue), so pressing a climb plays it. Used by the explicit "Preview"
+   * climb action and the deep-link / standalone climb-page route. Ignored on the
+   * `ref` fallback, which routes through the climb page and opens with its own
+   * default.
    */
-  setAsCurrent?: boolean;
+  preview?: boolean;
 };
 
 /**
@@ -53,8 +54,8 @@ export type OpenClimbOptions = {
  * (commit) or shown view-only (preview). A preview anchors navigation on a fresh
  * queue item without committing it; an active open lets the drawer commit.
  */
-function openModeOptions(climb: Climb, setAsCurrent: boolean): Pick<OpenPlayDrawerOptions, 'previewQueueItem'> {
-  return setAsCurrent ? {} : { previewQueueItem: climbToQueueItem(climb) };
+function openModeOptions(climb: Climb, preview: boolean): Pick<OpenPlayDrawerOptions, 'previewQueueItem'> {
+  return preview ? { previewQueueItem: climbToQueueItem(climb) } : {};
 }
 
 /**
@@ -67,11 +68,11 @@ function openModeOptions(climb: Climb, setAsCurrent: boolean): Pick<OpenPlayDraw
  */
 export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, options?: OpenClimbOptions): void {
   const { openPlayDrawer, router } = deps;
-  const setAsCurrent = options?.setAsCurrent ?? false;
+  const preview = options?.preview ?? false;
 
   if (args.kind === 'climb') {
     openPlayDrawer(args.climb, {
-      ...openModeOptions(args.climb, setAsCurrent),
+      ...openModeOptions(args.climb, preview),
       boardConfig: args.boardConfig,
       source: 'climb_view',
     });
@@ -83,7 +84,7 @@ export function openClimbInPlayDrawer(args: OpenClimbArgs, deps: OpenClimbDeps, 
     const config = getBoardConfigForPlaylist(args.tick.boardType, args.tick.layoutId);
     if (climb && config) {
       openPlayDrawer(climb, {
-        ...openModeOptions(climb, setAsCurrent),
+        ...openModeOptions(climb, preview),
         boardConfig: {
           boardName: config.boardName,
           layoutId: config.layoutId,

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -350,6 +350,21 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     addToQueue({ uuid: randomUUID(), climb: climbActions.climb });
   }, [climbActions, addToQueue]);
 
+  const handleClimbActionsPreview = useCallback(() => {
+    if (!climbActions) return;
+    // View-only: open with a previewQueueItem (badge + "Set active") instead of
+    // committing. Mirror the board-sheet override rule so a cross-board climb
+    // still renders the switch-board overlay; same-board needs no override.
+    const boardConfigOverride = boardConfigsMatch(climbActions.boardConfig, activeBoardConfigRef.current)
+      ? undefined
+      : climbActions.boardConfig;
+    openPlayDrawer(climbActions.climb, {
+      previewQueueItem: climbToQueueItem(climbActions.climb),
+      boardConfig: boardConfigOverride,
+      source: 'climb_view',
+    });
+  }, [climbActions, openPlayDrawer]);
+
   const handleClimbActionsToggleFavorite = useCallback(() => {
     if (!climbActions) return;
     const isNowFavorited = !favoritesStore.getIsFavorited(climbActions.climb.uuid);
@@ -660,6 +675,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           setIds={climbActions.boardConfig.setIds}
           angle={climbActions.boardConfig.angle}
           currentUserId={profile?.id ?? null}
+          onPreview={handleClimbActionsPreview}
           onAddToQueue={handleClimbActionsAddToQueue}
           onOpenPlaylist={handleClimbActionsOpenPlaylist}
           onToggleFavorite={handleClimbActionsToggleFavorite}

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -684,6 +684,7 @@
       "benchmark": "Benchmark"
     },
     "climbActions": {
+      "preview": "Preview",
       "copyLink": "Copy link",
       "linkCopied": "Link copied",
       "tick": "Log a tick",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -484,6 +484,7 @@
   },
   "playView": {
     "previewBadge": "Preview",
+    "onWallBadge": "Now on the wall",
     "setActive": "Set active",
     "previousFrame": "Previous frame",
     "nextFrame": "Next frame",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -484,7 +484,7 @@
   },
   "playView": {
     "previewBadge": "Preview",
-    "onWallBadge": "Now on the wall",
+    "onWallBadge": "On the wall",
     "setActive": "Set active",
     "previousFrame": "Previous frame",
     "nextFrame": "Next frame",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -684,6 +684,7 @@
       "benchmark": "Benchmark"
     },
     "climbActions": {
+      "preview": "Vista previa",
       "copyLink": "Copiar enlace",
       "linkCopied": "Enlace copiado",
       "tick": "Registrar un envío",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -484,6 +484,7 @@
   },
   "playView": {
     "previewBadge": "Vista previa",
+    "onWallBadge": "Ahora en el muro",
     "setActive": "Activar",
     "previousFrame": "Fotograma anterior",
     "nextFrame": "Fotograma siguiente",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -484,7 +484,7 @@
   },
   "playView": {
     "previewBadge": "Vista previa",
-    "onWallBadge": "Ahora en el muro",
+    "onWallBadge": "En el muro",
     "setActive": "Activar",
     "previousFrame": "Fotograma anterior",
     "nextFrame": "Fotograma siguiente",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -684,6 +684,7 @@
       "benchmark": "Benchmark"
     },
     "climbActions": {
+      "preview": "Aperçu",
       "copyLink": "Copier le lien",
       "linkCopied": "Lien copié",
       "tick": "Enregistrer une croix",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -484,7 +484,7 @@
   },
   "playView": {
     "previewBadge": "Aperçu",
-    "onWallBadge": "Sur le mur maintenant",
+    "onWallBadge": "Sur le mur",
     "setActive": "Activer",
     "previousFrame": "Image précédente",
     "nextFrame": "Image suivante",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -484,6 +484,7 @@
   },
   "playView": {
     "previewBadge": "Aperçu",
+    "onWallBadge": "Sur le mur maintenant",
     "setActive": "Activer",
     "previousFrame": "Image précédente",
     "nextFrame": "Image suivante",


### PR DESCRIPTION
Two related play-drawer changes for the mobile app.

## 1. Accessory-bar peer wall climb → "On the wall" status

Tapping the bottom accessory bar while a session peer (or another climber on the board) drives the wall over BLE used to open the play drawer with an orange **"Preview"** badge + a **"Set active"** button. The climb is physically on the wall, so that's wrong.

It now shows a quiet **"on the wall" status** that speaks the same language as the BoardSheet "Now on the wall" hero: a small amber broadcast glyph + footnote in the header's leading slot (left of the climb name, opposite the grade) — **"Lit by {name}"** when the holder is known, **"On the wall"** when anonymous. No pill, theme-driven amber (adapts light/dark + Liquid Glass/Material), gentle fade-in. The header balances both flanks so the name stays centered.

Threaded via an explicit `previewIsWallClimb` flag from the accessory tap (deterministic — that branch only fires for the wall climb), so the drawer doesn't re-read board presence through the gorhom portal.

## 2. Tapping a climb sets it active; preview is now an explicit action

Pressing a climb anywhere (feed, profile, sessions, logbook) opened the drawer in view-only **preview** (badge + Set active), leaving the queue untouched. That inverts the expectation that pressing a climb plays it — and the preview was a workaround for a BLE mismatch that committing actually **fixes** (displayed climb == current climb, so the lightbulb acts on what's on screen). Cross-board climbs already gate the controls with the switch-board overlay.

- Flipped the default in `openClimbInPlayDrawer` from preview → **set active** (`setAsCurrent` → `preview`, default `false`).
- **Preview** is now an explicit "Preview" row (eye icon) in the climb actions sheet.
- **Deep-link / standalone climb-page** opens stay **preview-by-default** so a shared link doesn't disturb the queue (in a session, the shared current climb). All `ref`-routed opens inherit this.
- Cross-board → switch-board overlay (unchanged). All preview machinery (`PlayDrawerPreviewBanner`, etc.) retained.

**Behavior note:** in a party session, tapping a climb now changes the shared current climb for everyone (consistent with always-live sessions).

## Validation

- `vp run typecheck:mobile` ✓
- `vp test run --project mobile` — 2385/2385 ✓ (added on-wall banner, preview-row, and default-flip tests)
- i18n `catalog-completeness` parity (`playView.onWallBadge`, `mobile.climbActions.preview`) ✓
- `vp run check:mobile-bundle` — OK (10.9 MB) ✓
- `vp check` — lint/format clean ✓
- Manual QA on device: looks good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)