### PR TITLE
fix(mobile): reliable pinch-to-zoom on the create/search boards (Android)

### DIFF
--- a/packages/mobile/src/components/create-climb/HoldTarget.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTarget.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { type MutableRefObject, useMemo } from 'react';
 import { View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
 
 type HoldTargetProps = {
@@ -14,6 +14,10 @@ type HoldTargetProps = {
   dotColor: string;
   onPaint: (holdId: number) => void;
   onLongPress: (holdId: number) => void;
+  /** The board's ancestor pinch, so this per-hold tap/long-press declares itself
+   *  simultaneous with it. Without that, two fingers on two hold targets each
+   *  claim a pointer and the pinch can't acquire both — zoom stalls on Android. */
+  pinchRef?: MutableRefObject<GestureType | undefined>;
 };
 
 /**
@@ -36,6 +40,7 @@ export const HoldTarget = React.memo(function HoldTarget({
   dotColor,
   onPaint,
   onLongPress,
+  pinchRef,
 }: HoldTargetProps) {
   const gesture = useMemo(() => {
     const tap = Gesture.Tap()
@@ -51,9 +56,16 @@ export const HoldTarget = React.memo(function HoldTarget({
         'worklet';
         runOnJS(onLongPress)(holdId);
       });
+    // Let the ancestor pinch recognize even while this finger sits on the hold —
+    // applied per-leg because the relation method lives on the individual
+    // gestures, not the Exclusive composite.
+    if (pinchRef) {
+      tap.simultaneousWithExternalGesture(pinchRef);
+      longPress.simultaneousWithExternalGesture(pinchRef);
+    }
     // Long-press wins; tap fires only if the long-press fails (released early).
     return Gesture.Exclusive(longPress, tap);
-  }, [holdId, onPaint, onLongPress]);
+  }, [holdId, onPaint, onLongPress, pinchRef]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/packages/mobile/src/components/create-climb/HoldTarget.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTarget.tsx
@@ -1,7 +1,7 @@
 import React, { type MutableRefObject, useMemo } from 'react';
 import { View } from 'react-native';
 import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
-import { runOnJS } from 'react-native-reanimated';
+import { runOnJS, type SharedValue } from 'react-native-reanimated';
 
 type HoldTargetProps = {
   holdId: number;
@@ -18,6 +18,11 @@ type HoldTargetProps = {
    *  simultaneous with it. Without that, two fingers on two hold targets each
    *  claim a pointer and the pinch can't acquire both — zoom stalls on Android. */
   pinchRef?: MutableRefObject<GestureType | undefined>;
+  /** True while a pinch is in progress. Because the tap/long-press are
+   *  simultaneous with the pinch (above), RNGH no longer fails them when the
+   *  pinch activates, so a small/slow pinch could otherwise paint a hold or open
+   *  the role sheet — gate both callbacks on this. */
+  isPinchingSV?: SharedValue<boolean>;
 };
 
 /**
@@ -41,6 +46,7 @@ export const HoldTarget = React.memo(function HoldTarget({
   onPaint,
   onLongPress,
   pinchRef,
+  isPinchingSV,
 }: HoldTargetProps) {
   const gesture = useMemo(() => {
     const tap = Gesture.Tap()
@@ -48,12 +54,17 @@ export const HoldTarget = React.memo(function HoldTarget({
       .maxDistance(15)
       .onStart(() => {
         'worklet';
+        // Bail if a pinch is active — see isPinchingSV. The tap recognizes on
+        // finger-lift, so without this a finger that's part of a small pinch
+        // would paint the hold it happened to be resting on.
+        if (isPinchingSV?.value) return;
         runOnJS(onPaint)(holdId);
       });
     const longPress = Gesture.LongPress()
       .minDuration(400)
       .onStart(() => {
         'worklet';
+        if (isPinchingSV?.value) return;
         runOnJS(onLongPress)(holdId);
       });
     // Let the ancestor pinch recognize even while this finger sits on the hold —
@@ -65,7 +76,7 @@ export const HoldTarget = React.memo(function HoldTarget({
     }
     // Long-press wins; tap fires only if the long-press fails (released early).
     return Gesture.Exclusive(longPress, tap);
-  }, [holdId, onPaint, onLongPress, pinchRef]);
+  }, [holdId, onPaint, onLongPress, pinchRef, isPinchingSV]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
@@ -1,6 +1,7 @@
 import React, { type MutableRefObject, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { GestureType } from 'react-native-gesture-handler';
+import type { SharedValue } from 'react-native-reanimated';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { holdGeometry } from './holdLayout';
 import { HoldTarget } from './HoldTarget';
@@ -20,6 +21,8 @@ type HoldTargetLayerProps = {
   /** The board's ancestor pinch, forwarded to each hold so per-hold gestures
    *  declare themselves simultaneous with it (reliable pinch-to-zoom). */
   pinchRef?: MutableRefObject<GestureType | undefined>;
+  /** Forwarded to each hold so its tap/long-press bail while a pinch is active. */
+  isPinchingSV?: SharedValue<boolean>;
 };
 
 const FAINT_DOT = 'rgba(255,255,255,0.22)';
