### PR TITLE
fix(mobile): auto-activate the first board in screenshot mode

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -56,9 +56,6 @@ directly into its shots — no Maestro element races a transient auth screen.
 - `SCREENSHOT_USER_EMAIL` — test account email (default `test@boardsesh.com`).
 - `SCREENSHOT_USER_PASSWORD` — test account password. **Not committed** — pass it
   at runtime (prod differs from the local-DB `test`).
-- `MAESTRO_BOARD_PICK_POINT` — the percentage tap point for the board picker, passed
-  by the orchestrator per iOS device (the one surviving coordinate tap; everything
-  else the iOS flow needs is a deep link).
 - `EXPO_PUBLIC_SCREENSHOT_LOCALE` — the app locale baked into the bundle for the
   current capture pass (the orchestrator reruns the flow once per locale; see
   `screenshot-mode.ts`).
@@ -99,15 +96,19 @@ on boot. They live only in screenshot-only builds; the separate prod-stripping o
   `://profile?screenshotTab=sessions` opens the Sessions tab and auto-opens the
   newest session's detail. For any screen shot twice, the plain visit runs before
   the param visit so no stale param leaks in.
+- **Board activation**: the active board is auto-selected on boot in screenshot
+  mode — `auth-provider.tsx` activates the user's first saved board (Marco's board)
+  right after the auto-sign-in, so board-backed screens (Climbs, Board View) render
+  real content. This replaced a fragile board-picker coordinate tap that missed on a
+  loaded runner and left those screens stuck on the "No board selected" empty state.
 - **Coordinate taps**: on this iOS 26 / RN Fabric build Maestro's accessibility
   tree only exposes native text inputs and system dialogs — plain Views, Text,
   reanimated pressables and gesture rows don't surface, so app buttons can't be
-  matched by id/text. After moving the board view to a deep link, iOS keeps just
-  **one** `point:` tap — the board pick — supplied per device by the orchestrator as
-  `MAESTRO_BOARD_PICK_POINT` (so a single flow captures the whole device matrix);
-  Android additionally keeps the board-switcher tap (`78%,10%`) for its board-sheet
-  shot. Re-check the points if a device's layout differs. There's no login step at all
-  — the app auto-signs-in on boot and never shows a login screen.
+  matched by id/text. The iOS flow now has **no** `point:` taps (every screen is a
+  deep link, the board is active from boot). Android keeps just the board-switcher
+  tap (`78%,10%`) for its board-sheet shot; re-check it if the emulator layout
+  differs. There's no login step at all — the app auto-signs-in on boot and never
+  shows a login screen.
 - Screenshot mode (the build-time `EXPO_PUBLIC_SCREENSHOT_MODE=1` flag) auto-signs-in
   on boot with the baked `SCREENSHOT_USER_*` credentials, locks the theme to dark, the
   locale to `EXPO_PUBLIC_SCREENSHOT_LOCALE`, and the platform variant, pre-selects the

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -16,13 +16,13 @@ name: app-store screenshots android
 #   ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
 #
 # One coordinate tap survives, pinned to the CI Pixel 2 emulator at 1080x1920:
-#   board pick = '24%,45%' (first "Your boards" card on /boards)
 #   board sheet = '78%,10%' (board-switcher glyph in the climbs top chrome)
-# The old board-view '50%,26%' tap is gone — it mis-tapped and duplicated the climb-list
-# shot; the board view is now a deterministic deep link.
+# The board itself is auto-selected on boot in screenshot mode (auth-provider.tsx activates
+# the user's first saved board), so there's no board-pick tap. The old board-view '50%,26%'
+# tap is gone too — the board view is now a deterministic deep link.
 #
-# Order: board-independent shots first (home/discover/profile/session); board-dependent
-# shots after the board is picked. Plain visits run before screenshot-param visits.
+# Order: plain visits run before screenshot-param visits (no stale param leaks). The board
+# is active from boot, so the board-backed shots need no in-flow board-pick step.
 - launchApp
 # Auto-signs-in on boot and lands straight on home (no login screen).
 
@@ -48,13 +48,8 @@ name: app-store screenshots android
 - waitForAnimationToEnd
 - takeScreenshot: 07-session-detail
 
