### PR TITLE
feat(mobile): translation-help CTA under the language picker

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -6,7 +6,8 @@ import type { ThemeOverride, UiVariantPreference } from '@boardsesh/key-value-st
 import { SUPPORTED_LOCALES, LOCALE_LABELS } from '@boardsesh/i18n';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { useLocalePreference } from '../../../src/providers/i18n-provider';
-import type { LocaleOverride } from '../../../src/lib/i18n/locale-preference';
+import { resolveLanguage, type LocaleOverride } from '../../../src/lib/i18n/locale-preference';
+import { openExternalUrl } from '../../../src/lib/open-url';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { borderRadius, spacing } from '../../../src/theme/tokens';
@@ -25,6 +26,11 @@ import { useToast } from '../../../src/providers/toast-provider';
 import { useFeatureFlag } from '../../../src/providers/feature-flags-provider';
 import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
 import { reportError } from '../../../src/lib/error-reporting';
+
+// Translations live in the shared catalog at packages/shared/i18n/locales/<locale>/.
+// We deep-link to the active language's folder so a community member lands on the
+// exact files to edit.
+const GITHUB_LOCALES_TREE_URL = 'https://github.com/boardsesh/boardsesh/tree/main/packages/shared/i18n/locales';
 
 export default function MoreScreen() {
   const { systemColors, brandColors, themeOverride, setThemeOverride, uiVariantPreference, setUiVariant } = useTheme();
@@ -47,6 +53,14 @@ export default function MoreScreen() {
     { key: 'system', label: t('mobile.more.language.system') },
     ...SUPPORTED_LOCALES.map((locale) => ({ key: locale, label: LOCALE_LABELS[locale] })),
   ];
+
+  // The community keeps the es/fr translations current; deep-link the CTA to the
+  // folder for whatever language the app is currently showing ('system' resolves
+  // to the device locale).
+  const activeLocale = resolveLanguage(localePreference);
+  const handleHelpTranslate = () => {
+    void openExternalUrl(`${GITHUB_LOCALES_TREE_URL}/${activeLocale}`, 'more-help-translate');
+  };
 
   const appearanceOptions: { key: ThemeOverride; label: string }[] = [
     { key: 'system', label: t('mobile.more.appearance.system') },
@@ -194,6 +208,16 @@ export default function MoreScreen() {
         <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.languageHint}>
           {t('mobile.more.language.description')}
         </Text>
+        <View style={[styles.card, styles.contributeCard, { backgroundColor: systemColors.secondaryBackground }]}>
+          <ListRow
+            title={t('mobile.more.language.contributeTitle')}
+            subtitle={t('mobile.more.language.contributeSubtitle', { language: LOCALE_LABELS[activeLocale] })}
+            leading={<Icon name="github" size={22} color={systemColors.secondaryLabel} />}
+            showChevron
+            showSeparator={false}
+            onPress={handleHelpTranslate}
+          />
+        </View>
       </View>
 
       <View style={styles.section}>
@@ -309,6 +333,9 @@ const styles = StyleSheet.create({
   languageHint: {
     marginTop: spacing[2],
     paddingHorizontal: spacing[4],
+  },
+  contributeCard: {
+    marginTop: spacing[3],
   },
   accountEmail: {
     paddingHorizontal: spacing[4],

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -90,7 +90,9 @@
       "language": {
         "title": "Language",
         "system": "System",
-        "description": "System follows your device language."
+        "description": "System follows your device language.",
+        "contributeTitle": "Help translate Boardsesh",
+        "contributeSubtitle": "These come from the community. Open the {{language}} files on GitHub to fix or add a phrase."
       },
       "diagnostics": {
         "title": "Privacy",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -288,7 +288,9 @@
       "language": {
         "title": "Idioma",
         "system": "Sistema",
-        "description": "Sistema usa el idioma de tu dispositivo."
+        "description": "Sistema usa el idioma de tu dispositivo.",
+        "contributeTitle": "Ayuda a traducir Boardsesh",
+        "contributeSubtitle": "Las traducciones las mantiene la comunidad. Abre los archivos de {{language}} en GitHub para corregir o añadir una frase."
       },
       "diagnostics": {
         "title": "Privacidad",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -90,7 +90,9 @@
       "language": {
         "title": "Langue",
         "system": "Système",
-        "description": "Système suit la langue de votre appareil."
+        "description": "Système suit la langue de votre appareil.",
+        "contributeTitle": "Aidez à traduire Boardsesh",
+        "contributeSubtitle": "Les traductions sont maintenues par la communauté. Ouvrez les fichiers {{language}} sur GitHub pour corriger ou ajouter une phrase."
       },
       "diagnostics": {
         "title": "Confidentialité",


### PR DESCRIPTION
## What

The `es`/`fr` translations are maintained by community members, but the language picker in the mobile **More** tab gave no way to contribute. This adds a tappable "Help translate Boardsesh" row directly under the picker.

Tapping it opens the in-app browser at the GitHub folder for the **currently active language**:
`https://github.com/boardsesh/boardsesh/tree/main/packages/shared/i18n/locales/<locale>` — `.../en-US`, `.../es`, or `.../fr`. `'system'` resolves to the device locale via the existing `resolveLanguage()`, and the subtitle names that language (e.g. "Open the Español files on GitHub…") since the active locale always matches the UI language.

## Changes

- `packages/mobile/app/(tabs)/profile/more.tsx` — CTA `ListRow` (GitHub icon, title, subtitle, chevron) in its own card under the language hint; `GITHUB_LOCALES_TREE_URL` constant, `activeLocale` derivation, and `handleHelpTranslate` reusing `openExternalUrl`.
- `packages/shared/i18n/locales/{en-US,es,fr}/common.json` — `mobile.more.language.contributeTitle` + `contributeSubtitle` (with `{{language}}` placeholder) added to all three locales.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2392 pass
- i18n catalog completeness — 28 pass (locale parity)
- `vp run check:mobile-bundle` — OK

## Verify in-app

`vp run dev:mobile` → **More** → **Language**: the row shows below the hint; tapping opens the locale folder. Switching to Español / Français updates both the subtitle and the link target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)