### PR TITLE
fix(mobile-screenshots): reliable Android board-view via relaunch capture

### DIFF
--- a/.github/workflows/mobile-screenshots-android.yml
+++ b/.github/workflows/mobile-screenshots-android.yml
@@ -230,27 +230,6 @@ jobs:
           SCREENSHOT_ANDROID_DEVICE: ${{ inputs.android_device || 'Pixel 2' }}
           SCREENSHOT_APK_PATH: /tmp/boardsesh-screenshot.apk
 
-      # The flow captures the flaky board-view several times (02-board-view,
-      # 02-board-view-r1..r3). Promote the largest — the non-blank render, since a
-      # blank compresses to ~16KB vs >140KB — to the canonical 02-board-view.png and
-      # drop the extras, so the count/dimension gates and upload see exactly one.
-      - name: Keep the best board-view capture
-        if: ${{ inputs.flow != 'onboarding' }}
-        run: |
-          set -euo pipefail
-          device_dir=$(find app-stores/google/screenshots -mindepth 1 -maxdepth 1 -type d | head -1)
-          [ -n "$device_dir" ] || { echo "::error::no screenshots directory"; exit 1; }
-          shopt -s nullglob
-          candidates=("$device_dir"/02-board-view*.png)
-          [ "${#candidates[@]}" -ge 1 ] || { echo "::error::no board-view captures"; exit 1; }
-          best=$(ls -S "${candidates[@]}" | head -1)
-          echo "Picked $best ($(stat -c%s "$best") bytes) of ${#candidates[@]} board-view captures:"
-          ls -S -l "${candidates[@]}" | awk '{print "  " $5 "  " $NF}'
-          tmp=$(mktemp)
-          cp "$best" "$tmp"
-          rm -f "$device_dir"/02-board-view*.png
-          mv "$tmp" "$device_dir/02-board-view.png"
-
       # Hard backstop against a blank capture (the play-drawer modal occasionally
       # didn't composite into adb screencap — a blank board-view hero even reached
       # the store once). A blank frame is just the status bar and compresses to

--- a/.github/workflows/mobile-screenshots-android.yml
+++ b/.github/workflows/mobile-screenshots-android.yml
@@ -230,6 +230,27 @@ jobs:
           SCREENSHOT_ANDROID_DEVICE: ${{ inputs.android_device || 'Pixel 2' }}
           SCREENSHOT_APK_PATH: /tmp/boardsesh-screenshot.apk
 
+      # The flow captures the flaky board-view several times (02-board-view,
+      # 02-board-view-r1..r3). Promote the largest — the non-blank render, since a
+      # blank compresses to ~16KB vs >140KB — to the canonical 02-board-view.png and
+      # drop the extras, so the count/dimension gates and upload see exactly one.
+      - name: Keep the best board-view capture
+        if: ${{ inputs.flow != 'onboarding' }}
+        run: |
+          set -euo pipefail
+          device_dir=$(find app-stores/google/screenshots -mindepth 1 -maxdepth 1 -type d | head -1)
+          [ -n "$device_dir" ] || { echo "::error::no screenshots directory"; exit 1; }
+          shopt -s nullglob
+          candidates=("$device_dir"/02-board-view*.png)
+          [ "${#candidates[@]}" -ge 1 ] || { echo "::error::no board-view captures"; exit 1; }
+          best=$(ls -S "${candidates[@]}" | head -1)
+          echo "Picked $best ($(stat -c%s "$best") bytes) of ${#candidates[@]} board-view captures:"
+          ls -S -l "${candidates[@]}" | awk '{print "  " $5 "  " $NF}'
+          tmp=$(mktemp)
+          cp "$best" "$tmp"
+          rm -f "$device_dir"/02-board-view*.png
+          mv "$tmp" "$device_dir/02-board-view.png"
+
       # Hard backstop against a blank capture (the play-drawer modal occasionally
       # didn't composite into adb screencap — a blank board-view hero even reached
       # the store once). A blank frame is just the status bar and compresses to

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -83,16 +83,14 @@ name: app-store screenshots android
     timeout: 30000
 - takeScreenshot: 04-workout-generator
 
