### PR TITLE
feat(screenshot): "Everyone" home feed + a 2nd board-view shot

### DIFF
--- a/app-stores/apple/app-store-metadata.md
+++ b/app-stores/apple/app-store-metadata.md
@@ -45,10 +45,10 @@ Canonical: [`fastlane/metadata/en-US/release_notes.txt`](../../fastlane/metadata
 
 iPhone 6.9" (1320×2868), captured + uploaded by `vp run mobile:screenshots` (Maestro → fastlane; see `packages/mobile/.maestro/README.md`). Ten slots, in store display order (the filename prefix sets the order):
 
-1. `00-home` — activity feed, your crew's sessions
+1. `00-home` — the global "Everyone" activity feed
 2. `01-climbs` — browse the board's climbs
 3. `02-board-view` — a climb with the holds lit (the signature view)
-4. `03-party` — a live, shared Party Mode session (filled by the party flow)
+4. `03-board-view-2` — a climb lit on a second board (`myBoards[1]`), showing multi-board support
 5. `04-session-detail` — a session recap: stats, leaderboard, sends
 6. `05-workout-generator` — the Record tab's workout generator
 7. `06-discover` — the playlist library

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -10,13 +10,14 @@ name: app-store screenshots
 # the build only honours when EXPO_PUBLIC_SCREENSHOT_MODE=1 (see
 # packages/mobile/src/lib/screenshot-mode.ts):
 #     ://climbs?screenshotOpenFirst=1    -> auto-opens the first climb's board view
+#     ://climbs?screenshotBoardIndex=1   -> renders myBoards[1] (the 2nd followed board)
 #     ://profile?screenshotTab=logbook   -> profile Logbook tab
 #     ://profile?screenshotTab=sessions  -> profile Sessions tab; auto-opens newest session
-# There are NO coordinate taps. The active board is auto-selected on boot in screenshot
-# mode (auth-provider.tsx activates the user's first saved board, like the auto-sign-in),
-# so the board-backed screens render real content without a fragile board-picker tap. The
-# old board-pick / board-view / board-sheet coordinate taps are all gone — a missed pick
-# used to leave Climbs/Board View stuck on the "No board selected" empty state.
+# There are NO coordinate taps. The active board is auto-activated on boot in screenshot
+# mode (ScreenshotBoardAutoActivator activates the user's first followed board), so the
+# board-backed screens render real content without a fragile board-picker tap. The old
+# board-pick / board-view / board-sheet coordinate taps are all gone — a missed pick used
+# to leave Climbs/Board View stuck on the "No board selected" empty state.
 #
 # This flow is captured once per (device, locale) pair: the orchestrator bakes
 # EXPO_PUBLIC_SCREENSHOT_LOCALE into the Metro bundle per locale and reruns it on each
@@ -37,14 +38,15 @@ name: app-store screenshots
 #   shots no longer depend on an in-flow board-pick step.)
 # - The Record/session screen renders the WORKOUT GENERATOR because Metro bundles
 #   EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume).
-# - Filenames are numbered for store DISPLAY order (00..09), not capture order. 03 is the
-#   live-party shot, added by the party-session flow (see app-store-party.yaml / PR2).
+# - Filenames are numbered for store DISPLAY order (00..09), not capture order. Slot 03 is
+#   the second board-view (myBoards[1]); it was reserved for a party shot the flow never took.
 #
 # The screenshot build auto-signs-in on boot and lands straight on home (no login screen);
 # the orchestrator waits for home (the `$screen /home` log) before running Maestro, so the
 # flow opens right into the shots.
 
-# Home — feed populated by the prod test user's follows.
+# Home — the global "Everyone" feed. The home screen defaults to it in screenshot
+# mode (see home/index.tsx) for a livelier hero than the test user's own crew.
 - waitForAnimationToEnd
 - takeScreenshot: 00-home
 
@@ -126,3 +128,16 @@ name: app-store screenshots
 - waitForAnimationToEnd
 - waitForAnimationToEnd
 - takeScreenshot: 02-board-view
+
+# Board view on the SECOND followed board (myBoards[1]) — a second wall lit up, so
+# the listing shows Boardsesh works across boards. screenshotBoardIndex=1 switches
+# the active board to the user's 2nd follow (sorted by follow date) before opening
+# its first climb. LAST too (also opens the play drawer). Slot 03 was the reserved
+# party shot, which the main flow never captured.
+- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1&screenshotBoardIndex=1
+- tapOn:
+    text: 'Open'
+    optional: true
+- waitForAnimationToEnd
+- waitForAnimationToEnd
+- takeScreenshot: 03-board-view-2

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -166,7 +166,10 @@ vi.mock('../../../../src/hooks/use-bottom-chrome-metrics', () => ({
   }),
 }));
 
