### PR TITLE
fix(app-store): mirror Spanish store copy to es-MX + point Play doc at the RN workflow

### DIFF
--- a/app-stores/google/play-store-submission-guide.md
+++ b/app-stores/google/play-store-submission-guide.md
@@ -92,26 +92,41 @@ never uploads.
 
 The Play Store requires AAB format, not APK. (APKs are fine for sideloading and testing, but Play Store submissions must use AAB.)
 
-### Production build (EAS Build)
+### Manual build (EAS Build)
 
-`packages/mobile/` is a managed Expo project. Production AABs go through EAS
-Build:
+`packages/mobile/` is a managed Expo project, so you can produce a one-off
+production AAB with EAS Build:
 
 ```bash
 eas build --profile production -p android
 ```
 
 EAS runs `expo prebuild`, compiles the generated Android project, signs it, and
-returns a downloadable `.aab`. The `eas.json` `production` profile uses
-`appVersionSource: "remote"`, so the version name and version code are managed
-remotely — you do not edit `versionCode` by hand.
+returns a downloadable `.aab`. This is a manual escape hatch; the automated
+release path is the CI workflow below, which builds the AAB on GitHub's runners
+instead. The `eas.json` `production` profile uses `appVersionSource: "remote"`,
+so the version name and version code are managed remotely (you do not edit
+`versionCode` by hand).
 
-### CI build
+### CI build (the actual release path)
 
-The GitHub Actions workflow (`.github/workflows/android-release.yml`) runs the
-same `eas build --profile production -p android` on the production pipeline. If
-the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret is configured, EAS Submit can also
-upload the AAB to the Google Play internal testing track automatically.
+The React Native app (`packages/mobile/`) ships through
+`.github/workflows/android-apk-rn.yml`, which runs on every push to `main` that
+touches `packages/mobile/` or the shared packages (and on manual dispatch). It
+does **not** use EAS Build: it runs `expo prebuild` to generate the Android
+project, builds a signed AAB with Gradle (`./gradlew bundleRelease`), and, when
+the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret is set, uploads that AAB to the
+Google Play **internal** track via the `r0adkll/upload-google-play` action, with
+the "What's new" note staged from
+`fastlane/metadata/android/en-US/changelogs/default.txt`. The same run also
+publishes the signed sideload APK as a GitHub Release. Without the
+service-account secret the build still succeeds and the Play upload is skipped
+(the first internal-track upload is a one-time manual step in Play Console; see
+`docs/android-sideload-build.md`).
+
+Don't watch `.github/workflows/android-release.yml` for a Play submission. That
+is the retired Capacitor build (it triggers on `mobile/**`, not
+`packages/mobile/**`) and produces no RN AAB.
 
 ### Local build
 

--- a/fastlane/metadata/es-MX/description.txt
+++ b/fastlane/metadata/es-MX/description.txt
@@ -3,7 +3,7 @@ Busca una vía y mira cómo tu muro ilumina las presas. Toca un bloque, las pres
 UNA APP PARA TODOS TUS MUROS
 Kilter, Tension y MoonBoard tienen cada uno su propia app para su propio muro. Boardsesh funciona con todos ellos, más Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Busca cualquier vía y Boardsesh la manda al muro por Bluetooth, encendiendo las presas. Control total de los LED en los siete muros.
 
-La gracia de tener una sola app son las dos cosas que una app de un solo muro no te da: el historial del muro siempre activo y las sesiones que llevas con tu peña.
+Una sola app te da dos cosas que una app de un solo muro no puede: el historial del muro siempre activo y las sesiones que llevas con tu peña.
 
 HISTORIAL DEL MURO, SIEMPRE ACTIVO
 Cada muro al que te conectas tiene un feed en directo de lo que está encendido en esa pared ahora mismo: la vía que hay puesta en este momento, quién la encendió, el grado y el ángulo, quién la montó y los encadenes recientes. No tienes que abrir nada. Está ahí cuando estás en ese muro, actualizándose según caen las pegadas.

