### PR TITLE
fix(asc): add es-MX App Store listing text so it isn't screenshots-only

### DIFF
--- a/app-stores/apple/app-store-metadata.md
+++ b/app-stores/apple/app-store-metadata.md
@@ -6,10 +6,14 @@
 > below — the App Name, Subtitle, Description, Keywords, Promotional Text, and
 > What's New copy live in `name.txt`, `subtitle.txt`, `description.txt`,
 > `keywords.txt`, `promotional_text.txt`, and `release_notes.txt` respectively.
-> The listing is localized: `en-US` (default), `es-ES`, and `fr-FR` each have
-> their own folder under `fastlane/metadata/`, and `deliver` uploads every locale
-> folder it finds. This doc keeps the operational material that `deliver` can't
-> upload: review notes, privacy labels, and the screenshot map.
+> The listing is localized: `en-US` (default), `es-ES`, `es-MX`, and `fr-FR` each
+> have their own folder under `fastlane/metadata/`, and `deliver` uploads every
+> locale folder it finds. There's one Spanish app translation but no universal
+> App Store Spanish (unlike `en-US`, which covers every English storefront), so the
+> same `es` copy serves both `es-ES` (Spain) and `es-MX` (Mexico/Latin America) —
+> matching the two Spanish screenshot locales. This doc keeps the operational
+> material that `deliver` can't upload: review notes, privacy labels, and the
+> screenshot map.
 
 ## Basic Info
 

--- a/fastlane/metadata/es-MX/description.txt
+++ b/fastlane/metadata/es-MX/description.txt
@@ -1,0 +1,33 @@
+Busca una vía y mira cómo tu muro ilumina las presas. Toca un bloque, las presas se encienden, te cuelgas. Boardsesh conecta tu móvil con tu muro por Bluetooth, así que pasas la sesión escalando en vez de leer números en una pantalla.
+
+UNA APP PARA TODOS TUS MUROS
+Kilter, Tension y MoonBoard tienen cada uno su propia app para su propio muro. Boardsesh funciona con todos ellos, más Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Busca cualquier vía y Boardsesh la manda al muro por Bluetooth, encendiendo las presas. Control total de los LED en los siete muros.
+
+La gracia de tener una sola app son las dos cosas que una app de un solo muro no te da: el historial del muro siempre activo y las sesiones que llevas con tu peña.
+
+HISTORIAL DEL MURO, SIEMPRE ACTIVO
+Cada muro al que te conectas tiene un feed en directo de lo que está encendido en esa pared ahora mismo: la vía que hay puesta en este momento, quién la encendió, el grado y el ángulo, quién la montó y los encadenes recientes. No tienes que abrir nada. Está ahí cuando estás en ese muro, actualizándose según caen las pegadas.
+
+SESIONES CON TU PEÑA
+Abre una sesión y tú y tu peña compartís una cola que cualquiera puede llevar. Cualquiera manda la siguiente vía al muro: nadie tiene que ir pasando el móvil ni esperar su turno. La enciende quien esté conectado por Bluetooth. Al terminar te llevas un resumen y el seguimiento: encadenes e intentos, reparto de grados, tu vía más dura y el progreso a lo largo del tiempo.
+
+Lleva la sesión desde la pantalla bloqueada (iOS 17+)
+Las Live Activities ponen la vía actual, tu sitio en la cola y la siguiente/anterior en la pantalla bloqueada y el Dynamic Island, así cambias de vía sin abrir la app.
+
+Móntate un entreno
+Elige Volumen, Pirámide, Escalera o Foco de Grado, fija un grado objetivo y el calentamiento, previsualiza las vías y mándalas al muro pegada a pegada.
+
+Registra tu escalada
+Apunta encadenes, flashes e intentos, recibe un resumen con la duración, el reparto de grados y tu vía más dura, y mira tus encadenes y grados en la pestaña Progreso.
+
+Llévate tu historial contigo
+Guarda tu sesión en Apple Health e importa tu logbook antiguo de Kilter y Tension desde Aurora Climbing.
+
+Encuentra más para escalar
+Sigue a tu peña y a los aperturistas, busca escaladores y fija playlists desde Discover.
+
+Gratis, sin anuncios, sin suscripciones. Código abierto en GitHub.
+
+Muros compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
+
+Boardsesh funciona con estos muros y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.

--- a/fastlane/metadata/es-MX/keywords.txt
+++ b/fastlane/metadata/es-MX/keywords.txt
@@ -1,0 +1,1 @@
+MoonBoard,kilter,tension,boulder,escalada,bloque,bluetooth,led,rocodromo,croquis,sesion,aperturista

