### PR TITLE
ci(mobile-screenshots): parallelize iOS by locale and stop the simulator thrash

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -7,16 +7,27 @@ name: Mobile Screenshots (Native)
 # The screenshot app is a Debug dev-client that loads its JS from Metro, so the
 # native .app is reusable: it's cached (actions/cache) keyed on native inputs and
 # only rebuilt when those change. A JS-only run is a cache hit → install + Metro +
-# Maestro (~5 min) instead of a ~30-min from-scratch native compile.
+# Maestro instead of a ~30-min from-scratch native compile.
+#
+# iOS is a 3-job fan-out so locales capture in parallel and a single overloaded
+# runner never thrashes:
+#   ios-build    — build/restore the cached .app ONCE (no per-shard cold build).
+#   ios-capture  — matrix over locale (en-US, es, fr); each shard captures its 3
+#                  devices sequentially under one Metro, with --shutdown so only
+#                  ONE simulator is booted at a time (3 booted at once is what made
+#                  the old single-job run thrash and time out at "iOS driver not
+#                  ready in time").
+#   ios-finalize — merge the per-locale artifacts into one tree, run the dimension
+#                  gate (it needs all four App Store locales at once), and upload.
 #
 # All runs capture against PROD signed in as the test user (the canonical store
 # recipe), so there's no local backend / Colima — the build just talks to the
 # production backend.
 #
-# On a manual dispatch with `upload = true`, it also uploads the freshly captured
-# screenshots via fastlane (fastlane/Fastfile, screenshots ONLY — no binary or
-# text metadata). The nightly cron never uploads (it only captures); uploading
-# mutates live store listing assets, so it's opt-in per dispatch.
+# On a manual dispatch with `upload = true`, ios-finalize also uploads the freshly
+# captured screenshots via fastlane (fastlane/Fastfile, screenshots ONLY — no
+# binary or text metadata). The nightly cron never uploads (it only captures);
+# uploading mutates live store listing assets, so it's opt-in per dispatch.
 
 on:
   workflow_dispatch:
@@ -61,15 +72,88 @@ permissions:
   contents: read
 
 jobs:
-  ios:
+  # Build (or restore) the prebuilt simulator dev-client .app ONCE, so the three
+  # ios-capture shards don't each cold-build it on a cache miss (the thundering
+  # herd). It's a dev-client shell that loads its JS from Metro, so the native
+  # binary only changes when NATIVE inputs change — the key hashes exactly those
+  # (Expo/RN/native-module versions in packages/mobile/package.json, native config
+  # in app.config.ts, the config plugins + native modules, patch-package patches,
+  # and the root @expo/cli / react-native-screens pins). JS/TS-only and web-only
+  # changes (incl. bun.lock churn) do NOT bust it, so the common path is a cache
+  # hit and skips the ~30-min native build. Bump `-v1-` to force a rebuild.
+  # runner.arch is in the key because a simulator .app is arch-specific.
+  ios-build:
     runs-on: macos-26
-    timeout-minutes: 180
+    timeout-minutes: 60
+    outputs:
+      cache-key: ${{ steps.appkey.outputs.key }}
+    env:
+      # Reused from ios-rn-ci.yml so the Expo build links the same native config.
+      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      # Compute the .app cache key ONCE and surface it as a job output so every
+      # ios-capture shard restores the exact same bucket.
+      - name: Compute app cache key
+        id: appkey
+        run: echo "key=${{ runner.os }}-${{ runner.arch }}-screenshot-sim-app-v1-${{ hashFiles('packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'packages/mobile/package.json', 'patches/**', 'package.json') }}" >> "$GITHUB_OUTPUT"
+
+      # lookup-only: this job only needs to KNOW whether the .app is cached (the
+      # shards do the actual restore), so on a hit we skip downloading a .app this
+      # job never uses — keeping the common-path critical path to ~1-2 min.
+      - name: Check for cached simulator app
+        id: app-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: packages/mobile/.app-cache
+          key: ${{ steps.appkey.outputs.key }}
+          lookup-only: true
+
+      # Deps are only needed to build; skipped entirely on a cache hit.
+      - name: Install Node.js dependencies
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: bun install --frozen-lockfile
+
+      # Cache miss (a native-input change) → build the .app from scratch with
+      # xcodebuild (runs to completion; no `expo run:ios` launch-step hang).
+      - name: Build simulator dev-client app
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: vp run mobile:build-sim-app -- --app-out packages/mobile/.app-cache --clean
+
+      # Save for the ios-capture shards (and future runs). Only on a miss — on a
+      # hit the entry already exists.
+      - name: Save simulator app to cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: packages/mobile/.app-cache
+          key: ${{ steps.appkey.outputs.key }}
+
+  ios-capture:
+    needs: ios-build
+    runs-on: macos-26
+    timeout-minutes: 60
+    strategy:
+      # One locale failing shouldn't abandon the others — let them all finish so
+      # ios-finalize can report exactly which locale is short.
+      fail-fast: false
+      matrix:
+        locale: [en-US, es, fr]
 
     env:
