### PR TITLE
fix(mobile-screenshots): enable KVM for Android, shard iOS by device × locale

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -9,15 +9,16 @@ name: Mobile Screenshots (Native)
 # only rebuilt when those change. A JS-only run is a cache hit → install + Metro +
 # Maestro instead of a ~30-min from-scratch native compile.
 #
-# iOS is a 3-job fan-out so locales capture in parallel and a single overloaded
-# runner never thrashes:
+# iOS is a 3-stage fan-out so every (locale, device) captures in parallel and a
+# single overloaded runner never thrashes:
 #   ios-build    — build/restore the cached .app ONCE (no per-shard cold build).
-#   ios-capture  — matrix over locale (en-US, es, fr); each shard captures its 3
-#                  devices sequentially under one Metro, with --shutdown so only
-#                  ONE simulator is booted at a time (3 booted at once is what made
-#                  the old single-job run thrash and time out at "iOS driver not
-#                  ready in time").
-#   ios-finalize — merge the per-locale artifacts into one tree, run the dimension
+#   ios-capture  — matrix of locale (en-US, es, fr) × device (3 common iPhones) =
+#                  9 shards, each its own runner: one Metro, one simulator, one
+#                  capture. --shutdown is kept as belt-and-suspenders (a shard only
+#                  ever boots one sim, so there's nothing to accumulate — 3 booted
+#                  at once on one runner is what made the old job thrash and time
+#                  out at "iOS driver not ready in time").
+#   ios-finalize — merge the per-shard artifacts into one tree, run the dimension
 #                  gate (it needs all four App Store locales at once), and upload.
 #
 # All runs capture against PROD signed in as the test user (the canonical store
@@ -39,23 +40,14 @@ on:
         options:
           - app-store
           - onboarding
-      devices:
-        # A subset only makes sense for local iteration: the dimension gate and the
-        # App Store Connect upload both require the full common-device matrix, so a
-        # narrowed list here fails the "Assert screenshot dimensions" step in CI.
-        description: 'iOS simulator devices: common (required for upload), or a comma-separated list for local iteration'
-        type: string
-        default: 'common'
+      # No iOS devices/locales inputs: the dimension gate + upload require the full
+      # set (3 common iPhones × en-US/es-ES/es-MX/fr-FR), so CI always runs the
+      # complete locale × device matrix below. For a narrowed local run, pass
+      # --devices / --locales to `vp run mobile:screenshots` directly.
       android_device:
         description: 'Android emulator device label used for screenshot output'
         type: string
         default: 'Pixel 2'
-      locales:
-        # Same as devices: the dimension gate + upload expect all four App Store
-        # locales (en-US, es-ES, es-MX, fr-FR), so a subset fails CI validation.
-        description: 'App locales: all (required for upload), or a comma-separated list such as en-US,es for local iteration'
-        type: string
-        default: 'all'
       upload:
         description: 'Upload captured screenshots to App Store Connect and Google Play. Never runs on the nightly cron.'
         type: boolean
@@ -147,11 +139,15 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     strategy:
-      # One locale failing shouldn't abandon the others — let them all finish so
-      # ios-finalize can report exactly which locale is short.
+      # One shard failing shouldn't abandon the rest — let them all finish so
+      # ios-finalize can report exactly which (locale, device) is short.
       fail-fast: false
       matrix:
         locale: [en-US, es, fr]
+        device:
+          - { name: iPhone 16 Pro Max, slug: iphone-16-pro-max }
+          - { name: iPhone 14 Plus, slug: iphone-14-plus }
+          - { name: iPhone 16 Pro, slug: iphone-16-pro }
 
     env:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
@@ -212,23 +208,22 @@ jobs:
           unzip -q maestro.zip -d "$HOME/.maestro-dist"
           echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"
 
-      - name: Capture screenshots (${{ matrix.locale }})
+      - name: Capture screenshots (${{ matrix.locale }} · ${{ matrix.device.slug }})
         # Installs the prebuilt .app, starts Metro with the screenshot env for this
-        # locale, and runs Maestro — no native build on this path. Always against
-        # prod (signed in as the test user); no EXPO_PUBLIC_BACKEND_URL override, so
-        # the bundle uses the app's production backend defaults. --locales is a
-        # single value here: `es` expands to both es-ES and es-MX in this shard, so
-        # the three shards together produce all four App Store locales. --shutdown
-        # tears down each device's simulator after its capture so only one sim is
-        # booted at a time (the fix for the multi-sim thrash that timed the old
-        # single-job run out at the 3rd device).
+        # locale, and runs Maestro for this ONE device — no native build on this
+        # path. Always against prod (signed in as the test user); no
+        # EXPO_PUBLIC_BACKEND_URL override, so the bundle uses the app's production
+        # backend defaults. --locales is a single value: `es` expands to both es-ES
+        # and es-MX for this device, so the 9 shards together produce all four App
+        # Store locales × 3 devices. --shutdown is belt-and-suspenders (a shard only
+        # boots this one sim, so there's nothing to accumulate).
         run: |
           set -euo pipefail
           vp run mobile:screenshots -- \
             --platform ios \
             --flow "${{ inputs.flow || 'app-store' }}" \
             --backend prod \
