### PR TITLE
feat(mobile-ota): generate a human-readable root CHANGELOG.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
               - 'bun.lock'
             changelogData:
               - 'packages/mobile/src/data/changelog.generated.json'
+              - 'CHANGELOG.md'
 
   setup:
     needs: [changes]
@@ -617,7 +618,7 @@ jobs:
     steps:
       - name: Reject manual changelog edits
         run: |
-          echo "::error::packages/mobile/src/data/changelog.generated.json is owned by the Mobile OTA Production workflow (it regenerates and pushes it on every OTA). Revert your change to this file — it should never be edited in a PR."
+          echo "::error::The changelog files (packages/mobile/src/data/changelog.generated.json and CHANGELOG.md) are owned by the Mobile OTA Production workflow (it regenerates and pushes them on every OTA). Revert your change — they're generated from PR Release Notes, never edited in a PR."
           exit 1
 
   test-report:

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -182,7 +182,9 @@ jobs:
           vp run generate:changelog
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add packages/mobile/src/data/changelog.generated.json
+          # Both outputs of the generator: the mobile JSON feed and the root
+          # human-readable CHANGELOG.md (deterministic from the same entries).
+          git add packages/mobile/src/data/changelog.generated.json CHANGELOG.md
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "Changelog unchanged — nothing to commit."
@@ -235,23 +237,29 @@ jobs:
         run: |
           set -euo pipefail
           cp packages/mobile/src/data/changelog.generated.json "$RUNNER_TEMP/changelog.json"
+          cp CHANGELOG.md "$RUNNER_TEMP/CHANGELOG.md"
           for attempt in 1 2 3; do
             git fetch origin main
-            # Idempotent on ENTRIES (ignore the generatedAt timestamp): if main
-            # already carries these entries, we're done — no churn, no conflict.
-            main_entries="$(git show origin/main:packages/mobile/src/data/changelog.generated.json 2>/dev/null | jq -cS '.entries' 2>/dev/null || echo 'missing')"
+            # Idempotent: skip only when main already carries BOTH the same JSON
+            # entries (ignoring the generatedAt timestamp) AND the same CHANGELOG.md.
+            # Checking the markdown too covers the bootstrap case where main has the
+            # entries but not yet the (newly added) CHANGELOG.md.
+            main_entries="$(git show origin/main:packages/mobile/src/data/changelog.generated.json 2>/dev/null | jq -cS '.entries' 2>/dev/null || echo 'missing-json')"
             our_entries="$(jq -cS '.entries' "$RUNNER_TEMP/changelog.json")"
-            if [ "$main_entries" = "$our_entries" ]; then
-              echo "main already has the current changelog entries — nothing to push."
+            main_md="$(git show origin/main:CHANGELOG.md 2>/dev/null || echo 'missing-md')"
+            our_md="$(cat "$RUNNER_TEMP/CHANGELOG.md")"
+            if [ "$main_entries" = "$our_entries" ] && [ "$main_md" = "$our_md" ]; then
+              echo "main already has the current changelog (json + CHANGELOG.md) — nothing to push."
               exit 0
             fi
-            # Land ONLY the changelog file on top of the latest main: hard-reset to
-            # main (so we never revert files changed since our checkout), then
-            # re-apply our generated file. No rebase — a full-file regen can't
+            # Land ONLY the two changelog files on top of the latest main: hard-reset
+            # to main (so we never revert files changed since our checkout), then
+            # re-apply our generated files. No rebase — a full-file regen can't
             # auto-merge a different generatedAt.
             git reset --hard origin/main
             cp "$RUNNER_TEMP/changelog.json" packages/mobile/src/data/changelog.generated.json
-            git add packages/mobile/src/data/changelog.generated.json
+            cp "$RUNNER_TEMP/CHANGELOG.md" CHANGELOG.md
+            git add packages/mobile/src/data/changelog.generated.json CHANGELOG.md
             if git diff --cached --quiet; then
               echo "Changelog matches main (timestamp aside) — nothing to push."
               exit 0

