### PR TITLE
[codex] Fix mobile climb share URLs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -517,6 +517,7 @@
       "name": "@boardsesh/play-view",
       "version": "1.0.0",
       "dependencies": {
+        "@boardsesh/board-config": "*",
         "@boardsesh/board-constants": "*",
         "@boardsesh/queue": "*",
         "@boardsesh/shared-schema": "*",

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
-import { buildClimbViewPath } from '@boardsesh/play-view';
+import { buildReadableClimbViewPath } from '@boardsesh/play-view';
 import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { ModalSheet } from './ModalSheet';
@@ -132,7 +132,15 @@ function ClimbActionsSheet({
   const handleCopyLink = useCallback(async () => {
     if (!climb) return;
     try {
-      const url = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}`;
+      const url = `${WEB_BASE_URL}${buildReadableClimbViewPath({
+        boardName,
+        layoutId,
+        sizeId,
+        setIds,
+        angle,
+        climbUuid: climb.uuid,
+        climbName: climb.name,
+      })}`;
       await Clipboard.setStringAsync(url);
       track(SHARED_EVENTS.ClimbShared, { method: 'copy_link', climbUuid: climb.uuid, boardName, layoutId });
       showToast(t('mobile.climbActions.linkCopied'), 'info');

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode, type Ref } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 
@@ -11,6 +11,8 @@ import type { Climb } from '@boardsesh/shared-schema';
 const modal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
 const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material', canUpdate: false }));
+const clipboard = vi.hoisted(() => ({ setStringAsync: vi.fn() }));
+const urlBuilder = vi.hoisted(() => ({ buildReadableClimbViewPath: vi.fn(() => '/readable/view/x') }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -46,9 +48,9 @@ vi.mock('../Icon', () => ({
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
-vi.mock('expo-clipboard', () => ({ setStringAsync: vi.fn() }));
+vi.mock('expo-clipboard', () => ({ setStringAsync: clipboard.setStringAsync }));
 vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn() }));
-vi.mock('@boardsesh/play-view', () => ({ buildClimbViewPath: () => '/view/x' }));
+vi.mock('@boardsesh/play-view', () => ({ buildReadableClimbViewPath: urlBuilder.buildReadableClimbViewPath }));
 vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => ctrl.canUpdate }));
 vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
@@ -101,6 +103,8 @@ const baseProps = {
 beforeEach(() => {
   modal.present.mockClear();
   modal.dismiss.mockClear();
+  clipboard.setStringAsync.mockClear();
+  urlBuilder.buildReadableClimbViewPath.mockClear();
   preview.props = null;
   ctrl.variant = 'liquidGlass';
   ctrl.canUpdate = false;
@@ -217,6 +221,27 @@ describe('ClimbActionsSheet present-on-visible (always-mounted toggle)', () => {
     fireEvent.click(screen.getByText('actions.playlist.popover.title'));
 
     expect(onOpenPlaylist).toHaveBeenCalledTimes(1);
+  });
+
+  it('copies a readable climb URL', async () => {
+    const onClose = vi.fn();
+    render(<ClimbActionsSheet visible={true} {...baseProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.copyLink'));
+
+    await waitFor(() => {
+      expect(clipboard.setStringAsync).toHaveBeenCalledWith('https://boardsesh.test/readable/view/x');
+    });
+    expect(urlBuilder.buildReadableClimbViewPath).toHaveBeenCalledWith({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+      angle: 40,
+      climbUuid: 'climb-1',
+      climbName: 'Test Climb',
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('hides the Edit entry row unless onEditEntry is provided', () => {

--- a/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
@@ -42,6 +42,9 @@ const baseArgs = {
   angle: 40,
 };
 
+const expectedReadableShareUrl =
+  'https://www.boardsesh.com/kilter/original/12x14-commerical/screw_bolt/40/view/test-climb-climb-uuid-123';
+
 describe('useShareClimb', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -67,10 +70,8 @@ describe('useShareClimb', () => {
       if (!firstCall) throw new Error('Share.share was not called');
       const payload = firstCall[0];
       if (!('url' in payload)) throw new Error('Expected iOS payload shape { message, url }');
-      expect(payload.url).toMatch(/^https:\/\/www\.boardsesh\.com\//);
-      expect(payload.url).toContain('climb-uuid-123');
-      expect(payload.url).toContain('kilter');
-      expect(payload.url).toContain('40');
+      expect(payload.url).toBe(expectedReadableShareUrl);
+      expect(payload.url).not.toContain('/1/7/1,20/');
       expect(payload.message).toBe('Test Climb');
       expect(payload.message).not.toMatch(/https?:\/\//);
       expect(payload).not.toHaveProperty('title');
@@ -93,9 +94,8 @@ describe('useShareClimb', () => {
       const payload = firstCall[0];
       if (!('message' in payload)) throw new Error('Expected Android payload shape { message }');
       expect(payload.message).toContain('Test Climb');
-      expect(payload.message).toMatch(/https:\/\/www\.boardsesh\.com\//);
-      expect(payload.message).toContain('climb-uuid-123');
-      expect(payload.message).toContain('kilter');
+      expect(payload.message).toContain(expectedReadableShareUrl);
+      expect(payload.message).not.toContain('/1/7/1,20/');
       expect(payload).not.toHaveProperty('url');
     });
   });

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { Platform, Share } from 'react-native';
-import { buildClimbViewPath } from '@boardsesh/play-view';
+import { buildReadableClimbViewPath } from '@boardsesh/play-view';
 import type { Climb } from '@boardsesh/shared-schema';
 import { WEB_BASE_URL } from '../lib/env';
 
@@ -16,7 +16,15 @@ type ShareClimbArgs = {
 export function useShareClimb({ climb, boardName, layoutId, sizeId, setIds, angle }: ShareClimbArgs) {
   return useCallback(async () => {
     if (!climb) return;
-    const url = `${WEB_BASE_URL}${buildClimbViewPath(boardName, layoutId, sizeId, setIds, angle, climb.uuid)}`;
+    const url = `${WEB_BASE_URL}${buildReadableClimbViewPath({
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      angle,
+      climbUuid: climb.uuid,
+      climbName: climb.name,
+    })}`;
     await Share.share(Platform.OS === 'ios' ? { message: climb.name, url } : { message: `${climb.name}\n${url}` });
   }, [climb, boardName, layoutId, sizeId, setIds, angle]);
 }

--- a/packages/shared/play-view/package.json
+++ b/packages/shared/play-view/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@boardsesh/board-config": "*",
     "@boardsesh/board-constants": "*",
     "@boardsesh/queue": "*",
     "@boardsesh/shared-schema": "*"

--- a/packages/shared/play-view/src/__tests__/url-utils.test.ts
+++ b/packages/shared/play-view/src/__tests__/url-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildClimbViewPath } from '../url-utils';
+import { buildClimbViewPath, buildReadableClimbViewPath } from '../url-utils';
 
 describe('buildClimbViewPath', () => {
   it('builds a correct climb view path', () => {
@@ -8,5 +8,64 @@ describe('buildClimbViewPath', () => {
 
   it('handles different board names', () => {
     expect(buildClimbViewPath('tension', 2, 20, '56', 25, 'xyz-789')).toBe('/tension/2/20/56/25/view/xyz-789');
+  });
+});
+
+describe('buildReadableClimbViewPath', () => {
+  it('builds the same readable Kilter Homewall view path as the web app', () => {
+    expect(
+      buildReadableClimbViewPath({
+        boardName: 'kilter',
+        layoutId: 8,
+        sizeId: 25,
+        setIds: '26,27,28,29',
+        angle: 35,
+        climbUuid: '2266B5B86CFF49489381FF21B4B4B60A',
+        climbName: 'Moon Landing',
+      }),
+    ).toBe(
+      '/kilter/homewall/10x12-full-ride/main-kicker_main_aux-kicker_aux/35/view/moon-landing-2266B5B86CFF49489381FF21B4B4B60A',
+    );
+  });
+
+  it('builds a readable path without a climb name', () => {
+    expect(
+      buildReadableClimbViewPath({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 7,
+        setIds: '1,20',
+        angle: 40,
+        climbUuid: 'abc123',
+      }),
+    ).toBe('/kilter/original/12x14-commerical/screw_bolt/40/view/abc123');
+  });
+
+  it('falls back to numeric path with a climb slug when static board data cannot resolve', () => {
+    expect(
+      buildReadableClimbViewPath({
+        boardName: 'kilter',
+        layoutId: 9999,
+        sizeId: 9999,
+        setIds: '9999',
+        angle: 40,
+        climbUuid: 'abc123',
+        climbName: 'Test Climb',
+      }),
+    ).toBe('/kilter/9999/9999/9999/40/view/test-climb-abc123');
+  });
+
+  it('falls back to numeric path when only some requested set ids resolve', () => {
+    expect(
+      buildReadableClimbViewPath({
+        boardName: 'kilter',
+        layoutId: 8,
+        sizeId: 25,
+        setIds: '26,9999',
+        angle: 35,
+        climbUuid: 'abc123',
+        climbName: 'Test Climb',
+      }),
+    ).toBe('/kilter/8/25/26,9999/35/view/test-climb-abc123');
   });
 });

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -8,4 +8,4 @@ export * from './board-utils';
 export * from './swipe-carousel';
 export * from './wall-confirm-bus';
 export * from './wall-confirm-fallback';
-export { buildClimbViewPath } from './url-utils';
+export { buildClimbViewPath, buildReadableClimbViewPath } from './url-utils';

--- a/packages/shared/play-view/src/url-utils.ts
+++ b/packages/shared/play-view/src/url-utils.ts
@@ -1,3 +1,17 @@
+import { getLayout, getProductSize, getSetsForLayoutAndSize } from '@boardsesh/board-constants/product-sizes';
+import { getMoonBoardDetails } from '@boardsesh/board-config';
+import { SUPPORTED_BOARDS, type BoardName } from '@boardsesh/shared-schema';
+
+type BuildReadableClimbViewPathArgs = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  angle: number;
+  climbUuid: string;
+  climbName?: string | null;
+};
+
 export function buildClimbViewPath(
   boardName: string,
   layoutId: number,
@@ -7,4 +21,192 @@ export function buildClimbViewPath(
   climbUuid: string,
 ): string {
   return `/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/view/${climbUuid}`;
+}
+
+const supportedBoardNames = new Set<string>(SUPPORTED_BOARDS);
+const boardNamePrefixRegex = new RegExp(`^(?:${SUPPORTED_BOARDS.join('|')})\\s*(?:board)?\\s*`, 'i');
+
+function toBoardName(boardName: string): BoardName | null {
+  return supportedBoardNames.has(boardName) ? (boardName as BoardName) : null;
+}
+
+function parseSetIds(setIds: string): number[] {
+  return setIds
+    .split(',')
+    .map((setId) => Number(setId.trim()))
+    .filter((setId) => Number.isFinite(setId));
+}
+
+function generateSlugFromText(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function generateDescriptionSlug(description: string): string {
+  return description
+    .toLowerCase()
+    .replace(/led\s*kit/gi, '')
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function generateLayoutSlug(layoutName: string): string {
+  const baseSlug = layoutName
+    .toLowerCase()
+    .trim()
+    .replace(boardNamePrefixRegex, '')
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  if (baseSlug === 'original-layout') {
+    return 'original';
+  }
+
+  if (baseSlug.startsWith('2-')) {
+    return baseSlug.replace('2-', 'two-');
+  }
+
+  return baseSlug;
+}
+
+function generateSizeSlug(sizeName: string, description?: string): string {
+  const sizeMatch = sizeName.match(/(\d+)\s*x\s*(\d+)/i);
+  const baseSlug = sizeMatch ? `${sizeMatch[1]}x${sizeMatch[2]}` : generateSlugFromText(sizeName);
+
+  if (description?.trim()) {
+    const descriptionSlug = generateDescriptionSlug(description);
+    if (descriptionSlug) {
+      return `${baseSlug}-${descriptionSlug}`;
+    }
+  }
+
+  return baseSlug;
+}
+
+function generateSetSlug(setNames: string[]): string {
+  return setNames
+    .map((name) => {
+      const lowercaseName = name.toLowerCase().trim();
+
+      const hasAux = lowercaseName.includes('auxiliary') || lowercaseName.includes('aux');
+      const hasMain = lowercaseName.includes('mainline') || lowercaseName.includes('main');
+      const hasKickerVariant = lowercaseName.includes('kickboard') || lowercaseName.includes('kicker');
+
+      if (hasAux && hasKickerVariant) {
+        return 'aux-kicker';
+      }
+      if (hasMain && hasKickerVariant) {
+        return 'main-kicker';
+      }
+      if (hasAux) {
+        return 'aux';
+      }
+      if (hasMain) {
+        return 'main';
+      }
+
+      let result = lowercaseName.replace(/\s+ons?$/i, '').replace(/\s+/g, '-');
+
+      if (result.startsWith('bolt')) {
+        result = 'bolt';
+      } else if (result.startsWith('screw')) {
+        result = 'screw';
+      }
+
+      return result;
+    })
+    .sort((leftSetSlug, rightSetSlug) => rightSetSlug.localeCompare(leftSetSlug))
+    .join('_');
+}
+
+function buildClimbSegment(climbUuid: string, climbName?: string | null): string {
+  if (climbName?.trim()) {
+    const climbSlug = generateSlugFromText(climbName.trim());
+    if (climbSlug) {
+      return `${climbSlug}-${climbUuid}`;
+    }
+  }
+
+  return climbUuid;
+}
+
+function buildNumericClimbViewPath({
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  angle,
+  climbUuid,
+  climbName,
+}: BuildReadableClimbViewPathArgs): string {
+  return `/${boardName}/${layoutId}/${sizeId}/${setIds}/${angle}/view/${buildClimbSegment(climbUuid, climbName)}`;
+}
+
+function resolveReadableBoardSegments({
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+}: Pick<BuildReadableClimbViewPathArgs, 'boardName' | 'layoutId' | 'sizeId' | 'setIds'>): {
+  boardName: BoardName;
+  layoutSlug: string;
+  sizeSlug: string;
+  setSlug: string;
+} | null {
+  const boardType = toBoardName(boardName);
+  if (!boardType) return null;
+
+  const setIdValues = parseSetIds(setIds);
+  if (setIdValues.length === 0) return null;
+
+  if (boardType === 'moonboard') {
+    try {
+      const moonBoardDetails = getMoonBoardDetails({ layout_id: layoutId, set_ids: setIdValues });
+      if (moonBoardDetails.size_id !== sizeId || moonBoardDetails.set_names.length !== setIdValues.length) return null;
+
+      return {
+        boardName: boardType,
+        layoutSlug: generateLayoutSlug(moonBoardDetails.layout_name),
+        sizeSlug: generateSizeSlug(moonBoardDetails.size_name, moonBoardDetails.size_description),
+        setSlug: generateSetSlug(moonBoardDetails.set_names),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  const layout = getLayout(boardType, layoutId);
+  const size = getProductSize(boardType, sizeId);
+  const availableSets = getSetsForLayoutAndSize(boardType, layoutId, sizeId);
+  const selectedSetNames = availableSets.filter((set) => setIdValues.includes(set.id)).map((set) => set.name);
+
+  if (!layout || !size || selectedSetNames.length !== setIdValues.length) {
+    return null;
+  }
+
+  return {
+    boardName: boardType,
+    layoutSlug: generateLayoutSlug(layout.name),
+    sizeSlug: generateSizeSlug(size.name, size.description),
+    setSlug: generateSetSlug(selectedSetNames),
+  };
+}
+
+export function buildReadableClimbViewPath(args: BuildReadableClimbViewPathArgs): string {
+  const readableSegments = resolveReadableBoardSegments(args);
+  if (!readableSegments) {
+    return buildNumericClimbViewPath(args);
+  }
+
+  return `/${readableSegments.boardName}/${readableSegments.layoutSlug}/${readableSegments.sizeSlug}/${readableSegments.setSlug}/${args.angle}/view/${buildClimbSegment(args.climbUuid, args.climbName)}`;
 }


### PR DESCRIPTION
## Summary
- Add a shared readable climb view URL builder in `@boardsesh/play-view`.
- Update React Native share and copy-link flows to share the same slugged climb URLs the web app uses.
- Cover the reported Kilter Homewall route and fallback behavior with focused tests.

## Root Cause
The React Native app built share URLs with the legacy numeric path helper, so shared links looked like `/kilter/8/25/26,27,28,29/35/view/{uuid}` instead of the readable canonical route that web sharing uses. Some smart-link crawlers inspect the exact shared URL, so mobile needed to emit the final readable route directly.

## Validation
- `vp test run packages/shared/play-view/src/__tests__/url-utils.test.ts packages/mobile/src/hooks/__tests__/use-share-climb.test.ts packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx --reporter=agent`
- `vp run typecheck:play-view`
- `vp run typecheck:mobile`
- `vp check packages/shared/play-view/src/url-utils.ts packages/shared/play-view/src/__tests__/url-utils.test.ts packages/shared/play-view/src/index.ts packages/mobile/src/hooks/use-share-climb.ts packages/mobile/src/hooks/__tests__/use-share-climb.test.ts packages/mobile/src/components/ClimbActionsSheet.tsx packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx packages/shared/play-view/package.json`
- `git diff --check`

Note: full `vp check` is currently blocked by pre-existing formatting issues in unrelated files: `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, two backend files, and several drizzle metadata JSON files.