### PR TITLE
fix(mobile): centre the checkmark glyph on its ink, not its box

### DIFF
--- a/packages/mobile/src/components/Icon.tsx
+++ b/packages/mobile/src/components/Icon.tsx
@@ -1,7 +1,7 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { SymbolView } from 'expo-symbols';
 import { Platform } from 'react-native';
-import { iconMap, type IconName } from './icon-map';
+import { iconMap, type IconMapping, type IconName } from './icon-map';
 
 type IconProps = {
   name: IconName;
@@ -13,10 +13,18 @@ type IconProps = {
 // Both glyph names live in icon-map.ts keyed by the same semantic IconName, so call
 // sites stay platform-agnostic.
 export function Icon({ name, size = 24, color }: IconProps) {
-  const mapping = iconMap[name];
+  const mapping: IconMapping = iconMap[name];
 
   if (Platform.OS === 'ios') {
-    return <SymbolView name={mapping.ios} size={size} tintColor={color} />;
+    // Some SF Symbols centre their bounding box, not their ink; icon-map records
+    // the per-glyph correction so every call site gets the same nudge. The
+    // transform is visual only, so the symbol still occupies `size` in layout.
+    const { iosOpticalCenterRatio } = mapping;
+    const opticalCenter = iosOpticalCenterRatio
+      ? { transform: [{ translateY: size * iosOpticalCenterRatio }] }
+      : undefined;
+
+    return <SymbolView name={mapping.ios} size={size} tintColor={color} style={opticalCenter} />;
   }
 
   return (

--- a/packages/mobile/src/components/__tests__/Icon.test.tsx
+++ b/packages/mobile/src/components/__tests__/Icon.test.tsx
@@ -34,8 +34,23 @@ vi.mock('expo-symbols', () => ({
 }));
 
 vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
-  default: ({ name, color }: { name: string; color?: string }) =>
-    createElement('div', { 'data-testid': 'mci', 'data-name': name, 'data-color': color }),
+  default: ({
+    name,
+    color,
+    style,
+  }: {
+    name: string;
+    color?: string;
+    // Surfaced so the "Android is never shifted" assertion is a real check: if
+    // the optical correction ever escaped the iOS branch, it would land here.
+    style?: { transform?: { translateY: number }[] };
+  }) =>
+    createElement('div', {
+      'data-testid': 'mci',
+      'data-name': name,
+      'data-color': color,
+      'data-translate-y': style?.transform?.[0]?.translateY,
+    }),
 }));
 
 import { Icon } from '../Icon';
@@ -65,23 +80,15 @@ describe('Icon platform rendering', () => {
     expect(mci?.getAttribute('data-color')).toBe('#00FF00');
   });
 
-  it('shifts an ink-off-centre SF Symbol down by its recorded fraction of the point size', () => {
+  // 18 and 26 are the smallest and largest sizes `check.small` is rendered at
+  // (YouFilterSheet / RadioGroup at the low end, LogAscentToolbarButton at the
+  // high end), so both ends of the range that has to stay centred are covered.
+  it.each([18, 26])('shifts an ink-off-centre SF Symbol down by its recorded fraction of %ipt', (size) => {
     const ratio = iconMap['check.small'].iosOpticalCenterRatio;
     expect(ratio).toBeGreaterThan(0);
 
-    const { queryByTestId } = render(<Icon name="check.small" size={26} />);
-    expect(queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(26 * ratio));
-  });
-
-  it('scales the shift with the icon size so every call site lands the same', () => {
-    const ratio = iconMap['check.small'].iosOpticalCenterRatio;
-
-    const small = render(<Icon name="check.small" size={18} />);
-    expect(small.queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(18 * ratio));
-    small.unmount();
-
-    const large = render(<Icon name="check.small" size={26} />);
-    expect(large.queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(26 * ratio));
+    const { queryByTestId } = render(<Icon name="check.small" size={size} />);
+    expect(queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(size * ratio));
   });
 
   it('leaves glyphs without a recorded correction untransformed', () => {

--- a/packages/mobile/src/components/__tests__/Icon.test.tsx
+++ b/packages/mobile/src/components/__tests__/Icon.test.tsx
@@ -92,14 +92,21 @@ describe('Icon platform rendering', () => {
   });
 
   it('leaves glyphs without a recorded correction untransformed', () => {
-    const { queryByTestId } = render(<Icon name="skip.next" size={26} />);
-    expect(queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBeNull();
+    const plain = render(<Icon name="skip.next" size={26} />);
+    expect(plain.queryByTestId('symbol-view')?.hasAttribute('data-translate-y')).toBe(false);
+    plain.unmount();
+
+    // Same renderer, same size, a glyph that does carry a correction — so the
+    // assertion above fails if the transform stopped being applied at all,
+    // rather than passing because nothing ever sets the attribute.
+    const corrected = render(<Icon name="check.small" size={26} />);
+    expect(corrected.queryByTestId('symbol-view')?.hasAttribute('data-translate-y')).toBe(true);
   });
 
   it('never shifts the Android glyph, which is already ink-centred', () => {
     ctrl.os = 'android';
     const { queryByTestId } = render(<Icon name="check.small" size={26} />);
-    expect(queryByTestId('mci')?.getAttribute('data-translate-y')).toBeNull();
+    expect(queryByTestId('mci')?.hasAttribute('data-translate-y')).toBe(false);
     expect(queryByTestId('symbol-view')).toBeNull();
   });
 

--- a/packages/mobile/src/components/__tests__/Icon.test.tsx
+++ b/packages/mobile/src/components/__tests__/Icon.test.tsx
@@ -16,8 +16,21 @@ vi.mock('react-native', () => ({
 
 // Stand-ins that surface the glyph name + colour so we can assert which renderer ran.
 vi.mock('expo-symbols', () => ({
-  SymbolView: ({ name, tintColor }: { name: string; tintColor?: string }) =>
-    createElement('div', { 'data-testid': 'symbol-view', 'data-name': name, 'data-tint': tintColor }),
+  SymbolView: ({
+    name,
+    tintColor,
+    style,
+  }: {
+    name: string;
+    tintColor?: string;
+    style?: { transform?: { translateY: number }[] };
+  }) =>
+    createElement('div', {
+      'data-testid': 'symbol-view',
+      'data-name': name,
+      'data-tint': tintColor,
+      'data-translate-y': style?.transform?.[0]?.translateY,
+    }),
 }));
 
 vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
@@ -50,6 +63,37 @@ describe('Icon platform rendering', () => {
     expect(queryByTestId('symbol-view')).toBeNull();
     expect(mci?.getAttribute('data-name')).toBe(iconMap['skip.next'].android);
     expect(mci?.getAttribute('data-color')).toBe('#00FF00');
+  });
+
+  it('shifts an ink-off-centre SF Symbol down by its recorded fraction of the point size', () => {
+    const ratio = iconMap['check.small'].iosOpticalCenterRatio;
+    expect(ratio).toBeGreaterThan(0);
+
+    const { queryByTestId } = render(<Icon name="check.small" size={26} />);
+    expect(queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(26 * ratio));
+  });
+
+  it('scales the shift with the icon size so every call site lands the same', () => {
+    const ratio = iconMap['check.small'].iosOpticalCenterRatio;
+
+    const small = render(<Icon name="check.small" size={18} />);
+    expect(small.queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(18 * ratio));
+    small.unmount();
+
+    const large = render(<Icon name="check.small" size={26} />);
+    expect(large.queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBe(String(26 * ratio));
+  });
+
+  it('leaves glyphs without a recorded correction untransformed', () => {
+    const { queryByTestId } = render(<Icon name="skip.next" size={26} />);
+    expect(queryByTestId('symbol-view')?.getAttribute('data-translate-y')).toBeNull();
+  });
+
+  it('never shifts the Android glyph, which is already ink-centred', () => {
+    ctrl.os = 'android';
+    const { queryByTestId } = render(<Icon name="check.small" size={26} />);
+    expect(queryByTestId('mci')?.getAttribute('data-translate-y')).toBeNull();
+    expect(queryByTestId('symbol-view')).toBeNull();
   });
 
   it('maps every transport glyph to its platform-specific name', () => {

--- a/packages/mobile/src/components/__tests__/icon-map.test.ts
+++ b/packages/mobile/src/components/__tests__/icon-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { iconMap, type IconName } from '../icon-map';
+import { iconMap, type IconMapping, type IconName } from '../icon-map';
 
 describe('iconMap', () => {
   it('every entry has both ios and android string values', () => {
@@ -8,6 +8,16 @@ describe('iconMap', () => {
       expect(mapping.ios.length).toBeGreaterThan(0);
       expect(typeof mapping.android).toBe('string');
       expect(mapping.android.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps every optical-centre correction a small downward fraction', () => {
+    for (const mapping of Object.values<IconMapping>(iconMap)) {
+      if (mapping.iosOpticalCenterRatio === undefined) continue;
+      // A nudge, not a relayout: anything beyond a fifth of the point size means
+      // the glyph is wrong for the slot, not merely off-centre.
+      expect(mapping.iosOpticalCenterRatio).toBeGreaterThan(0);
+      expect(mapping.iosOpticalCenterRatio).toBeLessThanOrEqual(0.2);
     }
   });
 

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -16,6 +16,12 @@ export type IconMapping = {
    * drifts the moment another screen renders the same symbol.
    *
    * iOS-only: the MaterialCommunityIcons glyphs are already ink-centred.
+   *
+   * Expected to be a small positive fraction — `icon-map.test.ts` holds it to
+   * `(0, 0.2]`, since anything larger means the glyph is wrong for the slot
+   * rather than merely off-centre. Omitting the field and setting it to `0` both
+   * mean "this glyph needs no correction"; `Icon` applies no transform for
+   * either, so the default costs nothing.
    */
   iosOpticalCenterRatio?: number;
 };

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -1,10 +1,23 @@
 import type { SymbolViewProps } from 'expo-symbols';
 
-type IconMapping = {
+export type IconMapping = {
   // SFSymbol union (from sf-symbols-typescript via expo-symbols) — every name is
   // validated at compile time, so a typo fails `vp run typecheck:mobile`.
   ios: SymbolViewProps['name'];
   android: string;
+  /**
+   * Downward nudge applied to the SF Symbol, as a fraction of its point size, so
+   * the glyph's *ink* lands on the centre line rather than its bounding box.
+   *
+   * A handful of SF Symbols reserve vertical space they never draw into, so
+   * `.scaleAspectFit` centres a box whose ink sits high. Every consumer of such
+   * a glyph is off by the same proportion, which is why the correction lives
+   * here with the glyph instead of at one call site — a per-call-site nudge
+   * drifts the moment another screen renders the same symbol.
+   *
+   * iOS-only: the MaterialCommunityIcons glyphs are already ink-centred.
+   */
+  iosOpticalCenterRatio?: number;
 };
 
 export const iconMap = {
@@ -61,7 +74,9 @@ export const iconMap = {
   'pin.fill': { ios: 'pin.fill', android: 'pin' },
   transfer: { ios: 'arrow.left.arrow.right', android: 'swap-horizontal' },
   tag: { ios: 'tag', android: 'tag-outline' },
-  'check.small': { ios: 'checkmark', android: 'check' },
+  // `checkmark` draws entirely above the baseline but reserves descender space
+  // below it, so the box centres ~9% of its point size higher than the ink does.
+  'check.small': { ios: 'checkmark', android: 'check', iosOpticalCenterRatio: 0.09 },
   flash: { ios: 'bolt.fill', android: 'flash' },
   // What's New / changelog. Mirrors the More tab's native changelog glyph
   // (sparkles on iOS) so the same feature reads consistently across surfaces.


### PR DESCRIPTION
## Summary

The `checkmark` SF Symbol draws entirely above the baseline but still reserves descender space below it. `.scaleAspectFit` centres that bounding box, so the ink lands about 9% of the point size high — most visible on the iOS 26 bottom accessory, where the log-ascent tick floats above the `V11` it sits next to.

`icon-map` owns the glyph (`check.small` → `checkmark`), so the correction goes there: a per-glyph `iosOpticalCenterRatio` that `Icon` turns into a `translateY` on the SF Symbol. The transform is visual only — the symbol still occupies `size` in layout — and it's iOS-only, since the MaterialCommunityIcons glyph is already ink-centred.

Putting it in `icon-map` rather than at the call site is the point. Seventeen render sites across fifteen files draw `check.small` (playlist done buttons, filter-sheet selections, settings rows, the Strava/Health share buttons, the session feed, the bottom-accessory tick). They are all off by the same proportion, because it's a property of the glyph and not of any one screen. A nudge applied in `LogAscentToolbarButton` fixes one of them and silently drifts from the other sixteen the next time someone touches it.

### Scope change

This PR opened in June as a two-part layout fix. Main has since solved the second part — and solved it better:

- `NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH` went 344 → **420** in 87f303c55, deliberately kept as a bound on very wide displays. This PR deleted it.
- `ACCESSORY_TRAILING_INSET` went `spacing[3]` → **`spacing[8]`** (12 → 32) in 3181b92c1, whose commit message names this exact symptom. This PR set it to `spacing[4]` (16).

Rebased on `main` with all four conflicts resolved to main verbatim, and the `QueueBottomAccessory` width change reverted. What's left is the glyph fix and its tests.

## Release Notes

- The tick next to the grade on the now-playing bar sits level with the text instead of floating above it. Same for the checkmarks in playlists, filters, and settings.

## Test plan

- `vp run typecheck:mobile` ✅
- `vp test run --project mobile` ✅ (4508 passed, 544 files)
- `vp check` ✅ (0 errors)
- `vp run check:mobile-bundle` ✅

New coverage in `Icon.test.tsx` asserts the shift is applied on iOS, scales with `size`, is absent for glyphs with no recorded ratio, and never reaches the Android renderer. `icon-map.test.ts` bounds any future ratio to a nudge. Mutation-checked: dropping `style={opticalCenter}` from `Icon` fails two of the new tests, so they are not tautologies.

### Outstanding gate: visual confirmation on device

**Not verified.** The screenshot tooling is macOS-only and this was done on Linux, so it skipped — I have not seen this render.

The before/after captures in the comments above are from June and no longer stand as evidence for this diff: they predate the platter widening to 420 and the trailing inset going to `spacing[8]`, so the layout the `0.09` was eyeballed against has changed. The ratio itself carries over from that single capture (iPhone 16 Pro Max, `iconSize` 24) and has never been checked at another size.

Cheapest way to close this: it's on the OTA channel **`pr-3038`**, so anyone with a TestFlight build can load it from What's New → Try a preview and look at the now-playing bar. No macOS build needed. Otherwise, dispatch **Mobile Screenshots (Native)** on this branch.

Either way, three things to check:

1. The bottom accessory — the tick's ink lines up with `V11` / the climb name. Retune `iosOpticalCenterRatio` if it over- or undershoots.
2. The Material docked capsule (`--variant material`) — renders the same tick, and no run has ever covered it.
3. A smaller call site (18pt, e.g. a playlist filter row) — the ratio assumes the offset is linear in point size, which one 24pt capture can't establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