--- a/scripts/__tests__/changelog-transform.test.ts
+++ b/scripts/__tests__/changelog-transform.test.ts
@@ -4,8 +4,10 @@ import {
   categorize,
   buildEntries,
   isContentEqual,
+  renderChangelogMarkdown,
   type RawPullRequest,
   type ChangelogData,
+  type ChangelogEntry,
 } from '../lib/changelog-transform';
 
 describe('extractReleaseNotes', () => {
@@ -199,5 +201,53 @@ describe('isContentEqual', () => {
     const first: ChangelogData = { generatedAt: 'x', entries };
     const second: ChangelogData = { generatedAt: 'x', entries: [] };
     expect(isContentEqual(first, second)).toBe(false);
+  });
+});
+
+describe('renderChangelogMarkdown', () => {
+  const entry = (over: Partial<ChangelogEntry> & { prNumber: number }): ChangelogEntry => ({
+    category: 'new',
+    title: `Title ${over.prNumber}`,
+    mergedAt: '2026-06-19T12:00:00Z',
+    prUrl: `https://github.com/boardsesh/boardsesh/pull/${over.prNumber}`,
+    ...over,
+  });
+
+  it('returns the preamble only when there are no entries', () => {
+    const md = renderChangelogMarkdown([]);
+    expect(md.startsWith('# Changelog')).toBe(true);
+    expect(md).not.toContain('## 20'); // no dated section
+  });
+
+  it('groups by date then New/Improved/Fixed, newest date first, with PR links', () => {
+    const md = renderChangelogMarkdown([
+      entry({ prNumber: 10, category: 'new', title: 'Newer day feature', mergedAt: '2026-06-19T10:00:00Z' }),
+      entry({ prNumber: 9, category: 'fixed', title: 'Older day fix', mergedAt: '2026-06-12T10:00:00Z' }),
+      entry({ prNumber: 8, category: 'improved', title: 'Older day tweak', mergedAt: '2026-06-12T09:00:00Z' }),
+    ]);
+    // Newest date section comes first.
+    expect(md.indexOf('## 2026-06-19')).toBeLessThan(md.indexOf('## 2026-06-12'));
+    // Category subsections + PR-linked bullet.
+    expect(md).toContain('### New\n\n- Newer day feature ([#10](https://github.com/boardsesh/boardsesh/pull/10))');
+    // Fixed order: Improved before Fixed within the 2026-06-12 section.
+    const day = md.slice(md.indexOf('## 2026-06-12'));
+    expect(day.indexOf('### Improved')).toBeLessThan(day.indexOf('### Fixed'));
+  });
+
+  it('omits empty category subsections', () => {
+    const md = renderChangelogMarkdown([entry({ prNumber: 1, category: 'fixed', title: 'Only a fix' })]);
+    expect(md).toContain('### Fixed');
+    expect(md).not.toContain('### New');
+    expect(md).not.toContain('### Improved');
+  });
+
+  it('renders an optional body as an indented continuation line', () => {
+    const md = renderChangelogMarkdown([entry({ prNumber: 2, title: 'Has body', body: 'More detail here.' })]);
+    expect(md).toContain('- Has body ([#2](https://github.com/boardsesh/boardsesh/pull/2))\n  More detail here.');
+  });
+
+  it('is deterministic (same entries → byte-identical output)', () => {
+    const entries = [entry({ prNumber: 3 }), entry({ prNumber: 4, category: 'fixed' })];
+    expect(renderChangelogMarkdown(entries)).toBe(renderChangelogMarkdown(entries));
   });
 });

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -1,11 +1,14 @@
 /// <reference types="node" />
 
 /**
- * Generates packages/mobile/src/data/changelog.generated.json — the entries
- * shown on the mobile "What's New" screen. Each entry is one merged PR that
- * carries a non-empty `## Release Notes` section in its description (the copy the
- * author wrote for users). Category is derived from the PR title's
- * Conventional-Commit type.
+ * Generates two views of the changelog from the SAME entries:
+ *   - packages/mobile/src/data/changelog.generated.json — the feed for the mobile
+ *     "What's New" screen.
+ *   - CHANGELOG.md (repo root) — a human-readable, Keep a Changelog-style render
+ *     for contributors browsing the repo.
+ * Each entry is one merged PR that carries a non-empty `## Release Notes` section
+ * in its description (the copy the author wrote for users). Category is derived
+ * from the PR title's Conventional-Commit type.
  *
  * Crawls merged PRs against `main` via paginated `gh api graphql` (public data,
  * works with the default Actions token). Bounded by a START date so history stays
@@ -25,7 +28,13 @@ import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildEntries, isContentEqual, type ChangelogData, type RawPullRequest } from './lib/changelog-transform';
+import {
+  buildEntries,
+  isContentEqual,
+  renderChangelogMarkdown,
+  type ChangelogData,
+  type RawPullRequest,
+} from './lib/changelog-transform';
 
 const REPO_OWNER = 'boardsesh';
 const REPO_NAME = 'boardsesh';
@@ -38,6 +47,10 @@ const CRAWL_START_DATE = '2026-06-01T00:00:00.000Z';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_PATH = resolve(here, '../packages/mobile/src/data/changelog.generated.json');
+// Human-readable rendering of the SAME entries, for contributors browsing the
+// repo. Owned + pushed by the OTA workflow exactly like the JSON; kept out of the
+// formatter (vite.config.ts fmt.ignore) so it never drifts from this output.
+const CHANGELOG_PATH = resolve(here, '../CHANGELOG.md');
 
 const isCheckMode = process.argv.includes('--check');
 
@@ -185,7 +198,10 @@ function main(): void {
   const data: ChangelogData = { generatedAt, entries };
   mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
   writeFileSync(OUTPUT_PATH, `${JSON.stringify(data, null, 2)}\n`);
-  console.log(`[changelog] wrote ${entries.length} entries`);
+  // CHANGELOG.md is a pure function of the entries (no timestamp), so it's
+  // deterministic — the same entries always produce a byte-identical file.
+  writeFileSync(CHANGELOG_PATH, renderChangelogMarkdown(entries));
+  console.log(`[changelog] wrote ${entries.length} entries (changelog.generated.json + CHANGELOG.md)`);
 }
 
 main();

--- a/scripts/lib/changelog-transform.ts
+++ b/scripts/lib/changelog-transform.ts
@@ -173,3 +173,60 @@ export function buildEntries(pullRequests: RawPullRequest[]): ChangelogEntry[] {
 export function isContentEqual(first: ChangelogData, second: ChangelogData): boolean {
   return JSON.stringify(first.entries) === JSON.stringify(second.entries);
 }
+
+// Human-readable labels + fixed render order for the markdown category
+// subsections. Empty groups are skipped.
+const CATEGORY_LABELS: ReadonlyArray<readonly [ChangelogCategory, string]> = [
+  ['new', 'New'],
+  ['improved', 'Improved'],
+  ['fixed', 'Fixed'],
+];
+
+const CHANGELOG_PREAMBLE = `# Changelog
+
+User-facing changes to Boardsesh, newest first. Auto-generated from the "Release
+Notes" section of merged pull requests — do not edit by hand (a CI check rejects
+manual changes). See docs/mobile-ota-updates.md.
+`;
+
+/**
+ * Renders the changelog entries as a human-readable, Keep a Changelog-style
+ * CHANGELOG.md: `## <YYYY-MM-DD>` sections newest-first, each with `### New /
+ * Improved / Fixed` subsections of PR-linked bullets. A pure function of the
+ * entries with no timestamps, so the same entries always produce a byte-identical
+ * file. `entries` is expected newest-first (as `buildEntries` returns).
+ */
+export function renderChangelogMarkdown(entries: ChangelogEntry[]): string {
+  if (entries.length === 0) return CHANGELOG_PREAMBLE;
+
+  // Group by UTC date, keeping the newest-first order in which each date first
+  // appears (entries are already sorted newest-first by mergedAt).
+  const dateOrder: string[] = [];
+  const byDate = new Map<string, ChangelogEntry[]>();
+  for (const entry of entries) {
+    const date = entry.mergedAt.slice(0, 10); // ISO 8601 → YYYY-MM-DD (UTC)
+    let group = byDate.get(date);
+    if (!group) {
+      group = [];
+      byDate.set(date, group);
+      dateOrder.push(date);
+    }
+    group.push(entry);
+  }
+
+  const sections = dateOrder.map((date) => {
+    const dayEntries = byDate.get(date) ?? [];
+    const blocks = CATEGORY_LABELS.flatMap(([category, label]) => {
+      const inCategory = dayEntries.filter((entry) => entry.category === category);
+      if (inCategory.length === 0) return [];
+      const bullets = inCategory.map((entry) => {
+        const line = `- ${entry.title} ([#${entry.prNumber}](${entry.prUrl}))`;
+        return entry.body ? `${line}\n  ${entry.body.replace(/\n/g, '\n  ')}` : line;
+      });
+      return [`### ${label}\n\n${bullets.join('\n')}`];
+    });
+    return `## ${date}\n\n${blocks.join('\n\n')}`;
+  });
+
+  return `${CHANGELOG_PREAMBLE}\n${sections.join('\n\n')}\n`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,10 @@ export default defineConfig({
     // formatting it produces noise diffs every time `vp check --fix`
     // runs without changing what ships, and the linter already ignores
     // the same path. Keep them in lock-step.
-    ignore: ['design/**', '**/generated/**', '**/board-controller/**'],
+    // CHANGELOG.md is generated (and owned/pushed) by the mobile OTA pipeline
+    // from PR Release Notes — never hand-format it, or the bot's output and a
+    // formatted copy would drift (and the push-to-main `vp check` would flag it).
+    ignore: ['design/**', '**/generated/**', '**/board-controller/**', 'CHANGELOG.md'],
   },
   lint: {
     ignorePatterns: ['**/board-controller/**'],


### PR DESCRIPTION
## Summary

Adds a human-readable **`CHANGELOG.md`** at the repo root for contributors, rendered from the *same* merged-PR Release Notes that already feed the in-app "What's New" JSON — so the two never drift.

- **Renderer**: a pure `renderChangelogMarkdown(entries)` in `changelog-transform.ts` — Keep a Changelog style (`## <date>` newest-first, `### New / Improved / Fixed` subsections, PR-linked bullets, optional body continuation). Deterministic (no timestamp) → byte-identical for the same entries.
- **Generator**: `generate-changelog.ts` writes `CHANGELOG.md` alongside the JSON.
- **OTA build owns both**: the publish workflow commits + pushes both files (idempotency now compares the JSON entries *and* the rendered markdown, so the bootstrap case — entries already on `main` but no `CHANGELOG.md` yet — still pushes it).
- **Guarded**: the `changelog-owned` CI guard now also blocks PRs from hand-editing `CHANGELOG.md`; and it's in the `vp` formatter ignore so the bot's output is never reformatted into drift.

**Bootstrapping:** this PR intentionally does **not** commit `CHANGELOG.md` (that would trip the guard it adds). The first post-merge OTA run creates and pushes it to `main` — same model as the JSON. I'll dispatch the OTA after merge to create it immediately.

## Release Notes
- none

## Test plan
- `vp check` + `vp test run --project scripts` — 153 pass, incl. 5 new `renderChangelogMarkdown` cases (date/category grouping, ordering, empty-category omission, body continuation, determinism).
- Local `vp run generate:changelog` produced the expected 2-entry `CHANGELOG.md`; re-run byte-identical.
- Post-merge: dispatch the OTA, confirm green + `CHANGELOG.md` appears on `main` in sync with `changelog.generated.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142LzvfoFMQ3sQMtkFFugTJ
