### PR TITLE
fix(mobile-ota): stop Release Notes at the PR footer / horizontal rule

### DIFF
--- a/scripts/__tests__/changelog-transform.test.ts
+++ b/scripts/__tests__/changelog-transform.test.ts
@@ -94,6 +94,16 @@ describe('extractReleaseNotes', () => {
     const body = '## Release Notes\nThe note\n# Another top heading\nNot included';
     expect(extractReleaseNotes(body)).toEqual({ title: 'The note' });
   });
+
+  it('stops the section at the PR footer / horizontal rule (no heading to bound it)', () => {
+    // The auto-generated footer right after the notes must not leak in.
+    const footered =
+      '## Release Notes\n- none\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://claude.ai/code/session_x';
+    expect(extractReleaseNotes(footered)).toBeNull();
+    // A real note is kept, but the trailing footer is excluded.
+    const withNote = '## Release Notes\nQueue sync is faster\n\n---\n🤖 Generated with [Claude Code](x)';
+    expect(extractReleaseNotes(withNote)).toEqual({ title: 'Queue sync is faster' });
+  });
 });
 
 describe('categorize', () => {

--- a/scripts/lib/changelog-transform.ts
+++ b/scripts/lib/changelog-transform.ts
@@ -61,6 +61,10 @@ const CODE_FENCE = /^\s*```/;
 // Dropped so it never becomes a changelog entry. A real sentence like
 // "none of the old buttons…" doesn't match (a letter follows `none`), so it's kept.
 const NONE_MARKER = /^none\s*(?:[([{:.\-–—].*)?$/i;
+// Also ends the section (besides the next heading): a markdown horizontal rule, or
+// the auto-generated PR footer (the "🤖 Generated with…" line). Stops a footer that
+// sits right after the notes — with no heading to bound it — from leaking in.
+const SECTION_BREAK = /^\s*(?:(?:-{3,}|\*{3,}|_{3,})\s*$|🤖)/;
 
 export type ReleaseNotes = { title: string; body?: string };
 
@@ -91,7 +95,7 @@ export function extractReleaseNotes(prBody: string | null | undefined): ReleaseN
       sectionLines.push(line);
       continue;
     }
-    if (!insideFence && ANY_HEADING.test(line)) break;
+    if (!insideFence && (ANY_HEADING.test(line) || SECTION_BREAK.test(line))) break;
     sectionLines.push(line);
   }
 


### PR DESCRIPTION
## Summary

The previous round's OTA ran fully green (push-back works, concurrency serializes, the `none (...)` junk is gone) — but it surfaced one more leak: a `🤖 Generated with [Claude Code]…` entry from #3072.

Cause: that PR's `## Release Notes` was the last heading, with the auto-generated footer right after it and no heading to bound the section — so once the `none` line was dropped, the footer became the entry.

Fix: end the Release Notes section at a markdown horizontal rule (`---`) or the `🤖` footer line, in addition to the next heading. After this merges, the next OTA regen drops the `🤖` row and `main`'s changelog settles at the 2 real entries (#3066, #3069).

## Release Notes
- none

## Test plan
- `vp check` + `vp test run --project scripts` (148 pass, incl. the new footer-bleed case).
- Post-merge: re-dispatch the OTA and confirm `main`'s changelog = 2 entries, push-back green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142LzvfoFMQ3sQMtkFFugTJ
