### PR TITLE
feat(mobile): edit display name & avatar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -247,6 +247,8 @@
         "expo-glass-effect": "~56.0.4",
         "expo-haptics": "~56.0.3",
         "expo-image": "~56.0.9",
+        "expo-image-manipulator": "~56.0.16",
+        "expo-image-picker": "~56.0.15",
         "expo-keep-awake": "~56.0.3",
         "expo-linear-gradient": "~56.0.4",
         "expo-linking": "~56.0.13",
@@ -2841,6 +2843,12 @@
     "expo-haptics": ["expo-haptics@56.0.3", "", { "peerDependencies": { "expo": "*" } }, "sha512-ycoahZJnR9tWAVh/0mJYxbETtHRYaWjiWS8cHlP6aDGU6Q6Y8rZ5NKsuBwWw6HR2Pe30mfVFgbF2HrBR6gtYmw=="],
 
     "expo-image": ["expo-image@56.0.9", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-FifiRehXnMul5XeUVHWv+COHFUeCAdsYf5MiCPUBlhr4pRb0sxjA4/floi/TEDpATOIw6GqxbrC4FdZBoyrJmw=="],
+
+    "expo-image-loader": ["expo-image-loader@56.0.3", "", { "peerDependencies": { "expo": "*" } }, "sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA=="],
+
+    "expo-image-manipulator": ["expo-image-manipulator@56.0.19", "", { "dependencies": { "expo-image-loader": "~56.0.3" }, "peerDependencies": { "expo": "*" } }, "sha512-FzMFgrIljDdHfNX6kXONU/y1WF2Eu8Mkqiq7jeortcOakQTsfzWj+1dMIv3AjIvFK2sf0d4L7Dqk7lqK8q+SZA=="],
+
+    "expo-image-picker": ["expo-image-picker@56.0.18", "", { "dependencies": { "expo-image-loader": "~56.0.3" }, "peerDependencies": { "expo": "*" } }, "sha512-sCjQ8M27bhGUv2vUavIE+uWdYo79b2D7Q5h9B66BSDZ+Rd8YyLVSf7vYGfIzQ7nMVoENZ6c4xo/JiDkEeQ9iTg=="],
 
     "expo-json-utils": ["expo-json-utils@56.0.0", "", {}, "sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg=="],
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -316,6 +316,17 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       ],
       'expo-updates',
       'expo-web-browser',
+      // Photo-library access for picking a profile avatar (Edit Profile screen).
+      // Library-only — the editor doesn't open the camera, so we don't request
+      // NSCameraUsageDescription. Adds NSPhotoLibraryUsageDescription on iOS and
+      // the READ_MEDIA_IMAGES permission on Android; native change, ships on the
+      // next build (not OTA).
+      [
+        'expo-image-picker',
+        {
+          photosPermission: 'Boardsesh uses your photo library so you can pick a profile picture.',
+        },
+      ],
       'react-native-ble-plx',
       // Makes Boardsesh a share target so a beta video link shared from
       // Instagram/TikTok (the OS share sheet) opens the app. iOS gets a no-UI

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -17,6 +17,7 @@ export default function ProfileLayout() {
           this stack. It sets its own header title from the loaded session. */}
       <Stack.Screen name="session/[sessionId]" options={{ headerShown: true }} />
       <Stack.Screen name="more" options={{ title: t('mobile.more.title') }} />
+      <Stack.Screen name="edit" options={{ title: tSettings('profile.editAction') }} />
       <Stack.Screen name="integrations" options={{ title: tSettings('integrations.title') }} />
       {/* i18n-ignore-next-line — preview-only screen */}
       <Stack.Screen name="branch-switcher" options={{ title: 'Branch Switcher' }} />

--- a/packages/mobile/app/(tabs)/profile/edit.tsx
+++ b/packages/mobile/app/(tabs)/profile/edit.tsx
@@ -1,0 +1,5 @@
+import { EditProfileScreen } from '../../../src/components/EditProfileScreen';
+
+export default function EditProfileRoute() {
+  return <EditProfileScreen />;
+}

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -12,6 +12,7 @@ import { useProfile } from '../../../src/lib/graphql/hooks';
 import { borderRadius, spacing } from '../../../src/theme/tokens';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
 import { Icon } from '../../../src/components/Icon';
+import { Avatar } from '../../../src/components/Avatar';
 import { Text } from '../../../src/components/Text';
 import { ListRow } from '../../../src/components/ListRow';
 import { SectionHeader } from '../../../src/components/SectionHeader';