-      # Marks an upload dispatch — gates the App Store Connect upload steps so the
-      # nightly cron and capture-only runs never touch ASC.
-      UPLOAD_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.upload }}
-      # Reused from ios-rn-ci.yml so the Expo build links the same native config.
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
@@ -78,6 +162,11 @@ jobs:
       # repo secrets if a different account is ever needed.
       SCREENSHOT_USER_EMAIL: ${{ secrets.SCREENSHOT_USER_EMAIL || 'test@boardsesh.com' }}
       SCREENSHOT_USER_PASSWORD: ${{ secrets.SCREENSHOT_USER_PASSWORD || 'test' }}
+      # Belt-and-suspenders ceiling for Maestro's XCTest driver startup. With
+      # --shutdown there's only one booted sim per shard so the default should
+      # pass; this is free on the happy path (a timeout cap, not a fixed wait) and
+      # guards against a slow cold runner ("iOS driver not ready in time").
+      MAESTRO_DRIVER_STARTUP_TIMEOUT: '300000'
 
     steps:
       - name: Checkout repository
@@ -93,28 +182,16 @@ jobs:
       - name: Install Node.js dependencies
         run: bun install --frozen-lockfile
 
-      # Restore the prebuilt simulator dev-client .app. It's a dev-client shell
-      # that loads its JS from Metro, so the native binary only changes when
-      # NATIVE inputs change — the key hashes exactly those (Expo/RN/native-module
-      # versions in packages/mobile/package.json, native config in app.config.ts,
-      # the config plugins + native modules, patch-package patches, and the root
-      # @expo/cli / react-native-screens pins). JS/TS-only and web-only changes
-      # (incl. bun.lock churn) do NOT bust it, so the common path is a cache hit
-      # and skips the ~30-min native build. Bump `-v1-` to force a rebuild.
-      # runner.arch is in the key because a simulator .app is arch-specific.
+      # Restore the .app ios-build produced — read-only (never save) and
+      # fail-on-cache-miss so a shard can NEVER silently cold-build. ios-build
+      # populates the cache before these shards start (needs: + cache saves at job
+      # end), so this restore is a guaranteed hit.
       - name: Restore prebuilt simulator app