-            --devices "${{ inputs.devices || 'common' }}" \
+            --device "${{ matrix.device.name }}" \
             --locales "${{ matrix.locale }}" \
             --shutdown \
             --app-path packages/mobile/.app-cache/Boardsesh.app
@@ -250,23 +245,23 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          # Per-locale name: upload-artifact@v4 rejects two uploads with the same
+          # Per-shard name: upload-artifact@v4 rejects two uploads with the same
           # name in one run.
-          name: capture-debug-${{ matrix.locale }}
+          name: capture-debug-${{ matrix.locale }}-${{ matrix.device.slug }}
           path: capture-debug/**
           if-no-files-found: warn
           retention-days: 14
 
-      # Hand this locale's PNGs to ios-finalize. The artifact's internal layout is
+      # Hand this shard's PNGs to ios-finalize. The artifact's internal layout is
       # <app-store-locale>/<device>/NN-name.png (upper paths stripped to the
-      # least-common-ancestor); locale dirs are disjoint across shards, so the
-      # merge in ios-finalize has no collisions. Short retention — it's an
+      # non-wildcard prefix); (locale, device) pairs are disjoint across shards, so
+      # the merge in ios-finalize has no collisions. Short retention — it's an
       # intermediate; the combined tree is re-uploaded by ios-finalize.
-      - name: Upload locale screenshots
+      - name: Upload shard screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ios-screenshots-${{ matrix.locale }}
+          name: ios-screenshots-${{ matrix.locale }}-${{ matrix.device.slug }}
           path: app-stores/apple/screenshots/**
           if-no-files-found: warn
           retention-days: 1
@@ -495,6 +490,18 @@ jobs:
           echo "${MAESTRO_SHA256}  maestro.zip" | shasum -a 256 -c -
           unzip -q maestro.zip -d "$HOME/.maestro-dist"
           echo "$HOME/.maestro-dist/maestro/bin" >> "$GITHUB_PATH"
+
+      # The x86_64 emulator needs KVM hardware acceleration. Without granting the
+      # runner user access to /dev/kvm it falls back to software (TCG) and is so
+      # slow that adb `settings` calls take 15-35s and the emulator crashes or
+      # times out during boot/setup before our script runs — the cause of the
+      # long-standing Android capture failures (boot timeout / "Broken pipe" /
+      # adb exit 224). This udev rule is the standard android-emulator-runner setup.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Capture Android screenshots
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
Follow-up to #2993, driven by the first real run ([27719803749](https://github.com/boardsesh/boardsesh/actions/runs/27719803749)).

## 1. Android: enable KVM (fixes a long-standing failure)

Android has failed on **every** recent run — including ones predating #2993, so it's not a regression from the matrix work. Root cause: the workflow never enables KVM, so the x86_64 emulator falls back to software (TCG). The tell is in the logs — `adb settings` calls take **15-35s each** (should be sub-second), then the emulator dies mid-setup with varying symptoms across runs:

- `Timeout waiting for emulator to boot`
- `cmd: Failure calling service settings: Broken pipe (32)` → `adb failed with exit code 224`
- `/usr/bin/sh failed with exit code 2`

All of these happen **before our capture script runs and before the APK is installed** — it's pure emulator instability, unrelated to the Gradle change.

Fix: add the standard `reactivecircus/android-emulator-runner` KVM udev rule before the emulator step so the runner user can use `/dev/kvm`.

## 2. iOS: shard by device × locale (was still slow)

The `--shutdown` fix from #2993 **works** — the `es` and `fr` "intl" shards that used to break both went green this run. But each of the 3 locale shards still captured its 3 devices **sequentially** (~22-28 min/shard). Expand the matrix to **locale × device = 9 shards**, one simulator per runner, fully parallel:

- Cuts the capture phase from ~24 min (3 serial devices) to ~one device per shard.
- Makes "only one simulator per runner" **structural** (each runner only ever boots one sim), instead of relying on `--shutdown`.
- Each shard uploads `ios-screenshots-<locale>-<device>`; `ios-finalize`'s `merge-multiple` still reconstructs the full `<store-locale>/<device>/NN.png` tree (the `es` shards each emit `es-ES` + `es-MX`, (locale,device) pairs are disjoint → no collisions → dimension gate sees all four locales × 3 devices).

Dropped the now-unused `devices`/`locales` dispatch inputs (the CI matrix is fixed to the upload-required full set; narrow locally via the `vp run mobile:screenshots` CLI flags).

## Tradeoff

9 macOS shards instead of 3 → more macOS runner-minutes, and wall-clock benefit depends on how many macOS runners run concurrently (if the org caps concurrency below 9, they run in waves). On a warm `.app` cache the per-shard work is ~8-12 min, so a fully-parallel run lands around **~15 min** for iOS end-to-end vs ~28+ today. Note the first run's 18-min `ios-build` was a one-time cold-cache compile — it's now cached on `main`.

## Validation

- YAML parses; matrix expands to the 9 expected (locale, device) shards; `vp check` reports the file formatted.
- Artifact round-trip re-verified for the 9-shard layout (each `<locale>/<device>/` subtree disjoint; `merge-multiple` reconstructs the full tree the gate + fastlane read).
- Android KVM step placed before the emulator runner.
- Run it from this branch (no `environment:` gate) with `upload=false` to confirm Android boots fast (sub-second `adb settings`) and all 9 iOS shards + finalize go green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)