### PR TITLE
fix(screenshot): prime the iOS "Open in Boardsesh?" dialog up front

### DIFF
--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -30,8 +30,9 @@ name: app-store screenshots
 # - Fresh install (orchestrator uninstalled/reinstalled + reset keychain): cold-loads with
 #   no active board (re-picked below), and the keychain reset forces the auto-sign-in to
 #   re-authenticate against the target backend rather than reuse a stale token.
-# - iOS shows an "Open in 'Boardsesh'?" confirmation for the first in-flow route deep link
-#   on a fresh sim; each openLink is followed by an optional tapOn "Open".
+# - iOS re-pops an "Open in 'Boardsesh'?" confirmation on the first 1-2 in-session deep
+#   links (inconsistently); the flow primes it away up front (the prime block below) so the
+#   captured screens never catch it. Each openLink keeps an optional tapOn "Open" as backup.
 # - Order: for any screen visited twice, the PLAIN visit runs before the screenshot-param
 #   visit so no stale param leaks into it. Board view is LAST because the play drawer it
 #   opens overlays the whole app. (The active board is set at boot, so the board-backed
@@ -45,26 +46,41 @@ name: app-store screenshots
 # the orchestrator waits for home (the `$screen /home` log) before running Maestro, so the
 # flow opens right into the shots.
 
-# Home — the global "Everyone" feed. The home screen defaults to it in screenshot
-# mode (see home/index.tsx) for a livelier hero than the test user's own crew.
-- waitForAnimationToEnd
-- takeScreenshot: 00-home
-
-# Discover — the playlist library (smart "Your Picks" + saved playlists).
-# This is the FIRST in-session deep link, so it pops iOS's "Open in 'Boardsesh'?"
-# confirmation, which BLOCKS the navigation until confirmed. The later openLinks
-# just use an optional tap, but here a racy optional tap left the dialog sitting
-# over the home feed (e.g. es / iPhone 16 Pro Max) AND stranded the shot on home.
-# So wait for the dialog explicitly and tap Open — it reliably appears on the fresh
-# sim the orchestrator guarantees (uninstall + reinstall + keychain reset), and iOS
-# remembers the choice for the rest of the session, so the later links don't
-# re-prompt and can't cascade a popup onto a captured screen.
-- openLink: com.boardsesh.app://discover
+# Prime the "Open in 'Boardsesh'?" dialog. simctl openurl of the custom scheme makes iOS
+# re-pop that confirmation on the first one or two in-session deep links (inconsistently —
+# en-US saw it once, es twice) and it BLOCKS the navigation until tapped. Dismiss it on
+# throwaway /home navigations BEFORE any capture, so no shot can catch the popup and every
+# real openLink below navigates cleanly (it's also why Discover needs no special handling
+# any more). The first openurl always pops it (wait + tap); the repeat mops up any
+# re-prompts (optional, after a settle so the dialog has appeared). iOS then remembers it.
+- openLink: com.boardsesh.app://home
 - extendedWaitUntil:
     visible: 'Open'
     timeout: 12000
 - tapOn:
     text: 'Open'
+- waitForAnimationToEnd
+- repeat:
+    times: 3
+    commands:
+      - openLink: com.boardsesh.app://home
+      - waitForAnimationToEnd
+      - tapOn:
+          text: 'Open'
+          optional: true
+      - waitForAnimationToEnd
+
+# Home — the global "Everyone" feed. The home screen defaults to it in screenshot
+# mode (see home/index.tsx) for a livelier hero than the test user's own crew.
+- waitForAnimationToEnd
+- takeScreenshot: 00-home
+
+# Discover — the playlist library (smart "Your Picks" + saved playlists). The dialog was
+# primed away above, so this navigates cleanly; the optional tap is just a backup.
+- openLink: com.boardsesh.app://discover
+- tapOn:
+    text: 'Open'
+    optional: true
 - waitForAnimationToEnd
 - takeScreenshot: 06-discover
 


### PR DESCRIPTION
## The bug

On run 27730512896, a couple of **Spanish** shots still showed the "Open in 'Boardsesh'?" popup. The log proved why: the dialog re-pops on the first **1–2** in-session deep links *inconsistently* (en-US hit it once, es twice), and it blocks the deep-link navigation. #3009 only hardened the *discover* step; the per-step optional taps on the others race, so the popup leaks — and the blocked nav also left `06-discover` byte-identical to `00-home`.

## The fix — prime it away once, up front

Before any capture, dismiss the dialog on throwaway `/home` navigations:

```yaml
- openLink: ://home
- extendedWaitUntil: { visible: 'Open', timeout: 12000 }   # first openurl always pops it
- tapOn: { text: 'Open' }
- waitForAnimationToEnd
- repeat:                      # mop up the inconsistent re-prompts
    times: 3
    commands:
      - openLink: ://home
      - waitForAnimationToEnd
      - tapOn: { text: 'Open', optional: true }
      - waitForAnimationToEnd
```

iOS then remembers the choice, so **every real openLink navigates cleanly** — no popup on any shot, and `06-discover` renders the actual Discover screen (no more home-dup). The per-step optional taps stay as a harmless backup.

## Supersedes
- **Reverts #3009's discover-specific `extendedWaitUntil`** — with the dialog primed away it would hang 12s waiting for a dialog that never appears.
- **Makes #3012 (discover re-nav) unnecessary** — I'll close it; priming fixes the discover home-dup too.

## Validation
YAML parses (10 shots, `repeat` block well-formed, only the prime step uses `extendedWaitUntil`); `vp check` clean. Real proof is the next run — every shot dialog-free, discover distinct from home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)