### PR TITLE
chore(screenshot): capture one device size (6.9" iPhone 16 Pro Max)

### DIFF
--- a/.github/workflows/mobile-screenshots.yml
+++ b/.github/workflows/mobile-screenshots.yml
@@ -9,14 +9,15 @@ name: Mobile Screenshots (Native)
 # only rebuilt when those change. A JS-only run is a cache hit → install + Metro +
 # Maestro instead of a ~30-min from-scratch native compile.
 #
-# iOS is a 3-stage fan-out so every (locale, device) captures in parallel and a
-# single overloaded runner never thrashes:
+# iOS is a 3-stage fan-out so every locale captures in parallel and a single
+# overloaded runner never thrashes:
 #   ios-build    — build/restore the cached .app ONCE (no per-shard cold build).
-#   ios-capture  — matrix of locale (en-US, es, fr) × device (3 common iPhones) =
-#                  9 shards, each its own runner: one Metro, one simulator, one
+#   ios-capture  — matrix of locale (en-US, es, fr) on one device size (the 6.9"
+#                  iPhone 16 Pro Max; Apple scales it down to all other iPhones) =
+#                  3 shards, each its own runner: one Metro, one simulator, one
 #                  capture. --shutdown is kept as belt-and-suspenders (a shard only
-#                  ever boots one sim, so there's nothing to accumulate — 3 booted
-#                  at once on one runner is what made the old job thrash and time
+#                  ever boots one sim, so there's nothing to accumulate — multiple
+#                  booted on one runner is what made the old job thrash and time
 #                  out at "iOS driver not ready in time").
 #   ios-finalize — merge the per-shard artifacts into one tree, run the dimension
 #                  gate (it needs all four App Store locales at once), and upload.
@@ -41,9 +42,9 @@ on:
           - app-store
           - onboarding
       # No iOS devices/locales inputs: the dimension gate + upload require the full
-      # set (3 common iPhones × en-US/es-ES/es-MX/fr-FR), so CI always runs the
-      # complete locale × device matrix below. For a narrowed local run, pass
-      # --devices / --locales to `vp run mobile:screenshots` directly.
+      # set (the 6.9" iPhone 16 Pro Max × en-US/es-ES/es-MX/fr-FR), so CI always runs
+      # the complete locale matrix below. For a narrowed local run, pass --devices /
+      # --locales to `vp run mobile:screenshots` directly.
       android_device:
         description: 'Android emulator device label used for screenshot output'
         type: string
@@ -142,12 +143,14 @@ jobs:
       # One shard failing shouldn't abandon the rest — let them all finish so
       # ios-finalize can report exactly which (locale, device) is short.
       fail-fast: false
+      # One device size only: the 6.9" iPhone 16 Pro Max. App Store Connect auto-scales
+      # it down to every smaller iPhone, so extra sizes add no value, only macOS-runner
+      # time. Locale is the axis that matters, so it stays a full sweep. Matrix = 3
+      # shards (one per locale), still one simulator per shard.
       matrix:
         locale: [en-US, es, fr]
         device:
           - { name: iPhone 16 Pro Max, slug: iphone-16-pro-max }
-          - { name: iPhone 14 Plus, slug: iphone-14-plus }
-          - { name: iPhone 16 Pro, slug: iphone-16-pro }
 
     env:
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
@@ -214,9 +217,9 @@ jobs:
         # path. Always against prod (signed in as the test user); no
         # EXPO_PUBLIC_BACKEND_URL override, so the bundle uses the app's production
         # backend defaults. --locales is a single value: `es` expands to both es-ES
-        # and es-MX for this device, so the 9 shards together produce all four App
-        # Store locales × 3 devices. --shutdown is belt-and-suspenders (a shard only
-        # boots this one sim, so there's nothing to accumulate).
+        # and es-MX, so the 3 shards together produce all four App Store locales on
+        # the one device size. --shutdown is belt-and-suspenders (a shard only boots
+        # this one sim, so there's nothing to accumulate).
         run: |
           set -euo pipefail
           vp run mobile:screenshots -- \

--- a/app-stores/apple/app-store-submission-guide.md
+++ b/app-stores/apple/app-store-submission-guide.md
@@ -39,12 +39,17 @@ user) and saves PNGs to `app-stores/apple/screenshots/<app-store-locale>/<device
 
 ### Required screenshot sizes
 
-| Device                           | Resolution | Required?                             |
-| -------------------------------- | ---------- | ------------------------------------- |
-| 6.9" iPhone (iPhone 16 Pro Max)  | 1320x2868  | Yes — captured by the Maestro flow    |
-| 6.5/6.7" iPhone (iPhone 14 Plus) | 1284x2778  | Optional, captured for common devices |
-| 6.3" iPhone (iPhone 16 Pro)      | 1206x2622  | Optional, captured for common devices |
-| 13" iPad (iPad Pro)              | 2064x2752  | Not required while tablet is disabled |
+| Device                          | Resolution | Required?                             |
+| ------------------------------- | ---------- | ------------------------------------- |
+| 6.9" iPhone (iPhone 16 Pro Max) | 1320x2868  | Yes — the only size the flow captures |
+| 13" iPad (iPad Pro)             | 2064x2752  | Not required while tablet is disabled |
+
+We capture a single device size, the 6.9" iPhone 16 Pro Max. App Store Connect
+**auto-scales the largest screenshot down** to every smaller iPhone, so one 6.9"
+set covers the whole device range — extra device sizes are invisible to users and
+add no ranking value, only CI time. The axis that helps the listing is locale, so
+that stays a full sweep. (See
+<https://developer.apple.com/help/app-store-connect/manage-app-information/upload-app-previews-and-screenshots/>.)
 
 The app currently has `supportsTablet: false`, so iPad screenshots are not part
 of the automated set. `--locales all` captures `en-US`, `es`, and `fr`; the

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -28,10 +28,11 @@ orchestrator builds with the prod `EXPO_PUBLIC_BACKEND_URL` and resets the
 simulator keychain first so login authenticates cleanly against prod.
 `--backend local` (the default) points at the seeded dev DB instead.
 
-By default the orchestrator captures the common Apple device matrix
-(`--devices common`: iPhone 16 Pro Max, iPhone 14 Plus, iPhone 16 Pro) and every
-app locale (`--locales all`: en-US, es, fr). Spanish is written to both App Store
-Connect Spanish folders (`es-ES` and `es-MX`).
+By default the orchestrator captures one device size (`--devices common`: the
+6.9" iPhone 16 Pro Max — App Store Connect scales it down to every smaller iPhone,
+so extra sizes add no value) across every app locale (`--locales all`: en-US, es,
+fr). Spanish is written to both App Store Connect Spanish folders (`es-ES` and
+`es-MX`).
 
 ## Flows
 

--- a/scripts/__tests__/assert-screenshot-dimensions.test.ts
+++ b/scripts/__tests__/assert-screenshot-dimensions.test.ts
@@ -54,17 +54,17 @@ describe('findOffenders', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('accepts the common iPhone Plus and Pro sizes', () => {
+  it('fails closed for the dropped Plus/Pro slugs (only 6.9" is captured now)', () => {
     expect(
       findOffenders('iphone-14-plus', [
         { name: 'iphone-14-plus/00-home.png', buffer: pngHeader({ width: 1284, height: 2778 }) },
-      ]),
-    ).toEqual([]);
+      ])[0].reason,
+    ).toMatch(/no accepted-size list/);
     expect(
       findOffenders('iphone-16-pro', [
         { name: 'iphone-16-pro/00-home.png', buffer: pngHeader({ width: 1206, height: 2622 }) },
-      ]),
-    ).toEqual([]);
+      ])[0].reason,
+    ).toMatch(/no accepted-size list/);
   });
 
   it('flags a wrong size, reporting both file and dimensions', () => {
@@ -101,18 +101,6 @@ describe('findScreenshotTreeOffenders', () => {
             buffer: pngHeader({ width: 1320, height: 2868 }),
           },
         ],
-        'iphone-14-plus': [
-          {
-            name: `${locale}/iphone-14-plus/00-home.png`,
-            buffer: pngHeader({ width: 1284, height: 2778 }),
-          },
-        ],
-        'iphone-16-pro': [
-          {
-            name: `${locale}/iphone-16-pro/00-home.png`,
-            buffer: pngHeader({ width: 1206, height: 2622 }),
-          },
-        ],
       };
     }
     for (const [locale, devices] of Object.entries(overrides)) {
@@ -143,18 +131,6 @@ describe('findScreenshotTreeOffenders', () => {
             buffer: pngHeader({ width: 1320, height: 2868 }),
           },
         ],
-        'iphone-14-plus': [
-          {
-            name: 'de-DE/iphone-14-plus/00-home.png',
-            buffer: pngHeader({ width: 1284, height: 2778 }),
-          },
-        ],
-        'iphone-16-pro': [
-          {
-            name: 'de-DE/iphone-16-pro/00-home.png',
-            buffer: pngHeader({ width: 1206, height: 2622 }),
-          },
-        ],
       },
     });
     const offenders = findScreenshotTreeOffenders(tree);
@@ -166,10 +142,11 @@ describe('findScreenshotTreeOffenders', () => {
   it('flags inconsistent device sets across locales', () => {
     const tree = screenshotTree({
       'es-ES': {
-        'iphone-16-pro-max': [
+        // A different device slug than the reference's iphone-16-pro-max.
+        'iphone-14-plus': [
           {
-            name: 'es-ES/iphone-16-pro-max/00-home.png',
-            buffer: pngHeader({ width: 1320, height: 2868 }),
+            name: 'es-ES/iphone-14-plus/00-home.png',
+            buffer: pngHeader({ width: 1284, height: 2778 }),
           },
         ],
       },
@@ -183,22 +160,11 @@ describe('findScreenshotTreeOffenders', () => {
   it('flags inconsistent PNG sets across locales', () => {
     const tree = screenshotTree({
       'es-MX': {
+        // Same device as the reference but a different PNG set (01-climbs vs 00-home).
         'iphone-16-pro-max': [
           {
             name: 'es-MX/iphone-16-pro-max/01-climbs.png',
             buffer: pngHeader({ width: 1320, height: 2868 }),
-          },
-        ],
-        'iphone-14-plus': [
-          {
-            name: 'es-MX/iphone-14-plus/00-home.png',
-            buffer: pngHeader({ width: 1284, height: 2778 }),
-          },
-        ],
-        'iphone-16-pro': [
-          {
-            name: 'es-MX/iphone-16-pro/00-home.png',
-            buffer: pngHeader({ width: 1206, height: 2622 }),
           },
         ],
       },

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -8,7 +8,7 @@ import {
   type ScreenshotOptions,
 } from '../mobile-screenshots';
 
-const commonDevices = ['iPhone 16 Pro Max', 'iPhone 14 Plus', 'iPhone 16 Pro'];
+const commonDevices = ['iPhone 16 Pro Max'];
 const allAppLocales: ScreenshotOptions['appLocales'] = ['en-US', 'es', 'fr'];
 
 function makeOptions(overrides: Partial<ScreenshotOptions> = {}): ScreenshotOptions {

--- a/scripts/assert-screenshot-dimensions.ts
+++ b/scripts/assert-screenshot-dimensions.ts
@@ -47,16 +47,14 @@ export const EXPECTED_APP_STORE_LOCALES = ['en-US', 'es-ES', 'es-MX', 'fr-FR'] a
  * slug can't sneak un-validated sizes past the gate.
  */
 export const ACCEPTED_SIZES: Record<string, readonly Dimensions[]> = {
-  // 6.9" iPhone slot. Apple accepts the iPhone 16 Pro Max native 1320x2868 or
-  // the prior-gen 1290x2796 in this slot.
+  // 6.9" iPhone slot — the ONLY size we capture. Apple auto-scales it down to every
+  // smaller iPhone, so one 6.9" set covers the whole device range and extra sizes add
+  // no store/ranking value (see app-store-submission-guide.md). Apple accepts the
+  // iPhone 16 Pro Max native 1320x2868 or the prior-gen 1290x2796 here.
   'iphone-16-pro-max': [
     { width: 1320, height: 2868 },
     { width: 1290, height: 2796 },
   ],
-  // 6.5"/6.7" iPhone Plus slot.
-  'iphone-14-plus': [{ width: 1284, height: 2778 }],
-  // Current non-Max Pro slot.
-  'iphone-16-pro': [{ width: 1206, height: 2622 }],
 };
 
 /** Read width/height from a PNG buffer's IHDR. Throws on a non-PNG / truncated file. */

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -91,21 +91,15 @@ export interface IosScreenshotDevice {
   typeId: string;
 }
 
-// The flow needs no per-device coordinate taps any more: every screen is a deep
-// link, and the active board is auto-selected on boot in screenshot mode (see
-// auth-provider.tsx), so there's no board-picker tap to tune per device.
+// Just the 6.9" iPhone 16 Pro Max. App Store Connect auto-scales the largest size
+// down to every smaller iPhone, so a single 6.9" set covers the whole range — extra
+// device sizes are invisible to users and add no ranking value, only CI time (see
+// app-stores/apple/app-store-submission-guide.md). Locale, not device size, is the
+// axis that helps the listing, so the orchestrator still captures every app locale.
 export const IOS_SCREENSHOT_DEVICES: readonly IosScreenshotDevice[] = [
   {
     name: 'iPhone 16 Pro Max',
     typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro-Max',
-  },
-  {
-    name: 'iPhone 14 Plus',
-    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-14-Plus',
-  },
-  {
-    name: 'iPhone 16 Pro',
-    typeId: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro',
   },
 ];
 


### PR DESCRIPTION
## Why

App Store Connect **auto-scales the largest screenshot down** to every smaller iPhone ([Apple docs](https://developer.apple.com/help/app-store-connect/manage-app-information/upload-app-previews-and-screenshots/)), so a single **6.9"** set covers the whole device range. Extra device sizes are invisible to users and add **no ranking value** — ranking is driven by conversion (screenshot quality) and localization, not device-size count. So the three adjacent sizes we captured (6.9" / 6.5" / 6.3") were just hand-made versions of what Apple generates for free.

## What

- Capture **only the 6.9" iPhone 16 Pro Max**; drop the iPhone 14 Plus and iPhone 16 Pro.
- **Keep all three locales** (en-US / es / fr → es-ES + es-MX) — locale is the axis that actually helps the listing.
- `ios-capture` matrix: **9 shards → 3** (one per locale), still one simulator per shard with `fail-fast: false`. This largely ends the macOS-runner queue wait.

## Changes
- `IOS_SCREENSHOT_DEVICES` → one entry
- dimension gate `ACCEPTED_SIZES` → `iphone-16-pro-max` only; the dropped slugs now **fail closed** (covered by an updated test)
- the gate's tests rebuilt around a 1-device tree (helper + the device-set / PNG-set mismatch cases use a different device/PNG to still exercise the mismatch paths)
- workflow matrix + comments; submission-guide + `.maestro/README.md` docs
- fastlane is device-agnostic → untouched

## Validation
`vp test run` (gate + script tests) ✓ 40/40 · matrix expands to 3 shards · `vp check` ✓ (format + types). Independent of the dialog-priming PR (#3013) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)