-# Board view — the full-screen play drawer intermittently fails to composite into
-# adb screencap, so a single shot came out blank ~half the time (the carousel-free
-# board sheet below — which relaunches first — never flakes; only the full-screen
-# drawer is racy, and only at the capture moment: the in-app overlay marker is found
-# on blank runs too, so the render is fine). Rather than chase the race, capture it
-# 4 times, each via a fresh relaunch + reopen (the reliable sheet pattern, and far
-# sturdier than back/tap which dropped off the climbs list). The workflow's "keep
-# the best board-view" step then promotes the largest (non-blank) 02-board-view*.png
-# to 02-board-view.png and drops the rest. Every wait below is a reliably-found
-# anchor (home-screen, climb-row, the overlay marker), so no round aborts the flow.
+# Board view — the full-screen play drawer intermittently failed to composite into
+# adb screencap when captured mid-session (~half the time blank). Capturing it via a
+# fresh relaunch + reopen — the same pattern the never-flaky board sheet uses — fixed
+# the render (a verify run got 4/4 non-blank that way). Two rounds, not more: each
+# extra relaunch risks a flaky "Unable to launch app", and the workflow's "keep the
+# best board-view" step already promotes the largest (non-blank) 02-board-view*.png
+# to 02-board-view.png (with the blank gate as the backstop). Every wait is a
+# reliably-found anchor (home-screen, climb-row, overlay marker), so no round aborts.
 - launchApp
 - extendedWaitUntil:
     visible:
@@ -129,42 +127,6 @@ name: app-store screenshots android
 - waitForAnimationToEnd:
     timeout: 30000
 - takeScreenshot: 02-board-view-r1
-# Round 3
-- launchApp
-- extendedWaitUntil:
-    visible:
-      id: 'home-screen'
-    timeout: 90000
-- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
-- extendedWaitUntil:
-    visible:
-      id: 'climb-row'
-    timeout: 60000
-- extendedWaitUntil:
-    visible:
-      id: 'play-drawer-board-overlay'
-    timeout: 60000
-- waitForAnimationToEnd:
-    timeout: 30000
-- takeScreenshot: 02-board-view-r2
-# Round 4
-- launchApp
-- extendedWaitUntil:
-    visible:
-      id: 'home-screen'
-    timeout: 90000
-- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
-- extendedWaitUntil:
-    visible:
-      id: 'climb-row'
-    timeout: 60000
-- extendedWaitUntil:
-    visible:
-      id: 'play-drawer-board-overlay'
-    timeout: 60000
-- waitForAnimationToEnd:
-    timeout: 30000
-- takeScreenshot: 02-board-view-r3
 
 # Board sheet — relaunch first so the play drawer from the board-view shot is gone, then
 # open the board-presence sheet deterministically via the screenshot-mode param (no fragile

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -85,12 +85,13 @@ name: app-store screenshots android
 
 # Board view — the full-screen play drawer intermittently failed to composite into
 # adb screencap when captured mid-session (~half the time blank). Capturing it via a
-# fresh relaunch + reopen — the same pattern the never-flaky board sheet uses — fixed
-# the render (a verify run got 4/4 non-blank that way). Two rounds, not more: each
-# extra relaunch risks a flaky "Unable to launch app", and the workflow's "keep the
-# best board-view" step already promotes the largest (non-blank) 02-board-view*.png
-# to 02-board-view.png (with the blank gate as the backstop). Every wait is a
-# reliably-found anchor (home-screen, climb-row, overlay marker), so no round aborts.
+# FRESH relaunch + reopen — the same pattern the never-flaky board sheet uses — fixes
+# the render: every fresh-launch capture in verification was a full ~1.1MB frame.
+# Just ONE round: back-to-back relaunches flaked with "Unable to launch app" (the
+# app hadn't fully terminated), and this single launch isn't adjacent to another, so
+# it stays as reliable as the start/sheet launches. The blank gate below is the
+# backstop. Every wait is a reliably-found anchor (home-screen, climb-row, overlay
+# marker), so the round never aborts the flow.
 - launchApp
 - extendedWaitUntil:
     visible:
@@ -108,25 +109,6 @@ name: app-store screenshots android
 - waitForAnimationToEnd:
     timeout: 30000
 - takeScreenshot: 02-board-view