-vi.mock('../../../../src/lib/graphql/hooks', () => ({ useGrades: () => ({ data: [] }) }));
+vi.mock('../../../../src/lib/graphql/hooks', () => ({
+  useGrades: () => ({ data: [] }),
+  useMyBoards: () => ({ data: undefined }),
+}));
 vi.mock('../../../../src/hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGradeByDifficultyId: (difficultyId: number) => String(difficultyId) }),
 }));
@@ -205,6 +208,7 @@ vi.mock('../../../../src/lib/graphql/use-active-board', () => ({
     data: { boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1', angle: 40 },
     isLoading: false,
   }),
+  useSetActiveBoard: () => async () => {},
 }));
 
 vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -44,7 +44,8 @@ import { getHttpClient } from '../../../src/lib/graphql/client';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { toQueueClimb, toQueueClimbs } from '../../../src/lib/climb-types';
 import { parseSetIdsParam, prewarmCreateBoardHolds } from '../../../src/lib/create-board-holds';
-import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
+import { useActiveBoard, useSetActiveBoard } from '../../../src/lib/graphql/use-active-board';
+import { useMyBoards } from '../../../src/lib/graphql/hooks';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { ensureBackgroundsCached } from '../../../src/lib/background-image-cache';
 import {
@@ -124,7 +125,12 @@ function ClimbListInner() {
   const router = useRouter();
   // Screenshot mode opens the first climb's board view via this deep-link param
   // (see the auto-open effect below). Absent on the plain `/climbs` list shot.
-  const { screenshotOpenFirst } = useLocalSearchParams<{ screenshotOpenFirst?: string }>();
+  // screenshotBoardIndex picks which followed board to render (default [0]); the
+  // second board-view shot passes 1 to render myBoards[1].
+  const { screenshotOpenFirst, screenshotBoardIndex } = useLocalSearchParams<{
+    screenshotOpenFirst?: string;
+    screenshotBoardIndex?: string;
+  }>();
   const { t } = useTranslation('climbs');
   const { openClimbActions, openAddToPlaylist, openBoardSheet } = useDrawerHost();
   // The board capsule opens the wall's "now on the wall" sheet (the board
@@ -280,6 +286,24 @@ function ClimbListInner() {
   }, [isAuthenticated]);
 
   const { data: activeBoard, isLoading: isBoardLoading } = useActiveBoard();
+
+  // Screenshot mode: a second board-view shot renders myBoards[1] (the user's 2nd
+  // followed board) via ?screenshotBoardIndex=1. Boards are sorted by follow date
+  // so [0]/[1] are deterministic; the auto-activator sets [0] on boot for every
+  // other shot. All of this dead-strips in normal builds (the gate is inlined).
+  const setActiveBoard = useSetActiveBoard();
+  const { data: screenshotBoardConnection } = useMyBoards(undefined, {
+    enabled: process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && isAuthenticated && !!screenshotBoardIndex,
+  });
+  const screenshotTargetBoard = useMemo(() => {
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1' || !screenshotBoardIndex) return null;
+    const index = Number.parseInt(screenshotBoardIndex, 10);
+    if (!Number.isInteger(index) || index < 0) return null;
+    const sorted = [...(screenshotBoardConnection?.boards ?? [])].sort(
+      (first, second) => new Date(first.createdAt).getTime() - new Date(second.createdAt).getTime(),
+    );
+    return sorted[index] ?? null;
+  }, [screenshotBoardIndex, screenshotBoardConnection]);
 
   const boardName = activeBoard?.boardType ?? '';
   const layoutId = activeBoard?.layoutId ?? 0;
@@ -546,20 +570,31 @@ function ClimbListInner() {
     [activateClimbListClimb, blurSearchInputs],
   );
 
+  // Screenshot mode: when a specific board index is requested, switch the active
+  // board to it first; the open-first effect below waits until it's active.
+  useEffect(() => {
+    if (!screenshotTargetBoard || activeBoard?.uuid === screenshotTargetBoard.uuid) return;
+    void setActiveBoard(screenshotTargetBoard);
+  }, [screenshotTargetBoard, activeBoard, setActiveBoard]);
+
   // Screenshot mode: deterministically open the first climb's play drawer (the
   // board-view shot) instead of a Maestro coordinate tap, which can't match RN
   // rows on this iOS build and was capturing the climb list twice. Gated on the
   // deep-link param so the plain `/climbs` list shot is untouched; fires once the
-  // board's results land, and at most once. Dead-strips in normal builds.
-  const screenshotBoardViewOpenedRef = useRef(false);
+  // board's results land. Keyed by the active board's uuid (not a one-shot bool)
+  // so a SECOND board-view shot on a different board re-fires. Dead-strips in
+  // normal builds.
+  const screenshotOpenedForBoardRef = useRef<string | null>(null);
   useEffect(() => {
     if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE !== '1' || !screenshotOpenFirst) return;
-    if (screenshotBoardViewOpenedRef.current) return;
+    // When a specific board is requested, wait until it's the active board.
+    if (screenshotTargetBoard && activeBoard?.uuid !== screenshotTargetBoard.uuid) return;
+    if (!activeBoard || screenshotOpenedForBoardRef.current === activeBoard.uuid) return;
     const firstClimb = visibleClimbs[0];
     if (!searchReady || !firstClimb) return;
-    screenshotBoardViewOpenedRef.current = true;
+    screenshotOpenedForBoardRef.current = activeBoard.uuid;
     handleClimbPress(firstClimb);
-  }, [screenshotOpenFirst, searchReady, visibleClimbs, handleClimbPress]);
+  }, [screenshotOpenFirst, searchReady, visibleClimbs, handleClimbPress, screenshotTargetBoard, activeBoard]);
 
   const handleAddToQueue = useCallback(
     (climb: Climb) => {

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -94,7 +94,10 @@ export default function HomeTab() {
   // or the "Everyone" global feed). It defaults to the inferred home board once
   // it resolves; the view stays on `crew`.
   const { board: homeBoard, isResolving: isResolvingHomeBoard, boards: ownedBoards } = useHomeBoard();
-  const [mode, setMode] = useState<FeedMode>('crew');
+  // Screenshot builds open on the global "Everyone" feed (gym + no board) — a
+  // livelier hero shot than the test user's own crew. Inlined so it dead-strips
+  // in normal builds, where the default stays `crew`.
+  const [mode, setMode] = useState<FeedMode>(process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? 'gym' : 'crew');
   const [selectedBoard, setSelectedBoard] = useState<UserBoard | null>(null);
   // Once home-board inference settles, point the crew/gym filter at the home
   // board. The view stays on `crew`; with no home board it's the unfiltered crew.
@@ -102,6 +105,9 @@ export default function HomeTab() {
   useEffect(() => {
     if (hasDefaultedScope.current || isResolvingHomeBoard) return;
     hasDefaultedScope.current = true;
+    // Screenshot mode stays on the global "Everyone" feed, so don't scope the
+    // gym view to the home board (that would turn it into one board's feed).
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return;
     if (homeBoard) setSelectedBoard(homeBoard);
   }, [homeBoard, isResolvingHomeBoard]);
 


### PR DESCRIPTION
Two store-listing improvements, both driven by **which boards the test account follows** — no hardcoded UUIDs, so you change what's featured just by changing follows.

## 1. Home feed → "Everyone"
`00-home` now opens on the global **"Everyone"** feed in screenshot mode (gym scope + no board) instead of the test user's own crew — a livelier hero shot. Implemented by defaulting `mode` to `gym` and skipping the home-board scoping effect when `EXPO_PUBLIC_SCREENSHOT_MODE === '1'`. No flow change (no openLink → no "Open in Boardsesh?" dialog).

## 2. A 10th screenshot — a climb on your 2nd board
New `03-board-view-2`: a climb lit on the user's **second** followed board (`myBoards[1]`), so the listing shows Boardsesh works across boards (e.g. a Kilter board-view at `02`, a Tension Board 2 at `03`).

- New deep-link param: `://climbs?screenshotOpenFirst=1&screenshotBoardIndex=1`.
- The climbs screen sorts `myBoards` by **follow date** so `[0]`/`[1]` are deterministic (you control them by follow order).
- Race-safe: the open-first effect is now keyed by **board uuid** (not a one-shot bool) and gated on the target board being the active board — so the 2nd shot re-fires on the right board instead of being blocked by the boot-activated `myBoards[0]`, and can't open `[0]`'s climb before `[1]` activates.

Slot `03` was reserved for an unbuilt party shot, so this fits within Apple's 10-screenshot cap.

All of it is gated on `EXPO_PUBLIC_SCREENSHOT_MODE` and dead-strips in normal builds.

## Files
- `home/index.tsx` — Everyone default in screenshot mode
- `climbs/index.tsx` — `screenshotBoardIndex` param, deterministic board ordering, race-safe open-first
- `climbs/__tests__/index-keyboard.test.tsx` — mock the new `useMyBoards`/`useSetActiveBoard` usage
- `.maestro/app-store.yaml` — the new step + updated comments (also fixed a stale auth-provider note → `ScreenshotBoardAutoActivator`)
- `app-stores/apple/app-store-metadata.md` — updated screenshot map (00 = Everyone, 03 = 2nd board-view)

## Validation
`vp run typecheck:mobile` ✓ · `vp check` ✓ · `vp run check:mobile-bundle` ✓ · `vp run test:mobile` ✓ (2404/2404). Real confirmation is the next `mobile-screenshots.yml` run (iOS sims are macOS-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)