### PR TITLE
ci(mobile): gate native builds on the OTA fingerprint (build only when new)

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -33,41 +33,133 @@ concurrency:
 permissions:
   contents: write # required for softprops/action-gh-release
 
+# ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
+# Declared at the workflow level so the cheap `gate` job (fingerprint resolve)
+# and the `build-and-release` job (expo prebuild) resolve a byte-identical config
+# and can't drift. MUST stay identical to ios-testflight-rn.yml /
+# mobile-ota-production.yml — scripts/mobile-ci-env-parity.test.ts fails the
+# build if they do. Config-affecting vars (EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+# GOOGLE_MAPS_API_KEY, EXPO_UPDATES_URL, EXPO_UPDATES_CHANNEL) move the
+# fingerprint runtimeVersion directly; the rest reach it via the hashed .env file
+# the jobs write. Don't add other fingerprint-affecting vars here (EAS_BUILD,
+# EAS_BUILD_PROFILE, BOARDSESH_APP_VARIANT, …) — they're unset in the build too.
+env:
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+  # Self-hosted OTA (expo-open-ota). EXPO_UPDATES_URL is the server's manifest
+  # endpoint (e.g. https://ota.boardsesh.com/manifest), set as a repo variable
+  # so the domain isn't hardcoded; until it's set, app.config.ts falls back to
+  # the EAS URL and OTA stays inert (harmless). The channel is baked into the
+  # binary via AndroidManifest by `expo prebuild`. See docs/mobile-ota-updates.md.
+  EXPO_UPDATES_CHANNEL: production
+  EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+  # NOTE: currently inert at runtime — the mobile app has no
+  # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
+  # DSN is not read by the running app; client-side errors go to PostHog only
+  # (reportError → captureError). Kept so adding Sentry later needs no workflow
+  # change. Same DSN/project as web + backend; not secret — already hardcoded
+  # in packages/web and packages/backend source.
+  EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+  # PostHog product analytics. Intentionally the SAME project token as web
+  # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity
+  # resolves to one person. EXPO_PUBLIC_* vars are inlined into the JS bundle at
+  # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
+  # false, so every track() silently no-ops (the app shipped zero events before).
+  EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Android Google Maps key, baked into the resolved android.config at prebuild
+  # time when present (the build succeeds without it; the board-search map just
+  # stays blank). It changes the Android fingerprint, so both the gate's resolve
+  # and the build's prebuild read it from here. iOS never sets it (Apple Maps),
+  # which is why the per-platform fingerprints differ.
+  GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
 jobs:
+  # Fingerprint gate: resolve the Android runtimeVersion fingerprint and skip the
+  # native build when a binary with that fingerprint already shipped (a
+  # fingerprint-android-<hash> tag exists). The OTA publish
+  # (mobile-ota-production.yml) still delivers the JS to matching binaries. The
+  # build job re-resolves and tags THAT value on success. Gate + build both run
+  # on Linux, so the fingerprints match exactly. See docs/mobile-ota-updates.md.
+  gate:
+    # Push is always on main; a manual dispatch (any branch) always builds, so
+    # `workflow_dispatch` keeps producing an APK artifact off a feature branch.
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      should_build: ${{ steps.fp.outputs.should_build }}
+      fingerprint: ${{ steps.fp.outputs.fingerprint }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install Node.js dependencies (workspace root)
+        run: bun install --frozen-lockfile
+
+      # The .env is hashed into the fingerprint, so it must be byte-identical to
+      # the build job's (same heredoc + same workflow env) or the gate would
+      # resolve a different fingerprint than the build bakes.
+      - name: Write .env for Expo build-time inlining
+        working-directory: packages/mobile
+        run: |
+          cat > .env <<EOF
+          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+          EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
+          EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EOF
+
+      - name: Resolve fingerprint and check for an existing native build
+        id: fp
+        run: |
+          set -uo pipefail
+          # GOOGLE_MAPS_API_KEY is inherited from the workflow env (it changes the
+          # Android fingerprint, so the resolve must match the build's prebuild).
+          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform android 2>/dev/null || true)"
+          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
+          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
+            echo "::warning::Could not resolve the Android fingerprint — building to be safe."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "fingerprint=$fp" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Manual dispatch — building Android regardless of fingerprint $fp."
+            exit 0
+          fi
+          tag="fingerprint-android-$fp"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Android fingerprint $fp already built (tag $tag) — skipping the native build; the OTA delivers the JS."
+          else
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Android fingerprint $fp is new — running the native build."
+          fi
+
   build-and-release:
+    needs: gate
+    if: needs.gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # Scopes the job to the Production GitHub Environment so it can read the
     # signing and deployment-notification secrets.
     environment: Production
