### PR TITLE
Add PR lifecycle rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,13 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 
 ## PR Lifecycle (mandatory)
 
-After every PR is created, **always call `mcp__github__subscribe_pr_activity`** and stay subscribed until the PR is merged or closed.
+We'll always create a PR, never asks if a PR should be created, open as a draft. After every PR is created, **always** subscribe to PR feedback until the PR is merged or closed.
 
 - **CI failures**: diagnose and push a fix. Retry until green. If a failure is genuinely out of scope, explain and block on the user.
 - **Merge conflicts**: rebase on `main` and `git push --force-with-lease` — don't ask first.
 - **Review feedback**: fix minor, cosmetic, and style comments autonomously and push. For correctness disagreements, architectural changes, or ambiguous instructions, use `AskUserQuestion` before acting.
 - **Release notes**: every PR description must include the `## Release Notes` section from the PR template. Write in climber voice — describe what the user gets, not what the code does. Internal-only changes (refactor, CI, deps, tests) get `none`.
-- **Ready to merge signal**: once CI is green, no unresolved review comments remain, and there are no conflicts, post exactly this message to the user: `**Ready to merge.** CI green, no conflicts, all feedback addressed.` Do not add caveats or padding.
+- **Ready to merge signal**: once CI is green, no unresolved review comments remain, and there are no conflicts, remove the draft status from the PR marking it ready for review.
 
 ## Monorepo Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 
 ## PR Lifecycle (mandatory)
 
-After every PR is created, **always call `subscribe_pr_activity`** and stay subscribed until the PR is merged or closed.
+After every PR is created, **always call `mcp__github__subscribe_pr_activity`** and stay subscribed until the PR is merged or closed.
 
 - **CI failures**: diagnose and push a fix. Retry until green. If a failure is genuinely out of scope, explain and block on the user.
-- **Merge conflicts**: rebase on `main` and push — don't ask first.
-- **Review feedback**: fix minor, cosmetic, and correctness comments autonomously and push. For architectural disagreements or ambiguous instructions, use `AskUserQuestion` before acting.
+- **Merge conflicts**: rebase on `main` and `git push --force-with-lease` — don't ask first.
+- **Review feedback**: fix minor, cosmetic, and style comments autonomously and push. For correctness disagreements, architectural changes, or ambiguous instructions, use `AskUserQuestion` before acting.
 - **Release notes**: every PR description must include the `## Release Notes` section from the PR template. Write in climber voice — describe what the user gets, not what the code does. Internal-only changes (refactor, CI, deps, tests) get `none`.
 - **Ready to merge signal**: once CI is green, no unresolved review comments remain, and there are no conflicts, post exactly this message to the user: `**Ready to merge.** CI green, no conflicts, all feedback addressed.` Do not add caveats or padding.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ After every PR is created, **always call `subscribe_pr_activity`** and stay subs
 - **CI failures**: diagnose and push a fix. Retry until green. If a failure is genuinely out of scope, explain and block on the user.
 - **Merge conflicts**: rebase on `main` and push — don't ask first.
 - **Review feedback**: fix minor, cosmetic, and correctness comments autonomously and push. For architectural disagreements or ambiguous instructions, use `AskUserQuestion` before acting.
+- **Release notes**: every PR description must include the `## Release Notes` section from the PR template. Write in climber voice — describe what the user gets, not what the code does. Internal-only changes (refactor, CI, deps, tests) get `none`.
 - **Ready to merge signal**: once CI is green, no unresolved review comments remain, and there are no conflicts, post exactly this message to the user: `**Ready to merge.** CI green, no conflicts, all feedback addressed.` Do not add caveats or padding.
 
 ## Monorepo Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,15 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 - No buzzwords. Concrete numbers, plain language.
 - Default to action. Full autonomy except no data deletion without asking.
 
+## PR Lifecycle (mandatory)
+
+After every PR is created, **always call `subscribe_pr_activity`** and stay subscribed until the PR is merged or closed.
+
+- **CI failures**: diagnose and push a fix. Retry until green. If a failure is genuinely out of scope, explain and block on the user.
+- **Merge conflicts**: rebase on `main` and push — don't ask first.
+- **Review feedback**: fix minor, cosmetic, and correctness comments autonomously and push. For architectural disagreements or ambiguous instructions, use `AskUserQuestion` before acting.
+- **Ready to merge signal**: once CI is green, no unresolved review comments remain, and there are no conflicts, post exactly this message to the user: `**Ready to merge.** CI green, no conflicts, all feedback addressed.` Do not add caveats or padding.
+
 ## Monorepo Structure
 
 ```


### PR DESCRIPTION
## Summary

- Adds a **PR Lifecycle** section to CLAUDE.md instructing Claude to always call `subscribe_pr_activity` after creating a PR and stay subscribed until merge/close.
- CI failures, merge conflicts, and minor/cosmetic review feedback are handled autonomously (push fixes without asking).
- Architectural or ambiguous feedback triggers `AskUserQuestion` before acting.
- Once CI is green, no unresolved comments, and no conflicts, Claude posts a clear **"Ready to merge."** message.

## Test plan

- [ ] Verify the new section appears correctly in CLAUDE.md
- [ ] Confirm future Claude sessions pick up the PR watch behaviour automatically

---
_Generated by [Claude Code](https://claude.ai/code/session_018HM47DhCmdjryg8AbKmCNo)_