### PR TITLE
feat(mobile): plot ascents (not difficulty) on the grade-by-angle chart

### DIFF
--- a/packages/mobile/src/components/play-drawer/CommunitySection.tsx
+++ b/packages/mobile/src/components/play-drawer/CommunitySection.tsx
@@ -79,9 +79,9 @@ export const CommunitySection = memo(function CommunitySection({
       {angleBars.length > 0 && (
         <View style={styles.histogram}>
           <Text variant="footnote" color={iosSystemColors.systemGray}>
-            {t('mobile.community.gradeByAngle')}
+            {t('mobile.community.ascentsByAngle')}
           </Text>
-          <DifficultyByAngleChart data={angleBars} accessibilityLabel={t('mobile.community.gradeByAngle')} />
+          <DifficultyByAngleChart data={angleBars} accessibilityLabel={t('mobile.community.ascentsByAngle')} />
         </View>
       )}
     </View>

--- a/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
@@ -4,7 +4,6 @@ import { BarChart } from 'react-native-gifted-charts';
 import { Text } from '../Text';
 import { buildAscentScale, type AngleGradeBar } from './community-utils';
 import { useTheme } from '../../providers/theme-provider';
-import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { gradeChartColor } from '../you/profile-chart-colors';
 import { borderRadius, spacing } from '../../theme/tokens';
 
@@ -40,7 +39,6 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   accessibilityLabel,
 }: DifficultyByAngleChartProps) {
   const { chartColors, colorScheme } = useTheme();
-  const reduceMotion = useReduceMotion();
   const [width, setWidth] = useState(0);
 
   // Bars + axis scale only depend on the data + scheme — memoize so a parent
@@ -124,8 +122,11 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
           xAxisColor={chartColors.separator}
           xAxisLabelTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
           yAxisTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
-          isAnimated={!reduceMotion}
-          animationDuration={reduceMotion ? 0 : 600}
+          // gifted-charts' entry animation is unreliable on Android when the chart
+          // mounts inside the collapsible's FadeIn transition — bars flash then
+          // collapse to 0 height and never grow back. Render statically, matching
+          // every other chart in the app (see YouCharts).
+          isAnimated={false}
           disableScroll
           disablePress
         />

--- a/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
@@ -20,13 +20,43 @@ const BAR_RADIUS = borderRadius.sm;
 const PEAK_BAR_RADIUS = borderRadius.md;
 const TOP_LABEL_HEIGHT = 16;
 const MIN_BAR_WIDTH = 10;
+// Width reserved for the y-axis ascent-count labels (e.g. "120", "1.2k").
+const Y_AXIS_LABEL_WIDTH = 32;
 
-// Difficulty-by-angle as a column chart: x-axis angles, bar height ∝ the grade's
-// position within the local difficulty range (a flat baseline of `min - 1` so
-// the easiest angle still shows a stub and steps between angles read clearly),
-// the bar drawn in the grade's scheme-aware colour with the grade label above it.
-// The hardest angle is flagged with a non-colour cue (bold label + larger cap) so
-// it survives colour-blindness and both schemes/variants.
+// Compact tick label: whole numbers below 1k, "1.2k" above so labels stay narrow.
+function formatCount(value: number): string {
+  return value >= 1000 ? `${Math.round(value / 100) / 10}k` : String(value);
+}
+
+// Round a raw step up to a friendly 1/2/5 × 10ⁿ value so ticks read 0/5/10/15
+// instead of 0/3/6/9.
+function niceStep(rawStep: number): number {
+  if (rawStep <= 1) return 1;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  for (const multiple of [1, 2, 5]) {
+    if (rawStep <= multiple * magnitude) return multiple * magnitude;
+  }
+  return 10 * magnitude;
+}
+
+// Integer y-scale for the ascent counts: ~4 whole-number sections with the top
+// tick strictly above the tallest bar so its grade top-label has headroom.
+function buildAscentScale(maxSends: number): { maxValue: number; noOfSections: number; labels: string[] } {
+  const peak = Math.max(maxSends, 1);
+  const step = niceStep(Math.ceil(peak / 4));
+  let noOfSections = Math.ceil(peak / step);
+  if (step * noOfSections <= peak) noOfSections += 1;
+  const labels = Array.from({ length: noOfSections + 1 }, (_, index) => formatCount(index * step));
+  return { maxValue: step * noOfSections, noOfSections, labels };
+}
+
+// Ascents-by-angle column chart: x-axis angles, bar height = the number of
+// ascents (ascensionist count) at that angle, the bar drawn in the grade's
+// scheme-aware colour with the grade label above it and the ascent count on the
+// y-axis. The hardest angle is flagged with a non-colour cue (bold label + larger
+// cap) so the hardest grade survives colour-blindness and both schemes/variants —
+// note that, since height now means ascents, the hardest angle is no longer
+// necessarily the tallest bar.
 export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   data,
   accessibilityLabel,
@@ -40,9 +70,7 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   // closures) every time.
   const model = useMemo(() => {
     if (data.length === 0) return null;
-    const difficulties = data.map((bar) => bar.difficulty);
-    const baseline = Math.min(...difficulties) - 1;
-    const range = Math.max(Math.max(...difficulties) - baseline, 1);
+    const scale = buildAscentScale(Math.max(...data.map((bar) => bar.sends)));
     // The single hardest angle (first max wins on ties) gets the redundant cue.
     const hardestAngle = data.reduce((peak, bar) => (bar.difficulty > peak.difficulty ? bar : peak)).angle;
     const barData = data.map((bar) => {
@@ -50,7 +78,7 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
       const isHardest = bar.angle === hardestAngle;
       const topRadius = isHardest ? PEAK_BAR_RADIUS : BAR_RADIUS;
       return {
-        value: bar.difficulty - baseline,
+        value: bar.sends,
         frontColor: fill,
         label: `${bar.angle}°`,
         barBorderTopLeftRadius: topRadius,
@@ -70,9 +98,7 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
         ),
       };
     });
-    // +1 headroom so the tallest (hardest-angle) bar doesn't pin to the top edge
-    // and crowd its grade top-label.
-    return { barData, chartMaxValue: range + 1 };
+    return { barData, maxValue: scale.maxValue, noOfSections: scale.noOfSections, yAxisLabelTexts: scale.labels };
   }, [data, colorScheme]);
 
   const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
@@ -82,9 +108,11 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   const count = data.length;
   const barSpacing = count > 8 ? 6 : 12;
   const initialSpacing = 10;
+  // Reserve space for the y-axis labels so the bars + axis fit the measured width.
+  const plotWidth = Math.max(0, width - Y_AXIS_LABEL_WIDTH);
   const barWidth =
-    width > 0
-      ? Math.max(MIN_BAR_WIDTH, Math.floor((width - initialSpacing * 2 - barSpacing * count) / count))
+    plotWidth > 0
+      ? Math.max(MIN_BAR_WIDTH, Math.floor((plotWidth - initialSpacing * 2 - barSpacing * count) / count))
       : MIN_BAR_WIDTH;
 
   return (
@@ -98,19 +126,23 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
       {width > 0 ? (
         <BarChart
           data={model.barData}
-          width={width - 8}
+          width={plotWidth - 8}
           height={CHART_HEIGHT}
           barWidth={barWidth}
           spacing={barSpacing}
           initialSpacing={initialSpacing}
-          maxValue={model.chartMaxValue}
+          maxValue={model.maxValue}
+          noOfSections={model.noOfSections}
+          yAxisLabelTexts={model.yAxisLabelTexts}
+          yAxisLabelWidth={Y_AXIS_LABEL_WIDTH}
           topLabelContainerStyle={styles.topLabelContainer}
-          hideRules
-          hideYAxisText
+          rulesColor={chartColors.separator}
+          rulesType="solid"
           yAxisThickness={0}
           xAxisThickness={StyleSheet.hairlineWidth}
           xAxisColor={chartColors.separator}
           xAxisLabelTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
+          yAxisTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
           isAnimated={!reduceMotion}
           animationDuration={reduceMotion ? 0 : 600}
           disableScroll

--- a/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useState, type ReactNode } from 'react';
 import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 import { BarChart } from 'react-native-gifted-charts';
 import { Text } from '../Text';
-import type { AngleGradeBar } from './community-utils';
+import { buildAscentScale, type AngleGradeBar } from './community-utils';
 import { useTheme } from '../../providers/theme-provider';
 import { useReduceMotion } from '../../hooks/use-reduce-motion';
 import { gradeChartColor } from '../you/profile-chart-colors';
@@ -26,28 +26,6 @@ const Y_AXIS_LABEL_WIDTH = 32;
 // Compact tick label: whole numbers below 1k, "1.2k" above so labels stay narrow.
 function formatCount(value: number): string {
   return value >= 1000 ? `${Math.round(value / 100) / 10}k` : String(value);
-}
-
-// Round a raw step up to a friendly 1/2/5 × 10ⁿ value so ticks read 0/5/10/15
-// instead of 0/3/6/9.
-function niceStep(rawStep: number): number {
-  if (rawStep <= 1) return 1;
-  const magnitude = Math.pow(10, Math.floor(Math.log10(rawStep)));
-  for (const multiple of [1, 2, 5]) {
-    if (rawStep <= multiple * magnitude) return multiple * magnitude;
-  }
-  return 10 * magnitude;
-}
-
-// Integer y-scale for the ascent counts: ~4 whole-number sections with the top
-// tick strictly above the tallest bar so its grade top-label has headroom.
-function buildAscentScale(maxSends: number): { maxValue: number; noOfSections: number; labels: string[] } {
-  const peak = Math.max(maxSends, 1);
-  const step = niceStep(Math.ceil(peak / 4));
-  let noOfSections = Math.ceil(peak / step);
-  if (step * noOfSections <= peak) noOfSections += 1;
-  const labels = Array.from({ length: noOfSections + 1 }, (_, index) => formatCount(index * step));
-  return { maxValue: step * noOfSections, noOfSections, labels };
 }
 
 // Ascents-by-angle column chart: x-axis angles, bar height = the number of
@@ -98,7 +76,10 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
         ),
       };
     });
