### PR TITLE
Note community translations in es/fr release notes

### DIFF
--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -9,4 +9,6 @@ La misma app, reconstruida para volar:
 - Apunta encadenes, flashes e intentos y mira cómo tus grados se dibujan en la pestaña Progreso.
 - Guarda tus sesiones en Apple Health e importa tu logbook de Kilter y Tension desde Aurora Climbing.
 
+Y ahora Boardsesh habla español, traducido por la comunidad de escaladores.
+
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -9,4 +9,6 @@ La misma app, reconstruida para volar:
 - Apunta encadenes, flashes e intentos y mira cómo tus grados se dibujan en la pestaña Progreso.
 - Guarda tus sesiones en Apple Health e importa tu logbook de Kilter y Tension desde Aurora Climbing.
 
+Y ahora Boardsesh habla español, traducido por la comunidad de escaladores.
+
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -9,4 +9,6 @@ La même appli, refaite pour voler :
 - Suis tes sends, tes flashs et tes essais, et regarde tes cotations se tracer dans l'onglet Progression.
 - Enregistre tes sessions dans Apple Health et importe ton ancien carnet Kilter et Tension depuis Aurora Climbing.
 
+Et maintenant Boardsesh parle français, traduit par la communauté de grimpeurs.
+
 Gratuit, sans pub, open source.


### PR DESCRIPTION
Follow-up to #3019. Boardsesh 2.0 ships community-translated Spanish and French, so the store "What's New" for those locales now says so.

## What changed

A short line added before the free/open-source closer in the iOS "What's New":

- **es-ES / es-MX:** "Y ahora Boardsesh habla español, traducido por la comunidad de escaladores."
- **fr-FR:** "Et maintenant Boardsesh parle français, traduit par la communauté de grimpeurs."

en-US is unchanged. The Android Play changelogs are untouched — they're at the 500-char cap, and only the en-US Android note ships to Play today.

## Verification

- iOS char counts well under 4000 (es 1200, fr 1290); es-ES == es-MX.
- `vp check` flags only pre-existing unrelated files; none of these 3.

## Publishing

Merging triggers **Mobile Store Metadata**, which pushes the updated es/fr iOS notes to the editable App Store version (same flow as #3019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUgG91MegBADZzy3R8PN62