### PR TITLE
fix(mobile): separate ActiveContextBar positioning from Reanimated entering animation (Android 16 touch-blocking)

### DIFF
--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -71,9 +71,13 @@ export function ActiveContextBar({
     ? (measuredTabBarHeight ?? bottomChrome.tabBarBottom) - TABBAR_SEAM_OVERLAP
     : bottomChrome.tabBarBottom + gapAboveTabBar;
 
+  // Outer shell: plain View so `pointerEvents="box-none"` is respected on Android.
+  // Reanimated's `entering` animations ignore pointerEvents on the animated view
+  // itself, causing the overlay to block all touches below it (Android 16 / API 36
+  // regresses this the hardest). The inner Animated.View is sized to its content
+  // so even without pointerEvents it only covers the visible bar. #5728
   return (
-    <Animated.View
-      entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}
+    <View
       pointerEvents="box-none"
       style={[
         styles.toolbar,
@@ -84,24 +88,26 @@ export function ActiveContextBar({
         },
       ]}
     >
-      {fillPrimary ? (
-        <View style={styles.fillRow} pointerEvents="box-none" importantForAccessibility="auto">
-          {primary}
-        </View>
-      ) : (
-        <Animated.View style={styles.row} pointerEvents="box-none" importantForAccessibility="auto">
-          <View style={styles.sideSlot} pointerEvents={leading ? 'box-none' : 'none'}>
-            {leading}
-          </View>
-          <View style={styles.centerSlot} pointerEvents="box-none">
+      <Animated.View entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}>
+        {fillPrimary ? (
+          <View style={styles.fillRow} pointerEvents="box-none" importantForAccessibility="auto">
             {primary}
           </View>
-          <View style={[styles.heroSlot, { width: trailingWidth }]} pointerEvents="box-none">
-            {trailing}
+        ) : (
+          <View style={styles.row} pointerEvents="box-none" importantForAccessibility="auto">
+            <View style={styles.sideSlot} pointerEvents={leading ? 'box-none' : 'none'}>
+              {leading}
+            </View>
+            <View style={styles.centerSlot} pointerEvents="box-none">
+              {primary}
+            </View>
+            <View style={[styles.heroSlot, { width: trailingWidth }]} pointerEvents="box-none">
+              {trailing}
+            </View>
           </View>
-        </Animated.View>
-      )}
-    </Animated.View>
+        )}
+      </Animated.View>
+    </View>
   );
 }
 

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -22,7 +22,10 @@ vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  // Expose `style` as `data-style` so positioning assertions can query the outer
+  // plain View shell (which now owns the absolute layout, not the Animated.View).
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-style': JSON.stringify(style) }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
 
@@ -187,8 +190,13 @@ describe('PersistentQueueBar', () => {
     expect(capsule?.getAttribute('data-fill-width')).toBe('true');
     expect(capsule?.getAttribute('data-height')).toBe('48');
     expect(capsule?.getAttribute('data-surface-treatment')).toBe('docked');
-    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"left":0');
-    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"right":0');
+    // Positioning lives on the outer plain View shell (parentElement of the
+    // Animated.View), not on the Animated.View itself — the Reanimated entering
+    // bug was fixed by separating the positioning View from the animated View.
+    expect(container.querySelector('[data-animated]')?.parentElement?.getAttribute('data-style')).toContain('"left":0');
+    expect(container.querySelector('[data-animated]')?.parentElement?.getAttribute('data-style')).toContain(
+      '"right":0',
+    );
     expect(container.querySelector('[data-tick-inline]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();
   });
@@ -221,6 +229,8 @@ describe('PersistentQueueBar', () => {
     cfg.variant = 'material';
     cfg.measuredTabBarHeight = 80;
     const { container } = render(<PersistentQueueBar />);
-    expect(container.querySelector('[data-animated]')?.getAttribute('data-style')).toContain('"bottom":79');
+    expect(container.querySelector('[data-animated]')?.parentElement?.getAttribute('data-style')).toContain(
+      '"bottom":79',
+    );
   });
 });


### PR DESCRIPTION
## Problem

On Android 16 (Pixel 10), selecting any climb on the climb list screen made the screen completely unresponsive to scroll and touch input. Only left/right tab swiping, the queue modal, and split-screen mode would unblock it. Uninstall/reinstall didn't fix it; clearing storage and re-logging in did, but only until selecting the next climb.

**Root cause:** `ActiveContextBar` renders a Reanimated `Animated.View` with both `entering={FadeIn}` and `pointerEvents="box-none"` on the same element. On Android, Reanimated's `entering` animations ignore `pointerEvents` — the animated view absorbs all touch events regardless. Since `ActiveContextBar` is `position: 'absolute'` (mounted at the app root, outside the navigation Stack) with no explicit `top` or `height`, it can expand to cover the full screen above its `bottom` anchor, blocking the entire climb list.

This explains every observed symptom:
- **Frozen after selecting a climb**: `ActiveContextBar` mounts with `FadeIn`, Reanimated ignores `pointerEvents`
- **Queue modal still scrollable**: gorhom renders bottom sheets in a new native Android window
- **Left/right swipe still works**: tab gesture runs above the blocking view
- **Split-screen unblocks it**: window resize triggers layout recalculation, remounting the bar
- **Works on GrapheneOS Pixel 7**: different Android version, less aggressive behavior
- **Reinstall doesn't fix it**: triggered on every session the moment a climb is selected

## Fix

Separate concerns: the outer positioning shell is now a plain `View` (which correctly passes `pointerEvents="box-none"` through on all Android versions), and only the inner `Animated.View` runs the `FadeIn` entering animation. The inner view is content-sized with no absolute positioning, so even if Reanimated ignores its `pointerEvents`, it can only block touches over the visible bar area.

This is the same pattern already used correctly in `QueueAddedSnackbar` and `UndoWallChangeSnackbar`.

## Test plan

- [ ] Select a climb on Android 16 — climb list should remain scrollable and touch-responsive
- [ ] The `ActiveContextBar` fade-in animation should still play when a climb is first selected
- [ ] Queue modal, tab switching, and all other controls should work normally
- [ ] Pixel 7 / older Android versions should be unaffected
- [ ] All 2491 mobile tests pass, Metro bundle clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPoqEUJrxgvn3koVDDjbat