### PR TITLE
fix(ci): scope the 16 KB alignment check to 64-bit ABIs

### DIFF
--- a/scripts/__tests__/check-16kb-alignment.test.ts
+++ b/scripts/__tests__/check-16kb-alignment.test.ts
@@ -72,8 +72,8 @@ describe.skipIf(!toolsPresent)('check-16kb-alignment.sh', () => {
     fs.rmSync(workdir, { recursive: true, force: true });
   });
 
-  function newLibDir(name: string): string {
-    const libDir = path.join(workdir, name, 'lib', 'arm64-v8a');
+  function newLibDir(name: string, abi = 'arm64-v8a'): string {
+    const libDir = path.join(workdir, name, 'lib', abi);
     fs.mkdirSync(libDir, { recursive: true });
     return libDir;
   }
@@ -95,6 +95,23 @@ describe.skipIf(!toolsPresent)('check-16kb-alignment.sh', () => {
     const libDir = newLibDir('misaligned');
     writeMisalignedCopy(alignedSo, path.join(libDir, 'libforged.so'));
     expect(runGuard(zipTopDir('misaligned', 'lib'))).toBe(1);
+  });
+
+  it('skips a misaligned 32-bit lib but still checks the 64-bit ones (passes)', () => {
+    // Mirrors a real AAB: aligned 64-bit libs alongside 4 KB-aligned 32-bit libs.
+    // The 16 KB rule is 64-bit only, so the armeabi-v7a lib must be skipped, not
+    // fail the release.
+    const arm64 = newLibDir('mixed-abi', 'arm64-v8a');
+    fs.copyFileSync(alignedSo, path.join(arm64, 'libboard_renderer_ffi.so'));
+    const armeabi = newLibDir('mixed-abi', 'armeabi-v7a');
+    writeMisalignedCopy(alignedSo, path.join(armeabi, 'libforged.so'));
+    expect(runGuard(zipTopDir('mixed-abi', 'lib'))).toBe(0);
+  });
+
+  it('still fails a misaligned x86_64 lib (64-bit is not caught by the x86 skip)', () => {
+    const x64 = newLibDir('x86_64-bad', 'x86_64');
+    writeMisalignedCopy(alignedSo, path.join(x64, 'libforged.so'));
+    expect(runGuard(zipTopDir('x86_64-bad', 'lib'))).toBe(1);
   });
 
   it('fails (not just warns) when an archive ships no native libraries', () => {

--- a/scripts/check-16kb-alignment.sh
+++ b/scripts/check-16kb-alignment.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Verify that every native library (.so) bundled in an Android APK or AAB has its
-# ELF LOAD segments aligned to >= 16 KB (0x4000). Apps targeting Android 15+ (API
-# 35+) must support 16 KB memory page sizes: a 4 KB-aligned .so fails to dlopen on
-# 16 KB-page devices (Pixel 8/9, etc.) with "not 16 KB aligned" → UnsatisfiedLinkError,
-# and Google Play rejects the AAB at upload. This check is the CI guard that proves
-# our own libs (the board-renderer JNI wrapper + prebuilt Rust FFI) are aligned and
-# catches any third-party lib that regresses.
+# Verify that every 64-bit native library (.so) bundled in an Android APK or AAB
+# has its ELF LOAD segments aligned to >= 16 KB (0x4000). Apps targeting Android
+# 15+ (API 35+) must support 16 KB memory page sizes: a 4 KB-aligned .so fails to
+# dlopen on 16 KB-page devices (Pixel 8/9, etc.) with "not 16 KB aligned" →
+# UnsatisfiedLinkError, and Google Play rejects the AAB at upload. This check is
+# the CI guard that proves our own libs (the board-renderer JNI wrapper + prebuilt
+# Rust FFI) are aligned and catches any third-party lib that regresses.
+#
+# 64-bit ONLY: the 16 KB requirement applies to arm64-v8a and x86_64. 16 KB-page
+# devices run a 64-bit kernel and never load 32-bit code, so Google Play does not
+# enforce 16 KB on armeabi-v7a / x86 — those ship 4 KB-aligned by design. Auditing
+# them too would false-fail every release, so 32-bit ABIs are skipped below.
 #
 # Usage: scripts/check-16kb-alignment.sh <path-to-apk-or-aab> [more-archives...]
 #
@@ -52,8 +57,19 @@ for archive in "$@"; do
   found_so=0
   while IFS= read -r -d '' so; do
     found_so=1
-    checked_any=1
     rel="${so#"$dir"/}"
+
+    # 64-bit only (see header): the ABI is the directory directly holding the .so
+    # (lib/<abi>/… or base/lib/<abi>/…). Skip 32-bit ABIs, which legitimately ship
+    # 4 KB-aligned. Matched exactly so x86_64 is NOT caught by the x86 case.
+    abi="$(basename "$(dirname "$so")")"
+    case "$abi" in
+    armeabi-v7a | x86)
+      echo "  skip (32-bit ABI, 16 KB N/A): $rel"
+      continue
+      ;;
+    esac
+    checked_any=1
 
     # Collect the p_align of every LOAD segment (last column of each LOAD line),
     # e.g. "0x4000" or "0x1000". readelf -W avoids line-wrapping the wide output.


### PR DESCRIPTION
## Summary

The Android build (`android-apk-rn.yml`) has been failing at **"Verify 16 KB native-library alignment (APK + AAB)"** since #3069 added that guard — which also blocks the AAB auto-upload to the Play internal track (the upload step never runs once the job fails).

The failure is a **false positive**. All 64-bit libs (`arm64-v8a`, `x86_64`) are already 16 KB aligned and pass. The 34 failures are **only 32-bit** — every `armeabi-v7a` and `x86` `.so` ships 4 KB-aligned (`0x1000`):

```
base/lib/x86/libreactnative.so ... below 16 KB: 0x1000
base/lib/armeabi-v7a/libhermesvm.so ... below 16 KB: 0x1000
   (17 armeabi-v7a + 17 x86, 0 arm64-v8a, 0 x86_64)
```

The 16 KB page-size requirement is **64-bit only**: 16 KB-page devices (Pixel 8/9, …) run a 64-bit kernel and never load 32-bit code, and Google Play enforces 16 KB alignment only on `arm64-v8a` / `x86_64`. 32-bit libs ship 4 KB-aligned by design and Play accepts them. The guard over-reached by auditing all ABIs.

## Fix

- `scripts/check-16kb-alignment.sh` skips `armeabi-v7a` and `x86` (matched **exactly**, so `x86_64` is still checked).
- Tests: a mixed archive (aligned 64-bit + misaligned 32-bit) now **passes**; a misaligned `x86_64` lib still **fails** (proves `x86_64` isn't caught by the `x86` skip). Verified locally against a real `readelf` (7/7 pass).

## Impact

Unblocks the Android build → AAB builds → with the foreground-service declaration now completed in Play Console, the AAB auto-uploads to the internal track resume. (Does not drop 32-bit device support — those ABIs still ship, just aren't held to a requirement that doesn't apply to them.)

## Release Notes

none

## Test plan

`vp test run scripts/__tests__/check-16kb-alignment.test.ts` (7/7 pass with readelf). After merge, watch the next `android-apk-rn` run: the verify step should pass and the AAB should upload to the internal track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)