### PR TITLE
fix(mobile): resolve named-board (/b/{slug}) sessions when joining

### DIFF
--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -3,7 +3,7 @@ import { Alert, StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { parseBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
+import { parseBoardPath, parseNamedBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../src/lib/analytics';
 import { Text } from '../../src/components/Text';
@@ -16,7 +16,13 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useQueueSessionId, useQueueActions } from '../../src/providers/queue-provider';
 import { useToast } from '../../src/providers/toast-provider';
-import { useSessionPreview, useMyBoards, useCreateBoard } from '../../src/lib/graphql/hooks';
+import {
+  useSessionPreview,
+  useMyBoards,
+  useCreateBoard,
+  useBoardBySlug,
+  fetchBoardBySlug,
+} from '../../src/lib/graphql/hooks';
 import { resolveBoardForSession } from '../../src/lib/board-path-to-user-board';
 import { spacing, borderRadius } from '../../src/theme/tokens';
 
@@ -52,6 +58,21 @@ export default function JoinSessionScreen() {
     [session, t],
   );
 
+  // Named-board sessions (`/b/{slug}`) carry no parseable config in the path, so
+  // resolve the slug to a real board for the confirmation-card label.
+  const namedBoard = useMemo(() => (session ? parseNamedBoardPath(session.boardPath) : null), [session]);
+  const slugBoard = useBoardBySlug(namedBoard?.slug ?? null, {
+    enabled: isAuthenticated && namedBoard != null,
+  });
+  const boardLabel = useMemo(() => {
+    if (namedBoard && slugBoard.data) {
+      const name = formatBoardDisplayName(slugBoard.data.boardType);
+      const angle = namedBoard.angle ?? slugBoard.data.angle;
+      return `${name} · ${angle}°`;
+    }
+    return session ? boardLabelFromPath(session.boardPath) : '';
+  }, [namedBoard, slugBoard.data, session]);
+
   const performJoin = useCallback(async () => {
     if (!session) return;
     setIsJoining(true);
@@ -69,20 +90,21 @@ export default function JoinSessionScreen() {
       const userBoard = await resolveBoardForSession(session.boardPath, {
         ownedBoards,
         createBoard: (input) => createBoard.mutateAsync(input),
+        fetchBoardBySlug,
       });
       await joinSession(session.id, { boardPath: session.boardPath, userBoard });
       // Web fires `Session Joined` on a genuine new-session entry (board-session-
       // bridge). The mobile equivalent is a successful deep-link join — the
       // queue provider only emits Session Started/Ended, never Joined. Mirror
-      // web's props (session_id, board_name, layout_id), derived from the path.
+      // web's props (session_id, board_name, layout_id). Derive from the resolved
+      // board so the event still fires for named-board (`/b/{slug}`) sessions,
+      // whose path can't be parsed.
       const parsedBoard = parseBoardPath(session.boardPath);
-      if (parsedBoard) {
-        track(SHARED_EVENTS.SessionJoined, {
-          session_id: session.id,
-          board_name: parsedBoard.boardName,
-          layout_id: parsedBoard.layoutId,
-        });
-      }
+      track(SHARED_EVENTS.SessionJoined, {
+        session_id: session.id,
+        board_name: parsedBoard?.boardName ?? userBoard.boardType,
+        layout_id: parsedBoard?.layoutId ?? userBoard.layoutId,
+      });
       // Land on the Record tab so the user drops straight into the joined session.
       router.replace('/(tabs)/record');
     } catch (error) {
@@ -207,7 +229,7 @@ export default function JoinSessionScreen() {
           {t('mobileJoin.confirmTitle', { host: hostName })}
         </Text>
         <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.boardLabel}>
-          {t('mobileJoin.boardLabel', { board: boardLabelFromPath(session.boardPath), count: session.users.length })}
+          {t('mobileJoin.boardLabel', { board: boardLabel, count: session.users.length })}
         </Text>
 
         <View style={styles.avatarRow}>

--- a/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
+++ b/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
@@ -20,11 +20,23 @@ const preview = vi.hoisted(() => ({
     boardPath: '/kilter/1/10/1,2/40',
     endedAt: null as string | null,
     users: [{ id: 'u1', username: 'host', avatarUrl: null, isLeader: true }],
-  } as unknown,
+  } as { id: string; boardPath: string; endedAt: string | null; users: unknown[] },
   isLoading: false,
   isError: false,
   refetch: vi.fn(),
 }));
+
+// Reconfigurable board-config + resolver mocks so each test can drive a tuple or
+// named-board (`/b/{slug}`) path.
+const boardConfig = vi.hoisted(() => ({
+  parseBoardPath: vi.fn((_path: string) => ({ boardName: 'kilter', layoutId: 1, angle: 40 }) as unknown),
+  parseNamedBoardPath: vi.fn((_path: string) => null as unknown),
+  formatBoardDisplayName: vi.fn(() => 'Kilter'),
+}));
+const boardResolver = vi.hoisted(() => ({
+  resolveBoardForSession: vi.fn(async () => ({ uuid: 'board-1', boardType: 'kilter', layoutId: 1 }) as unknown),
+}));
+const slugBoardQuery = vi.hoisted(() => ({ data: null as unknown }));
 
 // Capture the confirmation card's Join button so the test can press it.
 const buttons = vi.hoisted(() => ({ joinPress: null as (() => void) | null }));
@@ -45,8 +57,9 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0 }) }));
 
 vi.mock('@boardsesh/board-config', () => ({
-  parseBoardPath: () => ({ boardName: 'kilter', layoutId: 1, angle: 40 }),
-  formatBoardDisplayName: () => 'Kilter',
+  parseBoardPath: boardConfig.parseBoardPath,
+  parseNamedBoardPath: boardConfig.parseNamedBoardPath,
+  formatBoardDisplayName: boardConfig.formatBoardDisplayName,
 }));
 
 // The first Button rendered in the confirmation card is the Join action.
