### PR TITLE
[codex] Version avatar upload URLs

### DIFF
--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -1,11 +1,13 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import Busboy from 'busboy';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import { mkdir, writeFile, unlink, access } from 'fs/promises';
 import { applyCorsHeaders } from './cors';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3, deleteUserAvatarsFromS3 } from '../storage/s3';
 import { logger } from '../utils/logger';
+import { buildStaticAvatarUrl } from '../lib/avatar-url';
 
 // Avatar upload configuration
 const AVATARS_DIR = './avatars';
@@ -232,6 +234,7 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
 
       // Determine file extension
       const ext = MIME_TO_EXT[mimeType] || 'jpg';
+      const avatarFileName = `${userId}.${ext}`;
       let avatarUrl: string;
 
       try {
@@ -240,19 +243,19 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
           await deleteUserAvatarsFromS3(userId);
 
           // Upload to S3
-          const s3Key = `avatars/${userId}.${ext}`;
+          const s3Key = `avatars/${avatarFileName}`;
           await uploadToS3(fileBuffer, s3Key, mimeType);
           // Return backend-relative URL instead of direct S3 URL
           // This allows the backend to proxy the image, avoiding S3 public access requirements
-          avatarUrl = `/static/avatars/${userId}.${ext}`;
+          avatarUrl = buildStaticAvatarUrl(avatarFileName, randomUUID());
         } else {
           // Delete any existing avatars for this user (all extensions) from local storage
           await deleteExistingAvatars(userId);
 
           // Save to local file system
-          const filePath = path.join(AVATARS_DIR, `${userId}.${ext}`);
+          const filePath = path.join(AVATARS_DIR, avatarFileName);
           await writeFile(filePath, fileBuffer);
-          avatarUrl = `/static/avatars/${userId}.${ext}`;
+          avatarUrl = buildStaticAvatarUrl(avatarFileName, randomUUID());
         }
       } catch (saveErr) {
         logger.error('Failed to save avatar:', saveErr);

--- a/packages/backend/src/lib/__tests__/avatar-url.test.ts
+++ b/packages/backend/src/lib/__tests__/avatar-url.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildStaticAvatarUrl } from '../avatar-url';
+
+describe('buildStaticAvatarUrl', () => {
+  it('adds a cache-busting version query param to a static avatar path', () => {
+    expect(buildStaticAvatarUrl('user-1.jpg', 'upload-123')).toBe('/static/avatars/user-1.jpg?v=upload-123');
+  });
+
+  it('encodes the version value for use in a URL', () => {
+    expect(buildStaticAvatarUrl('user-1.jpg', '2026-06-18 10:00')).toBe(
+      '/static/avatars/user-1.jpg?v=2026-06-18%2010%3A00',
+    );
+  });
+});

--- a/packages/backend/src/lib/avatar-url.ts
+++ b/packages/backend/src/lib/avatar-url.ts
@@ -1,0 +1,3 @@
+export function buildStaticAvatarUrl(fileName: string, version: string): string {
+  return `/static/avatars/${fileName}?v=${encodeURIComponent(version)}`;
+}

