### PR TITLE
fix(mobile): activate the screenshot board reactively, not in checkAuth

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -42,6 +42,7 @@ import { PersistentQueueBar } from '../src/components/queue-control/persistent-q
 import { UserDrawerProvider } from '../src/components/user-drawer/UserDrawerProvider';
 import { useMobileClimbActionsData } from '../src/lib/graphql/hooks';
 import { useActiveBoard } from '../src/lib/graphql/use-active-board';
+import { ScreenshotBoardAutoActivator } from '../src/components/screenshot-board-auto-activator';
 import { Text } from '../src/components/Text';
 import { Icon } from '../src/components/Icon';
 import { brandColors } from '../src/theme/colors';
@@ -212,6 +213,10 @@ function BoardProviderWrapper({ children }: { children: ReactNode }) {
   const { data: activeBoard } = useActiveBoard();
   return (
     <BoardProvider boardName={toBoardName(activeBoard?.boardType)} boardUuid={activeBoard?.uuid}>
+      {/* Screenshot builds only (inlined check → dead-strips in normal builds):
+          auto-activate the user's first board so board-backed shots aren't stuck
+          on the "No board selected" picker. */}
+      {process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && <ScreenshotBoardAutoActivator />}
       {children}
     </BoardProvider>
   );

--- a/packages/mobile/src/components/screenshot-board-auto-activator.tsx
+++ b/packages/mobile/src/components/screenshot-board-auto-activator.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useMyBoards } from '../lib/graphql/hooks';
+import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
+import { useAuth } from '../providers/auth-provider';
+
+/**
+ * Screenshot builds only: make the signed-in user's first saved board (Marco's
+ * board) active so the board-backed screens (Climbs, Board View) render real
+ * content instead of the "No board selected" picker. Replaces the Maestro flow's
+ * fragile board-picker coordinate tap.
+ *
+ * Reactive + self-healing on purpose. It uses the SAME `useMyBoards` /
+ * `useSetActiveBoard` hooks the real board picker uses — so it inherits React
+ * Query's auth/retry/timing instead of a hand-rolled fetch wedged into the auth
+ * boot sequence (which raced the token + the query cache GC and silently no-op'd).
+ * Because it keeps `useActiveBoard` observed, the activated board is never
+ * garbage-collected, and if anything clears it (e.g. a sign-out cleanup on a boot
+ * AppState race) the effect re-runs and re-activates.
+ *
+ * Mount only behind an inlined `EXPO_PUBLIC_SCREENSHOT_MODE === '1'` check so it
+ * dead-strips in normal builds and never runs for real users.
+ */
+export function ScreenshotBoardAutoActivator(): null {
+  const { isAuthenticated } = useAuth();
+  const { data: activeBoard } = useActiveBoard();
+  // Same call shape as the board picker. Keeping it observed also keeps the
+  // boards data warm in the React Query cache for the re-activation path.
+  const { data: boardConnection } = useMyBoards(undefined, { enabled: isAuthenticated });
+  const setActiveBoard = useSetActiveBoard();
+
+  useEffect(() => {
+    if (!isAuthenticated || activeBoard) return;
+    const firstBoard = boardConnection?.boards?.[0];
+    if (!firstBoard) return;
+    // Logged so a screenshot run is debuggable from the Metro output the
+    // orchestrator tees (a missing line means the boards fetch came back empty).
+    console.log(`[screenshot] auto-activating board ${firstBoard.uuid} (${firstBoard.boardType})`);
+    void setActiveBoard(firstBoard);
+  }, [isAuthenticated, activeBoard, boardConnection, setActiveBoard]);
+
+  return null;
+}

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { AppState } from 'react-native';
 import { useSegments, Redirect } from 'expo-router';
