### PR TITLE
chore(repo): add posthog-product-health-audit skill

### DIFF
--- a/.claude/skills/posthog-product-health-audit/SKILL.md
+++ b/.claude/skills/posthog-product-health-audit/SKILL.md
@@ -36,7 +36,7 @@ The workflow runs in the background; you get notified on completion. Watch live 
 
 **2 — Verify (pipeline per candidate).** `classify` (label + severity + suspected file via repo grep + whether a fix already exists) → `refute` (adversarial skeptic that tries to kill it; defaults to a lower keep level when uncertain). Each candidate ends as `issue`, `hygiene`, or `drop`.
 
-**3 — Dedup gate (mandatory, dedicated agent).** Before anything is filed, an agent searches **open and closed** issues (`gh issue list --search`, `gh search issues`) for the same root cause. `duplicate:true` candidates are recorded with a link and not filed; near-matches go in `relatedIssues`. When unsure, it errs toward `duplicate:false` (a reviewed near-dup beats a missed bug).
+**3 — Dedup gate (mandatory).** A dedicated dedup agent runs for **each** surviving candidate as the final stage of the verify `pipeline()` (so dedup for one finding overlaps verification of the next — no barrier). It searches **open and closed** issues (`gh issue list --search`, `gh search issues`) for the same root cause. `duplicate:true` candidates are recorded with a link and not filed; near-matches go in `relatedIssues`. When unsure, it errs toward `duplicate:false` (a reviewed near-dup beats a missed bug).
 
 **4 — Synthesize → File.** One issue per root cause, climber-voice title, body = symptom + PostHog evidence link + occurrences/users/sessions + suspected file + severity rationale + related issues. Then create them with `gh` (see below).
 
@@ -53,7 +53,7 @@ Every filed issue also gets `bug`, the provenance label `from-posthog`, and a pl
 
 ## Noise policy
 
-Real-but-not-user-facing telemetry (user cancels thrown as errors, dev/screenshot-only `ReferenceError`s, log spam) is **not** filed one-per-item. The synthesis step rolls it into a single **P3 "error-tracking hygiene"** issue as a checklist (what to stop logging / guard, and where). Transient infra blips (a lone 502/504, a DNS miss) and expected behaviour (e.g. "auth required" when logged out — confirm in code first) are dropped, with the reason recorded.
+Real-but-not-user-facing telemetry (user cancels thrown as errors, dev/screenshot-only `ReferenceError`s, log spam) is **not** filed one-per-item. The synthesis step rolls it into a single **P3 "error-tracking hygiene"** issue as a checklist (what to stop logging / guard, and where). When a run turns up no such noise, `issueSpecs.hygiene` is `null` — skip it, don't file a placeholder. Transient infra blips (a lone 502/504, a DNS miss) and expected behaviour (e.g. "auth required" when logged out — confirm in code first) are dropped, with the reason recorded.
 
 ## Filing (Phase 4)
 