--- a/fastlane/metadata/es-MX/keywords.txt
+++ b/fastlane/metadata/es-MX/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,kilter,tension,boulder,escalada,bloque,bluetooth,led,rocodromo,croquis,sesion,aperturista
+MoonBoard,Kilter,Tension,boulder,escalada,bloque,bluetooth,led,rocodromo,croquis,sesion,aperturista

--- a/fastlane/metadata/es-MX/promotional_text.txt
+++ b/fastlane/metadata/es-MX/promotional_text.txt
@@ -1,1 +1,1 @@
-Busca una vía y mira cómo tu muro ilumina las presas por Bluetooth. Encadena con tu peña, lleva la sesión desde la pantalla bloqueada y mira tu progreso.
+Novedad: las sesiones ya son en directo. Abre una y tu peña comparte una cola: cualquiera manda la siguiente vía al muro. Sin conductor, sin esperar turno.

--- a/fastlane/metadata/es-MX/subtitle.txt
+++ b/fastlane/metadata/es-MX/subtitle.txt
@@ -1,1 +1,1 @@
-Ilumina cualquier panel LED
+Ilumina cualquier muro LED


### PR DESCRIPTION
Follow-up to the review of #3006 (de-Capacitor store docs + conversion-first copy). Two P2 findings, docs/metadata only.

## 1. Mirror the Spanish App Store copy to es-MX

#3006 rewrote the conversion-first Spanish copy in `fastlane/metadata/es-ES/` only. But the Apple `metadata` lane uploads **every** locale folder:

- `fastlane/Fastfile`: `EXPECTED_DELIVER_LOCALES = ["en-US", "es-ES", "es-MX", "fr-FR"]`, and the `metadata` lane runs `upload_to_app_store(..., skip_metadata: false)` over `metadata_path`, so `deliver` pushes each `<locale>/*.txt`.

So when the metadata workflow next runs, Mexican/LatAm storefronts (`es-MX`) keep the **old** subtitle, keywords, promotional text, and description while Spain (`es-ES`) gets the new copy — even though the docs say the same Spanish translation serves both locales.

Fix: copy the four changed files from `es-ES` into `es-MX`. The two directories are byte-identical again.

| File | es-MX before | es-MX after (now matches es-ES) |
| --- | --- | --- |
| `subtitle.txt` | `Ilumina cualquier panel LED` | `Ilumina cualquier muro LED` |
| `keywords.txt` | `…,kilter,tension,…` | `…,Kilter,Tension,…` |
| `promotional_text.txt` | old "Busca una vía…" | new "Novedad: las sesiones ya son en directo…" |
| `description.txt` | "La gracia de tener una sola app son las dos cosas…" | "Una sola app te da dos cosas que una app de un solo muro no puede…" |

All four fields stay within Apple's limits (subtitle 26/30 chars; the rest were already validated in #3006).

## 2. Point Play submissions at the RN workflow

`app-stores/google/play-store-submission-guide.md` ("CI build" section) pointed readers at `.github/workflows/android-release.yml` and EAS Submit. But that workflow is the **retired Capacitor build** — it triggers on `mobile/**` and runs Gradle against `mobile/android/`, and produces no RN AAB for `packages/mobile/`.

The actual RN package pipeline is `.github/workflows/android-apk-rn.yml`:
- `expo prebuild` to generate `android/`
- Gradle `./gradlew bundleRelease` for a signed AAB
- `r0adkll/upload-google-play` to the Play **internal** track (gated on `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`), with "What's new" staged from `fastlane/metadata/android/en-US/changelogs/default.txt`

Following the old doc on a Play submission means watching/running the wrong workflow and can leave no RN AAB uploaded.

Fix:
- Rewrote the "CI build" section to describe `android-apk-rn.yml` accurately (Gradle, not EAS) and added a callout: don't watch `android-release.yml` for a Play submission.
- Reframed the "Production build (EAS Build)" section as a manual escape hatch so it no longer contradicts the CI section.

## Validation

- `vp check` clean on both changed files (the 9 unrelated formatting hits are pre-existing on `main`).
- `es-ES` and `es-MX` directories now byte-identical (`diff -rq` reports no differences).
- No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)