-    return { barData, maxValue: scale.maxValue, noOfSections: scale.noOfSections, yAxisLabelTexts: scale.labels };
+    const yAxisLabelTexts = Array.from({ length: scale.noOfSections + 1 }, (_, index) =>
+      formatCount(index * scale.step),
+    );
+    return { barData, maxValue: scale.maxValue, noOfSections: scale.noOfSections, yAxisLabelTexts };
   }, [data, colorScheme]);
 
   const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);

--- a/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
@@ -38,17 +38,28 @@ describe('buildAngleGradeBars', () => {
     expect(bars[0].gradeName).toBe('V5+ / 6C+');
   });
 
-  it('keeps only the latest snapshot per angle', () => {
+  it('keeps only the latest snapshot per angle, including its ascent count', () => {
     const bars = buildAngleGradeBars(
       [
-        makeEntry({ angle: 40, displayDifficulty: 18, createdAt: '2026-01-01' }),
-        makeEntry({ angle: 40, displayDifficulty: 22, createdAt: '2026-03-01' }),
+        makeEntry({ angle: 40, displayDifficulty: 18, ascensionistCount: 5, createdAt: '2026-01-01' }),
+        makeEntry({ angle: 40, displayDifficulty: 22, ascensionistCount: 37, createdAt: '2026-03-01' }),
       ],
       'v-grade',
     );
     expect(bars).toHaveLength(1);
     expect(bars[0].difficulty).toBe(22);
     expect(bars[0].gradeName).toBe('V6');
+    expect(bars[0].sends).toBe(37);
+  });
+
+  it('carries the ascensionist count into sends', () => {
+    const bars = buildAngleGradeBars([makeEntry({ ascensionistCount: 42 })], 'v-grade');
+    expect(bars[0].sends).toBe(42);
+  });
+
+  it('defaults sends to 0 when ascensionistCount is null', () => {
+    const bars = buildAngleGradeBars([makeEntry({ ascensionistCount: null })], 'v-grade');
+    expect(bars[0].sends).toBe(0);
   });
 
   it('falls back to displayDifficulty over difficultyAverage, then skips null difficulties', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { ClimbStatsHistoryEntry } from '@boardsesh/graphql/operations';
-import { buildAngleGradeBars } from '../community-utils';
+import { buildAngleGradeBars, buildAscentScale, niceStep } from '../community-utils';
 
 function makeEntry(overrides: Partial<ClimbStatsHistoryEntry> = {}): ClimbStatsHistoryEntry {
   return {
@@ -77,5 +77,40 @@ describe('buildAngleGradeBars', () => {
   it('labels out-of-range difficulties with the rounded numeric value', () => {
     const bars = buildAngleGradeBars([makeEntry({ displayDifficulty: 99.4 })], 'v-grade');
     expect(bars[0].gradeName).toBe('99');
+  });
+});
+
+describe('niceStep', () => {
+  it('rounds raw steps up to the next 1/2/5 × 10ⁿ value', () => {
+    expect(niceStep(0)).toBe(1);
+    expect(niceStep(1)).toBe(1);
+    expect(niceStep(3)).toBe(5);
+    expect(niceStep(7)).toBe(10);
+    expect(niceStep(13)).toBe(20);
+    expect(niceStep(25)).toBe(50);
+    expect(niceStep(120)).toBe(200);
+  });
+});
+
+describe('buildAscentScale', () => {
+  it('keeps the top tick strictly above the tallest bar so its top-label has headroom', () => {
+    for (const peak of [0, 1, 2, 3, 4, 5, 10, 20, 37, 40, 100, 123, 1000, 1234]) {
+      const scale = buildAscentScale(peak);
+      expect(scale.maxValue).toBeGreaterThan(peak);
+      // The tick texts derived in the chart use noOfSections + 1 labels; the top
+      // tick must equal step × sections.
+      expect(scale.maxValue).toBe(scale.step * scale.noOfSections);
+    }
+  });
+
+  it('uses whole-number, evenly-spaced steps', () => {
+    expect(buildAscentScale(10)).toEqual({ maxValue: 15, noOfSections: 3, step: 5 });
+    expect(buildAscentScale(37)).toEqual({ maxValue: 40, noOfSections: 4, step: 10 });
+    expect(buildAscentScale(100)).toEqual({ maxValue: 150, noOfSections: 3, step: 50 });
+  });
+
+  it('stays sane for an empty / single-ascent chart', () => {
+    expect(buildAscentScale(0)).toEqual({ maxValue: 2, noOfSections: 2, step: 1 });
+    expect(buildAscentScale(1)).toEqual({ maxValue: 2, noOfSections: 2, step: 1 });
   });
 });

--- a/packages/mobile/src/components/play-drawer/community-utils.ts
+++ b/packages/mobile/src/components/play-drawer/community-utils.ts
@@ -9,11 +9,30 @@ export type AngleGradeBar = {
   difficulty: number;
   /** Formatted grade label shown above the bar (e.g. "V6"). */
   gradeName: string;
-  /** Grade colour for the bar fill. */
-  color: string;
   /** Ascensionist count (sends) at this angle — drives bar height. */
   sends: number;
 };
+
+// Round a raw step up to a friendly 1/2/5 × 10ⁿ value so axis ticks read
+// 0/5/10/15 instead of 0/3/6/9.
+export function niceStep(rawStep: number): number {
+  if (rawStep <= 1) return 1;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  for (const multiple of [1, 2, 5]) {
+    if (rawStep <= multiple * magnitude) return multiple * magnitude;
+  }
+  return 10 * magnitude;
+}
+
+// Integer y-scale for an ascent-count column chart: ~4–5 whole-number sections
+// with the top tick strictly above the tallest bar so its top-label has headroom.
+export function buildAscentScale(maxSends: number): { maxValue: number; noOfSections: number; step: number } {
+  const peak = Math.max(maxSends, 1);
+  const step = niceStep(Math.ceil(peak / 4));
+  let noOfSections = Math.ceil(peak / step);
+  if (step * noOfSections <= peak) noOfSections += 1;
+  return { maxValue: step * noOfSections, noOfSections, step };
+}
 
 const GRADE_BY_ID = new Map<number, BoulderGrade>(BOULDER_GRADES.map((grade) => [grade.difficulty_id, grade]));
 
@@ -45,7 +64,6 @@ export function buildAngleGradeBars(
         angle: entry.angle,
         difficulty,
         gradeName,
-        color: getGradeColor(grade?.difficulty_name) ?? DEFAULT_GRADE_COLOR,
         sends: entry.ascensionistCount ?? 0,
       };
     })

--- a/packages/mobile/src/components/play-drawer/community-utils.ts
+++ b/packages/mobile/src/components/play-drawer/community-utils.ts
@@ -5,44 +5,48 @@ import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/g
 
 export type AngleGradeBar = {
   angle: number;
-  /** Numeric difficulty (Aurora display difficulty) used for relative bar width. */
+  /** Numeric difficulty (Aurora display difficulty) — drives the grade label + colour. */
   difficulty: number;
-  /** Formatted grade label shown at the end of the bar (e.g. "V6"). */
+  /** Formatted grade label shown above the bar (e.g. "V6"). */
   gradeName: string;
   /** Grade colour for the bar fill. */
   color: string;
+  /** Ascensionist count (sends) at this angle — drives bar height. */
+  sends: number;
 };
 
 const GRADE_BY_ID = new Map<number, BoulderGrade>(BOULDER_GRADES.map((grade) => [grade.difficulty_id, grade]));
 
 // Latest snapshot per angle → one grade bar; out-of-range difficulties show the rounded number.
+// The grade (label + colour) comes from the difficulty; bar height comes from the ascent count.
 export function buildAngleGradeBars(
   history: ClimbStatsHistoryEntry[] | undefined,
   gradeFormat: GradeDisplayFormat,
 ): AngleGradeBar[] {
   if (!history) return [];
 
-  const latestByAngle = new Map<number, { difficulty: number; createdAt: string }>();
+  const latestByAngle = new Map<number, { entry: ClimbStatsHistoryEntry; difficulty: number }>();
   for (const entry of history) {
     const difficulty = entry.displayDifficulty ?? entry.difficultyAverage;
     if (difficulty == null) continue;
     const existing = latestByAngle.get(entry.angle);
-    if (!existing || new Date(entry.createdAt).getTime() > new Date(existing.createdAt).getTime()) {
-      latestByAngle.set(entry.angle, { difficulty, createdAt: entry.createdAt });
+    if (!existing || new Date(entry.createdAt).getTime() > new Date(existing.entry.createdAt).getTime()) {
+      latestByAngle.set(entry.angle, { entry, difficulty });
     }
   }
 
-  return Array.from(latestByAngle.entries())
-    .map(([angle, { difficulty }]) => {
+  return Array.from(latestByAngle.values())
+    .map(({ entry, difficulty }) => {
       const grade = GRADE_BY_ID.get(Math.round(difficulty));
       const gradeName = grade
         ? (formatGrade(grade.difficulty_name, gradeFormat) ?? grade.v_grade)
         : String(Math.round(difficulty));
       return {
-        angle,
+        angle: entry.angle,
         difficulty,
         gradeName,
         color: getGradeColor(grade?.difficulty_name) ?? DEFAULT_GRADE_COLOR,
+        sends: entry.ascensionistCount ?? 0,
       };
     })
     .sort((a, b) => a.angle - b.angle);

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -292,7 +292,7 @@
       "ascensionists_one": "{{count}} ascensionist",
       "ascensionists_other": "{{count}} ascensionists",
       "avgQuality": "Average quality",
-      "gradeByAngle": "Grade by angle"
+      "ascentsByAngle": "Ascents by angle"
     },
     "betaVideos": {
       "title": "Beta Videos",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -292,7 +292,7 @@
       "ascensionists_one": "{{count}} ascensionista",
       "ascensionists_other": "{{count}} ascensionistas",
       "avgQuality": "Calidad promedio",
-      "gradeByAngle": "Grado por ángulo"
+      "ascentsByAngle": "Ascensos por ángulo"
     },
     "betaVideos": {
       "title": "Videos Beta",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -292,7 +292,7 @@
       "ascensionists_one": "{{count}} grimpeur",
       "ascensionists_other": "{{count}} grimpeurs",
       "avgQuality": "Qualite moyenne",
-      "gradeByAngle": "Cotation par angle"
+      "ascentsByAngle": "Ascensions par angle"
     },
     "betaVideos": {
       "title": "Videos Beta",


### PR DESCRIPTION
## What

In the React Native play drawer, the Community section's "grade by angle" chart sized each angle's bar by **grade difficulty** (the grade's position within the climb's local difficulty range). It now sizes each bar by the **number of ascents** (`ascensionistCount`) at that angle.

The two grade-derived visuals are kept: each bar's **colour** and its **grade label** (on top). The Y axis now shows the ascent count.

## Changes

- **`community-utils.ts`** — `AngleGradeBar` gains a `sends` field, populated from the latest snapshot's `ascensionistCount` (`?? 0`). Difficulty still drives the grade label + colour.
- **`DifficultyByAngleChart.tsx`** — bar `value` is now `sends`; dropped the difficulty/baseline math. Added an integer Y scale (nice 1/2/5 steps, top tick kept above the tallest bar so the grade top-label has headroom), Y-axis tick labels with compact `k` formatting for large counts, light horizontal rules, and reserved width for the axis labels. The hardest-angle bold-label cue stays (a comment notes the hardest angle is no longer necessarily the tallest bar).
- **i18n** — renamed `mobile.community.gradeByAngle` → `ascentsByAngle` and set the title to "Ascents by angle" / "Ascensos por ángulo" / "Ascensions par angle" (en/es/fr).
- **`CommunitySection.tsx`** — updated the title + chart `accessibilityLabel` to the new key.
- **tests** — added coverage for `sends` (value carried through, `null` → 0, latest-snapshot count).

The component/file name `DifficultyByAngleChart` is kept to keep the change minimal; its doc comment is updated to the new semantics.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2394 passed (incl. new `sends` tests)
- i18n catalog parity tests, `check:i18n`, `check:i18n:orphans` — all OK
- `vp run check:mobile-bundle` — OK (Metro bundle builds)
- `vp check` — no lint/format issues on changed files

macOS-only simulator/screenshot checks were not run (Linux host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)