### PR TITLE
fix(mobile): 16 KB-align board-renderer native lib for Android 15+

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -433,9 +433,14 @@ jobs:
       # APK and the Play AAB, so it checks the board-renderer JNI wrapper + prebuilt
       # Rust FFI lib, React Native's own libs, and every third-party lib in one pass.
       - name: Verify 16 KB native-library alignment (APK + AAB)
+        # `mapfile` is a bash builtin; don't rely on the runner's default shell.
+        shell: bash
         run: |
           set -euo pipefail
-          # Check every release APK (any ABI split) and the AAB, not a hardcoded name.
+          # Check every release APK (any ABI split) and the AAB, not a hardcoded
+          # name. The guard audits ALL bundled libs — ours plus React Native's and
+          # every third-party native module — so a non-16-KB upstream lib will also
+          # block the release (intentional: Play rejects the whole upload).
           mapfile -t archives < <(
             find packages/mobile/android/app/build/outputs/apk/release -maxdepth 1 -name '*.apk'
             find packages/mobile/android/app/build/outputs/bundle/release -maxdepth 1 -name '*.aab'

--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -435,9 +435,16 @@ jobs:
       - name: Verify 16 KB native-library alignment (APK + AAB)
         run: |
           set -euo pipefail
-          aab="$(find packages/mobile/android/app/build/outputs/bundle/release -name '*.aab' | head -n 1)"
-          apk=packages/mobile/android/app/build/outputs/apk/release/boardsesh-rn-android-arm64-v8a.apk
-          ./scripts/check-16kb-alignment.sh "$apk" "$aab"
+          # Check every release APK (any ABI split) and the AAB, not a hardcoded name.
+          mapfile -t archives < <(
+            find packages/mobile/android/app/build/outputs/apk/release -maxdepth 1 -name '*.apk'
+            find packages/mobile/android/app/build/outputs/bundle/release -maxdepth 1 -name '*.aab'
+          )
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "::error::No release APK/AAB found to verify."
+            exit 1
+          fi
+          ./scripts/check-16kb-alignment.sh "${archives[@]}"
 
       - name: Upload AAB as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -428,6 +428,17 @@ jobs:
           SENTRY_DISABLE_AUTO_UPLOAD: 'true'
         run: ./gradlew bundleRelease --no-daemon --console=plain --stacktrace
 
+      # Block the GitHub Release / Play upload if any bundled native lib isn't 16 KB
+      # page aligned (Android 15+ / API 35+ requirement). Covers both the sideload
+      # APK and the Play AAB, so it checks the board-renderer JNI wrapper + prebuilt
+      # Rust FFI lib, React Native's own libs, and every third-party lib in one pass.
+      - name: Verify 16 KB native-library alignment (APK + AAB)
+        run: |
+          set -euo pipefail
+          aab="$(find packages/mobile/android/app/build/outputs/bundle/release -name '*.aab' | head -n 1)"
+          apk=packages/mobile/android/app/build/outputs/apk/release/boardsesh-rn-android-arm64-v8a.apk
+          ./scripts/check-16kb-alignment.sh "$apk" "$aab"
+
       - name: Upload AAB as artifact
         uses: actions/upload-artifact@v4
         if: always()

--- a/packages/mobile/modules/board-renderer/android/src/main/cpp/CMakeLists.txt
+++ b/packages/mobile/modules/board-renderer/android/src/main/cpp/CMakeLists.txt
@@ -7,3 +7,12 @@ add_library(board_renderer_jni SHARED jni_bridge.cpp)
 # libboard_renderer_ffi.so, not this machine's absolute source path.
 target_link_directories(board_renderer_jni PRIVATE ${CMAKE_SOURCE_DIR}/../jniLibs/${ANDROID_ABI})
 target_link_libraries(board_renderer_jni PRIVATE board_renderer_ffi log)
+
+# Align LOAD segments to 16 KB. Android 15 devices with 16 KB memory pages
+# (Pixel 8/9, etc.) refuse to dlopen a .so whose segments are only 4 KB aligned
+# ("not 16 KB aligned" → UnsatisfiedLinkError), and Google Play rejects an AAB
+# with such libs when targeting API 35+. The NDK that ships with React Native
+# (r27) still links to 4 KB by default, so force it here — the same flag the
+# prebuilt Rust FFI lib already uses in scripts/build-native-renderer.sh. 16 KB
+# aligned libs also load fine on 4 KB devices, so this is unconditionally safe.
+target_link_options(board_renderer_jni PRIVATE "-Wl,-z,max-page-size=16384")

--- a/packages/mobile/modules/board-renderer/android/src/main/cpp/CMakeLists.txt
+++ b/packages/mobile/modules/board-renderer/android/src/main/cpp/CMakeLists.txt
@@ -8,11 +8,7 @@ add_library(board_renderer_jni SHARED jni_bridge.cpp)
 target_link_directories(board_renderer_jni PRIVATE ${CMAKE_SOURCE_DIR}/../jniLibs/${ANDROID_ABI})
 target_link_libraries(board_renderer_jni PRIVATE board_renderer_ffi log)
 
-# Align LOAD segments to 16 KB. Android 15 devices with 16 KB memory pages
-# (Pixel 8/9, etc.) refuse to dlopen a .so whose segments are only 4 KB aligned
-# ("not 16 KB aligned" → UnsatisfiedLinkError), and Google Play rejects an AAB
-# with such libs when targeting API 35+. The NDK that ships with React Native
-# (r27) still links to 4 KB by default, so force it here — the same flag the
-# prebuilt Rust FFI lib already uses in scripts/build-native-renderer.sh. 16 KB
-# aligned libs also load fine on 4 KB devices, so this is unconditionally safe.
+# 16 KB-align LOAD segments for Android 15+ 16 KB-page devices / Play upload (the
+# NDK that ships with RN still defaults to 4 KB); mirrors the FFI flag in
+# scripts/build-native-renderer.sh, and is a no-op on 4 KB devices.
 target_link_options(board_renderer_jni PRIVATE "-Wl,-z,max-page-size=16384")

--- a/scripts/__tests__/check-16kb-alignment.test.ts
+++ b/scripts/__tests__/check-16kb-alignment.test.ts
@@ -1,0 +1,122 @@
+/// <reference types="node" />
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Exercises scripts/check-16kb-alignment.sh end-to-end: pack .so files into an
+// APK-shaped zip and assert the guard's exit code. The "good" fixture is the
+// real committed FFI lib (already 16 KB aligned); the "bad" one is that lib with
+// its ELF LOAD-segment alignment rewritten to 4 KB, so no compiler is needed.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(here, '..', '..');
+const guardScript = path.join(repoRoot, 'scripts', 'check-16kb-alignment.sh');
+const alignedSo = path.join(
+  repoRoot,
+  'packages/mobile/modules/board-renderer/android/src/main/jniLibs/arm64-v8a/libboard_renderer_ffi.so',
+);
+
+function hasTool(name: string): boolean {
+  try {
+    execFileSync('sh', ['-c', `command -v ${name}`], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The guard (and this test) shell out to these; skip on hosts without them, e.g.
+// a macOS dev box without binutils. CI's Linux runner has them all.
+const toolsPresent = ['bash', 'zip', 'unzip', 'readelf'].every(hasTool) && fs.existsSync(alignedSo);
+
+// Forge a 4 KB-aligned copy of an ELF64 little-endian .so: set every PT_LOAD
+// segment's p_align to 0x1000. ELF64 header has e_phoff @0x20 (u64), e_phentsize
+// @0x36 (u16), e_phnum @0x38 (u16); p_align is the trailing u64 of each 56-byte
+// program-header entry (offset 48).
+function writeMisalignedCopy(sourceSo: string, destSo: string): void {
+  const bytes = fs.readFileSync(sourceSo);
+  const phOffset = Number(bytes.readBigUInt64LE(0x20));
+  const entrySize = bytes.readUInt16LE(0x36);
+  const entryCount = bytes.readUInt16LE(0x38);
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = phOffset + index * entrySize;
+    if (bytes.readUInt32LE(entry) === 1) {
+      bytes.writeBigUInt64LE(0x1000n, entry + 48);
+    }
+  }
+  fs.writeFileSync(destSo, bytes);
+}
+
+// Run the guard; return its exit code (0 on success, the failure code otherwise).
+function runGuard(...archives: string[]): number {
+  try {
+    execFileSync('bash', [guardScript, ...archives], { stdio: 'pipe' });
+    return 0;
+  } catch (error) {
+    return (error as { status?: number }).status ?? 1;
+  }
+}
+
+describe.skipIf(!toolsPresent)('check-16kb-alignment.sh', () => {
+  let workdir: string;
+
+  beforeAll(() => {
+    workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'align-guard-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  });
+
+  function newLibDir(name: string): string {
+    const libDir = path.join(workdir, name, 'lib', 'arm64-v8a');
+    fs.mkdirSync(libDir, { recursive: true });
+    return libDir;
+  }
+
+  function zipTopDir(name: string, topDir: string): string {
+    const archive = path.join(workdir, `${name}.apk`);
+    const cwd = path.join(workdir, name);
+    execFileSync('zip', ['-qr', archive, topDir], { cwd });
+    return archive;
+  }
+
+  it('passes when every bundled .so is 16 KB aligned', () => {
+    const libDir = newLibDir('aligned');
+    fs.copyFileSync(alignedSo, path.join(libDir, 'libboard_renderer_ffi.so'));
+    expect(runGuard(zipTopDir('aligned', 'lib'))).toBe(0);
+  });
+
+  it('fails when a bundled .so is only 4 KB aligned', () => {
+    const libDir = newLibDir('misaligned');
+    writeMisalignedCopy(alignedSo, path.join(libDir, 'libforged.so'));
+    expect(runGuard(zipTopDir('misaligned', 'lib'))).toBe(1);
+  });
+
+  it('fails (not just warns) when an archive ships no native libraries', () => {
+    const resDir = path.join(workdir, 'nolibs', 'res');
+    fs.mkdirSync(resDir, { recursive: true });
+    fs.writeFileSync(path.join(resDir, 'placeholder.txt'), 'x');
+    expect(runGuard(zipTopDir('nolibs', 'res'))).toBe(1);
+  });
+
+  it('fails when an archive path does not exist', () => {
+    expect(runGuard(path.join(workdir, 'missing.apk'))).toBe(1);
+  });
+
+  it('fails the run when any one of several archives is misaligned', () => {
+    const goodDir = newLibDir('multi-good');
+    fs.copyFileSync(alignedSo, path.join(goodDir, 'lib.so'));
+    const good = zipTopDir('multi-good', 'lib');
+
+    const badDir = newLibDir('multi-bad');
+    writeMisalignedCopy(alignedSo, path.join(badDir, 'lib.so'));
+    const bad = zipTopDir('multi-bad', 'lib');
+
+    expect(runGuard(good, bad)).toBe(1);
+  });
+});

--- a/scripts/check-16kb-alignment.sh
+++ b/scripts/check-16kb-alignment.sh
@@ -75,12 +75,16 @@ for archive in "$@"; do
   done < <(find "$dir" -type f -name '*.so' -print0)
 
   if [ "$found_so" -eq 0 ]; then
-    echo "::warning::No .so files found in $archive"
+    # A release APK/AAB always ships native libs; zero .so means a stripped or
+    # malformed artifact. Fail rather than pass silently (false green).
+    echo "::error::No .so files found in $archive"
+    overall_fail=1
   fi
 done
 
 if [ "$checked_any" -eq 0 ]; then
-  echo "::warning::No native libraries were checked."
+  echo "::error::No native libraries were checked."
+  overall_fail=1
 fi
 
 if [ "$overall_fail" -ne 0 ]; then

--- a/scripts/check-16kb-alignment.sh
+++ b/scripts/check-16kb-alignment.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that every native library (.so) bundled in an Android APK or AAB has its
+# ELF LOAD segments aligned to >= 16 KB (0x4000). Apps targeting Android 15+ (API
+# 35+) must support 16 KB memory page sizes: a 4 KB-aligned .so fails to dlopen on
+# 16 KB-page devices (Pixel 8/9, etc.) with "not 16 KB aligned" → UnsatisfiedLinkError,
+# and Google Play rejects the AAB at upload. This check is the CI guard that proves
+# our own libs (the board-renderer JNI wrapper + prebuilt Rust FFI) are aligned and
+# catches any third-party lib that regresses.
+#
+# Usage: scripts/check-16kb-alignment.sh <path-to-apk-or-aab> [more-archives...]
+#
+# Requires: unzip, readelf (GNU binutils — preinstalled on ubuntu-latest runners).
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <archive.apk|archive.aab> [more-archives...]" >&2
+  exit 2
+fi
+
+# 16 KB in bytes; a LOAD segment's p_align must be at least this.
+MIN_ALIGN=16384
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+overall_fail=0
+checked_any=0
+
+for archive in "$@"; do
+  if [ ! -f "$archive" ]; then
+    echo "::error::Archive not found: $archive"
+    overall_fail=1
+    continue
+  fi
+
+  echo "==> Checking native libraries in $archive"
+  dir="$workdir/$(basename "$archive").extracted"
+  mkdir -p "$dir"
+  # APKs store libs under lib/<abi>/*.so; AABs under base/lib/<abi>/*.so. Pull both.
+  unzip -qo "$archive" '*.so' -d "$dir" || true
+
+  found_so=0
+  while IFS= read -r -d '' so; do
+    found_so=1
+    checked_any=1
+    rel="${so#"$dir"/}"
+
+    # Collect the p_align of every LOAD segment (last column of each LOAD line),
+    # e.g. "0x4000" or "0x1000". readelf -W avoids line-wrapping the wide output.
+    bad_aligns=""
+    while IFS= read -r align; do
+      [ -n "$align" ] || continue
+      # Bash understands the 0x… hex literal directly.
+      if [ "$((align))" -lt "$MIN_ALIGN" ]; then
+        bad_aligns="${bad_aligns:+$bad_aligns }$align"
+      fi
+    done < <(readelf -lW "$so" | awk '$1 == "LOAD" { print $NF }')
+
+    if [ -n "$bad_aligns" ]; then
+      echo "::error::$rel has LOAD segment alignment below 16 KB: $bad_aligns"
+      overall_fail=1
+    else
+      echo "  OK (16 KB aligned): $rel"
+    fi
+  done < <(find "$dir" -type f -name '*.so' -print0)
+
+  if [ "$found_so" -eq 0 ]; then
+    echo "::warning::No .so files found in $archive"
+  fi
+done
+
+if [ "$checked_any" -eq 0 ]; then
+  echo "::warning::No native libraries were checked."
+fi
+
+if [ "$overall_fail" -ne 0 ]; then
+  echo "::error::One or more native libraries are not 16 KB page aligned (Android 15+ / Play requirement)."
+  exit 1
+fi
+
+echo "==> All native libraries are 16 KB page aligned."

--- a/scripts/check-16kb-alignment.sh
+++ b/scripts/check-16kb-alignment.sh
@@ -38,7 +38,16 @@ for archive in "$@"; do
   dir="$workdir/$(basename "$archive").extracted"
   mkdir -p "$dir"
   # APKs store libs under lib/<abi>/*.so; AABs under base/lib/<abi>/*.so. Pull both.
-  unzip -qo "$archive" '*.so' -d "$dir" || true
+  # unzip exits 11 when the archive has no matching .so (handled by the no-.so
+  # warning below); any other non-zero code is a real extraction failure — surface
+  # it instead of silently reporting a false-green "0 libs checked".
+  unzip_status=0
+  unzip -qo "$archive" '*.so' -d "$dir" || unzip_status=$?
+  if [ "$unzip_status" -ne 0 ] && [ "$unzip_status" -ne 11 ]; then
+    echo "::error::Failed to extract $archive (unzip exit $unzip_status)"
+    overall_fail=1
+    continue
+  fi
 
   found_so=0
   while IFS= read -r -d '' so; do


### PR DESCRIPTION
## Why

Apps targeting Android 15+ (the RN app targets API 36) must support 16 KB memory page sizes on 64-bit devices. Every bundled `.so` needs its ELF `LOAD` segments aligned to ≥ 16 KB (`0x4000`), or the lib fails to `dlopen` on 16 KB-page devices (Pixel 8/9, etc.) with `UnsatisfiedLinkError`, and Google Play rejects the AAB at upload.

## What was wrong

The mobile app ships several native libs. Audit result:

- ✅ The prebuilt Rust FFI lib `libboard_renderer_ffi.so` was **already** compliant — `scripts/build-native-renderer.sh` builds it with `-Wl,-z,max-page-size=16384` and the committed binaries verify at `0x4000`.
- ❌ **The gap:** the JNI wrapper `libboard_renderer_jni.so` is compiled from `jni_bridge.cpp` by CMake **at gradle/CI build time**, and `CMakeLists.txt` did not pass the 16 KB flag. React Native 0.85 pins NDK r27, whose linker still defaults to 4 KB alignment, so this wrapper shipped non-compliant.
- ❌ **No CI guard** verified alignment — a regression (here or in any third-party lib) would only surface when Google Play rejects the upload.

## Changes

1. **`modules/board-renderer/android/src/main/cpp/CMakeLists.txt`** — add `target_link_options(board_renderer_jni PRIVATE "-Wl,-z,max-page-size=16384")` so the JNI wrapper is deterministically 16 KB-aligned regardless of NDK version (no-op on 4 KB devices).
2. **`scripts/check-16kb-alignment.sh`** — a `readelf`-based guard that unzips every `.so` from an APK/AAB and asserts all `LOAD` segments are ≥ `0x4000`, failing (not warning) on a misaligned lib, an unreadable archive, or one that ships no native libs.
3. **`.github/workflows/android-apk-rn.yml`** — run the guard against every release APK and the Play AAB before release, blocking a non-compliant upload. This audits the JNI wrapper, the Rust FFI lib, React Native's own libs, and every third-party lib in one pass.
4. **`scripts/__tests__/check-16kb-alignment.test.ts`** — fixture-based tests for the guard so a regression to the safety check itself is caught.

Deliberately **not** bumping the NDK / adding `expo-build-properties`: the explicit linker flag has a smaller blast radius, matches the existing Rust pattern, and the CI check catches anything the default would miss.

## Release Notes

The board view now renders natively on the newest Android phones that use 16 KB memory pages (Android 15 and later, 64-bit devices).

## Verification

- Committed FFI libs report `0x4000` for every `LOAD` segment (`readelf -lW`).
- The new tests pack the committed aligned lib (and a forged 4 KB-aligned copy) into APK-shaped zips and assert the guard's exit code: aligned → pass, misaligned / no-libs / missing / mixed → fail.
- Full end-to-end proof is the CI step on the Android build: after this change `libboard_renderer_jni.so` reports `0x4000` (was `0x1000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)