### PR TITLE
fix(web): label BLE send failures by real cause, not characteristic_unavailable

### DIFF
--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -12,6 +12,7 @@ import {
 import { getMoonboardBluetoothPacket, isMoonboardDeviceName } from '@boardsesh/ble-protocol/moonboard';
 import {
   classifyBleFailure,
+  classifyBleFailureReason,
   isDisconnectionError,
   type BleFailureCategory,
 } from '@boardsesh/ble-protocol/connection-error';
@@ -239,13 +240,6 @@ function mergeAbortSignals(signalA: AbortSignal, signalB: AbortSignal): { signal
   signalB.addEventListener('abort', onAbort);
 
   return { signal: controller.signal, dispose: detach };
-}
-
-function classifyBleFailureReason(error: unknown): string {
-  if (isDisconnectionError(error)) return 'disconnected';
-  if (error instanceof Error && error.message.includes('Mirrored hold ID')) return 'missing_mirror_mapping';
-  if (error instanceof DOMException) return `dom_${error.name || 'exception'}`;
-  return 'write_failed';
 }
 
 export function useBoardBluetooth({

--- a/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { classifyBleFailure, isDisconnectionError, type BleFailureCategory } from '../connection-error';
+import {
+  classifyBleFailure,
+  classifyBleFailureReason,
+  isDisconnectionError,
+  type BleFailureCategory,
+  type BleSendFailureReason,
+} from '../connection-error';
 
 // Mimics a react-native-ble-plx BleError: an Error subclass whose `name` is
 // 'BleError' (so the predicate classifies from the message, not the name).
@@ -156,6 +162,41 @@ describe('isDisconnectionError', () => {
   for (const { name, error } of notDisconnects) {
     it(`treats as non-disconnect: ${name}`, () => {
       expect(isDisconnectionError(error)).toBe(false);
+    });
+  }
+});
+
+describe('classifyBleFailureReason', () => {
+  const cases: Array<{ name: string; error: unknown; expected: BleSendFailureReason }> = [
+    // A dead-link write is the dominant real cause — it must win over the
+    // DOMException fallback (NetworkError is a DOMException too).
+    {
+      name: 'web NetworkError (GATT disconnected)',
+      error: new DOMException('GATT Server is disconnected.', 'NetworkError'),
+      expected: 'disconnected',
+    },
+    { name: 'native "Not connected"', error: new Error('Not connected'), expected: 'disconnected' },
+    // The mirror builder throws this exact phrase when a hold has no mirror id.
+    {
+      name: 'mirror mapping missing',
+      error: new Error('Mirrored hold ID is not defined for hold ID 42.'),
+      expected: 'missing_mirror_mapping',
+    },
+    // A DOMException we don't otherwise classify is namespaced by its name.
+    {
+      name: 'unclassified DOMException',
+      error: new DOMException('boom', 'OperationError'),
+      expected: 'dom_OperationError',
+    },
+    { name: 'DOMException with empty name', error: new DOMException('boom', ''), expected: 'dom_exception' },
+    // Anything else thrown on a live link.
+    { name: 'opaque write error', error: new Error('something opaque'), expected: 'write_failed' },
+    { name: 'plain string', error: 'a plain string', expected: 'write_failed' },
+  ];
+
+  for (const { name, error, expected } of cases) {
+    it(`classifies: ${name} -> ${expected}`, () => {
+      expect(classifyBleFailureReason(error)).toBe(expected);
     });
   }
 });

--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -16,6 +16,23 @@ export type BleFailureCategory =
   | 'service_missing' // connected but UART service/characteristic absent
   | 'unknown';
 
+/**
+ * Reason a *send* to the board failed, tracked on `Climb Sent to Board Failure`.
+ * The classifier below covers the thrown-during-write cases; callers also set
+ * the explicit, pre-write reasons (`incompatible_climb`, `missing_led_placements`,
+ * `missing_mirror_data`) directly at their return-false sites. Kept as one union
+ * so web and mobile emit byte-identical strings and the reliability metric is
+ * comparable across platforms.
+ */
+export type BleSendFailureReason =
+  | 'disconnected' // write threw on a dead GATT link (board dropped / stolen)
+  | 'incompatible_climb' // every placement skipped — climb is for another board
+  | 'missing_led_placements' // LED placement map empty for this board config
+  | 'missing_mirror_data' // mirroring requested but holdsData absent (pre-write)
+  | 'missing_mirror_mapping' // a hold had no mirrored id while building the mirror
+  | 'write_failed' // any other thrown write failure on a live link
+  | `dom_${string}`; // a DOMException name we don't otherwise classify
+
 function errorName(error: unknown): string | undefined {
   // Guard DOMException for non-DOM environments (native iOS adapter does the
   // same) — `instanceof DOMException` would throw a ReferenceError otherwise.
@@ -124,4 +141,23 @@ export function isDisconnectionError(error: unknown): boolean {
   return /GATT (server|operation).*(disconnect|not connected)|not connected|disconnected|peripheral.*(disconnect|unreachable)/i.test(
     message,
   );
+}
+
+/**
+ * Classify an error thrown from a *send* (BLE write) into a `failureReason` for
+ * the `Climb Sent to Board Failure` event. The dominant real cause on these
+ * last-connection-wins boards is a mid-session disconnect — surfacing it as
+ * `disconnected` (instead of a generic bucket) is what makes the reliability gap
+ * visible in analytics. Pure TS so both the web and mobile hooks share one
+ * source of truth. DOMException is feature-detected because the native iOS /
+ * Android RN adapters run where it may be undefined.
+ */
+export function classifyBleFailureReason(error: unknown): BleSendFailureReason {
+  if (isDisconnectionError(error)) return 'disconnected';
+  // `convertToMirroredFramesString` throws this when a hold has no mirrored id.
+  if (error instanceof Error && error.message.includes('Mirrored hold ID')) return 'missing_mirror_mapping';
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
+    return `dom_${error.name || 'exception'}`;
+  }
+  return 'write_failed';
 }

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-board-presence.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-board-presence.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../use-board-bluetooth', () => ({
       connect: vi.fn(),
       disconnect: vi.fn(),
       sendFramesToBoard: mockSendFrames,
+      lastSendFailureReasonRef: { current: null },
       pickerState: null,
       reconnectSerialForCurrentBoard: null,
     };

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { BluetoothProvider, useBluetoothContext } from '../bluetooth-context';
 import type { BoardDetails } from '@/app/lib/types';
+import type { BleSendFailureReason } from '@boardsesh/ble-protocol/connection-error';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
 vi.mock('react-i18next', () => ({
@@ -31,12 +32,18 @@ type PickerStateMock = {
   handleCancel: () => void;
 } | null;
 
+// Mirrors the ref the real hook returns. The hook sets `.current` synchronously
+// on its failing path before resolving `false`; tests pre-set it to simulate
+// that, since the AutoSender reads it right after the awaited send resolves.
+const mockSendFailureReasonRef: { current: BleSendFailureReason | null } = { current: null };
+
 let mockBluetoothState = {
   isConnected: false,
   loading: false,
   connect: mockConnect,
   disconnect: mockDisconnect,
   sendFramesToBoard: mockSendFramesToBoard,
+  lastSendFailureReasonRef: mockSendFailureReasonRef,
 };
 let mockPickerState: PickerStateMock = null;
 
@@ -208,12 +215,14 @@ describe('BluetoothProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCurrentClimbQueueItem = null;
+    mockSendFailureReasonRef.current = null;
     mockBluetoothState = {
       isConnected: false,
       loading: false,
       connect: mockConnect,
       disconnect: mockDisconnect,
       sendFramesToBoard: mockSendFramesToBoard,
+      lastSendFailureReasonRef: mockSendFailureReasonRef,
     };
     mockPickerState = null;
     lastPickerProps = null;
@@ -359,7 +368,78 @@ describe('BluetoothProvider', () => {
       });
     });
 
-    it('tracks failure analytics when send fails', async () => {
+    // The hook reports the precise cause via the ref; the AutoSender must label
+    // the failure with that reason — not the retired catch-all
+    // `characteristic_unavailable`, which hid the dominant mid-session drop.
+    const failureReasons: BleSendFailureReason[] = [
+      'disconnected',
+      'incompatible_climb',
+      'missing_led_placements',
+      'missing_mirror_data',
+      'write_failed',
+    ];
+    for (const reason of failureReasons) {
+      it(`tracks failure with the hook-reported reason: ${reason}`, async () => {
+        mockSendFailureReasonRef.current = reason;
+        mockSendFramesToBoard.mockResolvedValue(false);
+        mockCurrentClimbQueueItem = {
+          climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+        };
+        mockBluetoothState.isConnected = true;
+
+        renderHook(() => useBluetoothContext(), {
+          wrapper: createWrapper(),
+        });
+
+        await act(async () => {
+          await vi.waitFor(() => {
+            expect(mockTrack).toHaveBeenCalledWith('Climb Sent to Board Failure', {
+              climbUuid: 'climb-1',
+              boardLayout: 'Original',
+              boardId: undefined,
+              failureReason: reason,
+              climbHoldCount: 1,
+            });
+          });
+        });
+
+        // The misnomer must be gone for good.
+        expect(mockTrack).not.toHaveBeenCalledWith(
+          'Climb Sent to Board Failure',
+          expect.objectContaining({ failureReason: 'characteristic_unavailable' }),
+        );
+      });
+    }
+
+    it('reads the reason the hook set at resolution time (not a hardcoded label)', async () => {
+      // Faithful to the real hook: set the ref synchronously on the failing path
+      // right before resolving false. The AutoSender reads it in the same
+      // microtask the await resolves in.
+      mockSendFramesToBoard.mockImplementation(async () => {
+        mockSendFailureReasonRef.current = 'disconnected';
+        return false;
+      });
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.waitFor(() => {
+          expect(mockTrack).toHaveBeenCalledWith(
+            'Climb Sent to Board Failure',
+            expect.objectContaining({ failureReason: 'disconnected' }),
+          );
+        });
+      });
+    });
+
+    it('falls back to "unknown" when the hook left no reason', async () => {
+      mockSendFailureReasonRef.current = null;
       mockSendFramesToBoard.mockResolvedValue(false);
       mockCurrentClimbQueueItem = {
         climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
@@ -372,13 +452,10 @@ describe('BluetoothProvider', () => {
 
       await act(async () => {
         await vi.waitFor(() => {
-          expect(mockTrack).toHaveBeenCalledWith('Climb Sent to Board Failure', {
-            climbUuid: 'climb-1',
-            boardLayout: 'Original',
-            boardId: undefined,
-            failureReason: 'characteristic_unavailable',
-            climbHoldCount: 1,
-          });
+          expect(mockTrack).toHaveBeenCalledWith(
+            'Climb Sent to Board Failure',
+            expect.objectContaining({ failureReason: 'unknown' }),
+          );
         });
       });
     });
@@ -429,6 +506,52 @@ describe('BluetoothProvider', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith('Error sending climb to board:', expect.any(Error));
       consoleSpy.mockRestore();
+    });
+
+    // Part B regression: after a mid-session drop the AutoSender unmounts
+    // (isConnected → false), and on the take-back reconnect it remounts with a
+    // fresh dedup signature — which re-sends the queued climb on its own. This
+    // is the silent-drop recovery; it must fire EXACTLY ONCE per reconnect (no
+    // explicit reassert stacked on top, which would double-send and double-count
+    // analytics).
+    it('re-sends the current climb exactly once after a drop and take-back reconnect', async () => {
+      mockSendFramesToBoard.mockResolvedValue(true);
+      mockCurrentClimbQueueItem = {
+        climb: { uuid: 'climb-1', frames: 'p1r12', mirrored: false },
+      };
+      mockBluetoothState.isConnected = true;
+
+      const { rerender, result } = renderHook(() => useBluetoothContext(), {
+        wrapper: createWrapper(),
+      });
+
+      // Initial connection: AutoSender mounts and sends the climb once.
+      await act(async () => {
+        await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1));
+      });
+
+      // Board dropped: AutoSender unmounts, no further sends.
+      await act(async () => {
+        mockBluetoothState.isConnected = false;
+        rerender();
+      });
+      expect(result.current.isConnected).toBe(false);
+      expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1);
+
+      // Take-back reconnect: AutoSender remounts (fresh dedup signature) and
+      // re-lights the same climb. Let the remount's send effect drain.
+      await act(async () => {
+        mockBluetoothState.isConnected = true;
+        rerender();
+        await new Promise((resolve) => setTimeout(resolve, 60));
+      });
+
+      // Exactly one re-send for the unchanged climb — never a double.
+      expect(mockSendFramesToBoard).toHaveBeenCalledTimes(2);
+      expect(mockTrack).toHaveBeenCalledWith(
+        'Climb Sent to Board Success',
+        expect.objectContaining({ climbUuid: 'climb-1' }),
+      );
     });
   });
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/use-board-bluetooth.test.ts
@@ -397,11 +397,57 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(sendResult).toBe(false);
+    expect(result.current.lastSendFailureReasonRef.current).toBe('missing_led_placements');
     expect(mockShowMessage).toHaveBeenCalledWith(
       'Could not send to board — LED data missing for this board configuration.',
       'error',
     );
     expect(mockAdapter.write).not.toHaveBeenCalledWith(new Uint8Array([1, 2, 3]), undefined);
+  });
+
+  it('records incompatible_climb when every Aurora placement is skipped', async () => {
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Empty packet + skipped placements => the climb is for a different board.
+    mockGetAuroraBluetoothPacket.mockReturnValueOnce({
+      packet: new Uint8Array([]),
+      skippedPositionCount: 3,
+      skippedRoleCount: 0,
+      totalPlacements: 3,
+    });
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let sendResult: boolean | undefined;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p4131r42');
+    });
+
+    expect(sendResult).toBe(false);
+    expect(result.current.lastSendFailureReasonRef.current).toBe('incompatible_climb');
+    expect(mockShowMessage).toHaveBeenCalledWith('This climb is for a different board configuration.', 'error');
+    warnSpy.mockRestore();
+  });
+
+  it('records missing_mirror_data when a mirrored send has no holdsData', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // mockBoardDetails advertises supportsMirroring but carries no holdsData,
+    // so a mirrored send can't build the mirror and bails before the write.
+    const { result } = renderHook(() => useBoardBluetooth({ boardDetails: mockBoardDetails }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    let sendResult: boolean | undefined;
+    await act(async () => {
+      sendResult = await result.current.sendFramesToBoard('p4131r42', true);
+    });
+
+    expect(sendResult).toBe(false);
+    expect(result.current.lastSendFailureReasonRef.current).toBe('missing_mirror_data');
+    errorSpy.mockRestore();
   });
 
   // Traditional `[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/...` routes
@@ -654,6 +700,13 @@ describe('useBoardBluetooth', () => {
 
       expect(sendResult).toBe(false);
       expect(result.current.isConnected).toBe(false);
+      // The real cause is recorded for the AutoSender to label, and the
+      // tug-of-war is tracked (mirrors mobile) instead of staying silent.
+      expect(result.current.lastSendFailureReasonRef.current).toBe('disconnected');
+      expect(mockTrack).toHaveBeenCalledWith('Bluetooth Connection Stolen', {
+        boardLayout: 'Original',
+        boardId: undefined,
+      });
       errorSpy.mockRestore();
     });
 
@@ -677,6 +730,11 @@ describe('useBoardBluetooth', () => {
 
       expect(sendResult).toBe(false);
       expect(result.current.isConnected).toBe(false);
+      expect(result.current.lastSendFailureReasonRef.current).toBe('disconnected');
+      expect(mockTrack).toHaveBeenCalledWith('Bluetooth Connection Stolen', {
+        boardLayout: 'Original',
+        boardId: undefined,
+      });
       errorSpy.mockRestore();
     });
 
@@ -697,6 +755,9 @@ describe('useBoardBluetooth', () => {
 
       expect(sendResult).toBe(false);
       expect(result.current.isConnected).toBe(true);
+      // A live-link write failure is `write_failed`, NOT a stolen-board signal.
+      expect(result.current.lastSendFailureReasonRef.current).toBe('write_failed');
+      expect(mockTrack).not.toHaveBeenCalledWith('Bluetooth Connection Stolen', expect.anything());
       errorSpy.mockRestore();
     });
   });

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-context.tsx
@@ -33,6 +33,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import type { BoardPresenceClimb, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 import type { DiscoveredDevice } from '@/app/lib/ble/types';
 import type { PickerState } from './use-board-bluetooth';
+import type { BleSendFailureReason } from '@boardsesh/ble-protocol/connection-error';
 import { useLedColorOverrides, type LedColorOverrides } from '@/app/lib/led-color-overrides-db';
 import { accumulateFramesToMaps, accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
 import type { BoardName } from '@boardsesh/shared-schema';
@@ -140,6 +141,7 @@ function presenceClimbToQueueItemInput(presenceClimb: BoardPresenceClimb): Climb
 
 function BluetoothAutoSender({
   sendFramesToBoard,
+  lastSendFailureReasonRef,
   layoutName,
   boardName,
   boardId,
@@ -152,6 +154,12 @@ function BluetoothAutoSender({
     signal?: AbortSignal,
     climbUuid?: string,
   ) => Promise<boolean | undefined>;
+  /**
+   * The reason the hook's most recent `sendFramesToBoard` returned `false`,
+   * read synchronously on the `false` branch below to label the failure with
+   * its real cause. See the ref's declaration in `use-board-bluetooth.ts`.
+   */
+  lastSendFailureReasonRef: React.RefObject<BleSendFailureReason | null>;
   layoutName: string;
   boardName: BoardName;
   boardId: number | null;
@@ -301,11 +309,17 @@ function BluetoothAutoSender({
               // and via WS broadcast for other party members).
               onWallConfirmedRef.current(item, sendSignature);
             } else if (result === false) {
+              // The hook set this synchronously on its failing path right before
+              // returning false; we read it here in the same microtask the await
+              // resolved in, so the real cause — usually `disconnected` after a
+              // mid-session board drop — is recorded instead of the old catch-all
+              // `characteristic_unavailable`.
+              const failureReason = lastSendFailureReasonRef.current ?? 'unknown';
               track('Climb Sent to Board Failure', {
                 climbUuid: item.climb?.uuid,
                 boardLayout: layoutName,
                 boardId: boardId ?? undefined,
-                failureReason: 'characteristic_unavailable',
+                failureReason,
                 climbHoldCount,
               });
             }
@@ -483,15 +497,23 @@ export function BluetoothProvider({
     [setSessionBoardSerial, boardDetails, resetReportDedup],
   );
 
-  const { isConnected, loading, connect, disconnect, sendFramesToBoard, pickerState, reconnectSerialForCurrentBoard } =
-    useBoardBluetooth({
-      boardDetails: boardDetails ?? undefined,
-      boardUuid,
-      ledColorOverrides,
-      analyticsBoardId: presenceBoardId,
-      onConnectSuccess: handleConnectSuccess,
-      onConnectionChange: handleConnectionChange,
-    });
+  const {
+    isConnected,
+    loading,
+    connect,
+    disconnect,
+    sendFramesToBoard,
+    lastSendFailureReasonRef,
+    pickerState,
+    reconnectSerialForCurrentBoard,
+  } = useBoardBluetooth({
+    boardDetails: boardDetails ?? undefined,
+    boardUuid,
+    ledColorOverrides,
+    analyticsBoardId: presenceBoardId,
+    onConnectSuccess: handleConnectSuccess,
+    onConnectionChange: handleConnectionChange,
+  });
 
   // Bumped by reassertWall() to force the auto-sender to re-push the current
   // climb once even when it's byte-identical to the last send.
@@ -906,6 +928,7 @@ export function BluetoothProvider({
       {isConnected && partyMode === 'off' && boardDetails && (
         <BluetoothAutoSender
           sendFramesToBoard={sendFramesToBoard}
+          lastSendFailureReasonRef={lastSendFailureReasonRef}
           layoutName={boardDetails.layout_name ?? ''}
           boardName={boardDetails.board_name}
           boardId={presenceBoardId}

--- a/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
+++ b/packages/web/app/components/board-bluetooth-control/use-board-bluetooth.ts
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { classifyBleFailure, isDisconnectionError } from '@boardsesh/ble-protocol/connection-error';
+import {
+  classifyBleFailure,
+  classifyBleFailureReason,
+  type BleSendFailureReason,
+} from '@boardsesh/ble-protocol/connection-error';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { normaliseSetIds } from '@/app/lib/ble/board-config-match';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { RECORD_BOARD_SERIAL } from '@boardsesh/graphql/operations';
@@ -222,6 +227,17 @@ export function useBoardBluetooth({
   // listener on every change.
   const reconnectSerialRef = useRef<string | null>(null);
 
+  // The reason the most recent `sendFramesToBoard` returned `false`. The
+  // AutoSender reads this synchronously right after its own `await` resolves to
+  // `false` to label `Climb Sent to Board Failure` with the real cause —
+  // `disconnected` dominates, not the old catch-all `characteristic_unavailable`.
+  // Set immediately before EVERY `return false` below (never reset elsewhere);
+  // the AutoSender only reads it on the `false` branch, so a stale value left by
+  // a prior successful send is never observed. Writes serialise through
+  // `writeChainRef`, so a concurrent play-view send can't overwrite this between
+  // a failing call resolving and the AutoSender's same-microtask read.
+  const lastSendFailureReasonRef = useRef<BleSendFailureReason | null>(null);
+
   // Device picker state for custom Capacitor scanning.
   // pickerRejectRef holds the pending promise's reject so unmount cleanup
   // can drain it, which causes the adapter's finally block to call stopLEScan.
@@ -368,6 +384,7 @@ export function useBoardBluetooth({
               },
             );
             showMessage('This climb has unrecognised hold data and cannot be sent to the board.', 'error');
+            lastSendFailureReasonRef.current = 'incompatible_climb';
             return false;
           }
 
@@ -406,6 +423,7 @@ export function useBoardBluetooth({
         if (mirrored && boardDetails.supportsMirroring === true) {
           if (!boardDetails.holdsData || Object.keys(boardDetails.holdsData).length === 0) {
             console.error('Cannot mirror frames: holdsData is missing or empty');
+            lastSendFailureReasonRef.current = 'missing_mirror_data';
             return false;
           }
           framesToSend = convertToMirroredFramesString(frames, boardDetails.holdsData);
@@ -428,6 +446,7 @@ export function useBoardBluetooth({
               'Board configuration may be incorrect or LED data may need regeneration.',
           );
           showMessage('Could not send to board — LED data missing for this board configuration.', 'error');
+          lastSendFailureReasonRef.current = 'missing_led_placements';
           return false;
         }
 
@@ -459,6 +478,7 @@ export function useBoardBluetooth({
             },
           );
           showMessage('This climb is for a different board configuration.', 'error');
+          lastSendFailureReasonRef.current = 'incompatible_climb';
           return false;
         }
 
@@ -496,19 +516,26 @@ export function useBoardBluetooth({
           return;
         }
         console.error('Error sending frames to board:', error);
+        const failureReason = classifyBleFailureReason(error);
+        lastSendFailureReasonRef.current = failureReason;
         // A write that fails because the GATT link is gone (the board dropped or
         // another device grabbed it — these boards are last-connection-wins) is
         // the only signal we get when the adapter's disconnect event never
-        // fires. Mark the connection lost so the lightbulb stops showing
-        // "connected" and a deliberate reconnect can run. handleDisconnection
-        // dedups its own take-back prompt, so a burst of failing writes is safe.
-        if (isDisconnectionError(error)) {
+        // fires. Record the tug-of-war (mirrors mobile's BluetoothConnectionStolen)
+        // and mark the connection lost so the lightbulb stops showing "connected"
+        // and a deliberate reconnect can run. handleDisconnection dedups its own
+        // take-back prompt, so a burst of failing writes is safe.
+        if (failureReason === 'disconnected') {
+          track(SHARED_EVENTS.BluetoothConnectionStolen, {
+            boardLayout: `${boardDetails.layout_name}`,
+            boardId: analyticsBoardId ?? undefined,
+          });
           handleDisconnection();
         }
         return false;
       }
     },
-    [boardDetails, showMessage, ledColorOverrides, serialisedWrite, handleDisconnection],
+    [boardDetails, showMessage, ledColorOverrides, serialisedWrite, handleDisconnection, analyticsBoardId],
   );
 
   const configureConnectedBoard = useCallback(
@@ -802,6 +829,7 @@ export function useBoardBluetooth({
     connect,
     disconnect,
     sendFramesToBoard,
+    lastSendFailureReasonRef,
     pickerState,
     reconnectSerialForCurrentBoard,
   };


### PR DESCRIPTION
## Summary

Closes #3084.

The web/Capacitor AutoSender tagged **every** failed `sendFramesToBoard()` as `failureReason: 'characteristic_unavailable'`. PostHog (30d) shows that's 98.4% of all send failures (5120 events, all `lib=js`) — but there is no characteristic-discovery bug. The dominant real cause is a mid-session BLE drop: another phone grabs the last-connection-wins board, a GATT write throws, `isDisconnectionError` matches, the hook runs `handleDisconnection()` and returns `false`, and the AutoSender blindly stamped it `characteristic_unavailable`. The misnomer hid the real ~9% reliability gap.

This makes the hook report the precise cause and the AutoSender label the `Climb Sent to Board Failure` event with it — mirroring mobile's `classifyBleFailureReason`.

### What changed
- **Shared classifier**: `classifyBleFailureReason` + `BleSendFailureReason` move into `@boardsesh/ble-protocol/connection-error`; mobile's local copy is deleted so web and mobile emit byte-identical strings.
- **Web hook** (`use-board-bluetooth.ts`): sets a `lastSendFailureReasonRef` synchronously at every `return false` site (`disconnected`, `incompatible_climb`, `missing_led_placements`, `missing_mirror_data`, `missing_mirror_mapping`, `write_failed`), and emits `Bluetooth Connection Stolen` on a disconnect-during-write (mobile parity). The retired `characteristic_unavailable` string is gone.
- **AutoSender** (`bluetooth-context.tsx`): reads that ref on the `false` branch (same microtask the awaited send resolved in — race-safe because writes serialize through `writeChainRef`) and uses it as `failureReason`.
- **Drop recovery**: tracing showed a take-back reconnect already re-lights the queued climb — the AutoSender unmounts on `isConnected→false` and remounts with a fresh dedup signature, re-sending exactly once. So instead of adding a `reassertWall()` (which would **double-send**), we add a regression test locking that single re-send in.

### Why the ref (not a richer return type)
Callers (`light-control-drawer`, hook tests) use exact `=== false`/`=== true` checks; a discriminated-union return would ripple through all of them for no behavioural gain.

## Release Notes

- [x] No release note needed (internal / telemetry change — no user-facing UI change)

## Test plan

- `vp test run --project web` — **4749 passed**, incl. new per-reason labelling, `Bluetooth Connection Stolen` on disconnect-write, the `unknown` fallback, and the drop→reconnect single-re-send regression.
- `vp test run --reporter=agent connection-error` — shared classifier units (43 passed).
- `vp run test:mobile` — mobile parity, 43 passed (local classifier removed).
- `vp run typecheck:web`, `typecheck:mobile`, `typecheck:shared` — green.
- `vp check` — lint + format clean on changed files.
- Real BLE / Web Bluetooth can't be exercised headless; manual smoke notes in `.boardsesh/qa-notes.md`. Telemetry shift is observable post-merge in PostHog (`characteristic_unavailable` → split across granular reasons; `disconnected` should dominate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bhp2ZRaVMe231FPiAk4Mxv