### PR TITLE
fix(mobile): reopen play drawer when re-tapping the active climb

### DIFF
--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -12,12 +12,16 @@ import { usePlaylistActivation } from '../use-playlist-activation';
 // second React copy and trip the dispatcher.)
 type ActiveBoard = { boardType: string; layoutId: number; sizeId: number; setIds: string; angle: number } | null;
 
+type SuggestionSource = { playlistUuid: string; activatedClimbUuid: string; boardKey: string } | null;
+
 const mocks = vi.hoisted(() => ({
   setCurrentClimb: vi.fn(),
+  setPlaylistSuggestionSource: vi.fn(),
   refreshPlaylistSuggestionSource: vi.fn(),
   openPlayDrawer: vi.fn(),
   activeBoard: { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
   activeClimbUuid: null as string | null,
+  suggestionSource: null as SuggestionSource,
   activate: vi.fn<(climb: Climb) => Promise<void>>(),
   fetchSuggestion: vi.fn(),
   captured: undefined as UsePlaylistClimbActivationOptions | undefined,
@@ -34,9 +38,11 @@ vi.mock('@boardsesh/playlists-react', () => ({
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({
     setCurrentClimb: mocks.setCurrentClimb,
+    setPlaylistSuggestionSource: mocks.setPlaylistSuggestionSource,
     refreshPlaylistSuggestionSource: mocks.refreshPlaylistSuggestionSource,
   }),
   useActiveClimbUuid: () => mocks.activeClimbUuid,
+  usePlaylistSuggestionSource: () => mocks.suggestionSource,
 }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: mocks.openPlayDrawer }),
@@ -85,6 +91,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.activeBoard = { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
   mocks.activeClimbUuid = null;
+  mocks.suggestionSource = null;
   mocks.captured = undefined;
   mocks.activate.mockResolvedValue(undefined);
   mocks.queueItemCounter = 0;
@@ -172,22 +179,47 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
   });
 
-  it('re-tapping the already-active climb just reopens the drawer (no re-activate)', async () => {
+  it('re-tapping the active climb whose suggestions already follow this list just reopens', async () => {
     mocks.activeClimbUuid = 'a';
+    // Suggestions already anchored on 'a' from this very list (sourceId 'pl-1').
+    mocks.suggestionSource = { playlistUuid: 'pl-1', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
     const { result } = renderActivation();
     const climb = makeClimb('a');
     await result.current(climb);
 
-    // The drawer reopens for the active climb, but the shared activation does NOT
-    // run — re-activating would duplicate it in the queue and reset the pass.
+    // Pure reopen — the shared activation does NOT run (re-activating would
+    // duplicate it in the queue / pointlessly rebuild the same source).
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
     expect(mocks.activate).not.toHaveBeenCalled();
+  });
 
-    // No item was pinned, so the next genuine activation builds a fresh one rather
-    // than reusing a stale pinned item for the same climb uuid.
-    const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
+  it('re-tapping the active climb from a DIFFERENT list re-activates to follow it', async () => {
+    mocks.activeClimbUuid = 'a';
+    // 'a' is active, but its suggestions follow another list ('climblist'), not
+    // this one ('pl-1'). The drawer's next/previous must switch to follow 'pl-1'.
+    mocks.suggestionSource = { playlistUuid: 'climblist', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
+    const { result } = renderActivation();
+    const climb = makeClimb('a');
+    await result.current(climb);
+
+    expect(mocks.activate).toHaveBeenCalledWith(climb);
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
+  });
+
+  it('queueApi refreshes the source in place for the active climb (no duplicate append)', async () => {
+    mocks.activeClimbUuid = 'a';
+    renderActivation();
+    const climb = makeClimb('a');
+    const source = { playlistUuid: 'pl-1', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3', climbs: [] };
+
+    const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: source });
+
+    // The active climb is not re-dispatched (would append a duplicate); only the
+    // suggestion source is updated, and a non-null item is still returned so the
+    // shared hook proceeds to its async refresh.
+    expect(mocks.setCurrentClimb).not.toHaveBeenCalled();
+    expect(mocks.setPlaylistSuggestionSource).toHaveBeenCalledWith(source);
     expect(item?.climb).toEqual(climb);
-    expect(mocks.setCurrentClimb.mock.calls[0][0]).toBe(item);
   });
 
   it('activates a non-active climb even when a different climb is active', async () => {

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   refreshPlaylistSuggestionSource: vi.fn(),
   openPlayDrawer: vi.fn(),
   activeBoard: { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 } as ActiveBoard,
+  activeClimbUuid: null as string | null,
   activate: vi.fn<(climb: Climb) => Promise<void>>(),
   fetchSuggestion: vi.fn(),
   captured: undefined as UsePlaylistClimbActivationOptions | undefined,
@@ -35,6 +36,7 @@ vi.mock('../../../providers/queue-provider', () => ({
     setCurrentClimb: mocks.setCurrentClimb,
     refreshPlaylistSuggestionSource: mocks.refreshPlaylistSuggestionSource,
   }),
+  useActiveClimbUuid: () => mocks.activeClimbUuid,
 }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: mocks.openPlayDrawer }),
@@ -82,6 +84,7 @@ function captured(): UsePlaylistClimbActivationOptions {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.activeBoard = { boardType: 'kilter', layoutId: 1, sizeId: 2, setIds: '3', angle: 40 };
+  mocks.activeClimbUuid = null;
   mocks.captured = undefined;
   mocks.activate.mockResolvedValue(undefined);
   mocks.queueItemCounter = 0;
@@ -165,6 +168,35 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
 
     // Every tap drives the shared activation — there is no non-driver preview
     // branch that skips it anymore.
+    expect(mocks.activate).toHaveBeenCalledWith(climb);
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
+  });
+
+  it('re-tapping the already-active climb just reopens the drawer (no re-activate)', async () => {
+    mocks.activeClimbUuid = 'a';
+    const { result } = renderActivation();
+    const climb = makeClimb('a');
+    await result.current(climb);
+
+    // The drawer reopens for the active climb, but the shared activation does NOT
+    // run — re-activating would duplicate it in the queue and reset the pass.
+    expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
+    expect(mocks.activate).not.toHaveBeenCalled();
+
+    // No item was pinned, so the next genuine activation builds a fresh one rather
+    // than reusing a stale pinned item for the same climb uuid.
+    const item = await captured().queueApi!.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    expect(item?.climb).toEqual(climb);
+    expect(mocks.setCurrentClimb.mock.calls[0][0]).toBe(item);
+  });
+
+  it('activates a non-active climb even when a different climb is active', async () => {
+    mocks.activeClimbUuid = 'b';
+    const { result } = renderActivation();
+    const climb = makeClimb('a');
+    await result.current(climb);
+
+    // 'a' is not the active climb ('b' is), so this still starts a fresh pass.
     expect(mocks.activate).toHaveBeenCalledWith(climb);
     expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
   });

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -13,7 +13,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
 import { getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
-import { useActiveClimbUuid, useQueueActions } from '../../providers/queue-provider';
+import { useActiveClimbUuid, usePlaylistSuggestionSource, useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
@@ -53,16 +53,21 @@ export function usePlaylistActivation({
   fetchPage,
   refreshErrorMessage,
 }: UsePlaylistActivationOptions): (climb: Climb) => Promise<void> {
-  const { setCurrentClimb, refreshPlaylistSuggestionSource } = useQueueActions();
+  const { setCurrentClimb, setPlaylistSuggestionSource, refreshPlaylistSuggestionSource } = useQueueActions();
   const { openPlayDrawer } = useDrawerHost();
   const activeBoard = useActiveBoard().data ?? null;
 
-  // Mirror the active climb uuid into a ref so the returned callback can guard a
-  // re-tap of the already-active climb without taking a dependency on it (keeps
-  // the callback identity stable).
+  // Mirror the active climb uuid + the live suggestion source into refs so the
+  // returned callback can decide how to handle a re-tap of the already-active
+  // climb without taking a dependency on either (keeps the callback identity
+  // stable). The source tells us whether the drawer's next/previous already
+  // follow THIS list or some other one.
   const activeClimbUuid = useActiveClimbUuid();
   const activeClimbUuidRef = useRef(activeClimbUuid);
   activeClimbUuidRef.current = activeClimbUuid;
+  const playlistSuggestionSource = usePlaylistSuggestionSource();
+  const playlistSuggestionSourceRef = useRef(playlistSuggestionSource);
+  playlistSuggestionSourceRef.current = playlistSuggestionSource;
 
   // The queue item the returned callback built for this tap. queueApi.setCurrentClimb
   // dispatches that exact instance so the drawer's navigation anchor and the queue
@@ -80,6 +85,16 @@ export function usePlaylistActivation({
       setCurrentClimb: async (climb: Climb, options: Parameters<typeof setCurrentClimb>[1]) => {
         const pendingItem = pendingQueueItemRef.current;
         pendingQueueItemRef.current = null;
+        // The tapped climb is already the active climb (re-tapped from a list
+        // whose suggestions don't yet follow it). Don't re-append it — that would
+        // duplicate it in the queue and reset the pass. Just point the suggestion
+        // source at the tapped list so the drawer's next/previous follow it; the
+        // shared hook's async refresh then upgrades that source in place. Return a
+        // non-null item so the hook treats activation as succeeded.
+        if (activeClimbUuidRef.current === climb.uuid) {
+          setPlaylistSuggestionSource(options?.playlistSuggestionSource ?? null);
+          return pendingItem ?? climbToQueueItem(toSchemaClimb(climb));
+        }
         const item =
           pendingItem && pendingItem.climb.uuid === climb.uuid ? pendingItem : climbToQueueItem(toSchemaClimb(climb));
         // Commit synchronously: the drawer now renders from currentClimbQueueItem
@@ -91,7 +106,7 @@ export function usePlaylistActivation({
       },
       refreshPlaylistSuggestionSource,
     }),
-    [setCurrentClimb, refreshPlaylistSuggestionSource],
+    [setCurrentClimb, setPlaylistSuggestionSource, refreshPlaylistSuggestionSource],
   );
 
   const resolveTarget = useCallback(
@@ -153,27 +168,38 @@ export function usePlaylistActivation({
   // preview.
   return useCallback(
     (climb: Climb) => {
-      // Re-tapping the already-active climb just reopens its drawer. Building a
-      // fresh queue item and re-activating would duplicate it in the queue and
-      // reset the active pass. The drawer renders from currentClimbQueueItem
-      // (committedExternally), which already points at this climb — so don't set
-      // pendingQueueItemRef here, or a stale item could be reused on the next tap.
-      if (activeClimbUuidRef.current === climb.uuid) {
-        openPlayDrawer(toSchemaClimb(climb), { committedExternally: true });
+      const schemaClimb = toSchemaClimb(climb);
+      const isAlreadyActive = activeClimbUuidRef.current === climb.uuid;
+      const source = playlistSuggestionSourceRef.current;
+      const suggestionsAlreadyFollowThisList =
+        source?.playlistUuid === sourceId && source?.activatedClimbUuid === climb.uuid;
+
+      // Pure reopen: the tapped climb is already active AND the drawer's
+      // next/previous already follow THIS list anchored on it. Re-activating
+      // would duplicate it in the queue and pointlessly rebuild the same source,
+      // so just reopen — the drawer renders from currentClimbQueueItem
+      // (committedExternally), which already points at this climb.
+      if (isAlreadyActive && suggestionsAlreadyFollowThisList) {
+        openPlayDrawer(schemaClimb, { committedExternally: true });
         return Promise.resolve();
       }
-      // Always-live: every tap activates the climb for the whole session (no
-      // driver/preview gate). The drawer opens first (same frame as the tap),
-      // then the shared activation builds the suggestion source and commits the
-      // queue update.
-      const item = climbToQueueItem(toSchemaClimb(climb));
-      pendingQueueItemRef.current = item;
-      openPlayDrawer(toSchemaClimb(climb), { committedExternally: true });
+
+      // Otherwise activate. Pin a fresh queue item only for a genuinely new
+      // activation, so the drawer's nav anchor and the appended queue entry share
+      // one uuid. When the climb is already active (tapped from a different list),
+      // queueApi refreshes the suggestion source in place instead of appending, so
+      // there's nothing to pin — and pinning a stale item could be reused on the
+      // next tap. The drawer opens first (same frame as the tap), then the shared
+      // activation builds the suggestion source.
+      if (!isAlreadyActive) {
+        pendingQueueItemRef.current = climbToQueueItem(schemaClimb);
+      }
+      openPlayDrawer(schemaClimb, { committedExternally: true });
       return activate(climb).catch((error: unknown) => {
         console.error('Playlist climb activation failed:', error);
         reportHandledError(error, { tags: { source: 'playlist', op: 'activate-climb' } });
       });
     },
-    [activate, openPlayDrawer],
+    [activate, openPlayDrawer, sourceId],
   );
 }

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -13,7 +13,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { usePlaylistClimbActivation, fetchPlaylistSuggestionClimbs } from '@boardsesh/playlists-react';
 import { getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
-import { useQueueActions } from '../../providers/queue-provider';
+import { useActiveClimbUuid, useQueueActions } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { climbToQueueItem } from '../climb-to-queue-item';
@@ -56,6 +56,13 @@ export function usePlaylistActivation({
   const { setCurrentClimb, refreshPlaylistSuggestionSource } = useQueueActions();
   const { openPlayDrawer } = useDrawerHost();
   const activeBoard = useActiveBoard().data ?? null;
+
+  // Mirror the active climb uuid into a ref so the returned callback can guard a
+  // re-tap of the already-active climb without taking a dependency on it (keeps
+  // the callback identity stable).
+  const activeClimbUuid = useActiveClimbUuid();
+  const activeClimbUuidRef = useRef(activeClimbUuid);
+  activeClimbUuidRef.current = activeClimbUuid;
 
   // The queue item the returned callback built for this tap. queueApi.setCurrentClimb
   // dispatches that exact instance so the drawer's navigation anchor and the queue
@@ -146,6 +153,15 @@ export function usePlaylistActivation({
   // preview.
   return useCallback(
     (climb: Climb) => {
+      // Re-tapping the already-active climb just reopens its drawer. Building a
+      // fresh queue item and re-activating would duplicate it in the queue and
+      // reset the active pass. The drawer renders from currentClimbQueueItem
+      // (committedExternally), which already points at this climb — so don't set
+      // pendingQueueItemRef here, or a stale item could be reused on the next tap.
+      if (activeClimbUuidRef.current === climb.uuid) {
+        openPlayDrawer(toSchemaClimb(climb), { committedExternally: true });
+        return Promise.resolve();
+      }
       // Always-live: every tap activates the climb for the whole session (no
       // driver/preview gate). The drawer opens first (same frame as the tap),
       // then the shared activation builds the suggestion source and commits the


### PR DESCRIPTION
## Problem

On mobile, tapping a climb in the climbs/search list (and the playlist / smart-playlist lists) runs `usePlaylistActivation`, which **always** built a fresh `ClimbQueueItem` (new uuid) and committed it via the shared activation hook. When the tapped climb was *already the currently-active climb*, this duplicated it in the queue and reset the active pass — instead of just reopening it.

The play drawer's own direct-open path already guards this (`isAlreadyCurrent` in `PlayDrawer.openDrawer`), but the list-tap path bypassed that guard: it opens with `committedExternally: true` and commits separately in the activation hook, so the guard never ran.

## Fix

In `packages/mobile/src/lib/playlists/use-playlist-activation.ts`, short-circuit when the tapped climb is already the active climb:

```ts
if (activeClimbUuidRef.current === climb.uuid) {
  openPlayDrawer(toSchemaClimb(climb), { committedExternally: true });
  return Promise.resolve();
}
```

- Reads the active climb uuid via the existing lightweight `useActiveClimbUuid()` selector, mirrored into a ref to keep the returned callback dependency-stable.
- Opens the drawer for the existing active queue item (the drawer renders from `currentClimbQueueItem`) and skips both the fresh-item build and `activate()`.
- The early return runs **before** `pendingQueueItemRef` is set, so no stale pinned item lingers to be wrongly reused on the next tap.

**Scope:** only the currently-active climb. A climb that's in the queue but not active still starts a fresh pass (unchanged).

## Tests

Two cases added to `use-playlist-activation.test.tsx`:
- Re-tapping the active climb reopens the drawer, does **not** call `activate`, and pins no stale item.
- Tapping a non-active climb still activates even when a *different* climb is active.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (2381 passed, incl. 2 new)
- `vp check` on the changed files ✅ (lint + format clean)
- `vp run check:mobile-bundle` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)