### PR TITLE
feat(mobile-ota): post production OTA publishes to the Discord deploy channel

### DIFF
--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -131,6 +131,7 @@ jobs:
       # iOS binary) and the Android publish WITH it (to match the Android binary). A
       # single `--platform all` publish with one env could only ever match one side.
       - name: Publish iOS OTA
+        id: publish_ios
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
         run: |
           args=(--channel production --platform ios)
@@ -138,6 +139,7 @@ jobs:
           vp run mobile:publish -- "${args[@]}"
 
       - name: Publish Android OTA
+        id: publish_android
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
         env:
           # Must match the Android native prebuild (android-apk-rn.yml) so the
@@ -147,3 +149,48 @@ jobs:
           args=(--channel production --platform android)
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"
+
+      # Announce the publish to the Discord deploy channel (same webhook + pattern
+      # as ios-testflight-rn.yml / android-apk-rn.yml). Only when an OTA actually
+      # went out: gate wired AND at least one platform succeeded. A `--platform ios`
+      # run reports just "iOS" (the Android step is skipped, not success).
+      - name: Notify deployments channel
+        if: github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
+          ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          platforms=""
+          [ "$IOS_OUTCOME" = "success" ] && platforms="iOS"
+          [ "$ANDROID_OUTCOME" = "success" ] && platforms="${platforms:+$platforms, }Android"
+          # INPUT_MESSAGE is the dispatch input (job env); fall back to the commit
+          # subject, which is the default update message mobile-publish.ts uses.
+          MESSAGE="${INPUT_MESSAGE:-$(git log -1 --pretty=%s)}"
+          CONTENT=$(printf '🚀 **Production OTA published** on `%s`\n• platforms: %s\n• channel: production\n• message: %s\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$platforms" "$MESSAGE" "$RUN_URL")
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"
+
+      - name: Notify deployments channel of failure
+        if: github.ref == 'refs/heads/main' && failure()
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          CONTENT=$(printf '🚨 **Production OTA publish failed** on `%s`\n<%s>' "${COMMIT_SHA:0:7}" "$RUN_URL")
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -54,7 +54,9 @@ OTA whose fingerprint no current binary has yet, so it only lands once the match
 ships. Until the server is wired (no `EXPO_UPDATES_URL` variable or committed cert), the workflow
 skips with a green no-op. The matching native builds (`ios-testflight-rn` / `android-apk-rn`) run
 on the same push but are **fingerprint-gated** — they only build when the fingerprint is new (see
-[Native-build gating](#native-build-gating-ota-only-when-the-fingerprint-is-unchanged) below).
+[Native-build gating](#native-build-gating-ota-only-when-the-fingerprint-is-unchanged) below). A
+successful publish (and any failure) posts to the Discord deploy channel via the
+`DISCORD_DEPLOY_WEBHOOK` secret, the same channel the native build workflows use.
 
 **Manual** (one branch, ad hoc) — once the server is deployed and you're logged in (`bunx eas
 login`, or `EXPO_TOKEN` set):


### PR DESCRIPTION
## Why

First step in productionising the self-hosted OTA pipeline: **observability**. Nothing announced a production OTA publish anywhere — which is exactly why the `eoas` "Script not found" failure (#3062) silently shipped zero updates for so long before it was noticed. Now every production publish (and every failure) lands in the Discord deploy channel.

## What

`mobile-ota-production.yml` gains two notification steps that reuse the existing `DISCORD_DEPLOY_WEBHOOK` + `jq`/`curl --fail-with-body` pattern already used by `ios-testflight-rn.yml` and `android-apk-rn.yml` (no new secrets):

- **Success** → `🚀 Production OTA published` with the platforms that actually went out, `channel: production`, the update message (commit subject by default), and the run link. Fires only when the gate is wired **and** at least one platform succeeded — so a not-wired skip stays quiet, and a `--platform ios` run reports just iOS (the Android step is `skipped`, not `success`).
- **Failure** → `🚨 Production OTA publish failed` on any failed publish run.

The publish steps got `id: publish_ios` / `id: publish_android` so the notify step can read their per-platform outcomes. Both notifications are gated to `main` (matching the native workflows' deploy-channel convention).

**Scope:** production only — preview per-branch publishes already comment on the PR, so the deploy channel stays signal, not noise. (Confirmed with maintainer.)

## Verification

- YAML parses; `vp fmt` reports clean; `scripts/mobile-ci-env-parity.test.ts` still passes 14/14 (env blocks untouched).
- After merge: `gh workflow run mobile-ota-production.yml --ref main` (a no-op republish) → confirm the "Notify deployments channel" step's curl returns 2xx in the run log and the message lands in Discord.

## Follow-ups (out of scope)

- DRY the now-5×-duplicated Discord block into a `.github/actions/discord-notify` composite action.
- Optionally include the resolved `runtimeVersion`/fingerprint in the message so readers can tell which store build will receive the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECKU2KefyLAzys1zByyPKp