### PR TITLE
feat(backend): extend board-presence Redis history TTL from 24h to 1 week

### DIFF
--- a/packages/backend/src/graphql/resolvers/board-presence/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/queries.ts
@@ -16,7 +16,7 @@ import { computeBoardPresenceStats } from './stats';
 export const boardPresenceQueries = {
   /**
    * Backfill the recent "now on the wall" history for a board from the Redis
-   * FIFO (last ~50, 24h window). Used by late joiners before the live
+   * FIFO (last ~50, 1-week window). Used by late joiners before the live
    * `boardNowPlaying` subscription takes over. Empty without Redis.
    *
    * Auth-optional: this is the backfill half of the live "now on the wall" feed,
@@ -38,7 +38,7 @@ export const boardPresenceQueries = {
 
   /**
    * Durable history of what was pushed to a board, from `board_climb_events`
-   * (survives past the 24h Redis window). Newest-first, keyset-paged via
+   * (survives past the 1-week Redis window). Newest-first, keyset-paged via
    * `before`: an opaque cursor that is the `seq` of the last row of the
    * previous page.
    *
@@ -51,7 +51,7 @@ export const boardPresenceQueries = {
    * Intentionally public: a board's send log is shared, leaderboard-style data,
    * so any authenticated user may read any active board's history (no
    * membership check). Proof-of-presence gates *writes* (see reportBoardClimb),
-   * not reads. `boardRecentClimbs` is the hot 24h cache for the same data.
+   * not reads. `boardRecentClimbs` is the hot 1-week cache for the same data.
    */
   boardHistory: async (
     _: unknown,

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -22,8 +22,11 @@ type BoardPresenceSubscriber = (event: BoardPresenceEvent) => void;
 // "now on the wall" feed is ephemeral; this buffer backfills late joiners
 // before the `boardNowPlaying` subscription takes over.
 const BOARD_HISTORY_SIZE = 50; // Keep the last 50 climbs per board
-const BOARD_HISTORY_TTL = 86_400; // 24 hours
-const BOARD_SEQ_TTL = 86_400; // 24 hours
+const BOARD_HISTORY_TTL = 604_800; // 1 week
+// Must track BOARD_HISTORY_TTL: the per-board seq counter and the history buffer
+// expire together, so the seq never resets to 1 while history rows still exist
+// (which would collide / mis-order the keyset cursor).
+const BOARD_SEQ_TTL = 604_800; // 1 week
 // Proof-of-presence window: how long after connecting (resolveBoardForSerial /
 // resolveBoardForConfig) a user may report climbs to that board's feed. Long
 // enough for a climbing session; a reconnect re-stamps it.
@@ -717,7 +720,7 @@ class PubSub {
   /**
    * Atomically allocate the next monotonic sequence number for a board.
    * Redis `INCR` (cluster-safe across instances); falls back to an in-memory
-   * counter in local-only mode. The key expires after 24h of inactivity so
+   * counter in local-only mode. The key expires after a week of inactivity so
    * an idle board's counter doesn't leak in Redis — a new climb that day just
    * restarts at 1, which is fine because the history buffer expires together.
    */
@@ -745,7 +748,7 @@ class PubSub {
 
   /**
    * Append a climb to a board's durable FIFO history (newest-first, capped at
-   * 50, 24h TTL). No-op without Redis — late joiners then just rely on the
+   * 50, 1-week TTL). No-op without Redis — late joiners then just rely on the
    * live subscription.
    */
   async storeBoardClimb(boardId: string, climb: BoardPresenceClimb): Promise<void> {


### PR DESCRIPTION
## What

The "now on the wall" feed backfills late joiners from a Redis FIFO (`boardRecentClimbs` → `pubsub.getRecentBoardClimbs`). Its TTL was **24h**, so a board that sat idle for a day lost its recent history — the mobile accessory bar / board sheet then showed nothing until someone re-lit a climb.

Bumps `BOARD_HISTORY_TTL` 24h → **1 week**, and `BOARD_SEQ_TTL` with it: the per-board monotonic seq counter and the history buffer must expire together, otherwise the seq could reset to 1 while history rows still exist and collide / mis-order the keyset cursor.

Comment-only touch-ups in `pubsub/index.ts` and `board-presence/queries.ts` to keep the "24h window" docs accurate.

## Scope

- Redis hot-cache window only. Durable Postgres history (`board_climb_events`, read by `boardHistory`) is unchanged.
- `BOARD_MEMBERSHIP_TTL` (12h proof-of-presence / writer) is intentionally left alone — that's "who's connected now", not history.

## Follow-up

Tracked separately: flush the Redis recent history to Postgres so the live feed survives expiry entirely, without the current logged-in + 60s-dwell gating that limits `board_climb_events`.

## Validation

- `vp run typecheck:backend` ✓
- `vp check` (lint/format) ✓
- No test pins the TTL value (`board-presence.test.ts` keeps its own local constant), so behavior is unchanged; CI runs the full backend suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)