### PR TITLE
fix(mobile-ota): make the Android fingerprint gate actually skip JS-only builds

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -88,6 +88,14 @@ jobs:
     # Push is always on main; a manual dispatch (any branch) always builds, so
     # `workflow_dispatch` keeps producing an APK artifact off a feature branch.
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    # GOOGLE_MAPS_API_KEY is a Production-environment secret, and it changes the
+    # resolved android.config — hence the fingerprint. Without `environment:
+    # Production` the gate reads an EMPTY key and resolves a map-less hash that
+    # never matches the with-maps binary, so Android would always rebuild. Scope
+    # to Production on main only: the env is main-only by branch policy, and a
+    # non-main dispatch always builds anyway (it never reaches the tag check, so
+    # it doesn't need the key).
+    environment: ${{ github.ref == 'refs/heads/main' && 'Production' || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -475,17 +483,21 @@ jobs:
 
       # Record that a binary with this fingerprint shipped, so future JS-only
       # pushes with the same fingerprint skip this build (the gate checks for the
-      # tag). Placed AFTER the AAB build + Play upload and gated on every channel
-      # so a partial ship never tags (which would wrongly skip the next push):
-      #   - github_release succeeded → the always-on sideload APK shipped;
-      #   - build_aab succeeded → a failed AAB must NOT tag, or Play never gets
-      #     this fingerprint and the next push wrongly skips it;
-      #   - play_upload did not FAIL → 'skipped' (Play disabled before bootstrap)
-      #     is fine, but an actual upload failure leaves no tag so the next push
-      #     rebuilds and Play retries automatically.
+      # tag). Gated on the reliable, always-on signals that a native binary with
+      # this fingerprint exists and is distributed:
+      #   - github_release succeeded → the sideload APK shipped;
+      #   - build_aab succeeded → a failed AAB build must NOT tag (else the next
+      #     push wrongly skips before any AAB exists).
+      # NOT gated on the Play upload: it's best-effort (continue-on-error) and can
+      # fail for Console-policy reasons (e.g. the Foreground-services declaration)
+      # that have nothing to do with the binary. Coupling the fingerprint tag to
+      # Play would let a persistent Play-Console issue permanently disable Android
+      # gating (rebuild forever). The Play channel keeps its own failure warning +
+      # manual-retry path; a missed Play upload is recovered by re-uploading the
+      # retained AAB artifact, not by rebuilding identical native binaries.
       # Idempotent for concurrent runs.
       - name: Tag the shipped Android fingerprint
-        if: github.ref == 'refs/heads/main' && steps.github_release.outcome == 'success' && steps.build_aab.outcome == 'success' && steps.play_upload.outcome != 'failure' && env.FINGERPRINT_ANDROID != ''
+        if: github.ref == 'refs/heads/main' && steps.github_release.outcome == 'success' && steps.build_aab.outcome == 'success' && env.FINGERPRINT_ANDROID != ''
         run: |
           set -uo pipefail
           tag="fingerprint-android-${FINGERPRINT_ANDROID}"

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -128,11 +128,16 @@ from a `workflow_dispatch` on any branch (artifact-only, matching its pre-existi
 - Force a rebuild of a fingerprint that already has a tag:
   `git push --delete origin fingerprint-<platform>-<hash>`, then re-push to `main` (or run the
   workflow via dispatch).
-- The Android tag is recorded only after **all** of its channels ship for that fingerprint: the
-  sideload APK (GitHub Release), the AAB build, and a Play upload that didn't fail. So a failed AAB
-  build or a flaky Play upload leaves no tag and the next push **automatically rebuilds and
-  retries** — no manual step. Before the Play bootstrap (Play upload disabled), the tag is still
-  recorded once the APK + AAB build, since Play isn't a channel yet.
+- The Android tag is recorded once the **sideload APK (GitHub Release) and the AAB build** succeed
+  — the reliable signal that a binary with this fingerprint exists. It is **not** gated on the Play
+  upload: that step is best-effort and can fail for Console-policy reasons (e.g. the
+  Foreground-services declaration) unrelated to the binary, and coupling the tag to it would let a
+  persistent Play issue rebuild Android forever. A failed Play upload is recovered by re-uploading
+  the retained AAB artifact (or rerunning the workflow), not by withholding the fingerprint tag.
+- The Android **gate** job runs in the `Production` environment so it can read
+  `GOOGLE_MAPS_API_KEY` (a Production-scoped secret that changes the Android fingerprint) and
+  resolve the same hash the build bakes. Without it the gate computes a map-less fingerprint that
+  never matches the binary, and Android never skips.
 
 Resolve the current fingerprint locally to predict what the gate will see: `cd packages/mobile &&
 bunx expo-updates runtimeversion:resolve --platform ios` (add the production env to match CI


### PR DESCRIPTION
## The bug

The native-build fingerprint gate works for iOS but **never skips Android**. The JS-only IG-share-fixes merge (#3054) proved it: iOS build `skipped` ✅, Android build *ran* ❌ — and the build log flagged why:

> `Android fingerprint differs between the gate (29a7e407…) and this build (2bdcf2ae…) — both run on Linux, so this is unexpected; investigate.`

Two independent root causes, both fixed here:

### 1. The gate resolved a map-less fingerprint
`GOOGLE_MAPS_API_KEY` is a **Production-environment** secret, and it changes the resolved `android.config` → the fingerprint. The `gate` job had **no `environment: Production`**, so it read the key as empty and resolved a *map-less* hash that can never match the *with-maps* hash the build bakes into the binary. The gate's tag check looked for a tag the build never creates → Android always rebuilt.

**Fix:** scope the gate to `Production` on main: `environment: ${{ github.ref == 'refs/heads/main' && 'Production' || '' }}`. The conditional keeps non-main `workflow_dispatch` working (the Production env is main-only by branch policy; a non-main dispatch always builds and never reaches the tag check, so it doesn't need the key).

This was **safe, not silently wrong** — the self-correcting design (tag the build's value, gate on the gate's value) degrades a mismatch to "always build", never a wrong skip. So nothing shipped incorrectly; Android just got no savings.

### 2. The tag was coupled to the (failing) Play upload
The tag step required `steps.play_upload.outcome != 'failure'`. But the Play upload is best-effort (`continue-on-error`) and currently fails on a **Play Console policy task** — `##[error]You must let us know whether your app uses any Foreground Service permissions` — which has nothing to do with the binary. That withheld the `fingerprint-android` tag entirely, so even after fix #1, Android could never skip.

**Fix:** tag once the **GitHub Release (sideload APK) + AAB build** succeed — the reliable signal a binary with this fingerprint exists. A failed AAB *build* still withholds the tag (real build failures retry). Play stays best-effort with its existing failure warning + manual re-upload path. (Refines the earlier Codex-review gating: it correctly retries on AAB-build failure, but no longer lets a persistent Play-Console issue disable Android gating forever.)

> Note: the Play "Foreground service permissions" declaration is Play Console UI-only — the Play Developer API / fastlane can't set it. It'll be declared manually in the Console; this PR just stops it from blocking OTA gating.

## Effect
After this lands, the next Android build resolves the real (with-maps) fingerprint, tags it, and subsequent JS-only pushes **skip** the ~Android native build — matching iOS.

## Verification
- YAML parses; the conditional `environment` resolves to `Production` on main / `''` (no env) on non-main dispatch; the tag condition no longer references `play_upload`.
- `vp fmt` clean; `scripts/mobile-ci-env-parity.test.ts` passes 14/14.
- Post-merge: the first Android build creates `fingerprint-android-<hash>`; a follow-up JS-only push then shows `build-and-release: skipped` and the gate logs "already built … skipping". The "fingerprint differs" warning should disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECKU2KefyLAzys1zByyPKp