### PR TITLE
fix(mobile): cut PostHog error-tracking noise from auth + BLE flows

### DIFF
--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -198,6 +198,18 @@ the code below keys off "not a known status code" rather than a specific code.)
 `native_error_code`, and a local dev build prints a hint — see
 `nativeSignInErrorCode` in `packages/mobile/src/lib/native-auth-analytics.ts`.
 
+**Spotting it in PostHog.** This lands in error tracking as a handled exception
+tagged `source: native-auth`, `provider: google` — message `DEVELOPER_ERROR` on
+the classic flow, or a generic `Error` with the troubleshooting URL on the
+Credential Manager flow. It was the single highest-volume mobile issue in June
+2026 (163 occurrences, 11 users). A spike here is almost always an unregistered
+signing key, not a code regression — it can't be fixed in-repo. Work the table
+below: enumerate every key currently shipping `com.boardsesh.app`, confirm each
+SHA-1 has an Android OAuth client in project **401523882502**, and add any that's
+missing. (Because handled exceptions without a JS stack group together, that same
+PostHog issue also absorbs unrelated messages like "Bluetooth connection timed
+out" — don't read the whole bucket as Google Sign-In.)
+
 `com.boardsesh.app` is signed by up to three different keys, each needing its own
 Android OAuth client (same package, different SHA-1 — they coexist):
 

--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -207,8 +207,8 @@ signing key, not a code regression — it can't be fixed in-repo. Work the table
 below: enumerate every key currently shipping `com.boardsesh.app`, confirm each
 SHA-1 has an Android OAuth client in project **401523882502**, and add any that's
 missing. (Because handled exceptions without a JS stack group together, that same
-PostHog issue also absorbs unrelated messages like "Bluetooth connection timed
-out" — don't read the whole bucket as Google Sign-In.)
+PostHog issue can also absorb unrelated handled errors — filter to
+`source = native-auth` rather than reading the whole bucket as Google Sign-In.)
 
 `com.boardsesh.app` is signed by up to three different keys, each needing its own
 Android OAuth client (same package, different SHA-1 — they coexist):

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -22,6 +22,19 @@ describe('reportHandledError', () => {
     expect(mockedCaptureError).not.toHaveBeenCalled();
   });
 
+  it('drops expected auth-required GraphQL errors (a session-only query ran logged-out)', () => {
+    // graphql-request ClientError shape: the backend returns HTTP 200 with the
+    // guard message in response.errors[]. Must drop before the network check.
+    const authError = Object.assign(new Error('Authentication required to perform this operation'), {
+      response: {
+        status: 200,
+        errors: [{ message: 'Authentication required to perform this operation', path: ['myBoards'] }],
+      },
+    });
+    reportHandledError(authError, { tags: { source: 'react-query' } });
+    expect(mockedCaptureError).not.toHaveBeenCalled();
+  });
+
   it('downgrades offline fetch failures to a warning and tags them network', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { tags: { source: 'react-query' } });

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -35,6 +35,20 @@ describe('reportHandledError', () => {
     expect(mockedCaptureError).not.toHaveBeenCalled();
   });
 
+  it('drops the auth error before the network check, even when it looks transport-shaped', () => {
+    // A ClientError whose response carries no numeric status is otherwise treated
+    // as a transport/network failure and downgraded to a warning. The auth check
+    // runs first, so this is dropped entirely — locks in that ordering so a future
+    // reorder can't start leaking auth errors as network warnings.
+    const authError = Object.assign(new Error('Authentication required to perform this operation'), {
+      response: {
+        errors: [{ message: 'Authentication required to perform this operation', path: ['myBoards'] }],
+      },
+    });
+    reportHandledError(authError, { tags: { source: 'react-query' } });
+    expect(mockedCaptureError).not.toHaveBeenCalled();
+  });
+
   it('downgrades offline fetch failures to a warning and tags them network', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { tags: { source: 'react-query' } });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -112,7 +112,12 @@ import {
   subscribeNativeBleConnected,
 } from '../adapter-factory';
 import { parseBoardTypeFromDeviceName, parseSerialNumber } from '@boardsesh/ble-protocol/aurora';
-import { convertToMirroredFramesString, dispatchMoonboardPacket, useBoardBluetooth } from '../use-board-bluetooth';
+import {
+  bleConnectReportLevel,
+  convertToMirroredFramesString,
+  dispatchMoonboardPacket,
+  useBoardBluetooth,
+} from '../use-board-bluetooth';
 
 // ── Factory helpers ────────────────────────────────────────────────────────
 
@@ -1170,5 +1175,22 @@ describe('dispatchMoonboardPacket', () => {
 
     expect(result).toBe(true);
     expect(write).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bleConnectReportLevel', () => {
+  it('does not report a user-cancelled picker dismissal (null)', () => {
+    expect(bleConnectReportLevel('user_cancelled')).toBeNull();
+  });
+
+  it('downgrades environmental failures to warning', () => {
+    expect(bleConnectReportLevel('board_not_found')).toBe('warning');
+    expect(bleConnectReportLevel('connect_failed')).toBe('warning');
+  });
+
+  it('keeps genuine faults at error level', () => {
+    expect(bleConnectReportLevel('unavailable')).toBe('error');
+    expect(bleConnectReportLevel('service_missing')).toBe('error');
+    expect(bleConnectReportLevel('unknown')).toBe('error');
   });
 });

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -10,7 +10,11 @@ import {
   type LedColorOverrides,
 } from '@boardsesh/ble-protocol/aurora';
 import { getMoonboardBluetoothPacket, isMoonboardDeviceName } from '@boardsesh/ble-protocol/moonboard';
-import { classifyBleFailure, isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
+import {
+  classifyBleFailure,
+  isDisconnectionError,
+  type BleFailureCategory,
+} from '@boardsesh/ble-protocol/connection-error';
 import { boardSupportsMirroring } from '@boardsesh/play-view';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -29,6 +33,20 @@ import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
 import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
+
+// Exported for testing. Decides how a connect-failure category reaches error
+// tracking:
+//  - null  → don't report. The user dismissed the device picker
+//    ('user_cancelled') — that's the app doing exactly what was asked, not a fault.
+//  - 'warning' → environmental, not an app bug: the board is off, out of range,
+//    or the GATT connect timed out ('board_not_found' / 'connect_failed').
+//  - 'error' → a genuine fault worth surfacing ('unavailable' / 'service_missing'
+//    / 'unknown').
+export function bleConnectReportLevel(category: BleFailureCategory): 'warning' | 'error' | null {
+  if (category === 'user_cancelled') return null;
+  if (category === 'board_not_found' || category === 'connect_failed') return 'warning';
+  return 'error';
+}
 
 // Exported for testing — isolates the .packet extraction so regressions are caught.
 //
@@ -736,8 +754,23 @@ export function useBoardBluetooth({
         });
         return true;
       } catch (error) {
-        console.error('Error connecting to Bluetooth:', error);
-        reportHandledError(error, { tags: { source: 'ble-connect' } });
+        // Classify once, up front: it decides both whether this reaches error
+        // tracking and the user copy below. A user dismissing the device picker
+        // ('user_cancelled') isn't a failure — don't log it as one or report it.
+        // board_not_found / connect_failed are environmental (board off, out of
+        // range, GATT timeout), not app bugs, so they go in as warnings. Genuine
+        // faults (unavailable / service_missing / unknown) stay at error level.
+        const failureCategory = classifyBleFailure(error);
+        const reportLevel = bleConnectReportLevel(failureCategory);
+        if (reportLevel === null) {
+          console.warn('Bluetooth device selection cancelled by user');
+        } else {
+          console.error('Error connecting to Bluetooth:', error);
+          reportHandledError(error, {
+            level: reportLevel,
+            tags: { source: 'ble-connect', failure_category: failureCategory },
+          });
+        }
         setIsConnected(false);
 
         // Dismiss the picker sheet if it's still showing. When a reconnect-by-
@@ -751,14 +784,12 @@ export function useBoardBluetooth({
         pickerRejectRef.current = null;
         setPickerState(null);
 
-        // Classify the failure into actionable user copy via the shared,
-        // deliberately-tight predicate. A previous bare `/cancel/i` regex here
-        // also matched CoreBluetooth's "operation cancelled" / ble-plx's
-        // "Operation was cancelled", so those real failures showed nothing —
-        // the connect just looked like a dead tap. Only an explicit
-        // user-cancel stays silent now. Literal-key switch (the i18n linter
-        // forbids `t(variable)`).
-        const failureCategory = classifyBleFailure(error);
+        // failureCategory (classified above) maps to actionable user copy via the
+        // shared, deliberately-tight predicate. A previous bare `/cancel/i` regex
+        // here also matched CoreBluetooth's "operation cancelled" / ble-plx's
+        // "Operation was cancelled", so those real failures showed nothing — the
+        // connect just looked like a dead tap. Only an explicit user-cancel stays
+        // silent now. Literal-key switch (the i18n linter forbids `t(variable)`).
         switch (failureCategory) {
           case 'user_cancelled':
             break;

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,4 +1,5 @@
 import { captureError } from './posthog-client';
+import { isExpectedAuthError } from './graphql/extract-error-message';
 
 export type ErrorReportContext = {
   level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
@@ -51,6 +52,7 @@ function isNetworkError(error: unknown): boolean {
  * inline message, or degraded state) rather than letting crash. Applies the
  * noise policy so error tracking stays signal-rich:
  *   - cancellations are dropped entirely,
+ *   - expected auth-required GraphQL failures are dropped entirely,
  *   - offline/network failures are downgraded to `warning` and tagged `network`,
  *   - everything else reports at the caller's level (default `error`).
  * Use this from React Query caches, GraphQL-WS, and catch blocks; use the raw
@@ -58,6 +60,7 @@ function isNetworkError(error: unknown): boolean {
  */
 export function reportHandledError(error: unknown, context?: ErrorReportContext): void {
   if (isCancellation(error)) return;
+  if (isExpectedAuthError(error)) return;
   if (isNetworkError(error)) {
     reportError(error, {
       ...context,

--- a/packages/mobile/src/lib/graphql/__tests__/extract-error-message.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/extract-error-message.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractGraphqlMessage, isGraphqlRateLimitedError } from '../extract-error-message';
+import { extractGraphqlMessage, isExpectedAuthError, isGraphqlRateLimitedError } from '../extract-error-message';
 
 describe('GraphQL error extraction', () => {
   it('extracts the first graphql-request response message', () => {
@@ -43,5 +43,39 @@ describe('GraphQL error extraction', () => {
     };
 
     expect(isGraphqlRateLimitedError(error)).toBe(false);
+  });
+});
+
+describe('isExpectedAuthError', () => {
+  it('matches the backend requireAuthenticated message', () => {
+    const error = {
+      response: {
+        status: 200,
+        errors: [{ message: 'Authentication required to perform this operation', path: ['myBoards'] }],
+      },
+    };
+
+    expect(isExpectedAuthError(error)).toBe(true);
+  });
+
+  it('matches an UNAUTHENTICATED extensions code', () => {
+    const error = {
+      response: { errors: [{ message: 'Nope', extensions: { code: 'UNAUTHENTICATED' } }] },
+    };
+
+    expect(isExpectedAuthError(error)).toBe(true);
+  });
+
+  it('does not match other server errors', () => {
+    const error = {
+      response: { errors: [{ message: 'Something else broke', extensions: { code: 'INTERNAL_SERVER_ERROR' } }] },
+    };
+
+    expect(isExpectedAuthError(error)).toBe(false);
+  });
+
+  it('returns false for non-GraphQL errors', () => {
+    expect(isExpectedAuthError(new Error('plain'))).toBe(false);
+    expect(isExpectedAuthError(null)).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -35,3 +35,24 @@ export function isGraphqlRateLimitedError(error: unknown): boolean {
 
   return getGraphqlErrors(error).some((graphqlError) => graphqlError.extensions?.code === 'RATE_LIMITED');
 }
+
+// The backend's `requireAuthenticated` guard throws this exact message (a plain
+// Error, so no extensions.code) whenever a session-only resolver runs without a
+// signed-in user. graphql-request surfaces it as a ClientError carrying
+// response.errors[].
+const AUTH_REQUIRED_MESSAGE = 'Authentication required to perform this operation';
+
+/**
+ * An *expected* authentication failure: a session-only query ran without a
+ * session (e.g. on a logged-out cold start) or raced a token expiry. Call sites
+ * should gate authed queries with React Query `enabled`, and the 401 interceptor
+ * already forces sign-out, so these carry no action — error tracking drops them.
+ * Matches only the exact backend message / UNAUTHENTICATED code so genuine
+ * authorization faults still surface.
+ */
+export function isExpectedAuthError(error: unknown): boolean {
+  return getGraphqlErrors(error).some(
+    (graphqlError) =>
+      graphqlError.message === AUTH_REQUIRED_MESSAGE || graphqlError.extensions?.code === 'UNAUTHENTICATED',
+  );
+}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -138,7 +138,15 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const queueSheetRef = useRef<QueueSheetHandle>(null);
   const boardSheetRef = useRef<BoardSheetHandle>(null);
   const { data: activeBoard } = useActiveBoard();
-  const { data: myBoardsConn } = useMyBoards();
+  // Auth gates two things here. (1) myBoards requires authentication: running it
+  // while logged out throws "Authentication required to perform this operation"
+  // (pure noise in error tracking) and returns nothing useful — every other call
+  // site gates the same way. (2) "Add beta video" keys off auth state, not
+  // profile?.id, which can lag behind a fresh sign-in (profile query still
+  // resolving) and would show the action in the play drawer but not here.
+  // PlayDrawer uses the same predicate.
+  const { isAuthenticated } = useAuth();
+  const { data: myBoardsConn } = useMyBoards(undefined, { enabled: isAuthenticated });
   const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
   const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
   const [climbActions, setClimbActions] = useState<{
@@ -170,10 +178,6 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   boardPresenceBoardIdRef.current = boardPresenceBoardId;
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
   const { data: profile } = useProfile();
-  // Gate "Add beta video" on auth state, not profile?.id — the latter can lag
-  // behind a fresh sign-in (profile query still resolving), which would show the
-  // action in the play drawer but not here. PlayDrawer uses the same predicate.
-  const { isAuthenticated } = useAuth();
 
   // Climb to open after the boardConfig override has committed. We can't
   // open synchronously inside openPlayDrawer when an override is supplied


### PR DESCRIPTION
## Why

Triaged the React Native error-tracking issues in PostHog (`posthog-react-native` lib). Two of the biggest issues are **already fixed in `main`** and confirmed stopped: the `SCREENSHOT_MODE` cold-start crash (`fa4c902cb`) and the `bulkVoteSummaries` empty-array error (`44333fa73`, zero occurrences in the last 3 days). This PR clears the remaining non-actionable noise.

## What changed

**1. Gate `myBoards` on auth** (`drawer-host-provider.tsx`) — ~19 "Authentication required to perform this operation" errors.
`DrawerHostProvider` was the one call site running `useMyBoards()` with no `enabled` flag, so on a logged-out cold start the session-only query threw and got reported. Hoisted the existing `useAuth()` read above the query and passed `{ enabled: isAuthenticated }`, matching every other call site (e.g. `app/boards/manage.tsx`).

**2. Stop error-tracking BLE outcomes that aren't app bugs** (`use-board-bluetooth.ts`) — ~19 "Device selection cancelled" errors.
The connect catch block called `reportHandledError` unconditionally *before* classifying the failure, so a user dismissing the device picker landed as an `error`. Now it classifies first via a new pure, tested `bleConnectReportLevel`:
- `user_cancelled` → not reported at all (the app did exactly what was asked)
- `board_not_found` / `connect_failed` → `warning` (board off / out of range / GATT timeout — environmental)
- `unavailable` / `service_missing` / `unknown` → `error`

User-facing alerts and the `BluetoothConnectionFailed` analytics event are unchanged.

**3. Drop expected auth-required GraphQL errors centrally** (`error-reporting.ts` + `extract-error-message.ts`).
`reportHandledError` now skips ClientErrors carrying the backend's `requireAuthenticated` message (or an `UNAUTHENTICATED` code) the same way it already drops cancellations — a belt-and-suspenders for any authed query that briefly races a token expiry.

**4. Google Sign-In `DEVELOPER_ERROR` (163, highest-volume) — documented, not code.**
This is an Android signing-cert SHA-1 registration problem, not fixable in-repo. Added a PostHog-triage note into the existing runbook in `docs/android-sideload-build.md` (which already documents the per-key SHA-1 registration). Owner action: register the distributed builds' SHA-1s as Android OAuth clients in project `401523882502`.

## Tests

- `bleConnectReportLevel` category → report-level mapping (all 6 categories)
- `isExpectedAuthError` matches the backend message / `UNAUTHENTICATED`, ignores other errors
- `reportHandledError` drops the auth-required ClientError

`vp run typecheck:mobile` ✓ · `vp run test:mobile` (2387 tests) ✓ · `vp run check:mobile-bundle` ✓ · pre-commit `vp staged` ✓

## Follow-up (post-merge, not in this PR)

Once this rides out on the next mobile build/OTA, re-query PostHog to confirm `myBoards` and "Device selection cancelled" go to ~0, then mark those + the already-fixed SCREENSHOT_MODE / bulkVoteSummaries issues resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)