### PR TITLE
docs(store): polish English listing copy and align iOS + Android

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,9 +1,9 @@
-Search a climb and watch your wall light the holds over Bluetooth. Tap a problem, the holds glow, you pull on. Spend your session climbing instead of reading numbers off a screen.
+Search a climb, watch your wall light up. Less time on your phone, more time on the wall.
 
 Pick your board once and get climbing.
 
 LIGHT THE HOLDS
-Search any climb and Boardsesh sends it to the wall over Bluetooth, lighting the holds on Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL. Full LED control on all seven, not browse-only.
+Search any climb and Boardsesh lights the holds on the wall over Bluetooth, on Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL. Full LED control on all seven, not browse-only.
 
 ONE APP FOR EVERY BOARD YOU CLIMB
 Kilter, Tension and MoonBoard each ship their own app for their own board. Boardsesh works across all of them, plus Decoy, Touchstone, Grasshopper and So iLL, in one place. One login, one queue, one place your history lives, whichever wall you walk up to.
@@ -12,16 +12,16 @@ STAYS CONNECTED
 Boardsesh holds the link to your board in the background, so the holds stay lit through your burns even when the screen turns off or you switch apps. You are not reconnecting between climbs.
 
 SEE WHAT IS LIT ON THIS WALL
-Walk up to a board and a live feed is already there: the climb lit right now, who lit it, the grade and angle, who set it, and recent sends. Nothing to start. It is tied to the wall and updates as burns happen.
+Walk up to a board and a live feed is already there: the climb lit right now, who lit it, who set it, the grade and angle, and recent sends. Nothing to start. It is tied to the wall and updates as burns happen.
 
 CLIMB WITH YOUR CREW
-Start a session and everyone in it shares one queue. Anyone sends the next climb to the wall, so there is no driver to hand the phone around and no turn to wait for. Whoever is connected over Bluetooth lights it.
+Start a session and everyone in it shares one queue. Anyone lights the next climb, so the phone never gets passed around and nobody waits a turn. Whoever is connected over Bluetooth lights it.
 
 GET A RECAP
 When the session ends, your crew gets a recap: sends and attempts, grade spread, hardest send, and how your climbing stacks up week after week on the Progress tab.
 
 BUILD A WORKOUT
-Pick Volume, Pyramid, Ladder or Grade Focus, set a target grade and warm-up, preview the climbs, then send them to the wall one burn at a time.
+Pick Volume, Pyramid, Ladder or Grade Focus, set a target grade and warm-up, preview the climbs, then push them to the wall one at a time.
 
 TRACK YOUR CLIMBING
 Record sends, flashes and attempts. Bring your past Kilter and Tension climbs across by importing your logbook from Aurora Climbing.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Light any LED board over Bluetooth. Share one queue and send with your crew.
+Light Kilter, Tension, MoonBoard & more. Share one queue, climb as a crew.

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,24 +1,26 @@
+Search a climb, watch your wall light up. Less time on your phone, more time on the wall.
+
 ONE APP FOR EVERY BOARD YOU CLIMB
-Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL each have their own app for their own board. Boardsesh works across all of them in one place. Search any climb and Boardsesh sends it to the wall over Bluetooth, lighting the holds. Your full history of climbs across all boards in one convinient app.
+Kilter, Tension and MoonBoard each ship their own app for their own board. Boardsesh works across all of them, plus Decoy, Touchstone, Grasshopper and So iLL, in one place. Your whole climbing history across every board lives here.
 
 BOARD HISTORY, ALWAYS ON
-When sharing a board, it's always hard to remember what the last climb was, and the board is often changed by mistake.
-In Boardsesh every board you connect to has a live feed of what's lit on that wall right now: it's name, who lit it, the grade, and recent sends. That history is always there, updating as climbs are changed, no more confusion.
+Share a board and you lose track of the last climb fast, and someone always wipes it by accident.
+In Boardsesh every board you connect to has a live feed of what's lit on that wall right now: the climb's name, who lit it, who set it, the grade and angle, and recent sends. It updates as the wall changes, so you always know what's up there.
 
 SESSIONS WITH YOUR CREW
-Start a session and you and your crew can share one queue everyone can drive. Anyone can send the next climb to the wall. When you're done you get a recap and tracking: sends and attempts, grade spread, your hardest send, and progress over time.
+Start a session and you and your crew can share one queue everyone can drive. Anyone can light the next climb on the wall. When you're done you get a recap and tracking: sends and attempts, grade spread, your hardest send, and progress over time.
 
 CONTROL FROM YOUR LOCK SCREEN (iOS 17+)
 iOS Live Activities tell you what climb is on from your lock screen, and allow you to change it without leaving your lock screen.
 
 BUILD A WORKOUT