-
-    env:
-      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
-      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
-      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
-      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
-      # Self-hosted OTA (expo-open-ota). EXPO_UPDATES_URL is the server's manifest
-      # endpoint (e.g. https://ota.boardsesh.com/manifest), set as a repo variable
-      # so the domain isn't hardcoded; until it's set, app.config.ts falls back to
-      # the EAS URL and OTA stays inert (harmless). The channel is baked into the
-      # binary via AndroidManifest by `expo prebuild`. See docs/mobile-ota-updates.md.
-      EXPO_UPDATES_CHANNEL: production
-      EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
-      # NOTE: currently inert at runtime — the mobile app has no
-      # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
-      # DSN is not read by the running app; client-side errors go to PostHog only
-      # (reportError → captureError). Kept so adding Sentry later needs no workflow
-      # change. Same DSN/project as web + backend; not secret — already hardcoded
-      # in packages/web and packages/backend source.
-      EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
-      # PostHog product analytics. Intentionally the SAME project token as web
-      # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity
-      # resolves to one person. EXPO_PUBLIC_* vars are inlined into the JS bundle at
-      # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
-      # false, so every track() silently no-ops (the app shipped zero events before).
-      EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+    # Shared EXPO_PUBLIC_* / EXPO_UPDATES_* / GOOGLE_MAPS_API_KEY env lives at the
+    # workflow level (above) so the gate and build jobs resolve a byte-identical
+    # fingerprint.
 
     steps:
       - name: Checkout repository
@@ -133,12 +225,27 @@ jobs:
           echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
           echo "::warning::Sentry source-map upload is disabled for Android release builds until the Gradle upload task is compatible with the generated Gradle version."
 
+      # Re-resolve the fingerprint (Linux, same runner class as the gate) before
+      # prebuild, and tag this value on a successful release (final tag step).
+      # GOOGLE_MAPS_API_KEY is inherited from the workflow env.
+      - name: Resolve fingerprint for tagging
+        run: |
+          set -uo pipefail
+          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform android 2>/dev/null || true)"
+          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
+          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
+            echo "::warning::Could not resolve the Android fingerprint on the build runner — the fingerprint tag will be skipped (the next push rebuilds)."
+          else
+            echo "FINGERPRINT_ANDROID=$fp" >> "$GITHUB_ENV"
+            if [ "$fp" != "${{ needs.gate.outputs.fingerprint }}" ]; then
+              echo "::warning::Android fingerprint differs between the gate (${{ needs.gate.outputs.fingerprint }}) and this build ($fp) — both run on Linux, so this is unexpected; investigate."
+            fi
+          fi
+
       - name: Expo prebuild (generate android/)
         working-directory: packages/mobile
-        env:
-          # Android Google Maps key, baked in at prebuild time when present. Build
-          # succeeds without it; the board-search map just stays blank.
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+        # GOOGLE_MAPS_API_KEY is inherited from the workflow env (baked into the
+        # resolved android.config at prebuild time when present).
         run: bunx expo prebuild --platform android --clean --no-install
 
       # versionCode = max(sideload floor, Play track ceiling + 1), resolved by
@@ -292,6 +399,28 @@ jobs:
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
+
+      # Record that a binary with this fingerprint shipped, so future JS-only
+      # pushes with the same fingerprint skip this build (the gate checks for the
+      # tag). Gated on the GitHub Release (the always-on sideload channel) — a
+      # failed build must not tag, or the next push would wrongly skip. If the
+      # later Play upload flakes, the sideload APK with this fingerprint still
+      # shipped; to force a rebuild for Play, delete the tag (see
+      # docs/mobile-ota-updates.md). Idempotent for concurrent runs.
+      - name: Tag the shipped Android fingerprint
+        if: github.ref == 'refs/heads/main' && steps.github_release.outcome == 'success' && env.FINGERPRINT_ANDROID != ''
+        run: |
+          set -uo pipefail
+          tag="fingerprint-android-${FINGERPRINT_ANDROID}"
+          git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
+          if git push origin "refs/tags/$tag"; then
+            echo "::notice::Tagged $tag — future JS-only pushes with this fingerprint skip the Android native build."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::notice::$tag already exists (concurrent run) — nothing to do."
+          else
+            echo "::error::Failed to push $tag."
+            exit 1
+          fi
 
       # The Play Store distributes app bundles, not APKs. Build the AAB from the
       # SAME prebuild + same env-conditional signingConfig + same versionCode as

--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -400,28 +400,6 @@ jobs:
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
 
-      # Record that a binary with this fingerprint shipped, so future JS-only
-      # pushes with the same fingerprint skip this build (the gate checks for the
-      # tag). Gated on the GitHub Release (the always-on sideload channel) — a
-      # failed build must not tag, or the next push would wrongly skip. If the
-      # later Play upload flakes, the sideload APK with this fingerprint still
-      # shipped; to force a rebuild for Play, delete the tag (see
-      # docs/mobile-ota-updates.md). Idempotent for concurrent runs.
-      - name: Tag the shipped Android fingerprint
-        if: github.ref == 'refs/heads/main' && steps.github_release.outcome == 'success' && env.FINGERPRINT_ANDROID != ''
-        run: |
-          set -uo pipefail
-          tag="fingerprint-android-${FINGERPRINT_ANDROID}"
-          git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
-          if git push origin "refs/tags/$tag"; then
-            echo "::notice::Tagged $tag — future JS-only pushes with this fingerprint skip the Android native build."
-          elif git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "::notice::$tag already exists (concurrent run) — nothing to do."
-          else
-            echo "::error::Failed to push $tag."
-            exit 1
-          fi
-
       # The Play Store distributes app bundles, not APKs. Build the AAB from the
       # SAME prebuild + same env-conditional signingConfig + same versionCode as
       # the APK above (the `release` build type is shared), so the two channels
