### PR TITLE
fix(mobile): M3 top app bars for Home & Discover on Android

### DIFF
--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -38,6 +38,7 @@ import { iconMap } from '../../../src/components/icon-map';
 import { selectByVariant } from '../../../src/theme/variants';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
+import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT } from '../../../src/theme/layout';
 
 const FOR_YOU_SMART_PLAYLIST_TYPES: SmartPlaylistType[] = [
   'LIKED_CLIMBS',
@@ -83,13 +84,13 @@ export default function DiscoverLibrary() {
   const { brandColors, variant } = useTheme();
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   const bottomChrome = useBottomChromeMetrics();
-  // The screen sits above the in-flow Material tab bar, so the FAB's `bottom` is
-  // measured from the tab-bar top — NOT the screen bottom. fixedFooterBottom is the
-  // footer metric for exactly this case: it clears the docked queue accessory bar
-  // (and is 0 when no climb is queued), without re-adding the tab-bar height the way
-  // floatingControlBottom (built for full-screen overlays) does. +16dp = standard
-  // FAB gap above the accessory bar / tab bar.
-  const createFabBottom = bottomChrome.fixedFooterBottom + spacing[4];
+  // The screen sits ABOVE the in-flow Material tab bar, so the FAB's `bottom` is
+  // measured from the tab-bar top. It only needs to clear the docked queue accessory
+  // bar (a root overlay that covers the screen's bottom edge when a climb is queued),
+  // plus a 16dp gap. Computed directly rather than via floatingControlBottom /
+  // fixedFooterBottom, which re-add the tab-bar height (built for full-screen overlays)
+  // and floated the FAB ~tab-bar-height too high above the accessory bar.
+  const createFabBottom = (bottomChrome.jsQueueToolbarVisible ? MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT : 0) + spacing[4];
   const insets = useSafeAreaInsets();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { data: token = null, isLoading: tokenLoading } = useAuthToken();

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { router, useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { FAB } from 'react-native-paper';
 import {
   useDiscoverPlaylists,
   useUserPlaylists,
@@ -33,6 +34,8 @@ import { useAuthToken } from '../../../src/lib/graphql/use-auth-token';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
+import { iconMap } from '../../../src/components/icon-map';
+import { selectByVariant } from '../../../src/theme/variants';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 
@@ -77,7 +80,8 @@ function pinnedSmartPlaylistsStorageKey(userId: string): string {
 
 export default function DiscoverLibrary() {
   const { t } = useTranslation('playlists');
-  const { brandColors } = useTheme();
+  const { brandColors, variant } = useTheme();
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   const bottomChrome = useBottomChromeMetrics();
   const insets = useSafeAreaInsets();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
@@ -622,6 +626,20 @@ export default function DiscoverLibrary() {
         onHeightChange={setChromeHeight}
       />
 
+      {/* Material's primary create affordance is an M3 FAB — the canonical place for
+          a screen's "new" action. Liquid Glass keeps the create "+" island in the
+          floating chrome (via CollapsingTopChrome), so the FAB is material-only. */}
+      {isMaterial && isAuthenticated ? (
+        <FAB
+          icon={iconMap.plus.android}
+          onPress={handleCreatePress}
+          accessibilityLabel={t('library.createFab.ariaLabel')}
+          variant="primary"
+          mode="elevated"
+          style={[styles.createFab, { bottom: bottomChrome.floatingControlBottom + spacing[2] }]}
+        />
+      ) : null}
+
       <PlaylistFormSheet
         mode="create"
         visible={createVisible}
@@ -636,6 +654,13 @@ export default function DiscoverLibrary() {
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
+  },
+  // Material create FAB: bottom-trailing, the list scrolls under it; the host sets
+  // `bottom` from the variant-correct floating-control offset (clears tab bar +
+  // queue accessory).
+  createFab: {
+    position: 'absolute',
+    right: spacing[4],
   },
   screenTitle: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -83,6 +83,13 @@ export default function DiscoverLibrary() {
   const { brandColors, variant } = useTheme();
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   const bottomChrome = useBottomChromeMetrics();
+  // The screen sits above the in-flow Material tab bar, so the FAB's `bottom` is
+  // measured from the tab-bar top — NOT the screen bottom. fixedFooterBottom is the
+  // footer metric for exactly this case: it clears the docked queue accessory bar
+  // (and is 0 when no climb is queued), without re-adding the tab-bar height the way
+  // floatingControlBottom (built for full-screen overlays) does. +16dp = standard
+  // FAB gap above the accessory bar / tab bar.
+  const createFabBottom = bottomChrome.fixedFooterBottom + spacing[4];
   const insets = useSafeAreaInsets();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { data: token = null, isLoading: tokenLoading } = useAuthToken();
@@ -636,7 +643,7 @@ export default function DiscoverLibrary() {
           accessibilityLabel={t('library.createFab.ariaLabel')}
           variant="primary"
           mode="elevated"
-          style={[styles.createFab, { bottom: bottomChrome.floatingControlBottom + spacing[2] }]}
+          style={[styles.createFab, { bottom: createFabBottom }]}
         />
       ) : null}
 

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -642,9 +642,12 @@ export default function DiscoverLibrary() {
           icon={iconMap.plus.android}
           onPress={handleCreatePress}
           accessibilityLabel={t('library.createFab.ariaLabel')}
-          variant="primary"
+          // Solid brand fill (the app's filled-button colour), not Paper's default
+          // `primaryContainer` tonal variant — that muted tone reads as washed-out /
+          // semi-transparent over the dark feed.
+          color={brandColors.onPrimary as string}
           mode="elevated"
-          style={[styles.createFab, { bottom: createFabBottom }]}
+          style={[styles.createFab, { bottom: createFabBottom, backgroundColor: brandColors.primaryFill }]}
         />
       ) : null}
 

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -15,7 +15,7 @@ import { Card } from '../../../src/components/Card';
 import { Button } from '../../../src/components/Button';
 import { SessionFeedCard } from '../../../src/components/you/SessionFeedCard';
 import { CommentSheet } from '../../../src/components/you/CommentSheet';
-import { FeedScopeTitle } from '../../../src/components/feed/FeedScopeTitle';
+import { HomeTopChrome, TOP_ISLAND_BAND } from '../../../src/components/feed/HomeTopChrome';
 import { type AppMenuAction } from '../../../src/components/AppMenu';
 import {
   useBulkVoteSummaries,
@@ -29,9 +29,6 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { useToast } from '../../../src/providers/toast-provider';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
-import { ProgressiveBlur } from '../../../src/components/ProgressiveBlur';
-import { GlassActionToolbar, GlassToolbarAction, TOP_ACTION_SIZE } from '../../../src/components/chrome';
-import { UserAvatarToolbarAction } from '../../../src/components/user-drawer/UserAvatarToolbarAction';
 import { dedupeSessionsById } from '../../../src/lib/feed-time-buckets';
 import { deriveFeedScopeInput, type FeedMode } from '../../../src/lib/feed/feed-scope';
 import { openClimbInPlayDrawer } from '../../../src/lib/open-climb-in-play-drawer';
@@ -43,10 +40,6 @@ import { BETA_CARD_HEIGHT, BETA_CARD_WIDTH } from '../../../src/components/play-
 
 const RECENT_BETA_LIMIT = 20;
 const SHELF_GAP = spacing[3];
-// The floating avatar island's vertical band (matches the other tabs' chrome
-// row): used to inset the feed below it and size the top blur.
-const TOP_ISLAND_BAND = spacing[1] + TOP_ACTION_SIZE + spacing[2];
-const ROW_GUTTER = spacing[4];
 const BETA_SKELETON_KEYS = ['beta-skeleton-1', 'beta-skeleton-2', 'beta-skeleton-3'];
 const INITIAL_FEED_SKELETON_KEYS = ['home-feed-skeleton-1', 'home-feed-skeleton-2', 'home-feed-skeleton-3'];
 const NEXT_PAGE_FEED_SKELETON_KEYS = ['home-feed-footer-skeleton-1', 'home-feed-footer-skeleton-2'];
@@ -87,6 +80,10 @@ export default function HomeTab() {
   const listRef = useRef<FlashListRef<SessionFeedItem>>(null);
   const commentSheetRef = useRef<BottomSheet | null>(null);
   const [commentTarget, setCommentTarget] = useState<CommentTarget | null>(null);
+  // Measured top-chrome height so the feed clears the chrome (seeded to the floating
+  // band's height — exact for Liquid Glass, corrected by the Material app bar's
+  // onLayout on the next frame).
+  const [chromeHeight, setChromeHeight] = useState(() => insets.top + TOP_ISLAND_BAND);
 
   // Feed scope. `mode` chooses the view — `crew` (people you follow) is the
   // default; `gym` is everyone on the selected board. `selectedBoard` is the
@@ -368,10 +365,10 @@ export default function HomeTab() {
         // iOS-only `automatic` behaviour left an Android gap), so pad manually.
         contentInsetAdjustmentBehavior="never"
         contentContainerStyle={{
-          paddingTop: insets.top + TOP_ISLAND_BAND,
+          paddingTop: chromeHeight,
           paddingBottom: bottomChrome.scrollBottomPadding + spacing[5],
         }}
-        scrollIndicatorInsets={{ top: insets.top + TOP_ISLAND_BAND }}
+        scrollIndicatorInsets={{ top: chromeHeight }}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         ListHeaderComponent={header}
@@ -431,34 +428,15 @@ export default function HomeTab() {
           feed.isFetchingNextPage ? <ActivitySkeletonList skeletonKeys={NEXT_PAGE_FEED_SKELETON_KEYS} /> : null
         }
       />
-      {/* Frost content scrolling under the chrome band, matching the other tabs. */}
-      <ProgressiveBlur style={[styles.topBlur, { height: insets.top + TOP_ISLAND_BAND }]} />
-      {/* Floating header: the user-avatar island (left) and the scope menu (a glass
-          title-menu pill, centred) over the blur — matching the other tabs. */}
-      <View pointerEvents="box-none" style={[styles.headerChrome, { paddingTop: insets.top + spacing[1] }]}>
-        <View pointerEvents="box-none" style={styles.headerRow}>
-          <GlassActionToolbar actionCount={1}>
-            <UserAvatarToolbarAction variant="glass" />
-          </GlassActionToolbar>
-          <View pointerEvents="box-none" style={styles.headerCenter}>
-            <FeedScopeTitle
-              title={scopeMenu.title}
-              actions={scopeMenu.actions}
-              onSelectIndex={scopeMenu.onSelectIndex}
-              accessibilityHint={t('mobile.home.scope.hint')}
-            />
-          </View>
-          {/* Find-climbers action: balances the avatar so the scope menu reads
-              centred, and opens the full-screen climber search. Uses a
-              person-add glyph (not a magnifier) so it doesn't read as a second
-              "search" next to the Climbs tab's bottom-bar magnifier. */}
-          <GlassActionToolbar actionCount={1}>
-            <GlassToolbarAction onPress={handleOpenSearch} accessibilityLabel={t('mobile.home.searchAction')}>
-              <Icon name="person.badge.plus" size={22} color={systemColors.label} />
-            </GlassToolbarAction>
-          </GlassActionToolbar>
-        </View>
-      </View>
+      <HomeTopChrome
+        scopeTitle={scopeMenu.title}
+        scopeActions={scopeMenu.actions}
+        onSelectScopeIndex={scopeMenu.onSelectIndex}
+        onOpenSearch={handleOpenSearch}
+        searchAccessibilityLabel={t('mobile.home.searchAction')}
+        scopeAccessibilityHint={t('mobile.home.scope.hint')}
+        onHeightChange={setChromeHeight}
+      />
       <CommentSheet
         sheetRef={commentSheetRef}
         entityId={commentTarget?.entityId ?? null}
@@ -691,31 +669,6 @@ function RecentBetaCard({
 
 const styles = StyleSheet.create({
   flex: { flex: 1 },
-  topBlur: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-  },
-  headerChrome: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginHorizontal: ROW_GUTTER,
-    height: TOP_ACTION_SIZE,
-  },
-  headerCenter: {
-    flex: 1,
-    minWidth: 0,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: spacing[2],
-  },
   centered: {
     flex: 1,
     alignItems: 'center',

--- a/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
@@ -1,6 +1,9 @@
-import { type ReactNode, isValidElement } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { type ReactNode, isValidElement, useCallback } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Appbar } from 'react-native-paper';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useNativeGlass } from '../../hooks/use-native-glass';
@@ -8,9 +11,11 @@ import { shadows } from '../../theme/tokens';
 import { Icon } from '../Icon';
 import { GlassSurface } from '../GlassSurface';
 import { BoardToolbarAction } from './BoardToolbarAction';
+import { BoardSwitcherButton } from './BoardSwitcherButton';
 import { GlassActionToolbar, GlassToolbarAction, TOP_ACTION_SIZE } from './GlassActionToolbar';
 import { AngleToolbarAction } from './AngleToolbarAction';
 import { LightbulbToolbarAction } from './LightbulbToolbarAction';
+import { MaterialAngleAction, MaterialLightbulbAction } from './MaterialBoardActions';
 import { CollapsingLargeTitleHeader } from './CollapsingLargeTitleHeader';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 
@@ -84,10 +89,58 @@ export function CollapsingTopChrome({
   hideLight = false,
   children,
 }: CollapsingTopChromeProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, variant } = useTheme();
+  const insets = useSafeAreaInsets();
   const nativeGlass = useNativeGlass();
   const { data: activeBoard } = useActiveBoard();
   const bluetooth = useOptionalBluetoothContext();
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
+    [onHeightChange],
+  );
+
+  // Material (Android default): a real M3 small top app bar instead of the floating
+  // glass islands. Climbs/Record short-circuit to their own Appbar before delegating
+  // here, so in practice only Discover reaches this branch — the avatar, board
+  // switcher, angle, and lightbulb come from the shared Material helpers. The create
+  // action is the screen's Material FAB (see `DiscoverLibrary`), not an app-bar
+  // control, so `canCreate` / `onCreate` are intentionally unused here. The `children`
+  // / `centerTitle` / leading / trailing props are liquid-glass-only affordances
+  // (Climbs' search row, Record's session controls) and never reach this branch.
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  if (isMaterial) {
+    return (
+      <View
+        pointerEvents="box-none"
+        style={[
+          styles.materialContainer,
+          {
+            paddingTop: insets.top,
+            backgroundColor: systemColors.secondaryBackground,
+            borderBottomColor: systemColors.separator,
+          },
+        ]}
+        onLayout={handleLayout}
+      >
+        <Appbar.Header
+          statusBarHeight={0}
+          mode="small"
+          elevated
+          style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
+        >
+          <UserAvatarToolbarAction variant="material" />
+          <BoardSwitcherButton
+            onPress={onOpenBoardSwitcher}
+            accessibilityHint={boardPillAccessibilityHint}
+            badge={boardBadge}
+          />
+          <MaterialAngleAction />
+          <MaterialLightbulbAction />
+        </Appbar.Header>
+      </View>
+    );
+  }
 
   const canOpenAngle = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
   // A fragment/element of leading actions reads as one element, so callers passing
@@ -174,5 +227,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-end',
     overflow: 'hidden',
+  },
+  // Material small app bar (mirrors ClimbTopChrome / RecordTopChrome): absolutely
+  // positioned so the list scrolls under it, height reported via onLayout.
+  materialContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  materialAppbar: {
+    elevation: 0,
+    shadowOpacity: 0,
   },
 });

--- a/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
+++ b/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
@@ -1,0 +1,105 @@
+// The Material variant's board-context app-bar actions: an angle control and a
+// bluetooth lightbulb, both as M3 `Appbar.Action`s. Extracted from
+// `ClimbTopChrome` so the Climbs app bar and the shared `CollapsingTopChrome`
+// material branch (Discover) render the same controls instead of duplicating
+// them. They are the flat M3 counterparts of the liquid-glass `AngleToolbarAction`
+// / `LightbulbToolbarAction` islands — each reads its own state and renders
+// nothing when it doesn't apply (no adjustable board / no bluetooth).
+
+import { useCallback, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Appbar } from 'react-native-paper';
+import { useTheme } from '../../providers/theme-provider';
+import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
+import { hapticLight } from '../../lib/haptics';
+import { useLightbulbControl } from '../ble/use-lightbulb-control';
+import { Text } from '../Text';
+import { iconMap } from '../icon-map';
+import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
+
+export function MaterialAngleAction() {
+  const { systemColors } = useTheme();
+  const { t: tSession } = useTranslation('session');
+  const { data: activeBoard } = useActiveBoard();
+  const setActiveBoard = useSetActiveBoard();
+  const [visible, setVisible] = useState(false);
+
+  const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
+  const angleIcon = useCallback(
+    () => (
+      <Text variant="caption1" style={[styles.materialAngleText, { color: systemColors.label }]}>
+        {activeBoard?.angle}°
+      </Text>
+    ),
+    [activeBoard?.angle, systemColors.label],
+  );
+  const handleOpen = useCallback(() => {
+    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
+    hapticLight();
+    setVisible(true);
+  }, [activeBoard]);
+  const handleClose = useCallback(() => setVisible(false), []);
+  const handleAngleChange = useCallback(
+    (newAngle: number) => {
+      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
+      void setActiveBoard({ ...activeBoard, angle: newAngle });
+    },
+    [activeBoard, setActiveBoard],
+  );
+
+  if (!activeBoard || !canAdjust) return null;
+
+  return (
+    <>
+      <Appbar.Action
+        icon={angleIcon}
+        onPress={handleOpen}
+        accessibilityLabel={tSession('mobile.angleSelector.title')}
+      />
+      <AngleSelectorSheet
+        visible={visible}
+        onClose={handleClose}
+        boardName={activeBoard.boardType}
+        layoutId={activeBoard.layoutId}
+        currentAngle={activeBoard.angle}
+        onAngleChange={handleAngleChange}
+      />
+    </>
+  );
+}
+
+export function MaterialLightbulbAction() {
+  const { systemColors, brandColors } = useTheme();
+  const { t: tCommon } = useTranslation('common');
+  const { t: tSettings } = useTranslation('settings');
+  const { bluetooth, lit, localConnected, onPress } = useLightbulbControl({ source: 'lightbulb_toolbar' });
+
+  const handlePress = useCallback(() => {
+    hapticLight();
+    onPress();
+  }, [onPress]);
+
+  if (!bluetooth) return null;
+
+  const iconName = lit ? iconMap['lightbulb.fill'].android : iconMap.lightbulb.android;
+  const iconColor = lit ? brandColors.warning : systemColors.label;
+
+  return (
+    <Appbar.Action
+      icon={iconName}
+      color={iconColor as string}
+      onPress={handlePress}
+      // The label reflects what tapping does (this device's link), not the fill —
+      // the bulb can read lit because a session peer holds the wall.
+      accessibilityLabel={localConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  materialAngleText: {
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
@@ -19,6 +19,7 @@ const ctrl = vi.hoisted(() => ({
   board: null as BoardFields | null,
   bluetooth: null as BluetoothCtx,
   setActiveBoard: vi.fn(),
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 const haptics = vi.hoisted(() => ({ light: vi.fn() }));
 
@@ -49,14 +50,40 @@ vi.mock('react-native-safe-area-context', () => ({
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@boardsesh/board-config', () => ({ formatBoardDisplayName: (boardType: string) => `Display:${boardType}` }));
 
+// Material branch renders an M3 Appbar (via react-native-paper). Stub it so the
+// jsdom suite doesn't pull in Paper's native runtime.
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Header: ({ children }: { children?: ReactNode }) =>
+      createElement('div', { 'data-appbar-header': 'true' }, children),
+    Content: ({ title }: { title?: ReactNode }) => createElement('span', { 'data-appbar-title': 'true' }, title),
+    Action: ({
+      icon,
+      onPress,
+      accessibilityLabel,
+    }: {
+      icon?: ReactNode | ((props: { color: string; size: number }) => ReactNode);
+      onPress?: () => void;
+      accessibilityLabel?: string;
+    }) =>
+      createElement(
+        'button',
+        { onClick: onPress, 'data-appbar-action': accessibilityLabel ?? '' },
+        typeof icon === 'function' ? icon({ color: '#000', size: 24 }) : icon,
+      ),
+  },
+}));
+
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    variant: ctrl.variant,
     systemColors: {
       label: '#000',
       secondaryLabel: '#888',
       separator: '#ccc',
       elevatedSurface: '#fff',
       background: '#fff',
+      secondaryBackground: '#fff',
     },
     brandColors: { warning: '#FF9500' },
   }),
@@ -153,6 +180,7 @@ describe('CollapsingTopChrome', () => {
   beforeEach(() => {
     ctrl.board = null;
     ctrl.bluetooth = null;
+    ctrl.variant = 'liquidGlass';
     haptics.light.mockClear();
   });
 
@@ -269,5 +297,30 @@ describe('CollapsingTopChrome', () => {
     const { container } = render(<CollapsingTopChrome {...makeProps({ onHeightChange })} />);
     fireEvent.click(container.querySelector('[data-has-layout="true"]') as HTMLElement);
     expect(onHeightChange).toHaveBeenCalledWith(64);
+  });
+
+  describe('Material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
+
+    it('renders an M3 app bar (avatar + board switcher) instead of the floating glass islands', () => {
+      ctrl.board = board;
+      const { container } = render(<CollapsingTopChrome {...makeProps()} />);
+      // The M3 small app bar replaces the floating glass islands.
+      expect(container.querySelector('[data-appbar-header]')).not.toBeNull();
+      expect(container.querySelector('[data-avatar-variant="material"]')).not.toBeNull();
+      // The board switcher carries the board label (a `•`-bearing PressableSurface).
+      expect(boardAction(container)).not.toBeNull();
+      // No floating GlassSurface island on Material.
+      expect(container.querySelector('[data-glass]')).toBeNull();
+    });
+
+    it('reports the app bar height through onHeightChange', () => {
+      const onHeightChange = vi.fn();
+      const { container } = render(<CollapsingTopChrome {...makeProps({ onHeightChange })} />);
+      fireEvent.click(container.querySelector('[data-has-layout="true"]') as HTMLElement);
+      expect(onHeightChange).toHaveBeenCalledWith(64);
+    });
   });
 });

--- a/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
@@ -19,6 +19,7 @@ const ctrl = vi.hoisted(() => ({
   board: null as BoardFields | null,
   bluetooth: null as BluetoothCtx,
   setActiveBoard: vi.fn(),
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
 }));
 const haptics = vi.hoisted(() => ({ light: vi.fn() }));
 
@@ -49,14 +50,40 @@ vi.mock('react-native-safe-area-context', () => ({
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('@boardsesh/board-config', () => ({ formatBoardDisplayName: (boardType: string) => `Display:${boardType}` }));
 
+// The Material branch (CollapsingTopChrome) renders an M3 Appbar via react-native-paper.
+// Stub it so the jsdom suite doesn't pull in Paper's native runtime.
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Header: ({ children }: { children?: ReactNode }) =>
+      createElement('div', { 'data-appbar-header': 'true' }, children),
+    Content: ({ title }: { title?: ReactNode }) => createElement('span', { 'data-appbar-title': 'true' }, title),
+    Action: ({
+      icon,
+      onPress,
+      accessibilityLabel,
+    }: {
+      icon?: ReactNode | ((props: { color: string; size: number }) => ReactNode);
+      onPress?: () => void;
+      accessibilityLabel?: string;
+    }) =>
+      createElement(
+        'button',
+        { onClick: onPress, 'data-appbar-action': accessibilityLabel ?? '' },
+        typeof icon === 'function' ? icon({ color: '#000', size: 24 }) : icon,
+      ),
+  },
+}));
+
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    variant: ctrl.variant,
     systemColors: {
       label: '#000',
       secondaryLabel: '#888',
       separator: '#ccc',
       elevatedSurface: '#fff',
       background: '#fff',
+      secondaryBackground: '#fff',
     },
     brandColors: { warning: '#FF9500' },
   }),
@@ -149,6 +176,7 @@ describe('DiscoverTopChrome', () => {
   beforeEach(() => {
     ctrl.board = null;
     ctrl.bluetooth = null;
+    ctrl.variant = 'liquidGlass';
     haptics.light.mockClear();
   });
 
@@ -197,5 +225,23 @@ describe('DiscoverTopChrome', () => {
     const { container } = render(<DiscoverTopChrome {...makeProps({ onHeightChange })} />);
     fireEvent.click(container.querySelector('[data-has-layout="true"]') as HTMLElement);
     expect(onHeightChange).toHaveBeenCalledWith(72);
+  });
+
+  describe('Material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
+
+    it('renders the M3 app bar (no floating glass island, no in-chrome create) on Android', () => {
+      ctrl.board = board;
+      const { container } = render(<DiscoverTopChrome {...makeProps({ canCreate: true })} />);
+      expect(container.querySelector('[data-appbar-header]')).not.toBeNull();
+      expect(container.querySelector('[data-avatar-variant="material"]')).not.toBeNull();
+      expect(boardAction(container)).not.toBeNull();
+      // No glass surface, and the create "+" is the screen-level FAB (DiscoverLibrary),
+      // not an in-chrome island.
+      expect(container.querySelector('[data-glass]')).toBeNull();
+      expect(createAction(container)).toBeNull();
+    });
   });
 });

--- a/packages/mobile/src/components/chrome/index.ts
+++ b/packages/mobile/src/components/chrome/index.ts
@@ -6,3 +6,4 @@ export { LightbulbToolbarAction } from './LightbulbToolbarAction';
 export { CollapsingLargeTitleHeader } from './CollapsingLargeTitleHeader';
 export { CollapsingTopChrome } from './CollapsingTopChrome';
 export { DiscoverTopChrome } from './DiscoverTopChrome';
+export { MaterialAngleAction, MaterialLightbulbAction } from './MaterialBoardActions';

--- a/packages/mobile/src/components/feed/FeedScopeTitle.tsx
+++ b/packages/mobile/src/components/feed/FeedScopeTitle.tsx
@@ -1,14 +1,19 @@
-// The Home feed's scope control: a glass header pill showing the active scope
-// ("My crew" / a gym name / "Everyone") with a down-caret. Tapping it opens a
-// dropdown menu (a Material 3 Paper menu on Material, the native iOS UIMenu on
-// Liquid Glass) to switch scope / pick a gym — a title-menu button in the floating
-// chrome rather than a large in-body title.
+// The Home feed's scope control, routed by UI variant. It shows the active scope
+// ("My crew" / a gym name / "Everyone") with a down-caret and opens a dropdown menu
+// to switch scope / pick a gym.
+//
+// Liquid Glass: a floating glass pill (the title-menu button that sits in the
+// floating chrome). Material: the flat M3 app-bar title — leading-aligned, no pill
+// background — that grows to fill the app bar's title slot (mirroring
+// `BoardSwitcherButton`). Both open the same dropdown (a Paper menu on Material, the
+// native iOS UIMenu on Liquid Glass) via `AppMenu`.
 
 import { StyleSheet, View } from 'react-native';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { GlassSurface } from '../GlassSurface';
 import { AppMenu, type AppMenuAction } from '../AppMenu';
+import { createVariantComponent } from '../../theme/variants';
 import { useNativeGlass } from '../../hooks/use-native-glass';
 import { spacing, shadows } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
@@ -18,20 +23,25 @@ const PILL_HEIGHT = glassSize.capsule;
 const PILL_RADIUS = PILL_HEIGHT / 2;
 
 type FeedScopeTitleProps = {
-  /** The active scope, shown in the pill. */
+  /** The active scope, shown in the pill / title. */
   title: string;
   /** Menu items, in render order; `onSelectIndex` is called with the tapped index. */
   actions: AppMenuAction[];
   onSelectIndex: (index: number) => void;
-  /** VoiceOver hint — the pill is a menu, so cue what activating it does. */
+  /** VoiceOver hint — the control is a menu, so cue what activating it does. */
   accessibilityHint?: string;
 };
 
-export function FeedScopeTitle({ title, actions, onSelectIndex, accessibilityHint }: FeedScopeTitleProps) {
+export const FeedScopeTitle = createVariantComponent('FeedScopeTitle', {
+  liquidGlass: FeedScopeTitleGlass,
+  material: FeedScopeTitleMaterial,
+});
+
+function FeedScopeTitleGlass({ title, actions, onSelectIndex, accessibilityHint }: FeedScopeTitleProps) {
   const { systemColors } = useTheme();
   const nativeGlass = useNativeGlass();
-  // `AppMenu` owns the per-variant menu (Paper menu vs native dropdown) and the
-  // selected-row marker; the actions are already in its neutral shape.
+  // `AppMenu` owns the per-variant menu (native dropdown) and the selected-row
+  // marker; the actions are already in its neutral shape.
   return (
     <AppMenu
       actions={actions}
@@ -67,6 +77,33 @@ export function FeedScopeTitle({ title, actions, onSelectIndex, accessibilityHin
   );
 }
 
+function FeedScopeTitleMaterial({ title, actions, onSelectIndex, accessibilityHint }: FeedScopeTitleProps) {
+  const { systemColors } = useTheme();
+  // The flat M3 app-bar title (no pill): the menu anchor itself is the centered row
+  // (filling the title slot, flex: 1), so the title + caret stay vertically centred
+  // with the avatar / trailing action — mirroring `BoardSwitcherButton`.
+  return (
+    <AppMenu
+      actions={actions}
+      onSelectIndex={onSelectIndex}
+      accessibilityLabel={title}
+      accessibilityHint={accessibilityHint}
+      style={styles.materialMenu}
+    >
+      <Text
+        variant="title3"
+        color={systemColors.label}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        style={styles.materialTitle}
+      >
+        {title}
+      </Text>
+      <Icon name="chevron.down" size={18} color={systemColors.secondaryLabel} />
+    </AppMenu>
+  );
+}
+
 const styles = StyleSheet.create({
   // Size the anchor to its content so the tap target is the pill.
   menu: { alignSelf: 'center' },
@@ -82,4 +119,13 @@ const styles = StyleSheet.create({
     maxWidth: 240,
   },
   title: { fontWeight: '700', flexShrink: 1 },
+  // Material: the anchor fills the app-bar title slot and centres its row, so the
+  // avatar/search actions hold the edges and the title aligns with them.
+  materialMenu: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  materialTitle: { fontWeight: '700', flexShrink: 1 },
 });

--- a/packages/mobile/src/components/feed/FeedScopeTitle.tsx
+++ b/packages/mobile/src/components/feed/FeedScopeTitle.tsx
@@ -119,13 +119,15 @@ const styles = StyleSheet.create({
     maxWidth: 240,
   },
   title: { fontWeight: '700', flexShrink: 1 },
-  // Material: the anchor fills the app-bar title slot and centres its row, so the
-  // avatar/search actions hold the edges and the title aligns with them.
+  // Material: a leading, content-width menu anchor (Paper's Menu wraps it in a
+  // content-width View, so flex: 1 here wouldn't reach the app-bar row). The host
+  // right-aligns the trailing action with a flex spacer; `maxWidth` keeps a long
+  // scope name from crowding it. The row centres the title + caret vertically.
   materialMenu: {
-    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[1],
+    maxWidth: 220,
   },
   materialTitle: { fontWeight: '700', flexShrink: 1 },
 });

--- a/packages/mobile/src/components/feed/HomeTopChrome.tsx
+++ b/packages/mobile/src/components/feed/HomeTopChrome.tsx
@@ -151,6 +151,10 @@ function HomeTopChromeMaterial({
           onSelectIndex={onSelectScopeIndex}
           accessibilityHint={scopeAccessibilityHint}
         />
+        {/* Flex spacer holds the find-climbers action to the trailing edge — the
+            scope title-menu is a Paper Menu (content-width anchor), so it can't flex
+            into the slot itself the way Appbar.Content / BoardSwitcherButton do. */}
+        <View style={styles.materialSpacer} />
         <Appbar.Action
           icon={iconMap['person.badge.plus'].android}
           color={systemColors.label as string}
@@ -206,5 +210,10 @@ const styles = StyleSheet.create({
   materialAppbar: {
     elevation: 0,
     shadowOpacity: 0,
+  },
+  // Pushes the find-climbers action to the trailing edge (the scope title-menu can't
+  // flex, so the spacer takes the slack instead).
+  materialSpacer: {
+    flex: 1,
   },
 });

--- a/packages/mobile/src/components/feed/HomeTopChrome.tsx
+++ b/packages/mobile/src/components/feed/HomeTopChrome.tsx
@@ -1,0 +1,210 @@
+// Top chrome for the Home (feed) tab, routed by UI variant.
+//
+// Liquid Glass: the floating chrome shared with the other tabs — an always-on
+// progressive blur plus a row of glass islands (account avatar left, the
+// `FeedScopeTitle` title-menu pill centred, a find-climbers action right). The feed
+// scrolls under the blur.
+//
+// Material: an absolutely-positioned, `onHeightChange`-measured M3 small app bar
+// (mirroring `ProfileTopChrome` / `ClimbTopChrome`) — the account avatar, the
+// `FeedScopeTitle` as the flat app-bar title-menu, and the find-climbers
+// `Appbar.Action`. Home has no board/angle/light controls and no create action, so
+// the bar stays avatar · scope · find-climbers.
+
+import { useCallback } from 'react';
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Appbar } from 'react-native-paper';
+import { useTheme } from '../../providers/theme-provider';
+import { createVariantComponent } from '../../theme/variants';
+import { spacing } from '../../theme/tokens';
+import { Icon } from '../Icon';
+import { iconMap } from '../icon-map';
+import { type AppMenuAction } from '../AppMenu';
+import { ProgressiveBlur } from '../ProgressiveBlur';
+import { GlassActionToolbar, GlassToolbarAction, TOP_ACTION_SIZE } from '../chrome';
+import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
+import { FeedScopeTitle } from './FeedScopeTitle';
+
+const ROW_GUTTER = spacing[4];
+// The floating avatar island's vertical band (matches the other tabs' chrome row):
+// used to size the top blur and seed the host's list inset before the real height
+// is measured.
+export const TOP_ISLAND_BAND = spacing[1] + TOP_ACTION_SIZE + spacing[2];
+
+export type HomeTopChromeProps = {
+  /** The active feed scope, shown as the title-menu. */
+  scopeTitle: string;
+  /** Scope menu rows, in render order. */
+  scopeActions: AppMenuAction[];
+  onSelectScopeIndex: (index: number) => void;
+  /** Open the full-screen climber search (the find-climbers action). */
+  onOpenSearch: () => void;
+  /** VoiceOver label for the find-climbers action. */
+  searchAccessibilityLabel: string;
+  /** VoiceOver hint for the scope title-menu. */
+  scopeAccessibilityHint?: string;
+  /** Report the measured chrome height so the feed insets its top padding. */
+  onHeightChange: (height: number) => void;
+};
+
+export const HomeTopChrome = createVariantComponent('HomeTopChrome', {
+  liquidGlass: HomeTopChromeGlass,
+  material: HomeTopChromeMaterial,
+});
+
+function HomeTopChromeGlass({
+  scopeTitle,
+  scopeActions,
+  onSelectScopeIndex,
+  onOpenSearch,
+  searchAccessibilityLabel,
+  scopeAccessibilityHint,
+  onHeightChange,
+}: HomeTopChromeProps) {
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
+    [onHeightChange],
+  );
+
+  return (
+    <>
+      {/* Frost content scrolling under the chrome band, matching the other tabs. */}
+      <ProgressiveBlur style={[styles.topBlur, { height: insets.top + TOP_ISLAND_BAND }]} />
+      {/* Floating header: the user-avatar island (left) and the scope menu (a glass
+          title-menu pill, centred) over the blur — matching the other tabs. */}
+      <View
+        pointerEvents="box-none"
+        style={[styles.headerChrome, { paddingTop: insets.top + spacing[1] }]}
+        onLayout={handleLayout}
+      >
+        <View pointerEvents="box-none" style={styles.headerRow}>
+          <GlassActionToolbar actionCount={1}>
+            <UserAvatarToolbarAction variant="glass" />
+          </GlassActionToolbar>
+          <View pointerEvents="box-none" style={styles.headerCenter}>
+            <FeedScopeTitle
+              title={scopeTitle}
+              actions={scopeActions}
+              onSelectIndex={onSelectScopeIndex}
+              accessibilityHint={scopeAccessibilityHint}
+            />
+          </View>
+          {/* Find-climbers action: balances the avatar so the scope menu reads
+              centred, and opens the full-screen climber search. Uses a person-add
+              glyph (not a magnifier) so it doesn't read as a second "search" next to
+              the Climbs tab's bottom-bar magnifier. */}
+          <GlassActionToolbar actionCount={1}>
+            <GlassToolbarAction onPress={onOpenSearch} accessibilityLabel={searchAccessibilityLabel}>
+              <Icon name="person.badge.plus" size={22} color={systemColors.label} />
+            </GlassToolbarAction>
+          </GlassActionToolbar>
+        </View>
+      </View>
+    </>
+  );
+}
+
+function HomeTopChromeMaterial({
+  scopeTitle,
+  scopeActions,
+  onSelectScopeIndex,
+  onOpenSearch,
+  searchAccessibilityLabel,
+  scopeAccessibilityHint,
+  onHeightChange,
+}: HomeTopChromeProps) {
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
+    [onHeightChange],
+  );
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[
+        styles.materialContainer,
+        {
+          paddingTop: insets.top,
+          backgroundColor: systemColors.secondaryBackground,
+          borderBottomColor: systemColors.separator,
+        },
+      ]}
+      onLayout={handleLayout}
+    >
+      <Appbar.Header
+        statusBarHeight={0}
+        mode="small"
+        elevated
+        style={[styles.materialAppbar, { backgroundColor: systemColors.secondaryBackground }]}
+      >
+        <UserAvatarToolbarAction variant="material" />
+        <FeedScopeTitle
+          title={scopeTitle}
+          actions={scopeActions}
+          onSelectIndex={onSelectScopeIndex}
+          accessibilityHint={scopeAccessibilityHint}
+        />
+        <Appbar.Action
+          icon={iconMap['person.badge.plus'].android}
+          color={systemColors.label as string}
+          onPress={onOpenSearch}
+          accessibilityLabel={searchAccessibilityLabel}
+        />
+      </Appbar.Header>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Progressive blur layer (height applied inline): spans from the top of the screen
+  // down to just below the islands row, behind the islands.
+  topBlur: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  headerChrome: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    // Pad the band's bottom so the measured height matches `insets.top +
+    // TOP_ISLAND_BAND` (the value the host seeds the list inset with).
+    paddingBottom: spacing[2],
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: ROW_GUTTER,
+    height: TOP_ACTION_SIZE,
+  },
+  headerCenter: {
+    flex: 1,
+    minWidth: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[2],
+  },
+  // Material small app bar (mirrors ProfileTopChrome / ClimbTopChrome): absolutely
+  // positioned so the feed scrolls under it, height reported via onLayout.
+  materialContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  materialAppbar: {
+    elevation: 0,
+    shadowOpacity: 0,
+  },
+});

--- a/packages/mobile/src/components/feed/__tests__/FeedScopeTitle.test.tsx
+++ b/packages/mobile/src/components/feed/__tests__/FeedScopeTitle.test.tsx
@@ -12,6 +12,7 @@ const capture = vi.hoisted(() => ({
   onSelectIndex: undefined as ((index: number) => void) | undefined,
   accessibilityLabel: undefined as string | undefined,
 }));
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
@@ -45,6 +46,7 @@ vi.mock('../../GlassSurface', () => ({ GlassSurface: () => createElement('div', 
 vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    variant: ctrl.variant,
     systemColors: { label: '#000', secondaryLabel: '#999', separator: '#ccc', elevatedSurface: '#fff' },
   }),
 }));
@@ -62,6 +64,7 @@ beforeEach(() => {
   capture.actions = undefined;
   capture.onSelectIndex = undefined;
   capture.accessibilityLabel = undefined;
+  ctrl.variant = 'liquidGlass';
 });
 
 describe('FeedScopeTitle', () => {
@@ -77,5 +80,25 @@ describe('FeedScopeTitle', () => {
     expect(capture.accessibilityLabel).toBe('My crew');
     capture.onSelectIndex?.(1);
     expect(onSelectIndex).toHaveBeenCalledWith(1);
+  });
+
+  it('renders the floating glass pill on Liquid Glass', () => {
+    const { container } = render(
+      createElement(FeedScopeTitle, { title: 'My crew', actions: ACTIONS, onSelectIndex: () => {} }),
+    );
+    expect(container.querySelector('[data-glass]')).not.toBeNull();
+  });
+
+  it('renders the flat M3 title-menu (no glass pill) on Material, still forwarding its actions', () => {
+    ctrl.variant = 'material';
+    const { container } = render(
+      createElement(FeedScopeTitle, { title: 'My crew', actions: ACTIONS, onSelectIndex: () => {} }),
+    );
+    // The Material app-bar title is flat — no floating GlassSurface pill.
+    expect(container.querySelector('[data-glass]')).toBeNull();
+    // Still a menu anchored to the title, still forwarding its actions + label.
+    expect(container.querySelector('[data-app-menu]')).not.toBeNull();
+    expect(capture.actions).toBe(ACTIONS);
+    expect(capture.accessibilityLabel).toBe('My crew');
   });
 });

--- a/packages/mobile/src/components/feed/__tests__/HomeTopChrome.test.tsx
+++ b/packages/mobile/src/components/feed/__tests__/HomeTopChrome.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { AppMenuAction } from '../../AppMenu';
+
+const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+
+type ViewMockProps = {
+  children?: ReactNode;
+  onLayout?: (event: { nativeEvent: { layout: { height: number } } }) => void;
+};
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: ViewMockProps) =>
+    createElement(
+      'div',
+      {
+        'data-has-layout': onLayout ? 'true' : 'false',
+        onClick: onLayout ? () => onLayout({ nativeEvent: { layout: { height: 80 } } }) : undefined,
+      },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Header: ({ children }: { children?: ReactNode }) =>
+      createElement('div', { 'data-appbar-header': 'true' }, children),
+    Action: ({ onPress, accessibilityLabel }: { onPress?: () => void; accessibilityLabel?: string }) =>
+      createElement('button', { onClick: onPress, 'data-appbar-action': accessibilityLabel ?? '' }),
+  },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    systemColors: { label: '#000', secondaryLabel: '#999', separator: '#ccc', secondaryBackground: '#fff' },
+  }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 4: 16 } }));
+
+vi.mock('../../ProgressiveBlur', () => ({ ProgressiveBlur: () => createElement('div', { 'data-blur': 'true' }) }));
+vi.mock('../../chrome', () => ({
+  TOP_ACTION_SIZE: 48,
+  GlassActionToolbar: ({ children }: { children?: ReactNode }) =>
+    createElement('div', { 'data-island': 'true' }, children),
+  GlassToolbarAction: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'data-pressable': accessibilityLabel ?? '' }, children),
+}));
+vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
+  UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) =>
+    createElement('button', { 'data-avatar-variant': variant }),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../FeedScopeTitle', () => ({
+  FeedScopeTitle: ({ title }: { title: string }) => createElement('div', { 'data-feed-scope': 'true' }, title),
+}));
+
+import { HomeTopChrome, type HomeTopChromeProps } from '../HomeTopChrome';
+
+const ACTIONS: AppMenuAction[] = [{ label: 'My crew', selected: true }];
+
+function makeProps(over: Partial<HomeTopChromeProps> = {}) {
+  return {
+    scopeTitle: 'My crew',
+    scopeActions: ACTIONS,
+    onSelectScopeIndex: vi.fn(),
+    onOpenSearch: vi.fn(),
+    searchAccessibilityLabel: 'searchLabel',
+    scopeAccessibilityHint: 'hint',
+    onHeightChange: vi.fn(),
+    ...over,
+  };
+}
+
+const searchAction = (root: HTMLElement) =>
+  (root.querySelector('[data-pressable="searchLabel"]') ??
+    root.querySelector('[data-appbar-action="searchLabel"]')) as HTMLButtonElement | null;
+
+describe('HomeTopChrome', () => {
+  beforeEach(() => {
+    ctrl.variant = 'liquidGlass';
+  });
+
+  describe('Liquid Glass variant', () => {
+    it('renders the floating glass chrome (blur + avatar/search islands + scope title)', () => {
+      const { container } = render(<HomeTopChrome {...makeProps()} />);
+      expect(container.querySelector('[data-blur]')).not.toBeNull();
+      expect(container.querySelector('[data-avatar-variant="glass"]')).not.toBeNull();
+      expect(container.querySelector('[data-feed-scope]')?.textContent).toBe('My crew');
+      expect(searchAction(container)).not.toBeNull();
+      // No M3 app bar on glass.
+      expect(container.querySelector('[data-appbar-header]')).toBeNull();
+    });
+
+    it('fires onOpenSearch when the find-climbers action is pressed', () => {
+      const onOpenSearch = vi.fn();
+      const { container } = render(<HomeTopChrome {...makeProps({ onOpenSearch })} />);
+      fireEvent.click(searchAction(container)!);
+      expect(onOpenSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports its measured height through onHeightChange', () => {
+      const onHeightChange = vi.fn();
+      const { container } = render(<HomeTopChrome {...makeProps({ onHeightChange })} />);
+      fireEvent.click(container.querySelector('[data-has-layout="true"]') as HTMLElement);
+      expect(onHeightChange).toHaveBeenCalledWith(80);
+    });
+  });
+
+  describe('Material variant', () => {
+    beforeEach(() => {
+      ctrl.variant = 'material';
+    });
+
+    it('renders an M3 app bar (avatar + scope title-menu + find-climbers action), no glass chrome', () => {
+      const { container } = render(<HomeTopChrome {...makeProps()} />);
+      expect(container.querySelector('[data-appbar-header]')).not.toBeNull();
+      expect(container.querySelector('[data-avatar-variant="material"]')).not.toBeNull();
+      expect(container.querySelector('[data-feed-scope]')?.textContent).toBe('My crew');
+      expect(searchAction(container)).not.toBeNull();
+      // No floating blur / glass islands on Material.
+      expect(container.querySelector('[data-blur]')).toBeNull();
+      expect(container.querySelector('[data-island]')).toBeNull();
+    });
+
+    it('fires onOpenSearch from the app-bar action', () => {
+      const onOpenSearch = vi.fn();
+      const { container } = render(<HomeTopChrome {...makeProps({ onOpenSearch })} />);
+      fireEvent.click(searchAction(container)!);
+      expect(onOpenSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports the app bar height through onHeightChange', () => {
+      const onHeightChange = vi.fn();
+      const { container } = render(<HomeTopChrome {...makeProps({ onHeightChange })} />);
+      fireEvent.click(container.querySelector('[data-has-layout="true"]') as HTMLElement);
+      expect(onHeightChange).toHaveBeenCalledWith(80);
+    });
+  });
+});

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -7,7 +7,7 @@
 // persistently in the centre. The Material variant keeps a dedicated
 // Appbar.Header with the board as its subtitle plus grade / filter quick chips.
 
-import { type RefObject, useCallback, useState } from 'react';
+import { type RefObject, useCallback } from 'react';
 import { Keyboard, type LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -17,16 +17,17 @@ import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
-import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { spacing } from '../../theme/tokens';
-import { hapticLight } from '../../lib/haptics';
-import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
-import { Text } from '../Text';
 import { iconMap } from '../icon-map';
-import { BoardSwitcherButton, CollapsingTopChrome, TOP_ACTION_SIZE } from '../chrome';
+import {
+  BoardSwitcherButton,
+  CollapsingTopChrome,
+  MaterialAngleAction,
+  MaterialLightbulbAction,
+  TOP_ACTION_SIZE,
+} from '../chrome';
 import { GradeRangeRail } from '../grade';
-import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
 import { FilterButton } from './FilterButton';
 import { GradeFilterControl } from './GradeFilterControl';
@@ -274,85 +275,6 @@ export function ClimbTopChrome({
   );
 }
 
-function MaterialAngleAction() {
-  const { systemColors } = useTheme();
-  const { t: tSession } = useTranslation('session');
-  const { data: activeBoard } = useActiveBoard();
-  const setActiveBoard = useSetActiveBoard();
-  const [visible, setVisible] = useState(false);
-
-  const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
-  const angleIcon = useCallback(
-    () => (
-      <Text variant="caption1" style={[styles.materialAngleText, { color: systemColors.label }]}>
-        {activeBoard?.angle}°
-      </Text>
-    ),
-    [activeBoard?.angle, systemColors.label],
-  );
-  const handleOpen = useCallback(() => {
-    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
-    hapticLight();
-    setVisible(true);
-  }, [activeBoard]);
-  const handleClose = useCallback(() => setVisible(false), []);
-  const handleAngleChange = useCallback(
-    (newAngle: number) => {
-      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
-      void setActiveBoard({ ...activeBoard, angle: newAngle });
-    },
-    [activeBoard, setActiveBoard],
-  );
-
-  if (!activeBoard || !canAdjust) return null;
-
-  return (
-    <>
-      <Appbar.Action
-        icon={angleIcon}
-        onPress={handleOpen}
-        accessibilityLabel={tSession('mobile.angleSelector.title')}
-      />
-      <AngleSelectorSheet
-        visible={visible}
-        onClose={handleClose}
-        boardName={activeBoard.boardType}
-        layoutId={activeBoard.layoutId}
-        currentAngle={activeBoard.angle}
-        onAngleChange={handleAngleChange}
-      />
-    </>
-  );
-}
-
-function MaterialLightbulbAction() {
-  const { systemColors, brandColors } = useTheme();
-  const { t: tCommon } = useTranslation('common');
-  const { t: tSettings } = useTranslation('settings');
-  const { bluetooth, lit, localConnected, onPress } = useLightbulbControl({ source: 'lightbulb_toolbar' });
-
-  const handlePress = useCallback(() => {
-    hapticLight();
-    onPress();
-  }, [onPress]);
-
-  if (!bluetooth) return null;
-
-  const iconName = lit ? iconMap['lightbulb.fill'].android : iconMap.lightbulb.android;
-  const iconColor = lit ? brandColors.warning : systemColors.label;
-
-  return (
-    <Appbar.Action
-      icon={iconName}
-      color={iconColor as string}
-      onPress={handlePress}
-      // The label reflects what tapping does (this device's link), not the fill —
-      // the bulb can read lit because a session peer holds the wall.
-      accessibilityLabel={localConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')}
-    />
-  );
-}
-
 const styles = StyleSheet.create({
   searchStack: {
     paddingHorizontal: spacing[4],
@@ -413,9 +335,5 @@ const styles = StyleSheet.create({
   },
   materialGradeRail: {
     marginTop: spacing[1],
-  },
-  materialAngleText: {
-    fontWeight: '700',
-    textAlign: 'center',
   },
 });

--- a/scripts/mobile-variant-guard.sh
+++ b/scripts/mobile-variant-guard.sh
@@ -56,4 +56,53 @@ if [ -n "$matches" ]; then
   exit 1
 fi
 
-echo "✓ No raw theme-variant compares in mobile components/screens."
+# ── Floating glass chrome must carry a Material branch ──────────────────────────
+# The second leak class (fixed in the Home/Discover M3 chrome PR): a screen or top
+# chrome that MOUNTS the floating iOS-island primitives — GlassActionToolbar or
+# CollapsingLargeTitleHeader — with no Material counterpart. GlassSurface only swaps
+# the island FILL by variant (frosted vs opaque), never the LAYOUT, so an unbranched
+# mount renders floating glass FABs/islands on Android (Material) where an M3 top app
+# bar belongs. Flag any file that uses those primitives in JSX but contains no
+# selectByVariant / createVariantComponent branch.
+#
+# Heuristic, not a proof: this is file-level (mounts a primitive AND mentions a
+# branch helper somewhere) — a file that branches on an unrelated value could
+# false-pass. That's acceptable for a backstop; the real guarantee is the per-screen
+# Material Appbar branch + the screenshot diff.
+#
+# GLASS_CHROME_ALLOWLIST — glass-only sub-components whose CALLER owns the branch:
+#  - PlaylistOwnerToolbar: the playlist-detail `renderActions(collapsed)` only mounts
+#    it on the expanded-hero (collapsed=false) path; PlaylistDetailView asks for the
+#    collapsed form on Material, which returns a variant-branched GlassIconButton
+#    overflow instead. So it never renders on Android Material.
+GLASS_CHROME_ALLOWLIST='playlist/PlaylistOwnerToolbar\.tsx'
+
+glass_chrome_unbranched=''
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  if ! grep -qE 'selectByVariant|createVariantComponent' "$file"; then
+    glass_chrome_unbranched="${glass_chrome_unbranched}${file}"$'\n'
+  fi
+done < <(
+  grep -rlE "<(GlassActionToolbar|CollapsingLargeTitleHeader)\b" \
+    packages/mobile/src/components packages/mobile/app \
+    --include='*.tsx' \
+    | grep -v '__tests__' \
+    | grep -vE "$GLASS_CHROME_ALLOWLIST" \
+    || true
+)
+
+if [ -n "$glass_chrome_unbranched" ]; then
+  echo "✖ Floating glass chrome mounted without a Material branch:"
+  echo "$glass_chrome_unbranched"
+  echo "  These primitives render the iOS floating-island LAYOUT on every variant"
+  echo "  (GlassSurface swaps only the fill). On Android (Material) that reads as glass"
+  echo "  FABs/islands instead of an M3 top app bar. Route the chrome through"
+  echo "  selectByVariant / createVariantComponent with a Material Appbar branch (see"
+  echo "  CollapsingTopChrome / HomeTopChrome / ProfileTopChrome), or — for a glass-only"
+  echo "  sub-component whose caller owns the branch — add it to GLASS_CHROME_ALLOWLIST"
+  echo "  with a documented reason."
+  exit 1
+fi
+
+echo "✓ No raw theme-variant compares, and no unbranched floating glass chrome, in mobile components/screens."


### PR DESCRIPTION
## What

On Android (Material 3 variant), the **Home** and **Discover** tabs rendered the iOS Liquid-Glass floating-island chrome — opaque floating pills, a blur scrim, and a glass create FAB — instead of an M3 top app bar. They were missed when Profile, Climbs, and Record got their Material `Appbar.Header` branches. `GlassSurface` swaps only the island *fill* by variant (frosted ↔ opaque), never the *layout*, so the floating-island layout leaked onto Android.

## Screenshots (Android, Material variant)

| | Before (glass islands) | After (M3 app bar) |
|---|---|---|
| **Home** | <img src="https://raw.githubusercontent.com/boardsesh/boardsesh/m3-chrome-review-shots/home-before.png" width="250"> | <img src="https://raw.githubusercontent.com/boardsesh/boardsesh/m3-chrome-review-shots/home-after.png" width="250"> |
| **Discover** | <img src="https://raw.githubusercontent.com/boardsesh/boardsesh/m3-chrome-review-shots/discover-before.png" width="250"> | <img src="https://raw.githubusercontent.com/boardsesh/boardsesh/m3-chrome-review-shots/discover-after.png" width="250"> |

_Captured on an emulator. The blue "Tools" bubble and the bottom sheet in the after-shots are the Expo dev-launcher (dev-only, absent in release builds); Discover's new create FAB sits behind that sheet, bottom-right._

## Changes

- **Discover** — branch the shared `CollapsingTopChrome` with `selectByVariant`: Material renders an M3 `Appbar.Header` (avatar · board switcher · angle · lightbulb). Climbs/Record short-circuit to their own Appbar before delegating, so only Discover hits the new branch; the Liquid Glass path is unchanged. `DiscoverTopChrome` is untouched.
- **Discover create** — the "+" becomes a Material **FAB** (M3's canonical primary-create affordance, screen-level like `ClimbFilterFab`); Liquid Glass keeps the create island.
- **Home** — extract `HomeTopChrome` as a `createVariantComponent` (glass = the prior inline chrome verbatim; material = an M3 `Appbar.Header`: avatar · scope title-menu · find-climbers action). The feed's top inset now tracks the measured chrome height.
- **FeedScopeTitle** — split by variant (glass pill / flat M3 app-bar title-menu, vertically centred like `BoardSwitcherButton`).
- **Shared helper** — `MaterialAngleAction` + `MaterialLightbulbAction` extracted from `ClimbTopChrome` into `chrome/MaterialBoardActions.tsx` (reused by Climbs + Discover).
- **CI guard** — `mobile-variant-guard.sh` now also fails when a screen/chrome mounts `GlassActionToolbar` / `CollapsingLargeTitleHeader` without a `selectByVariant` / `createVariantComponent` branch, so the next tab can't silently regress.

## Not changed (audited clean)

Profile, Climbs, Record (already branch to M3 app bars); the board/play-view action bar, the Beta Videos "+", and `PlaylistOwnerToolbar` (its caller requests the collapsed form on Material → a variant-branched overflow `IconButton`, so the glass toolbar never renders on Android).

## Verification

- `vp run typecheck:mobile`, `vp run test:mobile` (2481 passing, incl. new Home/Discover/FeedScopeTitle material cases), `vp check` (incl. `check:mobile-variants` with the new guard), `vp run check:mobile-bundle` — all green.
- Android emulator (Material variant, the default): Home & Discover go from floating glass islands → flat M3 app bars; Climbs/Record/Profile unchanged; iOS Liquid Glass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoeeaGtFvNmtxSbsmGJ7RK