-# Activate a board so the board-backed shots render real content. Open the board picker
-# and tap the first card under "Your boards".
-- openLink: com.boardsesh.app://boards
-- waitForAnimationToEnd
-- tapOn:
-    point: '24%,45%'
-- waitForAnimationToEnd
+# The active board is already selected (auto-activated on boot in screenshot mode), so the
+# board-backed shots below render real content with no board-picker step.
 
 # Climbs — the main browse surface. Plain link FIRST (the list shot).
 - openLink: com.boardsesh.app://climbs

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -5,22 +5,18 @@ name: app-store screenshots
 #
 # Capture mechanism on this iOS 26 / RN Fabric build: Maestro's accessibility tree only
 # exposes native text inputs + system dialogs — plain Views/Text/pressables and gesture
-# rows do NOT surface, so app controls can't be matched by id/text. We drive the app two
-# ways:
-#   1. Deep links (com.boardsesh.app://...), including screenshot-mode query params that
-#      the build only honours when EXPO_PUBLIC_SCREENSHOT_MODE=1 (see
-#      packages/mobile/src/lib/screenshot-mode.ts):
-#        ://climbs?screenshotOpenFirst=1    -> auto-opens the first climb's board view
-#        ://profile?screenshotTab=logbook   -> profile Logbook tab
-#        ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
-#   2. ONE coordinate tap that survives — the board picker (the first "Your boards" card
-#      on /boards). The orchestrator passes its percentage as MAESTRO_BOARD_PICK_POINT,
-#      per device, so this one flow captures the whole device matrix (see
-#      IOS_SCREENSHOT_DEVICES in scripts/mobile-screenshots.ts); re-check the point if a
-#      device's layout differs.
-#   The old board-view '50%,26%' and board-sheet '78%,10%' taps are GONE: the board view
-#   is now a deterministic deep link (it used to mis-tap and duplicate the climb-list
-#   shot), and the board-switcher sheet shot was retired.
+# rows do NOT surface, so app controls can't be matched by id/text. So the flow is driven
+# entirely by deep links (com.boardsesh.app://...), including screenshot-mode query params
+# the build only honours when EXPO_PUBLIC_SCREENSHOT_MODE=1 (see
+# packages/mobile/src/lib/screenshot-mode.ts):
+#     ://climbs?screenshotOpenFirst=1    -> auto-opens the first climb's board view
+#     ://profile?screenshotTab=logbook   -> profile Logbook tab
+#     ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
+# There are NO coordinate taps. The active board is auto-selected on boot in screenshot
+# mode (auth-provider.tsx activates the user's first saved board, like the auto-sign-in),
+# so the board-backed screens render real content without a fragile board-picker tap. The
+# old board-pick / board-view / board-sheet coordinate taps are all gone — a missed pick
+# used to leave Climbs/Board View stuck on the "No board selected" empty state.
 #
 # This flow is captured once per (device, locale) pair: the orchestrator bakes
 # EXPO_PUBLIC_SCREENSHOT_LOCALE into the Metro bundle per locale and reruns it on each
@@ -35,11 +31,10 @@ name: app-store screenshots
 #   re-authenticate against the target backend rather than reuse a stale token.
 # - iOS shows an "Open in 'Boardsesh'?" confirmation for the first in-flow route deep link
 #   on a fresh sim; each openLink is followed by an optional tapOn "Open".
-# - Order: board-INDEPENDENT shots (home/discover/profile/logbook/session) run first so a
-#   board-pick miss can't lose them; board-DEPENDENT shots (climbs/workout/playlist/board
-#   view) run after the board is active. For any screen visited twice, the PLAIN visit
-#   runs before the screenshot-param visit so no stale param leaks into it. Board view is
-#   LAST because the play drawer it opens overlays the whole app.
+# - Order: for any screen visited twice, the PLAIN visit runs before the screenshot-param
+#   visit so no stale param leaks into it. Board view is LAST because the play drawer it
+#   opens overlays the whole app. (The active board is set at boot, so the board-backed
+#   shots no longer depend on an in-flow board-pick step.)
 # - The Record/session screen renders the WORKOUT GENERATOR because Metro bundles
 #   EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume).
 # - Filenames are numbered for store DISPLAY order (00..09), not capture order. 03 is the
@@ -90,17 +85,8 @@ name: app-store screenshots
 - waitForAnimationToEnd
 - takeScreenshot: 04-session-detail
 
