### PR TITLE
fix(mobile-ota): idempotent changelog push-back + single-run concurrency

### DIFF
--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -39,9 +39,14 @@ permissions:
   contents: read
 
 concurrency:
-  # Never cancel a production publish mid-flight (matches android-apk-rn.yml).
-  # Serialized per ref, so two OTA runs never race on the changelog push-back.
-  group: mobile-ota-production-${{ github.ref }}
+  # EXACTLY ONE production OTA publish at a time, repo-wide. This workflow owns
+  # changelog.generated.json (regenerate + push to main), so two concurrent runs
+  # would race on that file. A constant group (not per-ref) serializes push +
+  # dispatch + any branch into a single lane. cancel-in-progress: false never
+  # kills a publish mid-flight; a newer run just queues behind it and supersedes
+  # an older pending one — harmless, since the generator crawls all merged PRs, so
+  # the run that wins republishes the latest state anyway.
+  group: mobile-ota-production
   cancel-in-progress: false
 
 # ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
@@ -229,13 +234,29 @@ jobs:
         if: always() && github.ref == 'refs/heads/main' && steps.generate.outputs.changed == 'true' && vars.OTA_PUSH_APP_ID != ''
         run: |
           set -euo pipefail
+          cp packages/mobile/src/data/changelog.generated.json "$RUNNER_TEMP/changelog.json"
           for attempt in 1 2 3; do
             git fetch origin main
-            if ! git rebase origin/main; then
-              git rebase --abort || true
-              echo "::error::Rebasing the changelog onto main conflicted — unexpected, this workflow is its only writer."
-              exit 1
+            # Idempotent on ENTRIES (ignore the generatedAt timestamp): if main
+            # already carries these entries, we're done — no churn, no conflict.
+            main_entries="$(git show origin/main:packages/mobile/src/data/changelog.generated.json 2>/dev/null | jq -cS '.entries' 2>/dev/null || echo 'missing')"
+            our_entries="$(jq -cS '.entries' "$RUNNER_TEMP/changelog.json")"
+            if [ "$main_entries" = "$our_entries" ]; then
+              echo "main already has the current changelog entries — nothing to push."
+              exit 0
             fi
+            # Land ONLY the changelog file on top of the latest main: hard-reset to
+            # main (so we never revert files changed since our checkout), then
+            # re-apply our generated file. No rebase — a full-file regen can't
+            # auto-merge a different generatedAt.
+            git reset --hard origin/main
+            cp "$RUNNER_TEMP/changelog.json" packages/mobile/src/data/changelog.generated.json
+            git add packages/mobile/src/data/changelog.generated.json
+            if git diff --cached --quiet; then
+              echo "Changelog matches main (timestamp aside) — nothing to push."
+              exit 0
+            fi
+            git commit -m "chore(changelog): refresh from merged PRs [skip ci]"
             if git push origin HEAD:main; then
               echo "Pushed refreshed changelog to main."
               exit 0

--- a/scripts/__tests__/changelog-transform.test.ts
+++ b/scripts/__tests__/changelog-transform.test.ts
@@ -64,6 +64,14 @@ describe('extractReleaseNotes', () => {
     expect(extractReleaseNotes('## Release Notes\n- none')).toBeNull();
     // Multiple `none` placeholders must not slip through as a junk entry.
     expect(extractReleaseNotes('## Release Notes\n- none\n- none')).toBeNull();
+    // A `none` marker with a parenthetical/punctuated explanation is still skip.
+    expect(extractReleaseNotes('## Release Notes\n- none (CI / release-plumbing only)')).toBeNull();
+    expect(extractReleaseNotes('## Release Notes\nNone — internal refactor')).toBeNull();
+    expect(extractReleaseNotes('## Release Notes\nnone.')).toBeNull();
+    // But a real sentence starting with the word "none" is kept.
+    expect(extractReleaseNotes('## Release Notes\nNone of the old buttons jump anymore')).toEqual({
+      title: 'None of the old buttons jump anymore',
+    });
   });
 
   it('drops "none" lines mixed with real notes', () => {

--- a/scripts/lib/changelog-transform.ts
+++ b/scripts/lib/changelog-transform.ts
@@ -56,6 +56,11 @@ const LIST_MARKER = /^(?:[-*+]|\d+\.)\s+/;
 // A fenced-code-block delimiter. Tracked so a `#` line *inside* a fence doesn't
 // get mistaken for the section's end heading.
 const CODE_FENCE = /^\s*```/;
+// A "none" marker — the convention for "no user-facing change" — optionally with
+// a parenthetical/punctuated explanation (e.g. `none (CI only)`, `none — chore`).
+// Dropped so it never becomes a changelog entry. A real sentence like
+// "none of the old buttons…" doesn't match (a letter follows `none`), so it's kept.
+const NONE_MARKER = /^none\s*(?:[([{:.\-–—].*)?$/i;
 
 export type ReleaseNotes = { title: string; body?: string };
 
@@ -94,7 +99,7 @@ export function extractReleaseNotes(prBody: string | null | undefined): ReleaseN
   // a mix of real notes and `none` placeholders never ship a junk "none" entry).
   const cleaned = sectionLines
     .map((line) => line.replace(LIST_MARKER, '').trim())
-    .filter((line) => line.length > 0 && line.toLowerCase() !== 'none');
+    .filter((line) => line.length > 0 && !NONE_MARKER.test(line));
 
   if (cleaned.length === 0) return null;
 


### PR DESCRIPTION
## Summary

Follow-ups after the first live production OTA (which **published successfully** to iOS + Android and pushed the changelog to `main` via the app token). Three robustness fixes:

1. **Single-run concurrency** — the OTA publish now uses a constant concurrency group (`mobile-ota-production`, not per-ref) with `cancel-in-progress: false`, so **exactly one** production OTA runs at a time and two can never race on `changelog.generated.json`.
2. **Idempotent, conflict-free push-back** — compares **entries** (ignoring the `generatedAt` timestamp); if `main` already has them, it pushes nothing. When they differ it **hard-resets to latest `main` and re-applies only the changelog file** (no rebase), so a full-file regen with a different timestamp can't conflict and never reverts files changed since checkout. This fixes the `CONFLICT (content)` failure seen on the last run.
3. **Generator skips `none (...)`** — a release note like `none (CI only)` now counts as "no entry", so CI-only PRs stop leaking junk entries (the two `none (CI / release-plumbing only)` rows currently on `main` get dropped on the next regen).

## Release Notes
- none

## Test plan
- `vp check` + `vp test run --project scripts` (147 pass, incl. new `none (...)` cases).
- Workflow YAML parses; concurrency group is the constant `mobile-ota-production`; push-back uses `reset --hard` (no `git rebase`).
- Post-merge: re-dispatch the OTA and confirm `main`'s changelog drops to the 2 real entries and the push-back step is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142LzvfoFMQ3sQMtkFFugTJ
