### PR TITLE
fix(mobile): reaction-menu review polish (a11y, unhandled rejections, key)

### DIFF
--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -193,6 +193,10 @@ export function ClimbReactionMenu({
             falls through to the backdrop Pressable. */}
         <View
           pointerEvents="box-none"
+          // Contain VoiceOver focus to the floating content (don't let it wander into
+          // the screen behind), and let the VO escape gesture dismiss the overlay.
+          accessibilityViewIsModal={Platform.OS === 'ios'}
+          onAccessibilityEscape={dismiss}
           style={[styles.content, { paddingTop: insets.top + spacing[5], paddingBottom: insets.bottom + spacing[5] }]}
         >
           <Animated.View pointerEvents="box-none" style={[styles.preview, previewStyle]}>

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -291,7 +291,8 @@ export function useClimbActions({
           // (openBrowserAsync only resolves when the browser is closed).
           after();
           track(SHARED_EVENTS.OpenInAuroraApp, { climbUuid: climb.uuid, boardName, layoutId });
-          void WebBrowser.openBrowserAsync(auroraAppUrl);
+          // .catch so a browser-open rejection doesn't become an unhandled rejection.
+          void WebBrowser.openBrowserAsync(auroraAppUrl).catch(() => {});
         },
       });
     }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -670,6 +670,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           long-pressed (RN-screens doesn't strictly guarantee cross-overlay z-order). */}
       {climbActions ? (
         <ClimbReactionMenu
+          key={climbActions.climb.uuid}
           climb={climbActions.climb}
           boardConfig={climbActions.boardConfig}
           currentUserId={profile?.id ?? null}


### PR DESCRIPTION
Follow-up to #3018 (climb reaction menu), applying the non-blocking findings from the release-safety review. Stacked on `feature/mobile-climb-context-menu` (retarget to `main` once #3018 merges).

## Changes
- **Unhandled rejection** — the dismiss-before-async open-in-app action now `.catch`es so a rare `WebBrowser` rejection can't surface as an unhandled promise rejection. (Copy link became Share on #3018, and that action already `.catch`es.)
- **Accessibility** — `ClimbReactionMenu`: add `accessibilityViewIsModal` (iOS) + `onAccessibilityEscape` so VoiceOver focus is contained to the floating content and the escape gesture dismisses the overlay.
- **Remount key** — key `ClimbReactionMenu` by climb uuid so opening it for a different climb cleanly remounts and replays the enter animation.

None of these were release-blocking; the review's overall verdict on #3018 was ship.

## Validation
`vp run typecheck:mobile` ✅ · `vp run test:mobile` ✅ (2441) · `vp run check:mobile-bundle` ✅ · pre-commit ✅.

## Not included (needs a device)
The reviewers' one standing caveat is the iOS `FullWindowOverlay`-over-`FullWindowOverlay` z-order when long-pressing a row **inside** the open Queue/Board sheet — best-effort mitigated by render order on #3018, but it needs simulator/device verification, not a code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC2RP9ocFAxt5NcZHnq8CV