### PR TITLE
docs(store): name all supported boards in the non-affiliation disclaimer

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -28,4 +28,4 @@ Follow your crew and setters, search climbers, and pin playlists from Discover.
 FREE, NO ADS, NO SUBSCRIPTIONS
 Open source on GitHub.
 
-Boardsesh works with these boards and is not affiliated with or endorsed by Aurora Climbing or Moon Climbing.
+Boardsesh works with these boards and is not affiliated with or endorsed by Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing or any board manufacturer.

--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -28,4 +28,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 GRATIS, SIN ANUNCIOS, SIN SUSCRIPCIONES
 Código abierto en GitHub.
 
-Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.
+Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing ni ningún fabricante de tablas.

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -28,4 +28,4 @@ Suis ta crew et les ouvreurs, cherche des grimpeurs, et épingle des playlists d
 GRATUIT, SANS PUB, SANS ABONNEMENT
 Open source sur GitHub.
 
-Boardsesh fonctionne avec ces boards et n'est ni affilié à, ni soutenu par Aurora Climbing ou Moon Climbing.
+Boardsesh fonctionne avec ces boards et n'est ni affilié à, ni soutenu par Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing ou tout autre fabricant de boards.

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -27,4 +27,4 @@ Follow your crew and setters, search climbers, and pin playlists from Discover.
 
 Supported boards: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper and So iLL.
 
-Boardsesh works with these boards and is not affiliated with or endorsed by Aurora Climbing or Moon Climbing.
+Boardsesh works with these boards and is not affiliated with or endorsed by Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing or any board manufacturer.

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -27,4 +27,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 
 Tablas compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
 
-Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.
+Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing ni ningún fabricante de tablas.

--- a/fastlane/metadata/es-MX/description.txt
+++ b/fastlane/metadata/es-MX/description.txt
@@ -27,4 +27,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 
 Tablas compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
 
-Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Aurora Climbing ni Moon Climbing.
+Boardsesh funciona con estas tablas y no está afiliado ni respaldado por Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing ni ningún fabricante de tablas.

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -27,4 +27,4 @@ Suis ta crew et les ouvreurs, cherche des grimpeurs, et épingle des playlists d
 
 Boards prises en charge : Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper et So iLL.
 
-Boardsesh fonctionne avec ces boards et n'est ni affilié à, ni soutenu par Aurora Climbing ou Moon Climbing.
+Boardsesh fonctionne avec ces boards et n'est ni affilié à, ni soutenu par Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL, Aurora Climbing, Moon Climbing ou tout autre fabricant de boards.


### PR DESCRIPTION
The store descriptions only disclaimed affiliation with Aurora Climbing and Moon Climbing. Extend the line to name every supported board brand (Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper, So iLL) and add the "or any board manufacturer" catch-all, matching the canonical wording in LEGAL.md / common.json.

Applied to the iOS descriptions (en-US, es-ES, es-MX, fr-FR) and the Android full descriptions (en-US, es-ES, fr-FR). es/fr reuse the established legal-catalog phrasing ("ni ningún fabricante de tablas" / "ou tout autre fabricant de boards"). es-MX stays mirrored to es-ES.


Claude-Session: https://claude.ai/code/session_0116JR3xW5DVNE97pYoAjznW