-# Round 2 — relaunch resets the screenshotOpenFirst guard + overlay marker, so the
-# deep link auto-opens the drawer fresh again.
-- launchApp
-- extendedWaitUntil:
-    visible:
-      id: 'home-screen'
-    timeout: 90000
-- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
-- extendedWaitUntil:
-    visible:
-      id: 'climb-row'
-    timeout: 60000
-- extendedWaitUntil:
-    visible:
-      id: 'play-drawer-board-overlay'
-    timeout: 60000
-- waitForAnimationToEnd:
-    timeout: 30000
-- takeScreenshot: 02-board-view-r1
 
 # Board sheet — relaunch first so the play drawer from the board-view shot is gone, then
 # open the board-presence sheet deterministically via the screenshot-mode param (no fragile

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -83,11 +83,19 @@ name: app-store screenshots android
     timeout: 30000
 - takeScreenshot: 04-workout-generator
 
-# Board view — open the first climb (wall with holds lit) via the screenshot-mode param.
-# The play drawer presents immediately over a placeholder, then the board mounts and the
-# Rust holds-overlay renders a beat later (slow on the software renderer) — so a bare
-# waitForAnimationToEnd shot caught a blank drawer. Anchor on the overlay layer itself,
-# which only mounts once the lit board has rendered, then let the fade settle.
+# Board view — the full-screen play drawer intermittently fails to composite into
+# adb screencap, so a single shot came out blank ~half the time (the carousel-free
+# board sheet below never flakes — it's the full-screen drawer that's racy). Rather
+# than chase the compositing race, capture it up to 4 times, reopening the drawer
+# each round; the workflow's "keep the best board-view" step then promotes the
+# largest (non-blank) 02-board-view*.png to 02-board-view.png and drops the rest.
+# A fresh launch first mirrors the reliable board-sheet path; the overlay anchor
+# waits for the lit board to paint each round (the marker re-arms on each reopen).
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'home-screen'
+    timeout: 90000
 - openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
 - extendedWaitUntil:
     visible:
@@ -97,20 +105,50 @@ name: app-store screenshots android
     visible:
       id: 'play-drawer-board-overlay'
     timeout: 60000
-# The play-drawer modal composites onto a layer adb screencap doesn't read until
-# the window redraws, so it captured blank even with the board painted (it only
-# captured before because the onboarding tip's root view forced a recomposite). A
-# small horizontal swipe on the board forces the modal window to redraw; the
-# carousel springs back to the same climb (sub-threshold), and waitForAnimationToEnd
-# holds until it settles — with the board now in the captured frame.
-- swipe:
-    start: '55%, 45%'
-    end: '42%, 45%'
-- waitForAnimationToEnd:
-    timeout: 30000
 - waitForAnimationToEnd:
     timeout: 30000
 - takeScreenshot: 02-board-view
+# Reopen + recapture (×3). `back` closes the drawer; tapping the first row reopens
+# it (screenshotOpenFirst only auto-opens once per board, so re-tap instead).
+- back
+- waitForAnimationToEnd:
+    timeout: 15000
+- tapOn:
+    id: 'climb-row'
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: 'play-drawer-board-overlay'
+    timeout: 60000
+- waitForAnimationToEnd:
+    timeout: 30000
+- takeScreenshot: 02-board-view-r1
+- back
+- waitForAnimationToEnd:
+    timeout: 15000
+- tapOn:
+    id: 'climb-row'
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: 'play-drawer-board-overlay'
+    timeout: 60000
+- waitForAnimationToEnd:
+    timeout: 30000
+- takeScreenshot: 02-board-view-r2
+- back
+- waitForAnimationToEnd:
+    timeout: 15000
+- tapOn:
+    id: 'climb-row'
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: 'play-drawer-board-overlay'
+    timeout: 60000
+- waitForAnimationToEnd:
+    timeout: 30000
+- takeScreenshot: 02-board-view-r3
 
 # Board sheet — relaunch first so the play drawer from the board-view shot is gone, then
 # open the board-presence sheet deterministically via the screenshot-mode param (no fragile

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -85,12 +85,14 @@ name: app-store screenshots android
 
 # Board view — the full-screen play drawer intermittently fails to composite into
 # adb screencap, so a single shot came out blank ~half the time (the carousel-free
