### PR TITLE
fix(mobile): defer board-holds prewarm off the interaction thread

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -31,6 +31,14 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
   RefreshControl: () => createElement('div', { 'data-refresh-control': 'true' }),
   Keyboard: { dismiss: mocks.dismissKeyboard },
+  // Run deferred work synchronously in tests; the prewarm + background-cache
+  // effects schedule through InteractionManager.runAfterInteractions in the screen.
+  InteractionManager: {
+    runAfterInteractions: (callback: () => void) => {
+      callback();
+      return { cancel: () => undefined };
+    },
+  },
 }));
 
 vi.mock('@shopify/flash-list', () => ({

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback, useMemo, useRef, useEffect, type ComponentProps } from 'react';
-import { View, StyleSheet, RefreshControl, Keyboard } from 'react-native';
+import { View, StyleSheet, RefreshControl, Keyboard, InteractionManager } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -406,15 +406,21 @@ function ClimbListInner() {
 
   useEffect(() => {
     if (!boardConfig || !searchReady) return;
+    let task: ReturnType<typeof InteractionManager.runAfterInteractions> | null = null;
     const timeout = setTimeout(() => {
-      prewarmCreateBoardHolds({
-        boardName: boardConfig.boardName as BoardName,
-        layoutId: boardConfig.layoutId,
-        sizeId: boardConfig.sizeId,
-        setIds: parseSetIdsParam(boardConfig.setIds),
+      task = InteractionManager.runAfterInteractions(() => {
+        prewarmCreateBoardHolds({
+          boardName: boardConfig.boardName as BoardName,
+          layoutId: boardConfig.layoutId,
+          sizeId: boardConfig.sizeId,
+          setIds: parseSetIdsParam(boardConfig.setIds),
+        });
       });
     }, PREWARM_BOARD_HOLDS_DELAY_MS);
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+      task?.cancel();
+    };
   }, [boardConfig, searchReady]);
 
   useEffect(() => {
@@ -457,13 +463,18 @@ function ClimbListInner() {
   // over HTTP (the production CDN/WAF 403s the app's request).
   useEffect(() => {
     if (!activeBoard) return;
-    const parsedSetIds = activeBoard.setIds.split(',').map(Number);
-    void ensureBackgroundsCached({
-      boardName: activeBoard.boardType as BoardName,
-      layoutId: activeBoard.layoutId,
-      sizeId: activeBoard.sizeId,
-      setIds: parsedSetIds,
+    const task = InteractionManager.runAfterInteractions(() => {
+      const parsedSetIds = activeBoard.setIds.split(',').map(Number);
+      void ensureBackgroundsCached({
+        boardName: activeBoard.boardType as BoardName,
+        layoutId: activeBoard.layoutId,
+        sizeId: activeBoard.sizeId,
+        setIds: parsedSetIds,
+      });
     });
+    return () => {
+      task.cancel();
+    };
   }, [activeBoard]);
 
   const searchInput = useMemo(


### PR DESCRIPTION
## Summary

Fixes the Android "app goes completely dead after a couple of minutes" freeze that is **live in production** (build `2000356`, the current Play Store build). The trigger is **selecting a board**.

Selecting a board ran `prewarmCreateBoardHolds` + `ensureBackgroundsCached` synchronously on the JS thread, forcing Hermes (no JIT on Android) to evaluate the 241 KB `packages/board-constants/src/generated/product-sizes-data.ts` module — wedging the JS thread so touch dies. iOS (JSC/JIT) tolerates it and web runs the same lookups server-side, which is why the freeze is Android-only. This defers both effects to `InteractionManager.runAfterInteractions` (with cancellation) so board selection stays responsive.

### Authorship
This is **@alejandrosanchezcabana's fix from #3095**, rebased onto current `main` and CI-greened (his branch was based on a stale `main` that predated `scripts/check-commit-message.ts`, so its hooks/CI couldn't pass). The commit author is preserved as Alex Sánchez. **Supersedes #3095** — close that one in favor of this.

### Follow-up (separate PR)
The holds are static data; we should not materialize the all-boards 241 KB module just to browse. A fast-follow will split `product-sizes-data.ts` per board + lazy-load so the eval never blocks at any entry point (board view, create-climb, filters), not just board-select.

## Release Notes

Pick a board and keep climbing — fixed an Android freeze that hit right after switching boards.

- [ ] No release note needed (internal / technical change)

## Test plan

- `vp run test:mobile` — 341 files / 2523 tests pass (added the missing `InteractionManager` mock to the climbs-list test, the real cause of `test-default` failing on #3095).
- `vp run typecheck:mobile` and `vp check` green; pre-commit + commit-lint hooks pass.
- Device repro to confirm: Android 16 (Samsung S24 / Pixel 10) — select a board on the climb list, confirm no freeze / touch stays live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny9KuZRymZJ7g2XF92mgxk