@@ -432,6 +410,7 @@ jobs:
       # APK build: the Sentry Gradle upload task is currently incompatible with
       # the generated Gradle version.
       - name: Build signed release AAB
+        id: build_aab
         working-directory: packages/mobile/android
         env:
           ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/packages/mobile/android/app/release.keystore
@@ -493,6 +472,32 @@ jobs:
         if: github.ref == 'refs/heads/main' && env.PLAY_UPLOAD_ENABLED == 'true' && steps.play_upload.outcome == 'failure'
         run: |
           echo "::warning::Play upload failed after the signed APK/AAB were built and the GitHub Release was published. If Play reports 'You must let us know whether your app uses any Foreground Service permissions', complete Play Console > App content > Foreground services for FOREGROUND_SERVICE_CONNECTED_DEVICE, then rerun the workflow or upload the AAB artifact manually."
+
+      # Record that a binary with this fingerprint shipped, so future JS-only
+      # pushes with the same fingerprint skip this build (the gate checks for the
+      # tag). Placed AFTER the AAB build + Play upload and gated on every channel
+      # so a partial ship never tags (which would wrongly skip the next push):
+      #   - github_release succeeded → the always-on sideload APK shipped;
+      #   - build_aab succeeded → a failed AAB must NOT tag, or Play never gets
+      #     this fingerprint and the next push wrongly skips it;
+      #   - play_upload did not FAIL → 'skipped' (Play disabled before bootstrap)
+      #     is fine, but an actual upload failure leaves no tag so the next push
+      #     rebuilds and Play retries automatically.
+      # Idempotent for concurrent runs.
+      - name: Tag the shipped Android fingerprint
+        if: github.ref == 'refs/heads/main' && steps.github_release.outcome == 'success' && steps.build_aab.outcome == 'success' && steps.play_upload.outcome != 'failure' && env.FINGERPRINT_ANDROID != ''
+        run: |
+          set -uo pipefail
+          tag="fingerprint-android-${FINGERPRINT_ANDROID}"
+          git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
+          if git push origin "refs/tags/$tag"; then
+            echo "::notice::Tagged $tag — future JS-only pushes with this fingerprint skip the Android native build."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::notice::$tag already exists (concurrent run) — nothing to do."
+          else
+            echo "::error::Failed to push $tag."
+            exit 1
+          fi
 
       - name: Clean up keystore
         if: always()

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -20,9 +20,120 @@ concurrency:
   group: ios-testflight-rn-${{ github.ref }}
   cancel-in-progress: true
 
+# ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
+# Declared at the workflow level so the cheap `gate` job (fingerprint resolve)
+# and the `build-and-upload` job (expo prebuild) resolve a byte-identical config
+# and can't drift. MUST stay identical to android-apk-rn.yml /
+# mobile-ota-production.yml — scripts/mobile-ci-env-parity.test.ts fails the
+# build if they do. Config-affecting vars (EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+# EXPO_UPDATES_URL, EXPO_UPDATES_CHANNEL) move the fingerprint runtimeVersion
+# directly; the rest reach it via the hashed .env file the jobs write. Don't add
+# other fingerprint-affecting vars here (EAS_BUILD, EAS_BUILD_PROFILE,
+# BOARDSESH_APP_VARIANT, …) — they're unset in the native build too.
+env:
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+  # Self-hosted OTA (expo-open-ota). EXPO_UPDATES_URL is the server's manifest
+  # endpoint (e.g. https://ota.boardsesh.com/manifest), set as a repo variable
+  # so the domain isn't hardcoded; until it's set, app.config.ts falls back to
+  # the EAS URL and OTA stays inert (harmless). The channel is baked into the
+  # binary via Expo.plist by `expo prebuild`. See docs/mobile-ota-updates.md.
+  EXPO_UPDATES_CHANNEL: production
+  EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+  # NOTE: currently inert at runtime — the mobile app has no
+  # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
+  # DSN is not read by the running app; client-side errors go to PostHog only
+  # (reportError → captureError). Kept so adding Sentry later needs no workflow
+  # change. Same DSN/project as web + backend; not secret — already hardcoded
+  # in packages/web and packages/backend source.
+  EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+  # PostHog product analytics. Intentionally the SAME project token as web
+  # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity
+  # resolves to one person. EXPO_PUBLIC_* vars are inlined into the JS bundle at
+  # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
+  # false, so every track() silently no-ops (the app shipped zero events before).
+  EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+
 jobs:
-  build-and-upload:
+  # Fingerprint gate: resolve the iOS runtimeVersion fingerprint on a cheap Linux
+  # runner and skip the ~60-min macOS build when a binary with that fingerprint
+  # already shipped (a fingerprint-ios-<hash> tag exists). The OTA publish
+  # (mobile-ota-production.yml) still delivers the JS to matching binaries. The
+  # build job re-resolves on macOS and tags THAT value, so a Linux/macOS
+  # fingerprint divergence can only ever make iOS over-build, never wrongly skip.
+  # See docs/mobile-ota-updates.md.
+  gate:
     if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      should_build: ${{ steps.fp.outputs.should_build }}
