### PR TITLE
feat(mobile-ota): add a 'No release note needed' changelog skip flag

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,9 +14,11 @@ Write in climber voice. Describe what the user gets, not what the feature does:
 One short line per user-facing change. The first line is the headline; any extra
 lines fill in the detail. Keep it to what someone would actually notice.
 
-Internal-only change (refactor, CI, deps, tests)? Write `none` below, or add the
-`skip-changelog` label.
+Nothing user-facing (refactor, CI, deps, tests)? Tick the checkbox below instead
+(or add the `skip-changelog` label). Leaving this section blank fails CI.
 -->
+
+- [ ] No release note needed (internal / technical change)
 
 ## Test plan
 

--- a/scripts/__tests__/changelog-transform.test.ts
+++ b/scripts/__tests__/changelog-transform.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   extractReleaseNotes,
+  isNoReleaseNoteBoxChecked,
   categorize,
   buildEntries,
   isContentEqual,
@@ -92,6 +93,18 @@ describe('extractReleaseNotes', () => {
     expect(extractReleaseNotes(undefined)).toBeNull();
   });
 
+  it('strips the "No release note needed" checkbox line (checked or not)', () => {
+    // Checked box, nothing else → no entry.
+    expect(
+      extractReleaseNotes('## Release Notes\n- [x] No release note needed (internal / technical change)'),
+    ).toBeNull();
+    // Unchecked box left in the template, but real notes written → notes win.
+    expect(
+      extractReleaseNotes(
+        '## Release Notes\n- [ ] No release note needed (internal / technical change)\n- Resume where you left off',
+      ),
+    ).toEqual({ title: 'Resume where you left off' });
+  });
   it('stops the section at the next heading of any level', () => {
     const body = '## Release Notes\nThe note\n# Another top heading\nNot included';
     expect(extractReleaseNotes(body)).toEqual({ title: 'The note' });
@@ -105,6 +118,21 @@ describe('extractReleaseNotes', () => {
     // A real note is kept, but the trailing footer is excluded.
     const withNote = '## Release Notes\nQueue sync is faster\n\n---\n🤖 Generated with [Claude Code](x)';
     expect(extractReleaseNotes(withNote)).toEqual({ title: 'Queue sync is faster' });
+  });
+});
+
+describe('isNoReleaseNoteBoxChecked', () => {
+  it('is true only when the checkbox is ticked', () => {
+    expect(
+      isNoReleaseNoteBoxChecked('## Release Notes\n- [x] No release note needed (internal / technical change)'),
+    ).toBe(true);
+    expect(isNoReleaseNoteBoxChecked('- [X] No release note needed')).toBe(true);
+    expect(
+      isNoReleaseNoteBoxChecked('## Release Notes\n- [ ] No release note needed (internal / technical change)'),
+    ).toBe(false);
+    expect(isNoReleaseNoteBoxChecked('## Release Notes\n- A real user-facing change')).toBe(false);
+    expect(isNoReleaseNoteBoxChecked('')).toBe(false);
+    expect(isNoReleaseNoteBoxChecked(null)).toBe(false);
   });
 });
 

