### PR TITLE
fix(mobile): make Android climb reaction menu read as a raised M3 surface

### DIFF
--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -28,7 +28,8 @@ import { useGradeFormat } from '../../hooks/use-grade-format';
 import { useTheme } from '../../providers/theme-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { springs, timing } from '../../theme/animations';
-import { spacing, borderRadius } from '../../theme/tokens';
+import { spacing, borderRadius, overlays } from '../../theme/tokens';
+import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
 import { useClimbActions } from './use-climb-actions';
 
 type ClimbReactionMenuProps = {
@@ -86,6 +87,7 @@ export function ClimbReactionMenu({
   const insets = useSafeAreaInsets();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const { formatGrade } = useGradeFormat();
+  const surfaceMode = useEffectiveSurfaceMode();
 
   const progress = useSharedValue(0);
 
@@ -165,14 +167,26 @@ export function ClimbReactionMenu({
     transform: [{ translateY: (1 - progress.value) * 18 }, { scale: 0.96 + progress.value * 0.04 }],
   }));
 
-  const scrimColor = colorScheme === 'dark' ? 'rgba(0,0,0,0.5)' : 'rgba(0,0,0,0.35)';
+  // When a real blur sits underneath (iOS Liquid Glass / its < 26 blur fallback), a
+  // light tint completes the dim — the blur already makes the busy board-art grid
+  // recede. With no blur (Android, or Reduce Transparency / Material-on-iOS), the tint
+  // alone lets the grid bleed through, so use a denser scrim to recede it the way the
+  // blur otherwise would. Gated on the same surface mode `GlassSurface` switches on.
+  const hasBlur = surfaceMode === 'glass' || surfaceMode === 'blur';
+  const scrimColor = hasBlur
+    ? colorScheme === 'dark'
+      ? 'rgba(0,0,0,0.5)'
+      : 'rgba(0,0,0,0.35)'
+    : colorScheme === 'dark'
+      ? overlays.scrim
+      : 'rgba(0,0,0,0.4)';
 
   return (
     <OverlayPortal onRequestClose={dismiss}>
       <View style={StyleSheet.absoluteFill}>
         {/* Blurred / dimmed backdrop, tap to dismiss. */}
         <Animated.View style={[StyleSheet.absoluteFill, backdropStyle]}>
-          {Platform.OS === 'ios' ? (
+          {hasBlur && Platform.OS === 'ios' ? (
             <BlurView
               blurType={colorScheme === 'dark' ? 'dark' : 'light'}
               blurAmount={12}
@@ -236,21 +250,20 @@ export function ClimbReactionMenu({
           </Animated.View>
 
           <Animated.View style={[styles.menuWrap, menuStyle]}>
-            <GlassSurface role="base" level="level2" borderRadius={borderRadius.xl} style={styles.menuCard}>
+            <GlassSurface role="high" level="level3" borderRadius={borderRadius.xl} style={styles.menuCard}>
               <ScrollView
                 style={{ maxHeight: menuMaxHeight }}
                 bounces={false}
                 showsVerticalScrollIndicator={false}
                 contentContainerStyle={styles.menuContent}
               >
-                {actions.map((action, index) => (
+                {actions.map((action) => (
                   <ListRow
                     key={action.id}
                     title={action.title}
-                    leading={<Icon name={action.icon} size={22} color={action.color} />}
+                    leading={<Icon name={action.icon} size={24} color={action.color} />}
                     onPress={action.run}
-                    showSeparator={index < actions.length - 1}
-                    separatorInset={56}
+                    showSeparator={false}
                   />
                 ))}
               </ScrollView>
@@ -309,8 +322,11 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
   menuCard: {
+    // No `overflow: 'hidden'` here: GlassSurface's Material branch puts the elevation
+    // cast on the same view as this style, and clipping would swallow the Android
+    // shadow. GlassSurface clips its own glass/blur shapes; the rows are transparent,
+    // so nothing pokes past the rounded corners.
     borderRadius: borderRadius.xl,
-    overflow: 'hidden',
   },
   menuContent: {
     paddingVertical: spacing[1],

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -186,7 +186,7 @@ export function ClimbReactionMenu({
       <View style={StyleSheet.absoluteFill}>
         {/* Blurred / dimmed backdrop, tap to dismiss. */}
         <Animated.View style={[StyleSheet.absoluteFill, backdropStyle]}>
-          {hasBlur && Platform.OS === 'ios' ? (
+          {hasBlur ? (
             <BlurView
               blurType={colorScheme === 'dark' ? 'dark' : 'light'}
               blurAmount={12}
@@ -322,10 +322,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
   menuCard: {
-    // No `overflow: 'hidden'` here: GlassSurface's Material branch puts the elevation
-    // cast on the same view as this style, and clipping would swallow the Android
-    // shadow. GlassSurface clips its own glass/blur shapes; the rows are transparent,
-    // so nothing pokes past the rounded corners.
+    // No overflow clip — it would swallow GlassSurface's Material elevation cast (same view).
     borderRadius: borderRadius.xl,
   },
   menuContent: {


### PR DESCRIPTION
## Screenshots (Android · dark)

| Before (reported) | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/boardsesh/boardsesh/screenshots/android-reaction-menu/before-android-dark.png" width="280" alt="Before"> | <img src="https://raw.githubusercontent.com/boardsesh/boardsesh/screenshots/android-reaction-menu/after-android-dark.png" width="280" alt="After"> |

_Captured on an Android emulator. After: per-row dividers removed, background dimmed back so the board grid recedes, the card sits on an M3 surface-container-high tone with a level-3 elevation cast, Material icon colors kept, icons 24dp._

---

## What & why

The climb long-press **reaction menu** looked weird on Android (reported with a screenshot). On iOS it's a frosted, clearly-floating card; on Android two platform-specific rendering problems flattened it:

1. **No backdrop blur on Android** — iOS draws a `BlurView`; Android only had a thin scrim (`rgba(0,0,0,0.5)`/`0.35`), so the colorful board-art grid and floating buttons bled through and the menu didn't read as a focused overlay.
2. **The card's M3 elevation cast was clipped** — the card passed `overflow:'hidden'` into `GlassSurface`, whose Material branch puts that style on the *same view* it paints the elevation cast on, so the Android shadow was clipped to nothing and the dark tonal card melted into the dim.

A Material 3 design panel reviewed the design: this centered, modal, scrim-dimming, non-anchored overlay is an **M3 dialog**, so the card should be `surface-container-high` + a `level3` cast on a scrim heavy enough (no blur) to recede the background.

## Changes (all in `ClimbReactionMenu.tsx`)

- **Un-clip the elevation cast** — drop `overflow:'hidden'` from the card style so the Material `level` cast renders. Rows are transparent, so nothing pokes past the rounded corners.
- **Raise the card** to `role="high" level="level3"` (was `base`/`level2`). Material-only props — iOS glass/blur ignore them.
- **Denser scrim on the no-blur path**, gated on `useEffectiveSurfaceMode()` (the axis `GlassSurface` itself switches on, so it also covers Material-on-iOS): dark = `overlays.scrim` (0.6), light = `0.4`. The iOS blur path keeps today's lighter tint, so **iOS is unchanged**.
- **Drop the per-row dividers** (`showSeparator={false}`) — M3 action lists and iOS context menus are dividerless.
- **Leading icons 22 → 24** (M3). **Material semantic icon colors kept** (green add / red heart / violet edit·share), per the requested scope.

No new tokens; no `variant === …` branching (CI guard); only platform branch stays `Platform.OS === 'ios'` for the `BlurView` host.

## Scope notes
Kept to changes that fix Android without altering the approved iOS look. Deliberately deferred (would change iOS or expand scope): corner radius xl→lg, routing motion through `theme.motion`, removing the iOS scrim-over-blur, 48dp Material rows, a dark-mode hairline outline, and the favorite-red WCAG fix in the shared `resolveActionColors` token. The hairline outline is a ready follow-up if reviewers want a crisper dark-mode card edge.

## Validation
- `vp run typecheck:mobile`, `vp run test:mobile` (2470 pass), `vp run check:mobile-bundle` — all green.
- Verified on an Android emulator (dark): dividers gone, background recedes, card reads as a distinct M3 surface, Material icon colors intact. Light mode not captured (emulator instability in the sandbox) but is the high-contrast case and the light scrim was tuned to 0.4 to avoid an "accidental dark mode."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
