### PR TITLE
fix(screenshot): re-open Discover after dismissing the iOS dialog

### DIFF
--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -52,19 +52,23 @@ name: app-store screenshots
 
 # Discover — the playlist library (smart "Your Picks" + saved playlists).
 # This is the FIRST in-session deep link, so it pops iOS's "Open in 'Boardsesh'?"
-# confirmation, which BLOCKS the navigation until confirmed. The later openLinks
-# just use an optional tap, but here a racy optional tap left the dialog sitting
-# over the home feed (e.g. es / iPhone 16 Pro Max) AND stranded the shot on home.
-# So wait for the dialog explicitly and tap Open — it reliably appears on the fresh
-# sim the orchestrator guarantees (uninstall + reinstall + keychain reset), and iOS
-# remembers the choice for the rest of the session, so the later links don't
-# re-prompt and can't cascade a popup onto a captured screen.
+# confirmation, which BLOCKS the navigation until confirmed. Wait for the dialog
+# explicitly and tap Open (it reliably appears on the fresh sim the orchestrator
+# guarantees: uninstall + reinstall + keychain reset) to clear the popup. But that
+# first navigation is left half-done behind the dialog and renders too late — 06 then
+# captured the home feed, with `$screen /discover` firing only AFTER the shot — so
+# RE-OPEN the link. The dialog is now confirmed (iOS remembers it for the session),
+# so the second open navigates straight to Discover, and the later links navigate
+# cleanly for the same reason (their optional taps just no-op).
 - openLink: com.boardsesh.app://discover
 - extendedWaitUntil:
     visible: 'Open'
     timeout: 12000
 - tapOn:
     text: 'Open'
+- waitForAnimationToEnd
+- openLink: com.boardsesh.app://discover
+- waitForAnimationToEnd
 - waitForAnimationToEnd
 - takeScreenshot: 06-discover
 


### PR DESCRIPTION
## The bug

On run 27730512896 (everything else green — Everyone feed, both board-views, live upload all worked), `06-discover` came back **byte-identical to `00-home`**. The Maestro log shows why:

```
Open ://discover... COMPLETED
Tap on "Open"... COMPLETED          ← #3009 cleared the popup ✓
Take screenshot 06-discover...      ← but the app is still on home
Open ://profile... $screen /discover  ← Discover finally renders AFTER the shot
```

#3009 fixed the **popup**, but the "Open in Boardsesh?" dialog also **blocks the deep-link navigation**. After the tap dismisses it, that first navigation is left half-done and renders too late, so the shot lands on the home feed.

## The fix

After dismissing the dialog (which iOS now remembers for the session), **re-open the discover link** — the second navigation goes straight to Discover with no dialog in the way — then settle and capture:

```yaml
- openLink: ://discover
- extendedWaitUntil: { visible: 'Open', timeout: 12000 }
- tapOn: { text: 'Open' }
- waitForAnimationToEnd
- openLink: ://discover            # re-nav, dialog already confirmed
- waitForAnimationToEnd
- waitForAnimationToEnd
- takeScreenshot: 06-discover
```

Only the discover step (the first openLink) needs this; later links navigate cleanly because the dialog is already confirmed.

## Validation
- YAML parses; discover now has 2 openLinks; `vp check` clean.
- Real proof is the next run — `06-discover` should show the Discover playlist library, distinct from `00-home`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)