@@ -255,6 +256,17 @@ export default function MoreScreen() {
 
       <View style={styles.section}>
         <SectionHeader title={tProfile('mobile.account')} />
+        {profile?.id ? (
+          <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
+            <ListRow
+              title={tSettings('profile.editAction')}
+              leading={<Avatar uri={profile.avatarUrl} name={profile.displayName ?? profile.email ?? null} size={28} />}
+              showChevron
+              showSeparator={false}
+              onPress={() => router.push('/(tabs)/profile/edit')}
+            />
+          </View>
+        ) : null}
         {profile?.email ? (
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.accountEmail}>
             {profile.email}
@@ -312,6 +324,7 @@ const styles = StyleSheet.create({
   },
   accountEmail: {
     paddingHorizontal: spacing[4],
+    marginTop: spacing[3],
     marginBottom: spacing[3],
   },
   signOut: {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -58,6 +58,8 @@
     "expo-glass-effect": "~56.0.4",
     "expo-haptics": "~56.0.3",
     "expo-image": "~56.0.9",
+    "expo-image-manipulator": "~56.0.16",
+    "expo-image-picker": "~56.0.15",
     "expo-keep-awake": "~56.0.3",
     "expo-linear-gradient": "~56.0.4",
     "expo-linking": "~56.0.13",

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import * as ImagePicker from 'expo-image-picker';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import type { UpdateProfileInput } from '@boardsesh/shared-schema';
+import { useTheme } from '../providers/theme-provider';
+import { useToast } from '../providers/toast-provider';
+import { useProfile, useUpdateProfile } from '../lib/graphql/hooks';
+import { uploadAvatar, type AvatarUploadFile } from '../lib/avatar-upload';
+import { reportError } from '../lib/error-reporting';
+import { spacing } from '../theme/tokens';
+import { Avatar } from './Avatar';
+import { AuthTextInput } from './AuthTextInput';
+import { Button } from './Button';
+import { Text } from './Text';
+
+const DISPLAY_NAME_MAX = 100;
+// Match the web client (settings-page-content.tsx): cap the longest side at
+// 1024px and re-encode as JPEG q0.85 so a multi-megapixel camera photo lands
+// comfortably under the backend's 2MB avatar limit.
+const MAX_DIMENSION = 1024;
+const COMPRESSION_QUALITY = 0.85;
+
+/**
+ * Resize (if needed) and re-encode a picked image to a small JPEG, returning the
+ * local file URI. Resizing a single dimension preserves the aspect ratio; we
+ * constrain whichever side is longer. A 0 dimension (the picker couldn't report
+ * size) skips the resize but still re-encodes to shrink the file.
+ */
+async function compressAvatar(uri: string, width: number, height: number): Promise<string> {
+  const context = ImageManipulator.manipulate(uri);
+  const longestSide = Math.max(width, height);
+  if (longestSide > MAX_DIMENSION) {
+    if (width >= height) {
+      context.resize({ width: MAX_DIMENSION });
+    } else {
+      context.resize({ height: MAX_DIMENSION });
+    }
+  }
+  const image = await context.renderAsync();
+  const result = await image.saveAsync({ compress: COMPRESSION_QUALITY, format: SaveFormat.JPEG });
+  return result.uri;
+}
+
+export function EditProfileScreen() {
+  const { t } = useTranslation('settings');
+  const { systemColors } = useTheme();
+  const { showToast } = useToast();
+  const router = useRouter();
+
+  const { data: profile } = useProfile();
+  const updateProfile = useUpdateProfile();
+
+  const [displayName, setDisplayName] = useState('');
+  const [pickedAvatar, setPickedAvatar] = useState<AvatarUploadFile | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Seed the name field from the loaded profile exactly once. The query is
+  // usually warm (the avatar/drawer already read it), but guard the case where
+  // it resolves after mount, and stop re-seeding once the user starts editing.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (!seededRef.current && profile) {
+      setDisplayName(profile.displayName ?? '');
+      seededRef.current = true;
+    }
+  }, [profile]);
+
+  const trimmedName = displayName.trim();
+  const nameTooLong = trimmedName.length > DISPLAY_NAME_MAX;
+  const previewUri = pickedAvatar?.uri ?? profile?.avatarUrl;
+  const avatarName = trimmedName || profile?.email || null;
+  const hasChanges = pickedAvatar != null || trimmedName.length > 0;
+  const canSave = !isSaving && !nameTooLong && hasChanges && !!profile?.id;
+
+  const handlePickAvatar = async () => {
+    try {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!permission.granted) {
+        showToast(t('profile.avatar.permissionDenied'), 'warning');
+        return;
+      }
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsEditing: true,
+        aspect: [1, 1],
+        // We compress ourselves below; ask the picker for the full-quality crop.
+        quality: 1,
+      });
+      if (result.canceled) return;
+      const asset = result.assets[0];
+      const compressedUri = await compressAvatar(asset.uri, asset.width, asset.height);
+      setPickedAvatar({ uri: compressedUri, name: 'avatar.jpg', type: 'image/jpeg' });
+    } catch (error) {
+      reportError(error);
+      showToast(t('profile.validation.compressionFailed'), 'error');
+    }
+  };
+
+  const handleSave = async () => {
+    if (!canSave || !profile?.id) return;
+    setIsSaving(true);
+    try {
+      const input: UpdateProfileInput = {};
+      if (trimmedName.length > 0) {
+        input.displayName = trimmedName;
+      }
+
+      if (pickedAvatar) {
+        try {
+          input.avatarUrl = await uploadAvatar(pickedAvatar, profile.id);
+        } catch (error) {
+          // Match web: a failed avatar upload warns but still saves the name, so
+          // the user doesn't lose a name edit to an image hiccup.
+          reportError(error);
+          showToast(t('profile.avatarUploadFailed'), 'warning');
+        }
+      }
+
+      // Nothing left to persist (e.g. avatar-only attempt whose upload failed).
+      if (input.displayName === undefined && input.avatarUrl === undefined) {
+        return;
+      }
+
+      await updateProfile.mutateAsync(input);
+      // showToast fires the success/error haptic itself based on the variant.
+      showToast(t('profile.saved'), 'success');
+      router.back();
+    } catch (error) {
+      reportError(error);
+      showToast(t('profile.saveError'), 'error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="handled"
+    >
+      <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.subtitle}>
+        {t('profile.subtitle')}
+      </Text>
+
+      <View style={styles.avatarBlock}>
+        <Avatar uri={previewUri} name={avatarName} size={96} />
+        <Button
+          title={previewUri ? t('profile.avatar.change') : t('profile.avatar.upload')}
+          variant="outlined"
+          icon="camera"
+          onPress={() => {
+            void handlePickAvatar();
+          }}
+          disabled={isSaving}
+        />
+        <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.avatarHint}>
+          {t('profile.avatar.hint')}
+        </Text>
+      </View>
+
+      <View style={styles.form}>
+        <AuthTextInput
+          label={t('profile.displayName.label')}
+          value={displayName}
+          onChangeText={setDisplayName}
+          placeholder={t('profile.displayName.placeholder')}
+          error={nameTooLong ? t('profile.validation.displayNameTooLong') : undefined}
+          editable={!isSaving}
+          autoCapitalize="words"
+          autoCorrect={false}
+          returnKeyType="done"
+        />
+
+        <AuthTextInput
+          label={t('profile.email.label')}
+          value={profile?.email ?? ''}
+          onChangeText={() => undefined}
+          editable={false}
+          hint={t('profile.email.help')}
+          autoCapitalize="none"
+        />
+      </View>
+
+      <View style={styles.actions}>
+        <Button
+          title={t('profile.save')}
+          variant="filled"
+          onPress={() => {
+            void handleSave();
+          }}
+          disabled={!canSave}
+          loading={isSaving}
+        />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    paddingTop: spacing[4],
+    paddingBottom: spacing[8],
+  },
+  subtitle: {
+    paddingHorizontal: spacing[4],
+    textAlign: 'center',
+  },
+  avatarBlock: {
+    alignItems: 'center',
+    gap: spacing[3],
+    marginTop: spacing[5],
+    paddingHorizontal: spacing[4],
+  },
+  avatarHint: {
+    textAlign: 'center',
+  },
+  form: {
+    marginTop: spacing[6],
+    paddingHorizontal: spacing[4],
+    gap: spacing[4],
+  },
+  actions: {
+    marginTop: spacing[6],
+    paddingHorizontal: spacing[4],
+  },
+});

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -40,8 +40,14 @@ async function compressAvatar(uri: string, width: number, height: number): Promi
     }
   }
   const image = await context.renderAsync();