-        id: app-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: packages/mobile/.app-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-screenshot-sim-app-v1-${{ hashFiles('packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'packages/mobile/package.json', 'patches/**', 'package.json') }}
-
-      # Cache miss (a native-input change) → build the .app from scratch with
-      # xcodebuild (runs to completion; no `expo run:ios` launch-step hang).
-      # actions/cache saves packages/mobile/.app-cache at job end for the next run.
-      - name: Build simulator dev-client app
-        if: steps.app-cache.outputs.cache-hit != 'true'
-        run: vp run mobile:build-sim-app -- --app-out packages/mobile/.app-cache --clean
+          key: ${{ needs.ios-build.outputs.cache-key }}
+          fail-on-cache-miss: true
 
       - name: Install Maestro
         # Pinned to a specific GitHub Releases asset and verified against a
@@ -135,11 +212,16 @@ jobs:
           unzip -q maestro.zip -d "$HOME/.maestro-dist"
           echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"
 
-      - name: Capture screenshots
-        # Installs the prebuilt .app, starts Metro with the screenshot env, and
-        # runs Maestro — no native build on this path. Always against prod (signed
-        # in as the test user); no EXPO_PUBLIC_BACKEND_URL override, so the bundle
-        # uses the app's production backend defaults.
+      - name: Capture screenshots (${{ matrix.locale }})
+        # Installs the prebuilt .app, starts Metro with the screenshot env for this
+        # locale, and runs Maestro — no native build on this path. Always against
+        # prod (signed in as the test user); no EXPO_PUBLIC_BACKEND_URL override, so
+        # the bundle uses the app's production backend defaults. --locales is a
+        # single value here: `es` expands to both es-ES and es-MX in this shard, so
+        # the three shards together produce all four App Store locales. --shutdown
+        # tears down each device's simulator after its capture so only one sim is
+        # booted at a time (the fix for the multi-sim thrash that timed the old
+        # single-job run out at the 3rd device).
         run: |
           set -euo pipefail
           vp run mobile:screenshots -- \
@@ -147,7 +229,8 @@ jobs:
             --flow "${{ inputs.flow || 'app-store' }}" \
             --backend prod \
             --devices "${{ inputs.devices || 'common' }}" \
-            --locales "${{ inputs.locales || 'all' }}" \
+            --locales "${{ matrix.locale }}" \
+            --shutdown \
             --app-path packages/mobile/.app-cache/Boardsesh.app
 
       # On a capture failure, save Maestro's debug output (the failure screenshot +
@@ -167,15 +250,69 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: capture-debug
+          # Per-locale name: upload-artifact@v4 rejects two uploads with the same
+          # name in one run.
+          name: capture-debug-${{ matrix.locale }}
           path: capture-debug/**
           if-no-files-found: warn
           retention-days: 14
 
+      # Hand this locale's PNGs to ios-finalize. The artifact's internal layout is
+      # <app-store-locale>/<device>/NN-name.png (upper paths stripped to the
+      # least-common-ancestor); locale dirs are disjoint across shards, so the
+      # merge in ios-finalize has no collisions. Short retention — it's an
+      # intermediate; the combined tree is re-uploaded by ios-finalize.
+      - name: Upload locale screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-screenshots-${{ matrix.locale }}
+          path: app-stores/apple/screenshots/**
+          if-no-files-found: warn
+          retention-days: 1
+
+  ios-finalize:
+    needs: ios-capture
+    # Run even if a capture shard failed, so the dimension gate still reports the
+    # gap (a missing locale fails it loudly rather than uploading a partial set).
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      # Marks an upload dispatch — gates the App Store Connect upload steps so the
+      # nightly cron and capture-only runs never touch ASC.
+      UPLOAD_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.upload }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Install Node.js dependencies
+        run: bun install --frozen-lockfile
+
+      # Merge every per-locale artifact back into ONE app-stores/apple/screenshots
+      # tree. merge-multiple flattens all matching artifacts into the single path,
+      # preserving each one's <locale>/<device>/NN-name.png layout — so the gate
+      # and fastlane see the full four-locale tree.
+      - name: Download locale screenshots
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ios-screenshots-*
+          path: app-stores/apple/screenshots
+          merge-multiple: true
+
       # Fail loudly if any capture isn't an App Store-accepted size for its slot,
-      # so deliver can't get silently rejected by Apple (or route to the wrong
-      # slot). Runs on every capture, including nightly — an early warning if a
-      # future simulator/Xcode bump changes the capture resolution.
+      # or if a locale/device folder is missing — so deliver can't get silently
+      # rejected by Apple (or upload a partial set). Requires all four App Store
+      # locales at once, which is why it runs here after the merge, not per-shard.
       - name: Assert screenshot dimensions
         run: vp run check:screenshot-dimensions -- --platform ios
 
@@ -183,7 +320,9 @@ jobs:
       # Screenshots ONLY — no binary, no metadata, no review submission. Gated
       # behind the `upload` input, which is unset on the schedule cron. The
       # `success() &&` prefix is required: a custom `if:` overrides the default
-      # success() status check, so without it these would run even if capture failed.
+      # success() status check, so without it these would run even if a prior step
+      # failed. fastlane's screenshots lane is a pure network upload (no Xcode), so
+      # it runs fine on ubuntu.
       - name: Set up Ruby + fastlane
         if: success() && env.UPLOAD_RUN == 'true'
         uses: ruby/setup-ruby@v1
@@ -284,13 +423,20 @@ jobs:
           yes | sdkmanager --licenses > /dev/null 2>&1 || true
           sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
+      # ~/.gradle/caches holds the cross-run Gradle build cache (--build-cache
+      # below), which caches the expensive native/CMake/Kotlin compile by content
+      # hash — the dominant cost. The release APK bakes the JS bundle in, so it's
+      # never cached as a whole; only inputs-unchanged tasks are reused, and the
+      # JS-bundle task always re-runs when the JS changes (so screenshots can't go
+      # stale). The key busts on native-config inputs (app.config.ts, plugins,
+      # patches) so a stale build cache can't mask a native change.
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-rn-screenshots-${{ hashFiles('packages/mobile/package.json', 'bun.lock') }}
+          key: ${{ runner.os }}-gradle-rn-screenshots-${{ hashFiles('packages/mobile/package.json', 'packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'patches/**', 'bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-gradle-rn-screenshots-
 
@@ -321,7 +467,10 @@ jobs:
         working-directory: packages/mobile/android
         env:
           SENTRY_DISABLE_AUTO_UPLOAD: 'true'
-        run: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64 -PboardseshAbiFilters=x86_64 --no-daemon --console=plain --stacktrace
+        # --build-cache reuses inputs-unchanged task outputs from ~/.gradle/caches
+        # (the native compile is the big win); --no-daemon stays as deliberate
+        # OOM insurance on the ephemeral runner.
+        run: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64 -PboardseshAbiFilters=x86_64 --build-cache --no-daemon --console=plain --stacktrace
 
       - name: Normalize screenshot APK path
         run: |


### PR DESCRIPTION
## Why

The iOS screenshot job (`mobile-screenshots.yml`) was slow **and broke partway through** — reported as "it breaks once we get to the intl screenshots."

Root cause (confirmed from [run 27687774008](https://github.com/boardsesh/boardsesh/actions/runs/27687774008/job/81890630575)): everything ran serially on one macOS runner — `for each locale (en-US, es, fr) { start Metro; for each device { capture } }` — and CI never passed `--shutdown`, so `captureIosDevice` left every simulator booted. By the **3rd device, three iOS-26 sims were booted at once** plus Metro + the Maestro XCTest driver. The runner thrashed: an **11-minute `simctl bootstatus`**, then Maestro failed with `iOS driver not ready in time`. The further into the run, the worse — hence the "breaks at intl" symptom.

## What changed (YAML only — no source changes)

Split the monolithic `ios` job into a fan-out:

| Job | Runner | Role |
|---|---|---|
| `ios-build` | macos-26 | Build/cache the dev-client `.app` **once** (`lookup-only` on a hit → no per-shard cold build, no pointless restore). |
| `ios-capture` | macos-26, **matrix: locale [en-US, es, fr]** | Each shard captures its 3 devices under one Metro **with `--shutdown`** → only one sim booted at a time (the fix), locales in parallel. |
| `ios-finalize` | ubuntu-latest | `merge-multiple` the per-locale artifacts → run the all-four-locale dimension gate → gated fastlane upload (Linux-safe) → re-upload the combined `mobile-screenshots-ios` artifact. |

`--locales es` expands to both `es-ES` and `es-MX` inside one shard, so the three shards produce all four App Store locales — no script change. `scripts/mobile-screenshots.ts` already supported `--locales <one>`, `--app-path`, and `--shutdown`.

**Android:** add Gradle `--build-cache` and widen the cache key to bust on native-config inputs. The JS bundle still rebuilds every run (the build cache only reuses inputs-unchanged native tasks), so screenshots can't go stale. (Skipped `--configuration-cache`: real plugin-compat risk in RN/Expo, ~zero benefit since `prebuild --clean` wipes it each run.)

## Impact

- **Reliability:** the multi-simulator thrash / `iOS driver not ready in time` break is eliminated (one booted sim per shard).
- **Speed:** iOS wall-clock ~45-60 min (when it didn't break) → **~20-28 min**; Android trimmed to ~15-22 min on a warm cache.

Preserved verbatim: the `upload`/`UPLOAD_RUN` gating (cron never uploads), `concurrency`, `permissions`, and the dimension gate running on every run.

## Validation

- YAML parses; `vp check` reports the file correctly formatted.
- Adversarial review traced all behavior-preservation risks (upload gating, cache handoff, the artifact round-trip incl. `es`→`es-ES`+`es-MX`, the loud-fail gate, the `--shutdown` fix) — no regressions found.
- **CI dry-run (recommended before/after merge):** `mobile-screenshots.yml` has no `environment:` gate, so it can be `workflow_dispatch`-ed from this branch with **`upload=false`**. Run it twice (cold cache → warm cache) and confirm: one booted sim at a time in the shard logs, no 11-min boot, and the merged `mobile-screenshots-ios` artifact has all 4 store locales × 3 devices with the dimension gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)