### PR TITLE
fix(mobile): open beta videos on Android (drop canOpenURL gate)

### DIFF
--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FlatList, Linking, Pressable, RefreshControl, StyleSheet, View } from 'react-native';
+import { FlatList, Pressable, RefreshControl, StyleSheet, View } from 'react-native';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
@@ -35,6 +35,7 @@ import { UserAvatarToolbarAction } from '../../../src/components/user-drawer/Use
 import { dedupeSessionsById } from '../../../src/lib/feed-time-buckets';
 import { deriveFeedScopeInput, type FeedMode } from '../../../src/lib/feed/feed-scope';
 import { openClimbInPlayDrawer } from '../../../src/lib/open-climb-in-play-drawer';
+import { openValidatedUrl } from '../../../src/lib/open-external-link';
 import { hapticLight } from '../../../src/lib/haptics';
 import { navigateToSessionFeedItem } from '../../../src/lib/session-feed-navigation';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
@@ -65,14 +66,6 @@ function detectPlatform(url: string): { name: 'instagram' | 'tiktok'; icon: Icon
   if (isInstagramUrl(url)) return { name: 'instagram', icon: 'instagram' };
   if (isTikTokUrl(url)) return { name: 'tiktok', icon: 'tiktok' };
   return null;
-}
-
-function isSafeBetaVideoUrl(url: string): boolean {
-  try {
-    return new URL(url).protocol === 'https:' && isBetaVideoUrl(url);
-  } catch {
-    return false;
-  }
 }
 
 export default function HomeTab() {
@@ -621,18 +614,8 @@ function RecentBetaCard({
 
   const handleOpenVideo = useCallback(async () => {
     hapticLight();
-    try {
-      if (!isSafeBetaVideoUrl(video.betaLink.link)) {
-        showToast(t('mobile.home.betaOpenError'), 'error');
-        return;
-      }
-      const canOpen = await Linking.canOpenURL(video.betaLink.link);
-      if (!canOpen) {
-        showToast(t('mobile.home.betaOpenError'), 'error');
-        return;
-      }
-      await Linking.openURL(video.betaLink.link);
-    } catch {
+    const opened = await openValidatedUrl(video.betaLink.link, isBetaVideoUrl);
+    if (!opened) {
       showToast(t('mobile.home.betaOpenError'), 'error');
     }
   }, [showToast, t, video.betaLink.link]);

--- a/packages/mobile/src/components/play-drawer/BetaVideoCard.tsx
+++ b/packages/mobile/src/components/play-drawer/BetaVideoCard.tsx
@@ -1,10 +1,10 @@
 import { memo, useCallback, useState } from 'react';
-import { Pressable, View, StyleSheet, Linking } from 'react-native';
+import { Pressable, View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import * as Haptics from 'expo-haptics';
 import { useTranslation } from 'react-i18next';
 import type { BetaLink } from '@boardsesh/shared-schema';
-import { isInstagramUrl, isTikTokUrl } from '@boardsesh/shared-schema';
+import { isBetaVideoUrl, isInstagramUrl, isTikTokUrl } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -12,6 +12,7 @@ import { Avatar } from '../Avatar';
 import type { IconName } from '../icon-map';
 import { useToast } from '../../providers/toast-provider';
 import { track } from '../../lib/analytics';
+import { openValidatedUrl } from '../../lib/open-external-link';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
@@ -41,14 +42,8 @@ export const BetaVideoCard = memo(function BetaVideoCard({ link, uploaderName, u
       climbUuid: link.climb_uuid,
       platform: detectPlatform(link.link)?.name ?? null,
     });
-    try {
-      const canOpen = await Linking.canOpenURL(link.link);
-      if (!canOpen) {
-        showToast(t('mobile.betaVideos.openError'), 'error');
-        return;
-      }
-      await Linking.openURL(link.link);
-    } catch {
+    const opened = await openValidatedUrl(link.link, isBetaVideoUrl);
+    if (!opened) {
       showToast(t('mobile.betaVideos.openError'), 'error');
     }
   }, [link.climb_uuid, link.link, showToast, t]);

--- a/packages/mobile/src/components/you/PublicProfileHeaderBlock.tsx
+++ b/packages/mobile/src/components/you/PublicProfileHeaderBlock.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Linking, Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { PublicUserProfile } from '@boardsesh/shared-schema';
@@ -12,6 +12,7 @@ import { useToggleUserFollow } from '../../lib/graphql/hooks';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { hapticLight } from '../../lib/haptics';
+import { openValidatedUrl } from '../../lib/open-external-link';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { selectByVariant } from '../../theme/variants';
 
@@ -138,13 +139,8 @@ function InstagramLink({ url }: { url: string }) {
 
   const handleOpen = useCallback(async () => {
     hapticLight();
-    try {
-      if (!isInstagramUrl(url) || !(await Linking.canOpenURL(url))) {
-        showToast(t('mobile.social.instagramOpenError'), 'error');
-        return;
-      }
-      await Linking.openURL(url);
-    } catch {
+    const opened = await openValidatedUrl(url, isInstagramUrl);
+    if (!opened) {
       showToast(t('mobile.social.instagramOpenError'), 'error');
     }
   }, [showToast, t, url]);

--- a/packages/mobile/src/components/you/SessionFeedCard.tsx
+++ b/packages/mobile/src/components/you/SessionFeedCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useState } from 'react';
-import { View, StyleSheet, Linking } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { isBetaVideoUrl, isInstagramUrl, isTikTokUrl } from '@boardsesh/shared-schema';
@@ -22,6 +22,7 @@ import { FeedSocialRow } from './FeedSocialRow';
 import { SessionGradeStrip } from './SessionGradeStrip';
 import { gradeBadgeColor } from './profile-chart-colors';
 import { mapBetaLink } from '../../lib/beta-video-url';
+import { openValidatedUrl } from '../../lib/open-external-link';
 import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
 import { tickToClimb } from '../../lib/tick-to-climb';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -59,14 +60,6 @@ function tickStatusLabel(status: string, t: (key: string) => string): string {
 
 function compactJoin(parts: Array<string | null | undefined>): string {
   return parts.filter((part): part is string => !!part).join(' · ');
-}
-
-function isSafeBetaVideoUrl(url: string): boolean {
-  try {
-    return new URL(url).protocol === 'https:' && isBetaVideoUrl(url);
-  } catch {
-    return false;
-  }
 }
 
 function detectPlatform(url: string): { icon: IconName } | null {
@@ -158,13 +151,8 @@ export const SessionFeedCard = memo(function SessionFeedCard({
   const handleOpenBeta = useCallback(async () => {
     if (!betaUrl) return;
     hapticLight();
-    try {
-      if (!isSafeBetaVideoUrl(betaUrl) || !(await Linking.canOpenURL(betaUrl))) {
-        showToast(t('mobile.home.betaOpenError'), 'error');
-        return;
-      }
-      await Linking.openURL(betaUrl);
-    } catch {
+    const opened = await openValidatedUrl(betaUrl, isBetaVideoUrl);
+    if (!opened) {
       showToast(t('mobile.home.betaOpenError'), 'error');
     }
   }, [betaUrl, showToast, t]);

--- a/packages/mobile/src/lib/__tests__/open-external-link.test.ts
+++ b/packages/mobile/src/lib/__tests__/open-external-link.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const linking = vi.hoisted(() => ({ openURL: vi.fn(), canOpenURL: vi.fn() }));
+
+vi.mock('react-native', () => ({ Linking: linking }));
+
+import { openValidatedUrl } from '../open-external-link';
+
+const allow = () => true;
+const deny = () => false;
+
+beforeEach(() => {
+  linking.openURL.mockReset();
+  linking.canOpenURL.mockReset();
+});
+
+describe('openValidatedUrl', () => {
+  it('opens a valid URL and reports success', async () => {
+    linking.openURL.mockResolvedValue(undefined);
+
+    const opened = await openValidatedUrl('https://www.instagram.com/reel/abc/', allow);
+
+    expect(opened).toBe(true);
+    expect(linking.openURL).toHaveBeenCalledWith('https://www.instagram.com/reel/abc/');
+  });
+
+  it('rejects an invalid URL without calling openURL', async () => {
+    const opened = await openValidatedUrl('javascript:alert(1)', deny);
+
+    expect(opened).toBe(false);
+    expect(linking.openURL).not.toHaveBeenCalled();
+  });
+
+  it('returns false when openURL rejects (no handler available)', async () => {
+    linking.openURL.mockRejectedValue(new Error('no activity found'));
+
+    const opened = await openValidatedUrl('https://www.tiktok.com/@u/video/1', allow);
+
+    expect(opened).toBe(false);
+  });
+
+  // Regression guard for the Android beta-video bug: never gate on canOpenURL,
+  // which returns false on Android 11+ for undeclared schemes even though
+  // openURL succeeds.
+  it('never calls canOpenURL', async () => {
+    linking.openURL.mockResolvedValue(undefined);
+
+    await openValidatedUrl('https://www.instagram.com/reel/abc/', allow);
+
+    expect(linking.canOpenURL).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/open-external-link.ts
+++ b/packages/mobile/src/lib/open-external-link.ts
@@ -1,0 +1,24 @@
+import { Linking } from 'react-native';
+
+/**
+ * Open an external URL, returning whether it actually opened.
+ *
+ * Skips `Linking.canOpenURL` on purpose: on Android 11+ package-visibility rules
+ * make it return `false` for https/app URLs unless the matching intent is
+ * declared in `<queries>` in the manifest — even though `openURL` itself
+ * succeeds (firing an intent needs no visibility declaration; only querying
+ * does). Gating on `canOpenURL` is what broke opening beta videos on Android.
+ *
+ * Instead we validate the URL up front via `isValid` (so we never hand an
+ * arbitrary scheme to `openURL`) and let `openURL`'s own rejection signal a
+ * genuine failure. Mirrors `src/lib/instagram.ts`.
+ */
+export async function openValidatedUrl(url: string, isValid: (url: string) => boolean): Promise<boolean> {
+  if (!isValid(url)) return false;
+  try {
+    await Linking.openURL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem

Beta videos (Instagram/TikTok clips attached to climbs) couldn't be opened in the **Android** app — tapping a card showed the "couldn't open" toast. iOS worked fine.

## Root cause

Every tap-to-open handler gated `Linking.openURL` behind `Linking.canOpenURL`:

```ts
const canOpen = await Linking.canOpenURL(link.link);
if (!canOpen) { showToast(...openError...); return; }   // ← Android dies here
await Linking.openURL(link.link);
```

On **Android 11+ (API 30+)**, package-visibility rules make `canOpenURL` return `false` for `https://` URLs unless the matching `VIEW`/`https` intent is declared in a `<queries>` block in the manifest (we don't have one — only `/join` App Links). So the gate fails and `openURL` is never reached — even though `openURL` itself succeeds (firing an intent needs no visibility declaration; only *querying* does). iOS isn't subject to this, hence the platform split.

The repo already knew this footgun: `src/lib/instagram.ts` deliberately uses `openURL` + `catch` and documents the exact reasoning. The beta paths just never adopted it.

## PostHog evidence

- The native beta feature is ~2 weeks old: `Beta Video Link Clicked` with `$lib = posthog-react-native` was 0 until the week of Jun 7, then 45 the week of Jun 14. Earlier high counts were mobile **web** browsers (`$lib = js`), not the app.
- Click → `Application Backgrounded` funnel (mobile only): iOS 12/12 background in ~831 ms median (Instagram launches); only 2 Android users ever clicked. Too small to prove statistically — the firsthand report + the code defect are the signal, and low Android volume is itself consistent with it being broken since launch.

## Fix

- New `src/lib/open-external-link.ts` → `openValidatedUrl(url, isValid)`: validate up front, call `openURL` directly, return whether it opened. Mirrors `instagram.ts`.
- Adopt it in all four open paths: `BetaVideoCard`, the home recent-beta shelf (`RecentBetaCard`), the session-feed hero (`SessionFeedCard`), and the public-profile Instagram chip (`PublicProfileHeaderBlock`).
- Removed the two duplicate `isSafeBetaVideoUrl` helpers in favour of the shared `isBetaVideoUrl` (accept regexes are already `https`-anchored, so the wrapper was redundant). `BetaVideoCard` previously had **no** URL validation — it now does.

**JS-only change → ships via EAS Update (OTA), no native rebuild.** A `<queries>` manifest entry was considered and rejected (needs a native rebuild, more fragile, contradicts the existing `instagram.ts` pattern).

## Testing

- New `open-external-link.test.ts` covers open-success / invalid-URL / openURL-reject, plus a **regression guard asserting `canOpenURL` is never called**.
- `vp run typecheck:mobile`, `vp run test:mobile` (2474 passed), `vp run check:mobile-bundle` (OK) all green.
- Manual: best verified on a real Android device via the branch's OTA preview (`mobile-eas-update.yml` auto-publishes) — the four flows in `.boardsesh/qa-notes.md` should open Instagram/TikTok (or the browser) instead of the error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NePSVzNWAmufgwTDFcj4UV