-  const result = await image.saveAsync({ compress: COMPRESSION_QUALITY, format: SaveFormat.JPEG });
-  return result.uri;
+  try {
+    const result = await image.saveAsync({ compress: COMPRESSION_QUALITY, format: SaveFormat.JPEG });
+    return result.uri;
+  } finally {
+    // Release the native bitmap the rendered ref holds; the saved file URI is a
+    // path on disk and stays valid after the ref is gone.
+    image.release();
+  }
 }
 
 export function EditProfileScreen() {
@@ -58,15 +64,22 @@ export function EditProfileScreen() {
   const [isSaving, setIsSaving] = useState(false);
 
   // Seed the name field from the loaded profile exactly once. The query is
-  // usually warm (the avatar/drawer already read it), but guard the case where
-  // it resolves after mount, and stop re-seeding once the user starts editing.
+  // usually warm (the avatar/drawer already read it), but on a cold load the
+  // field is editable before `profile` resolves — so also skip the seed if the
+  // user has already typed, or the late resolve would clobber their edit.
   const seededRef = useRef(false);
+  const nameEditedRef = useRef(false);
   useEffect(() => {
-    if (!seededRef.current && profile) {
+    if (!seededRef.current && !nameEditedRef.current && profile) {
       setDisplayName(profile.displayName ?? '');
       seededRef.current = true;
     }
   }, [profile]);
+
+  const handleChangeName = useCallback((text: string) => {
+    nameEditedRef.current = true;
+    setDisplayName(text);
+  }, []);
 
   const trimmedName = displayName.trim();
   const nameTooLong = trimmedName.length > DISPLAY_NAME_MAX;
@@ -99,8 +112,15 @@ export function EditProfileScreen() {
     }
   };
 
+  // Synchronous reentrancy guard: `canSave`/`isSaving` are state read from the
+  // render closure and don't update until the next render, so a fast double-tap
+  // could enter `handleSave` twice (double upload + double router.back). The ref
+  // flips immediately.
+  const savingRef = useRef(false);
+
   const handleSave = async () => {
-    if (!canSave || !profile?.id) return;
+    if (savingRef.current || !canSave || !profile?.id) return;
+    savingRef.current = true;
     setIsSaving(true);
     try {
       const input: UpdateProfileInput = {};
@@ -119,7 +139,9 @@ export function EditProfileScreen() {
         }
       }
 
-      // Nothing left to persist (e.g. avatar-only attempt whose upload failed).
+      // Nothing left to persist — e.g. an avatar-only save whose upload failed.
+      // Stay on the screen (no router.back) so the user can retry; the warning
+      // toast already fired, and `finally` still resets the saving state.
       if (input.displayName === undefined && input.avatarUrl === undefined) {
         return;
       }
@@ -133,6 +155,7 @@ export function EditProfileScreen() {
       showToast(t('profile.saveError'), 'error');
     } finally {
       setIsSaving(false);
+      savingRef.current = false;
     }
   };
 
@@ -158,7 +181,7 @@ export function EditProfileScreen() {
           disabled={isSaving}
         />
         <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.avatarHint}>
-          {t('profile.avatar.hint')}
+          {t('profile.avatar.hintMobile')}
         </Text>
       </View>
 
@@ -166,7 +189,7 @@ export function EditProfileScreen() {
         <AuthTextInput
           label={t('profile.displayName.label')}
           value={displayName}
-          onChangeText={setDisplayName}
+          onChangeText={handleChangeName}
           placeholder={t('profile.displayName.placeholder')}
           error={nameTooLong ? t('profile.validation.displayNameTooLong') : undefined}
           editable={!isSaving}

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -40,6 +40,7 @@ function currentBoardReturnTo(segments: readonly string[]): '/(tabs)/discover' |
 
 export function UserDrawerProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation('common');
+  const { t: tSettings } = useTranslation('settings');
   const { systemColors, brandColors } = useTheme();
   const { isAuthenticated, signOut } = useAuth();
   const profileQuery = useProfile({ enabled: isAuthenticated });
@@ -112,6 +113,11 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     router.push('/(tabs)/profile/more');
   }, [closeUserDrawer]);
 
+  const openEditProfile = useCallback(() => {
+    closeUserDrawer();
+    router.push('/(tabs)/profile/edit');
+  }, [closeUserDrawer]);
+
   const openPlaylists = useCallback(() => {
     closeUserDrawer();
     router.push('/(tabs)/discover/all');
@@ -175,19 +181,41 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
             >
-              <View style={styles.profileHeader}>
-                <Avatar uri={profile?.avatarUrl} name={profileDisplayName} size={60} />
-                <View style={styles.profileText}>
-                  <Text variant="headline" numberOfLines={1} style={styles.profileName}>
-                    {profileDisplayName}
-                  </Text>
-                  {profileEmail ? (
-                    <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
-                      {profileEmail}
+              {profile?.id ? (
+                <Pressable
+                  style={styles.profileHeader}
+                  onPress={openEditProfile}
+                  accessibilityRole="button"
+                  accessibilityLabel={tSettings('profile.editAction')}
+                >
+                  <Avatar uri={profile.avatarUrl} name={profileDisplayName} size={60} />
+                  <View style={styles.profileText}>
+                    <Text variant="headline" numberOfLines={1} style={styles.profileName}>
+                      {profileDisplayName}
                     </Text>
-                  ) : null}
+                    {profileEmail ? (
+                      <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
+                        {profileEmail}
+                      </Text>
+                    ) : null}
+                  </View>
+                  <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+                </Pressable>
+              ) : (
+                <View style={styles.profileHeader}>
+                  <Avatar uri={profile?.avatarUrl} name={profileDisplayName} size={60} />
+                  <View style={styles.profileText}>
+                    <Text variant="headline" numberOfLines={1} style={styles.profileName}>
+                      {profileDisplayName}
+                    </Text>
+                    {profileEmail ? (
+                      <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
+                        {profileEmail}
+                      </Text>
+                    ) : null}
+                  </View>
                 </View>
-              </View>
+              )}
 
               <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
                 <DrawerRow icon="boards" title={t('userDrawer.changeBoard')} onPress={() => openBoards()} />

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -181,6 +181,9 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
             >
+              {/* Tappable to edit only when signed in; otherwise a plain header.
+                  Both branches render the same body, differing only in the
+                  wrapper + chevron. */}
               {profile?.id ? (
                 <Pressable
                   style={styles.profileHeader}
@@ -188,32 +191,20 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
                   accessibilityRole="button"
                   accessibilityLabel={tSettings('profile.editAction')}
                 >
-                  <Avatar uri={profile.avatarUrl} name={profileDisplayName} size={60} />
-                  <View style={styles.profileText}>
-                    <Text variant="headline" numberOfLines={1} style={styles.profileName}>
-                      {profileDisplayName}
-                    </Text>
-                    {profileEmail ? (
-                      <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
-                        {profileEmail}
-                      </Text>
-                    ) : null}
-                  </View>
+                  <ProfileHeaderBody
+                    avatarUrl={profile.avatarUrl}
+                    displayName={profileDisplayName}
+                    email={profileEmail}
+                  />
                   <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
                 </Pressable>
               ) : (
                 <View style={styles.profileHeader}>
-                  <Avatar uri={profile?.avatarUrl} name={profileDisplayName} size={60} />
-                  <View style={styles.profileText}>
-                    <Text variant="headline" numberOfLines={1} style={styles.profileName}>
-                      {profileDisplayName}
-                    </Text>
-                    {profileEmail ? (
-                      <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
-                        {profileEmail}
-                      </Text>
-                    ) : null}
-                  </View>
+                  <ProfileHeaderBody
+                    avatarUrl={profile?.avatarUrl}
+                    displayName={profileDisplayName}
+                    email={profileEmail}
+                  />
                 </View>
               )}
 
@@ -255,6 +246,33 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
       </Modal>
       <FeedbackSheet sheetRef={feedbackSheetRef} mode={feedbackMode} />
     </UserDrawerContext.Provider>
+  );
+}
+
+type ProfileHeaderBodyProps = {
+  avatarUrl: string | null | undefined;
+  displayName: string;
+  email: string | null;
+};
+
+// The avatar + name + email block shared by the tappable (signed-in) and plain
+// (signed-out) header variants, so the markup lives in one place.
+function ProfileHeaderBody({ avatarUrl, displayName, email }: ProfileHeaderBodyProps) {
+  const { systemColors } = useTheme();
+  return (
+    <>
+      <Avatar uri={avatarUrl} name={displayName} size={60} />
+      <View style={styles.profileText}>
+        <Text variant="headline" numberOfLines={1} style={styles.profileName}>
+          {displayName}
+        </Text>
+        {email ? (
+          <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
+            {email}
+          </Text>
+        ) : null}
+      </View>
+    </>
   );
 }
 

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// Fixed backend origin so the relative→absolute logic is deterministic and
+// independent of EXPO_PUBLIC_BACKEND_URL.
+vi.mock('../env', () => ({
+  BACKEND_URL: 'https://ws.example.com',
+}));
+
+// Mock the auth wrapper so we don't pull in auth-store → expo-secure-store, and
+// so we can assert on the request the helper makes.
+const mockAuthenticatedFetch = vi.fn();
+vi.mock('../auth-interceptor', () => ({
+  authenticatedFetch: (...args: unknown[]) => mockAuthenticatedFetch(...args),
+}));
+
+import { absolutizeAvatarUrl, uploadAvatar } from '../avatar-upload';
+
+const BACKEND = 'https://ws.example.com';
+const file = { uri: 'file:///tmp/avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' };
+const userId = '11111111-2222-3333-4444-555555555555';
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('absolutizeAvatarUrl', () => {
+  it('prefixes a backend-relative path with the backend origin', () => {
+    expect(absolutizeAvatarUrl('/static/avatars/abc.jpg')).toBe(`${BACKEND}/static/avatars/abc.jpg`);
+  });
+
+  it('passes an already-absolute URL through unchanged', () => {
+    const external = 'https://lh3.googleusercontent.com/a/abc';
+    expect(absolutizeAvatarUrl(external)).toBe(external);
+  });
+});
+
+describe('uploadAvatar', () => {
+  it('POSTs multipart form data to the avatars endpoint and returns the absolute URL', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ success: true, avatarUrl: '/static/avatars/me.jpg' }));
+
+    const result = await uploadAvatar(file, userId);
+
+    expect(result).toBe(`${BACKEND}/static/avatars/me.jpg`);
+    expect(mockAuthenticatedFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, options] = (mockAuthenticatedFetch as Mock).mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe(`${BACKEND}/api/avatars`);
+    expect(options.method).toBe('POST');
+    // No explicit Content-Type — RN sets the multipart boundary itself.
+    expect(options.headers).toBeUndefined();
+    const body = options.body as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('userId')).toBe(userId);
+    expect(body.has('avatar')).toBe(true);
+  });
+
+  it('throws the server-provided error message on a non-ok response', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ error: 'File too large' }, false));
+    await expect(uploadAvatar(file, userId)).rejects.toThrow('File too large');
+  });
+
+  it('throws when the response is missing an avatarUrl', async () => {
+    mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ success: true }));
+    await expect(uploadAvatar(file, userId)).rejects.toThrow('Avatar upload failed');
+  });
+});

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -1,0 +1,72 @@
+import { authenticatedFetch } from './auth-interceptor';
+import { BACKEND_URL } from './env';
+
+// The backend caps avatars at 2MB and accepts jpg/png/gif/webp. The picker +
+// expo-image-manipulator compress to a ≤1024px JPEG before we ever get here, so
+// in practice every upload is a small JPEG well under the limit.
+const AVATAR_ENDPOINT = `${BACKEND_URL}/api/avatars`;
+
+/** A picked (and already-compressed) local image ready to upload. */
+export type AvatarUploadFile = {
+  /** Local file URI (file://...) from the picker/manipulator. */
+  uri: string;
+  /** Filename sent in the multipart part; defaults to `avatar.jpg`. */
+  name?: string;
+  /** MIME type; defaults to `image/jpeg` (what the manipulator emits). */
+  type?: string;
+};
+
+/**
+ * The avatar handler returns a backend-relative URL (`/static/avatars/{id}.{ext}`)
+ * so the backend can proxy/resize it. Persisted profiles store the absolute URL,
+ * matching the web client (settings-page-content.tsx). Third-party absolute URLs
+ * pass through untouched.
+ */
+export function absolutizeAvatarUrl(url: string): string {
+  return url.startsWith('/') ? `${BACKEND_URL}${url}` : url;
+}
+
+/**
+ * Upload an avatar image to the backend REST endpoint and return its absolute
+ * URL (ready to hand to `updateProfile`). Reuses `authenticatedFetch`, which
+ * attaches the bearer token, refreshes it when stale, and retries once on 401.
+ * We deliberately do NOT set `Content-Type` — React Native fills in the
+ * multipart boundary for a `FormData` body, and `authenticatedFetch` only ever
+ * touches the `Authorization` header.
+ */
+export async function uploadAvatar(file: AvatarUploadFile, userId: string): Promise<string> {
+  const formData = new FormData();
+  // React Native's FormData accepts a `{ uri, name, type }` file descriptor at
+  // runtime; the DOM lib types only know `Blob`, so cast through `unknown`.
+  formData.append('avatar', {
+    uri: file.uri,
+    name: file.name ?? 'avatar.jpg',
+    type: file.type ?? 'image/jpeg',
+  } as unknown as Blob);
+  formData.append('userId', userId);
+
+  const response = await authenticatedFetch(AVATAR_ENDPOINT, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error(await readErrorMessage(response));
+  }
+
+  const data = (await response.json()) as { success?: boolean; avatarUrl?: string };
+  if (!data.avatarUrl) {
+    throw new Error('Avatar upload failed');
+  }
+  return absolutizeAvatarUrl(data.avatarUrl);
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: string };
+    if (data.error) return data.error;
+  } catch {
+    // Non-JSON error body — fall through to the generic message.
+  }
+  return 'Avatar upload failed';
+}

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -12,6 +12,7 @@ import type {
   CreateBoardInput,
   SetterStatsInput,
   UserProfile,
+  UpdateProfileInput,
   SessionSummary,
   SessionHealthExport,
 } from '@boardsesh/shared-schema';
