### PR TITLE
fix(screenshot): reliably dismiss the iOS "Open in Boardsesh?" dialog

### DIFF
--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -49,10 +49,20 @@ name: app-store screenshots
 - takeScreenshot: 00-home
 
 # Discover — the playlist library (smart "Your Picks" + saved playlists).
+# This is the FIRST in-session deep link, so it pops iOS's "Open in 'Boardsesh'?"
+# confirmation, which BLOCKS the navigation until confirmed. The later openLinks
+# just use an optional tap, but here a racy optional tap left the dialog sitting
+# over the home feed (e.g. es / iPhone 16 Pro Max) AND stranded the shot on home.
+# So wait for the dialog explicitly and tap Open — it reliably appears on the fresh
+# sim the orchestrator guarantees (uninstall + reinstall + keychain reset), and iOS
+# remembers the choice for the rest of the session, so the later links don't
+# re-prompt and can't cascade a popup onto a captured screen.
 - openLink: com.boardsesh.app://discover
+- extendedWaitUntil:
+    visible: 'Open'
+    timeout: 12000
 - tapOn:
     text: 'Open'
-    optional: true
 - waitForAnimationToEnd
 - takeScreenshot: 06-discover
 


### PR DESCRIPTION
## The bug

On run 27726994089, `es / iPhone 16 Pro Max / 06-discover` captured the **"Open in 'Boardsesh'?"** system dialog sitting over the home feed.

The first in-session deep link (`://discover`) pops that confirmation, and on iOS it **blocks the deep-link navigation until you tap Open**. The flow dismissed it with a racy `tapOn { text: 'Open', optional: true }`; when the tap missed, two things broke at once:
1. the dialog stayed up → captured in the screenshot, and
2. the navigation never happened → the shot was stranded on the **home feed** instead of Discover.

Proof it's the same root cause: on a shard where the tap *did* land (en-US / 16 Pro Max), `06-discover` shows the correct **Discover** screen.

## The fix

On the discover step (the only one that pops the dialog — it's the first openLink, and iOS remembers the choice afterwards), replace the racy optional tap with an explicit wait:

```yaml
- openLink: com.boardsesh.app://discover
- extendedWaitUntil:
    visible: 'Open'
    timeout: 12000
- tapOn:
    text: 'Open'
- waitForAnimationToEnd
- takeScreenshot: 06-discover
```

The dialog reliably appears on the fresh sim the orchestrator guarantees (uninstall + reinstall + keychain reset), so waiting for it is deterministic. Dismissing it here fixes **both** symptoms and prevents any cascade onto later shots. The later openLinks keep their optional taps as belt-and-suspenders (they don't re-prompt).

## Validation
- YAML parses (multi-doc Maestro flow, 38 steps); `extendedWaitUntil` block well-formed; `vp check` clean.
- iOS sims are macOS-only, so the real confirmation is the next `mobile-screenshots.yml` run — `06-discover` should show Discover with no dialog across all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)