--- a/.claude/skills/posthog-product-health-audit/SKILL.md
+++ b/.claude/skills/posthog-product-health-audit/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: posthog-product-health-audit
+description: Mine Boardsesh's PostHog telemetry (error tracking, session recordings, product analytics) with a multi-agent workflow, then file verified, deduplicated, severity-labelled GitHub issues. Use when asked to analyse PostHog errors/recordings/analytics, do a production-health or bug sweep, or turn telemetry into tracked issues. Project id 412845; repo boardsesh/boardsesh.
+---
+
+# PostHog product-health audit
+
+Turns production telemetry into a short list of real, deduplicated bugs and files them as GitHub issues with the right severity. Built around the PostHog MCP (`mcp__posthog__exec`) and a four-phase `Workflow`. The canonical implementation lives next to this file: **`audit-workflow.js`**.
+
+## When to use
+
+- "Analyse our PostHog errors / recordings / analytics."
+- "Do a production-health sweep / find bugs from telemetry."
+- "Triage what users are hitting and open issues."
+
+Read-only against PostHog. The only writes are the GitHub issues you create in Phase 4, plus a one-time `from-posthog` label.
+
+## Run it
+
+```
+Workflow({ scriptPath: ".claude/skills/posthog-product-health-audit/audit-workflow.js" })
+```
+
+Optional `args`: `{ project: "412845", repo: "boardsesh/boardsesh", lookbackDays: 30 }`. The workflow returns structured findings and **drafts** issue specs — it does not file. You review `issueSpecs`, then file (Phase 4). This keeps a human checkpoint before anything lands on a public repo.
+
+The workflow runs in the background; you get notified on completion. Watch live with `/workflows`.
+
+## The four phases
+
+**1 — Collect (4 parallel agents, PostHog MCP, read-only).** Each follows the schema-first discipline below.
+
+- _Errors_ — `query-error-tracking-issues-list` (active, `-30d`, by occurrences, test accounts filtered), then `query-error-tracking-issue` + `query-error-tracking-issue-events` to pull stack frame, screen/URL, app version, `$lib` (platform), and `$session_id`s for the top ~8 root causes. Run a second pass with `library: "posthog-js"` — the top list skews mobile (`posthog-react-native`), so confirm web `$exception` coverage rather than assume it.
+- _Analytics_ — `web-analytics-weekly-digest` for the macro picture, then **failure rates** (not raw counts) from `execute-sql` over paired events (`Bluetooth Connection Failed`/`…Success`, `Climb Sent to Board Failure`/`…Success`, `Tick Save Failed`/`Tick Logged`, …) and `query-funnel` for `Login Attempted→Succeeded`, `Onboarding Tour Started→Completed`, `Session Started→Climb Sent to Board Success`. A growing site inflates absolute counts and bounce-rate by composition — flag rates and drop-off, never raw jumps.
+- _Recordings_ — `query-session-recordings-list` for `console_error_count > 0` and short high-click sessions, then `session-recording-summarize` on ~5 high-signal replays to get the user-facing symptom. Deep-link as `https://us.posthog.com/project/<id>/replay/<recording_id>`.
+- _Web hygiene_ — `$csp_violation`, poor `$web_vitals` (LCP/CLS) by page, `$dead_click` hotspots.
+
+**2 — Verify (pipeline per candidate).** `classify` (label + severity + suspected file via repo grep + whether a fix already exists) → `refute` (adversarial skeptic that tries to kill it; defaults to a lower keep level when uncertain). Each candidate ends as `issue`, `hygiene`, or `drop`.
+
+**3 — Dedup gate (mandatory, dedicated agent).** Before anything is filed, an agent searches **open and closed** issues (`gh issue list --search`, `gh search issues`) for the same root cause. `duplicate:true` candidates are recorded with a link and not filed; near-matches go in `relatedIssues`. When unsure, it errs toward `duplicate:false` (a reviewed near-dup beats a missed bug).
+
+**4 — Synthesize → File.** One issue per root cause, climber-voice title, body = symptom + PostHog evidence link + occurrences/users/sessions + suspected file + severity rationale + related issues. Then create them with `gh` (see below).
+
+## Severity rubric → labels
+
+| Severity | Meaning                                                                           | Label         |
+| -------- | --------------------------------------------------------------------------------- | ------------- |
+| P0       | crash / data-loss / security / total blocker for many users                       | `priority:P0` |
+| P1       | core-flow bug or gap (login broken, send-to-board fails, board list blocked)      | `priority:P1` |
+| P2       | noticeable, has a workaround (e.g. a validation error, a _recurring_ 5xx pattern) | `priority:P2` |
+| P3       | cosmetic / long-tail / hygiene                                                    | `priority:P3` |
+
+Every filed issue also gets `bug`, the provenance label `from-posthog`, and a platform label (`ios` / `android` / `mobile` / `web`). Only use labels that already exist — check `gh label list`.
+
+## Noise policy
+
+Real-but-not-user-facing telemetry (user cancels thrown as errors, dev/screenshot-only `ReferenceError`s, log spam) is **not** filed one-per-item. The synthesis step rolls it into a single **P3 "error-tracking hygiene"** issue as a checklist (what to stop logging / guard, and where). Transient infra blips (a lone 502/504, a DNS miss) and expected behaviour (e.g. "auth required" when logged out — confirm in code first) are dropped, with the reason recorded.
+
+## Filing (Phase 4)
+
+```bash
+# one-time provenance label, mirrors the existing from-sentry convention
+gh label create from-posthog --color BFD4F2 --description "Filed from PostHog product telemetry" 2>/dev/null || true
+
+# per issue, from issueSpecs.issues[]
+gh issue create --repo boardsesh/boardsesh \
+  --title "<title>" --body "<body>" \
+  --label "priority:P1,bug,from-posthog,android"
+
+# the single bundled hygiene issue from issueSpecs.hygiene
+```
+
+Afterwards print a summary: filed (`#`, title, severity), skipped-as-duplicate (→ existing `#`), skipped-as-noise/transient. Confirm with `gh issue list --label from-posthog`.
+
+## PostHog MCP discipline (do not skip)
+
+`mcp__posthog__exec` is CLI-style. The order is mandatory, like reading a file before editing it:
+
+1. `search <regex>` or `info <tool>` to find the tool.
+2. `info <tool>` **before every** `call <tool>`.
+3. For `query-*` tools, `schema <tool> <field>` before populating array fields (e.g. `schema query-funnel series`).
+4. Confirm every event/property name with `read-data-schema` (`kind: events` / `event_properties` / `event_property_values`) — names like `$pageview` still need confirming per project; the Boardsesh taxonomy drifts.
+5. `call`s that touch collected data need a `context` arg: 15–25 words, third person.
+
+Key tools: `query-error-tracking-issues-list`, `query-error-tracking-issue`, `query-error-tracking-issue-events`, `query-session-recordings-list`, `session-recording-summarize`, `web-analytics-weekly-digest`, `query-trends`, `query-funnel`, `execute-sql`, `read-data-schema`.
+
+## Re-running
+
+Safe to re-run on a schedule. The dedup gate keeps it from re-filing anything already tracked, so each run only surfaces genuinely new problems. Bump `lookbackDays` for a wider sweep; the first collector pass auto-discovers fresh top errors, so no seed list is needed.