+      fingerprint: ${{ steps.fp.outputs.fingerprint }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install Node.js dependencies (workspace root)
+        run: bun install --frozen-lockfile
+
+      # The .env is hashed into the fingerprint, so it must be byte-identical to
+      # the build job's (same heredoc + same workflow env) or the gate would
+      # resolve a different fingerprint than the build bakes.
+      - name: Write .env for Expo build-time inlining
+        working-directory: packages/mobile
+        run: |
+          cat > .env <<EOF
+          EXPO_PUBLIC_BACKEND_URL=$EXPO_PUBLIC_BACKEND_URL
+          EXPO_PUBLIC_WS_URL=$EXPO_PUBLIC_WS_URL
+          EXPO_PUBLIC_WEB_URL=$EXPO_PUBLIC_WEB_URL
+          EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID
+          EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=$EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID
+          EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
+          EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
+          EOF
+
+      - name: Resolve fingerprint and check for an existing native build
+        id: fp
+        run: |
+          set -uo pipefail
+          # No GOOGLE_MAPS_API_KEY here: iOS uses Apple Maps, so the iOS binary's
+          # fingerprint is resolved without it (the Android gate sets it).
+          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform ios 2>/dev/null || true)"
+          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
+          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
+            echo "::warning::Could not resolve the iOS fingerprint — building to be safe."
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "fingerprint=$fp" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Manual dispatch — building iOS regardless of fingerprint $fp."
+            exit 0
+          fi
+          tag="fingerprint-ios-$fp"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::iOS fingerprint $fp already built (tag $tag) — skipping the native build; the OTA delivers the JS."
+          else
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::iOS fingerprint $fp is new — running the native build."
+          fi
+
+  build-and-upload:
+    needs: gate
+    if: github.ref == 'refs/heads/main' && needs.gate.outputs.should_build == 'true'
+    permissions:
+      contents: write # push the fingerprint-ios-<hash> tag on a successful upload
     # macos-26 = Xcode 26 + iOS 26 SDK, which App Store Connect now requires
     # for all uploads. Expo SDK 56 / RN 0.85 ships a fmt that compiles cleanly
     # under Xcode 26's strict C++20 constexpr evaluator.
@@ -41,32 +152,8 @@ jobs:
       EXPORT_OPTIONS_PLIST: packages/mobile/ExportOptions.plist
       KEYCHAIN_NAME: build.keychain
       KEYCHAIN_PASSWORD: ${{ github.run_id }}
-      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
-      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
-      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
-      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
-      # Self-hosted OTA (expo-open-ota). EXPO_UPDATES_URL is the server's manifest
-      # endpoint (e.g. https://ota.boardsesh.com/manifest), set as a repo variable
-      # so the domain isn't hardcoded; until it's set, app.config.ts falls back to
-      # the EAS URL and OTA stays inert (harmless). The channel is baked into the
-      # binary via Expo.plist by `expo prebuild`. See docs/mobile-ota-updates.md.
-      EXPO_UPDATES_CHANNEL: production
-      EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
-      # NOTE: currently inert at runtime — the mobile app has no
-      # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
-      # DSN is not read by the running app; client-side errors go to PostHog only
-      # (reportError → captureError). Kept so adding Sentry later needs no workflow
-      # change. Same DSN/project as web + backend; not secret — already hardcoded
-      # in packages/web and packages/backend source.
-      EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
-      # PostHog product analytics. Intentionally the SAME project token as web
-      # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity
-      # resolves to one person. EXPO_PUBLIC_* vars are inlined into the JS bundle at
-      # build time; without this, analytics.ts sees no key and isAnalyticsEnabled is
-      # false, so every track() silently no-ops (the app shipped zero events before).
-      EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      # Shared EXPO_PUBLIC_* / EXPO_UPDATES_* env lives at the workflow level
+      # (above) so the gate and build jobs resolve a byte-identical fingerprint.
 
     steps:
       - name: Checkout repository
@@ -90,6 +177,24 @@ jobs:
           EXPO_PUBLIC_SENTRY_DSN=$EXPO_PUBLIC_SENTRY_DSN
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
           EOF
+
+      # Re-resolve the fingerprint on THIS (macOS) runner, before prebuild, and
+      # tag this value on a successful upload (final step). The gate checks the
+      # Linux value; tagging the build-runner value means a cross-OS divergence
+      # can only ever over-build, never wrongly skip.
+      - name: Resolve fingerprint for tagging
+        run: |
+          set -uo pipefail
+          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform ios 2>/dev/null || true)"
+          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
+          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
+            echo "::warning::Could not resolve the iOS fingerprint on the build runner — the fingerprint tag will be skipped (the next push rebuilds)."
+          else
+            echo "FINGERPRINT_IOS=$fp" >> "$GITHUB_ENV"
+            if [ "$fp" != "${{ needs.gate.outputs.fingerprint }}" ]; then
+              echo "::warning::iOS fingerprint differs between the Linux gate (${{ needs.gate.outputs.fingerprint }}) and this macOS build ($fp); the gate will conservatively keep building iOS until they agree. Investigate cross-OS @expo/fingerprint determinism."
+            fi
+          fi
 
       - name: Expo prebuild (generate ios/)
         working-directory: packages/mobile
