### PR TITLE
Harden userAscentCaptionMatches (stranded review fixes from #3054)

### DIFF
--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -587,31 +587,42 @@ export const tickQueries = {
     { userId, caption }: { userId: string; caption: string },
     ctx?: ConnectionContext,
   ): Promise<AscentFeedRow[]> => {
-    const quotedNames = extractQuotedClimbNames(caption);
-    if (quotedNames.length === 0) return [];
+    // Public resolver that fans out to DB queries — rate-limit it like the other
+    // public reads (ctx is always present for a real request; tests pass none).
+    if (ctx) await applyRateLimit(ctx, 10, 'userAscentCaptionMatches');
 
-    // A caption virtually always quotes a single climb; cap lookups defensively.
+    // Cap the caption before any scanning so a multi-MB payload can't make
+    // matchAll/extract walk the whole string. 2 KB is ample for a real reel.
+    const MAX_CAPTION_LENGTH = 2048;
     const MAX_NAME_LOOKUPS = 4;
     const MAX_SUGGESTIONS = 8;
 
-    const gathered: AscentFeedRow[] = [];
-    for (const quotedName of quotedNames.slice(0, MAX_NAME_LOOKUPS)) {
-      // statusMode 'send' = flash + send (beta attaches to ascents, not attempts,
-      // so a flash-only climb is still included). The climbName filter is an
-      // indexed, per-user ILIKE that returns a handful of rows — not the whole
-      // logbook — and resolves aliased/deduped climbs to their canonical name.
-      const feed = await tickQueries.userAscentsFeed(
-        _,
-        { userId, input: { climbName: quotedName, statusMode: 'send', limit: 50 } },
-        ctx,
-      );
-      gathered.push(...feed.items);
-    }
+    const safeCaption = caption.slice(0, MAX_CAPTION_LENGTH);
+    const quotedNames = extractQuotedClimbNames(safeCaption);
+    if (quotedNames.length === 0) return [];
+
+    // statusMode 'send' = flash + send (beta attaches to ascents, not attempts,
+    // so a flash-only climb is still included). The climbName filter is an
+    // indexed, per-user ILIKE that returns a handful of rows — not the whole
+    // logbook — and resolves aliased/deduped climbs to their canonical name.
+    // Lookups run in parallel (captions occasionally quote more than one climb).
+    const feeds = await Promise.all(
+      quotedNames
+        .slice(0, MAX_NAME_LOOKUPS)
+        .map((quotedName) =>
+          tickQueries.userAscentsFeed(
+            _,
+            { userId, input: { climbName: quotedName, statusMode: 'send', limit: 50 } },
+            ctx,
+          ),
+        ),
+    );
+    const gathered = feeds.flatMap((feed) => feed.items);
 
     // Exact-match the quoted name(s) against the fetched rows — drops ILIKE
     // substring over-matches and comment-only hits — then de-dupe by climb
     // (keeping the most recent send, since the feed is recency-sorted) and rank.
-    return matchClimbsToCaption(caption, gathered).slice(0, MAX_SUGGESTIONS);
+    return matchClimbsToCaption(safeCaption, gathered).slice(0, MAX_SUGGESTIONS);
   },
 
   /**

--- a/packages/mobile/src/providers/__tests__/share-target-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/share-target-provider.test.tsx
@@ -188,4 +188,19 @@ describe('ShareTargetProvider', () => {
     });
     expect(storage.has(PENDING_SHARE_KEY)).toBe(false);
   });
+
+  it('reuses the open modal (setParams) when a stashed link is replayed after login while share-beta is already open', async () => {
+    storage.set(PENDING_SHARE_KEY, INSTAGRAM_LINK);
+    authState.isAuthenticated = true;
+    segmentsState.value = ['share-beta'];
+    shareState.hasShareIntent = false;
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(setParamsMock).toHaveBeenCalledWith({ link: INSTAGRAM_LINK });
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(storage.has(PENDING_SHARE_KEY)).toBe(false);
+  });
 });

--- a/packages/mobile/src/providers/share-target-provider.tsx
+++ b/packages/mobile/src/providers/share-target-provider.tsx
@@ -55,10 +55,10 @@ export function ShareTargetProvider({ children }: { children: ReactNode }) {
   const { showToast } = useToast();
 
   // Whether the /share-beta modal is the focused route, read by the navigate
-  // handler without resubscribing. Root-level modal → its first segment is the
-  // route name.
+  // handler without resubscribing. `includes` (not segments[0]) so a future
+  // route-group nesting can't silently break the reuse check.
   const onShareBetaRef = useRef(false);
-  onShareBetaRef.current = segments[0] === 'share-beta';
+  onShareBetaRef.current = segments.includes('share-beta');
   // resetOnBackground defaults to true; turn it off so the OAuth round-trip
   // (which backgrounds the app) can't wipe a share before we've consumed it.
   const { hasShareIntent, shareIntent, resetShareIntent } = useShareIntent({ resetOnBackground: false });


### PR DESCRIPTION
Follow-up to #3054, which **merged at `19569f99f`** — 2 seconds after the `claude-review` bot posted its round-3 feedback. The commit addressing that feedback (`63552eb8c`) landed on the branch *after* the merge, so it never made it into `main`. This PR carries those changes (cherry-picked) so the now-live public resolver gets the hardening.

### `userAscentCaptionMatches`
- **Rate limit** — `applyRateLimit(ctx, 10, …)` (matching `userClimbPercentile`). It's a public resolver that fans out to DB queries; without this a crafted multi-quote caption drives up to 4 ILIKE lookups per request unthrottled.
- **Caption length cap** — slice to 2 KB before `extractQuotedClimbNames`, so a multi-MB payload can't make `matchAll` walk the whole string.
- **Parallel fan-out** — the per-quoted-name lookups run via `Promise.all` instead of sequential `await`s.

### share-target-provider
- Modal-reuse check is now `segments.includes('share-beta')` instead of `segments[0]`, so a future route-group nesting can't silently fall back to stacking the modal.
- Added the missing test: post-login replay landing on an already-open modal → `setParams` reuse (no second push).

Green: typecheck (backend + mobile), backend `tick-queries` (31), `share-target-provider` (13), lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)