-# Activate a board so the board-backed shots render real content: open the board picker
-# and tap the first card under "Your boards" (the one surviving coordinate tap, supplied
-# per device as MAESTRO_BOARD_PICK_POINT), which activates it and dismisses back to Climbs.
-- openLink: com.boardsesh.app://boards
-- tapOn:
-    text: 'Open'
-    optional: true
-- waitForAnimationToEnd
-- tapOn:
-    point: ${MAESTRO_BOARD_PICK_POINT}
-- waitForAnimationToEnd
+# The active board is already selected (auto-activated on boot in screenshot mode), so the
+# board-backed shots below render real content with no board-picker step.
 
 # Climbs — the main browse surface (now board-backed). Plain link FIRST (the list shot),
 # before the board-view param visit below.

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { AppState } from 'react-native';
 import { useSegments, Redirect } from 'expo-router';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { getAuthToken, isTokenExpiringSoon } from '../lib/auth-store';
 import {
@@ -17,11 +17,12 @@ import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screensh
 import { reset as resetAnalytics, track } from '../lib/analytics';
 import { reportError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
-import { resetHttpClient } from '../lib/graphql/client';
+import { getHttpClient, resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
 import { clearStoredSessionId } from '../lib/session-store';
-import { clearStoredActiveBoard } from '../lib/active-board-store';
+import { clearStoredActiveBoard, setStoredActiveBoard } from '../lib/active-board-store';
 import { ACTIVE_BOARD_QUERY_KEY } from '../lib/graphql/use-active-board';
+import { GET_MY_BOARDS, type GetMyBoardsQueryResponse } from '@boardsesh/graphql/operations/boards';
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -33,6 +34,27 @@ type AuthState = {
   signOut: (method?: 'manual' | 'account_deleted') => Promise<void>;
   refreshAuthState: () => Promise<void>;
 };
+
+// Screenshot builds only: fetch the signed-in user's saved boards and make the
+// first one active, so board-backed screens (Climbs, Board View) render real
+// content on first paint instead of the "No board selected" empty state. This is
+// the screenshot-mode analogue of auto-sign-in and replaces the Maestro flow's
+// fragile board-picker coordinate tap (which missed on a loaded runner, leaving
+// every board-dependent shot stuck on the picker). Best-effort: a failure just
+// leaves no active board, never blocks the already-successful sign-in. Dead-strips
+// in normal builds — only called from the inlined SCREENSHOT_MODE branch below.
+async function activateFirstBoardForScreenshots(queryClient: QueryClient): Promise<void> {
+  try {
+    const { myBoards } = await getHttpClient().request<GetMyBoardsQueryResponse>(GET_MY_BOARDS);
+    const firstBoard = myBoards?.boards?.[0];
+    if (firstBoard) {
+      await setStoredActiveBoard(firstBoard);
+      queryClient.setQueryData(ACTIVE_BOARD_QUERY_KEY, firstBoard);
+    }
+  } catch (boardError) {
+    reportError(boardError);
+  }
+}
 
 const AuthContext = createContext<AuthState | null>(null);
 
@@ -126,6 +148,9 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
           const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
           if (screenshotSignIn.success) {
+            // Make the first saved board active before the loading gate clears, so
+            // board-backed screens never flash the "No board selected" picker.
+            await activateFirstBoardForScreenshots(queryClient);
             setIsAuthenticated(true);
             return;
           }
@@ -156,7 +181,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [handleSignedOutTransition]);
+  }, [handleSignedOutTransition, queryClient]);
 
   useEffect(() => {
     // Belt-and-braces: checkAuth already resolves its own rejections, but keep

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -89,27 +89,23 @@ export type ScreenshotTheme = 'light' | 'dark';
 export interface IosScreenshotDevice {
   name: string;
   typeId: string;
-  // The one surviving coordinate tap (the board picker), passed to the flow as
-  // MAESTRO_BOARD_PICK_POINT. Everything else the flow needs is a deep link, so
-  // there's no per-device board-view / board-sheet tap any more.
-  boardPickPoint: string;
 }
 
+// The flow needs no per-device coordinate taps any more: every screen is a deep
+// link, and the active board is auto-selected on boot in screenshot mode (see
+// auth-provider.tsx), so there's no board-picker tap to tune per device.
 export const IOS_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
   {
     name: 'iPhone 16 Pro Max',
     typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
-    boardPickPoint: '24%,45%',
   },
   {
     name: 'iPhone 14 Plus',
     typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-14-Plus',
-    boardPickPoint: '24%,45%',
   },
   {
     name: 'iPhone 16 Pro',
     typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro',
-    boardPickPoint: '24%,45%',
   },
 ];
 
@@ -391,12 +387,10 @@ function resolveIosScreenshotDevices(deviceNames: readonly string[]): IosScreens
     if (knownDevice) return knownDevice;
     // An unlisted device name: usable only if a simulator by that name already
     // exists (typeId: '' tells findOrCreateIosDevice it can't auto-create one, so
-    // it errors with a clear message instead). It gets the shared default
-    // board-pick point — add an IOS_SCREENSHOT_DEVICES entry to tune it per device.
+    // it errors with a clear message instead).
     return {
       name: deviceName,
       typeId: '',
-      boardPickPoint: '24%,45%',
     };
   });
 }
