### PR TITLE
fix(mobile): reliable Android board-view screenshot + blank-upload gate

### DIFF
--- a/.github/workflows/mobile-screenshots-android.yml
+++ b/.github/workflows/mobile-screenshots-android.yml
@@ -230,6 +230,30 @@ jobs:
           SCREENSHOT_ANDROID_DEVICE: ${{ inputs.android_device || 'Pixel 2' }}
           SCREENSHOT_APK_PATH: /tmp/boardsesh-screenshot.apk
 
+      # Hard backstop against a blank capture (the play-drawer modal occasionally
+      # didn't composite into adb screencap — a blank board-view hero even reached
+      # the store once). A blank frame is just the status bar and compresses to
+      # ~16KB; every real screen here is >140KB. Fail the run if any shot is
+      # suspiciously small, so the upload below (gated on success()) can't push a
+      # blank. Bump min_bytes if a legitimately sparse screen is ever added.
+      - name: Assert screenshots are not blank
+        if: ${{ inputs.flow != 'onboarding' }}
+        run: |
+          set -euo pipefail
+          shots_dir=app-stores/google/screenshots
+          min_bytes=61440
+          fail=0
+          while IFS= read -r -d '' shot; do
+            size=$(stat -c%s "$shot")
+            if [ "$size" -lt "$min_bytes" ]; then
+              echo "::error::Blank/near-empty screenshot: $shot is ${size} bytes (< ${min_bytes}); likely a failed modal capture."
+              fail=1
+            else
+              echo "ok: $shot (${size} bytes)"
+            fi
+          done < <(find "$shots_dir" -type f -name '*.png' -print0)
+          [ "$fail" -eq 0 ] || exit 1
+
       - name: Assert screenshot dimensions
         # The onboarding flow captures different screens than the Play Store set, so
         # the dimension gate doesn't apply to it.

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -197,8 +197,17 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   return (
     <GestureDetector gesture={composedGesture}>
       <View style={styles.container} onLayout={handleLayout}>
-        <Animated.View style={[styles.boardWrapper, boardBox ? { width: boardBox.width } : null, currentStyle]}>
-          <Animated.View style={animatedZoomStyle}>
+        {process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? (
+          // Screenshot mode: render the board in PLAIN (non-reanimated) Views.
+          // The swipe/zoom `Animated.View` wrappers promote the board to a render
+          // layer that Android's `adb screencap` (Maestro's capture) intermittently
+          // misses inside the play-drawer modal — the board-view shot came out blank
+          // ~half the time even with a redraw swipe. The transforms are identity at
+          // rest, so the static board is pixel-identical without them; the simpler
+          // board-presence sheet (no carousel) already captures reliably, confirming
+          // the carousel layer is the culprit. overlayTestID anchors on the painted
+          // holds overlay.
+          <View style={[styles.boardWrapper, boardBox ? { width: boardBox.width } : null]}>
             <BoardImageNative
               frames={currentFrameOverride ?? currentFrames}
               boardName={boardName}
@@ -209,13 +218,26 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               boardHeight={boardHeight}
               mirrored={mirrored}
               style={boardStyle}
-              // Anchor for screenshot/e2e flows: present only once the lit-holds
-              // overlay has painted (see LayeredClimbImage). Screenshot-mode only,
-              // so the marker + onLoad dead-strip out of normal builds.
-              overlayTestID={process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? 'play-drawer-board-overlay' : undefined}
+              overlayTestID="play-drawer-board-overlay"
             />
+          </View>
+        ) : (
+          <Animated.View style={[styles.boardWrapper, boardBox ? { width: boardBox.width } : null, currentStyle]}>
+            <Animated.View style={animatedZoomStyle}>
+              <BoardImageNative
+                frames={currentFrameOverride ?? currentFrames}
+                boardName={boardName}
+                layoutId={layoutId}
+                sizeId={sizeId}
+                setIds={setIds}
+                boardWidth={boardWidth}
+                boardHeight={boardHeight}
+                mirrored={mirrored}
+                style={boardStyle}
+              />
+            </Animated.View>
           </Animated.View>
-        </Animated.View>
+        )}
 
         <Animated.View style={[styles.peekWrapper, peekStyle]} pointerEvents="none">
           {peekFrames && (

--- a/packages/mobile/src/hooks/use-deferred-after-interactions.ts
+++ b/packages/mobile/src/hooks/use-deferred-after-interactions.ts
@@ -24,6 +24,17 @@ export function useDeferredAfterInteractions(active: boolean, resetKey?: string 
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
+    // Screenshot mode: mount heavy content synchronously (no defer) so it
+    // composites in the same frames as the open animation. The deferred mount
+    // lands at a variable time (runAfterInteractions, else the timeout fallback),
+    // and Android's `adb screencap` (Maestro) captured the play-drawer board-view
+    // blank ~half the time as a result — the carousel-free board-presence sheet,
+    // which renders synchronously, never flaked. Folds out of normal builds.
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') {
+      setReady(active);
+      return;
+    }
+
     if (!active) {
       setReady(false);
       return;


### PR DESCRIPTION
## What

Makes the Android **board-view** store screenshot capture reliably (it was flaky — a blank board-view hero was even uploaded to the live Play listing once), and adds a hard gate so a blank can never be uploaded again.

Follow-up to #3051 (which merged only the disk-space fix before these commits existed).

## Why it was blank ~half the time

`06-board-sheet` (renders its board synchronously) captured reliably every run, while `02-board-view` flaked ~50%. The play-drawer board uses `useDeferredAfterInteractions`, which mounts the board at a **variable** time (`runAfterInteractions`, else a 350ms fallback). So the play-drawer modal composited into Android's `adb screencap` (Maestro's capture) only some of the time — when the deferred mount happened to land before the capture. Earlier mitigations (a redraw swipe, an overlay-paint anchor) didn't fix the underlying race.

## Fix

1. **Synchronous mount in screenshot mode** — bypass the defer so the board mounts in the same frames as the open animation (matching the reliable board-sheet path). Dead-strips in normal builds.
2. **Plain (non-reanimated) board in screenshot mode** — drop the swipe/zoom `Animated.View` wrappers (identity at rest, so pixel-identical) to remove a layer screencap can miss.
3. **Blank-upload gate** — before the Play upload, fail the run if any screenshot is suspiciously small (a blank frame compresses to ~16KB vs >140KB for real screens). Hard backstop so a blank can't reach the store.

## Verification

Two parallel capture-only runs, both produced the correct ~1.1 MB board-view (vs ~16 KB when blank):

- run [27794693623](https://github.com/boardsesh/boardsesh/actions/runs/27794693623) — `02-board-view` 1,105,844 bytes, blank-gate ✅
- run [27794694789](https://github.com/boardsesh/boardsesh/actions/runs/27794694789) — `02-board-view` 1,105,862 bytes, blank-gate ✅

After this merges, re-running the Android workflow with `upload=true` on `main` will replace the blank hero currently live on the Play listing (the gate guarantees it won't push another blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