@@ -442,6 +547,26 @@ jobs:
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
+
+      # Record that a binary with this fingerprint shipped, so future JS-only
+      # pushes with the same fingerprint skip this build (the gate checks for the
+      # tag). Only on a successful TestFlight upload — a failed build must not
+      # create the tag or the next push would wrongly skip. Idempotent: a
+      # concurrent run that already pushed the tag is treated as success.
+      - name: Tag the shipped iOS fingerprint
+        if: github.ref == 'refs/heads/main' && steps.testflight_upload.outcome == 'success' && env.FINGERPRINT_IOS != ''
+        run: |
+          set -uo pipefail
+          tag="fingerprint-ios-${FINGERPRINT_IOS}"
+          git tag "$tag" "$GITHUB_SHA" 2>/dev/null || true
+          if git push origin "refs/tags/$tag"; then
+            echo "::notice::Tagged $tag — future JS-only pushes with this fingerprint skip the iOS native build."
+          elif git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::notice::$tag already exists (concurrent run) — nothing to do."
+          else
+            echo "::error::Failed to push $tag."
+            exit 1
+          fi
 
       - name: Clean up keychain and credentials
         if: always()

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -67,6 +67,10 @@ jobs:
   # fingerprint divergence can only ever make iOS over-build, never wrongly skip.
   # See docs/mobile-ota-updates.md.
   gate:
+    # main-only: the iOS build is main-only by design (it uploads to TestFlight),
+    # so a dispatch forces a build only from main — there's no point running the
+    # gate off a feature branch where build-and-upload would skip anyway. (Android
+    # additionally builds artifacts from a feature-branch dispatch; iOS does not.)
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -40,6 +40,38 @@ concurrency:
   group: mobile-ota-production-${{ github.ref }}
   cancel-in-progress: false
 
+# ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
+# MUST stay byte-identical to ios-testflight-rn.yml / android-apk-rn.yml, for two
+# distinct reasons (both at the workflow level there too, so the gate + build +
+# this publish all resolve the same fingerprint):
+#   1. Fingerprint parity. The fingerprint runtimeVersion hashes the *resolved
+#      Expo config* + the written .env (NOT the JS bundle). The vars that feed
+#      that config must match the native build or the published fingerprint won't
+#      match the shipped binary and the OTA silently never lands:
+#      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID (→ google-signin iosUrlScheme, a native
+#      CFBundleURLScheme), GOOGLE_MAPS_API_KEY (→ android.config; set per-platform
+#      on the Android publish step below), and — once the committed cert activates
+#      the self-hosted updates block — EXPO_UPDATES_URL + EXPO_UPDATES_CHANNEL.
+#   2. Bundle correctness. The remaining EXPO_PUBLIC_* are inlined into the JS
+#      bundle (and hashed via .env); drift there ships an OTA pointing at the
+#      wrong backend/analytics. Both classes are enforced by
+#      scripts/mobile-ci-env-parity.test.ts. Keep this free of other
+#      fingerprint-affecting vars (EAS_BUILD, EAS_BUILD_PROFILE,
+#      BOARDSESH_APP_VARIANT, …) — they're unset in the native builds too.
+env:
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+  EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+  EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  # Baked into the binary by `expo prebuild`; the server maps this channel to a
+  # same-named branch. Part of the resolved config, so it's fingerprint-relevant.
+  EXPO_UPDATES_CHANNEL: production
+  EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -51,36 +83,6 @@ jobs:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
       INPUT_MESSAGE: ${{ github.event.inputs.message }}
-      # ─── SHARED BUILD ENV ────────────────────────────────────────────────────
-      # MUST stay byte-identical to ios-testflight-rn.yml / android-apk-rn.yml, for
-      # two distinct reasons:
-      #   1. Fingerprint parity. The fingerprint runtimeVersion hashes the
-      #      *resolved Expo config* (NOT the JS bundle). The vars that feed that
-      #      config must match the native build or the published fingerprint won't
-      #      match the shipped binary and the OTA silently never lands:
-      #      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID (→ google-signin iosUrlScheme, a
-      #      native CFBundleURLScheme), GOOGLE_MAPS_API_KEY (→ android.config; set
-      #      per-platform below), and — once the committed cert activates the
-      #      self-hosted updates block — EXPO_UPDATES_URL + EXPO_UPDATES_CHANNEL.
-      #   2. Bundle correctness. The remaining EXPO_PUBLIC_* are inlined into the
-      #      JS bundle (not the fingerprint); drift there ships an OTA pointing at
-      #      the wrong backend/analytics — a runtime bug, not a delivery failure.
-      # Both classes are enforced by scripts/mobile-ci-env-parity.test.ts. Keep the
-      # job env free of other fingerprint-affecting vars (EAS_BUILD,
-      # EAS_BUILD_PROFILE, BOARDSESH_APP_VARIANT, …) — they're unset in the native
-      # builds too, so introducing one here would desync the fingerprint.
-      EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
-      EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
-      EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
-      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
-      EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
-      EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
-      EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
-      # Baked into the binary by `expo prebuild`; the server maps this channel to a
-      # same-named branch. Part of the resolved config, so it's fingerprint-relevant.
-      EXPO_UPDATES_CHANNEL: production
-      EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
 
     steps:
       - name: Checkout repository

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -117,17 +117,20 @@ Linux like its gate, so they always agree. (Expo's own action trusts cross-OS de
 ours is strictly safer.)
 
 **Fail-safe.** If the gate can't resolve the fingerprint, it builds. A manual `workflow_dispatch`