--- a/.claude/skills/posthog-product-health-audit/SKILL.md
+++ b/.claude/skills/posthog-product-health-audit/SKILL.md
@@ -21,7 +21,7 @@ Read-only against PostHog. The only writes are the GitHub issues you create in P
 Workflow({ scriptPath: ".claude/skills/posthog-product-health-audit/audit-workflow.js" })
 ```
 
-Optional `args`: `{ project: "412845", repo: "boardsesh/boardsesh", lookbackDays: 30 }`. The workflow returns structured findings and **drafts** issue specs — it does not file. You review `issueSpecs`, then file (Phase 4). This keeps a human checkpoint before anything lands on a public repo.
+Optional `args`: `{ project, repo, lookbackDays }` — defaults (`412845` / `boardsesh/boardsesh` / `30`) live in `audit-workflow.js`; that file is the source of truth if these drift. The workflow returns structured findings and **drafts** issue specs — it does not file. You review `issueSpecs`, then file (Phase 4). This keeps a human checkpoint before anything lands on a public repo.
 
 The workflow runs in the background; you get notified on completion. Watch live with `/workflows`.
 
@@ -86,3 +86,9 @@ Key tools: `query-error-tracking-issues-list`, `query-error-tracking-issue`, `qu
 ## Re-running
 
 Safe to re-run on a schedule. The dedup gate keeps it from re-filing anything already tracked, so each run only surfaces genuinely new problems. Bump `lookbackDays` for a wider sweep; the first collector pass auto-discovers fresh top errors, so no seed list is needed.