@@ -42,6 +45,7 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
   onPaint,
   onLongPress,
   pinchRef,
+  isPinchingSV,
 }: HoldTargetLayerProps) {
   const targets = useMemo(() => {
     if (measuredWidth <= 0) return null;
@@ -61,6 +65,7 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
           onPaint={onPaint}
           onLongPress={onLongPress}
           pinchRef={pinchRef}
+          isPinchingSV={isPinchingSV}
         />
       );
     });
@@ -75,6 +80,7 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
     onPaint,
     onLongPress,
     pinchRef,
+    isPinchingSV,
   ]);
 
   return (

--- a/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { type MutableRefObject, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
+import type { GestureType } from 'react-native-gesture-handler';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { holdGeometry } from './holdLayout';
 import { HoldTarget } from './HoldTarget';
@@ -16,6 +17,9 @@ type HoldTargetLayerProps = {
   showHoldMarkers?: boolean;
   onPaint: (holdId: number) => void;
   onLongPress: (holdId: number) => void;
+  /** The board's ancestor pinch, forwarded to each hold so per-hold gestures
+   *  declare themselves simultaneous with it (reliable pinch-to-zoom). */
+  pinchRef?: MutableRefObject<GestureType | undefined>;
 };
 
 const FAINT_DOT = 'rgba(255,255,255,0.22)';
@@ -37,6 +41,7 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
   showHoldMarkers = true,
   onPaint,
   onLongPress,
+  pinchRef,
 }: HoldTargetLayerProps) {
   const targets = useMemo(() => {
     if (measuredWidth <= 0) return null;
@@ -55,6 +60,7 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
           dotColor={showAllHolds ? BRIGHT_DOT : FAINT_DOT}
           onPaint={onPaint}
           onLongPress={onLongPress}
+          pinchRef={pinchRef}
         />
       );
     });
@@ -68,6 +74,7 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
     showHoldMarkers,
     onPaint,
     onLongPress,