@@ -613,8 +607,6 @@ function captureIosDevice(
         `SCREENSHOT_USER_EMAIL=${email}`,
         '-e',
         `SCREENSHOT_USER_PASSWORD=${password}`,
-        '-e',
-        `MAESTRO_BOARD_PICK_POINT=${screenshotDevice.boardPickPoint}`,
       ],
       process.env,
       captureDir,


### PR DESCRIPTION
## The bug

On the captured App Store screenshots (run [27719803749](https://github.com/boardsesh/boardsesh/actions/runs/27719803749)), the **Climbs (01)** and **Board View (02)** shots showed the empty **"No board selected — Choose your board"** state across device sizes, instead of real climb/wall content.

Cause: the Maestro flow activated a board with **one fixed coordinate tap** (`MAESTRO_BOARD_PICK_POINT = 24%,45%`) on the `/boards` picker. On a loaded CI runner the board cards hadn't rendered when the tap fired, so it missed, no board became active, and every board-backed screen fell back to the picker. The flow comments even admitted "re-check the point if a device's layout differs" — it was inherently fragile (Maestro's accessibility tree can't match the board card by id/text on this RN Fabric build, so it was a blind coordinate guess).

## The fix

Replace the coordinate tap with a **deterministic boot-time activation**, mirroring the existing screenshot-mode auto-sign-in. After the auto sign-in succeeds, `auth-provider.tsx` fetches the user's saved boards and makes the **first one (Marco's board)** active — persisting to the active-board store and the React Query cache, exactly like the real board picker does. So board-backed screens render real content **before any screen mounts**: no Maestro timing race, no coordinate guess.

- Gated on `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`, so it **dead-strips in normal builds**. Best-effort: a fetch failure just leaves no active board, never blocks the (already successful) sign-in.
- **Android benefits identically** — the activation is in shared auth code, so its flow no longer needs a board-pick tap either.
- Removes the now-dead board-pick step from both Maestro flows and the `MAESTRO_BOARD_PICK_POINT` / `boardPickPoint` plumbing in the orchestrator (`scripts/mobile-screenshots.ts`), per "remove dead code as you go." The Android board-switcher tap (`78%,10%`) for its board-sheet shot is unaffected.

## Why boot-time (not a deep-link param)

The board is set during `checkAuth` before the loading gate clears, so it's active before the first screen renders — zero coupling to Maestro flow timing. A `?screenshotActivateFirst=1` param on the boards screen would reintroduce a load-then-activate race against the next `openLink`.

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` ✓ (2379/2379) + the orchestrator script test ✓ (21/21)
- `vp run check:mobile-bundle` ✓ (the new `@boardsesh/graphql/operations/boards` import resolves in the Metro bundle)
- `vp check` ✓ (lint/format)
- Real-device validation: dispatch `mobile-screenshots.yml` (`upload=false`) and confirm `01-climbs` / `02-board-view` show real content instead of the picker. (iOS-sim runs are macOS-only, so this can't be exercised on the Linux dev box.)

## Notes
- This is independent of #2996 (CI infra: KVM + device sharding) — disjoint files.
- The run that surfaced this also hit a transient Apple **ASC 500** during the fastlane upload (a known flaky `deliver` error, unrelated to this change); re-dispatching `upload=true` after this lands should push correct screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)