+
+**Watch-outs on re-run** (the pipeline logic isn't unit-tested — verify by eye):
+
+- The dedup gate is keyword-driven `gh search`. On a large tracker, skim `issueSpecs` against `gh issue list --label from-posthog` before filing to confirm nothing already-tracked slipped through — especially issues phrased differently from the error string.
+- A finding marked `keep: "drop"` skips dedup entirely (intended — dropped items are never filed). A finding marked `hygiene` that the dedup gate flags as a duplicate is excluded from the bundle and routed to `duplicates`.
+- When every candidate is dropped/deduped, `issueSpecs` is `{ issues: [], hygiene: null }` and no synth agent runs — a clean run with nothing to file is a valid outcome, not an error.

--- a/.claude/skills/posthog-product-health-audit/audit-workflow.js
+++ b/.claude/skills/posthog-product-health-audit/audit-workflow.js
@@ -1,0 +1,299 @@
+// Canonical implementation for the `posthog-product-health-audit` skill.
+//
+// Run it with the Workflow tool:
+//   Workflow({ scriptPath: ".claude/skills/posthog-product-health-audit/audit-workflow.js" })
+//
+// It fans out four read-only PostHog MCP collectors, triages every candidate
+// (classify -> adversarial refute -> mandatory dedup against existing GitHub
+// issues), and returns drafted issue specs. It deliberately does NOT file
+// anything — the calling session reviews `issueSpecs` and files with `gh`
+// (see SKILL.md, "Phase 4 — File"). PostHog project id is read from `args`
+// (default 412845) so the skill can target a different project without edits.
+
+export const meta = {
+  name: 'posthog-product-health-audit',
+  description:
+    'Audit Boardsesh PostHog telemetry (errors, recordings, analytics), verify and dedup findings, draft severity-labelled GitHub issue specs.',
+  phases: [
+    { title: 'Collect', detail: 'parallel PostHog MCP collectors: errors, analytics, recordings, web hygiene' },
+    { title: 'Verify', detail: 'classify + severity, then adversarially refute each candidate' },
+    { title: 'Dedup', detail: 'dedicated agent confirms each candidate is not an existing GH issue' },
+    { title: 'Synthesize', detail: 'merge by root cause, draft issue specs + one hygiene issue' },
+  ],
+};
+
+const PROJECT = args && args.project ? String(args.project) : '412845';
+const REPO = args && args.repo ? String(args.repo) : 'boardsesh/boardsesh';
+const LOOKBACK = args && args.lookbackDays ? String(args.lookbackDays) : '30';
+
+const MCP_PREAMBLE = `You are auditing Boardsesh's PostHog project (id ${PROJECT}, base https://us.posthog.com). To use PostHog: first call ToolSearch with query "select:mcp__posthog__exec" to load the tool, then drive it CLI-style via mcp__posthog__exec({command, context}). HARD RULE: run \`info <tool>\` before \`call <tool>\`, and for query-* tools drill \`schema <tool> <field>\` before populating array fields. Confirm any event name exists with \`call read-data-schema {"query":{"kind":"events"}}\` — never guess event names. The \`context\` arg must be 15-25 words, third person, no first person. Test accounts must be filtered out (filterTestAccounts/filter_test_accounts true).`;
+
+const CONFIRMED_EVENTS = `Boardsesh custom events worth trending include: Bluetooth Connection Success/Failed, Bluetooth Disconnected, Pairing Failed, Climb Sent to Board Success/Failure, Tick Logged, Tick Save Failed, Quick Tick Saved/Failed, Queue Operation / Queue Operation Error, Climb Created / Climb Create Failed, Login Attempted/Succeeded/Failed, Signup Completed, Onboarding Tour Started/Completed/Skipped, Session Started/Joined/Ended, Board Render Error, Wall Confirmed, Wall Confirm Timeout, $rageclick, $dead_click, $exception, $csp_violation, $web_vitals, $pageview, $screen. Confirm each with read-data-schema before querying — the taxonomy drifts.`;
+
+const CANDIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['source', 'candidates'],
+  properties: {
+    source: { type: 'string' },
+    context: { type: 'string', description: 'Freeform notes: metrics, rates, what was checked, what was clean.' },
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['key', 'title', 'evidence'],
+        properties: {
+          key: { type: 'string', description: 'kebab-case stable slug' },
+          title: { type: 'string' },
+          platform: { type: 'string', description: 'ios | android | mobile | web | backend | unknown' },
+          severityGuess: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+          occurrences: { type: ['number', 'null'] },
+          users: { type: ['number', 'null'] },
+          sessions: { type: ['number', 'null'] },
+          evidence: { type: 'string', description: 'stack frame / screen / URL / symptom / rate' },
+          evidenceUrl: { type: ['string', 'null'], description: 'PostHog _posthogUrl or replay deep link' },
+          sessionIds: { type: 'array', items: { type: 'string' } },
+          suspectedAreaHint: { type: ['string', 'null'] },
+        },
+      },
+    },
+  },
+};
+
+phase('Collect');
+const collectors = await parallel([
+  () =>
+    agent(
+      `${MCP_PREAMBLE}
+
+ROLE: Error-tracking collector. Enumerate production exceptions and capture enough evidence to file precise bug reports.
+STEPS:
+1. info then call query-error-tracking-issues-list {"status":"active","dateRange":{"date_from":"-${LOOKBACK}d"},"orderBy":"occurrences","orderDirection":"DESC","limit":50,"offset":0,"volumeResolution":0,"filterTestAccounts":true}.
+2. Run it again adding "library":"posthog-js" to confirm whether WEB ($exception) errors exist as well as mobile (posthog-react-native). Report web coverage explicitly in context.
+3. For the top ~8 DISTINCT root causes (merge issues that are obviously the same error), drill: info+call query-error-tracking-issue {"issueId":"<id>"} and query-error-tracking-issue-events {"issueId":"<id>","limit":3} to capture a representative stack frame, $current_url or $screen_name, $app_version / release, $lib (platform), and up to 3 $session_id values.
+Return one candidate per distinct root cause with REAL fresh numbers, the _posthogUrl as evidenceUrl, the platform from $lib, and sessionIds. Set severityGuess: P0 crash/data-loss/security/total-blocker for many users; P1 core-flow bug (login broken, send-to-board fails, board list blocked); P2 noticeable w/ workaround; P3 cosmetic/long-tail/noise. Include noisy ones (user-cancel-as-error, dev-only leaks) too — they are triaged later.`,
+      { label: 'collect:errors', phase: 'Collect', schema: CANDIDATE_SCHEMA },
+    ),
+
+  () =>
+    agent(
+      `${MCP_PREAMBLE}
+
+ROLE: Analytics & failure-rate collector. Find product problems that show up as bad RATES or funnel drop-off, NOT raw counts — a growing site inflates absolute counts and bounce-rate by composition, so never flag those alone.
+${CONFIRMED_EVENTS}
+STEPS:
+1. info+call web-analytics-weekly-digest {"compare":true,"days":${LOOKBACK}} for the macro picture.
+2. Compute FAILURE RATES over -${LOOKBACK}d. The reliable path is execute-sql (run info execute-sql first): SELECT event, count() FROM events WHERE event IN ('Bluetooth Connection Failed','Bluetooth Connection Success','Climb Sent to Board Failure','Climb Sent to Board Success','Tick Save Failed','Tick Logged','Quick Tick Failed','Quick Tick Saved','Queue Operation Error','Climb Create Failed','Climb Created','Pairing Failed','Login Failed','Login Succeeded','Board Render Error','Wall Confirm Timeout','$rageclick','$dead_click') AND timestamp > now() - INTERVAL ${LOOKBACK} DAY GROUP BY event ORDER BY count() DESC. Confirm names via read-data-schema first; drop any that are absent.
+3. Build funnels with query-funnel (drill schema query-funnel series first): Login Attempted -> Login Succeeded; Onboarding Tour Started -> Onboarding Tour Completed; Session Started -> Climb Sent to Board Success.
+Return a candidate ONLY for a genuine product problem: a failure event whose rate vs its success counterpart is materially high (e.g. >10-15%), a funnel with surprising drop-off, or a rage/dead-click concentration. Put the computed rates and funnel conversions in context even when clean.`,
+      { label: 'collect:analytics', phase: 'Collect', schema: CANDIDATE_SCHEMA },
+    ),
+
+  () =>
+    agent(
+      `${MCP_PREAMBLE}
+
+ROLE: Session-recording collector. Find real user friction.
+STEPS:
+1. info+call query-session-recordings-list {"date_from":"-14d","filter_test_accounts":true,"properties":[{"key":"console_error_count","operator":"gt","type":"recording","value":0}],"order":"console_error_count","limit":15}.
+2. Also list short high-click sessions (possible rage/confusion): order "click_count", date_from "-14d", limit 10.
+3. Pick the ~5 highest-signal recordings and summarise each: info+call session-recording-summarize with the recording id, to extract what the user was trying to do and what broke.
+Return a candidate for each distinct friction pattern you can substantiate from a summary (not speculation), with the replay deep link https://us.posthog.com/project/${PROJECT}/replay/<id> as evidenceUrl. If recordings are sparse or all clean, say so in context and return few/zero candidates.`,
+      { label: 'collect:recordings', phase: 'Collect', schema: CANDIDATE_SCHEMA },
+    ),
+
+  () =>
+    agent(
+      `${MCP_PREAMBLE}
+
+ROLE: Web hygiene collector (lighter pass).
+${CONFIRMED_EVENTS}
+STEPS: confirm events exist, then over -${LOOKBACK}d check: (a) $csp_violation volume and the top blocked directives/URIs (execute-sql group by the violation properties); (b) poor Core Web Vitals from $web_vitals (high LCP/CLS) by page; (c) $dead_click hotspots by $current_url/element.
+Return a candidate only for a real, actionable web problem (a recurring CSP violation of one kind, a page with consistently bad LCP, or a dead-click hotspot on something users expect to be clickable). Put what you checked in context, including clean results.`,
+      { label: 'collect:web-hygiene', phase: 'Collect', schema: CANDIDATE_SCHEMA },
+    ),
+]);
+
+const valid = collectors.filter(Boolean);
+const collectorContext = valid.map((c) => `### ${c.source}\n${c.context || '(no notes)'}`).join('\n\n');
+const rawCandidates = valid.flatMap((c) => (c.candidates || []).map((x) => ({ ...x, source: c.source })));
+log(`Collected ${rawCandidates.length} candidate problems across ${valid.length} sources`);
+
+const CLASSIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['classification', 'severity', 'platform', 'reasoning'],
+  properties: {
+    classification: { type: 'string', enum: ['user-facing-bug', 'transient-infra', 'noise', 'expected-behavior'] },
+    severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+    platform: { type: 'string' },
+    suspectedFile: { type: ['string', 'null'] },
+    fixAlreadyExists: { type: 'boolean' },
+    reasoning: { type: 'string' },
+  },
+};
+const REFUTE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['keep', 'severity', 'reasoning'],
+  properties: {
+    keep: {
+      type: 'string',
+      enum: ['issue', 'hygiene', 'drop'],
+      description:
+        'issue=file a bug; hygiene=real but non-user-facing noise to bundle; drop=transient/expected/false/already-fixed',
+    },
+    severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+    reasoning: { type: 'string' },
+  },
+};
+const DEDUP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['duplicate', 'existingIssue', 'reasoning'],
+  properties: {
+    duplicate: { type: 'boolean' },
+    existingIssue: { type: ['integer', 'null'] },
+    relatedIssues: { type: 'array', items: { type: 'integer' } },
+    reasoning: { type: 'string' },
+  },
+};
+
+phase('Verify');
+const triaged = await pipeline(
+  rawCandidates,
+  (c) =>
+    agent(
+      `Classify this Boardsesh telemetry finding for issue triage. You are in the Boardsesh monorepo working tree — use Bash (rg/ls) to grep packages/mobile, packages/web, packages/backend for the suspected code area and to check whether a guard/fix already exists.
+
+FINDING (JSON):
+${JSON.stringify(c, null, 2)}
+
+Severity rubric: P0 crash/data-loss/security/total-blocker for many users; P1 core-flow bug or gap; P2 noticeable with a workaround; P3 cosmetic/long-tail/hygiene. Classifications: user-facing-bug (file it), transient-infra (single 502/504/DNS blips), noise (real but not user-facing — user cancels thrown as errors, dev/screenshot-only leaks), expected-behavior (e.g. "auth required" when logged out — confirm by reading code before assuming). Point suspectedFile at a real path when you can.`,
+      { label: `classify:${c.key}`, phase: 'Verify', schema: CLASSIFY_SCHEMA },
+    ).then((classify) => ({ ...c, classify })),
+
+  (r) =>
+    agent(
+      `Adversarially review whether this finding deserves its own GitHub bug issue. Try to REFUTE it. Default to a lower keep level when uncertain.
+
+FINDING + CLASSIFICATION (JSON):
+${JSON.stringify(r, null, 2)}
+
+Decide keep: "issue" only if it is a real, actionable, user-facing bug with enough evidence to act on; "hygiene" if real but non-user-facing noise (user-cancel-as-error, dev-only ReferenceError, log-spam) that should be bundled into one cleanup issue; "drop" if transient/infra, expected behaviour, unsubstantiated, or already fixed in the code. Adjust severity if the classifier over/under-rated it. Be skeptical of single-digit-occurrence infra blips and of metrics inflated by a traffic spike.`,
+      { label: `verify:${r.key}`, phase: 'Verify', schema: REFUTE_SCHEMA },
+    ).then((refute) => ({ ...r, refute })),
+
+  (r) =>
+    r.refute.keep === 'drop'
+      ? r
+      : agent(
+          `DEDUP GATE. Confirm whether this finding is ALREADY tracked as a GitHub issue in ${REPO} before it gets filed. Use Bash gh:
+- gh issue list --repo ${REPO} --state all --limit 80 --search "<keywords>"
+- gh search issues --repo ${REPO} "<other keywords>" --state all
+Try several keyword sets (the error string, the feature, the symptom).
+
+FINDING (JSON):
+${JSON.stringify({ key: r.key, title: r.title, evidence: r.evidence, platform: r.platform, classify: r.classify, refute: r.refute }, null, 2)}
+
+Return duplicate=true ONLY if an existing issue clearly covers the same root cause (give its number as existingIssue). List merely-related issue numbers in relatedIssues. When unsure, duplicate=false (better a reviewed near-dup than a missed bug) but explain the closest match.`,
+          { label: `dedup:${r.key}`, phase: 'Dedup', schema: DEDUP_SCHEMA },
+        ).then((dedup) => ({ ...r, dedup })),
+);
+
+const triagedOk = triaged.filter(Boolean);
+const toFile = triagedOk.filter((r) => r.refute?.keep === 'issue' && !r.dedup?.duplicate);
+const hygiene = triagedOk.filter((r) => r.refute?.keep === 'hygiene');
+const duplicates = triagedOk.filter((r) => r.dedup?.duplicate);
+const dropped = triagedOk.filter((r) => r.refute?.keep === 'drop');
+log(
+  `To file: ${toFile.length} | hygiene-bundle: ${hygiene.length} | duplicates: ${duplicates.length} | dropped: ${dropped.length}`,
+);
+
+const SYNTH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['issues', 'hygiene'],
+  properties: {
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['key', 'title', 'body', 'labels', 'severity'],
+        properties: {
+          key: { type: 'string' },
+          title: { type: 'string' },
+          body: {
+            type: 'string',
+            description:
+              'Markdown. Symptom (climber voice) + Evidence (PostHog link, occurrences/users/sessions) + Suspected cause/file + Repro/notes + Severity rationale + Related issues.',
+          },
+          labels: { type: 'array', items: { type: 'string' } },
+          severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+        },
+      },
+    },
+    hygiene: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['title', 'body', 'labels'],
+      properties: {
+        title: { type: 'string' },
+        body: { type: 'string' },
+        labels: { type: 'array', items: { type: 'string' } },
+      },
+    },
+  },
+};
+
+phase('Synthesize');
+const synth = await agent(
+  `Draft final GitHub issue specs for the ${REPO} repo from verified, non-duplicate findings. Merge any that share a root cause.
+
+REAL BUGS TO FILE (JSON):
+${JSON.stringify(toFile, null, 2)}
+
+NOISE TO BUNDLE INTO ONE HYGIENE ISSUE (JSON):
+${JSON.stringify(hygiene, null, 2)}
+
+Rules:
+- One issue per distinct root cause. Title in climber/plain voice describing what is broken (not the stack trace).
+- Body markdown sections: **What's happening** (user-facing symptom), **Evidence** (PostHog _posthogUrl + occurrences/users/sessions over ${LOOKBACK}d, platform), **Suspected cause** (the suspectedFile if known), **Severity** (Px + one-line why), **Related** (relatedIssues numbers if any).
+- labels: priority:<severity> plus "bug" plus "from-posthog" plus platform ("ios"/"android"/"mobile"/"web") as applicable. Only use labels from this set.
+- Build exactly ONE hygiene issue at P3 titled around "error-tracking hygiene" that bundles the noise items as a checklist (each: what to stop logging / guard, and where). labels: priority:P3, from-posthog, plus platform if uniform.
+Return the spec. Do not file anything.`,
+  { label: 'synthesize', phase: 'Synthesize', schema: SYNTH_SCHEMA },
+);
+
+return {
+  collectorContext,
+  counts: {
+    collected: rawCandidates.length,
+    toFile: toFile.length,
+    hygiene: hygiene.length,
+    duplicates: duplicates.length,
+    dropped: dropped.length,
+  },
+  duplicates: duplicates.map((d) => ({
+    key: d.key,
+    title: d.title,
+    existingIssue: d.dedup.existingIssue,
+    reasoning: d.dedup.reasoning,
+  })),
+  dropped: dropped.map((d) => ({ key: d.key, title: d.title, reasoning: d.refute.reasoning })),
+  triaged: triagedOk.map((r) => ({
+    key: r.key,
+    title: r.title,
+    platform: r.platform,
+    occurrences: r.occurrences,
+    users: r.users,
+    classify: r.classify,
+    refute: r.refute,
+    dedup: r.dedup,
+    evidenceUrl: r.evidenceUrl,
+    sessionIds: r.sessionIds,
+  })),
+  issueSpecs: synth,
+};