-always builds (it bypasses the tag check), so it stays a reliable force-build escape hatch.
+bypasses the tag check and always builds — for iOS that means dispatching on `main` (the iOS build
+is `main`-only by design, since it uploads to TestFlight); the Android workflow additionally builds
+from a `workflow_dispatch` on any branch (artifact-only, matching its pre-existing behavior).
 
 **Manual overrides.**
 
 - Force a rebuild of a fingerprint that already has a tag:
   `git push --delete origin fingerprint-<platform>-<hash>`, then re-push to `main` (or run the
   workflow via dispatch).
-- The Android tag is recorded once the **GitHub Release** (sideload APK) publishes, which always
-  runs; the later Play upload is best-effort. If Play upload flakes, the sideload APK with that
-  fingerprint still shipped — to make Play catch up, either re-upload the AAB artifact by hand or
-  delete the tag to force a rebuild on the next push.
+- The Android tag is recorded only after **all** of its channels ship for that fingerprint: the
+  sideload APK (GitHub Release), the AAB build, and a Play upload that didn't fail. So a failed AAB
+  build or a flaky Play upload leaves no tag and the next push **automatically rebuilds and
+  retries** — no manual step. Before the Play bootstrap (Play upload disabled), the tag is still
+  recorded once the APK + AAB build, since Play isn't a channel yet.
 
 Resolve the current fingerprint locally to predict what the gate will see: `cd packages/mobile &&
 bunx expo-updates runtimeversion:resolve --platform ios` (add the production env to match CI

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -52,7 +52,9 @@ install, since the device couldn't verify the manifest came from us.
 runtimeVersion is a fingerprint, this is safe to run on every push: a native change publishes an
 OTA whose fingerprint no current binary has yet, so it only lands once the matching store build
 ships. Until the server is wired (no `EXPO_UPDATES_URL` variable or committed cert), the workflow
-skips with a green no-op.
+skips with a green no-op. The matching native builds (`ios-testflight-rn` / `android-apk-rn`) run
+on the same push but are **fingerprint-gated** — they only build when the fingerprint is new (see
+[Native-build gating](#native-build-gating-ota-only-when-the-fingerprint-is-unchanged) below).
 
 **Manual** (one branch, ad hoc) — once the server is deployed and you're logged in (`bunx eas
 login`, or `EXPO_TOKEN` set):
@@ -86,6 +88,50 @@ enforced/handled in CI:
   Apple Maps) and it changes the resolved config — hence the fingerprint — for **both** platforms.
   So the workflow publishes iOS **without** the key and Android **with** it, in separate steps. A
   single `--platform all` publish with one env could only ever match one side.
+
+## Native-build gating (OTA-only when the fingerprint is unchanged)
+
+The OTA publish is cheap and runs on every push, but the native builds (`ios-testflight-rn`,
+~60 min on macOS; `android-apk-rn`, on Linux) only need to run when the fingerprint actually
+changes. A JS/TS-only change keeps the same fingerprint, so installed binaries pull the new JS over
+the air and a fresh native build is wasted. Each native workflow gates itself on the fingerprint —
+the self-hosted equivalent of Expo's `continuous-deploy-fingerprint`:
+
+1. A cheap Linux **`gate` job** resolves the platform fingerprint with `bunx expo-updates
+runtimeversion:resolve` using the same **workflow-level** env the build uses (iOS without
+   `GOOGLE_MAPS_API_KEY`, Android with it). The shared env sits at the workflow level so the gate
+   and build can't drift, and the gate writes the same `.env` the build does — the `.env` is itself
+   hashed into the fingerprint, so an absent or different one would resolve a different hash.
+2. If a git tag `fingerprint-<platform>-<hash>` already exists, a binary with that fingerprint has
+   already shipped → the native build **skips** (the OTA delivers the JS). Otherwise it **runs**.
+3. On a successful build + store upload, the build job pushes `fingerprint-<platform>-<hash>`.
+
+**Why a wrong skip is impossible.** The gate resolves on Linux, but the iOS binary is baked on
+macOS. Rather than trust cross-OS fingerprint determinism for correctness, the build job
+re-resolves the fingerprint **on its own runner** and tags _that_ value, while the gate checks the
+_Linux_ value. Tags therefore only ever hold build-OS fingerprints. If Linux and macOS ever
+disagree, the gate never finds a matching tag and iOS simply always builds (wasteful, but safe) —
+it can never wrongly skip and strand users on an old binary. The build emits a `::warning::` when
+the two fingerprints disagree, so the degraded "always build" mode is visible. Android builds on
+Linux like its gate, so they always agree. (Expo's own action trusts cross-OS determinism here;
+ours is strictly safer.)
+
+**Fail-safe.** If the gate can't resolve the fingerprint, it builds. A manual `workflow_dispatch`
+always builds (it bypasses the tag check), so it stays a reliable force-build escape hatch.
+
+**Manual overrides.**
+
+- Force a rebuild of a fingerprint that already has a tag:
+  `git push --delete origin fingerprint-<platform>-<hash>`, then re-push to `main` (or run the
+  workflow via dispatch).
+- The Android tag is recorded once the **GitHub Release** (sideload APK) publishes, which always
+  runs; the later Play upload is best-effort. If Play upload flakes, the sideload APK with that
+  fingerprint still shipped — to make Play catch up, either re-upload the AAB artifact by hand or
+  delete the tag to force a rebuild on the next push.
+
+Resolve the current fingerprint locally to predict what the gate will see: `cd packages/mobile &&
+bunx expo-updates runtimeversion:resolve --platform ios` (add the production env to match CI
+exactly — see the parity check above).
 
 ## One-time setup (infra — done outside this repo)
 
@@ -149,11 +195,6 @@ prebuild --platform ios --clean --no-install`, then confirm `ios/Boardsesh/Suppo
 
 ## Deferred
 
-- **Native-build gating** — record each shipped fingerprint as a git tag on a successful native
-  build, then skip the ~60-min `ios-testflight-rn` / `android-apk-rn` builds on `main` when the
-  current fingerprint already has a tag (OTA-only) and run them otherwise. The self-hosted
-  equivalent of Expo's `continuous-deploy-fingerprint` action; lands after the basic pipeline is
-  proven. Today both the native builds and the OTA publish fire on every mobile push to `main`.
 - **`beta` channel**: TestFlight on `beta`, App Store on `production`, promote at GA.
 - **Migrate the preview/dev-branch flow + in-app `BranchSwitcher`** (`src/lib/eas-api.ts`) off EAS
   hosting onto expo-open-ota, to drop the Expo dependency entirely.

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -32,10 +32,11 @@ const NATIVE_IOS = 'ios-testflight-rn.yml';
 const NATIVE_ANDROID = 'android-apk-rn.yml';
 const OTA = 'mobile-ota-production.yml';
 
-// Job-level env keys that feed the resolved config (fingerprint) and/or the
+// Workflow-level env keys that feed the resolved config (fingerprint) and/or the
 // inlined JS bundle (runtime correctness). Every one must be declared identically
-// in all three workflows. GOOGLE_MAPS_API_KEY is handled separately (it's
-// step-scoped and Android-only — see the dedicated test below).
+// in all three workflows. They live at the workflow level (not job level) so the
+// fingerprint `gate` job and the build job within a workflow can't drift.
+// GOOGLE_MAPS_API_KEY is handled separately (Android-only — see below).
 const SHARED_ENV_KEYS = [
   'EXPO_PUBLIC_BACKEND_URL',
   'EXPO_PUBLIC_WS_URL',
@@ -53,9 +54,9 @@ function readWorkflow(name: string): string {
   return readFileSync(resolve(WORKFLOW_DIR, name), 'utf8');
 }
 
-/** Extract a job-level `env:` value (6-space indent) by key, or null if absent. */
-function jobEnvValue(source: string, key: string): string | null {
-  const match = source.match(new RegExp(`^ {6}${key}:[ \\t]*(.+?)\\s*$`, 'm'));
+/** Extract a workflow-level `env:` value (2-space indent) by key, or null. */
+function workflowEnvValue(source: string, key: string): string | null {
+  const match = source.match(new RegExp(`^ {2}${key}:[ \\t]*(.+?)\\s*$`, 'm'));
   return match ? match[1] : null;
 }
 
@@ -63,10 +64,10 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
   const workflows = [NATIVE_IOS, NATIVE_ANDROID, OTA];
 
   it.each(SHARED_ENV_KEYS)('declares %s identically across all three workflows', (key) => {
-    const values = workflows.map((name) => ({ name, value: jobEnvValue(readWorkflow(name), key) }));
+    const values = workflows.map((name) => ({ name, value: workflowEnvValue(readWorkflow(name), key) }));
 
     for (const { name, value } of values) {
-      expect(value, `${key} missing from ${name} job env`).not.toBeNull();
+      expect(value, `${key} missing from ${name} workflow env`).not.toBeNull();
     }
 
     const distinct = new Set(values.map((entry) => entry.value));
@@ -97,8 +98,36 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
 
   it('keeps the OTA publish on the self-hosted server (production channel)', () => {
     const ota = readWorkflow(OTA);
-    expect(jobEnvValue(ota, 'EXPO_UPDATES_CHANNEL')).toBe('production');
+    expect(workflowEnvValue(ota, 'EXPO_UPDATES_CHANNEL')).toBe('production');
     expect(ota).toMatch(/--channel production --platform ios/);
     expect(ota).toMatch(/--channel production --platform android/);
+  });
+
+  it('gates each native build on its platform fingerprint (resolve + per-platform tag)', () => {
+    // The gate resolves the runtimeVersion fingerprint and skips the native build
+    // when a fingerprint-<platform>-<hash> tag already exists; the build records
+    // that tag on success. Per-platform because the fingerprints differ
+    // (GOOGLE_MAPS_API_KEY perturbs only Android) — a shared tag would be wrong.
+    const ios = readWorkflow(NATIVE_IOS);
+    const android = readWorkflow(NATIVE_ANDROID);
+
+    expect(ios).toMatch(/runtimeversion:resolve --platform ios/);
+    expect(ios).toMatch(/fingerprint-ios-/);
+    expect(android).toMatch(/runtimeversion:resolve --platform android/);
+    expect(android).toMatch(/fingerprint-android-/);
+  });
+
+  it('resolves the iOS fingerprint without GOOGLE_MAPS_API_KEY and Android with it', () => {
+    // GOOGLE_MAPS_API_KEY changes the resolved android.config — hence the
+    // fingerprint — so the gate must mirror the per-platform split the native
+    // builds bake in: never set on iOS (Apple Maps), set on Android, or a gate
+    // resolves a fingerprint the binary never had and skips/builds wrongly.
+    const ios = readWorkflow(NATIVE_IOS);
+    const android = readWorkflow(NATIVE_ANDROID);
+
+    // No env assignment of the key anywhere in the iOS workflow (a comment that
+    // merely names it is fine — match a YAML/shell key, not the bare word).
+    expect(ios).not.toMatch(/^\s*GOOGLE_MAPS_API_KEY:/m);
+    expect(android).toMatch(/^\s*GOOGLE_MAPS_API_KEY:\s*\$\{\{\s*secrets\.GOOGLE_MAPS_API_KEY\s*\}\}/m);
   });
 });


### PR DESCRIPTION
## What

Self-hosted production OTA is live on `main`, so every mobile push to `main` fires **both** the ~60-min native builds (`ios-testflight-rn`, `android-apk-rn`) **and** the cheap OTA publish. For a JS/TS-only change the `runtimeVersion` fingerprint is unchanged, so installed binaries pull the new JS over the air and the native build is wasted.

This adds the self-hosted equivalent of Expo's `continuous-deploy-fingerprint`: each native workflow gets a cheap Linux **`gate` job** that resolves its platform fingerprint and **skips** the native build when a `fingerprint-<platform>-<hash>` tag already exists (OTA delivers the JS); otherwise it **builds** and, on a successful upload, **pushes that tag**. The OTA publish is unchanged — it still runs on every push.

## Why a wrong skip is impossible

The gate resolves on Linux, but the iOS binary is baked on macOS. A wrong skip would strand users on an old native binary, so rather than trust cross-OS fingerprint determinism for correctness:

- the **gate** checks the **Linux**-resolved fingerprint against existing tags;
- the **build job** re-resolves on its **own runner** and tags **that** value.

Tags therefore only ever hold build-OS fingerprints. If Linux and macOS ever disagree, the gate never finds a matching tag → iOS simply **always builds** (wasteful, safe), never a wrong skip. The build emits a `::warning::` when the two disagree so the degraded mode is visible. (Android builds on Linux like its gate, so they always agree.) This is strictly safer than Expo's action, which trusts cross-OS determinism for correctness.

## Key details

- **Workflow-level shared env.** The `EXPO_PUBLIC_*` / `EXPO_UPDATES_*` env (and Android's `GOOGLE_MAPS_API_KEY`) move to workflow level so the gate and build resolve a byte-identical fingerprint and can't drift. The gate writes the same `.env` the build does — **the `.env` is itself hashed into the fingerprint** (verified: iOS `9f9cc7b…` without `.env` vs `9b4c630…` with it).
- **Per-platform tags + env.** iOS resolves **without** `GOOGLE_MAPS_API_KEY`, Android **with** it — the key flips the Android fingerprint (`82cfb16…` vs `cdb7ea9…`), so the per-platform tags differ; a shared tag would be wrong.
- **Fail-safe.** A resolve failure builds. `workflow_dispatch` bypasses the tag check and always builds — for iOS that means dispatching on `main` (the iOS build is `main`-only by design, since it uploads to TestFlight); Android additionally builds from a feature-branch dispatch (artifact-only, matching its pre-existing behavior).
- **Idempotent / race-safe tag push.** A concurrent run that already pushed the tag is treated as success.
- **Android tags only on a full ship.** The `fingerprint-android-<hash>` tag is pushed only after the sideload APK release, the AAB build, and a Play upload that did not fail — so a failed AAB or flaky Play upload leaves no tag and the next push rebuilds and retries automatically.

## Tests / validation

- `scripts/mobile-ci-env-parity.test.ts` updated to read **workflow-level** env, plus new assertions that each native build resolves its platform fingerprint, tags it, and keeps the per-platform `GOOGLE_MAPS_API_KEY` split (iOS none, Android set). **14/14 pass.**
- `vp run typecheck` clean; `vp check` clean on all changed files; all three workflow YAMLs parse.
- Confirmed locally that `bunx expo-updates runtimeversion:resolve` emits JSON (`.runtimeVersion`), and that `.env` + `GOOGLE_MAPS_API_KEY` both move the fingerprint.

## Follow-up to verify after merge

- A JS-only commit → gate finds the existing fingerprint → both native builds skip (OTA-only).
- A native change → new fingerprint → builds run and push new `fingerprint-<platform>-<hash>` tags; a subsequent JS-only push skips again.
- One-time: confirm the Linux gate fingerprint equals the macOS-baked `EXUpdatesRuntimeVersion` (expected for this CNG project) so iOS savings actually land — safety doesn't depend on it.

Docs: `docs/mobile-ota-updates.md` gains a "Native-build gating" section (incl. manual overrides) and the item is removed from Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECKU2KefyLAzys1zByyPKp