--- a/packages/mobile/src/components/Avatar.tsx
+++ b/packages/mobile/src/components/Avatar.tsx
@@ -20,7 +20,7 @@ type AvatarProps = {
  * bucket via the shared allowlist. Third-party avatar URLs are passed
  * through — the backend can only resize what it stores.
  */
-function sizedAvatarUri(uri: string, displaySize: number): string {
+export function sizedAvatarUri(uri: string, displaySize: number): string {
   if (!uri.includes('/static/avatars/')) return uri;
   const bucket = snapToAllowedImageSize(Math.ceil(displaySize * PixelRatio.get()));
   const separator = uri.includes('?') ? '&' : '?';

--- a/packages/mobile/src/components/__tests__/Avatar.test.tsx
+++ b/packages/mobile/src/components/__tests__/Avatar.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({
+  Image: () => null,
+  PixelRatio: { get: () => 3 },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: () => null,
+}));
+
+vi.mock('../Text', () => ({
+  Text: () => null,
+}));
+
+import { sizedAvatarUri } from '../Avatar';
+
+describe('sizedAvatarUri', () => {
+  it('passes third-party avatar URLs through unchanged', () => {
+    expect(sizedAvatarUri('https://lh3.googleusercontent.com/a/avatar', 40)).toBe(
+      'https://lh3.googleusercontent.com/a/avatar',
+    );
+  });
+
+  it('adds a size query param to backend-served avatars', () => {
+    expect(sizedAvatarUri('https://ws.example.com/static/avatars/user-1.jpg', 40)).toBe(
+      'https://ws.example.com/static/avatars/user-1.jpg?size=128',
+    );
+  });
+
+  it('preserves existing upload versions when adding size', () => {
+    expect(sizedAvatarUri('https://ws.example.com/static/avatars/user-1.jpg?v=upload-123', 40)).toBe(
+      'https://ws.example.com/static/avatars/user-1.jpg?v=upload-123&size=128',
+    );
+  });
+});

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -32,6 +32,12 @@ describe('absolutizeAvatarUrl', () => {
     expect(absolutizeAvatarUrl('/static/avatars/abc.jpg')).toBe(`${BACKEND}/static/avatars/abc.jpg`);
   });
 
+  it('preserves version query params on backend-relative paths', () => {
+    expect(absolutizeAvatarUrl('/static/avatars/abc.jpg?v=upload-123')).toBe(
+      `${BACKEND}/static/avatars/abc.jpg?v=upload-123`,
+    );
+  });
+
   it('passes an already-absolute URL through unchanged', () => {
     const external = 'https://lh3.googleusercontent.com/a/abc';
     expect(absolutizeAvatarUrl(external)).toBe(external);
@@ -40,11 +46,13 @@ describe('absolutizeAvatarUrl', () => {
 
 describe('uploadAvatar', () => {
   it('POSTs multipart form data to the avatars endpoint and returns the absolute URL', async () => {
-    mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ success: true, avatarUrl: '/static/avatars/me.jpg' }));
+    mockAuthenticatedFetch.mockResolvedValue(
+      jsonResponse({ success: true, avatarUrl: '/static/avatars/me.jpg?v=upload-123' }),
+    );
 
     const result = await uploadAvatar(file, userId);
 
-    expect(result).toBe(`${BACKEND}/static/avatars/me.jpg`);
+    expect(result).toBe(`${BACKEND}/static/avatars/me.jpg?v=upload-123`);
     expect(mockAuthenticatedFetch).toHaveBeenCalledTimes(1);
     const [calledUrl, options] = (mockAuthenticatedFetch as Mock).mock.calls[0] as [string, RequestInit];
     expect(calledUrl).toBe(`${BACKEND}/api/avatars`);

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-update-profile.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-update-profile.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PublicUserProfile } from '@boardsesh/shared-schema';
+import { UPDATE_PROFILE } from '../../operations';
+
+const requestMock = vi.fn();
+vi.mock('../../client', () => ({
+  getHttpClient: () => ({ request: requestMock }),
+}));
+vi.mock('../use-infinite-search-climbs', () => ({ useInfiniteSearchClimbs: vi.fn() }));
+vi.mock('../use-beta-link-preview', () => ({ useBetaLinkPreview: vi.fn() }));
+vi.mock('../use-mobile-climb-actions-data', () => ({ useMobileClimbActionsData: vi.fn() }));
+vi.mock('../use-you-data', () => ({
+  useAllBoardsTicks: vi.fn(),
+  useUserProfileStats: vi.fn(),
+  useUserClimbPercentile: vi.fn(),
+  useUserAscentsFeed: vi.fn(),
+  useActivityFeed: vi.fn(),
+  useSessionGroupedFeed: vi.fn(),
+}));
+vi.mock('../use-you-profile-data', () => ({ useYouProfileData: vi.fn() }));
+vi.mock('../use-social', () => ({
+  usePublicProfile: vi.fn(),
+  useFollowers: vi.fn(),
+  useFollowing: vi.fn(),
+  useSearchUsers: vi.fn(),
+  useToggleUserFollow: vi.fn(),
+  useUserClimbs: vi.fn(),
+  useVote: vi.fn(),
+  useBulkVoteSummaries: vi.fn(),
+  useChunkedBulkVoteSummaries: vi.fn(),
+  useGroupedBulkVoteSummaries: vi.fn(),
+  useComments: vi.fn(),
+  useAddComment: vi.fn(),
+}));
+vi.mock('../use-session-detail', () => ({ useSessionDetail: vi.fn(), useSessionPreview: vi.fn() }));
+vi.mock('../use-delete-account', () => ({ useDeleteAccountInfo: vi.fn(), useDeleteAccount: vi.fn() }));
+vi.mock('../use-integrations', () => ({
+  useIntegrationStatuses: vi.fn(),
+  useDisconnectIntegration: vi.fn(),
+  useSetIntegrationAutoSync: vi.fn(),
+  useSyncSessionToIntegration: vi.fn(),
+}));
+
+import { useUpdateProfile } from '../index';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, Wrapper };
+}
+
+beforeEach(() => {
+  requestMock.mockReset();
+});
+
+describe('useUpdateProfile', () => {
+  it('writes the returned profile into current and public profile caches', async () => {
+    const updatedProfile = {
+      id: 'user-1',
+      email: 'alex@example.com',
+      displayName: 'Alex Sender',
+      avatarUrl: 'https://ws.example.com/static/avatars/user-1.jpg?v=upload-123',
+    };
+    const cachedPublicProfile: PublicUserProfile = {
+      id: 'user-1',
+      displayName: 'Alex',
+      avatarUrl: 'https://ws.example.com/static/avatars/user-1.jpg?v=old',
+      followerCount: 10,
+      followingCount: 3,
+      isFollowedByMe: false,
+    };
+    requestMock.mockResolvedValue({ updateProfile: updatedProfile });
+    const { queryClient, Wrapper } = makeWrapper();
+    queryClient.setQueryData(['publicProfile', 'user-1'], cachedPublicProfile);
+
+    const { result } = renderHook(() => useUpdateProfile(), { wrapper: Wrapper });
+
+    await result.current.mutateAsync({ avatarUrl: updatedProfile.avatarUrl });
+
+    expect(requestMock).toHaveBeenCalledWith(UPDATE_PROFILE, { input: { avatarUrl: updatedProfile.avatarUrl } });
+    expect(queryClient.getQueryData(['profile'])).toEqual({ profile: updatedProfile });
+    expect(queryClient.getQueryData(['publicProfile', 'user-1'])).toEqual({
+      ...cachedPublicProfile,
+      displayName: updatedProfile.displayName,
+      avatarUrl: updatedProfile.avatarUrl,
+    });
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -13,6 +13,7 @@ import type {
   UpdateBoardInput,
   SetterStatsInput,
   UserProfile,
+  PublicUserProfile,
   UpdateProfileInput,
   SessionSummary,
   SessionHealthExport,
@@ -102,12 +103,11 @@ export function useProfile(options?: { enabled?: boolean }) {
 }
 
 /**
- * Update the current user's display name and/or avatar URL. Invalidating
- * `['profile']` is sufficient to refresh every consumer of the current user:
- * the toolbar avatar (UserAvatarToolbarAction), the account drawer header, and
- * PartyProfileProvider's `username`/`avatarUrl` (which derive from the same
- * query). The avatar image itself is uploaded separately via `uploadAvatar`
- * (REST), and its absolute URL is then persisted here.
+ * Update the current user's display name and/or avatar URL. The mutation result
+ * is written into the `['profile']` cache immediately, then invalidated so every
+ * current-user consumer refreshes against the backend. The avatar image itself
+ * is uploaded separately via `uploadAvatar` (REST), and its absolute URL is then
+ * persisted here.
  */
 export function useUpdateProfile() {
   const queryClient = useQueryClient();
@@ -116,8 +116,19 @@ export function useUpdateProfile() {
       const response = await getHttpClient().request<UpdateProfileMutationResponse>(UPDATE_PROFILE, { input });
       return response.updateProfile;
     },
-    onSuccess: () => {
+    onSuccess: (updatedProfile) => {
+      queryClient.setQueryData<GetProfileQueryResponse>(['profile'], { profile: updatedProfile });
+      queryClient.setQueryData<PublicUserProfile | null>(['publicProfile', updatedProfile.id], (cachedProfile) =>
+        cachedProfile
+          ? {
+              ...cachedProfile,
+              displayName: updatedProfile.displayName,
+              avatarUrl: updatedProfile.avatarUrl,
+            }
+          : cachedProfile,
+      );
       void queryClient.invalidateQueries({ queryKey: ['profile'] });
+      void queryClient.invalidateQueries({ queryKey: ['publicProfile', updatedProfile.id] });
     },
   });
 }


### PR DESCRIPTION
## Summary

Avatar uploads now return a versioned backend-relative URL, for example `/static/avatars/<user>.jpg?v=<upload-id>`, while continuing to store the file at the same S3/local key. Persisting a distinct URL per upload prevents web and React Native image caches from continuing to show the previous avatar after the file is replaced in place.

The mobile profile mutation also writes the returned profile into React Query immediately and patches the cached public profile for the same user, so the updated avatar URL is visible without waiting for a later refetch.

## Root Cause

The backend overwrote each user's avatar at a stable `/static/avatars/<userId>.<ext>` URL. Both the web UI and React Native could keep rendering cached bytes for that URL even after the upload and profile update completed successfully.

## Validation

- `vp test run --project backend packages/backend/src/lib/__tests__/avatar-url.test.ts`
- `vp test run --project mobile packages/mobile/src/lib/__tests__/avatar-upload.test.ts packages/mobile/src/components/__tests__/Avatar.test.tsx packages/mobile/src/lib/graphql/hooks/__tests__/use-update-profile.test.tsx`
- `vp test run --project mobile`
- `vp run typecheck:backend`
- `vp run typecheck:mobile`

Notes:
- `vp check` currently fails on pre-existing formatting issues in unrelated files (`CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, backend/db files), not in this diff.
- A local full backend test run hit `EADDRINUSE` on port `8082` in `src/__tests__/integration.test.ts`; backend integration should run in CI as discussed.