### PR TITLE
[codex] Fix mobile avatar upload handling

### DIFF
--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -8,8 +8,8 @@ import type { UpdateProfileInput } from '@boardsesh/shared-schema';
 import { useTheme } from '../providers/theme-provider';
 import { useToast } from '../providers/toast-provider';
 import { useProfile, useUpdateProfile } from '../lib/graphql/hooks';
-import { uploadAvatar, type AvatarUploadFile } from '../lib/avatar-upload';
-import { reportError } from '../lib/error-reporting';
+import { uploadAvatar, AvatarUploadError, type AvatarUploadFile } from '../lib/avatar-upload';
+import { reportError, reportHandledError } from '../lib/error-reporting';
 import { spacing } from '../theme/tokens';
 import { Avatar } from './Avatar';
 import { AuthTextInput } from './AuthTextInput';
@@ -82,10 +82,12 @@ export function EditProfileScreen() {
   }, []);
 
   const trimmedName = displayName.trim();
+  const trimmedProfileName = (profile?.displayName ?? '').trim();
+  const displayNameChanged = trimmedName.length > 0 && trimmedName !== trimmedProfileName;
   const nameTooLong = trimmedName.length > DISPLAY_NAME_MAX;
   const previewUri = pickedAvatar?.uri ?? profile?.avatarUrl;
   const avatarName = trimmedName || profile?.email || null;
-  const hasChanges = pickedAvatar != null || trimmedName.length > 0;
+  const hasChanges = pickedAvatar != null || displayNameChanged;
   const canSave = !isSaving && !nameTooLong && hasChanges && !!profile?.id;
 
   const handlePickAvatar = async () => {
@@ -124,7 +126,7 @@ export function EditProfileScreen() {
     setIsSaving(true);
     try {
       const input: UpdateProfileInput = {};
-      if (trimmedName.length > 0) {
+      if (displayNameChanged) {
         input.displayName = trimmedName;
       }
 
@@ -134,7 +136,10 @@ export function EditProfileScreen() {
         } catch (error) {
           // Match web: a failed avatar upload warns but still saves the name, so
           // the user doesn't lose a name edit to an image hiccup.
-          reportError(error);
+          reportHandledError(error, {
+            tags: { source: 'profile', op: 'avatar-upload' },
+            extra: { status: error instanceof AvatarUploadError ? error.status : undefined },
+          });
           showToast(t('profile.avatarUploadFailed'), 'warning');
         }
       }
@@ -151,7 +156,7 @@ export function EditProfileScreen() {
       showToast(t('profile.saved'), 'success');
       router.back();
     } catch (error) {
-      reportError(error);
+      reportHandledError(error, { tags: { source: 'profile', op: 'save' } });
       showToast(t('profile.saveError'), 'error');
     } finally {
       setIsSaving(false);

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -14,6 +14,19 @@ const resizeMock = vi.hoisted(() => vi.fn());
 const renderAsyncMock = vi.hoisted(() => vi.fn());
 const saveAsyncMock = vi.hoisted(() => vi.fn());
 const releaseMock = vi.hoisted(() => vi.fn());
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+const AvatarUploadErrorMock = vi.hoisted(
+  () =>
+    class AvatarUploadError extends Error {
+      readonly status: number;
+
+      constructor(message: string, status: number) {
+        super(message);
+        this.name = 'AvatarUploadError';
+        this.status = status;
+      }
+    },
+);
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
@@ -67,11 +80,13 @@ vi.mock('../../lib/graphql/hooks', () => ({
 }));
 
 vi.mock('../../lib/avatar-upload', () => ({
+  AvatarUploadError: AvatarUploadErrorMock,
   uploadAvatar: uploadAvatarMock,
 }));
 
 vi.mock('../../lib/error-reporting', () => ({
   reportError: vi.fn(),
+  reportHandledError: reportHandledErrorMock,
 }));
 
 vi.mock('../Avatar', () => ({
@@ -130,6 +145,7 @@ beforeEach(() => {
   renderAsyncMock.mockReset();
   saveAsyncMock.mockReset();
   releaseMock.mockReset();
+  reportHandledErrorMock.mockClear();
 
   requestMediaLibraryPermissionsMock.mockResolvedValue({ granted: true });
   launchImageLibraryMock.mockResolvedValue({
@@ -172,5 +188,29 @@ describe('EditProfileScreen', () => {
       avatarUrl: 'https://ws.example.com/static/avatars/11111111-1111-4111-8111-111111111111.jpg?v=upload-123',
     });
     expect(routerBackMock).toHaveBeenCalledOnce();
+  });
+
+  it('reports avatar upload failures with profile upload context', async () => {
+    const uploadError = new AvatarUploadErrorMock('File too large', 413);
+    uploadAvatarMock.mockRejectedValue(uploadError);
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://compressed-avatar.jpg');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(reportHandledErrorMock).toHaveBeenCalledWith(uploadError, {
+        tags: { source: 'profile', op: 'avatar-upload' },
+        extra: { status: 413 },
+      });
+    });
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+    expect(routerBackMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -19,8 +19,8 @@ const BACKEND = 'https://ws.example.com';
 const file = { uri: 'file:///tmp/avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' };
 const userId = '11111111-2222-3333-4444-555555555555';
 
-function jsonResponse(body: unknown, ok = true): Response {
-  return { ok, json: async () => body } as unknown as Response;
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 400): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
 }
 
 beforeEach(() => {
@@ -66,12 +66,42 @@ describe('uploadAvatar', () => {
   });
 
   it('throws the server-provided error message on a non-ok response', async () => {
-    mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ error: 'File too large' }, false));
-    await expect(uploadAvatar(file, userId)).rejects.toThrow('File too large');
+    mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ error: 'File too large' }, false, 413));
+    await expect(uploadAvatar(file, userId)).rejects.toMatchObject({ message: 'File too large', status: 413 });
   });
 
   it('throws when the response is missing an avatarUrl', async () => {
     mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ success: true }));
     await expect(uploadAvatar(file, userId)).rejects.toThrow('Avatar upload failed');
+  });
+});
+
+describe('avatar upload URL trailing-slash normalisation', () => {
+  it('strips a trailing slash from BACKEND_URL before joining upload and static paths', async () => {
+    vi.resetModules();
+    const trailingSlashFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        avatarUrl: '/static/avatars/me.jpg?v=upload-123',
+      }),
+    );
+    vi.doMock('../env', () => ({
+      BACKEND_URL: 'https://ws.example.com/',
+    }));
+    vi.doMock('../auth-interceptor', () => ({
+      authenticatedFetch: (...args: unknown[]) => trailingSlashFetch(...args),
+    }));
+
+    const reloaded = await import('../avatar-upload');
+    const result = await reloaded.uploadAvatar(file, userId);
+
+    expect(result).toBe(`${BACKEND}/static/avatars/me.jpg?v=upload-123`);
+    expect(trailingSlashFetch).toHaveBeenCalledWith(
+      `${BACKEND}/api/avatars`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(reloaded.absolutizeAvatarUrl('/static/avatars/me.jpg?v=upload-123')).toBe(
+      `${BACKEND}/static/avatars/me.jpg?v=upload-123`,
+    );
   });
 });

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -4,7 +4,7 @@ import { BACKEND_URL } from './env';
 // The backend caps avatars at 2MB and accepts jpg/png/gif/webp. The picker +
 // expo-image-manipulator compress to a ≤1024px JPEG before we ever get here, so
 // in practice every upload is a small JPEG well under the limit.
