### PR TITLE
[codex] Disable iOS app on Mac availability

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -389,6 +389,9 @@ export default ({ config }: ConfigContext): ExpoConfig & { newArchEnabled?: bool
       // Register this before @bacons/apple-targets so Expo's mod chain runs it
       // after the widget target has been created, while keeping the provider last.
       './plugins/with-boardsesh-widget-build-settings',
+      // Boardsesh is iPhone-only. Keep App Store Connect from validating the
+      // generated app target as a "Designed for iPhone/iPad" macOS binary.
+      './plugins/with-ios-app-store-build-settings',
       // Adds the BoardseshWidgets Xcode target on every `expo prebuild`. The
       // widget bundle hosts the Live Activity UI (lock screen + Dynamic
       // Island) plus the Next/Previous AppIntents. Target sources live in

--- a/packages/mobile/plugins/with-ios-app-store-build-settings.js
+++ b/packages/mobile/plugins/with-ios-app-store-build-settings.js
@@ -1,0 +1,78 @@
+const { createRunOncePlugin } = require('expo/config-plugins');
+const { withXcodeProjectBeta } = require('@bacons/apple-targets/build/with-bacons-xcode');
+
+const IOS_APPLICATION_PRODUCT_TYPE = 'com.apple.product-type.application';
+const IOS_APP_TARGET_NAME = 'Boardsesh';
+const MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING = 'SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD';
+const MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED = 'NO';
+
+function getProjectTargets(project) {
+  return project?.rootObject?.props?.targets ?? [];
+}
+
+function isNativeTarget(candidateTarget) {
+  return candidateTarget?.isa === 'PBXNativeTarget';
+}
+
+function isIosApplicationTarget(candidateTarget) {
+  return isNativeTarget(candidateTarget) && candidateTarget?.props?.productType === IOS_APPLICATION_PRODUCT_TYPE;
+}
+
+function isBoardseshApplicationTarget(candidateTarget) {
+  return (
+    isIosApplicationTarget(candidateTarget) &&
+    (candidateTarget?.props?.name === IOS_APP_TARGET_NAME ||
+      candidateTarget?.props?.productName === IOS_APP_TARGET_NAME)
+  );
+}
+
+function findIosApplicationTarget(project) {
+  const applicationTargets = getProjectTargets(project).filter(isIosApplicationTarget);
+  const boardseshTarget = applicationTargets.find(isBoardseshApplicationTarget);
+
+  if (boardseshTarget) {
+    return boardseshTarget;
+  }
+
+  if (applicationTargets.length === 1) {
+    return applicationTargets[0];
+  }
+
+  const targetNames = applicationTargets
+    .map((target) => target?.props?.name ?? target?.props?.productName)
+    .filter(Boolean)
+    .join(', ');
+
+  throw new Error(
+    `Could not find the ${IOS_APP_TARGET_NAME} iOS application target in the generated Xcode project.` +
+      (targetNames ? ` Found application targets: ${targetNames}.` : ''),
+  );
+}
+
+function configureIosAppStoreBuildSettings(project) {
+  const iosApplicationTarget = findIosApplicationTarget(project);
+
+  if (typeof iosApplicationTarget.setBuildSetting !== 'function') {
+    throw new Error(`${IOS_APP_TARGET_NAME} target does not support setBuildSetting().`);
+  }
+
+  // Boardsesh is an iPhone app that depends on BLE/background iOS behavior.
+  // Do not let App Store Connect validate it as a macOS destination.
+  iosApplicationTarget.setBuildSetting(
+    MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING,
+    MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED,
+  );
+}
+
+function withIosAppStoreBuildSettings(config) {
+  return withXcodeProjectBeta(config, async (modConfig) => {
+    configureIosAppStoreBuildSettings(modConfig.modResults);
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(withIosAppStoreBuildSettings, 'with-ios-app-store-build-settings', '1.0.0');
+module.exports.configureIosAppStoreBuildSettings = configureIosAppStoreBuildSettings;
+module.exports.IOS_APPLICATION_PRODUCT_TYPE = IOS_APPLICATION_PRODUCT_TYPE;
+module.exports.MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING = MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING;
+module.exports.MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED = MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED;

--- a/packages/mobile/src/lib/__tests__/ios-app-store-build-settings.test.ts
+++ b/packages/mobile/src/lib/__tests__/ios-app-store-build-settings.test.ts
@@ -1,0 +1,99 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type CapturingTarget = {
+  isa: 'PBXNativeTarget';
+  props: {
+    name?: string;
+    productName?: string;
+    productType?: string;
+  };
+  setBuildSetting(settingName: string, settingValue: string): void;
+};
+
+type CapturingProject = {
+  rootObject: {
+    props: {
+      targets: CapturingTarget[];
+    };
+  };
+};
+
+type IosAppStoreBuildSettingsPlugin = {
+  configureIosAppStoreBuildSettings(project: CapturingProject): void;
+  IOS_APPLICATION_PRODUCT_TYPE: string;
+  MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING: string;
+  MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED: string;
+};
+
+const appStoreBuildSettingsPlugin =
+  require('../../../plugins/with-ios-app-store-build-settings.js') as IosAppStoreBuildSettingsPlugin;
+
+function createCapturingTarget(props: CapturingTarget['props']): {
+  capturedBuildSettings: Record<string, string>;
+  target: CapturingTarget;
+} {
+  const capturedBuildSettings: Record<string, string> = {};
+
+  return {
+    capturedBuildSettings,
+    target: {
+      isa: 'PBXNativeTarget',
+      props,
+      setBuildSetting(settingName, settingValue) {
+        capturedBuildSettings[settingName] = settingValue;
+      },
+    },
+  };
+}
+
+describe('iOS App Store prebuild settings', () => {
+  it('opts the Boardsesh app target out of Mac Designed for iPhone/iPad availability', () => {
+    const boardseshTarget = createCapturingTarget({
+      name: 'Boardsesh',
+      productName: 'Boardsesh',
+      productType: appStoreBuildSettingsPlugin.IOS_APPLICATION_PRODUCT_TYPE,
+    });
+    const widgetTarget = createCapturingTarget({
+      name: 'BoardseshWidgets',
+      productName: 'BoardseshWidgets',
+      productType: 'com.apple.product-type.app-extension',
+    });
+
+    appStoreBuildSettingsPlugin.configureIosAppStoreBuildSettings({
+      rootObject: {
+        props: {
+          targets: [boardseshTarget.target, widgetTarget.target],
+        },
+      },
+    });
+
+    expect(
+      boardseshTarget.capturedBuildSettings[appStoreBuildSettingsPlugin.MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING],
+    ).toBe(appStoreBuildSettingsPlugin.MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED);
+    expect(widgetTarget.capturedBuildSettings).toEqual({});
+  });
+
+  it('uses the only iOS application target when Expo generates a variant target name', () => {
+    const devVariantTarget = createCapturingTarget({
+      name: 'Boardsesh Dev',
+      productName: 'Boardsesh Dev',
+      productType: appStoreBuildSettingsPlugin.IOS_APPLICATION_PRODUCT_TYPE,
+    });
+
+    appStoreBuildSettingsPlugin.configureIosAppStoreBuildSettings({
+      rootObject: {
+        props: {
+          targets: [devVariantTarget.target],
+        },
+      },
+    });
+
+    expect(
+      devVariantTarget.capturedBuildSettings[appStoreBuildSettingsPlugin.MAC_DESIGNED_FOR_IPHONE_IPAD_BUILD_SETTING],
+    ).toBe(appStoreBuildSettingsPlugin.MAC_DESIGNED_FOR_IPHONE_IPAD_DISABLED);
+  });
+});


### PR DESCRIPTION
## What changed

- Added an Expo config plugin that sets `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD=NO` on the generated iOS application target.
- Registered the plugin in `packages/mobile/app.config.ts` so EAS/native prebuilds keep the setting.
- Added a focused test that verifies the app target is opted out while extension targets are untouched.

## Why

App Store Connect accepted build 100384 but warned with `ITMS-90863` because the binary was being validated for Apple silicon Mac availability. Boardsesh is an iPhone-only BLE/background-session app, so the next App Store binary should not advertise the “Designed for iPhone/iPad on Mac” destination.

## Validation

- `vp test run --project mobile packages/mobile/src/lib/__tests__/ios-app-store-build-settings.test.ts packages/mobile/src/lib/live-activity/__tests__/widget-build-settings.test.ts`
- `vp run typecheck:mobile`
- `vp run check:mobile-patches`
- `vp check packages/mobile/plugins/with-ios-app-store-build-settings.js packages/mobile/src/lib/__tests__/ios-app-store-build-settings.test.ts packages/mobile/app.config.ts`

Note: full `vp check` still fails on unrelated pre-existing formatting drift in `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, backend tick files, and db drizzle metadata files.