### PR TITLE
feat(mobile): local Android emulator screenshot tooling

### DIFF
--- a/.claude/skills/android-screenshots/SKILL.md
+++ b/.claude/skills/android-screenshots/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: android-screenshots
+description: Capture screenshots of the Boardsesh React Native app (packages/mobile/) running on an Android emulator, driven against Metro with a cached dev-client APK. Use when asked to screenshot / see / visually verify the mobile app on Android, or to share mobile screenshots in chat. Linux/KVM-friendly; the iOS counterpart is `vp run mobile:screenshots`. Full reference: docs/android-emulator-screenshots.md.
+---
+
+# Android emulator screenshots
+
+Boots a headless x86_64 emulator, installs a cached **dev-client** APK (no bundled JS — it
+loads from Metro), runs the app, and captures with `adb exec-out screencap`. The APK is
+built/downloaded once and reused; only the JS regenerates per run.
+
+## Workflow (preferred: boot once, shoot many)
+
+1. **First run only — bootstrap.** `vp run mobile:android-doctor` installs the Android SDK and a
+   Temurin JDK 21 under `~/.cache/boardsesh/` (~2.5 GB, one-time) and reports KVM / JDK / AVD /
+   cached-APK status. Skip on subsequent runs (the main command auto-bootstraps anyway).
+
+2. **Pick login/data state:**
+   - **Prod test account (default):** export `SCREENSHOT_USER_PASSWORD=<prod test pw>` so the app
+     auto-logs-in `test@boardsesh.com` and shows real content. Without it, the app stops on the
+     login screen.
+   - **Local seeded data:** run `vp run dev` first, then add `--backend local` (seeded `test`/`test`).
+   - **Plain app (drive login yourself):** add `--no-screenshot-mode`.
+
+3. **Boot in the BACKGROUND.** The bare command holds Metro and blocks, so launch it with the
+   Bash tool's `run_in_background: true`:
+   `vp run mobile:android-shots` (plus `--backend local` / `--no-screenshot-mode` as chosen).
+   It boots the emulator, installs the APK (downloads the universal `rn-android-dev-*` release or
+   builds an x86_64 dev-client locally), starts Metro, `adb reverse`, and launches the app.
+
+4. **Wait for "Ready".** Poll the background task's output file (returned when you launched it)
+   with a second `run_in_background` Bash `until`-loop so you get one notification:
+   `until grep -qE "Ready\. Emulator|FAILED|did not finish booting" <output-file>; do sleep 3; done`
+
+5. **Capture (foreground).** For each screen:
+   `vp run mobile:android-shots -- screenshot --to <screen> --label <name>`
+   It navigates via deep link, captures, and prints the absolute PNG path. Screen names:
+   `home`, `climbs`, `board-view`, `board-sheet`, `discover`, `record`, `profile`,
+   `session-detail`, `logbook` — or pass a raw route, e.g. `--to 'climbs?screenshotBoardIndex=1'`.
+
+6. **Share.** `SendUserFile` each printed PNG path.
+
+7. **Stop when done.** `vp run mobile:android-shots -- shutdown` (kills emulator + Metro), and
+   stop the backgrounded boot task.
+
+## One-shot alternative (simplest, slower per shot)
+
+`vp run mobile:android-shots -- --to climbs --label climbs --shutdown` — boots, captures one
+screen, tears down, and exits in a single (long) foreground call. No emulator reuse, so prefer
+the background workflow for multiple shots.
+
+## Useful flags & env
+
+- `--flow app-store|onboarding` runs the committed Maestro flows instead of ad-hoc capture.
+- `--app-path <apk>` / `--apk-tag <tag>` / `--build-local` to control APK resolution.
+- Env: `BOARDSESH_EMULATOR_GPU` (renderer), `BOARDSESH_AVD_NAME`, `BOARDSESH_EMULATOR_BOOT_TIMEOUT`,
+  `BOARDSESH_METRO_PORT`. See `docs/android-emulator-screenshots.md` for the full table.
+
+## Requirements & troubleshooting
+
+- Needs a host with `/dev/kvm` (fast emulation) and a working software GPU renderer. On normal
+  dev machines and standard CI (GitHub Actions `ubuntu-latest`, used by the repo's Android
+  screenshot job) `swiftshader_indirect` works out of the box.
+- **Emulator exits immediately / "did not finish booting":** check `.boardsesh/android-emulator.log`.
+  If the renderer segfaults, some heavily-sandboxed or exotic-CPU VMs can't run the emulator's
+  software GPU at all — there's no software-only fallback; run on a normal host/CI. If running
+  inside a sandboxed agent environment and qemu dies instantly, the Bash sandbox may be blocking
+  its KVM/memory syscalls — retry the boot with the sandbox disabled.
+- Screenshots land in `.boardsesh/android-screenshots/NN-<label>.png` (gitignored).

--- a/.github/workflows/android-apk-dev-client.yml
+++ b/.github/workflows/android-apk-dev-client.yml
@@ -150,7 +150,12 @@ jobs:
           # Gradle version; keep runtime Sentry (via the DSN) but never let the
           # upload task fail the build. Mirrors the production workflow.
           SENTRY_DISABLE_AUTO_UPLOAD: 'true'
-        run: ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a -PboardseshAbiFilters=arm64-v8a --no-daemon --console=plain --stacktrace
+        # Universal (arm64-v8a + x86_64): runs on physical arm64 devices, Apple-Silicon
+        # emulators, AND x86_64 emulators (the fast KVM path on Linux/Intel, used by the
+        # local screenshot flow — see docs/android-emulator-screenshots.md). Both props
+        # must list both ABIs: -PreactNativeArchitectures governs the RN/Hermes core libs,
+        # -PboardseshAbiFilters the board-renderer CMake module.
+        run: ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a,x86_64 -PboardseshAbiFilters=arm64-v8a,x86_64 --no-daemon --console=plain --stacktrace
 
       - name: Stage APK asset
         run: |
@@ -179,7 +184,7 @@ jobs:
             **Dev-client** Android build from commit ${{ github.sha }} — for testing, not the Play Store.
 
             **Package:** `com.boardsesh.app.dev` — installs **side-by-side** with the production app (shows as "Boardsesh Dev" with a red icon).
