### PR TITLE
fix(mobile-screenshots): retry adb display setup after Android emulator boot

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -517,8 +517,21 @@ jobs:
             # `pipefail` — `set -euo pipefail` aborts the step before anything runs. No
             # pipes here, so `set -eu` is equivalent.
             set -eu
-            adb shell wm size 1080x1920
-            adb shell wm density 420
+            # `sys.boot_completed` fires before the window manager is fully up, so an
+            # `adb shell wm …` right after the runner reports "booted" can hit a
+            # transient "device offline" (exit 1) and abort the step under `set -e`.
+            # Wait for the device, then retry the display setup until it sticks.
+            adb wait-for-device
+            wm_ready=0
+            for attempt in 1 2 3 4 5 6; do
+              if adb shell wm size 1080x1920 && adb shell wm density 420; then
+                wm_ready=1
+                break
+              fi
+              echo "display setup not ready (attempt ${attempt}/6); retrying in 5s…"
+              sleep 5
+            done
+            [ "$wm_ready" = 1 ] || { echo "::error::adb wm display setup failed after retries"; exit 1; }
             vp run mobile:screenshots -- \
               --platform android \
               --flow "${{ inputs.flow || 'app-store' }}" \


### PR DESCRIPTION
## Why

Follow-up to the KVM fix (#2996). KVM **worked** — in run [27724123828](https://github.com/boardsesh/boardsesh/actions/runs/27724123828) the Android emulator booted in **~56s** (vs the old multi-minute thrash) and disabled animations sub-second. But the job still failed one step later:

```
[command] adb -s emulator-5554 shell settings put global animator_duration_scale 0.0   # fast, OK
[command] /usr/bin/sh -c adb shell wm size 1080x1920
[command] /usr/bin/sh -c adb shell wm density 420
##[error] The process '/usr/bin/sh' failed with exit code 1
```

(with an `adb: device offline` blip during boot just before). `sys.boot_completed` fires before the window manager is fully up, so an `adb shell wm …` right after "booted" can transiently fail, and `set -eu` aborts the whole step.

## What

In the emulator-runner `script:`, before capturing:
- `adb wait-for-device`
- retry `adb shell wm size 1080x1920 && adb shell wm density 420` up to 6× (5s apart) until it succeeds; hard-fail with a clear message if it never does.

POSIX-sh only (the runner executes the script under dash) — validated with `sh -n`.

## Status of the screenshot work
- iOS: fully green in 27724123828 — 9-shard matrix, **real board content** (the auto-activate fix), dimension gate, and the **live App Store Connect upload all succeeded**.
- Android was the last red; this is the only remaining blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)