--- a/scripts/check-release-notes.ts
+++ b/scripts/check-release-notes.ts
@@ -1,10 +1,12 @@
 /// <reference types="node" />
 
 /**
- * Fails (exit 1) when a PR has no non-empty `## Release Notes` section, unless
- * the `skip-changelog` label is present or the content is `none`. This is the
- * copy source the changelog generator reads, so a mobile/shared PR without it
- * would ship an OTA with nothing to show users.
+ * Fails (exit 1) when a PR has no non-empty `## Release Notes` section, unless it
+ * explicitly opts out: the template's "No release note needed" checkbox is ticked,
+ * or the `skip-changelog` label is present. An empty/missing section still fails
+ * (a forgotten note, not a deliberate skip). This is the copy source the changelog
+ * generator reads, so a mobile/shared PR without it would ship an OTA with nothing
+ * to show users.
  *
  * Inputs (designed so CI never has to shell-escape a multi-line markdown body):
  *   --body-file <path>   Read the PR body from a file (CI writes
@@ -19,7 +21,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { extractReleaseNotes, SKIP_LABEL } from './lib/changelog-transform';
+import { extractReleaseNotes, isNoReleaseNoteBoxChecked, SKIP_LABEL } from './lib/changelog-transform';
 
 function readBody(): string {
   const args = process.argv.slice(2);
@@ -77,6 +79,11 @@ function main(): void {
   }
 
   const body = readBody();
+  if (isNoReleaseNoteBoxChecked(body)) {
+    console.log('[release-notes] "No release note needed" checkbox ticked — Release Notes not required.');
+    return;
+  }
+
   const notes = extractReleaseNotes(body);
   if (notes) {
     console.log(`[release-notes] OK — "${notes.title}"`);
@@ -89,8 +96,8 @@ function main(): void {
       '',
       'Add a "## Release Notes" section to the PR description describing what the',
       'user gets (climber voice, one short line per change). See the PR template.',
-      `For internal-only changes, write "none" under the heading or apply the`,
-      `"${SKIP_LABEL}" label.`,
+      'For an internal/technical change with nothing user-facing, tick the',
+      `"No release note needed" checkbox in the template (or apply the "${SKIP_LABEL}" label).`,
     ].join('\n'),
   );
   process.exit(1);

--- a/scripts/lib/changelog-transform.ts
+++ b/scripts/lib/changelog-transform.ts
@@ -61,6 +61,13 @@ const CODE_FENCE = /^\s*```/;
 // Dropped so it never becomes a changelog entry. A real sentence like
 // "none of the old buttons…" doesn't match (a letter follows `none`), so it's kept.
 const NONE_MARKER = /^none\s*(?:[([{:.\-–—].*)?$/i;
+// The PR-template "No release note needed" checkbox (a flag for internal/technical
+// changes). Matched on the raw line (before list-marker stripping). The first form
+// matches it checked OR unchecked — those lines are never changelog content. The
+// second matches only the CHECKED box — an explicit "skip, on purpose" the gate
+// honors (vs an empty section, which is a forgotten note and still fails).
+const NO_RELEASE_NOTE_BOX = /^\s*[-*]\s*\[[ xX]\]\s*no release note/i;
+const NO_RELEASE_NOTE_BOX_CHECKED = /^[ \t]*[-*][ \t]*\[[xX]\][ \t]*no release note/im;
 // Also ends the section (besides the next heading): a markdown horizontal rule, or
 // the auto-generated PR footer (the "🤖 Generated with…" line). Stops a footer that
 // sits right after the notes — with no heading to bound it — from leaking in.
@@ -99,9 +106,11 @@ export function extractReleaseNotes(prBody: string | null | undefined): ReleaseN
     sectionLines.push(line);
   }
 
-  // Drop blank lines, bullet markers, and any standalone `none` (so `- none` or
-  // a mix of real notes and `none` placeholders never ship a junk "none" entry).
+  // Drop the "No release note needed" checkbox line (checked or not — it's a flag,
+  // never content), then blank lines, bullet markers, and any standalone `none`, so
+  // none of them ship as a junk entry.
   const cleaned = sectionLines
+    .filter((line) => !NO_RELEASE_NOTE_BOX.test(line))
     .map((line) => line.replace(LIST_MARKER, '').trim())
     .filter((line) => line.length > 0 && !NONE_MARKER.test(line));
 
@@ -110,6 +119,18 @@ export function extractReleaseNotes(prBody: string | null | undefined): ReleaseN
   const [title, ...rest] = cleaned;
   const body = rest.join('\n').trim();
   return body ? { title, body } : { title };
+}
+
+/**
+ * True when the PR ticks the template's "No release note needed" checkbox — an
+ * explicit, on-purpose skip (internal/technical change). The release-notes gate
+ * honors it as a pass; it never produces a changelog entry (the box line is
+ * stripped in `extractReleaseNotes`). Distinct from an empty/missing section,
+ * which is a forgotten note and still fails the gate.
+ */
+export function isNoReleaseNoteBoxChecked(prBody: string | null | undefined): boolean {
+  if (!prBody) return false;
+  return NO_RELEASE_NOTE_BOX_CHECKED.test(prBody);
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up: a PR-description **flag** for internal/technical changes that don't need a release note — a "No release note needed" checkbox.

Until now the only thing that skipped the release-notes gate was the `skip-changelog` label. Writing `none` in the description actually *failed* the gate (the generator drops `none` → the gate saw "no usable notes"), even though the gate's own hint told you to write `none`. This closes that gap with an explicit, discoverable checkbox.

- **PR template**: adds `- [ ] No release note needed (internal / technical change)`.
- **Generator** (`changelog-transform.ts`): strips that checkbox line (checked or not) so it never becomes a changelog entry; `isNoReleaseNoteBoxChecked()` detects a ticked box.
- **Gate** (`check-release-notes.ts`): passes when the box is ticked (or there are real notes, or the `skip-changelog` label). An empty/missing section **still fails** — a forgotten note, not a deliberate skip.

This PR dogfoods it — the box below is ticked.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` + `vp test run --project scripts` — 155 pass, incl. new checkbox + `isNoReleaseNoteBoxChecked` cases.
- Verified the gate end-to-end: checked box → pass (exit 0), real notes → pass, empty/unchecked → fail (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142LzvfoFMQ3sQMtkFFugTJ