--- a/.claude/skills/posthog-product-health-audit/audit-workflow.js
+++ b/.claude/skills/posthog-product-health-audit/audit-workflow.js
@@ -160,6 +160,11 @@ const DEDUP_SCHEMA = {
   },
 };
 
+// Verify + Dedup are stages of one concurrent pipeline(). Per the Workflow
+// guidance, pipeline stages pick their progress group via the per-agent `phase`
+// option (set below), NOT a global phase() call — a global call would race
+// across items running concurrently. That is why there is no phase('Dedup')
+// here: the dedup agents are grouped by their { phase: 'Dedup' } option.
 phase('Verify');
 const triaged = await pipeline(
   rawCandidates,
@@ -214,7 +219,7 @@ log(
 const SYNTH_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['issues', 'hygiene'],
+  required: ['issues'],
   properties: {
     issues: {
       type: 'array',
@@ -236,7 +241,7 @@ const SYNTH_SCHEMA = {
       },
     },
     hygiene: {
-      type: 'object',
+      type: ['object', 'null'],
       additionalProperties: false,
       required: ['title', 'body', 'labels'],
       properties: {
@@ -262,7 +267,7 @@ Rules:
 - One issue per distinct root cause. Title in climber/plain voice describing what is broken (not the stack trace).
 - Body markdown sections: **What's happening** (user-facing symptom), **Evidence** (PostHog _posthogUrl + occurrences/users/sessions over ${LOOKBACK}d, platform), **Suspected cause** (the suspectedFile if known), **Severity** (Px + one-line why), **Related** (relatedIssues numbers if any).
 - labels: priority:<severity> plus "bug" plus "from-posthog" plus platform ("ios"/"android"/"mobile"/"web") as applicable. Only use labels from this set.
-- Build exactly ONE hygiene issue at P3 titled around "error-tracking hygiene" that bundles the noise items as a checklist (each: what to stop logging / guard, and where). labels: priority:P3, from-posthog, plus platform if uniform.
+- If the NOISE list above is non-empty, build exactly ONE hygiene issue at P3 titled around "error-tracking hygiene" that bundles the noise items as a checklist (each: what to stop logging / guard, and where); labels priority:P3, from-posthog, plus platform if uniform. If the NOISE list is empty, set hygiene to null — do not invent a placeholder.
 Return the spec. Do not file anything.`,
   { label: 'synthesize', phase: 'Synthesize', schema: SYNTH_SCHEMA },
 );

--- a/.claude/skills/posthog-product-health-audit/audit-workflow.js
+++ b/.claude/skills/posthog-product-health-audit/audit-workflow.js
@@ -24,7 +24,8 @@ export const meta = {
 
 const PROJECT = args && args.project ? String(args.project) : '412845';
 const REPO = args && args.repo ? String(args.repo) : 'boardsesh/boardsesh';
-const LOOKBACK = String((args && parseInt(args.lookbackDays, 10)) || 30); // numeric days; falls back to 30 on missing/non-numeric input
+const LOOKBACK_DAYS = args && args.lookbackDays != null ? parseInt(args.lookbackDays, 10) : NaN;
+const LOOKBACK = String(Number.isFinite(LOOKBACK_DAYS) && LOOKBACK_DAYS > 0 ? LOOKBACK_DAYS : 30); // positive integer days; 0/negative/non-numeric → 30
 
 const MCP_PREAMBLE = `You are auditing Boardsesh's PostHog project (id ${PROJECT}, base https://us.posthog.com). To use PostHog: first call ToolSearch with query "select:mcp__posthog__exec" to load the tool, then drive it CLI-style via mcp__posthog__exec({command, context}). HARD RULE: run \`info <tool>\` before \`call <tool>\`, and for query-* tools drill \`schema <tool> <field>\` before populating array fields. Confirm any event name exists with \`call read-data-schema {"query":{"kind":"events"}}\` — never guess event names. The \`context\` arg must be 15-25 words, third person, no first person. Test accounts must be filtered out (filterTestAccounts/filter_test_accounts true).`;
 
@@ -194,10 +195,12 @@ Decide keep: "issue" only if it is a real, actionable, user-facing bug with enou
     r.refute.keep === 'drop'
       ? r
       : agent(
-          `DEDUP GATE. Confirm whether this finding is ALREADY tracked as a GitHub issue in ${REPO} before it gets filed. Use Bash gh:
-- gh issue list --repo ${REPO} --state all --limit 80 --search "<keywords>"
-- gh search issues --repo ${REPO} "<other keywords>" --state all
-Try several keyword sets (the error string, the feature, the symptom).
+          `DEDUP GATE. Confirm whether this finding is ALREADY tracked as a GitHub issue in ${REPO} before it gets filed. Use Bash gh.
+PRIMARY (full-text, searches ALL issues regardless of age — use this first, with several keyword sets):
+- gh search issues --repo ${REPO} "<keywords>" --state all --limit 100
+FALLBACK / corroboration (note: --limit caps the result set, so always pair with --search and never rely on the default recency window):
+- gh issue list --repo ${REPO} --state all --search "<keywords>" --limit 500
+Try several keyword sets (the exact error string, the feature, the user-facing symptom). A low limit on a plain (unsearched) list silently returns only the most-recent issues and misses older duplicates — so search, do not just list.
 
 FINDING (JSON):
 ${JSON.stringify({ key: r.key, title: r.title, evidence: r.evidence, platform: r.platform, classify: r.classify, refute: r.refute }, null, 2)}

--- a/.claude/skills/posthog-product-health-audit/audit-workflow.js
+++ b/.claude/skills/posthog-product-health-audit/audit-workflow.js
@@ -209,7 +209,7 @@ Return duplicate=true ONLY if an existing issue clearly covers the same root cau
 
 const triagedOk = triaged.filter(Boolean);
 const toFile = triagedOk.filter((r) => r.refute?.keep === 'issue' && !r.dedup?.duplicate);
-const hygiene = triagedOk.filter((r) => r.refute?.keep === 'hygiene');
+const hygiene = triagedOk.filter((r) => r.refute?.keep === 'hygiene' && !r.dedup?.duplicate);
 const duplicates = triagedOk.filter((r) => r.dedup?.duplicate);
 const dropped = triagedOk.filter((r) => r.refute?.keep === 'drop');
 log(

--- a/.claude/skills/posthog-product-health-audit/audit-workflow.js
+++ b/.claude/skills/posthog-product-health-audit/audit-workflow.js
@@ -24,7 +24,7 @@ export const meta = {
 
 const PROJECT = args && args.project ? String(args.project) : '412845';
 const REPO = args && args.repo ? String(args.repo) : 'boardsesh/boardsesh';
-const LOOKBACK = args && args.lookbackDays ? String(args.lookbackDays) : '30';
+const LOOKBACK = String((args && parseInt(args.lookbackDays, 10)) || 30); // numeric days; falls back to 30 on missing/non-numeric input
 
 const MCP_PREAMBLE = `You are auditing Boardsesh's PostHog project (id ${PROJECT}, base https://us.posthog.com). To use PostHog: first call ToolSearch with query "select:mcp__posthog__exec" to load the tool, then drive it CLI-style via mcp__posthog__exec({command, context}). HARD RULE: run \`info <tool>\` before \`call <tool>\`, and for query-* tools drill \`schema <tool> <field>\` before populating array fields. Confirm any event name exists with \`call read-data-schema {"query":{"kind":"events"}}\` — never guess event names. The \`context\` arg must be 15-25 words, third person, no first person. Test accounts must be filtered out (filterTestAccounts/filter_test_accounts true).`;
 
@@ -253,9 +253,12 @@ const SYNTH_SCHEMA = {
   },
 };
 
-phase('Synthesize');
-const synth = await agent(
-  `Draft final GitHub issue specs for the ${REPO} repo from verified, non-duplicate findings. Merge any that share a root cause.
+// Nothing survived triage (all dropped/deduped) → no synthesis agent to spawn.
+let synth = { issues: [], hygiene: null };
+if (toFile.length > 0 || hygiene.length > 0) {
+  phase('Synthesize');
+  synth = await agent(
+    `Draft final GitHub issue specs for the ${REPO} repo from verified, non-duplicate findings. Merge any that share a root cause.
 
 REAL BUGS TO FILE (JSON):
 ${JSON.stringify(toFile, null, 2)}
@@ -269,8 +272,9 @@ Rules:
 - labels: priority:<severity> plus "bug" plus "from-posthog" plus platform ("ios"/"android"/"mobile"/"web") as applicable. Only use labels from this set.
 - If the NOISE list above is non-empty, build exactly ONE hygiene issue at P3 titled around "error-tracking hygiene" that bundles the noise items as a checklist (each: what to stop logging / guard, and where); labels priority:P3, from-posthog, plus platform if uniform. If the NOISE list is empty, set hygiene to null — do not invent a placeholder.
 Return the spec. Do not file anything.`,
-  { label: 'synthesize', phase: 'Synthesize', schema: SYNTH_SCHEMA },
-);
+    { label: 'synthesize', phase: 'Synthesize', schema: SYNTH_SCHEMA },
+  );
+}
 
 return {
   collectorContext,


### PR DESCRIPTION
## Summary

Adds a reusable Claude skill, `posthog-product-health-audit`, that mines our PostHog telemetry and turns it into tracked, deduplicated, severity-labelled GitHub issues.

- `.claude/skills/posthog-product-health-audit/SKILL.md` — runbook: when to use, the four phases, the severity rubric → label mapping, the noise policy, and the PostHog MCP discipline.
- `.claude/skills/posthog-product-health-audit/audit-workflow.js` — canonical `Workflow` implementation. Four phases: **Collect** (4 parallel read-only PostHog MCP agents — error tracking, analytics failure-rates, session recordings, web hygiene) → **Verify** (classify + severity, then an adversarial skeptic per candidate) → **Dedup** (a dedicated agent confirms each candidate isn't an existing open/closed issue before anything is filed) → **Synthesize** (merge by root cause, draft issue specs + one bundled hygiene issue). It drafts specs and does **not** file — the operator reviews, then files with `gh`.

### First run results

Ran against project `412845` over 30 days. From 18 candidates it filed 5 issues (0 duplicates; 11 dropped, several verified as already fixed on `main`):

| # | Sev | Issue |
|---|-----|-------|
| #3084 | P1 | Sends silently fail ~10% of the time after a mid-session board drop (mislabelled `characteristic_unavailable`) |
| #3085 | P1 | Sign in with Apple dead-ends on iOS with no web fallback |
| #3086 | P2 | Climb list reflows while loading (CLS p75 0.27 on the main browsing route) |
| #3087 | P3 | "Sync error" toast when a party member ends the shared session |
| #3088 | P3 | Error-tracking hygiene (stop logging expected/user-cancel events as exceptions; attribute web BLE failures) |

Added a `from-posthog` label (mirrors `from-sentry`) and a `web` label for filtering.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` passes on both files (formatting + lint clean).
- Skill is discoverable as `/posthog-product-health-audit`.
- Workflow executed end-to-end on project 412845 (48 agents, 0 duplicates filed); the 5 issues above are live with correct `priority:Px` + platform + `from-posthog` labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Svscc3gioAn7o4t99riDjK
