### PR TITLE
Fix(Put caching and holds prewarming to background tasks)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback, useMemo, useRef, useEffect, type ComponentProps } from 'react';
-import { View, StyleSheet, RefreshControl, Keyboard } from 'react-native';
+import { View, StyleSheet, RefreshControl, Keyboard, InteractionManager } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -375,15 +375,21 @@ function ClimbListInner() {
 
   useEffect(() => {
     if (!boardConfig || !searchReady) return;
+    let task: ReturnType<typeof InteractionManager.runAfterInteractions> | null = null;
     const timeout = setTimeout(() => {
-      prewarmCreateBoardHolds({
-        boardName: boardConfig.boardName as BoardName,
-        layoutId: boardConfig.layoutId,
-        sizeId: boardConfig.sizeId,
-        setIds: parseSetIdsParam(boardConfig.setIds),
+      task = InteractionManager.runAfterInteractions(() => {
+        prewarmCreateBoardHolds({
+          boardName: boardConfig.boardName as BoardName,
+          layoutId: boardConfig.layoutId,
+          sizeId: boardConfig.sizeId,
+          setIds: parseSetIdsParam(boardConfig.setIds),
+        });
       });
     }, PREWARM_BOARD_HOLDS_DELAY_MS);
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+      task?.cancel();
+    };
   }, [boardConfig, searchReady]);
 
   useEffect(() => {
@@ -426,13 +432,18 @@ function ClimbListInner() {
   // over HTTP (the production CDN/WAF 403s the app's request).
   useEffect(() => {
     if (!activeBoard) return;
-    const parsedSetIds = activeBoard.setIds.split(',').map(Number);
-    void ensureBackgroundsCached({
-      boardName: activeBoard.boardType as BoardName,
-      layoutId: activeBoard.layoutId,
-      sizeId: activeBoard.sizeId,
-      setIds: parsedSetIds,
+    const task = InteractionManager.runAfterInteractions(() => {
+      const parsedSetIds = activeBoard.setIds.split(',').map(Number);
+      void ensureBackgroundsCached({
+        boardName: activeBoard.boardType as BoardName,
+        layoutId: activeBoard.layoutId,
+        sizeId: activeBoard.sizeId,
+        setIds: parsedSetIds,
+      });
     });
+    return () => {
+      task.cancel();
+    };
   }, [activeBoard]);
 
   const searchInput = useMemo(


### PR DESCRIPTION
## Summary
Fixing issue that makes the app go stale due to heavy foreground tasks, so moved them to background

## Release Notes

<!--
The line(s) below ship to users in the mobile "What's New" screen.

Write in climber voice. Describe what the user gets, not what the feature does:
  - "Resume a session right where you left off"  (good)
  - "Added session-resume state to the queue reducer"  (too internal)

One short line per user-facing change. The first line is the headline; any extra
lines fill in the detail. Keep it to what someone would actually notice.

Nothing user-facing (refactor, CI, deps, tests)? Tick the checkbox below instead
(or add the `skip-changelog` label). Leaving this section blank fails CI.
-->

- [ ] Fix issue that made the app go stale due to heavy tasks

## Test plan

<!-- How you verified this. Commands run, flows exercised, platforms checked. -->
