### PR TITLE
[codex] Add avatar upload coverage

### DIFF
--- a/packages/backend/src/__tests__/avatar-upload.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import { rm } from 'node:fs/promises';
+import path from 'node:path';
+
+const validateTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../middleware/auth', () => ({
+  validateToken: validateTokenMock,
+}));
+
+const { handleAvatarUpload, getAvatarsDir } = await import('../handlers/avatars');
+const { handleStaticAvatar } = await import('../handlers/static');
+const { parseSizeParam } = await import('../lib/image-resize');
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
+
+async function startAvatarServer(): Promise<{ baseUrl: string; server: Server }> {
+  const server = createServer((req, res) => {
+    void (async () => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+      if (url.pathname === '/api/avatars' && req.method === 'POST') {
+        await handleAvatarUpload(req, res);
+        return;
+      }
+      if (url.pathname.startsWith('/static/avatars/') && req.method === 'GET') {
+        const fileName = url.pathname.slice('/static/avatars/'.length);
+        await handleStaticAvatar(req, res, fileName, parseSizeParam(url.searchParams.get('size')));
+        return;
+      }
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    })().catch((error: unknown) => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }));
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${address.port}`, server };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function removeUploadedAvatar(): Promise<void> {
+  await rm(path.join(getAvatarsDir(), `${USER_ID}.jpg`), { force: true });
+}
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await removeUploadedAvatar();
+});
+
+describe('avatar upload routes', () => {
+  it('returns a versioned static avatar URL and serves it through the static route', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const formData = new FormData();
+      formData.set('userId', USER_ID);
+      formData.set('avatar', new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg');
+
+      const uploadResponse = await fetch(`${baseUrl}/api/avatars`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer avatar-token' },
+        body: formData,
+      });
+
+      expect(uploadResponse.status).toBe(200);
+      const uploadBody = (await uploadResponse.json()) as { success?: boolean; avatarUrl?: string };
+      expect(uploadBody.success).toBe(true);
+      expect(uploadBody.avatarUrl).toMatch(
+        /^\/static\/avatars\/11111111-1111-4111-8111-111111111111\.jpg\?v=[0-9a-f-]{36}$/,
+      );
+
+      const staticResponse = await fetch(`${baseUrl}${uploadBody.avatarUrl}&size=128`);
+
+      expect(staticResponse.status).toBe(200);
+      expect(staticResponse.headers.get('content-type')).toBe('image/jpeg');
+      expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ChangeEvent, createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const routerBackMock = vi.hoisted(() => vi.fn());
+const showToastMock = vi.hoisted(() => vi.fn());
+const mutateAsyncMock = vi.hoisted(() => vi.fn());
+const uploadAvatarMock = vi.hoisted(() => vi.fn());
+const requestMediaLibraryPermissionsMock = vi.hoisted(() => vi.fn());
+const launchImageLibraryMock = vi.hoisted(() => vi.fn());
+const manipulateMock = vi.hoisted(() => vi.fn());
+const resizeMock = vi.hoisted(() => vi.fn());
+const renderAsyncMock = vi.hoisted(() => vi.fn());
+const saveAsyncMock = vi.hoisted(() => vi.fn());
+const releaseMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-scroll-view': true }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ back: routerBackMock }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: requestMediaLibraryPermissionsMock,
+  launchImageLibraryAsync: launchImageLibraryMock,
+}));
+
+vi.mock('expo-image-manipulator', () => ({
+  ImageManipulator: { manipulate: manipulateMock },
+  SaveFormat: { JPEG: 'jpeg' },
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      secondaryLabel: '#666666',
+      tertiaryLabel: '#999999',
+    },
+  }),
+}));
+
+vi.mock('../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+vi.mock('../../lib/graphql/hooks', () => ({
+  useProfile: () => ({
+    data: {
+      id: '11111111-1111-4111-8111-111111111111',
+      email: 'alex@example.com',
+      displayName: null,
+      avatarUrl: null,
+    },
+  }),
+  useUpdateProfile: () => ({ mutateAsync: mutateAsyncMock }),
+}));
+
+vi.mock('../../lib/avatar-upload', () => ({
+  uploadAvatar: uploadAvatarMock,
+}));
+
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: vi.fn(),
+}));
+
+vi.mock('../Avatar', () => ({
+  Avatar: ({ uri }: { uri?: string | null }) =>
+    createElement('div', { 'data-testid': 'avatar', 'data-uri': uri ?? '' }),
+}));
+
+vi.mock('../AuthTextInput', () => ({
+  AuthTextInput: ({
+    label,
+    value,
+    onChangeText,
+    editable = true,
+  }: {
+    label: string;
+    value: string;
+    onChangeText: (text: string) => void;
+    editable?: boolean;
+  }) =>
+    createElement('input', {
+      'aria-label': label,
+      disabled: !editable,
+      onChange: (event: ChangeEvent<HTMLInputElement>) => onChangeText(event.currentTarget.value),
+      value,
+    }),
+}));
+
+vi.mock('../Button', () => ({
+  Button: ({ title, onPress, disabled = false }: { title: string; onPress: () => void; disabled?: boolean }) =>
+    createElement(
+      'button',
+      {
+        disabled,
+        onClick: onPress,
+        type: 'button',
+      },
+      title,
+    ),
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+import { EditProfileScreen } from '../EditProfileScreen';
+
+beforeEach(() => {
+  routerBackMock.mockClear();
+  showToastMock.mockClear();
+  mutateAsyncMock.mockReset();
+  uploadAvatarMock.mockReset();
+  requestMediaLibraryPermissionsMock.mockReset();
+  launchImageLibraryMock.mockReset();
+  manipulateMock.mockReset();
+  resizeMock.mockReset();
+  renderAsyncMock.mockReset();
+  saveAsyncMock.mockReset();
+  releaseMock.mockReset();
+
+  requestMediaLibraryPermissionsMock.mockResolvedValue({ granted: true });
+  launchImageLibraryMock.mockResolvedValue({
+    canceled: false,
+    assets: [{ uri: 'file://picked-avatar.jpg', width: 2400, height: 1600 }],
+  });
+  saveAsyncMock.mockResolvedValue({ uri: 'file://compressed-avatar.jpg' });
+  renderAsyncMock.mockResolvedValue({ saveAsync: saveAsyncMock, release: releaseMock });
+  manipulateMock.mockReturnValue({ resize: resizeMock, renderAsync: renderAsyncMock });
+  uploadAvatarMock.mockResolvedValue(
+    'https://ws.example.com/static/avatars/11111111-1111-4111-8111-111111111111.jpg?v=upload-123',
+  );
+  mutateAsyncMock.mockResolvedValue({
+    id: '11111111-1111-4111-8111-111111111111',
+    email: 'alex@example.com',
+    displayName: null,
+    avatarUrl: 'https://ws.example.com/static/avatars/11111111-1111-4111-8111-111111111111.jpg?v=upload-123',
+  });
+});
+
+describe('EditProfileScreen', () => {
+  it('uploads the picked avatar and saves the exact returned versioned URL', async () => {
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://compressed-avatar.jpg');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        { uri: 'file://compressed-avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      avatarUrl: 'https://ws.example.com/static/avatars/11111111-1111-4111-8111-111111111111.jpg?v=upload-123',
+    });
+    expect(routerBackMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Adds follow-up coverage for the avatar upload caching fix from the merged PR:

- backend HTTP route coverage for `POST /api/avatars` returning a versioned `/static/avatars/... ?v=...` URL
- backend static route coverage proving the returned avatar URL can be fetched through `/static/avatars/...&size=128`
- mobile edit-profile flow coverage proving a picked avatar is compressed, uploaded, and the exact returned versioned URL is sent to `useUpdateProfile`

## Why

The previous implementation fixed the stale avatar behavior by versioning uploaded avatar URLs and updating mobile profile caches. Reviewers found no functional blockers, but asked for endpoint/flow tests that exercise the behavior at the boundaries where regressions would show up.

## Validation

Passed:

- `vp test run --project backend packages/backend/src/__tests__/avatar-upload.test.ts`
- `vp test run --project mobile packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx`
- `vp run typecheck:backend`
- `vp run typecheck:board-config`
- `git diff --cached --check`

Known unrelated failures on current main:

- `vp check` still reports formatting issues in 9 existing files: `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, `packages/backend/src/__tests__/resolve-beta-link-tick-context.test.ts`, `packages/backend/src/graphql/resolvers/ticks/mutations.ts`, and `packages/db/drizzle/meta/0129_snapshot.json` through `_journal.json`. The new files are clean after `vp fmt`.
- `vp run typecheck:mobile` fails before this change on `packages/shared/play-view/src/url-utils.ts:2` because TypeScript cannot resolve `@boardsesh/board-config`. `vp run typecheck:board-config` itself passes.