-            **APK architecture:** arm64-v8a
+            **APK architecture:** universal (`arm64-v8a` + `x86_64`) — runs on physical arm64 devices, Apple-Silicon emulators, and x86_64 emulators (Linux/Intel + KVM).
 
             This APK has no bundled JS: it opens expo-dev-client's launcher and loads
             JavaScript from a Metro dev server. Start Metro (`vp run dev:mobile`),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ This project uses [Vite+](https://viteplus.dev) (`vp`) as its unified toolchain 
 - `vp lint` - Lint all packages
 - `vp fmt` - Format all files with Oxfmt
 - `vp run dev` - Start development databases, backend, and web server
+- `vp run dev:mobile` - Start the React Native (Expo) Metro dev server
+- `vp run mobile:android-shots` - Boot an Android emulator, run the app against Metro, and capture screenshots via adb (Linux/KVM friendly). One-time setup: `vp run mobile:android-doctor`. Full guide: `docs/android-emulator-screenshots.md`
 - `vp run dev:backend` - Start database and backend only
 - `vp run dev:web` - Start database and web server only
 - `vp run db:up` - Start development databases and run migrations only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ For indexable pages:
 
 ## Mobile Development (packages/mobile/)
 
-React Native + Expo SDK 53, React Native 0.79, Expo Router 5.
+React Native + Expo SDK 56, React Native 0.85, Expo Router 56.
 
 ### Stack
 
@@ -246,6 +246,10 @@ Use `vp run mobile:ios` for local `packages/mobile` iOS builds instead of raw `e
 - Pass `--app-path <Boardsesh.app>` to install a prebuilt/cached app (CI's common path). Without it, the script builds one via `vp run mobile:build-sim-app` (`scripts/mobile-build-sim-app.ts` → `expo prebuild` + `pod install` + `xcodebuild build -sdk iphonesimulator -configuration Debug`; **not** `expo run:ios`, whose launch step hangs in CI). Use `--clean` for a deterministic from-scratch build.
 - The default Apple capture is `--devices common --locales all`: iPhone 16 Pro Max, iPhone 14 Plus, and iPhone 16 Pro for app locales `en-US`, `es`, and `fr`. The Spanish app locale is written to both App Store Connect folders, `es-ES` and `es-MX`.
 - `.github/workflows/mobile-screenshots.yml` caches the `.app` (`actions/cache`) keyed on **native inputs only**: `packages/mobile/app.config.ts`, `plugins/**`, `modules/**`, `package.json`, `patches/**`, and the root `package.json` (which pins `@expo/cli` / `react-native-screens`), plus `runner.os`/`runner.arch`. JS/TS-only and web-only changes (including `bun.lock` churn) are a cache hit and skip the ~30-min native build; any native-input change busts the key and rebuilds. Bump the `-v1-` salt to force a rebuild. A native-dep change must invalidate the key — when adding native config, confirm it's covered by one of those globs.
+
+### Android emulator screenshots (local, dev-client + Metro)
+
+For quick ad-hoc shots of the live app on an Android emulator (the fast KVM path on Linux/Intel), `vp run mobile:android-shots` (`scripts/mobile-android-shots.ts`) boots an x86*64 emulator, installs a cached **dev-client** APK (`com.boardsesh.app.dev`, universal `arm64-v8a`+`x86_64`), starts Metro, and captures with `adb exec-out screencap`. Same `EXPO_PUBLIC_SCREENSHOT*_`env as iOS; the deep-link scheme is`com.boardsesh.app://`for both variants (only the package differs). The APK comes from the latest`rn-android-dev-_`release (or a local Gradle fallback). One-time setup:`vp run mobile:android-doctor`(bootstraps the SDK + JDK 21 under`~/.cache/boardsesh/`). Full guide: `docs/android-emulator-screenshots.md`. This is distinct from `vp run mobile:screenshots --platform android`, which installs a standalone store APK with bundled JS.
 
 ### OTA preview distribution (EAS Update)
 

--- a/docs/android-emulator-screenshots.md
+++ b/docs/android-emulator-screenshots.md
@@ -1,0 +1,146 @@
+# Android emulator screenshots (local, dev-client + Metro)
+
+Quick screenshots of the live React Native app (`packages/mobile/`) on an Android
+emulator, driven against a Metro dev server using a cached dev-client APK. This is the
+Android counterpart to the iOS simulator flow (`vp run mobile:screenshots`) and works on
+Linux: an x86_64 emulator runs natively on a host with KVM (`/dev/kvm`), so it's the fast
+path on Linux/Intel.
+
+The cached APK carries no JS — it loads from Metro at runtime — so JavaScript changes show
+up on the next reload without rebuilding the APK. Native deps change rarely, so the same
+cached APK serves run after run.
+
+## One-time setup
+
+Everything installs under `~/.cache/boardsesh/` (SDK, a Temurin JDK 21, the downloaded
+APK). On a clean box, the first `vp run mobile:android-shots` bootstraps it automatically.
+To do it up front and see a diagnostics report:
+
+```
+vp run mobile:android-doctor          # bootstrap SDK + JDK 21, report status
+vp run mobile:android-doctor -- --build   # also install build-tools (local APK fallback)
+vp run mobile:android-doctor -- --check   # report only, install nothing
+```
+
+Requirements the doctor checks: `/dev/kvm` (fast emulation), an authenticated `gh` (to
+download the cached APK), and — only for `--flow` runs — `maestro` on PATH.
+
+## Take screenshots
+
+One-shot (boot, capture one screen, tear down):
+
+```
+vp run mobile:android-shots -- --to climbs --label climbs --shutdown
+```
+
+Iterative (boot once, shoot many). Run the bare command in the background so it holds
+Metro + the emulator alive, then grab shots in the foreground:
+
+```
+vp run mobile:android-shots                                  # background this; it holds Metro
+vp run mobile:android-shots -- screenshot --to board-view --label board
+vp run mobile:android-shots -- screenshot --to profile --label profile
+vp run mobile:android-shots -- navigate --to discover        # deep-link only, no capture
+vp run mobile:android-shots -- shutdown                       # stop emulator + Metro
+```
+
+PNGs land in `.boardsesh/android-screenshots/NN-<label>.png` (gitignored); the absolute
+path is printed so it can be shared directly.
+
+### Screens (`--to`)
+
+`--to` accepts a friendly name or a raw deep-link route:
+
+| Name             | Route                               | Screen                  |
+| ---------------- | ----------------------------------- | ----------------------- |
+| `home`           | `home`                              | Feed                    |
+| `climbs`         | `climbs`                            | Browse list             |
+| `board-view`     | `climbs?screenshotOpenFirst=1`      | First climb on the wall |
+| `board-sheet`    | `climbs?screenshotOpenBoardSheet=1` | Board-presence sheet    |
+| `discover`       | `discover`                          | Playlist library        |
+| `record`         | `record`                            | Workout generator       |
+| `profile`        | `profile`                           | Profile / progress      |
+| `session-detail` | `profile?screenshotTab=sessions`    | Newest session recap    |
+| `logbook`        | `profile?screenshotTab=logbook`     | Climbing history        |
+
+The `screenshot*` params are app code (`packages/mobile/src/lib/screenshot-mode.ts`), so
+they work the same as in the Maestro flows. Pass any raw route to `--to`, e.g.
+`--to 'climbs?screenshotBoardIndex=1'`.
+
+## The APK
+
+By default the tool downloads the latest `rn-android-dev-*` prerelease asset
+(`boardsesh-dev-android.apk`, package `com.boardsesh.app.dev`) and caches it, then verifies
+it carries the `x86_64` ABI. The CI dev-client APK is **universal** (`arm64-v8a` + `x86_64`)
+— see `docs/android-sideload-build.md` and `.github/workflows/android-apk-dev-client.yml`.
+
+If the download is unavailable, the APK lacks `x86_64`, or you pass `--build-local`, the
+tool builds a dev-client APK locally (`BOARDSESH_APP_VARIANT=dev` prebuild +
+`gradlew assembleDebug` for `x86_64`) and caches it by a hash of the native inputs. The
+local build needs JDK 21 (auto-provisioned) and is slow the first time (NDK + Hermes).
+
+```
+vp run mobile:android-apk                       # download (or build) and print the path
+vp run mobile:android-apk -- --build-local      # force a local Gradle build
+vp run mobile:android-apk -- --apk-tag rn-android-dev-42
+```
+
+## Login state
+
+By default `EXPO_PUBLIC_SCREENSHOT_MODE` is on: the app auto-logs-in the test account
+(`test@boardsesh.com`) against prod and locks the dark theme, so board-backed screens show
+real content with no taps. Set `SCREENSHOT_USER_PASSWORD` to the prod test account password
+(the seeded `test`/`test` pair only exists on the local dev backend — use `--backend local`
+with `vp run dev` for that). Pass `--no-screenshot-mode` for the plain app where you drive
+login yourself.
+
+## Flags
+
+| Flag                             | Default                          | Meaning                                       |
+| -------------------------------- | -------------------------------- | --------------------------------------------- |
+| `--to <screen>`                  | –                                | Navigate before capturing (name or raw route) |
+| `--label <name>`                 | `--to` value                     | Screenshot filename label                     |
+| `--out <dir>`                    | `.boardsesh/android-screenshots` | Output directory                              |
+| `--shutdown`                     | off (keep-alive)                 | Tear down emulator + Metro after the run      |
+| `--no-screenshot-mode`           | off                              | Plain dev-client (shows login)                |
+| `--flow <app-store\|onboarding>` | –                                | Run the Maestro flow instead of ad-hoc        |
+| `--build-local`                  | off                              | Force a local Gradle APK build                |
+| `--apk-tag <tag>`                | latest                           | Pin the downloaded release tag                |
+| `--app-path <apk>`               | –                                | Use a specific APK                            |
+| `--backend <prod\|local>`        | `prod`                           | Backend the app points at                     |
+| `--windowed`                     | off (headless)                   | Boot the emulator with a window               |
+| `--settle <seconds>`             | `3`                              | Wait after navigation before capturing        |
+
+## Environment overrides (headless / CI hosts)
+
+The emulator's GPU renderer is the most host-sensitive part. Defaults match the repo's
+CI (`-gpu swiftshader_indirect`, KVM via `-accel auto`), and on a headless Linux box the
+tooling auto-wraps the emulator in `xvfb-run` when there's no `$DISPLAY`. Tune via env:
+
+| Env                               | Default                | Use                                               |
+| --------------------------------- | ---------------------- | ------------------------------------------------- |
+| `BOARDSESH_EMULATOR_GPU`          | `swiftshader_indirect` | Renderer (`guest` → host lavapipe, `host`, `off`) |
+| `BOARDSESH_AVD_NAME`              | `boardsesh-pixel`      | Point at a pre-made AVD (e.g. an `aosp_atd` one)  |
+| `BOARDSESH_EMULATOR_EXTRA_ARGS`   | –                      | Extra `emulator` flags (space-separated)          |
+| `BOARDSESH_EMULATOR_BOOT_TIMEOUT` | `300`                  | Boot wait in seconds (raise for slow/TCG hosts)   |
+| `BOARDSESH_METRO_PORT`            | `8081`                 | Metro port (per worktree)                         |
+| `SCREENSHOT_USER_PASSWORD`        | `test`                 | Prod test account password for auto-login         |
+
+Requirements for a fast emulator: a host with `/dev/kvm` (KVM), and a working software
+GPU renderer. On a normal dev machine or a standard CI runner (e.g. GitHub Actions
+`ubuntu-latest`, which is what `.github/workflows/mobile-screenshots.yml` already uses for
+the Android job) `swiftshader_indirect` works out of the box. Some heavily-sandboxed or
+exotic-CPU VMs can't run the emulator's software GPU at all (it segfaults during
+rendering); there's no software-only fallback for that — run the flow on a normal host/CI.
+
+## Gotchas
+
+- Deep links and the dev-client launch URL use scheme `com.boardsesh.app://` for both prod
+  and dev variants; only the installed **package** differs (`com.boardsesh.app.dev`). See
+  the comment at `packages/mobile/app.config.ts:111-114`.
+- `EXPO_PUBLIC_*` are inlined at JS-bundle time, so Metro is started with the screenshot env
+  baked in — the tool handles this; you don't set them after Metro is up.
+- Native Google Sign-In isn't registered for `com.boardsesh.app.dev`; use the email/password
+  auto-login path (the default).
+- `--flow` runs the committed Maestro flows with `-e APP_ID=com.boardsesh.app.dev` so
+  `launchApp` targets the dev-client package.

--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -251,7 +251,10 @@ who need to run local JS without compiling the app themselves. It produces a
 embeds `expo-dev-client`'s launcher, so the APK ships no bundled JS — it opens
 the "Development servers" screen and loads JavaScript from a Metro dev server.
 Start Metro with `vp run dev:mobile`, then enter its URL in the launcher (or
-switch between worktrees' servers from the dev menu).
+switch between worktrees' servers from the dev menu). The APK is **universal**
+(`arm64-v8a` + `x86_64`), so it also runs on an x86_64 emulator — see
+[Android emulator screenshots](./android-emulator-screenshots.md) for the local
+`vp run mobile:android-shots` flow that downloads and drives it automatically.
 
 It installs **side-by-side** with the production app. `app.config.ts` reads
 `BOARDSESH_APP_VARIANT=dev` (set as a job env var) and switches to:

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -1,4 +1,4 @@
-appId: com.boardsesh.app
+appId: ${APP_ID}
 name: app-store screenshots android
 ---
 # Play Store screenshots from the standalone screenshot APK. Unlike iOS, this APK already

--- a/packages/mobile/.maestro/onboarding-android.yaml
+++ b/packages/mobile/.maestro/onboarding-android.yaml
@@ -1,4 +1,4 @@
-appId: com.boardsesh.app
+appId: ${APP_ID}
 name: onboarding illustrations android
 ---
 # Android version of onboarding.yaml for the standalone screenshot APK. The

--- a/scripts/lib/android-app.ts
+++ b/scripts/lib/android-app.ts
@@ -1,0 +1,7 @@
+/// <reference types="node" />
+
+/** Deep-link scheme — identical for prod and dev variants (app.config.ts:136). */
+export const ANDROID_SCHEME = 'com.boardsesh.app';
+
+/** Package the dev-client APK installs under (built with BOARDSESH_APP_VARIANT=dev). */
+export const ANDROID_DEV_PACKAGE = 'com.boardsesh.app.dev';

--- a/scripts/lib/android-emulator.ts
+++ b/scripts/lib/android-emulator.ts
@@ -1,0 +1,158 @@
+/// <reference types="node" />
+
+/**
+ * Android AVD + emulator lifecycle for the local screenshot flow. Boots headless
+ * (works on a display-less Linux box; `adb exec-out screencap` captures correctly
+ * without a window) and reuses an already-running emulator so an agent can take
+ * many shots without rebooting.
+ */
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, openSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { commandExists, runCapture, runInherit, sleepSeconds } from './exec';
+import { SYSTEM_IMAGE, adbPath, avdmanagerPath, emulatorPath, resolveAndroidHome } from './android-sdk';
+
+const LOG = '[android-emulator]';
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const BOARDSESH_DIR = join(ROOT_DIR, '.boardsesh');
+const EMULATOR_LOG = join(BOARDSESH_DIR, 'android-emulator.log');
+
+export const AVD_NAME = 'boardsesh-pixel';
+const AVD_DEVICE_PROFILE = 'pixel_6';
+const EMULATOR_PORT = 5554;
+export const EMULATOR_SERIAL = `emulator-${EMULATOR_PORT}`;
+
+export function avdExists(name: string, env: NodeJS.ProcessEnv): boolean {
+  const result = runCapture(avdmanagerPath(resolveAndroidHome()), ['list', 'avd', '-c'], { env });
+  if (result.status !== 0) return false;
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .includes(name);
+}
+
+export function ensureAvd(env: NodeJS.ProcessEnv, name = AVD_NAME): void {
+  if (avdExists(name, env)) return;
+  const home = resolveAndroidHome();
+  console.log(`${LOG} Creating AVD ${name} (${SYSTEM_IMAGE}, ${AVD_DEVICE_PROFILE})...`);
+  // `echo no` declines the "create a custom hardware profile?" prompt.
+  const status = runInherit(
+    'sh',
+    [
+      '-c',
+      `echo no | "${avdmanagerPath(home)}" create avd -n "${name}" -k "${SYSTEM_IMAGE}" -d ${AVD_DEVICE_PROFILE} --force`,
+    ],
+    { env },
+  );
+  if (status !== 0) throw new Error(`Failed to create AVD ${name}`);
+}
+
+/** Serial of the first ready `emulator-*` device, or null. */
+export function resolveRunningEmulator(env: NodeJS.ProcessEnv): string | null {
+  const result = runCapture(adbPath(resolveAndroidHome()), ['devices'], { env });
+  if (result.status !== 0) return null;
+  const serial = result.stdout
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim().split(/\s+/))
+    .filter((parts) => parts[1] === 'device' && parts[0].startsWith('emulator-'))
+    .map((parts) => parts[0])[0];
+  return serial ?? null;
+}
+
+function waitForBoot(serial: string, env: NodeJS.ProcessEnv, timeoutSeconds = 300): boolean {
+  const adb = adbPath(resolveAndroidHome());
+  runCapture(adb, ['-s', serial, 'wait-for-device'], { env });
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    const booted = runCapture(adb, ['-s', serial, 'shell', 'getprop', 'sys.boot_completed'], { env });
+    if (booted.stdout.trim() === '1') {
+      // Dismiss the lock screen so the first screenshot isn't of the keyguard.
+      runCapture(adb, ['-s', serial, 'shell', 'input', 'keyevent', '82'], { env });
+      runCapture(adb, ['-s', serial, 'shell', 'wm', 'dismiss-keyguard'], { env });
+      return true;
+    }
+    sleepSeconds(2);
+  }
+  return false;
+}
+
+export interface BootOptions {
+  /** Reuse an already-running emulator instead of booting a new one (default true). */
+  reuse?: boolean;
+  /** Boot with `-no-window` (default true). */
+  headless?: boolean;
+}
+
+/** AVD to use — override with BOARDSESH_AVD_NAME to point at a pre-made AVD. */
+export function resolveAvdName(): string {
+  const override = process.env.BOARDSESH_AVD_NAME;
+  return override && override.length > 0 ? override : AVD_NAME;
+}
+
+function bootTimeoutSeconds(): number {
+  const raw = Number.parseInt(process.env.BOARDSESH_EMULATOR_BOOT_TIMEOUT ?? '', 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 300;
+}
+
+/** Boot (or reuse) the emulator and return its adb serial. */
+export function bootEmulator(env: NodeJS.ProcessEnv, options: BootOptions = {}): string {
+  const reuse = options.reuse ?? true;
+  const headless = options.headless ?? true;
+  const avdName = resolveAvdName();
+
+  if (reuse) {
+    const running = resolveRunningEmulator(env);
+    if (running) {
+      console.log(`${LOG} Reusing running emulator ${running}.`);
+      if (!waitForBoot(running, env, bootTimeoutSeconds()))
+        throw new Error(`Emulator ${running} did not finish booting`);
+      return running;
+    }
+  }
+
+  ensureAvd(env, avdName);
+  mkdirSync(BOARDSESH_DIR, { recursive: true });
+  const logFd = openSync(EMULATOR_LOG, 'w');
+
+  // GPU renderer is the most host-sensitive knob: swiftshader_indirect is the CI
+  // default, but a quirky headless host can override it (e.g. `guest` → lavapipe).
+  const gpu = process.env.BOARDSESH_EMULATOR_GPU || 'swiftshader_indirect';
+  const args = ['-avd', avdName, '-port', String(EMULATOR_PORT), '-no-snapshot', '-no-audio', '-no-boot-anim'];
+  args.push('-gpu', gpu, '-accel', 'auto');
+  if (headless) args.push('-no-window');
+  const extra = (process.env.BOARDSESH_EMULATOR_EXTRA_ARGS ?? '').trim();
+  if (extra) args.push(...extra.split(/\s+/));
+
+  // Headless swiftshader's GL context is steadier under a virtual X server; wrap
+  // with xvfb-run when there's no display and it's available.
+  let command = emulatorPath(resolveAndroidHome());
+  let commandArgs = args;
+  const useXvfb = headless && process.platform === 'linux' && !env.DISPLAY && commandExists('xvfb-run');
+  if (useXvfb) {
+    command = 'xvfb-run';
+    commandArgs = ['-a', emulatorPath(resolveAndroidHome()), ...args];
+  }
+
+  console.log(
+    `${LOG} Booting ${avdName} (headless=${headless}, gpu=${gpu}${useXvfb ? ', xvfb' : ''}); log: ${EMULATOR_LOG}`,
+  );
+  // Detached + unref so the emulator survives this process (keep-alive default).
+  const child = spawn(command, commandArgs, { env, detached: true, stdio: ['ignore', logFd, logFd] });
+  child.unref();
+
+  if (!waitForBoot(EMULATOR_SERIAL, env, bootTimeoutSeconds())) {
+    throw new Error(`Emulator did not finish booting within ${bootTimeoutSeconds()}s; see ${EMULATOR_LOG}`);
+  }
+  console.log(`${LOG} Emulator ${EMULATOR_SERIAL} booted.`);
+  return EMULATOR_SERIAL;
+}
+
+export function shutdownEmulator(serial: string, env: NodeJS.ProcessEnv): void {
+  console.log(`${LOG} Shutting down ${serial}...`);
+  runCapture(adbPath(resolveAndroidHome()), ['-s', serial, 'emu', 'kill'], { env });
+}
+
+export { EMULATOR_LOG };

--- a/scripts/lib/android-sdk.ts
+++ b/scripts/lib/android-sdk.ts
@@ -1,0 +1,225 @@
+/// <reference types="node" />
+
+/**
+ * Idempotent Android SDK + JDK bootstrap for the local emulator screenshot flow.
+ *
+ * Everything installs under ~/.cache/boardsesh/ so a clean Linux box (no Android
+ * Studio) becomes able to boot an emulator and run the RN dev-client with one
+ * command. If a real SDK already exists at $ANDROID_HOME we reuse it and only add
+ * the packages we need.
+ *
+ * Java note: sdkmanager/avdmanager (and the Gradle fallback build) are JVM tools
+ * that want JDK 21 — this box ships only JDK 26, which Gradle/the RN plugin reject.
+ * So we provision a Temurin 21 into the cache and point JAVA_HOME at it for every
+ * Java invocation. The emulator and adb are native binaries and need no JDK.
+ */
+
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { commandExists, runCapture, runInherit } from './exec';
+
+const LOG = '[android-sdk]';
+
+export const CACHE_ROOT = join(homedir(), '.cache', 'boardsesh');
+export const DEFAULT_SDK_HOME = join(CACHE_ROOT, 'android-sdk');
+export const JDK21_HOME = join(CACHE_ROOT, 'jdk-21');
+
+// Pinned Android command-line tools (linux). Bump deliberately; the build number
+// only gates sdkmanager itself, not which platform/image packages it can fetch.
+const CMDLINE_TOOLS_VERSION = '11076708';
+const CMDLINE_TOOLS_URL = `https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip`;
+
+// Latest Temurin 21 GA for linux/x64. Redirects to the actual tarball.
+const ADOPTIUM_JDK21_URL = 'https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse';
+
+// API level for the platform + system image. Matches CI (android-36).
+export const ANDROID_API_LEVEL = 36;
+export const SYSTEM_IMAGE = `system-images;android-${ANDROID_API_LEVEL};google_apis;x86_64`;
+export const BUILD_TOOLS_VERSION = `${ANDROID_API_LEVEL}.0.0`;
+
+// Core packages to boot an emulator and install/run an APK (no Java build needed).
+const SDK_PACKAGES_CORE = ['platform-tools', 'emulator', `platforms;android-${ANDROID_API_LEVEL}`, SYSTEM_IMAGE];
+// Extra packages the local Gradle fallback build needs.
+const SDK_PACKAGES_BUILD = [`build-tools;${BUILD_TOOLS_VERSION}`];
+
+export interface EnsureSdkOptions {
+  /** Also install build-tools — only needed for the local Gradle fallback build. */
+  includeBuildTools?: boolean;
+}
+
+export interface AndroidToolchain {
+  home: string;
+  java21: string | null;
+  env: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolve which SDK dir to use. Honour an already-populated $ANDROID_HOME (e.g. a
+ * contributor's Android Studio install); otherwise use our cache. The configured
+ * default on this box points at a non-existent path, so the existsSync gate matters.
+ */
+export function resolveAndroidHome(): string {
+  const configured = process.env.ANDROID_HOME ?? process.env.ANDROID_SDK_ROOT;
+  if (configured && (existsSync(join(configured, 'platform-tools')) || existsSync(join(configured, 'cmdline-tools')))) {
+    return configured;
+  }
+  return DEFAULT_SDK_HOME;
+}
+
+export function sdkmanagerPath(home: string): string {
+  return join(home, 'cmdline-tools', 'latest', 'bin', 'sdkmanager');
+}
+
+export function avdmanagerPath(home: string): string {
+  return join(home, 'cmdline-tools', 'latest', 'bin', 'avdmanager');
+}
+
+export function adbPath(home: string): string {
+  return join(home, 'platform-tools', 'adb');
+}
+
+export function emulatorPath(home: string): string {
+  return join(home, 'emulator', 'emulator');
+}
+
+/** Locate a JDK 21 (override env, our cache, a system install) without downloading. */
+function findJava21(): string | null {
+  const override = process.env.JAVA21_HOME ?? process.env.JAVA_21_HOME;
+  if (override && existsSync(join(override, 'bin', 'java'))) return override;
+  if (existsSync(join(JDK21_HOME, 'bin', 'java'))) return JDK21_HOME;
+
+  const searchDirs = ['/usr/lib/jvm', '/usr/java', join(homedir(), '.sdkman', 'candidates', 'java')];
+  for (const dir of searchDirs) {
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      if (!entry.includes('21')) continue;
+      const javaHome = join(dir, entry);
+      const javaBin = join(javaHome, 'bin', 'java');
+      if (!existsSync(javaBin)) continue;
+      const version = runCapture(javaBin, ['-version']);
+      if (/(version "21|openjdk 21|\b21\.\d)/.test(`${version.stderr}${version.stdout}`)) return javaHome;
+    }
+  }
+  return null;
+}
+
+function downloadJava21(): string {
+  console.log(
+    `${LOG} Provisioning Temurin JDK 21 (~190MB; sdkmanager/avdmanager/Gradle need it, this box has only JDK 26)...`,
+  );
+  mkdirSync(JDK21_HOME, { recursive: true });
+  const tarball = join(CACHE_ROOT, 'jdk-21.tar.gz');
+  const download = runCapture('curl', ['-fLs', '-o', tarball, ADOPTIUM_JDK21_URL]);
+  if (download.status !== 0) throw new Error(`Failed to download JDK 21: ${download.stderr || download.status}`);
+  // --strip-components=1 drops the tarball's top-level jdk-21.x dir so JDK21_HOME
+  // directly contains bin/, lib/, ...
+  const extract = runCapture('tar', ['-xzf', tarball, '-C', JDK21_HOME, '--strip-components=1']);
+  if (extract.status !== 0) throw new Error(`Failed to extract JDK 21: ${extract.stderr || extract.status}`);
+  rmSync(tarball, { force: true });
+  if (!existsSync(join(JDK21_HOME, 'bin', 'java'))) throw new Error('JDK 21 extracted but bin/java is missing');
+  return JDK21_HOME;
+}
+
+/** JDK 21 path, downloading a Temurin build into the cache when none is found. */
+export function resolveJava21(autoInstall = true): string | null {
+  const found = findJava21();
+  if (found) return found;
+  if (!autoInstall) return null;
+  return downloadJava21();
+}
+
+/** Augmented env: SDK paths on PATH, ANDROID_HOME/SDK_ROOT set, JAVA_HOME at JDK 21. */
+export function androidEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const home = resolveAndroidHome();
+  const java21 = findJava21();
+  const pathParts = [
+    join(home, 'cmdline-tools', 'latest', 'bin'),
+    join(home, 'platform-tools'),
+    join(home, 'emulator'),
+  ];
+  if (java21) pathParts.unshift(join(java21, 'bin'));
+  const env: NodeJS.ProcessEnv = {
+    ...base,
+    ANDROID_HOME: home,
+    ANDROID_SDK_ROOT: home,
+    PATH: `${pathParts.join(':')}:${base.PATH ?? ''}`,
+  };
+  if (java21) env.JAVA_HOME = java21;
+  return env;
+}
+
+function ensureCmdlineTools(home: string): void {
+  if (existsSync(sdkmanagerPath(home))) return;
+  if (!commandExists('unzip')) {
+    throw new Error('`unzip` is required to install the Android command-line tools but is not on PATH.');
+  }
+  console.log(`${LOG} Installing Android command-line tools (${CMDLINE_TOOLS_VERSION})...`);
+  mkdirSync(home, { recursive: true });
+  const zip = join(CACHE_ROOT, `cmdline-tools-${CMDLINE_TOOLS_VERSION}.zip`);
+  if (!existsSync(zip)) {
+    const download = runCapture('curl', ['-fLs', '-o', zip, CMDLINE_TOOLS_URL]);
+    if (download.status !== 0)
+      throw new Error(`Failed to download cmdline-tools: ${download.stderr || download.status}`);
+  }
+  const tmp = join(home, 'cmdline-tools', '.unzip-tmp');
+  rmSync(tmp, { recursive: true, force: true });
+  mkdirSync(tmp, { recursive: true });
+  const unzip = runCapture('unzip', ['-q', zip, '-d', tmp]);
+  if (unzip.status !== 0) throw new Error(`Failed to unzip cmdline-tools: ${unzip.stderr || unzip.status}`);
+  // The zip nests everything under a top-level `cmdline-tools/`; sdkmanager needs
+  // the layout cmdline-tools/latest/bin/sdkmanager.
+  const latest = join(home, 'cmdline-tools', 'latest');
+  rmSync(latest, { recursive: true, force: true });
+  renameSync(join(tmp, 'cmdline-tools'), latest);
+  rmSync(tmp, { recursive: true, force: true });
+  if (!existsSync(sdkmanagerPath(home))) throw new Error('cmdline-tools installed but sdkmanager is missing');
+}
+
+/** Map an sdkmanager package id to the on-disk path that proves it's installed. */
+function packageInstallPath(home: string, pkg: string): string {
+  if (pkg === 'platform-tools') return join(home, 'platform-tools', 'adb');
+  if (pkg === 'emulator') return join(home, 'emulator', 'emulator');
+  // `a;b;c` -> a/b/c
+  return join(home, ...pkg.split(';'));
+}
+
+function acceptLicenses(home: string, env: NodeJS.ProcessEnv): void {
+  // `yes` floods "y" to accept every license; its SIGPIPE exit is expected, so the
+  // status is ignored.
+  runCapture('sh', ['-c', `yes | "${sdkmanagerPath(home)}" --sdk_root="${home}" --licenses`], { env });
+}
+
+/**
+ * Ensure the SDK is present: cmdline-tools, platform-tools, emulator, platform, and
+ * an x86_64 system image (plus build-tools when includeBuildTools is set). No-op when
+ * everything is already installed.
+ */
+export function ensureAndroidSdk(options: EnsureSdkOptions = {}): AndroidToolchain {
+  const home = resolveAndroidHome();
+  mkdirSync(home, { recursive: true });
+
+  const wanted = [...SDK_PACKAGES_CORE, ...(options.includeBuildTools ? SDK_PACKAGES_BUILD : [])];
+  const needCmdlineTools = !existsSync(sdkmanagerPath(home));
+  const missing = wanted.filter((pkg) => !existsSync(packageInstallPath(home, pkg)));
+
+  // sdkmanager/avdmanager are Java tools — provision JDK 21 only when we must run
+  // them (a fresh install or missing packages). The download-only happy path on an
+  // already-bootstrapped box needs no JDK, so don't pull one just to build the env.
+  const java21 = needCmdlineTools || missing.length > 0 ? resolveJava21(true) : resolveJava21(false);
+
+  if (needCmdlineTools) ensureCmdlineTools(home);
+  const env = androidEnv(process.env);
+  if (java21) env.JAVA_HOME = java21;
+
+  if (missing.length > 0) {
+    acceptLicenses(home, env);
+    console.log(`${LOG} Installing SDK packages: ${missing.join(', ')}`);
+    const status = runInherit(sdkmanagerPath(home), [`--sdk_root=${home}`, ...missing], { env });
+    if (status !== 0) throw new Error(`sdkmanager failed installing: ${missing.join(', ')}`);
+  } else {
+    console.log(`${LOG} SDK packages already present.`);
+  }
+
+  return { home, java21, env };
+}

--- a/scripts/lib/exec.ts
+++ b/scripts/lib/exec.ts
@@ -1,0 +1,47 @@
+/// <reference types="node" />
+
+/**
+ * Tiny spawn helpers shared by the Android emulator tooling (scripts/lib/android-*,
+ * scripts/mobile-android-*). Kept dependency-free so the lib layer never imports a
+ * sibling orchestrator script.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+export interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RunOptions {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+}
+
+/** Run a command, capturing stdout/stderr. Never throws on a non-zero exit. */
+export function runCapture(command: string, args: string[], options: RunOptions = {}): RunResult {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    env: options.env,
+    cwd: options.cwd,
+    // sdkmanager listings / `unzip -l` on a big APK overflow the 1MB default.
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return { status: result.status ?? 1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+/** Run a command streaming its stdio to the console. Returns the exit code. */
+export function runInherit(command: string, args: string[], options: RunOptions = {}): number {
+  const result = spawnSync(command, args, { stdio: 'inherit', env: options.env, cwd: options.cwd });
+  return result.status ?? 1;
+}
+
+/** True if `command` resolves on PATH (or is an absolute path that exists/executes). */
+export function commandExists(command: string): boolean {
+  return spawnSync('command', ['-v', command], { shell: true, stdio: 'ignore' }).status === 0;
+}
+
+export function sleepSeconds(seconds: number): void {
+  spawnSync('sleep', [String(seconds)]);
+}

--- a/scripts/mobile-android-apk.ts
+++ b/scripts/mobile-android-apk.ts
@@ -1,0 +1,216 @@
+/// <reference types="node" />
+
+/**
+ * Resolve a ready Android dev-client APK for the local emulator screenshot flow.
+ *
+ * Order of preference:
+ *   1. --app-path <apk>           (bring your own)
+ *   2. cached/downloaded universal CI dev-client APK from the latest
+ *      rn-android-dev-* release (no Java/Gradle needed), guarded so an arm64-only
+ *      APK never gets installed on the x86_64 emulator
+ *   3. local Gradle build (BOARDSESH_APP_VARIANT=dev, x86_64), cached by a hash of
+ *      the native inputs — the offline / native-deps-changed fallback
+ *
+ * The APK has no bundled JS: it boots expo-dev-client and loads JS from Metro, so
+ * the same cached APK serves every screenshot run.
+ *
+ * Usage:
+ *   vp run mobile:android-apk                     # download (or build) and print the path
+ *   vp run mobile:android-apk -- --build-local    # force a local Gradle build
+ *   vp run mobile:android-apk -- --apk-tag rn-android-dev-42
+ */
+
+import { createHash, type Hash } from 'node:crypto';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { commandExists, runCapture, runInherit } from './lib/exec';
+import { ensureAndroidSdk } from './lib/android-sdk';
+
+const LOG = '[mobile:android-apk]';
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ANDROID_CACHE = join(homedir(), '.cache', 'boardsesh', 'android');
+const DOWNLOAD_DIR = join(ANDROID_CACHE, 'downloaded');
+const LOCAL_BUILD_DIR = join(ANDROID_CACHE, 'local-build');
+const APK_ASSET = 'boardsesh-dev-android.apk';
+// The emulator is x86_64 (the KVM fast path); the APK must carry that ABI.
+const REQUIRED_ABI = 'x86_64';
+
+export interface EnsureApkOptions {
+  buildLocal?: boolean;
+  apkTag?: string;
+  appPath?: string;
+}
+
+/** Latest rn-android-dev-N tag by build number (not list order). Null if none/unreachable. */
+export function resolveLatestDevTag(): string | null {
+  const result = runCapture('gh', ['release', 'list', '--limit', '50']);
+  if (result.status !== 0) return null;
+  const tags = result.stdout
+    .split(/\r?\n/)
+    .flatMap((line) => line.split(/\s+/))
+    .filter((token) => /^rn-android-dev-\d+$/.test(token))
+    .sort((a, b) => Number(a.replace(/\D/g, '')) - Number(b.replace(/\D/g, '')));
+  return tags[tags.length - 1] ?? null;
+}
+
+/** True if the APK ships native libs for `abi` (lib/<abi>/...). */
+function apkHasAbi(apkPath: string, abi: string): boolean {
+  const listing = runCapture('unzip', ['-l', apkPath]);
+  if (listing.status !== 0) return false;
+  return listing.stdout.includes(`lib/${abi}/`);
+}
+
+function downloadDevApk(tag: string): string {
+  const dir = join(DOWNLOAD_DIR, tag);
+  const apk = join(dir, APK_ASSET);
+  if (existsSync(apk)) {
+    console.log(`${LOG} Using cached ${tag} APK: ${apk}`);
+    return apk;
+  }
+  if (!commandExists('gh')) throw new Error('gh is not on PATH; cannot download the dev-client APK');
+  mkdirSync(dir, { recursive: true });
+  console.log(`${LOG} Downloading ${tag} dev-client APK...`);
+  const status = runInherit('gh', ['release', 'download', tag, '--pattern', APK_ASSET, '--dir', dir], {
+    env: process.env,
+  });
+  if (status !== 0) throw new Error(`gh release download ${tag} failed`);
+  if (!existsSync(apk)) throw new Error(`Downloaded ${tag} but ${APK_ASSET} is missing`);
+  // Guard against a truncated/corrupt download being cached forever: a valid APK is
+  // a readable zip. If not, delete it so the next run re-downloads (or falls back).
+  if (runCapture('unzip', ['-l', apk]).status !== 0) {
+    rmSync(apk, { force: true });
+    throw new Error(`Downloaded ${tag} APK is not a valid archive (removed); retry or use --build-local`);
+  }
+  return apk;
+}
+
+function hashDir(dir: string, root: string, hash: Hash): void {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'build' || entry.name === '.cxx') continue;
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) hashDir(abs, root, hash);
+    else if (entry.isFile()) hash.update(relative(root, abs)).update(readFileSync(abs));
+  }
+}
+
+/** Short hash over the inputs that change the native build (mirrors CI's cache key, broadened). */
+function nativeInputHash(): string {
+  const hash = createHash('sha256');
+  const files = ['packages/mobile/app.config.ts', 'packages/mobile/package.json', 'package.json', 'bun.lock'];
+  const dirs = ['packages/mobile/plugins', 'packages/mobile/modules', 'patches'];
+  for (const rel of files) {
+    const abs = join(ROOT_DIR, rel);
+    if (existsSync(abs)) hash.update(rel).update(readFileSync(abs));
+  }
+  for (const rel of dirs) {
+    const abs = join(ROOT_DIR, rel);
+    if (existsSync(abs)) hashDir(abs, ROOT_DIR, hash);
+  }
+  return hash.digest('hex').slice(0, 16);
+}
+
+function buildDevApkLocally(): string {
+  const hash = nativeInputHash();
+  const outDir = join(LOCAL_BUILD_DIR, hash);
+  const cachedApk = join(outDir, 'app-debug.apk');
+  if (existsSync(cachedApk)) {
+    console.log(`${LOG} Using cached local build (${hash}): ${cachedApk}`);
+    return cachedApk;
+  }
+
+  // The local build needs build-tools + JDK 21 (the gradle/RN toolchain).
+  const toolchain = ensureAndroidSdk({ includeBuildTools: true });
+  if (!toolchain.java21) {
+    throw new Error('Local APK build needs JDK 21; run `vp run mobile:android-doctor -- --build` first.');
+  }
+  const buildEnv: NodeJS.ProcessEnv = {
+    ...toolchain.env,
+    BOARDSESH_APP_VARIANT: 'dev',
+    JAVA_HOME: toolchain.java21,
+    // The Sentry Gradle upload task is incompatible with the Expo-generated Gradle
+    // version; keep runtime Sentry but never let the upload task fail the build.
+    SENTRY_DISABLE_AUTO_UPLOAD: 'true',
+  };
+
+  const mobileDir = join(ROOT_DIR, 'packages', 'mobile');
+  console.log(`${LOG} expo prebuild (android, dev variant)...`);
+  if (
+    runInherit('bunx', ['expo', 'prebuild', '--platform', 'android', '--clean'], { env: buildEnv, cwd: mobileDir }) !==
+    0
+  ) {
+    throw new Error('expo prebuild --platform android failed');
+  }
+
+  const androidDir = join(mobileDir, 'android');
+  const gradlew = join(androidDir, 'gradlew');
+  const gradleArgs = [
+    'assembleDebug',
+    `-PreactNativeArchitectures=${REQUIRED_ABI}`,
+    `-PboardseshAbiFilters=${REQUIRED_ABI}`,
+    '--no-daemon',
+    '--console=plain',
+  ];
+  console.log(`${LOG} gradlew assembleDebug (${REQUIRED_ABI}); first build is slow (NDK + Hermes)...`);
+  let status = runInherit(gradlew, gradleArgs, { env: buildEnv, cwd: androidDir });
+  if (status !== 0) {
+    // A cold New-Architecture codegen race can fail the first build; retry once.
+    console.log(`${LOG} gradle build failed once; retrying...`);
+    status = runInherit(gradlew, gradleArgs, { env: buildEnv, cwd: androidDir });
+    if (status !== 0) throw new Error('gradlew assembleDebug failed');
+  }
+
+  const built = join(androidDir, 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');
+  if (!existsSync(built)) throw new Error(`gradle reported success but ${built} is missing`);
+  mkdirSync(outDir, { recursive: true });
+  copyFileSync(built, cachedApk);
+  console.log(`${LOG} Cached local build: ${cachedApk}`);
+  return cachedApk;
+}
+
+/** Resolve a ready APK path per the preference order above. */
+export function ensureAndroidApk(options: EnsureApkOptions = {}): string {
+  if (options.appPath) {
+    if (!existsSync(options.appPath)) throw new Error(`--app-path not found: ${options.appPath}`);
+    return options.appPath;
+  }
+  if (options.buildLocal) return buildDevApkLocally();
+
+  try {
+    const tag = options.apkTag ?? resolveLatestDevTag();
+    if (!tag) throw new Error('no rn-android-dev-* release found');
+    const apk = downloadDevApk(tag);
+    if (apkHasAbi(apk, REQUIRED_ABI)) return apk;
+    console.warn(
+      `${LOG} ${tag} APK has no ${REQUIRED_ABI} ABI (the CI dev-client build is not universal yet). Building locally instead.`,
+    );
+  } catch (error) {
+    console.warn(
+      `${LOG} download path unavailable (${error instanceof Error ? error.message : String(error)}); building locally instead.`,
+    );
+  }
+  return buildDevApkLocally();
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const args = argv.filter((argument) => argument !== '--');
+  const buildLocal = args.includes('--build-local');
+  const tagIndex = args.indexOf('--apk-tag');
+  const apkTag = tagIndex >= 0 ? args[tagIndex + 1] : undefined;
+  const pathIndex = args.indexOf('--app-path');
+  const appPath = pathIndex >= 0 ? resolve(args[pathIndex + 1]) : undefined;
+  try {
+    const apk = ensureAndroidApk({ buildLocal, apkTag, appPath });
+    console.log(`${LOG} APK ready: ${apk}`);
+    return 0;
+  } catch (error) {
+    console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/mobile-android-doctor.ts
+++ b/scripts/mobile-android-doctor.ts
@@ -1,0 +1,105 @@
+/// <reference types="node" />
+
+/**
+ * Bootstrap the Android SDK + JDK 21 and report what's ready for the local
+ * emulator screenshot flow (vp run mobile:android-shots).
+ *
+ * Usage:
+ *   vp run mobile:android-doctor               # bootstrap (download path tools)
+ *   vp run mobile:android-doctor -- --build    # also install build-tools (Gradle fallback)
+ *   vp run mobile:android-doctor -- --check    # report only, don't install anything
+ */
+
+import { existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { commandExists, runCapture } from './lib/exec';
+import {
+  ANDROID_API_LEVEL,
+  adbPath,
+  androidEnv,
+  avdmanagerPath,
+  emulatorPath,
+  ensureAndroidSdk,
+  resolveAndroidHome,
+  resolveJava21,
+} from './lib/android-sdk';
+import { avdExists, resolveAvdName } from './lib/android-emulator';
+import { resolveLatestDevTag } from './mobile-android-apk';
+
+const LOG = '[mobile:android-doctor]';
+
+function ok(label: string, detail: string): void {
+  console.log(`  ✓ ${label.padEnd(22)} ${detail}`);
+}
+
+function warn(label: string, detail: string): void {
+  console.log(`  ✗ ${label.padEnd(22)} ${detail}`);
+}
+
+function reportLatestDevRelease(): void {
+  if (!commandExists('gh')) {
+    warn('dev-client release', 'gh not on PATH — cannot resolve the cached APK (use --build-local)');
+    return;
+  }
+  const tag = resolveLatestDevTag();
+  if (tag) ok('dev-client release', `${tag} (latest)`);
+  else warn('dev-client release', 'gh unauthenticated/offline or no rn-android-dev-* release found');
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const args = argv.filter((argument) => argument !== '--');
+  const checkOnly = args.includes('--check');
+  const includeBuildTools = args.includes('--build');
+
+  console.log(`${LOG} Android emulator screenshot environment\n`);
+
+  // Host capabilities (read-only).
+  const kvm = existsSync('/dev/kvm');
+  if (kvm) ok('KVM', '/dev/kvm present — hardware-accelerated x86_64 emulation');
+  else warn('KVM', '/dev/kvm missing — x86_64 emulation will be slow (TCG)');
+
+  const systemJava = runCapture('java', ['-version']);
+  ok('system java', (systemJava.stderr || systemJava.stdout).split(/\r?\n/)[0] || 'unknown');
+
+  if (!checkOnly) {
+    try {
+      ensureAndroidSdk({ includeBuildTools });
+    } catch (error) {
+      warn('bootstrap', error instanceof Error ? error.message : String(error));
+      return 1;
+    }
+  }
+
+  const home = resolveAndroidHome();
+  ok('ANDROID_HOME', home);
+  ok('API level', String(ANDROID_API_LEVEL));
+
+  const java21 = resolveJava21(false);
+  if (java21) ok('JDK 21', java21);
+  else warn('JDK 21', checkOnly ? 'not provisioned (run without --check)' : 'missing');
+
+  for (const [label, path] of [
+    ['adb', adbPath(home)],
+    ['emulator', emulatorPath(home)],
+    ['avdmanager', avdmanagerPath(home)],
+  ] as const) {
+    if (existsSync(path)) ok(label, path);
+    else warn(label, checkOnly ? 'not installed (run without --check)' : 'missing');
+  }
+
+  const avdName = resolveAvdName();
+  if (avdExists(avdName, androidEnv())) ok('AVD', `${avdName} ready`);
+  else warn('AVD', `${avdName} not created yet (created on first \`vp run mobile:android-shots\`)`);
+
+  if (commandExists('maestro')) ok('maestro', 'on PATH (--flow runs available)');
+  else warn('maestro', 'not on PATH (only needed for --flow Maestro runs)');
+
+  reportLatestDevRelease();
+
+  console.log(`\n${LOG} Done. Take screenshots with: vp run mobile:android-shots`);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/mobile-android-shots.ts
+++ b/scripts/mobile-android-shots.ts
@@ -1,0 +1,537 @@
+/// <reference types="node" />
+
+/**
+ * Quick Android-emulator screenshots of the live RN app (packages/mobile/).
+ *
+ * Boots an x86_64 emulator (the fast KVM path on Linux/Intel), installs a cached
+ * dev-client APK, starts Metro, wires `adb reverse` so the emulator reaches it,
+ * launches the app, and captures screens with `adb exec-out screencap`. The cached
+ * APK carries no JS — it loads from Metro — so JS changes show up without a rebuild.
+ *
+ * Usage:
+ *   vp run mobile:android-shots                       # boot + install + Metro + launch, then hold Metro
+ *   vp run mobile:android-shots -- --to climbs --label climbs --shutdown   # one-shot: boot, shoot, tear down
+ *   vp run mobile:android-shots -- screenshot --to board-view --label board   # shoot a running emulator
+ *   vp run mobile:android-shots -- navigate --to discover                  # deep-link only
+ *   vp run mobile:android-shots -- --flow app-store                        # run the Maestro flow
+ *   vp run mobile:android-shots -- shutdown                                # stop emulator + Metro
+ *
+ * Screenshots land in .boardsesh/android-screenshots/NN-<label>.png (absolute paths
+ * printed). Auto-login (prod test account) is on by default via EXPO_PUBLIC_SCREENSHOT_MODE;
+ * pass --no-screenshot-mode for the plain app, and set SCREENSHOT_USER_PASSWORD for the
+ * prod test account (the seeded test/test pair only exists on --backend local).
+ *
+ * Recommended agent flow: run the bare command in the background (it holds Metro),
+ * then use the `screenshot`/`navigate` subcommands in the foreground to grab shots.
+ */
+
+import { type ChildProcess, spawnSync } from 'node:child_process';
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { commandExists, runCapture, runInherit, sleepSeconds } from './lib/exec';
+import { adbPath, androidEnv, ensureAndroidSdk, resolveAndroidHome } from './lib/android-sdk';
+import { bootEmulator, resolveRunningEmulator, shutdownEmulator } from './lib/android-emulator';
+import { ANDROID_DEV_PACKAGE, ANDROID_SCHEME } from './lib/android-app';
+import { ensureAndroidApk } from './mobile-android-apk';
+import {
+  DEFAULT_USER_EMAIL,
+  DEFAULT_USER_PASSWORD,
+  METRO_PORT,
+  type ScreenshotOptions,
+  applyCleanAndroidStatusBar,
+  buildScreenshotEnv,
+  clearAndroidStatusBar,
+  deviceSlug,
+  homeReadyMarkerCount,
+  metroDevClientUrl,
+  portInUse,
+  prewarmMetroBundle,
+  startMetro,
+  stopMetro,
+  waitForHomeReady,
+  waitForMetro,
+} from './mobile-screenshots';
+
+const LOG = '[mobile:android-shots]';
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MAESTRO_DIR = join(ROOT_DIR, 'packages', 'mobile', '.maestro');
+const DEFAULT_OUT_DIR = join(ROOT_DIR, '.boardsesh', 'android-screenshots');
+
+// Friendly screen names -> deep-link routes (the screenshot-mode params are app
+// code; see packages/mobile/src/lib/screenshot-mode.ts and the .maestro flows).
+const SCREEN_ROUTES: Record<string, string> = {
+  home: 'home',
+  climbs: 'climbs',
+  discover: 'discover',
+  profile: 'profile',
+  record: 'record',
+  'board-view': 'climbs?screenshotOpenFirst=1',
+  'board-sheet': 'climbs?screenshotOpenBoardSheet=1',
+  'session-detail': 'profile?screenshotTab=sessions',
+  logbook: 'profile?screenshotTab=logbook',
+  progress: 'profile?screenshotTab=progress',
+};
+
+type ShotsCommand = 'run' | 'screenshot' | 'navigate' | 'shutdown';
+
+interface ShotsOptions {
+  command: ShotsCommand;
+  /** Screen name (SCREEN_ROUTES key) or a raw deep-link route. */
+  to: string | null;
+  label: string | null;
+  outDir: string;
+  /** Tear down emulator + Metro after the run instead of holding Metro alive. */
+  shutdown: boolean;
+  /** Inject EXPO_PUBLIC_SCREENSHOT_MODE (auto-login, locked theme) into the Metro bundle. */
+  screenshotMode: boolean;
+  flow: 'app-store' | 'onboarding' | null;
+  buildLocal: boolean;
+  apkTag: string | null;
+  appPath: string | null;
+  backend: 'prod' | 'local';
+  settleSeconds: number;
+  headless: boolean;
+}
+
+function expectValue(flag: string, value: string | undefined): string {
+  if (value === undefined || value.startsWith('--')) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function expectEnum(flag: string, value: string | undefined, allowed: readonly string[]): string {
+  const resolved = expectValue(flag, value);
+  if (!allowed.includes(resolved)) throw new Error(`${flag} must be one of: ${allowed.join(', ')} (got "${resolved}")`);
+  return resolved;
+}
+
+function parseShotsArgs(argv: readonly string[]): ShotsOptions {
+  const args = argv.filter((argument) => argument !== '--');
+  const options: ShotsOptions = {
+    command: 'run',
+    to: null,
+    label: null,
+    outDir: DEFAULT_OUT_DIR,
+    shutdown: false,
+    screenshotMode: true,
+    flow: null,
+    buildLocal: false,
+    apkTag: null,
+    appPath: null,
+    backend: 'prod',
+    settleSeconds: 3,
+    headless: true,
+  };
+
+  let index = 0;
+  if (args[index] && !args[index].startsWith('--')) {
+    const sub = args[index];
+    if (sub === 'screenshot' || sub === 'shot') options.command = 'screenshot';
+    else if (sub === 'navigate' || sub === 'nav') options.command = 'navigate';
+    else if (sub === 'shutdown') options.command = 'shutdown';
+    else if (sub === 'run') options.command = 'run';
+    else throw new Error(`Unknown subcommand: ${sub} (expected screenshot | navigate | shutdown)`);
+    index++;
+  }
+
+  for (; index < args.length; index++) {
+    const flag = args[index];
+    const value = args[index + 1];
+    switch (flag) {
+      case '--to':
+        options.to = expectValue(flag, value);
+        index++;
+        break;
+      case '--label':
+        options.label = expectValue(flag, value);
+        index++;
+        break;
+      case '--out':
+        options.outDir = resolve(expectValue(flag, value));
+        index++;
+        break;
+      case '--flow':
+        options.flow = expectEnum(flag, value, ['app-store', 'onboarding']) as 'app-store' | 'onboarding';
+        index++;
+        break;
+      case '--backend':
+        options.backend = expectEnum(flag, value, ['prod', 'local']) as 'prod' | 'local';
+        index++;
+        break;
+      case '--apk-tag':
+        options.apkTag = expectValue(flag, value);
+        index++;
+        break;
+      case '--app-path':
+        options.appPath = resolve(expectValue(flag, value));
+        index++;
+        break;
+      case '--settle': {
+        const seconds = Number(expectValue(flag, value));
+        if (!Number.isFinite(seconds) || seconds < 0) throw new Error('--settle requires a non-negative number');
+        options.settleSeconds = seconds;
+        index++;
+        break;
+      }
+      case '--build-local':
+        options.buildLocal = true;
+        break;
+      case '--shutdown':
+        options.shutdown = true;
+        break;
+      case '--keep-alive':
+        options.shutdown = false;
+        break;
+      case '--no-screenshot-mode':
+        options.screenshotMode = false;
+        break;
+      case '--windowed':
+        options.headless = false;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+/** Put the cache SDK on PATH so reused helpers that call bare `adb` resolve it. */
+function applyAndroidPath(env: NodeJS.ProcessEnv): void {
+  process.env.PATH = env.PATH;
+  process.env.ANDROID_HOME = env.ANDROID_HOME;
+  process.env.ANDROID_SDK_ROOT = env.ANDROID_SDK_ROOT;
+  if (env.JAVA_HOME) process.env.JAVA_HOME = env.JAVA_HOME;
+}
+
+function adb(serial: string, args: string[], env: NodeJS.ProcessEnv) {
+  return runCapture(adbPath(resolveAndroidHome()), ['-s', serial, ...args], { env });
+}
+
+// Conservative allowlist of deep-link route characters. The route is single-quoted
+// into an `adb shell` command string, so reject anything that could break out of the
+// quotes or inject device-shell commands (a raw `--to` is user-controlled).
+const SAFE_ROUTE = /^[A-Za-z0-9?=&_.:/%-]+$/;
+
+/** Fire a VIEW intent for a deep link. The URL is single-quoted for the device shell. */
+function navigate(serial: string, env: NodeJS.ProcessEnv, screen: string): void {
+  const route = SCREEN_ROUTES[screen] ?? screen;
+  if (!SAFE_ROUTE.test(route)) {
+    throw new Error(`Unsafe --to route: ${route} (allowed: ${SAFE_ROUTE.source})`);
+  }
+  const url = `${ANDROID_SCHEME}://${route}`;
+  console.log(`${LOG} Navigating to ${url}`);
+  adb(serial, ['shell', `am start -a android.intent.action.VIEW -d '${url}'`], env);
+}
+
+function nextIndex(outDir: string): number {
+  if (!existsSync(outDir)) return 0;
+  const indices = readdirSync(outDir)
+    .map((file) => /^(\d+)-/.exec(file)?.[1])
+    .filter((found): found is string => Boolean(found))
+    .map(Number);
+  return indices.length > 0 ? Math.max(...indices) + 1 : 0;
+}
+
+function captureScreenshot(serial: string, env: NodeJS.ProcessEnv, label: string, outDir: string): string {
+  mkdirSync(outDir, { recursive: true });
+  const index = String(nextIndex(outDir)).padStart(2, '0');
+  const file = join(outDir, `${index}-${deviceSlug(label)}.png`);
+  // exec-out streams raw PNG bytes (no on-device file, no CRLF mangling) — correct
+  // on a headless `-no-window` emulator. Write straight to the file descriptor.
+  const fd = openSync(file, 'w');
+  try {
+    const result = spawnSync(adbPath(resolveAndroidHome()), ['-s', serial, 'exec-out', 'screencap', '-p'], {
+      stdio: ['ignore', fd, 'inherit'],
+      env,
+    });
+    if (result.status !== 0) throw new Error(`adb screencap exited ${result.status ?? 'null'}`);
+  } finally {
+    closeSync(fd);
+  }
+  if (!existsSync(file) || statSync(file).size < 1000) throw new Error('screencap produced an empty image');
+  return file;
+}
+
+function runMaestroFlow(serial: string, options: ShotsOptions, env: NodeJS.ProcessEnv): void {
+  if (!commandExists('maestro')) {
+    throw new Error('Maestro is not on PATH; install it (https://maestro.mobile.dev) to use --flow.');
+  }
+  const flowFile = join(
+    MAESTRO_DIR,
+    options.flow === 'onboarding' ? 'onboarding-android.yaml' : 'app-store-android.yaml',
+  );
+  if (!existsSync(flowFile)) throw new Error(`flow not found: ${flowFile}`);
+  const email = process.env.SCREENSHOT_USER_EMAIL ?? DEFAULT_USER_EMAIL;
+  const password = process.env.SCREENSHOT_USER_PASSWORD ?? DEFAULT_USER_PASSWORD;
+  const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-android-flow-'));
+  try {
+    console.log(`${LOG} Running Maestro flow ${options.flow} on ${serial}...`);
+    const status = runInherit(
+      'maestro',
+      [
+        '--device',
+        serial,
+        'test',
+        flowFile,
+        '-e',
+        `APP_ID=${ANDROID_DEV_PACKAGE}`,
+        '-e',
+        `SCREENSHOT_USER_EMAIL=${email}`,
+        '-e',
+        `SCREENSHOT_USER_PASSWORD=${password}`,
+      ],
+      { env, cwd: captureDir },
+    );
+    if (status !== 0) throw new Error(`Maestro exited ${status}`);
+    mkdirSync(options.outDir, { recursive: true });
+    const pngs = readdirSync(captureDir).filter((file) => file.endsWith('.png'));
+    for (const png of pngs) cpSync(join(captureDir, png), join(options.outDir, png));
+    console.log(`${LOG} Copied ${pngs.length} flow screenshot(s) to ${options.outDir}`);
+  } finally {
+    rmSync(captureDir, { recursive: true, force: true });
+  }
+}
+
+/** Minimal ScreenshotOptions for buildScreenshotEnv (it reads theme/variant/workout/backend). */
+function screenshotEnvOptions(options: ShotsOptions): ScreenshotOptions {
+  return {
+    platform: 'android',
+    flow: 'app-store',
+    backend: options.backend,
+    devices: [],
+    androidDevice: 'Pixel 6',
+    appLocales: [],
+    variant: null,
+    theme: 'dark',
+    workout: null,
+    appPath: null,
+    shutdown: false,
+  };
+}
+
+function printReadyBanner(serial: string): void {
+  console.log(`\n${LOG} Ready. Emulator ${serial} | Metro http://localhost:${METRO_PORT}`);
+  console.log(`${LOG}   shot:      vp run mobile:android-shots -- screenshot --to climbs --label climbs`);
+  console.log(`${LOG}   navigate:  vp run mobile:android-shots -- navigate --to board-view`);
+  console.log(`${LOG}   stop:      vp run mobile:android-shots -- shutdown`);
+  console.log(`${LOG} Holding Metro — stop this process (or run \`shutdown\`) to release it.\n`);
+}
+
+function attachToEmulator(): { serial: string; env: NodeJS.ProcessEnv } {
+  const env = androidEnv();
+  applyAndroidPath(env);
+  if (!existsSync(adbPath(resolveAndroidHome()))) {
+    throw new Error('Android SDK not bootstrapped — run `vp run mobile:android-doctor` first.');
+  }
+  const serial = resolveRunningEmulator(env);
+  if (!serial) {
+    throw new Error('No running emulator — start one with `vp run mobile:android-shots` (in the background) first.');
+  }
+  return { serial, env };
+}
+
+function runScreenshotSubcommand(options: ShotsOptions): number {
+  const { serial, env } = attachToEmulator();
+  if (options.to) {
+    navigate(serial, env, options.to);
+    sleepSeconds(options.settleSeconds);
+  }
+  const label = options.label ?? options.to ?? 'shot';
+  const file = captureScreenshot(serial, env, label, options.outDir);
+  console.log(`${LOG} Saved ${file}`);
+  return 0;
+}
+
+function runNavigateSubcommand(options: ShotsOptions): number {
+  if (!options.to) throw new Error('navigate requires --to <screen>');
+  const { serial, env } = attachToEmulator();
+  navigate(serial, env, options.to);
+  return 0;
+}
+
+function killMetro(): void {
+  const result = runCapture('lsof', ['-nP', `-iTCP:${METRO_PORT}`, '-sTCP:LISTEN', '-t']);
+  const pids = result.stdout.split(/\s+/).filter(Boolean);
+  for (const pid of pids) runCapture('kill', [pid]);
+  if (pids.length > 0) console.log(`${LOG} Stopped Metro on port ${METRO_PORT}.`);
+}
+
+function runShutdownSubcommand(): number {
+  const env = androidEnv();
+  applyAndroidPath(env);
+  const serial = resolveRunningEmulator(env);
+  if (serial) {
+    clearAndroidStatusBar(serial);
+    shutdownEmulator(serial, env);
+  } else {
+    console.log(`${LOG} No running emulator.`);
+  }
+  killMetro();
+  return 0;
+}
+
+/**
+ * Hold the process alive while Metro runs (keep-alive). On Ctrl-C / SIGTERM, ask
+ * Metro's process group to stop, escalate to SIGKILL after a grace period so an
+ * unresponsive bundler doesn't orphan and hold the port, and resolve only once it
+ * has actually exited.
+ */
+function blockUntilExit(metro: ChildProcess): Promise<void> {
+  return new Promise<void>((resolvePromise) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      process.removeListener('SIGINT', onSignal);
+      process.removeListener('SIGTERM', onSignal);
+      resolvePromise();
+    };
+    const onSignal = (): void => {
+      stopMetro(metro);
+      if (metro.pid !== undefined) {
+        const pid = metro.pid;
+        setTimeout(() => {
+          try {
+            process.kill(-pid, 'SIGKILL');
+          } catch {
+            // already gone
+          }
+        }, 5000).unref();
+      }
+    };
+    process.once('SIGINT', onSignal);
+    process.once('SIGTERM', onSignal);
+    metro.on('exit', finish);
+  });
+}
+
+async function runFullPipeline(options: ShotsOptions): Promise<number> {
+  const toolchain = ensureAndroidSdk();
+  applyAndroidPath(toolchain.env);
+  const env = process.env;
+
+  const serial = bootEmulator(env, { headless: options.headless });
+
+  const apk = ensureAndroidApk({
+    buildLocal: options.buildLocal,
+    apkTag: options.apkTag ?? undefined,
+    appPath: options.appPath ?? undefined,
+  });
+
+  console.log(`${LOG} Installing ${apk} as ${ANDROID_DEV_PACKAGE}...`);
+  adb(serial, ['uninstall', ANDROID_DEV_PACKAGE], env); // ignore failure (not installed yet)
+  const install = runInherit(adbPath(resolveAndroidHome()), ['-s', serial, 'install', '-r', apk], { env });
+  if (install !== 0) throw new Error(`adb install failed (exit ${install})`);
+  adb(serial, ['shell', 'pm', 'clear', ANDROID_DEV_PACKAGE], env); // fresh: signed out, no stale board
+  applyCleanAndroidStatusBar(serial);
+
+  if (portInUse(METRO_PORT)) {
+    throw new Error(`port ${METRO_PORT} is already in use; stop it or set BOARDSESH_METRO_PORT to a free port.`);
+  }
+  const metroEnv = options.screenshotMode
+    ? buildScreenshotEnv(screenshotEnvOptions(options), process.env, null)
+    : { ...process.env };
+  console.log(
+    `${LOG} Starting Metro on ${METRO_PORT} (screenshotMode=${options.screenshotMode}, backend=${options.backend})...`,
+  );
+  const metro = startMetro(metroEnv);
+
+  let succeeded = false;
+  try {
+    if (!waitForMetro()) throw new Error(`Metro did not become ready on port ${METRO_PORT}`);
+    prewarmMetroBundle('android');
+    adb(serial, ['reverse', `tcp:${METRO_PORT}`, `tcp:${METRO_PORT}`], env);
+
+    const baseline = homeReadyMarkerCount();
+    console.log(`${LOG} Launching dev-client against Metro...`);
+    adb(serial, ['shell', `am start -a android.intent.action.VIEW -d '${metroDevClientUrl()}'`], env);
+
+    if (options.screenshotMode) {
+      if (waitForHomeReady(baseline, 240)) {
+        console.log(`${LOG} App reached home.`);
+      } else {
+        console.warn(
+          `${LOG} Did not see the '$screen /home' marker — the app may be on the login screen ` +
+            `(set SCREENSHOT_USER_PASSWORD for the prod test account, or use --backend local).`,
+        );
+      }
+    } else {
+      const settle = Math.max(options.settleSeconds, 20);
+      console.log(`${LOG} Waiting ${settle}s for the JS bundle to load...`);
+      sleepSeconds(settle);
+    }
+
+    if (options.flow) runMaestroFlow(serial, options, env);
+
+    if (options.to) {
+      navigate(serial, env, options.to);
+      sleepSeconds(options.settleSeconds);
+      const file = captureScreenshot(serial, env, options.label ?? options.to, options.outDir);
+      console.log(`${LOG} Saved ${file}`);
+    }
+
+    if (options.shutdown) {
+      console.log(`${LOG} --shutdown requested; tearing down.`);
+    } else {
+      printReadyBanner(serial);
+      await blockUntilExit(metro);
+    }
+    succeeded = true;
+  } finally {
+    if (options.shutdown) {
+      stopMetro(metro);
+      clearAndroidStatusBar(serial);
+      shutdownEmulator(serial, env);
+    } else if (!succeeded) {
+      // A mid-pipeline failure: free the Metro port, but leave the emulator up for
+      // debugging and tell the user how to stop it.
+      stopMetro(metro);
+      console.error(
+        `${LOG} Left emulator ${serial} running for debugging; stop it with: vp run mobile:android-shots -- shutdown`,
+      );
+    }
+  }
+
+  return 0;
+}
+
+export async function main(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
+  let options: ShotsOptions;
+  try {
+    options = parseShotsArgs(argv);
+  } catch (error) {
+    console.error(`${LOG} ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+  try {
+    switch (options.command) {
+      case 'screenshot':
+        return runScreenshotSubcommand(options);
+      case 'navigate':
+        return runNavigateSubcommand(options);
+      case 'shutdown':
+        return runShutdownSubcommand();
+      default:
+        return await runFullPipeline(options);
+    }
+  } catch (error) {
+    console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().then((code) => process.exit(code));
+}

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -50,12 +50,12 @@ const OUTPUT_ROOT = resolve(ROOT_DIR, 'app-stores');
 // Metro's stdout is tee'd here so waitForHomeReady can poll it for the app's
 // "$screen /home" readiness marker — the JS console logs land in Metro's output,
 // not the device's unified log.
-const METRO_LOG_PATH = join(tmpdir(), 'boardsesh-screenshot-metro.log');
+export const METRO_LOG_PATH = join(tmpdir(), 'boardsesh-screenshot-metro.log');
 // Metro dev server port the dev-client loads its JS bundle from. Defaults to
 // 8081; override with BOARDSESH_METRO_PORT when it's taken (this repo runs a
 // Metro per worktree). The orchestrator passes the matching dev-client URL to
 // Maestro via `-e MAESTRO_DEV_CLIENT_URL`, so the flows never hard-code a port.
-const METRO_PORT = Number.parseInt(process.env.BOARDSESH_METRO_PORT ?? '', 10) || 8081;
+export const METRO_PORT = Number.parseInt(process.env.BOARDSESH_METRO_PORT ?? '', 10) || 8081;
 // Output is grouped by store (the directory name), not by platform id.
 const STORE_BY_PLATFORM: Record<'ios' | 'android', string> = { ios: 'apple', android: 'google' };
 const LOG = '[mobile:screenshots]';
@@ -76,8 +76,8 @@ const DEFAULT_ANDROID_APK = resolve(
 // so localhost is correct for a sim build pointed at the local dev backend.
 const LOCAL_BACKEND_URL = 'http://localhost:8080';
 const LOCAL_WEB_URL = 'http://localhost:3000';
-const DEFAULT_USER_EMAIL = 'test@boardsesh.com';
-const DEFAULT_USER_PASSWORD = 'test';
+export const DEFAULT_USER_EMAIL = 'test@boardsesh.com';
+export const DEFAULT_USER_PASSWORD = 'test';
 const MAESTRO_INSTALL_HINT = 'Install Maestro: curl -Ls "https://get.maestro.mobile.dev" | bash';
 
 export type ScreenshotPlatform = 'ios' | 'android' | 'all';
@@ -679,6 +679,10 @@ function runAndroid(options: ScreenshotOptions): number {
         deviceId,
         'test',
         flowFile,
+        // The flows declare `appId: ${APP_ID}`; the standalone store APK is the
+        // production package (the local dev-client path passes the .dev package).
+        '-e',
+        `APP_ID=${APP_ID}`,
         '-e',
         `SCREENSHOT_USER_EMAIL=${email}`,
         '-e',
@@ -748,7 +752,7 @@ function resolveAndroidAppPath(options: ScreenshotOptions): string {
   );
 }
 
-function applyCleanAndroidStatusBar(deviceId: string): void {
+export function applyCleanAndroidStatusBar(deviceId: string): void {
   runCapture('adb', ['-s', deviceId, 'shell', 'settings', 'put', 'global', 'sysui_demo_allowed', '1']);
   runCapture('adb', [
     '-s',
@@ -828,7 +832,7 @@ function applyCleanAndroidStatusBar(deviceId: string): void {
   runCapture('adb', ['-s', deviceId, 'shell', 'cmd', 'notification', 'dismiss-all']);
 }
 
-function clearAndroidStatusBar(deviceId: string): void {
+export function clearAndroidStatusBar(deviceId: string): void {
   runCapture('adb', [
     '-s',
     deviceId,
@@ -921,12 +925,12 @@ function resolveAppPath(options: ScreenshotOptions): string {
 }
 
 /** expo-development-client deep link that loads the JS bundle from our Metro. */
-function metroDevClientUrl(): string {
+export function metroDevClientUrl(): string {
   return `${APP_ID}://expo-development-client/?url=${encodeURIComponent(`http://localhost:${METRO_PORT}`)}`;
 }
 
 /** True if anything is already listening on the port (a foreign Metro). */
-function portInUse(port: number): boolean {
+export function portInUse(port: number): boolean {
   return spawnSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t']).status === 0;
 }
 
@@ -934,7 +938,7 @@ function portInUse(port: number): boolean {
  * Start Metro in the background. `detached` so cleanup can kill the whole process
  * group; `CI=1` keeps expo non-interactive (no keypress menu / TTY expectations).
  */
-function startMetro(env: NodeJS.ProcessEnv): ChildProcess {
+export function startMetro(env: NodeJS.ProcessEnv): ChildProcess {
   // Pipe Metro's output through `tee` to METRO_LOG_PATH so waitForHomeReady can poll
   // it for the app's "$screen /home" marker — the JS console logs land in Metro's
   // stdout, NOT the device's unified log. `2>&1 | tee` keeps the output in the run
@@ -956,14 +960,14 @@ function startMetro(env: NodeJS.ProcessEnv): ChildProcess {
  * so Metro caches the right variant. Best-effort: a miss just falls back to
  * Maestro cold-loading the bundle (its wait is generous).
  */
-function prewarmMetroBundle(): void {
+export function prewarmMetroBundle(platform: 'ios' | 'android' = 'ios'): void {
   const manifest = runCapture('curl', [
     '-fsS',
     '--max-time',
     '30',
     `http://localhost:${METRO_PORT}/`,
     '-H',
-    'expo-platform: ios',
+    `expo-platform: ${platform}`,
     '-H',
     'Accept: application/expo+json,application/json',
   ]);
@@ -989,7 +993,7 @@ function prewarmMetroBundle(): void {
 }
 
 /** Poll Metro's /status until it answers (or ~120s elapse). */
-function waitForMetro(): boolean {
+export function waitForMetro(): boolean {
   const statusUrl = `http://localhost:${METRO_PORT}/status`;
   for (let attempt = 0; attempt < 60; attempt++) {
     if (runCapture('curl', ['-fsS', '-o', '/dev/null', statusUrl]).status === 0) {
@@ -1015,7 +1019,7 @@ function waitForPortToClose(port: number): boolean {
   return false;
 }
 
-function stopMetro(metro: ChildProcess | null): void {
+export function stopMetro(metro: ChildProcess | null): void {
   if (!metro || metro.pid === undefined) return;
   console.log(`${LOG} Stopping Metro...`);
   try {
@@ -1040,7 +1044,7 @@ function sleepSeconds(seconds: number): void {
  * analytics line lands in Metro's stdout (NOT the device's unified log), which
  * startMetro tee's to METRO_LOG_PATH — so count occurrences in that file.
  */
-function homeReadyMarkerCount(): number {
+export function homeReadyMarkerCount(): number {
   const metroLog = existsSync(METRO_LOG_PATH) ? readFileSync(METRO_LOG_PATH, 'utf8') : '';
   return metroLog.split('$screen /home').length - 1;
 }
@@ -1053,7 +1057,7 @@ function homeReadyMarkerCount(): number {
  * so wait for a NEW marker past `baselineCount` rather than any marker — the log
  * still holds the previous device's `$screen /home`.
  */
-function waitForHomeReady(baselineCount = 0, timeoutSeconds = 180): boolean {
+export function waitForHomeReady(baselineCount = 0, timeoutSeconds = 180): boolean {
   const deadline = Date.now() + timeoutSeconds * 1000;
   while (Date.now() < deadline) {
     if (homeReadyMarkerCount() > baselineCount) return true;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -527,6 +527,18 @@ export default defineConfig({
         command: 'tsx scripts/mobile-build-sim-app.ts',
         cache: false,
       },
+      'mobile:android-shots': {
+        command: 'tsx scripts/mobile-android-shots.ts',
+        cache: false,
+      },
+      'mobile:android-doctor': {
+        command: 'tsx scripts/mobile-android-doctor.ts',
+        cache: false,
+      },
+      'mobile:android-apk': {
+        command: 'tsx scripts/mobile-android-apk.ts',
+        cache: false,
+      },
       'check:screenshot-dimensions': {
         command: 'tsx scripts/assert-screenshot-dimensions.ts',
         cache: false,


### PR DESCRIPTION
## What

Trivial, standardized tooling so an AI agent (or any contributor) can boot the RN app
(`packages/mobile/`) in an Android emulator, run it against Metro using a **centrally cached
dev-client APK**, and grab screenshots. The Android counterpart to the iOS flow
(`vp run mobile:screenshots`), and Linux-friendly — an x86_64 emulator runs natively on a
KVM host. The cached APK has no bundled JS (it loads from Metro), so native deps (which change
rarely) are built/downloaded once and only the JS regenerates per run.

## Commands

- **`vp run mobile:android-shots`** — boot a headless x86_64 emulator → install the cached
  dev-client APK → start Metro → `adb reverse` → launch the app → capture with
  `adb exec-out screencap` into `.boardsesh/android-screenshots/`. Subcommands
  `screenshot` / `navigate` / `shutdown` (boot once, shoot many); `--flow` runs the Maestro flows.
- **`vp run mobile:android-doctor`** — one-time bootstrap of the SDK + Temurin JDK 21 under
  `~/.cache/boardsesh/`, plus a diagnostics report.
- **`vp run mobile:android-apk`** — resolve the APK: download the latest `rn-android-dev-*`
  universal release (x86_64 ABI + corrupt-download guards) or build an x86_64 dev-client
  locally, cached by a native-input hash.

## Notable

- **CI**: `android-apk-dev-client.yml` now builds a **universal** (`arm64-v8a` + `x86_64`)
  dev-client APK so the cached artifact runs on x86_64 emulators (the production
  `android-apk-rn.yml` is untouched).
- Reuses the Metro/status-bar helpers from `mobile-screenshots.ts` (now exported); the two
  Android Maestro flows are `appId`-parametrized (`-e APP_ID`) for the `com.boardsesh.app.dev`
  package. Deep-link scheme stays `com.boardsesh.app://` for both variants.
- Renderer/AVD/boot-timeout are overridable via env (`BOARDSESH_EMULATOR_GPU`,
  `BOARDSESH_AVD_NAME`, …); headless Linux auto-wraps the emulator in `xvfb-run`.
- Docs: new `docs/android-emulator-screenshots.md` + a CLAUDE.md section; stale Expo SDK/RN
  version note fixed.

## Testing

- `vp check` clean (format + lint + type) across all 8 new/changed scripts.
- End-to-end on a Linux/KVM box: SDK bootstrap, JDK 21, AVD creation, a 100 MB x86_64
  dev-client APK built locally, emulator launch, and adb connect all verified.
- A code-review pass was run; its findings (deep-link injection guard, Metro SIGKILL
  escalation, emulator-leak-on-error, corrupt-download guard) are applied.

## Notes for reviewers

- The download path serves the universal APK only **after this merges to `main`** and a
  dev-client build runs; until then `mobile:android-shots` auto-falls-back to the local
  x86_64 Gradle build.
- Prod auto-login needs `SCREENSHOT_USER_PASSWORD` (the seeded `test`/`test` only exists on
  the local dev backend; use `--backend local` with `vp run dev`).
- The dev environment this was built in couldn't render the emulator's software GPU (host-CPU
  limitation — swiftshader/lavapipe segfault there), so a live in-emulator screenshot wasn't
  captured here. `swiftshader_indirect` is the same renderer the existing Android CI job uses
  on `ubuntu-latest`, so this works on normal hosts/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jja1CA7wMJPeQqT5S4Muhc