-# board sheet below never flakes — it's the full-screen drawer that's racy). Rather
-# than chase the compositing race, capture it up to 4 times, reopening the drawer
-# each round; the workflow's "keep the best board-view" step then promotes the
-# largest (non-blank) 02-board-view*.png to 02-board-view.png and drops the rest.
-# A fresh launch first mirrors the reliable board-sheet path; the overlay anchor
-# waits for the lit board to paint each round (the marker re-arms on each reopen).
+# board sheet below — which relaunches first — never flakes; only the full-screen
+# drawer is racy, and only at the capture moment: the in-app overlay marker is found
+# on blank runs too, so the render is fine). Rather than chase the race, capture it
+# 4 times, each via a fresh relaunch + reopen (the reliable sheet pattern, and far
+# sturdier than back/tap which dropped off the climbs list). The workflow's "keep
+# the best board-view" step then promotes the largest (non-blank) 02-board-view*.png
+# to 02-board-view.png and drops the rest. Every wait below is a reliably-found
+# anchor (home-screen, climb-row, the overlay marker), so no round aborts the flow.
 - launchApp
 - extendedWaitUntil:
     visible:
@@ -108,14 +110,18 @@ name: app-store screenshots android
 - waitForAnimationToEnd:
     timeout: 30000
 - takeScreenshot: 02-board-view
-# Reopen + recapture (×3). `back` closes the drawer; tapping the first row reopens
-# it (screenshotOpenFirst only auto-opens once per board, so re-tap instead).
-- back
-- waitForAnimationToEnd:
-    timeout: 15000
-- tapOn:
-    id: 'climb-row'
-    index: 0
+# Round 2 — relaunch resets the screenshotOpenFirst guard + overlay marker, so the
+# deep link auto-opens the drawer fresh again.
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'home-screen'
+    timeout: 90000
+- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
+- extendedWaitUntil:
+    visible:
+      id: 'climb-row'
+    timeout: 60000
 - extendedWaitUntil:
     visible:
       id: 'play-drawer-board-overlay'
@@ -123,12 +129,17 @@ name: app-store screenshots android
 - waitForAnimationToEnd:
     timeout: 30000
 - takeScreenshot: 02-board-view-r1
-- back
-- waitForAnimationToEnd:
-    timeout: 15000
-- tapOn:
-    id: 'climb-row'
-    index: 0
+# Round 3
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'home-screen'
+    timeout: 90000
+- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
+- extendedWaitUntil:
+    visible:
+      id: 'climb-row'
+    timeout: 60000
 - extendedWaitUntil:
     visible:
       id: 'play-drawer-board-overlay'
@@ -136,12 +147,17 @@ name: app-store screenshots android
 - waitForAnimationToEnd:
     timeout: 30000
 - takeScreenshot: 02-board-view-r2
-- back
-- waitForAnimationToEnd:
-    timeout: 15000
-- tapOn:
-    id: 'climb-row'
-    index: 0
+# Round 4
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'home-screen'
+    timeout: 90000
+- openLink: com.boardsesh.app://climbs?screenshotOpenFirst=1
+- extendedWaitUntil:
+    visible:
+      id: 'climb-row'
+    timeout: 60000
 - extendedWaitUntil:
     visible:
       id: 'play-drawer-board-overlay'


### PR DESCRIPTION
## What

Makes the Android **board-view** screenshot render reliably. Follow-up to #3052 — the deferral/render fixes there reduced but didn't eliminate the flake; this captures it correctly every time.

## Why it was still flaky

`02-board-view` (the full-screen play-drawer modal) intermittently failed to composite into `adb screencap` when captured **mid-session** — blank ~half the time. The in-app render was fine (the `play-drawer-board-overlay` marker is found on blank runs too); only the capture moment raced. The carousel-free board-presence sheet (`06-board-sheet`) — which **relaunches the app first** — never flaked.

## Fix

Capture the board-view via a **fresh relaunch + reopen** (the same pattern the reliable board sheet uses) instead of mid-session. Every fresh-launch capture in verification was a full ~1.1 MB frame.

Just **one** round: an earlier multi-round version did back-to-back relaunches, which flaked with `Unable to launch app` (the app hadn't fully terminated). The flow now has 3 total `launchApp`s, none adjacent — as reliable as the existing start/sheet launches. The blank-upload gate from #3052 stays as the backstop, so a blank still can't reach the store.

## Verification

`02-board-view` came out 1,106,015 bytes (full lit-holds frame, vs ~16 KB blank): run [27799983720](https://github.com/boardsesh/boardsesh/actions/runs/27799983720) — capture ✅, blank-gate ✅.

(A parallel verify run died at the Gradle build with a runner OOM — a separate, pre-existing intermittent infra flake that never reached capture; unrelated to this change.)

After merge, an `upload=true` run on `main` will replace the blank board-view currently live on the Play listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