+    pinchRef,
   ]);
 
   return (

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -74,6 +74,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     pinchGesture,
     zoomPanGesture,
     isZoomed,
+    isPinchingSV,
     scaleSV,
     translateXSV,
     translateYSV,
@@ -113,6 +114,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     onTap: onPaint,
     onLongPress: onLongPressHold,
     pinchRef,
+    isPinchingSV,
   });
 
   return (
@@ -145,6 +147,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
               onPaint={onPaint}
               onLongPress={onLongPressHold}
               pinchRef={pinchRef}
+              isPinchingSV={isPinchingSV}
             />
             <PaintedHoldsLayer
               litUpHoldsMap={litUpHoldsMap}

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo, type ReactNode } from 'react';
+import React, { useMemo, useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { GestureDetector } from 'react-native-gesture-handler';
+import { GestureDetector, type GestureType } from 'react-native-gesture-handler';
 import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
 import { Text } from '../Text';
@@ -66,6 +66,10 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   overlay,
 }: InteractiveCreateBoardProps) {
   const { t } = useTranslation('common');
+  // Shared with the per-hold detectors and the zoomed overlay so they mark
+  // themselves simultaneous with the pinch — otherwise two fingers landing on
+  // two hold targets each claim a pointer and pinch-to-zoom stalls on Android.
+  const pinchRef = useRef<GestureType | undefined>(undefined);
   const {
     pinchGesture,
     zoomPanGesture,
@@ -82,6 +86,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     containerWidth: renderWidth,
     containerHeight: renderHeight,
     panActivationOffset: PAN_ACTIVATION_OFFSET,
+    pinchRef,
   });
 
   const holdById = useMemo(() => {
@@ -107,6 +112,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     hitTargets,
     onTap: onPaint,
     onLongPress: onLongPressHold,
+    pinchRef,
   });
 
   return (
@@ -138,6 +144,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
               showAllHolds={showAllHolds}
               onPaint={onPaint}
               onLongPress={onLongPressHold}
+              pinchRef={pinchRef}
             />
             <PaintedHoldsLayer
               litUpHoldsMap={litUpHoldsMap}

--- a/packages/mobile/src/components/create-climb/__tests__/HoldTarget.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/HoldTarget.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { SharedValue } from 'react-native-reanimated';
+
+// Capture the tap / long-press onStart worklets (and the pinch relation) so the
+// test can invoke them and assert the per-hold pinch gate without real gestures.
+const tapStartCallbacks: (() => void)[] = [];
+const longPressStartCallbacks: (() => void)[] = [];
+const simultaneousCalls: unknown[] = [];
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+vi.mock('react-native-reanimated', () => ({ runOnJS: (fn: unknown) => fn }));
+
+vi.mock('react-native-gesture-handler', () => {
+  const makeGesture = (recordStart: (cb: () => void) => void) => {
+    const gesture: Record<string, unknown> = {
+      maxDuration: () => gesture,
+      maxDistance: () => gesture,
+      minDuration: () => gesture,
+      onStart: (cb: () => void) => {
+        recordStart(cb);
+        return gesture;
+      },
+      simultaneousWithExternalGesture: (ref: unknown) => {
+        simultaneousCalls.push(ref);
+        return gesture;
+      },
+    };
+    return gesture;
+  };
+  return {
+    Gesture: {
+      Tap: () => makeGesture((cb) => tapStartCallbacks.push(cb)),
+      LongPress: () => makeGesture((cb) => longPressStartCallbacks.push(cb)),
+      Exclusive: (...members: unknown[]) => ({ composed: 'exclusive', members }),
+    },
+    GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  };
+});
+
+import { HoldTarget } from '../HoldTarget';
+
+function renderHoldTarget(overrides: { isPinchingSV?: SharedValue<boolean> } = {}) {
+  tapStartCallbacks.length = 0;
+  longPressStartCallbacks.length = 0;
+  simultaneousCalls.length = 0;
+  const onPaint = vi.fn();
+  const onLongPress = vi.fn();
+  render(
+    <HoldTarget
+      holdId={7}
+      leftPct={10}
+      topPct={20}
+      tapDiameter={30}
+      dotDiameter={6}
+      showDot
+      dotColor="#fff"
+      onPaint={onPaint}
+      onLongPress={onLongPress}
+      {...overrides}
+    />,
+  );
+  return { onPaint, onLongPress };
+}
+
+describe('HoldTarget', () => {
+  it('paints on tap and opens the role sheet on long-press when no pinch is active', () => {
+    const { onPaint, onLongPress } = renderHoldTarget({
+      isPinchingSV: { value: false } as unknown as SharedValue<boolean>,
+    });
+    tapStartCallbacks.at(-1)?.();
+    longPressStartCallbacks.at(-1)?.();
+    expect(onPaint).toHaveBeenCalledWith(7);
+    expect(onLongPress).toHaveBeenCalledWith(7);
+  });
+
+  it('does not paint or open the role sheet while a pinch is active', () => {
+    // tap/long-press are simultaneousWithExternalGesture(pinch), so RNGH no
+    // longer fails them when the pinch activates — the gate is what prevents an
+    // accidental paint / role-sheet open during a small or slow pinch.
+    const { onPaint, onLongPress } = renderHoldTarget({
+      isPinchingSV: { value: true } as unknown as SharedValue<boolean>,
+    });
+    tapStartCallbacks.at(-1)?.();
+    longPressStartCallbacks.at(-1)?.();
+    expect(onPaint).not.toHaveBeenCalled();
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('still paints when no pinch gate is wired (gate is optional)', () => {
+    const { onPaint } = renderHoldTarget();
+    tapStartCallbacks.at(-1)?.();
+    expect(onPaint).toHaveBeenCalledWith(7);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-zoomed-hold-tap-gesture.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/use-zoomed-hold-tap-gesture.test.ts
@@ -4,30 +4,37 @@ import { renderHook } from '@testing-library/react';
 import type { SharedValue } from 'react-native-reanimated';
 import type { GestureType } from 'react-native-gesture-handler';
 
-// Chainable no-op gesture builder; Race tags its result so we can assert which
-// branch the hook returned without driving real gestures. The builder records
-// simultaneousWithExternalGesture args so we can assert the pinch relation.
+// Chainable gesture builder per Gesture.Tap()/LongPress() call. Race tags its
+// result so we can assert which branch the hook returned without driving real
+// gestures. The builder records simultaneousWithExternalGesture args (to assert
+// the pinch relation) and the onStart worklet (to invoke it and assert the
+// pinch gate).
+type TapEvent = { x: number; y: number };
 const raceCalls: unknown[][] = [];
 const simultaneousCalls: unknown[] = [];
+const tapStartCallbacks: ((event: TapEvent) => void)[] = [];
+const longPressStartCallbacks: ((event: TapEvent) => void)[] = [];
 vi.mock('react-native-gesture-handler', () => {
-  const builder: Record<string, unknown> = new Proxy(
-    {},
-    {
-      get: (_target, prop) => {
-        if (prop === 'simultaneousWithExternalGesture') {
-          return (ref: unknown) => {
-            simultaneousCalls.push(ref);
-            return builder;
-          };
-        }
-        return () => builder;
+  const makeGesture = (recordStart: (cb: (event: TapEvent) => void) => void) => {
+    const gesture: Record<string, unknown> = {
+      maxDuration: () => gesture,
+      maxDistance: () => gesture,
+      minDuration: () => gesture,
+      onStart: (cb: (event: TapEvent) => void) => {
+        recordStart(cb);
+        return gesture;
       },
-    },
-  );
+      simultaneousWithExternalGesture: (ref: unknown) => {
+        simultaneousCalls.push(ref);
+        return gesture;
+      },
+    };
+    return gesture;
+  };
   return {
     Gesture: {
-      Tap: () => builder,
-      LongPress: () => builder,
+      Tap: () => makeGesture((cb) => tapStartCallbacks.push(cb)),
+      LongPress: () => makeGesture((cb) => longPressStartCallbacks.push(cb)),
       Race: (...members: unknown[]) => {
         raceCalls.push(members);
         return { composed: 'race', members };
@@ -99,5 +106,36 @@ describe('useZoomedHoldTapGesture', () => {
     simultaneousCalls.length = 0;
     renderHook(() => useZoomedHoldTapGesture(baseOptions({ onTap: vi.fn(), onLongPress: vi.fn() })));
     expect(simultaneousCalls).toHaveLength(0);
+  });
+
+  it('routes tap + long-press to the hold under the point when no pinch is active', () => {
+    tapStartCallbacks.length = 0;
+    longPressStartCallbacks.length = 0;
+    const onTap = vi.fn();
+    const onLongPress = vi.fn();
+    const isPinchingSV = { value: false } as unknown as SharedValue<boolean>;
+    renderHook(() => useZoomedHoldTapGesture(baseOptions({ onTap, onLongPress, isPinchingSV })));
+
+    // scale 1 + no translation → board point == screen point; (150,300) is hold 1.
+    tapStartCallbacks.at(-1)?.({ x: 150, y: 300 });
+    longPressStartCallbacks.at(-1)?.({ x: 150, y: 300 });
+    expect(onTap).toHaveBeenCalledWith(1);
+    expect(onLongPress).toHaveBeenCalledWith(1);
+  });
+
+  it('bails out of tap + long-press while a pinch is active', () => {
+    tapStartCallbacks.length = 0;
+    longPressStartCallbacks.length = 0;
+    const onTap = vi.fn();
+    const onLongPress = vi.fn();
+    // A re-pinch while zoomed must not also paint / open the picker — both legs
+    // are simultaneous with the pinch, so the gate is the only thing stopping it.
+    const isPinchingSV = { value: true } as unknown as SharedValue<boolean>;
+    renderHook(() => useZoomedHoldTapGesture(baseOptions({ onTap, onLongPress, isPinchingSV })));
+
+    tapStartCallbacks.at(-1)?.({ x: 150, y: 300 });
+    longPressStartCallbacks.at(-1)?.({ x: 150, y: 300 });
+    expect(onTap).not.toHaveBeenCalled();
+    expect(onLongPress).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-zoomed-hold-tap-gesture.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/use-zoomed-hold-tap-gesture.test.ts
@@ -5,10 +5,25 @@ import type { SharedValue } from 'react-native-reanimated';
 import type { GestureType } from 'react-native-gesture-handler';
 
 // Chainable no-op gesture builder; Race tags its result so we can assert which
-// branch the hook returned without driving real gestures.
+// branch the hook returned without driving real gestures. The builder records
+// simultaneousWithExternalGesture args so we can assert the pinch relation.
 const raceCalls: unknown[][] = [];
+const simultaneousCalls: unknown[] = [];
 vi.mock('react-native-gesture-handler', () => {
-  const builder: Record<string, unknown> = new Proxy({}, { get: () => () => builder });
+  const builder: Record<string, unknown> = new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (prop === 'simultaneousWithExternalGesture') {
+          return (ref: unknown) => {
+            simultaneousCalls.push(ref);
+            return builder;
+          };
+        }
+        return () => builder;
+      },
+    },
+  );
   return {
     Gesture: {
       Tap: () => builder,
@@ -70,5 +85,19 @@ describe('useZoomedHoldTapGesture', () => {
     const first = result.current;
     rerender();
     expect(result.current).toBe(first);
+  });
+
+  it('declares the tap + long-press legs simultaneous with the pinch when pinchRef is provided', () => {
+    simultaneousCalls.length = 0;
+    const pinchRef = { current: undefined } as unknown as { current: GestureType | undefined };
+    renderHook(() => useZoomedHoldTapGesture(baseOptions({ onTap: vi.fn(), onLongPress: vi.fn(), pinchRef })));
+    // Both legs must reference the pinch so a re-pinch while zoomed isn't blocked.
+    expect(simultaneousCalls.filter((ref) => ref === pinchRef)).toHaveLength(2);
+  });
+
+  it('wires no pinch relation when pinchRef is omitted', () => {
+    simultaneousCalls.length = 0;
+    renderHook(() => useZoomedHoldTapGesture(baseOptions({ onTap: vi.fn(), onLongPress: vi.fn() })));
+    expect(simultaneousCalls).toHaveLength(0);
   });
 });

--- a/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
+++ b/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { type MutableRefObject, useMemo, useRef } from 'react';
 import { Gesture, type ComposedGesture, type GestureType } from 'react-native-gesture-handler';
 import { runOnJS, type SharedValue } from 'react-native-reanimated';
 import { resolveHoldAtPoint, type HoldHitTarget } from './holdLayout';
@@ -36,6 +36,10 @@ type UseZoomedHoldTapGestureOptions = {
   /** Long-press handler (role sheet). Falls back to onTap when omitted, matching
    *  HoldTargetLayer which wires both. */
   onLongPress?: (holdId: number) => void;
+  /** The board's ancestor pinch. The overlay's tap/long-press declare themselves
+   *  simultaneous with it so a pinch-to-zoom-further while already zoomed isn't
+   *  blocked by this overlay. */
+  pinchRef?: MutableRefObject<GestureType | undefined>;
 };
 
 /**
@@ -73,6 +77,7 @@ export function useZoomedHoldTapGesture({
   hitTargets,
   onTap,
   onLongPress,
+  pinchRef,
 }: UseZoomedHoldTapGestureOptions): ComposedGesture | GestureType {
   const hasTap = onTap != null;
 
@@ -122,8 +127,16 @@ export function useZoomedHoldTapGesture({
         runOnJS(handleLongPress)(boardX, boardY);
       });
 
+    // Keep a re-pinch (while already zoomed) unblocked by this overlay's
+    // tap/long-press. Applied per-leg — the relation method is on the individual
+    // gestures, not the Race composite.
+    if (pinchRef) {
+      tap.simultaneousWithExternalGesture(pinchRef);
+      longPress.simultaneousWithExternalGesture(pinchRef);
+    }
+
     // handleTap/handleLongPress are intentionally not deps — captured once and
     // read render-scoped values through callbacksRef (see use-carousel-gesture).
     return Gesture.Race(zoomPanGesture, longPress, tap);
-  }, [hasTap, zoomPanGesture, scaleSV, translateXSV, translateYSV, containerWidthSV, containerHeightSV]);
+  }, [hasTap, zoomPanGesture, scaleSV, translateXSV, translateYSV, containerWidthSV, containerHeightSV, pinchRef]);
 }

--- a/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
+++ b/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
@@ -40,6 +40,11 @@ type UseZoomedHoldTapGestureOptions = {
    *  simultaneous with it so a pinch-to-zoom-further while already zoomed isn't
    *  blocked by this overlay. */
   pinchRef?: MutableRefObject<GestureType | undefined>;
+  /** True while a pinch is in progress. Since the overlay's tap/long-press are
+   *  simultaneous with the pinch (pinchRef), RNGH won't fail them when a re-pinch
+   *  activates, so gate both callbacks on this to avoid painting / opening the
+   *  role sheet mid-pinch. */
+  isPinchingSV?: SharedValue<boolean>;
 };
 
 /**
@@ -78,6 +83,7 @@ export function useZoomedHoldTapGesture({
   onTap,
   onLongPress,
   pinchRef,
+  isPinchingSV,
 }: UseZoomedHoldTapGestureOptions): ComposedGesture | GestureType {
   const hasTap = onTap != null;
 
@@ -107,6 +113,9 @@ export function useZoomedHoldTapGesture({
       .maxDistance(TAP_MAX_DISTANCE_PX)
       .onStart((event) => {
         'worklet';
+        // Bail if a pinch is active (see isPinchingSV) so a re-pinch while
+        // zoomed doesn't also paint the hold under a finger.
+        if (isPinchingSV?.value) return;
         // Inverse of animatedZoomStyle ([translate, scale], center origin). The
         // tested twin is inverseTransformPoint in holdLayout.ts — keep in sync.
         const cx = containerWidthSV.value / 2;
@@ -120,6 +129,7 @@ export function useZoomedHoldTapGesture({
       .minDuration(LONG_PRESS_MIN_DURATION_MS)
       .onStart((event) => {
         'worklet';
+        if (isPinchingSV?.value) return;
         const cx = containerWidthSV.value / 2;
         const cy = containerHeightSV.value / 2;
         const boardX = (event.x - translateXSV.value - cx) / scaleSV.value + cx;
@@ -138,5 +148,15 @@ export function useZoomedHoldTapGesture({
     // handleTap/handleLongPress are intentionally not deps — captured once and
     // read render-scoped values through callbacksRef (see use-carousel-gesture).
     return Gesture.Race(zoomPanGesture, longPress, tap);
-  }, [hasTap, zoomPanGesture, scaleSV, translateXSV, translateYSV, containerWidthSV, containerHeightSV, pinchRef]);
+  }, [
+    hasTap,
+    zoomPanGesture,
+    scaleSV,
+    translateXSV,
+    translateYSV,
+    containerWidthSV,
+    containerHeightSV,
+    pinchRef,
+    isPinchingSV,
+  ]);
 }

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useState, type ComponentType, type RefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentType,
+  type MutableRefObject,
+  type RefObject,
+} from 'react';
 import type { ViewStyle } from 'react-native';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import {
@@ -28,6 +36,13 @@ type UseZoomPanGestureOptions = {
    * play route briefly used wasn't in RNGH's tree). Typed as RNGH's GestureRef
    * shape so the method call needs no cast. */
   scrollRef?: RefObject<ComponentType | undefined | null>;
+  /** When set, the pinch gesture is tagged with this ref so the interactive
+   * boards' per-hold tap/long-press detectors can mark themselves
+   * `simultaneousWithExternalGesture(pinchRef)`. Without that relation, two
+   * fingers landing on two different per-hold detectors each claim a pointer and
+   * the ancestor pinch can't acquire both — pinch-to-zoom stalls on Android.
+   * The play-drawer board has no per-hold detectors, so it leaves this unset. */
+  pinchRef?: MutableRefObject<GestureType | undefined>;
 };
 
 type UseZoomPanGestureReturn = {
@@ -81,6 +96,7 @@ export function useZoomPanGesture({
   containerHeight,
   panActivationOffset,
   scrollRef,
+  pinchRef,
 }: UseZoomPanGestureOptions): UseZoomPanGestureReturn {
   const scale = useSharedValue(MIN_SCALE);
   const translateX = useSharedValue(0);
@@ -197,10 +213,14 @@ export function useZoomPanGesture({
           runOnJS(updateZoomState)(true);
         }
       });
+    // Tag the pinch so per-hold detectors can declare themselves simultaneous
+    // with it (see pinchRef doc above). Only the interactive boards pass a ref.
+    if (pinchRef) pinch.withRef(pinchRef);
     // Declare the pinch simultaneous with the surrounding RNGH ScrollView so a
     // 2-finger zoom isn't cancelled by the scroll. (The zoom-pan overlay lives on
     // a separate, zoomed-only GestureDetector and needs no scroll relation.)
-    return scrollRef ? pinch.simultaneousWithExternalGesture(scrollRef) : pinch;
+    if (scrollRef) pinch.simultaneousWithExternalGesture(scrollRef);
+    return pinch;
   }, [
     scale,
     translateX,
@@ -216,6 +236,7 @@ export function useZoomPanGesture({
     containerHeightSV,
     updateZoomState,
     scrollRef,
+    pinchRef,
   ]);
 
   // zoomPanGesture is rendered into a separate GestureDetector that only

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -50,6 +50,12 @@ type UseZoomPanGestureReturn = {
   zoomPanGesture: GestureType;
   isZoomed: boolean;
   isZoomedSV: SharedValue<boolean>;
+  /** True while a 2-finger pinch is in progress. The interactive boards gate
+   * their per-hold tap/long-press on this: those legs are
+   * `simultaneousWithExternalGesture(pinchRef)`, so RNGH no longer fails them
+   * when the pinch activates — without the gate a small or slow pinch could also
+   * paint a hold or open the role sheet. Stays false on boards with no pinchRef. */
+  isPinchingSV: SharedValue<boolean>;
   /** Live zoom scale on the UI thread, so an overlay inside the transform can
    * convert screen-pixel drag deltas into unscaled board-pixel deltas. */
   scaleSV: SharedValue<number>;
@@ -115,6 +121,9 @@ export function useZoomPanGesture({
   // also starts at 0 and updates after first onLayout; reading from a shared
   // value keeps the gesture objects stable across that one-shot update.
   const isZoomedSV = useSharedValue(false);
+  // See isPinchingSV in the return type. Only the interactive boards (pinchRef
+  // set) drive it; it stays false everywhere else.
+  const isPinchingSV = useSharedValue(false);
   const enabledSV = useSharedValue(enabled);
   const containerWidthSV = useSharedValue(containerWidth);
   const containerHeightSV = useSharedValue(containerHeight);
@@ -215,7 +224,23 @@ export function useZoomPanGesture({
       });
     // Tag the pinch so per-hold detectors can declare themselves simultaneous
     // with it (see pinchRef doc above). Only the interactive boards pass a ref.
-    if (pinchRef) pinch.withRef(pinchRef);
+    if (pinchRef) {
+      pinch.withRef(pinchRef);
+      // Drive isPinchingSV off the ancestor pinch's pointer stream — it sees
+      // every finger on the board, including those landing on per-hold targets.
+      // Set on the 2nd finger; cleared only when a fresh single-finger touch
+      // begins, never on pinch end. That way a hold's tap, which recognizes on
+      // finger-lift, still sees the pinch as active and bails (the lift would
+      // otherwise race the pinch's onEnd and leak a paint).
+      pinch.onTouchesDown((event) => {
+        'worklet';
+        if (event.numberOfTouches >= 2) {
+          isPinchingSV.value = true;
+        } else if (event.numberOfTouches === 1) {
+          isPinchingSV.value = false;
+        }
+      });
+    }
     // Declare the pinch simultaneous with the surrounding RNGH ScrollView so a
     // 2-finger zoom isn't cancelled by the scroll. (The zoom-pan overlay lives on
     // a separate, zoomed-only GestureDetector and needs no scroll relation.)
@@ -231,6 +256,7 @@ export function useZoomPanGesture({
     pinchFocalX,
     pinchFocalY,
     isZoomedSV,
+    isPinchingSV,
     enabledSV,
     containerWidthSV,
     containerHeightSV,
@@ -300,6 +326,7 @@ export function useZoomPanGesture({
     zoomPanGesture,
     isZoomed,
     isZoomedSV,
+    isPinchingSV,
     scaleSV: scale,
     translateXSV: translateX,
     translateYSV: translateY,

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -92,6 +92,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     pinchGesture,
     zoomPanGesture,
     isZoomed,
+    isPinchingSV,
     scaleSV,
     translateXSV,
     translateYSV,
@@ -140,12 +141,16 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
       .maxDistance(TAP_MAX_DISTANCE_PX)
       .onStart((event) => {
         'worklet';
+        // Bail if a pinch is active (see isPinchingSV) so a small pinch over the
+        // board doesn't also open the hold picker on release.
+        if (isPinchingSV?.value) return;
         runOnJS(handleRestHoldTap)(event.x, event.y);
       });
     const longPress = Gesture.LongPress()
       .minDuration(LONG_PRESS_MIN_DURATION_MS)
       .onStart((event) => {
         'worklet';
+        if (isPinchingSV?.value) return;
         runOnJS(handleRestHoldTap)(event.x, event.y);
       });
     // Let the ancestor pinch recognize even while a finger sits on this overlay
@@ -153,7 +158,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     tap.simultaneousWithExternalGesture(pinchRef);
     longPress.simultaneousWithExternalGesture(pinchRef);
     return Gesture.Exclusive(longPress, tap);
-  }, [hasHoldTap, handleRestHoldTap]);
+  }, [hasHoldTap, handleRestHoldTap, isPinchingSV]);
 
   const overlayGesture = useZoomedHoldTapGesture({
     zoomPanGesture,
@@ -167,6 +172,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     // picker too — same as HoldTargetLayer wiring both to onHoldTap at rest.
     onTap: onHoldTap,
     pinchRef,
+    isPinchingSV,
   });
 
   const holdById = useMemo(() => {
@@ -241,6 +247,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
                 onPaint={onHoldTap}
                 onLongPress={onHoldTap}
                 pinchRef={pinchRef}
+                isPinchingSV={isPinchingSV}
               />
             ) : null}
             {!isZoomed && restHoldTapGesture ? (

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -84,6 +84,10 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   renderInTransform,
 }: InteractiveFilterBoardProps) {
   const { t } = useTranslation('common');
+  // Shared with the per-hold detectors and the rest/zoom tap overlays so they
+  // mark themselves simultaneous with the pinch — same Android pinch-stall fix
+  // as the create board (two fingers on two hold targets must not block pinch).
+  const pinchRef = useRef<GestureType | undefined>(undefined);
   const {
     pinchGesture,
     zoomPanGesture,
@@ -100,6 +104,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     containerWidth: renderWidth,
     containerHeight: renderHeight,
     panActivationOffset: PAN_ACTIVATION_OFFSET,
+    pinchRef,
   });
 
   // The picker uses a long-press-style commit, but holds here only need a single
@@ -143,6 +148,10 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
         'worklet';
         runOnJS(handleRestHoldTap)(event.x, event.y);
       });
+    // Let the ancestor pinch recognize even while a finger sits on this overlay
+    // — applied per-leg (the relation method is on the individual gestures).
+    tap.simultaneousWithExternalGesture(pinchRef);
+    longPress.simultaneousWithExternalGesture(pinchRef);
     return Gesture.Exclusive(longPress, tap);
   }, [hasHoldTap, handleRestHoldTap]);
 
@@ -157,6 +166,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     // Long-press falls back to onTap in the hook, so a held hold opens the
     // picker too — same as HoldTargetLayer wiring both to onHoldTap at rest.
     onTap: onHoldTap,
+    pinchRef,
   });
 
   const holdById = useMemo(() => {
@@ -230,6 +240,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
                 showHoldMarkers={showHoldMarkers}
                 onPaint={onHoldTap}
                 onLongPress={onHoldTap}
+                pinchRef={pinchRef}
               />
             ) : null}
             {!isZoomed && restHoldTapGesture ? (

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -35,6 +35,7 @@ vi.mock('react-native-gesture-handler', () => {
       maxDistance: () => gesture,
       minDuration: () => gesture,
       onStart: () => gesture,
+      simultaneousWithExternalGesture: () => gesture,
     };
     return gesture;
   };


### PR DESCRIPTION
## Release Notes

- Pinch-to-zoom now works first try when setting a climb or filtering holds on Android, instead of taking several tries or swiping the sheet shut

## Problem

When **setting a climb** on Android (arm64-v8a), pinch-to-zoom on the board is very hard to trigger. Reported as: *"it kept either not zooming or swiping down took like 10 tries to be able to zoom."* Pinch works fine in the play/view drawer — only the create drawer (and, with the same root cause, the search hold-filter board) is flaky.

## Root cause

`InteractiveCreateBoard` wraps a single `Gesture.Pinch()` around an `Animated.View` that is carpeted with **one `GestureDetector` per hold** (often 150–500 of them), each running `Gesture.Exclusive(longPress, tap)`. There was **no gesture relation** between the ancestor pinch and these child detectors.

On Android, when two fingers land on two different hold-target views, each finger's tap/long-press handler claims its own pointer, and the ancestor `Gesture.Pinch` can't reliably acquire *both* — so the pinch stalls. The residual finger movement then leaks to the `@gorhom/bottom-sheet` content pan and the sheet slides down (the "swiping down" symptom).

The play-drawer board doesn't hit this because it's a plain image with no child gesture detectors (`Gesture.Simultaneous(pinch, swipe)` in one detector).

## Fix

Tag the board's pinch with a ref (`.withRef(pinchRef)`) and mark every competing per-hold / overlay tap+long-press `.simultaneousWithExternalGesture(pinchRef)`. That tells RNGH the per-hold gesture and the pinch may both be active, so the children no longer have to *fail* for the ancestor pinch to recognize — it acquires both pointers cleanly. This is the standard RNGH recipe for "parent pinch + child taps."

- Applied **per-leg** (on each `tap`/`longPress`) because the relation method lives on `BaseGesture`, not on the `Exclusive`/`Race` composite (verified against the installed `react-native-gesture-handler@2.31.2` source).
- The pinch ref is **optional** and only passed by the interactive boards. The play drawer / search-without-handlers paths pass no ref, so `.withRef`/`.simultaneousWithExternalGesture` are skipped — zero behavior change there.
- The gorhom bottom sheet is intentionally left untouched: once the pinch consumes the two-finger gesture, movement never reaches the sheet pan. (`waitFor` would stall single-finger scroll/close; `simultaneousHandlers` would let the sheet slide *while* pinching.)

Covers both `InteractiveCreateBoard` and `InteractiveFilterBoard`, which share the same `HoldTargetLayer` carpet and the same latent bug.

## Changes

- `play-drawer/use-zoom-pan-gesture.ts` — optional `pinchRef` option; `.withRef(pinchRef)` on the pinch when provided.
- `create-climb/HoldTarget.tsx`, `HoldTargetLayer.tsx` — thread `pinchRef`; per-hold legs declare `simultaneousWithExternalGesture(pinchRef)`.
- `create-climb/use-zoomed-hold-tap-gesture.ts` — same relation on the zoomed overlay's tap/long-press (keeps a re-pinch-while-zoomed unblocked).
- `create-climb/InteractiveCreateBoard.tsx`, `search/InteractiveFilterBoard.tsx` — create the `pinchRef` and wire it through.

## Tests

- Extended the gesture-relation unit test (`use-zoomed-hold-tap-gesture.test.ts`): asserts the tap+long-press legs call `simultaneousWithExternalGesture(pinchRef)` when a ref is provided, and not when omitted.
- Updated the `interactive-filter-board` test gesture mock to expose `simultaneousWithExternalGesture`.

## Validation

- `vp run typecheck:mobile` ✅
- `vp run test:mobile` ✅ (2472 passed)
- `vp run check:mobile-bundle` ✅ (Android bundle OK)

The bug is Android-arm64-only and can't be reproduced on Linux/macOS simulators, so final pinch confirmation should happen on an Android device via the normal preview/CI flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
