### PR TITLE
test(web): polish BLE failure-reason relabel (post-merge review notes)

### DIFF
--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -31,6 +31,7 @@ export type BleSendFailureReason =
   | 'missing_mirror_data' // mirroring requested but holdsData absent (pre-write)
   | 'missing_mirror_mapping' // a hold had no mirrored id while building the mirror
   | 'write_failed' // any other thrown write failure on a live link
+  | 'unknown' // defensive fallback: a `false` send left no reason set (unreachable in practice)
   | `dom_${string}`; // a DOMException name we don't otherwise classify
 
 function errorName(error: unknown): string | undefined {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-context.test.tsx
@@ -371,6 +371,11 @@ describe('BluetoothProvider', () => {
     // The hook reports the precise cause via the ref; the AutoSender must label
     // the failure with that reason — not the retired catch-all
     // `characteristic_unavailable`, which hid the dominant mid-session drop.
+    // These are the reasons the hook sets synchronously on a `return false`. The
+    // throw-path reasons (`missing_mirror_mapping`, `dom_*`) come from the hook's
+    // catch via `classifyBleFailureReason` and are unit-tested directly in
+    // connection-error.test.ts; from the AutoSender's side they read identically
+    // through the same ref, so they aren't re-parametrized here.
     const failureReasons: BleSendFailureReason[] = [
       'disconnected',
       'incompatible_climb',
@@ -538,13 +543,15 @@ describe('BluetoothProvider', () => {
       expect(result.current.isConnected).toBe(false);
       expect(mockSendFramesToBoard).toHaveBeenCalledTimes(1);
 
-      // Take-back reconnect: AutoSender remounts (fresh dedup signature) and
-      // re-lights the same climb. Let the remount's send effect drain.
+      // Take-back reconnect: commit the remount (fresh dedup signature) inside
+      // act, then poll OUTSIDE act for the remount's async send — polling rather
+      // than a fixed delay so the assertion holds under slow CI. (vi.waitFor
+      // nested inside act doesn't advance the drain here.)
       await act(async () => {
         mockBluetoothState.isConnected = true;
         rerender();
-        await new Promise((resolve) => setTimeout(resolve, 60));
       });
+      await vi.waitFor(() => expect(mockSendFramesToBoard).toHaveBeenCalledTimes(2));
 
       // Exactly one re-send for the unchanged climb — never a double.
       expect(mockSendFramesToBoard).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

Follow-up to #3091 (merged before these review-note fixups could land). Lands the three non-blocking `claude-review` suggestions from that PR:

1. Add `'unknown'` to the `BleSendFailureReason` union so the AutoSender's defensive fallback is part of the typed analytics vocabulary (unreachable in practice — every `return false` path sets the ref).
2. Comment on the parametrized failure-reason test array explaining why the throw-path reasons (`missing_mirror_mapping`, `dom_*`) are absent — they're covered by the shared classifier's own unit tests.
3. Replace the fixed `setTimeout(60)` in the drop/reconnect regression with `vi.waitFor` polling so the assertion holds under slow CI.

No behaviour change; the merged fix already worked. This is type-safety and test-robustness polish only.

## Release Notes

- [x] No release note needed (internal / tests)

## Test plan

- `vp test run --project web --reporter=agent bluetooth-context` — 52 passed (incl. the now-`vi.waitFor` regression).
- `vp test run --reporter=agent connection-error` — 43 passed (the `'unknown'` union member typechecks).
- `vp run typecheck:shared` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bhp2ZRaVMe231FPiAk4Mxv