-Pick Volume, Pyramid, Ladder or Grade Focus, set a target grade and warm-up, preview the climbs, then send them to the wall one burn at a time.
+Pick Volume, Pyramid, Ladder or Grade Focus, set a target grade and warm-up, preview the climbs, then push them to the wall one at a time.
 
 TRACK YOUR CLIMBING
-Record sends, flashes and attempts, get a recap with duration, grade spread and your hardest send, and see your sends and grades chart out on the Progress tab.
+Record sends, flashes and attempts, get a recap with duration, grade spread and your hardest send, and watch your sends and grades climb on the Progress tab.
 
 BRING YOUR HISTORY WITH YOU
-Save your session to Apple Health, and import your logbooks from the other apps
+Save your session to Apple Health, and import your past Kilter and Tension logbook from Aurora Climbing.
 
 FIND MORE TO CLIMB
 Follow your crew and setters, search climbers, and pin playlists from Discover.

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,Kilter,Tension,bouldering,climb,beta,send,bluetooth,led,workout,training,setter,session
+MoonBoard,Kilter,Tension,kilterboard,bouldering,beta,send,tick,logbook,led,workout,setter,party

--- a/fastlane/metadata/en-US/promotional_text.txt
+++ b/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-New: Boards now heve a life history. See whats on the board at any time.
+New: every board now has a live history. Walk up and see what's lit, who lit it, the grade, angle and recent sends, before you even connect.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,11 +1,11 @@
-Boardsesh 2.0 is the native rebuild. The whole app is rewritten, so it's fast where it used to lag. Lists scroll smooth, search is instant.
+Boardsesh 2.0 is a full native rebuild. The whole app is rewritten, so it's fast where it used to lag. Lists scroll smooth, search is instant.
 
-Same app, rebuilt to fly:
+Same app, just faster:
 - Search a climb and light the holds over Bluetooth on Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL.
 - Walk up to any wall and see what's on it right now: the lit climb, who lit it, the grade, angle and setter, live as people climb.
-- Climb with your crew in a live session: one shared queue anyone can add to, reorder and drive. 
+- Climb with your crew in a live session: one shared queue anyone can add to, reorder and drive.
 - Run the session from your lock screen and Dynamic Island on iOS 17+ with Live Activities.
-- Build a Volume, Pyramid, Ladder or Grade Focus workout, then send the climbs one burn at a time.
+- Build a Volume, Pyramid, Ladder or Grade Focus workout and fire the climbs to the wall one at a time.
 - Track sends, flashes and attempts, and watch your grades chart out on the Progress tab.
 - Save sessions to Apple Health and import your past Kilter and Tension logbook from Aurora Climbing.
 


### PR DESCRIPTION
Final marketing & comms pass over the **English** fastlane store copy before release: fix the base-layer typos, sharpen climber voice, and bring the **Android** files in line with the recent iOS edits so both stores tell the same story. Every field stays under its hard character cap.

### Decisions baked in
- **Promo text keeps the "New:" hook** on the always-on board-history feed (confirmed genuinely new).
- **iOS description reorders to lead with the payoff** (search → wall lights up), mirroring Android.

### iOS (`fastlane/metadata/en-US/`)
- **promotional_text** — fix `heve`/`life history`/`whats`; lead with the walk-up payoff. `140/170`
- **description** — payoff-first reorder; fix `convinient`, `it's name`→`the climb's name`, missing terminal period, `the other apps`→`Aurora Climbing`; add the setter to the feed line; reserve `send` for ticks (`light`/`push` for transmit). `2058/4000`
- **release_notes** — strip trailing whitespace; `rebuilt to fly`→`just faster`; fix the send/burn collision. Only speed framed as new. `937/4000`
- **keywords** — drop low-value/duplicate terms; add `kilterboard`, `tick`, `logbook`, `party`. `95/100`, no spaces after commas

### Android (`fastlane/metadata/android/en-US/`)
- **short_description** — name the top boards for Play search; `send with your crew`→`climb as a crew`. `74/80`
- **full_description** — align the `LIGHT THE HOLDS` verb and board-history field order to iOS; resolve the send/transmit collision. `2133/4000`

### Verified
- Every field within cap; keywords have no spaces after commas.
- Affiliation disclaimer intact on both long descriptions; trademark casing correct.
- Apple Health and Live Activities appear only in iOS copy; `STAYS CONNECTED` (background Bluetooth) is described as an existing feature on Android, never framed as new.

### Out of scope / follow-ups
- `es-ES` / `es-MX` / `fr-FR` listings now lag the English copy — re-sync as a community-translation pass.
- URL host inconsistency: en-US uses `https://www.boardsesh.com`; es/fr and docs use `https://boardsesh.com` (no www). Pick one convention repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)