-const AVATAR_ENDPOINT = `${BACKEND_URL}/api/avatars`;
+const AVATAR_ENDPOINT = backendPath('/api/avatars');
 
 /** A picked (and already-compressed) local image ready to upload. */
 export type AvatarUploadFile = {
@@ -16,6 +16,20 @@ export type AvatarUploadFile = {
   type?: string;
 };
 
+export class AvatarUploadError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'AvatarUploadError';
+    this.status = status;
+  }
+}
+
+function backendPath(path: string): string {
+  return `${BACKEND_URL.replace(/\/+$/, '')}${path}`;
+}
+
 /**
  * The avatar handler returns a backend-relative URL (`/static/avatars/{id}.{ext}`)
  * so the backend can proxy/resize it. Persisted profiles store the absolute URL,
@@ -23,7 +37,7 @@ export type AvatarUploadFile = {
  * pass through untouched.
  */
 export function absolutizeAvatarUrl(url: string): string {
-  return url.startsWith('/') ? `${BACKEND_URL}${url}` : url;
+  return url.startsWith('/') ? backendPath(url) : url;
 }
 
 /**
@@ -51,7 +65,7 @@ export async function uploadAvatar(file: AvatarUploadFile, userId: string): Prom
   });
 
   if (!response.ok) {
-    throw new Error(await readErrorMessage(response));
+    throw new AvatarUploadError(await readErrorMessage(response), response.status);
   }
 
   const data = (await response.json()) as { success?: boolean; avatarUrl?: string };


### PR DESCRIPTION
## Summary

Fixes the mobile avatar upload path to better match the working web upload behavior:

- normalizes the mobile backend base URL before joining `/api/avatars` and returned `/static/avatars/...` paths, matching the web path and other mobile backend helpers
- preserves the returned versioned avatar URL behavior from the previous merged fix
- reports handled mobile avatar upload/profile-save failures with PostHog-searchable context (`source=profile`, `op=avatar-upload` / `op=save`, and upload HTTP status when available)
- stops treating the seeded display name as a change, so an avatar-only upload failure no longer saves the unchanged name, shows success, and leaves the screen

## Why

Both avatar PRs were merged, but mobile still cannot update avatars in the latest build while web upload works. The remaining differences are in the mobile client path: mobile builds upload/static URLs by directly concatenating `BACKEND_URL`, and the edit screen could mask an avatar upload failure by saving an unchanged display name.

This keeps backend behavior unchanged and tightens the mobile path around the web-proven behavior.

## Validation

Passed:

- `vp test run --project mobile packages/mobile/src/lib/__tests__/avatar-upload.test.ts packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx`
- `git diff --check`
- `git diff --cached --check`

Known unrelated failures on current main / this worktree:

- `vp check` reports formatting issues outside this diff: `CODE_OF_CONDUCT.md`, `POSTHOG_INVENTORY.md`, backend/db files, plus `packages/mobile/src/components/session/SessionSummaryCard.tsx` and `SessionTickRow.tsx`.
- `vp run typecheck:mobile` fails before this change on `packages/shared/play-view/src/url-utils.ts:2` because TypeScript cannot resolve `@boardsesh/board-config`.
- Full `vp test run --project mobile` also fails on the same `@boardsesh/board-config` resolution issue; the focused avatar tests pass.