@@ -81,9 +94,11 @@ vi.mock('../../../src/lib/graphql/hooks', () => ({
   useSessionPreview: () => preview,
   useMyBoards: () => ({ data: { boards: [] }, refetch: vi.fn(async () => ({ data: { boards: [] } })) }),
   useCreateBoard: () => ({ mutateAsync: vi.fn(async () => ({})) }),
+  useBoardBySlug: () => slugBoardQuery,
+  fetchBoardBySlug: vi.fn(async () => null),
 }));
 vi.mock('../../../src/lib/board-path-to-user-board', () => ({
-  resolveBoardForSession: vi.fn(async () => ({ uuid: 'board-1' })),
+  resolveBoardForSession: boardResolver.resolveBoardForSession,
 }));
 vi.mock('../../../src/theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
 
@@ -93,7 +108,13 @@ beforeEach(() => {
   analytics.track.mockClear();
   queue.sessionId = null;
   queue.joinSession.mockClear();
+  router.replace.mockClear();
   buttons.joinPress = null;
+  preview.data.boardPath = '/kilter/1/10/1,2/40';
+  boardConfig.parseBoardPath.mockReturnValue({ boardName: 'kilter', layoutId: 1, angle: 40 });
+  boardConfig.parseNamedBoardPath.mockReturnValue(null);
+  boardResolver.resolveBoardForSession.mockResolvedValue({ uuid: 'board-1', boardType: 'kilter', layoutId: 1 });
+  slugBoardQuery.data = null;
 });
 
 describe('JoinSessionScreen analytics', () => {
@@ -113,6 +134,33 @@ describe('JoinSessionScreen analytics', () => {
         session_id: 'session-42',
         board_name: 'kilter',
         layout_id: 1,
+      }),
+    );
+
+    expect(queue.joinSession).toHaveBeenCalledTimes(1);
+    expect(router.replace).toHaveBeenCalledWith('/(tabs)/record');
+  });
+
+  it('fires "Session Joined" for a named-board (/b/{slug}) session, derived from the resolved board', async () => {
+    // The path can't be tuple-parsed; the resolved board supplies the props.
+    preview.data.boardPath = '/b/my-gym-moonboard/40/list';
+    boardConfig.parseBoardPath.mockReturnValue(null);
+    boardConfig.parseNamedBoardPath.mockReturnValue({ slug: 'my-gym-moonboard', angle: 40 });
+    slugBoardQuery.data = { boardType: 'moonboard', layoutId: 3, angle: 40 };
+    boardResolver.resolveBoardForSession.mockResolvedValue({ uuid: 'named-1', boardType: 'moonboard', layoutId: 3 });
+
+    render(createElement(JoinSessionScreen));
+    expect(buttons.joinPress).not.toBeNull();
+
+    await act(async () => {
+      buttons.joinPress?.();
+    });
+
+    await waitFor(() =>
+      expect(analytics.track).toHaveBeenCalledWith('Session Joined', {
+        session_id: 'session-42',
+        board_name: 'moonboard',
+        layout_id: 3,
       }),
     );
 

--- a/packages/mobile/src/lib/__tests__/board-path-to-user-board.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-path-to-user-board.test.ts
@@ -108,6 +108,7 @@ describe('resolveBoardForSession', () => {
     const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
       ownedBoards: [owned],
       createBoard,
+      fetchBoardBySlug: vi.fn(),
     });
     expect(result).toMatchObject({ uuid: 'board-uuid', angle: 30 });
     expect(createBoard).not.toHaveBeenCalled();
@@ -119,6 +120,7 @@ describe('resolveBoardForSession', () => {
     const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
       ownedBoards: [],
       createBoard,
+      fetchBoardBySlug: vi.fn(),
     });
     expect(createBoard).toHaveBeenCalledWith({
       boardType: 'kilter',
@@ -133,8 +135,48 @@ describe('resolveBoardForSession', () => {
   });
 
   it('throws on an unparseable board path', async () => {
-    await expect(resolveBoardForSession('garbage', { ownedBoards: [], createBoard: vi.fn() })).rejects.toThrow(
-      /Cannot resolve a board/,
-    );
+    await expect(
+      resolveBoardForSession('garbage', { ownedBoards: [], createBoard: vi.fn(), fetchBoardBySlug: vi.fn() }),
+    ).rejects.toThrow(/Cannot resolve a board/);
+  });
+
+  describe('named-board (/b/{slug}) paths', () => {
+    it('resolves a named board via fetchBoardBySlug, applying the path angle', async () => {
+      const namedBoard = makeBoard({ uuid: 'named-uuid', boardType: 'moonboard', slug: 'my-gym-moonboard', angle: 25 });
+      const fetchBoardBySlug = vi.fn().mockResolvedValue(namedBoard);
+      const createBoard = vi.fn();
+      const result = await resolveBoardForSession('/b/my-gym-moonboard/40/list', {
+        ownedBoards: [],
+        createBoard,
+        fetchBoardBySlug,
+      });
+      expect(fetchBoardBySlug).toHaveBeenCalledWith('my-gym-moonboard');
+      expect(result).toMatchObject({ uuid: 'named-uuid', angle: 40 });
+      // The shared entity is used directly — never minted as a personal copy.
+      expect(createBoard).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the board entity's stored angle for a bare /b/{slug}", async () => {
+      const namedBoard = makeBoard({ uuid: 'named-uuid', slug: 'my-gym-moonboard', angle: 25 });
+      const fetchBoardBySlug = vi.fn().mockResolvedValue(namedBoard);
+      const result = await resolveBoardForSession('/b/my-gym-moonboard', {
+        ownedBoards: [],
+        createBoard: vi.fn(),
+        fetchBoardBySlug,
+      });
+      expect(result).toBe(namedBoard);
+      expect(result.angle).toBe(25);
+    });
+
+    it('throws when the slug no longer resolves to a board', async () => {
+      const fetchBoardBySlug = vi.fn().mockResolvedValue(null);
+      await expect(
+        resolveBoardForSession('/b/deleted-board/40', {
+          ownedBoards: [],
+          createBoard: vi.fn(),
+          fetchBoardBySlug,
+        }),
+      ).rejects.toThrow(/Cannot resolve a board/);
+    });
   });
 });

--- a/packages/mobile/src/lib/board-path-to-user-board.ts
+++ b/packages/mobile/src/lib/board-path-to-user-board.ts
@@ -13,7 +13,7 @@
 // wires the real `useMyBoards` data + `useCreateBoard` mutation into `deps`.
 
 import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
-import { parseBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
+import { parseBoardPath, parseNamedBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
 import { findOwnedBoardForConfig } from '../components/board-discovery/board-items';
 
 /** A board config parsed out of a session boardPath, with a concrete angle. */
@@ -31,6 +31,10 @@ export type ResolveBoardDeps = {
   ownedBoards: UserBoard[];
   /** Persists a new board server-side and returns the full UserBoard. */
   createBoard: (input: CreateBoardInput) => Promise<UserBoard>;
+  /** Resolve a named board (`/b/{slug}`) to its full entity, or null when the
+   *  slug no longer resolves. Backs the named-board branch of
+   *  {@link resolveBoardForSession} (the `fetchBoardBySlug` GraphQL lookup). */
+  fetchBoardBySlug: (slug: string) => Promise<UserBoard | null>;
 };
 
 /**
@@ -85,11 +89,28 @@ export function buildCreateBoardInput(config: ResolvedBoardConfig): CreateBoardI
 
 /**
  * Resolve a session `boardPath` into a full `UserBoard`:
- * 1. Parse the path → config (throws on an unparseable / angle-less path).
- * 2. Reuse a matching owned board (angle overridden from the path), or
- * 3. Create a new board via `deps.createBoard`.
+ * - Named-board shape (`/b/{slug}` — how named gym boards, incl. MoonBoard, are
+ *   referenced): look the slug up via `deps.fetchBoardBySlug` and use that shared
+ *   board entity directly, applying the path's angle (or the entity's own angle
+ *   when the path carries none). We intentionally skip the owned-reuse/create
+ *   path here — a named gym board is the shared board you're climbing on, not a
+ *   personal copy to mint.
+ * - Tuple shape (`{board}/{layout}/{size}/{sets}/{angle}`):
+ *   1. Parse the path → config (throws on an unparseable / angle-less path).
+ *   2. Reuse a matching owned board (angle overridden from the path), or
+ *   3. Create a new board via `deps.createBoard`.
  */
 export async function resolveBoardForSession(boardPath: string, deps: ResolveBoardDeps): Promise<UserBoard> {
+  const named = parseNamedBoardPath(boardPath);
+  if (named) {
+    const board = await deps.fetchBoardBySlug(named.slug);
+    if (!board) {
+      throw new Error(`Cannot resolve a board from session boardPath: ${boardPath}`);
+    }
+    const angle = named.angle ?? board.angle;
+    return board.angle === angle ? board : { ...board, angle };
+  }
+
   const config = parseBoardConfigFromPath(boardPath);
   if (!config) {
     throw new Error(`Cannot resolve a board from session boardPath: ${boardPath}`);

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -40,9 +40,11 @@ import {
   UPDATE_BOARD,
   DELETE_BOARD,
   UNFOLLOW_BOARD,
+  GET_BOARD_BY_SLUG,
   type UpdateBoardMutationResponse,
   type DeleteBoardMutationResponse,
   type UnfollowBoardMutationResponse,
+  type GetBoardBySlugQueryResponse,
 } from '@boardsesh/graphql/operations/boards';
 import { getHttpClient } from '../client';
 import {
@@ -152,6 +154,28 @@ export function useBoard(boardUuid: string | null) {
     queryFn: () => getHttpClient().request<GetBoardQueryResponse>(GET_BOARD, { boardUuid }),
     select: (data) => data.board,
     enabled: !!boardUuid,
+  });
+}
+
+/**
+ * Resolve a named board by its URL slug (the `/b/{slug}` board-entity routes).
+ * Returns the full shared board entity including its stored angle — used to turn
+ * a session whose `boardPath` is a named-board shape into a usable board. The
+ * non-hook {@link fetchBoardBySlug} backs the same lookup at join time, where a
+ * hook can't run.
+ */
+export function fetchBoardBySlug(slug: string): Promise<UserBoard | null> {
+  return getHttpClient()
+    .request<GetBoardBySlugQueryResponse>(GET_BOARD_BY_SLUG, { slug })
+    .then((data) => data.boardBySlug);
+}
+
+export function useBoardBySlug(slug: string | null, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ['boardBySlug', slug],
+    queryFn: () => getHttpClient().request<GetBoardBySlugQueryResponse>(GET_BOARD_BY_SLUG, { slug }),
+    select: (data) => data.boardBySlug,
+    enabled: (options?.enabled ?? true) && !!slug,
   });
 }
 

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -37,7 +37,7 @@ import {
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { SessionSummary, SubscriptionQueueEvent, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 import { execute, GraphQLOperationError, isRateLimitedExtension } from '@boardsesh/graphql-client';
-import { buildBoardPath, parseBoardPath } from '@boardsesh/board-config';
+import { buildBoardPath, parseBoardPath, parseNamedBoardPath } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { JOIN_SESSION, LEAVE_SESSION } from '@boardsesh/graphql/operations/queue-session';
 import { getWsClient } from '../lib/graphql/ws-client';
@@ -788,6 +788,24 @@ export function QueueProvider({ children }: { children: ReactNode }) {
             // broadcasting. A null local participant id (peer event before our
             // JOIN_SESSION resolved) can't be the originator, so we apply it.
             if (event.changedByParticipantId && event.changedByParticipantId === participantIdRef.current) return;
+            // Named-board hosts (`/b/{slug}`) broadcast a slug path the tuple
+            // parser rejects. Follow the angle when we're on the SAME named board
+            // (slug match) — the angle table differs per board, so never cross
+            // boards (mirrors the tuple-identity guard below).
+            const named = parseNamedBoardPath(event.boardPath);
+            if (named) {
+              if (named.angle == null) return;
+              const nextNamedAngle = named.angle;
+              void (async () => {
+                const stored = await getStoredActiveBoard();
+                if (sessionIdRef.current !== sessionId) return;
+                if (!stored || stored.angle === nextNamedAngle) return;
+                if (stored.isAngleAdjustable === false) return;
+                if (!stored.slug || stored.slug !== named.slug) return;
+                await setActiveBoardRef.current({ ...stored, angle: nextNamedAngle });
+              })();
+              return;
+            }
             const parsed = parseBoardPath(event.boardPath);
             if (!parsed || parsed.angle == null) return;
             const nextAngle = parsed.angle;

--- a/packages/shared/board-config/src/__tests__/board-path.test.ts
+++ b/packages/shared/board-config/src/__tests__/board-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildBoardPath, parseBoardPath } from '../board-path';
+import { buildBoardPath, parseBoardPath, parseNamedBoardPath } from '../board-path';
 
 describe('buildBoardPath', () => {
   it('builds a path with angle', () => {
@@ -82,5 +82,39 @@ describe('parseBoardPath', () => {
     expect(parseBoardPath('')).toBeNull();
     expect(parseBoardPath('/b/my-board-slug/40')).toBeNull();
     expect(parseBoardPath('kilter/notanumber/17/26,27/40')).toBeNull();
+  });
+});
+
+describe('parseNamedBoardPath', () => {
+  it('parses a bare named-board path with no angle', () => {
+    expect(parseNamedBoardPath('/b/boiler-room-moonboard-c937dad5')).toEqual({
+      slug: 'boiler-room-moonboard-c937dad5',
+      angle: null,
+    });
+  });
+
+  it('parses a named-board path with an angle and trailing segments', () => {
+    expect(parseNamedBoardPath('/b/boiler-room-moonboard-c937dad5/40/list')).toEqual({
+      slug: 'boiler-room-moonboard-c937dad5',
+      angle: 40,
+    });
+  });
+
+  it('tolerates a missing leading slash', () => {
+    expect(parseNamedBoardPath('b/my-board/25')).toEqual({ slug: 'my-board', angle: 25 });
+  });
+
+  it('drops a leading locale segment', () => {
+    expect(parseNamedBoardPath('/es/b/my-board/40/list')).toEqual({ slug: 'my-board', angle: 40 });
+  });
+
+  it('returns angle null when the third segment is not numeric', () => {
+    expect(parseNamedBoardPath('/b/my-board/list')).toEqual({ slug: 'my-board', angle: null });
+  });
+
+  it('returns null for tuple board paths and other shapes', () => {
+    expect(parseNamedBoardPath('kilter/8/17/26,27/40')).toBeNull();
+    expect(parseNamedBoardPath('/b')).toBeNull();
+    expect(parseNamedBoardPath('')).toBeNull();
   });
 });

--- a/packages/shared/board-config/src/board-path.ts
+++ b/packages/shared/board-config/src/board-path.ts
@@ -52,3 +52,40 @@ export function parseBoardPath(path: string): ParsedBoardPath | null {
   const angle = angleRaw !== undefined && /^-?\d+$/.test(angleRaw) ? Number(angleRaw) : null;
   return { boardName, layoutId, sizeId, setIds, angle };
 }
+
+export type ParsedNamedBoardPath = {
+  slug: string;
+  angle: number | null;
+};
+
+/**
+ * Parse a named-board path — the `/b/{slug}` board-entity shape used for named
+ * gym boards (e.g. `/b/boiler-room-moonboard-c937dad5`), optionally carrying an
+ * angle and trailing route segments (`/b/{slug}/40/list`). Named boards are
+ * keyed by slug rather than the positional `{board}/{layout}/{size}/{sets}/{angle}`
+ * tuple, so {@link parseBoardPath} deliberately rejects this shape.
+ *
+ * Tolerant of a leading slash and a leading two-letter locale segment, mirroring
+ * `parseBoardPath`. `angle` is the numeric angle when the path carries one (e.g.
+ * `/b/{slug}/40/...`), otherwise `null` — a bare `/b/{slug}` has no angle, so the
+ * caller falls back to the board entity's stored angle. Returns `null` for any
+ * path that isn't a named-board path.
+ */
+export function parseNamedBoardPath(path: string): ParsedNamedBoardPath | null {
+  if (!path) return null;
+  const segments = path.split('/').filter((segment) => segment.length > 0);
+  // Drop a leading locale segment (two lowercase letters). The `/b/` marker is a
+  // single character, so this can't swallow it.
+  if (segments.length > 0 && /^[a-z]{2}$/.test(segments[0])) {
+    segments.shift();
+  }
+  // Named-board shape: `b/{slug}[/{angle}][/...]`. No positional board path uses
+  // `b` as its board-name segment, so this prefix is unambiguous.
+  if (segments.length < 2 || segments[0] !== 'b') return null;
+  const slug = segments[1];
+  if (!slug) return null;
+
+  const angleRaw = segments[2];
+  const angle = angleRaw !== undefined && /^-?\d+$/.test(angleRaw) ? Number(angleRaw) : null;
+  return { slug, angle };
+}


### PR DESCRIPTION
## Problem

Joining a party session from the React Native app fails with **"Couldn't join the session"** when the session was started from the web UI on a **named board** (`/b/{slug}` route — how MoonBoard boards are reached).

Confirmed against PostHog production data: error-tracking issue [`019ed501-…`](https://us.posthog.com/project/412845/error_tracking/019ed501-650e-7831-a44e-9a1ffb4453df) (*"Board path unavailable — cannot join session"*), and live MoonBoard web sessions run on routes like `/b/boiler-room-moonboard-c937dad5/40/list`.

## Root cause

When a session is started from a named board, the web app persists the session's `boardPath` as `/b/{slug}` (`start-sesh-drawer.tsx` → `use-create-session.ts`), later sometimes overwritten with the full pathname `/b/{slug}/{angle}/list`. Both start with `/b/` and are **intentionally refused** by `parseBoardPath` (`@boardsesh/board-config`), so mobile's `resolveBoardForSession` threw. The web client survives because its `/b/[slug]/[angle]` routes resolve the slug via the `boardBySlug` query — mobile had no equivalent in the join path.

This mostly surfaces on **MoonBoard** (reached almost exclusively as named boards); any named Kilter/Tension gym board is affected too, just more rarely.

## Fix (mobile-only, ships over-the-air via EAS Update)

- **`@boardsesh/board-config`** — new pure `parseNamedBoardPath(path)` → `{ slug, angle | null }`, tolerant of leading slash + locale.
- **mobile hooks** — new `useBoardBySlug` + non-hook `fetchBoardBySlug`, wrapping the existing `GET_BOARD_BY_SLUG` query (returns a full `UserBoard` incl. angle/slug).
- **`resolveBoardForSession`** — resolves `/b/{slug}` via `fetchBoardBySlug`, using the shared board entity directly with angle override (`path angle ?? entity angle`); the tuple path is unchanged.
- **join screen** — confirmation-card label and the `Session Joined` analytics event now derive from the resolved board, so both work for named-board sessions.
- **queue-provider** — `SessionBoardPathChanged` now follows the angle when a named-board host changes it (matched by slug).

No web or backend change — web relies on `boardPath` staying `/b/{slug}`, so resolving on the mobile read side is the right lever, and it fixes existing sessions.

## Tests / validation

- New unit tests: `parseNamedBoardPath` (6 cases), `resolveBoardForSession` named-board branch (3 cases), `Session Joined` for a `/b/{slug}` session.
- `vp run typecheck:mobile` + `typecheck:shared` clean.
- Full mobile suite **2460 tests pass**.
- `vp check` (lint + format) clean; `vp run check:mobile-bundle` OK.

## Manual QA

Start a session from a named board on web (`/b/{slug}`), grab the sessionId, open the join deep link `boardsesh://join/{sessionId}` on the device: join succeeds and lands on the Record tab, the card shows the board name + angle (not `/b/slug`), and a host angle change syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJLMUMW6Cx8R6nXEYJihKQ