--- a/fastlane/metadata/es-MX/marketing_url.txt
+++ b/fastlane/metadata/es-MX/marketing_url.txt
@@ -1,0 +1,1 @@
+https://boardsesh.com

--- a/fastlane/metadata/es-MX/name.txt
+++ b/fastlane/metadata/es-MX/name.txt
@@ -1,0 +1,1 @@
+Boardsesh

--- a/fastlane/metadata/es-MX/privacy_url.txt
+++ b/fastlane/metadata/es-MX/privacy_url.txt
@@ -1,0 +1,1 @@
+https://boardsesh.com/privacy

--- a/fastlane/metadata/es-MX/promotional_text.txt
+++ b/fastlane/metadata/es-MX/promotional_text.txt
@@ -1,0 +1,1 @@
+Busca una vía y mira cómo tu muro ilumina las presas por Bluetooth. Encadena con tu peña, lleva la sesión desde la pantalla bloqueada y mira tu progreso.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,0 +1,8 @@
+Las sesiones ahora están siempre en directo. Abre una sesión y tu peña comparte una cola que cualquiera puede llevar. Cualquiera manda la siguiente vía al muro, sin tener que ir pasando el móvil ni esperar turno. La enciende quien esté conectado por Bluetooth.
+
+También en esta versión:
+- Historial del muro, siempre activo: cada muro al que te conectas tiene un feed en directo de la vía encendida ahora mismo, quién la encendió, el grado, el ángulo y el aperturista, actualizándose según caen las pegadas.
+- Lleva la sesión desde la pantalla bloqueada y el Dynamic Island en iOS 17+ con las Live Activities.
+- Móntate un entreno con Volumen, Pirámide, Escalera o Foco de Grado y manda las vías pegada a pegada.
+- Registra encadenes, flashes e intentos, y mira tus encadenes y grados en la pestaña Progreso.
+- Guarda tus sesiones en Apple Health e importa tu logbook antiguo de Kilter y Tension desde Aurora Climbing.

--- a/fastlane/metadata/es-MX/subtitle.txt
+++ b/fastlane/metadata/es-MX/subtitle.txt
@@ -1,0 +1,1 @@
+Ilumina cualquier panel LED

--- a/fastlane/metadata/es-MX/support_url.txt
+++ b/fastlane/metadata/es-MX/support_url.txt
@@ -1,0 +1,1 @@
+https://boardsesh.com


### PR DESCRIPTION
## Why

Spotted while reviewing whether we should push `es-MX` screenshots at all. The state was incoherent:

| Surface | Spanish locales |
|---|---|
| App Store **screenshots** | `es-ES` **+ `es-MX`** |
| App Store **listing text** (`fastlane/metadata/`) | `es-ES` only |

So `es-MX` was an **orphan localization** — screenshots with no listing copy.

The question was whether to drop `es-MX` (like we don't bother with `en-GB`/`en-AU`) or complete it. The deciding factor: **`en-US` is App Store's *universal* English** (UK/Australia fall back to it), but there is **no universal Spanish** — `es-ES` (Spain) and `es-MX` (Mexico/LatAm) cover different storefronts and don't fall back to each other. So keeping both genuinely widens Spanish reach, and the single `es` app translation just serves both.

## What

- Add `fastlane/metadata/es-MX/` as a **verbatim copy of `es-ES`** (all 9 App Store text files). One `es` translation → same copy for both Spanish storefronts, mirroring how the app ships a single `es` bundle.
- Update `app-stores/apple/app-store-metadata.md` to list `es-MX` and explain the intent (no universal Spanish).

Now `es-MX` is a complete App Store localization (text + screenshots), consistent with the screenshot pipeline that already targets both Spanish locales (`APP_STORE_LOCALES_BY_APP_LOCALE`, `EXPECTED_APP_STORE_LOCALES`, `EXPECTED_DELIVER_LOCALES`).

## Scope notes
- **App Store only.** `es-MX` isn't a Google Play locale (Play uses `es-419`/`es-ES`), and Play screenshots are `en-US`-only, so nothing changes for Play.
- The `es-MX` text is pushed by the `ios metadata` lane (the *Mobile Store Metadata* workflow), not the screenshots workflow. If App Store Connect needs the `es-MX` localization enabled before first push, that's a one-time manual step in ASC.
- `es-MX` copy can be regionalized to Mexican Spanish later (e.g. terms like *rocódromo*/*aperturista* are Spain-leaning); for now it matches the single `es` translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)