### PR TITLE
fix(store): pin production version_code so listing uploads survive multi-release tracks

### DIFF
--- a/app-stores/google/play-store-metadata.md
+++ b/app-stores/google/play-store-metadata.md
@@ -114,6 +114,16 @@ every API-committed change queues under _Publishing overview → changes ready t
 publish_ and waits for a manual "Publish" — the listing will look stale again
 even though CI is green.
 
+**Multiple production releases.** supply resolves a single release in the
+production track before it uploads the (app-global) listing, and aborts with
+_"More than one release found in this track. Please specify with the :version_code
+option"_ when the track holds more than one — e.g. a new release in review next to
+the live one, or a staged/halted rollout. The lanes handle this by pinning
+`version_code` to the highest production version code
+(`play_production_version_code` in the Fastfile); the listing applies app-wide
+regardless of which release is selected, and changelogs stay skipped so the
+release itself is untouched.
+
 **If the listing stops updating:** check the Play Console _Publishing overview_
 first. A backlog of "ready to send for review" / "ready to publish" means a
 review/publishing gate, not a broken upload — the workflow logs will show

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -159,6 +159,33 @@ def with_upload_retries(max_attempts: 3, base_sleep: 30)
   end
 end
 
+# supply resolves a SINGLE release in the target track (default: production)
+# before it uploads listing metadata / images / screenshots — even though those
+# are app-global, not release-specific (perform_upload_meta -> fetch_track_and_release!).
+# When the production track holds more than one release (a staged or halted
+# rollout, or a new release still in review alongside the live one) it aborts with
+# "More than one release found in this track. Please specify with the :version_code
+# option to select a release." Pin it to the highest production version code so the
+# resolution is unambiguous; the app-global listing applies the same either way,
+# and skip_upload_changelogs means the selected release itself is never touched.
+# Returns nil when the track can't be read (or is empty), leaving a single-release
+# track to resolve on its own.
+def play_production_version_code(json_key_data)
+  codes = Array(
+    google_play_track_version_codes(
+      package_name: APP_IDENTIFIER,
+      json_key_data: json_key_data,
+      track: "production"
+    )
+  ).map(&:to_i)
+  return nil if codes.empty?
+  UI.message("Pinning the production version_code to #{codes.max} so supply can resolve a single release.")
+  codes.max
+rescue => error
+  UI.important("Could not read production version codes (#{error.message}); uploading without an explicit version_code.")
+  nil
+end
+
 platform :ios do
   desc "Upload App Store screenshots to App Store Connect (no binary, no metadata, no review)"
   lane :screenshots do
@@ -279,10 +306,13 @@ platform :android do
       pngs.each { |png| FileUtils.cp(png, File.join(phone_dir, File.basename(png))) }
       UI.message("Staged #{pngs.length} Play phone screenshot(s) into #{phone_dir}")
 
+      json_key_data = ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")
+      version_code = play_production_version_code(json_key_data)
       with_upload_retries do
         upload_to_play_store(
-          package_name: "com.boardsesh.app",
-          json_key_data: ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"),
+          package_name: APP_IDENTIFIER,
+          json_key_data: json_key_data,
+          version_code: version_code,
           metadata_path: metadata_dir,
           skip_upload_apk: true,
           skip_upload_aab: true,
@@ -306,9 +336,11 @@ platform :android do
 
   desc "Upload Play Store listing text (title + short/full description) — no binary, no changelog, no images"
   lane :metadata do
+    json_key_data = ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")
     upload_to_play_store(
       package_name: APP_IDENTIFIER,
-      json_key_data: ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"),
+      json_key_data: json_key_data,
+      version_code: play_production_version_code(json_key_data),
       metadata_path: ANDROID_METADATA_DIR,
       skip_upload_apk: true,
       skip_upload_aab: true,
@@ -337,9 +369,11 @@ platform :android do
 
   desc "Upload Play Store listing images (high-res icon, feature graphic) — no binary, no text, no screenshots"
   lane :images do
+    json_key_data = ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")
     upload_to_play_store(
       package_name: APP_IDENTIFIER,
-      json_key_data: ENV.fetch("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"),
+      json_key_data: json_key_data,
+      version_code: play_production_version_code(json_key_data),
       metadata_path: ANDROID_METADATA_DIR,
       skip_upload_apk: true,
       skip_upload_aab: true,


### PR DESCRIPTION
## Summary

Follow-up to #3078. The first post-merge `Mobile Store Metadata` run [failed](https://github.com/boardsesh/boardsesh/actions/runs/27854876363) — the loud failure working as designed, but it surfaced a **different** gate than the rescue:

> `[!] More than one release found in this track. Please specify with the :version_code option to select a release.`

`supply`'s `perform_upload_meta` → `fetch_track_and_release!` resolves a **single** release in the target track (default `production`) before it uploads listing assets — even though listing text/icon/screenshots are app-global, not release-specific. The production track now holds **more than one release** (a new release in review next to the live one, or a staged/halted rollout), so supply can't pick one and aborts *before uploading anything*. The pre-#3078 runs passed this point, so the track state changed — not the rescue flip.

### Fix

- Add `play_production_version_code(json_key_data)` to the Fastfile — reads the production track's version codes via `google_play_track_version_codes` and returns the highest.
- Pass it as `version_code:` to the `metadata` / `images` / `screenshots` lanes. The app-global listing applies the same regardless of which release is selected, and `skip_upload_changelogs` keeps the release itself untouched. Falls back to no `version_code` if the track can't be read (single-release tracks are unaffected).
- Doc note in `play-store-metadata.md`.

### Heads-up on the next gate

This unblocks the track resolution. The commit step may *then* hit the original `changesNotSentForReview` rejection (the gate #3078 made loud). If it does, the follow-up is to bundle listing changes with the AAB release edit or send them for review from the Console — we'll see on the next run.

**Worth a look:** the production track having >1 release is usually a new release in review or a staged rollout. If it's a stray draft release, discarding it in the Console is the cleaner fix. The `version_code` pin works either way.

## Release Notes

none

## Test plan

Validated on `main` after merge (Production env is main-locked): watch the `Mobile Store Metadata` → `android metadata`/`images`/`screenshots` steps. Green = listing sent for review (publishes once approved, managed publishing off). Red with `changesNotSentForReview` = next gate, see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)