### PR TITLE
ci(mobile-screenshots): free disk before the Android emulator

### DIFF
--- a/.github/workflows/mobile-screenshots-android.yml
+++ b/.github/workflows/mobile-screenshots-android.yml
@@ -166,6 +166,27 @@ jobs:
           fi
           cp -f "${apks[0]}" /tmp/boardsesh-screenshot.apk
 
+      # The release APK is now in /tmp, so the Gradle build tree is dead weight.
+      # Reclaim it plus the big preinstalled toolchains we never use, so the
+      # emulator system-image install has room — a full (cache-miss) build left
+      # the runner too full and `sdkmanager` failed with "No space left on
+      # device", aborting capture before it started. Leave ~/.gradle/caches so the
+      # post-step can still save the build cache. Best-effort.
+      - name: Free disk space for the emulator
+        run: |
+          set -eu
+          echo "Disk before cleanup:"; df -h /
+          rm -rf packages/mobile/android/app/build packages/mobile/android/build 2>/dev/null || true
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android/sdk/ndk \
+            /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/powershell \
+            /usr/local/share/chromium 2>/dev/null || true
+          sudo docker image prune --all --force 2>/dev/null || true
+          echo "Disk after cleanup:"; df -h /
+
       - name: Install Maestro
         env:
           MAESTRO_VERSION: 2.6.1


### PR DESCRIPTION
## What

Adds a disk-cleanup step to the Android screenshots job so the emulator has room.

## Why

The first `upload=true` run on `main` ([run 27789356693](https://github.com/boardsesh/boardsesh/actions/runs/27789356693)) **failed in capture**: the APK built fine, but `android-emulator-runner`'s `sdkmanager` then hit **`No space left on device`** installing the x86_64 system image, so capture aborted before it ran (dimension gate + upload skipped).

A cache-miss (full) Gradle build fills the hosted runner; the emulator system image (~GBs) then doesn't fit. The failed run also saved no Gradle cache, so the next `main` run is another cache-miss full build → it would recur.

## Fix

After the release APK is copied to `/tmp`, reclaim the now-dead Gradle build tree plus unused preinstalled toolchains (dotnet, Android NDK, GHC, CodeQL, PowerShell, Chromium, docker images) before the emulator step. `~/.gradle/caches` is kept so the build cache still saves.

Verified by a dispatch of this branch with `upload=true` (run linked in the PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
