### PR TITLE
feat(mobile): reinstate Preview in the climb reaction menu

### DIFF
--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -6,6 +6,7 @@ import type { ClimbActionId } from '../use-climb-actions';
 
 const ctrl = vi.hoisted(() => ({ canUpdate: false }));
 const openers = vi.hoisted(() => ({
+  openPlayDrawer: vi.fn(),
   openAddToPlaylist: vi.fn(),
   openLogAscent: vi.fn(),
   openAddBetaVideo: vi.fn(),
@@ -23,14 +24,18 @@ vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => ctrl.c
 vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: {} }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({
+    openPlayDrawer: openers.openPlayDrawer,
     openAddToPlaylist: openers.openAddToPlaylist,
     openLogAscent: openers.openLogAscent,
     openAddBetaVideo: openers.openAddBetaVideo,
+    boardConfig: null,
   }),
+  boardConfigsMatch: () => false,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({ addToQueue: openers.addToQueue }),
 }));
+vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: (climb: unknown) => ({ uuid: 'qi', climb }) }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     actionColors: { success: '#0a0', favorite: '#f00', accent: '#00f', neutral: '#fff', pin: '#6D28D9' },
@@ -71,6 +76,7 @@ beforeEach(() => {
 describe('useClimbActions gating', () => {
   it('returns the universal actions for a plain Kilter climb (no edit/beta/openInApp/editEntry)', () => {
     expect(ids({ climb, boardConfig: kilterBoard, isAuthenticated: false })).toEqual([
+      'preview',
       'queue',
       'playlist',
       'favorite',
@@ -141,5 +147,12 @@ describe('useClimbActions colours and dispatch', () => {
     const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
     result.current.find((action) => action.id === 'share')?.run();
     expect(openers.shareClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('preview.run opens the climb view-only in the play drawer', () => {
+    const { result } = renderHook(() => useClimbActions({ climb, boardConfig: kilterBoard, isAuthenticated: false }));
+    result.current.find((action) => action.id === 'preview')?.run();
+    expect(openers.openPlayDrawer).toHaveBeenCalledTimes(1);
+    expect(openers.openPlayDrawer).toHaveBeenCalledWith(climb, expect.objectContaining({ source: 'climb_view' }));
   });
 });

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -3,8 +3,8 @@
 // colour) plus a `run()` that performs the action and then calls `onAfterAction` (the
 // reaction menu passes its animated dismiss).
 //
-// The hook self-sources every opener (queue / playlist / tick / beta video) from
-// `useDrawerHost`, the favourite state + mutation from `useFavoriteStatus` /
+// The hook self-sources every opener (preview / queue / playlist / tick / beta video)
+// from `useDrawerHost`, the favourite state + mutation from `useFavoriteStatus` /
 // `useToggleFavorite`, the native share from `useShareClimb`, and the create-climb
 // routes from the router, so a caller only
 // supplies the climb, its board config, and the two contextual flags (`currentUserId`,
@@ -20,14 +20,16 @@ import type { Climb } from '@boardsesh/shared-schema';
 import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { IconName } from '../icon-map';
-import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
+import { useDrawerHost, boardConfigsMatch, type BoardConfig } from '../../providers/drawer-host-provider';
 import { useQueueActions } from '../../providers/queue-provider';
 import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
+import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import { useTheme } from '../../providers/theme-provider';
 import { useShareClimb } from '../../hooks/use-share-climb';
 import { track } from '../../lib/analytics';
 
 export type ClimbActionId =
+  | 'preview'
   | 'queue'
   | 'playlist'
   | 'favorite'
@@ -85,7 +87,13 @@ export function useClimbActions({
   const { actionColors } = useTheme();
   const { addToQueue } = useQueueActions();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
-  const { openAddToPlaylist, openLogAscent, openAddBetaVideo } = useDrawerHost();
+  const {
+    openPlayDrawer,
+    openAddToPlaylist,
+    openLogAscent,
+    openAddBetaVideo,
+    boardConfig: activeBoardConfig,
+  } = useDrawerHost();
   // Native share sheet — the same action the play drawer uses.
   const shareClimb = useShareClimb({
     climb,
@@ -132,6 +140,25 @@ export function useClimbActions({
     })();
 
     const items: ClimbActionItem[] = [];
+
+    // View-only open: a previewQueueItem (badge + "Set active") rather than committing.
+    // Mirror the board-sheet override rule so a cross-board climb still renders the
+    // switch-board overlay; same-board needs no override.
+    items.push({
+      id: 'preview',
+      title: t('mobile.climbActions.preview'),
+      icon: 'visibility',
+      color: accentColor,
+      run: () => {
+        const override = boardConfigsMatch(boardConfig, activeBoardConfig) ? undefined : boardConfig;
+        openPlayDrawer(climb, {
+          previewQueueItem: climbToQueueItem(climb),
+          boardConfig: override,
+          source: 'climb_view',
+        });
+        after();
+      },
+    });
 
     items.push({
       id: 'queue',
@@ -312,8 +339,10 @@ export function useClimbActions({
     addToQueue,
     toggleFavoriteMutate,
     isFavorited,
+    openPlayDrawer,
     openAddToPlaylist,
     openLogAscent,
     openAddBetaVideo,
+    activeBoardConfig,
   ]);
 }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -71,7 +71,7 @@ export type LogAscentInput = {
   consensusGradeName?: string;
 };
 
-function boardConfigsMatch(left: BoardConfig | null, right: BoardConfig | null): boolean {
+export function boardConfigsMatch(left: BoardConfig | null, right: BoardConfig | null): boolean {
   if (!left || !right) return false;
   return (
     left.boardName === right.boardName &&

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -684,6 +684,7 @@
       "benchmark": "Benchmark"
     },
     "climbActions": {
+      "preview": "Preview",
       "copyLink": "Copy link",
       "linkCopied": "Link copied",
       "tick": "Log a tick",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -684,6 +684,7 @@
       "benchmark": "Benchmark"
     },
     "climbActions": {
+      "preview": "Vista previa",
       "copyLink": "Copiar enlace",
       "linkCopied": "Enlace copiado",
       "tick": "Registrar un envío",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -684,6 +684,7 @@
       "benchmark": "Benchmark"
     },
     "climbActions": {
+      "preview": "Aperçu",
       "copyLink": "Copier le lien",
       "linkCopied": "Lien copié",
       "tick": "Enregistrer une croix",


### PR DESCRIPTION
Follow-up to the climb reaction menu (now on `main`): bring back the **Preview** action that was dropped when the overlay's floated climb was considered "preview enough".

The view-only open is distinct from the visual float — it opens the climb in the play drawer with the **Preview / Set active** banner, so you can see the full board and interact without committing it to the queue.

## Changes
- `useClimbActions`: re-add the `preview` action (first in the list) — `openPlayDrawer` with a `previewQueueItem` + `source: 'climb_view'`, mirroring the board-sheet override rule (a cross-board climb still renders the switch-board overlay).
- Re-export `boardConfigsMatch` from `DrawerHostProvider` (the preview override decision uses it).
- Restore the `mobile.climbActions.preview` i18n key (en/es/fr).
- Unit tests: preview is back in the action order + a dispatch test.

## Validation
`vp run typecheck:mobile` ✅ · `vp run test:mobile` ✅ (2440) · `vp run check:mobile-bundle` ✅ · `vp run check:i18n:orphans` ✅ · pre-commit ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MC2RP9ocFAxt5NcZHnq8CV