@@ -36,6 +37,7 @@ import { SEARCH_GYMS, type SearchGymsQueryResponse } from '@boardsesh/graphql/op
 import { getHttpClient } from '../client';
 import {
   GET_PROFILE,
+  UPDATE_PROFILE,
   GET_MY_BOARDS,
   GET_BOARD,
   SEARCH_BOARDS,
@@ -53,6 +55,7 @@ import {
   END_SESSION,
   TOGGLE_FAVORITE,
   type GetProfileQueryResponse,
+  type UpdateProfileMutationResponse,
   type GetMyBoardsQueryResponse,
   type GetBoardQueryResponse,
   type SearchBoardsQueryResponse,
@@ -86,6 +89,27 @@ export function useProfile(options?: { enabled?: boolean }) {
     queryFn: () => getHttpClient().request<GetProfileQueryResponse>(GET_PROFILE),
     select: (data) => data.profile,
     enabled: options?.enabled ?? true,
+  });
+}
+
+/**
+ * Update the current user's display name and/or avatar URL. Invalidating
+ * `['profile']` is sufficient to refresh every consumer of the current user:
+ * the toolbar avatar (UserAvatarToolbarAction), the account drawer header, and
+ * PartyProfileProvider's `username`/`avatarUrl` (which derive from the same
+ * query). The avatar image itself is uploaded separately via `uploadAvatar`
+ * (REST), and its absolute URL is then persisted here.
+ */
+export function useUpdateProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpdateProfileInput) => {
+      const response = await getHttpClient().request<UpdateProfileMutationResponse>(UPDATE_PROFILE, { input });
+      return response.updateProfile;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['profile'] });
+    },
   });
 }
 

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request';
 import type {
   UserProfile,
+  UpdateProfileInput,
   UserBoard,
   UserBoardConnection,
   Climb,
@@ -137,6 +138,25 @@ export const GET_PROFILE = gql`
 
 export type GetProfileQueryResponse = {
   profile: UserProfile | null;
+};
+
+export const UPDATE_PROFILE = gql`
+  mutation UpdateProfile($input: UpdateProfileInput!) {
+    updateProfile(input: $input) {
+      id
+      email
+      displayName
+      avatarUrl
+    }
+  }
+`;
+
+export type UpdateProfileMutationVariables = {
+  input: UpdateProfileInput;
+};
+
+export type UpdateProfileMutationResponse = {
+  updateProfile: UserProfile;
 };
 
 export const GET_PUBLIC_PROFILE = gql`

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -19,6 +19,7 @@
       "change": "Change",
       "remove": "Remove",
       "hint": "JPG, PNG, GIF, or WebP. Up to 10MB — auto-compressed.",
+      "hintMobile": "Cropped square and compressed automatically.",
       "permissionDenied": "Allow photo access in Settings to choose an avatar."
     },
     "displayName": {

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -12,12 +12,14 @@
   "profile": {
     "title": "Profile",
     "subtitle": "Customize how you appear on Boardsesh",
+    "editAction": "Edit Profile",
     "avatar": {
       "label": "Avatar",
       "upload": "Upload",
       "change": "Change",
       "remove": "Remove",
-      "hint": "JPG, PNG, GIF, or WebP. Up to 10MB — auto-compressed."
+      "hint": "JPG, PNG, GIF, or WebP. Up to 10MB — auto-compressed.",
+      "permissionDenied": "Allow photo access in Settings to choose an avatar."
     },
     "displayName": {
       "label": "Display Name",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -12,12 +12,14 @@
   "profile": {
     "title": "Perfil",
     "subtitle": "Personaliza cómo apareces en Boardsesh",
+    "editAction": "Editar perfil",
     "avatar": {
       "label": "Foto de perfil",
       "upload": "Subir",
       "change": "Cambiar",
       "remove": "Quitar",
-      "hint": "JPG, PNG, GIF o WebP. Hasta 10 MB — se comprime automáticamente."
+      "hint": "JPG, PNG, GIF o WebP. Hasta 10 MB — se comprime automáticamente.",
+      "permissionDenied": "Permite el acceso a las fotos en Ajustes para elegir una foto de perfil."
     },
     "displayName": {
       "label": "Nombre",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -19,6 +19,7 @@
       "change": "Cambiar",
       "remove": "Quitar",
       "hint": "JPG, PNG, GIF o WebP. Hasta 10 MB — se comprime automáticamente.",
+      "hintMobile": "Se recorta en cuadrado y se comprime automáticamente.",
       "permissionDenied": "Permite el acceso a las fotos en Ajustes para elegir una foto de perfil."
     },
     "displayName": {

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -19,6 +19,7 @@
       "change": "Modifier",
       "remove": "Retirer",
       "hint": "JPG, PNG, GIF ou WebP. Jusqu'à 10 Mo, compression automatique.",
+      "hintMobile": "Recadrée en carré et compressée automatiquement.",
       "permissionDenied": "Autorisez l'accès aux photos dans Réglages pour choisir une photo de profil."
     },
     "displayName": {

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -12,12 +12,14 @@
   "profile": {
     "title": "Profil",
     "subtitle": "Choisissez comment vous apparaissez sur Boardsesh",
+    "editAction": "Modifier le profil",
     "avatar": {
       "label": "Photo de profil",
       "upload": "Importer",
       "change": "Modifier",
       "remove": "Retirer",
-      "hint": "JPG, PNG, GIF ou WebP. Jusqu'à 10 Mo, compression automatique."
+      "hint": "JPG, PNG, GIF ou WebP. Jusqu'à 10 Mo, compression automatique.",
+      "permissionDenied": "Autorisez l'accès aux photos dans Réglages pour choisir une photo de profil."
     },
     "displayName": {
       "label": "Nom affiché",


### PR DESCRIPTION
## What

Adds an **Edit Profile** screen to the mobile app so a user can change their **display name** and **avatar** — parity with the web Settings page. No backend changes; the existing backend is reused.

## Where it lives (entry points)

Two entry points (the placement chosen after a designer fan-out):
- **Settings → Account section** — a new "Edit Profile" row (with a live avatar thumbnail) at the top of the Account block in the More/Settings screen.
- **Account drawer header** — the avatar + name + email card in the slide-out user drawer is now tappable (with a chevron) and opens the editor.

Both push to a dedicated `/(tabs)/profile/edit` screen (consistent with the existing `more` / `integrations` / `delete-account` pushed screens).

## How it works

- **Display name + avatar URL** persist through the existing `updateProfile` GraphQL mutation (validates name 1–100, avatar URL ≤500).
- **Avatar image** is picked with `expo-image-picker`, compressed to a ≤1024px JPEG (q0.85) with `expo-image-manipulator` so it stays under the backend's 2MB cap, then uploaded to the existing `POST {BACKEND_URL}/api/avatars` REST endpoint via the shared `authenticatedFetch` (bearer auth, no manual `Content-Type` so RN sets the multipart boundary). The returned relative URL is absolutized before saving — matching the web client.
- **Cache**: invalidating the `['profile']` query refreshes the toolbar avatar, the drawer header, and the party identity in one shot (`PartyProfileProvider` derives display fields from the same query — no `refreshPartyProfile()` needed, unlike web).
- A failed avatar upload warns but still saves the name (matches web).

## Files

- New: `app/(tabs)/profile/edit.tsx`, `src/components/EditProfileScreen.tsx`, `src/lib/avatar-upload.ts` (+ unit test).
- Wiring: `operations.ts` (`UPDATE_PROFILE`), `graphql/hooks/index.ts` (`useUpdateProfile`), `_layout.tsx`, `more.tsx`, `UserDrawerProvider.tsx`.
- Deps/config: `expo-image-picker` + `expo-image-manipulator`, plus the `expo-image-picker` plugin (photo-library permission) in `app.config.ts`.
- i18n: reuses the existing `settings` `profile.*` keys; two new keys (`profile.editAction`, `profile.avatar.permissionDenied`) added across en-US/es/fr.

## Heads up

The two image deps are **native modules**, so this ships on the **next dev-client / EAS build, not an OTA update**. JS-only validation (typecheck, tests, Metro bundle) is unaffected.

Display-name clearing isn't supported (a name is effectively required — Save is disabled when the field is empty and no avatar is picked); the GraphQL mutation has no instagram field, so that web-only field is intentionally omitted.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` — 2357 passed ✅ (incl. new `avatar-upload` unit test + i18n catalog completeness)
- `vp run check:mobile-bundle` ✅ (new native-module imports resolve)
- `vp check` / pre-commit hook ✅

### Manual QA (needs a dev-client build for the picker)

- Open the editor from both entry points; on both UI variants (Liquid Glass + Material).
- Change avatar from the photo library; edit the name; Save → toast, returns, and the new name/avatar appear in the toolbar island, drawer header, and party/queue identity.
- Length validation (>100), the avatar-upload-failure warning path, and rendering with the keyboard up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)