### PR TITLE
docs(store): community-effort non-affiliation disclaimer

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -28,4 +28,4 @@ Follow your crew and setters, search climbers, and pin playlists from Discover.
 FREE, NO ADS, NO SUBSCRIPTIONS
 Open source on GitHub.
 
-Boardsesh works with these boards and is not affiliated with or endorsed by Aurora Climbing or Moon Climbing.
+Boardsesh is a community effort that works with these boards and is not affiliated with or endorsed by any board manufacturer.

--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -28,4 +28,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 GRATIS, SIN ANUNCIOS, SIN SUSCRIPCIONES
 Código abierto en GitHub.
 
-Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.
+Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas.

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -28,4 +28,4 @@ Suis ta crew et les ouvreurs, cherche des grimpeurs, et épingle des playlists d
 GRATUIT, SANS PUB, SANS ABONNEMENT
 Open source sur GitHub.
 
-Boardsesh fonctionne avec ces boards et n'est ni affilié à, ni soutenu par Aurora Climbing ou Moon Climbing.
+Boardsesh est un projet communautaire qui fonctionne avec ces boards et n'est ni affilié à, ni soutenu par aucun fabricant de boards.

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -27,4 +27,4 @@ Follow your crew and setters, search climbers, and pin playlists from Discover.
 
 Supported boards: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper and So iLL.
 
-Boardsesh works with these boards and is not affiliated with or endorsed by Aurora Climbing or Moon Climbing.
+Boardsesh is a community effort that works with these boards and is not affiliated with or endorsed by any board manufacturer.

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -27,4 +27,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 
 Tablas compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
 
-Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.
+Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas.

--- a/fastlane/metadata/es-MX/description.txt
+++ b/fastlane/metadata/es-MX/description.txt
@@ -27,4 +27,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 
 Tablas compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
 
-Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.
+Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas.

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -27,4 +27,4 @@ Suis ta crew et les ouvreurs, cherche des grimpeurs, et épingle des playlists d
 
 Boards prises en charge : Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper et So iLL.
 
-Boardsesh fonctionne avec ces boards et n'est ni affilié à, ni soutenu par Aurora Climbing ou Moon Climbing.
+Boardsesh est un projet communautaire qui fonctionne avec ces boards et n'est ni affilié à, ni soutenu par aucun fabricant de boards.


### PR DESCRIPTION
Follow-up to #3024 (merged). Updates the non-affiliation disclaimer in the store descriptions.

## Change
The disclaimer named only Aurora Climbing and Moon Climbing. Reword it to frame Boardsesh as a community effort and disclaim affiliation with **any** board manufacturer (cleaner than listing every brand):

**Before:** "Boardsesh works with these boards and is not affiliated with or endorsed by Aurora Climbing or Moon Climbing."

**After:** "Boardsesh is a community effort that works with these boards and is not affiliated with or endorsed by any board manufacturer."

- **es:** "Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas."
- **fr:** "Boardsesh est un projet communautaire qui fonctionne avec ces boards et n'est ni affilié à, ni soutenu par aucun fabricant de boards."

The es/fr renderings reuse the established `/legal` catalog phrasing for "any board manufacturer" (`ningún fabricante de tablas` / `aucun fabricant de boards`).

## Files
iOS descriptions (en-US, es-ES, es-MX, fr-FR) + Android full descriptions (en-US, es-ES, fr-FR) — 7 files. es-MX stays byte-identical to es-ES; all well under the 4000-char cap.

Metadata uploads from `main` only, so this just lands the copy for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)