-import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { getAuthToken, isTokenExpiringSoon } from '../lib/auth-store';
 import {
@@ -17,12 +17,11 @@ import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screensh
 import { reset as resetAnalytics, track } from '../lib/analytics';
 import { reportError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
-import { getHttpClient, resetHttpClient } from '../lib/graphql/client';
+import { resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
 import { clearStoredSessionId } from '../lib/session-store';
-import { clearStoredActiveBoard, setStoredActiveBoard } from '../lib/active-board-store';
+import { clearStoredActiveBoard } from '../lib/active-board-store';
 import { ACTIVE_BOARD_QUERY_KEY } from '../lib/graphql/use-active-board';
-import { GET_MY_BOARDS, type GetMyBoardsQueryResponse } from '@boardsesh/graphql/operations/boards';
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -34,27 +33,6 @@ type AuthState = {
   signOut: (method?: 'manual' | 'account_deleted') => Promise<void>;
   refreshAuthState: () => Promise<void>;
 };
-
-// Screenshot builds only: fetch the signed-in user's saved boards and make the
-// first one active, so board-backed screens (Climbs, Board View) render real
-// content on first paint instead of the "No board selected" empty state. This is
-// the screenshot-mode analogue of auto-sign-in and replaces the Maestro flow's
-// fragile board-picker coordinate tap (which missed on a loaded runner, leaving
-// every board-dependent shot stuck on the picker). Best-effort: a failure just
-// leaves no active board, never blocks the already-successful sign-in. Dead-strips
-// in normal builds — only called from the inlined SCREENSHOT_MODE branch below.
-async function activateFirstBoardForScreenshots(queryClient: QueryClient): Promise<void> {
-  try {
-    const { myBoards } = await getHttpClient().request<GetMyBoardsQueryResponse>(GET_MY_BOARDS);
-    const firstBoard = myBoards?.boards?.[0];
-    if (firstBoard) {
-      await setStoredActiveBoard(firstBoard);
-      queryClient.setQueryData(ACTIVE_BOARD_QUERY_KEY, firstBoard);
-    }
-  } catch (boardError) {
-    reportError(boardError);
-  }
-}
 
 const AuthContext = createContext<AuthState | null>(null);
 
@@ -148,9 +126,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
           const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
           if (screenshotSignIn.success) {
-            // Make the first saved board active before the loading gate clears, so
-            // board-backed screens never flash the "No board selected" picker.
-            await activateFirstBoardForScreenshots(queryClient);
             setIsAuthenticated(true);
             return;
           }
@@ -181,7 +156,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [handleSignedOutTransition, queryClient]);
+  }, [handleSignedOutTransition]);
 
   useEffect(() => {
     // Belt-and-braces: checkAuth already resolves its own rejections, but keep


### PR DESCRIPTION
## The bug

#2997 tried to auto-activate the board from inside `checkAuth` (a fetch right after the screenshot sign-in). It **silently did nothing in CI** — run [27724123828](https://github.com/boardsesh/boardsesh/actions/runs/27724123828) still captured `01-climbs` / `02-board-view` as the empty **"No board selected"** picker, and (with `upload=true`) those broken shots went live.

The boot log showed auth + home but no board fetch and no error, so the hand-rolled `GET_MY_BOARDS` wedged into the auth boot sequence wasn't taking effect. Too many fragility points to debug remotely: it races the just-stored token, races the React Query GC of a `setQueryData` on an unobserved key, and could be wiped by the `handleSignedOutTransition` cleanup if the AppState-`active` listener fires a second `checkAuth` during boot.

## The fix

Replace it with a small **reactive component**, `<ScreenshotBoardAutoActivator>`, mounted in `BoardProviderWrapper` (below the Auth + Query providers) behind an inlined `process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1'` check so it **dead-strips in normal builds**.

It uses the **same `useMyBoards` / `useSetActiveBoard` hooks as the real board picker**, so it:
- inherits React Query's auth/retry/timing (no manual fetch racing the token),
- keeps `useActiveBoard` **observed**, so the activated board is never garbage-collected,
- is **self-healing** — if the board is ever cleared, the effect re-runs and re-activates,
- **logs** `[screenshot] auto-activating board <uuid>` so the next run is debuggable from the tee'd Metro output (a missing line ⇒ the boards fetch came back empty).

Reverts the `auth-provider.tsx` changes from #2997 (clean revert — verified byte-identical to the pre-#2997 file).

## Validation
- `vp run typecheck:mobile` ✓ · `vp check` ✓ · `vp run check:mobile-bundle` ✓ (the new component resolves in the Metro bundle) · `vp run test:mobile` ✓ (2392/2392)
- Can't run iOS sims on Linux, so the real proof is a `mobile-screenshots.yml` dispatch — **capture-only (`upload=false`) next time** to confirm `01`/`02` show real climbs *before* any upload overwrites the (currently broken) live set.

## Heads up
The broken screenshots from 27724123828 are **currently live on App Store Connect**. A correct run with `upload=true` will overwrite them (`sync_screenshots`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)