### PR TITLE
fix(mobile-ota): resolve a working bunx under `vp run` so production OTA publishes

### DIFF
--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -21,11 +21,41 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { resolve, dirname } from 'node:path';
+import { closeSync, openSync, readSync } from 'node:fs';
+import { resolve, dirname, join, delimiter } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
+
+// vp (Vite+) prepends its own bun shim directory to PATH, and that shim's `bunx`
+// is a `/bin/sh` wrapper that forwards to `bun` WITHOUT switching to x-mode — so
+// `bunx <pkg>` runs as `bun <pkg>` (script mode) and dies with
+// `Script not found "<pkg>"`. The real bunx (from bun / setup-bun) is a binary
+// symlink, never a `#!` script. Under `vp run` this breaks BOTH the eoas/eas
+// invocation below AND the `expo export` eoas spawns via --packageRunner bunx
+// (it inherits this env). Drop any PATH entry whose `bunx` is a `#!` script shim
+// so a working bunx wins — fixes CI (vp on PATH) and local `vp run mobile:publish`.
+function bunxIsScriptShim(dir: string): boolean {
+  let fd: number | undefined;
+  try {
+    fd = openSync(join(dir, 'bunx'), 'r');
+    const head = Buffer.alloc(2);
+    readSync(fd, head, 0, 2, 0);
+    return head[0] === 0x23 && head[1] === 0x21; // "#!"
+  } catch {
+    return false; // no readable bunx here → not a shim we need to drop
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function pathWithoutBrokenBunxShims(rawPath: string | undefined): string {
+  return (rawPath ?? '')
+    .split(delimiter)
+    .filter((dir) => dir.length > 0 && !bunxIsScriptShim(dir))
+    .join(delimiter);
+}
 
 function resolveCurrentBranchName(): string | null {
   try {
@@ -118,6 +148,9 @@ function publishToSelfHostedChannel(channelName: string, platform: string, expli
   // the caller's env can't redirect a production publish.
   const eoasEnv = { ...process.env };
   delete eoasEnv.EAS_BUILD;
+  // Drop vp's broken bunx shim dir so bunx — and the `bunx expo export` eoas
+  // spawns via --packageRunner bunx — resolve a working bunx.
+  eoasEnv.PATH = pathWithoutBrokenBunxShims(process.env.PATH);
 
   const result = spawnSync('bunx', eoasArgs, {
     cwd: MOBILE_DIR,
@@ -241,7 +274,7 @@ console.log('');
 const result = spawnSync('bunx', easArgs, {
   cwd: MOBILE_DIR,
   stdio: 'inherit',
-  env: { ...process.env },
+  env: { ...process.env, PATH: pathWithoutBrokenBunxShims(process.env.PATH) },
 });
 
 if (result.status !== 0) {


### PR DESCRIPTION
## The bug

**Production OTA publishing has never worked.** Every run of `mobile-ota-production.yml` (and a local `vp run mobile:publish -- --channel production`) dies instantly with:

```
[mobile:publish] Running: bunx eoas@2 publish --branch production --platform ios ...
error: Script not found "eoas@2"
```

So nothing has ever been published to the self-hosted expo-open-ota server — the OTA dashboard shows zero updates/downloads.

## Root cause

Under `vp run`, vp (Vite+) prepends its own bun shim directory to `PATH`. That shim's `bunx` is a `/bin/sh` wrapper that forwards to `bun` **without** switching to x-mode — so `bunx eoas@2 …` executes as `bun eoas@2 …` (script mode), and bun reports "Script not found" because there's no local script named `eoas@2`. The real `bunx` (bun / setup-bun) is a binary symlink, which bun detects as x-mode via `argv[0]`.

This broke **both**:
- the outer `spawnSync('bunx', ['eoas@2', …])` in `scripts/mobile-publish.ts`, and
- the `bunx expo export` eoas itself spawns via `--packageRunner bunx` (it inherits the same polluted env).

It's unrelated to the native-build-gating PR (#3061) — it failed identically on the commit before that merged.

## Fix

When spawning eoas (production) or eas-cli (preview), strip any `PATH` entry whose `bunx` is a `#!` script shim (vp's broken wrapper), so a working `bunx` wins. The real bunx is a binary symlink, so the heuristic targets only the broken shim and is portable (no hardcoded vp path). Fixes CI and local manual publishes alike.

## Validation

Ran `vp run mobile:publish -- --channel production --platform ios` locally with a throwaway server/token (so it can't publish anywhere real):

- **Before:** instant `error: Script not found "eoas@2"`.
- **After:** eoas runs the full pipeline — resolves the runtime version, exports the project, and the inner `bunx expo export` bundles iOS (3877 modules) + 352 assets — then (as expected) fails only when it tries to reach the fake server.

`vp check` clean.

## After merge

This is what makes JS-only changes (e.g. the IG share fixes) actually reach installed binaries over the air. The first production publish to land on a device still also needs the device's binary to carry the OTA runtime wiring and a matching fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECKU2KefyLAzys1zByyPKp