### PR TITLE
fix(backend): show playlist grades at the selected wall angle (#1596)

### DIFF
--- a/packages/backend/src/__tests__/hydrate-climbs.test.ts
+++ b/packages/backend/src/__tests__/hydrate-climbs.test.ts
@@ -225,8 +225,40 @@ describe('hydrateClimbsByRefs', () => {
       expect(result[0].angle).toBe(40);
     });
 
-    it('uses the override when it is a non-null number, even if statsAngle is set', async () => {
+    // The returned `angle` reflects the angle the stats row was actually joined
+    // at (`statsAngle`), so it always agrees with the difficulty/quality shown.
+    // The SQL joins at COALESCE(override-if-stats-exist, most-ascents), so when
+    // an override is applied the joined statsAngle IS the override angle.
+    it('returns the joined stats angle, which under an applied override is the override angle', async () => {
+      mockDb.select.mockReturnValueOnce(makeChain([{ ...baseRow, statsAngle: 25 }]));
+
+      const overrides = new Map<string, number | null>([['kilter:c1', 25]]);
+      const result = await hydrateClimbsByRefs([{ climbUuid: 'c1', boardType: 'kilter' }], {
+        angleOverrides: overrides,
+      });
+
+      expect(result[0].angle).toBe(25);
+    });
+
+    // When the override angle has no stats row, the SQL EXISTS guard drops the
+    // override and the join falls back to the most-ascended angle. The returned
+    // angle follows that fallback (statsAngle) so grade and angle stay in sync,
+    // rather than reporting an angle whose grade isn't shown.
+    it('follows the joined fallback angle when the override angle has no stats', async () => {
       mockDb.select.mockReturnValueOnce(makeChain([{ ...baseRow, statsAngle: 35 }]));
+
+      const overrides = new Map<string, number | null>([['kilter:c1', 25]]);
+      const result = await hydrateClimbsByRefs([{ climbUuid: 'c1', boardType: 'kilter' }], {
+        angleOverrides: overrides,
+      });
+
+      expect(result[0].angle).toBe(35);
+    });
+
+    // Only when the climb has no stats row at all (nothing to join) does the
+    // requested override angle survive as the reported angle.
+    it('uses the override as a last resort when the climb has no stats row', async () => {
+      mockDb.select.mockReturnValueOnce(makeChain([{ ...baseRow, statsAngle: null }]));
 
       const overrides = new Map<string, number | null>([['kilter:c1', 25]]);
       const result = await hydrateClimbsByRefs([{ climbUuid: 'c1', boardType: 'kilter' }], {

--- a/packages/backend/src/__tests__/playlist-climbs-active-angle.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-active-angle.test.ts
@@ -4,6 +4,12 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
 import { playlistQueries } from '../graphql/resolvers/playlists/queries';
 
+// Seeds use raw `sql` rather than `db.insert(...)` because the integration test
+// DB is built from a minimal hand-maintained DDL (schema-sql.ts), not the full
+// Drizzle schema — the query builder emits every default-bearing column (e.g.
+// quality_normalized) which that DDL omits, so a builder insert fails. Naming
+// only the columns the test DDL declares is the genuine raw-SQL exception.
+
 // Integration test (real DB) for #1596: in all-boards mode the playlist climbs
 // resolver must render on-active-board climbs' grades at the user's SELECTED
 // wall angle — not the angle with the most ascents. This exercises the actual
@@ -61,6 +67,8 @@ describe('playlistClimbs — active-angle override (real DB)', () => {
     await seedClimb('tension', 'climb-c', 'Off-board');
     await seedStats('tension', 'climb-c', 30, 16, 50);
 
+    // Explicit id keeps the playlist_climbs FK references below trivial; the
+    // TRUNCATE ... RESTART IDENTITY above frees id 1.
     await db.execute(sql`
       INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
       VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Active angle', true)

--- a/packages/backend/src/__tests__/playlist-climbs-active-angle.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-active-angle.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { playlistQueries } from '../graphql/resolvers/playlists/queries';
+
+// Integration test (real DB) for #1596: in all-boards mode the playlist climbs
+// resolver must render on-active-board climbs' grades at the user's SELECTED
+// wall angle — not the angle with the most ascents. This exercises the actual
+// COALESCE(override-if-stats-exist, most-ascents) + EXISTS guard SQL in
+// hydrateClimbsByRefs, which the mocked unit tests can't reach.
+//
+// The returned `angle` follows the stats row the query actually joined, so it
+// is a faithful proxy for "which angle's grade is displayed".
+
+const PLAYLIST_UUID = 'pl-active-angle-1596';
+
+function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: false,
+    userId: null,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+    ...overrides,
+  } as ConnectionContext;
+}
+
+async function seedClimb(boardType: string, uuid: string, name: string) {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+    VALUES (${uuid}, ${boardType}, 1, 'setter', ${name}, '', 'p1r1', true)
+  `);
+}
+
+async function seedStats(boardType: string, uuid: string, angle: number, displayDifficulty: number, ascents: number) {
+  await db.execute(sql`
+    INSERT INTO board_climb_stats (board_type, climb_uuid, angle, display_difficulty, difficulty_average, quality_average, ascensionist_count, benchmark_difficulty)
+    VALUES (${boardType}, ${uuid}, ${angle}, ${displayDifficulty}, ${displayDifficulty}, 3.0, ${ascents}, 0)
+  `);
+}
+
+describe('playlistClimbs — active-angle override (real DB)', () => {
+  beforeAll(async () => {
+    // Playlist tables aren't in the global per-file reset list, so own the cleanup.
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+
+    // climb-A (kilter): graded at BOTH 40° and 50°. 50° has far more ascents, so
+    // "most-ascents" = 50°. Added to the playlist at 50°.
+    await seedClimb('kilter', 'climb-a', 'On-board, has 40 stats');
+    await seedStats('kilter', 'climb-a', 40, 18, 5);
+    await seedStats('kilter', 'climb-a', 50, 22, 500);
+
+    // climb-B (kilter): graded ONLY at 50° (no 40° row). Added at 50°.
+    await seedClimb('kilter', 'climb-b', 'On-board, no 40 stats');
+    await seedStats('kilter', 'climb-b', 50, 21, 300);
+
+    // climb-C (tension): off the active board. Graded at 30°. Added at 30°.
+    await seedClimb('tension', 'climb-c', 'Off-board');
+    await seedStats('tension', 'climb-c', 30, 16, 50);
+
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public)
+      VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Active angle', true)
+    `);
+    await db.execute(sql`
+      INSERT INTO playlist_climbs (playlist_id, climb_uuid, angle, position)
+      VALUES (1, 'climb-a', 50, 0), (1, 'climb-b', 50, 1), (1, 'climb-c', 30, 2)
+    `);
+  });
+
+  it('renders on-active-board grades at the selected angle, falls back when stats are missing, and leaves off-board climbs alone', async () => {
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, activeBoardName: 'kilter', activeAngle: 40 } },
+      makeCtx(),
+    );
+
+    const byUuid = Object.fromEntries(result.climbs.map((climb) => [climb.uuid, climb]));
+
+    // climb-A: selected angle 40° beats the added-at (50°) AND the most-ascents
+    // angle (50°). The grade shown is the 40° grade, not the 50° one.
+    expect(byUuid['climb-a'].angle).toBe(40);
+    expect(byUuid['climb-a'].difficulty).toBeTruthy();
+
+    // climb-B: no stats at 40° → the EXISTS guard drops the override and the
+    // join falls back to most-ascents (50°). Crucially the grade is NOT blank.
+    expect(byUuid['climb-b'].angle).toBe(50);
+    expect(byUuid['climb-b'].difficulty).toBeTruthy();
+
+    // climb-C: different board → untouched by the kilter active board, stays 30°.
+    expect(byUuid['climb-c'].angle).toBe(30);
+    expect(byUuid['climb-c'].difficulty).toBeTruthy();
+  });
+
+  it('without an active board, on-board climbs still default to the most-ascents angle (unchanged behaviour)', async () => {
+    const result = await playlistQueries.playlistClimbs(null, { input: { playlistId: PLAYLIST_UUID } }, makeCtx());
+
+    const byUuid = Object.fromEntries(result.climbs.map((climb) => [climb.uuid, climb]));
+
+    // climb-A has a stored playlist angle of 50°, which wins as the override.
+    expect(byUuid['climb-a'].angle).toBe(50);
+    // climb-C keeps its stored 30°.
+    expect(byUuid['climb-c'].angle).toBe(30);
+  });
+});

--- a/packages/backend/src/__tests__/playlist-queries.test.ts
+++ b/packages/backend/src/__tests__/playlist-queries.test.ts
@@ -252,6 +252,71 @@ describe('playlistClimbs resolver', () => {
     expect(result.climbs[1].name).toBe('Tension Climb');
   });
 
+  it('renders on-active-board climbs at the selected angle and leaves off-board climbs on their added-at angle', async () => {
+    const ctx = makeCtx();
+
+    // 1. Playlist exists and is public
+    mockDb.select.mockReturnValueOnce(createMockChain([{ id: BigInt(1), isPublic: true }]));
+    // 2. Count query
+    mockDb.select.mockReturnValueOnce(createMockChain([{ count: 2 }]));
+    // 3. Refs: a kilter climb added at 40°, a tension climb added at 25°.
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        { climbUuid: 'climb-kilter', boardType: 'kilter', playlistAngle: 40 },
+        { climbUuid: 'climb-tension', boardType: 'tension', playlistAngle: 25 },
+      ]),
+    );
+    // 4. Hydrate rows. statsAngle is null here so the JS-resolved `angle` surfaces
+    // the override the resolver passed in — the kilter (active-board) climb should
+    // carry the selected angle (55), the tension (off-board) climb its added-at 25.
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          climbUuid: 'climb-kilter',
+          layoutId: 1,
+          boardType: 'kilter',
+          setter_username: 's',
+          name: 'Kilter Climb',
+          description: '',
+          frames: '',
+          statsAngle: null,
+          ascensionist_count: 10,
+          difficulty_id: 25,
+          quality_average: 3.5,
+          difficulty_error: 0.2,
+          benchmark_difficulty: null,
+        },
+        {
+          climbUuid: 'climb-tension',
+          layoutId: 2,
+          boardType: 'tension',
+          setter_username: 't',
+          name: 'Tension Climb',
+          description: '',
+          frames: '',
+          statsAngle: null,
+          ascensionist_count: 5,
+          difficulty_id: 15,
+          quality_average: 2.0,
+          difficulty_error: 0.1,
+          benchmark_difficulty: null,
+        },
+      ]),
+    );
+
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: 'test-pl', activeBoardName: 'kilter', activeAngle: 55 } },
+      ctx,
+    );
+
+    const byUuid = Object.fromEntries(result.climbs.map((climb) => [climb.uuid, climb]));
+    // Active-board climb: selected angle (55) wins over the added-at angle (40).
+    expect(byUuid['climb-kilter'].angle).toBe(55);
+    // Off-board climb: keeps its added-at angle (25), unaffected by the active board.
+    expect(byUuid['climb-tension'].angle).toBe(25);
+  });
+
   it('should return climbs in specific-board mode when boardName is provided', async () => {
     const ctx = makeCtx();
 

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/hydrate-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/hydrate-climbs.ts
@@ -39,6 +39,10 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
   const overrideEntries = [...(options?.angleOverrides ?? new Map<string, number | null>())].filter(
     (entry): entry is [string, number] => typeof entry[1] === 'number',
   );
+  // The override only wins when the climb actually has a stats row at that
+  // angle — the EXISTS guard makes a missing row yield NULL so the COALESCE
+  // falls through to the most-ascended angle rather than blanking the grade
+  // (a climb with no ascents at the user's selected angle still shows one).
   const overrideAngleExpr = overrideEntries.length
     ? sql`(SELECT ov.angle FROM (VALUES ${sql.join(
         overrideEntries.map(([key, angle]) => {
@@ -49,7 +53,13 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
         }),
         sql`, `,
       )}) AS ov(board_type, climb_uuid, angle)
-        WHERE ov.board_type = ${tables.climbs.boardType} AND ov.climb_uuid = ${tables.climbs.uuid})`
+        WHERE ov.board_type = ${tables.climbs.boardType} AND ov.climb_uuid = ${tables.climbs.uuid}
+          AND EXISTS (
+            SELECT 1 FROM board_climb_stats s_ov
+            WHERE s_ov.board_type = ${tables.climbs.boardType}
+              AND s_ov.climb_uuid = ${tables.climbs.uuid}
+              AND s_ov.angle = ov.angle
+          ))`
     : sql`NULL::int`;
 
   const rows = await db
@@ -108,7 +118,11 @@ export async function hydrateClimbsByRefs(refs: ClimbRef[], options?: HydrateCli
     const row = rowsByKey.get(key);
     if (!row) continue;
     const override = options?.angleOverrides?.get(key);
-    const angle = override ?? row.statsAngle ?? DEFAULT_ANGLE;
+    // Prefer the angle the stats row was actually joined at, so the returned
+    // `angle` always matches the difficulty/quality/ascents shown — the
+    // override can fall back to most-ascents (via the EXISTS guard above) when
+    // the climb has no stats at the requested angle.
+    const angle = row.statsAngle ?? override ?? DEFAULT_ANGLE;
     const boardName = (row.boardType || ref.boardType) as BoardName;
     climbs.push({
       uuid: row.climbUuid,

--- a/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/queries/playlist-climbs.ts
@@ -16,6 +16,10 @@ export type PlaylistClimbsInput = {
   sizeId?: number;
   setIds?: string;
   angle?: number;
+  // All-boards mode only: render on-active-board climbs at the user's selected
+  // angle instead of the added-at / most-ascents fallback.
+  activeBoardName?: string;
+  activeAngle?: number;
   page?: number;
   pageSize?: number;
 };
@@ -126,6 +130,7 @@ async function fetchSpecificBoardClimbs(
  */
 async function fetchAllBoardsClimbs(
   playlistId: bigint,
+  input: PlaylistClimbsInput,
   page: number,
   pageSize: number,
 ): Promise<{ climbs: Climb[]; hasMore: boolean }> {
@@ -146,9 +151,15 @@ async function fetchAllBoardsClimbs(
 
   const { items, hasMore } = paginateResults(refRows, pageSize);
 
+  // Climbs on the active board render their grade at the user's selected angle;
+  // every other climb keeps its added-at angle (most-ascents when null). The
+  // hydrator drops back to most-ascents if a climb has no stats at the override
+  // angle, so the selected angle never blanks a grade.
+  const { activeBoardName, activeAngle } = input;
   const angleOverrides = new Map<string, number | null>();
   for (const row of items) {
-    angleOverrides.set(`${row.boardType}:${row.climbUuid}`, row.playlistAngle ?? null);
+    const useActiveAngle = activeBoardName != null && activeAngle != null && row.boardType === activeBoardName;
+    angleOverrides.set(`${row.boardType}:${row.climbUuid}`, useActiveAngle ? activeAngle : (row.playlistAngle ?? null));
   }
 
   const climbs = await hydrateClimbsByRefs(
@@ -188,7 +199,7 @@ export const playlistClimbs = async (
     const { climbs, hasMore } = await fetchSpecificBoardClimbs(playlistId, input, page, pageSize);
     return { climbs, totalCount, hasMore };
   } else {
-    const { climbs, hasMore } = await fetchAllBoardsClimbs(playlistId, page, pageSize);
+    const { climbs, hasMore } = await fetchAllBoardsClimbs(playlistId, input, page, pageSize);
     return { climbs, totalCount, hasMore };
   }
 };

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -93,6 +93,10 @@ export const GetPlaylistClimbsInputSchema = z.object({
   sizeId: z.number().int().positive().optional(),
   setIds: z.string().min(1).optional(),
   angle: z.number().int().optional(),
+  // All-boards mode only: render on-active-board climbs' grades at the user's
+  // selected angle instead of the added-at / most-ascents fallback.
+  activeBoardName: BoardNameSchema.optional(),
+  activeAngle: z.number().int().min(0).max(90).optional(),
   page: z.number().int().min(0).optional(),
   pageSize: z.number().int().min(1).max(100).optional(),
 });

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -3,7 +3,12 @@ import { View, StyleSheet, Alert, Pressable } from 'react-native';
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { usePlaylistClimbs, usePlaylistMutations, usePlaylistItemMutations } from '@boardsesh/playlists-react';
+import {
+  usePlaylistClimbs,
+  usePlaylistMutations,
+  usePlaylistItemMutations,
+  type PlaylistClimbsBoardInput,
+} from '@boardsesh/playlists-react';
 import type { Climb } from '@boardsesh/queue';
 import {
   GET_PLAYLIST,
@@ -30,6 +35,7 @@ import {
 } from '../../../src/components/playlist';
 import { GlassIconButton } from '../../../src/components/GlassIconButton';
 import { getHttpClient } from '../../../src/lib/graphql/client';
+import { useActiveBoard } from '../../../src/lib/graphql/use-active-board';
 import { usePlaylistActivation } from '../../../src/lib/playlists/use-playlist-activation';
 import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-render-board';
 import { resolvePlaylistClimbRenderBoard } from '../../../src/lib/playlists/playlist-climb-render-board';
@@ -79,7 +85,23 @@ export default function PlaylistDetail() {
     enabled: !!playlistUuid,
   });
 
-  const { query, allClimbs } = usePlaylistClimbs({ playlistUuid });
+  // Render the list at the user's selected wall angle: in all-boards mode the
+  // resolver renders on-active-board climbs' grades at `activeAngle` instead of
+  // the added-at / most-ascents fallback. `boardName` is deliberately omitted so
+  // the resolver stays in all-boards mode and still lists off-board climbs
+  // (dimmed) rather than filtering them out.
+  const activeBoard = useActiveBoard().data ?? null;
+  const playlistClimbsBoardInput = useMemo<PlaylistClimbsBoardInput | undefined>(
+    () => (activeBoard ? { activeBoardName: activeBoard.boardType, activeAngle: activeBoard.angle } : undefined),
+    [activeBoard],
+  );
+  const { query, allClimbs } = usePlaylistClimbs({
+    playlistUuid,
+    // Key the cache by the active board so switching board/angle refetches at
+    // the new angle instead of serving stale grades.
+    boardUuid: activeBoard?.uuid ?? null,
+    boardInput: playlistClimbsBoardInput,
+  });
 
   // Suggestion-refresh fetcher: pages the same playlist scoped to the active
   // board so the play-drawer swipe walks the whole playlist on that board.

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1752,6 +1752,10 @@ input GetPlaylistClimbsInput {
   setIds: String
   "Board angle"
   angle: Int
+  "Active board type for grade rendering in all-boards mode (omit in specific-board mode). On-board climbs render their grade at activeAngle."
+  activeBoardName: String
+  "Selected wall angle to render grades at for on-active-board climbs in all-boards mode"
+  activeAngle: Int
   "Page number"
   page: Int
   "Page size"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1556,6 +1556,10 @@ export type GetMyPinnedPlaylistsInput = {
 
 /** Input for getting climbs in a playlist with full data. */
 export type GetPlaylistClimbsInput = {
+  /** Selected wall angle to render grades at for on-active-board climbs in all-boards mode */
+  activeAngle?: InputMaybe<Scalars['Int']['input']>;
+  /** Active board type for grade rendering in all-boards mode (omit in specific-board mode). On-board climbs render their grade at activeAngle. */
+  activeBoardName?: InputMaybe<Scalars['String']['input']>;
   /** Board angle */
   angle?: InputMaybe<Scalars['Int']['input']>;
   /** Board name for climb lookup (omit for all-boards mode) */

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -245,6 +245,10 @@ export const playlistsTypeDefs = /* GraphQL */ `
     setIds: String
     "Board angle"
     angle: Int
+    "Active board type for grade rendering in all-boards mode (omit in specific-board mode). On-board climbs render their grade at activeAngle."
+    activeBoardName: String
+    "Selected wall angle to render grades at for on-active-board climbs in all-boards mode"
+    activeAngle: Int
     "Page number"
     page: Int
     "Page size"

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1553,6 +1553,10 @@ export type GetMyPinnedPlaylistsInput = {
 
 /** Input for getting climbs in a playlist with full data. */
 export type GetPlaylistClimbsInput = {
+  /** Selected wall angle to render grades at for on-active-board climbs in all-boards mode */
+  activeAngle?: InputMaybe<Scalars['Int']['input']>;
+  /** Active board type for grade rendering in all-boards mode (omit in specific-board mode). On-board climbs render their grade at activeAngle. */
+  activeBoardName?: InputMaybe<Scalars['String']['input']>;
   /** Board angle */
   angle?: InputMaybe<Scalars['Int']['input']>;
   /** Board name for climb lookup (omit for all-boards mode) */

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -408,6 +408,10 @@ export type GetPlaylistClimbsInput = {
   sizeId?: number;
   setIds?: string;
   angle?: number;
+  // All-boards mode only: render on-active-board climbs' grades at the user's
+  // selected angle instead of the added-at / most-ascents fallback.
+  activeBoardName?: string;
+  activeAngle?: number;
   page?: number;
   pageSize?: number;
 };

--- a/packages/shared/playlists-react/src/use-playlist-climbs.ts
+++ b/packages/shared/playlists-react/src/use-playlist-climbs.ts
@@ -66,8 +66,15 @@ export function usePlaylistClimbs({
   const adapter = usePlaylistsAdapter();
   const executeGraphQL = executeGraphQLOverride ?? adapter.executeGraphQL;
 
+  // The selected angle parameterises the response (grades resolve at it), but a
+  // board's UUID is angle-agnostic — so the angle must be its own key segment.
+  // Without it, dialing to a new angle on the same board keeps the same key and
+  // React Query serves stale grades until staleTime lapses. Covers all-boards
+  // mode (activeAngle) and specific-board mode (angle).
+  const angleKey = boardInput?.activeAngle ?? boardInput?.angle ?? null;
+
   const query = useInfiniteQuery({
-    queryKey: ['playlistClimbs', playlistUuid, boardUuid ?? 'all', refreshKey],
+    queryKey: ['playlistClimbs', playlistUuid, boardUuid ?? 'all', angleKey, refreshKey],
     queryFn: async ({ pageParam }) => {
       const input: GetPlaylistClimbsInput = {
         playlistId: playlistUuid,


### PR DESCRIPTION
## Summary

Closes #1596.

In a playlist, a climb's grade showed the angle with the **most ascents** instead of the wall angle you'd selected — e.g. V13 (the popular angle) when you were set to 40° and the climb is V12 there. Confirmed on iOS.

The mobile playlist list runs in **all-boards mode** (so mixed-board playlists still show every climb, dimming the ones that don't fit your board). That path never told the server which angle was selected, so the grade fell back to the most-ascended angle. Web already passes a concrete board + angle when a board is picked, so it wasn't affected.

What changed:
- Added optional `activeBoardName` / `activeAngle` to the all-boards `playlistClimbs` input. Climbs on your active board now resolve their grade at the **selected** angle; off-board climbs keep their added-at / most-ascents fallback, so mixed-board playlists still list everything.
- `hydrateClimbsByRefs` gained an `EXISTS` guard: if a climb has no stats at the selected angle, the angle `COALESCE` drops back to the most-ascents angle instead of blanking the grade. The returned `angle` now follows the stats row that was actually joined, so the angle and the grade always agree.
- Mobile playlist screen reads the active board and keys the query on it, so switching board/angle refetches at the new angle.

## Release Notes

- Playlist grades now match the wall angle you've dialed in, instead of a climb's most-popular angle

## Test plan

- `vp run typecheck` (all packages) — green
- `vp run test:mobile` — 2516 passed
- Backend tests for the touched areas — `hydrate-climbs`, `playlist-queries`, `smart-playlists`, `operations-schema-validation`, `resolver-frames-fields` all green
- New real-DB integration test `playlist-climbs-active-angle.test.ts` proves: on-board climb renders at the selected angle (40°, not its most-ascents 50°); a climb with no stats at 40° falls back to most-ascents (grade not blanked); an off-board climb is untouched
- `vp run codegen` — generated schema/types regenerated, no drift
- Pre-existing unrelated failures in `integration.test.ts` / `board-presence.test.ts` (WebSocket daemon) reproduce on a clean tree without these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157PsyHaLfWs8aXxN1T3No9
