### PR TITLE
feat(mobile): mark native releases in the changelog + add check-for-updates

### DIFF
--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -113,6 +113,11 @@ jobs:
         with:
           # Full history so the changelog push-back can rebase onto the latest main.
           fetch-depth: 0
+          # The changelog generator reads the `fingerprint-<platform>-<hash>` tags
+          # (pushed by the native build workflows) to weave native-release markers
+          # into the changelog. fetch-depth: 0 already pulls tags, but be explicit
+          # so a future shallow tweak can't silently drop them.
+          fetch-tags: true
           # Persist the app token (when configured) so the push-back authenticates
           # as the app and bypasses the branch's PR rule. Falls back to the default
           # token (read-only checkout) when the app isn't set up.

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -188,9 +188,24 @@ Run `vp run mobile:ota-setup` with no argument for the ordered runbook.
 `## Release Notes` sections, commits it, **pushes it back to `main`** (commit tagged `[skip ci]` so
 the push can't re-trigger the OTA), and only then runs `eoas publish` (which needs a clean tree).
 Nothing else writes the file: the native build workflows and `refresh-acknowledgements.yml` only
-*read* it, and a CI guard (`changelog-owned` in `ci.yml`) fails any PR that edits it. The OTA still
+_read_ it, and a CI guard (`changelog-owned` in `ci.yml`) fails any PR that edits it. The OTA still
 publishes whether or not the push-back is wired — the push-back just keeps `main`'s copy (which the
 native binaries embed) current.
+
+### Native-release markers + on-demand update check
+
+The generator also reads the `fingerprint-<platform>-<hash>` tags the native build workflows push
+(after a successful store upload) and emits a `nativeReleases` array alongside `entries` — each marker
+records the shipping commit's date, platforms, and per-platform fingerprint. Both `CHANGELOG.md` and
+the in-app "What's New" interleave these as a dated **App update** divider, so the boundary between
+OTA-delivered and store-delivered changes is visible (the app filters markers to the running
+platform). The tag lands only after the store upload finishes, so a marker shows up on the _next_
+changelog regeneration, not the same push that triggered the native build. The OTA publish workflow
+checks out with `fetch-tags: true` so the tags are present when the generator runs.
+
+The changelog screen also has a **Check for updates** button (shown only when `Updates.isEnabled`,
+i.e. production OTA builds) that pulls an OTA on demand: `checkForUpdateAsync` → `fetchUpdateAsync` →
+"restart now?" → `reloadAsync`.
 
 **Push-back needs a bypass identity**, because `main` requires a pull request (enforce-admins on),
 which blocks the default `GITHUB_TOKEN` from pushing directly. One-time setup:
@@ -199,8 +214,8 @@ which blocks the default `GITHUB_TOKEN` from pushing directly. One-time setup:
    No webhook needed. Note its **App ID**.
 2. **Install** the App on `boardsesh/boardsesh` (only this repo).
 3. **Generate a private key** for the App (downloads a `.pem`).
-4. **Add the App to the bypass list**: repo → Settings → Branches → `main` rule → *Allow specified
-   actors to bypass required pull requests* → add the App.
+4. **Add the App to the bypass list**: repo → Settings → Branches → `main` rule → _Allow specified
+   actors to bypass required pull requests_ → add the App.
 5. **Wire the secrets**: set repo **variable** `OTA_PUSH_APP_ID` = the App ID, and repo **secret**
    `OTA_PUSH_APP_PRIVATE_KEY` = the `.pem` contents.
 

--- a/packages/mobile/app/changelog.tsx
+++ b/packages/mobile/app/changelog.tsx
@@ -1,20 +1,31 @@
-import { memo, useCallback, useEffect, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Stack } from 'expo-router';
-import { StyleSheet, View } from 'react-native';
+import { Alert, Platform, StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
 import * as Updates from 'expo-updates';
 import * as Application from 'expo-application';
+import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
 import { PressableSurface } from '../src/components/PressableSurface';
 import { Text } from '../src/components/Text';
 import { useBottomChromeMetrics } from '../src/hooks/use-bottom-chrome-metrics';
 import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
-import { entries, latestEntryDate, type ChangelogCategory, type ChangelogEntry } from '../src/lib/changelog';
+import {
+  timeline,
+  isNativeRelease,
+  latestEntryDate,
+  type ChangelogCategory,
+  type ChangelogEntry,
+  type NativeRelease,
+  type TimelineItem,
+} from '../src/lib/changelog';
 import { markChangelogSeen } from '../src/lib/changelog-seen';
 import { reportError } from '../src/lib/error-reporting';
 import { formatRelativeTime } from '../src/lib/format-relative-time';
+import { hapticError } from '../src/lib/haptics';
 import { openExternalUrl } from '../src/lib/open-url';
+import { useConfirm } from '../src/providers/dialog-provider';
 import { useTheme } from '../src/providers/theme-provider';
 import { borderRadius, spacing } from '../src/theme/tokens';
 import type { IconName } from '../src/components/icon-map';
@@ -118,7 +129,100 @@ const ChangelogEntryRow = memo(function ChangelogEntryRow({ entry, onPress }: Ch
   );
 });
 
-const keyExtractor = (entry: ChangelogEntry) => `pr-${entry.prNumber}`;
+// A native (store) release marker — a distinct, accent-bordered divider that marks
+// where a new app version shipped to the store. Tappable entries flow above/below
+// it; this one is informational only.
+const NativeReleaseRow = memo(function NativeReleaseRow({ release }: { release: NativeRelease }) {
+  const { t } = useTranslation('common');
+  const { systemColors, brandColors } = useTheme();
+  const storeLine =
+    Platform.OS === 'android'
+      ? t('mobile.changelog.nativeRelease.playStore')
+      : t('mobile.changelog.nativeRelease.appStore');
+  return (
+    <View
+      style={[
+        styles.nativeCard,
+        { backgroundColor: systemColors.secondaryBackground, borderColor: brandColors.primary },
+      ]}
+    >
+      <View style={styles.nativeHeader}>
+        <Icon name="star.fill" size={14} color={brandColors.primary} />
+        <Text variant="footnote" color={brandColors.primary} style={styles.nativeTitle}>
+          {t('mobile.changelog.nativeRelease.title')}
+        </Text>
+        <Text variant="caption1" color={systemColors.tertiaryLabel} numberOfLines={1} style={styles.nativeDate}>
+          {formatRelativeTime(release.date)}
+        </Text>
+      </View>
+      <Text variant="subheadline" color={systemColors.secondaryLabel}>
+        {storeLine}
+      </Text>
+    </View>
+  );
+});
+
+type UpdateStatus = 'idle' | 'checking' | 'downloading';
+
+// Pull an OTA on demand: check → download → "restart now?" → reload. Mirrors the
+// BranchSwitcherScreen flow. Hidden when Updates.isEnabled is false (dev / Expo Go),
+// where checkForUpdateAsync throws.
+const CheckForUpdatesButton = memo(function CheckForUpdatesButton() {
+  const { t } = useTranslation('common');
+  const confirm = useConfirm();
+  const [status, setStatus] = useState<UpdateStatus>('idle');
+
+  const handlePress = useCallback(async () => {
+    try {
+      setStatus('checking');
+      const check = await Updates.checkForUpdateAsync();
+      if (!check.isAvailable) {
+        setStatus('idle');
+        Alert.alert(t('mobile.changelog.upToDate.title'), t('mobile.changelog.upToDate.message'));
+        return;
+      }
+      setStatus('downloading');
+      await Updates.fetchUpdateAsync();
+      setStatus('idle');
+      const confirmed = await confirm({
+        title: t('mobile.changelog.updateReady.title'),
+        message: t('mobile.changelog.updateReady.message'),
+        confirmLabel: t('mobile.changelog.updateReady.restart'),
+        cancelLabel: t('mobile.changelog.updateReady.later'),
+      });
+      if (confirmed) await Updates.reloadAsync();
+    } catch (error) {
+      setStatus('idle');
+      hapticError();
+      reportError(error);
+      Alert.alert(t('mobile.changelog.checkError.title'), t('mobile.changelog.checkError.message'));
+    }
+  }, [confirm, t]);
+
+  if (!Updates.isEnabled) return null;
+
+  const title =
+    status === 'checking'
+      ? t('mobile.changelog.checking')
+      : status === 'downloading'
+        ? t('mobile.changelog.downloading')
+        : t('mobile.changelog.checkForUpdates');
+
+  return (
+    <Button
+      title={title}
+      onPress={() => void handlePress()}
+      variant="tonal"
+      size="small"
+      icon="refresh"
+      loading={status !== 'idle'}
+      disabled={status !== 'idle'}
+      style={styles.checkButton}
+    />
+  );
+});
+
+const keyExtractor = (item: TimelineItem) => (isNativeRelease(item) ? `native-${item.sha}` : `pr-${item.prNumber}`);
 
 export default function ChangelogScreen() {
   const { t } = useTranslation('common');
@@ -139,7 +243,12 @@ export default function ChangelogScreen() {
   }, []);
 
   const renderItem = useCallback(
-    ({ item }: { item: ChangelogEntry }) => <ChangelogEntryRow entry={item} onPress={handleOpenPr} />,
+    ({ item }: { item: TimelineItem }) =>
+      isNativeRelease(item) ? (
+        <NativeReleaseRow release={item} />
+      ) : (
+        <ChangelogEntryRow entry={item} onPress={handleOpenPr} />
+      ),
     [handleOpenPr],
   );
 
@@ -150,9 +259,10 @@ export default function ChangelogScreen() {
           wrapper it collapses to zero height and renders nothing (mirrors
           licenses.tsx). */}
       <View style={styles.flex}>
-        {entries.length === 0 ? (
+        {timeline.length === 0 ? (
           <View style={styles.emptyWrap}>
             <CurrentBuildChip />
+            <CheckForUpdatesButton />
             <Text variant="body" color={systemColors.secondaryLabel} style={styles.emptyText}>
               {t('mobile.changelog.empty')}
             </Text>
@@ -161,7 +271,7 @@ export default function ChangelogScreen() {
           // FlashList v2 self-measures rows — `estimatedItemSize` was removed and
           // no longer typechecks (see licenses.tsx for the same note).
           <FlashList
-            data={entries}
+            data={timeline}
             renderItem={renderItem}
             keyExtractor={keyExtractor}
             contentInsetAdjustmentBehavior="automatic"
@@ -175,7 +285,10 @@ export default function ChangelogScreen() {
                 <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.intro}>
                   {t('mobile.changelog.intro')}
                 </Text>
-                <CurrentBuildChip />
+                <View style={styles.headerMeta}>
+                  <CurrentBuildChip />
+                  <CheckForUpdatesButton />
+                </View>
               </View>
             }
             ItemSeparatorComponent={Separator}
@@ -197,6 +310,15 @@ const styles = StyleSheet.create({
   listHeader: {
     gap: spacing[3],
     marginBottom: spacing[4],
+  },
+  headerMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing[3],
+  },
+  checkButton: {
+    alignSelf: 'flex-start',
   },
   intro: {
     lineHeight: 20,
@@ -244,6 +366,25 @@ const styles = StyleSheet.create({
   },
   cardBody: {
     lineHeight: 20,
+  },
+  nativeCard: {
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    gap: spacing[2],
+    borderWidth: 1,
+  },
+  nativeHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  nativeTitle: {
+    fontWeight: '700',
+    textTransform: 'uppercase',
+  },
+  nativeDate: {
+    flex: 1,
+    textAlign: 'right',
   },
   emptyWrap: {
     flex: 1,

--- a/packages/mobile/src/lib/changelog.ts
+++ b/packages/mobile/src/lib/changelog.ts
@@ -9,6 +9,7 @@
  * than lazily loaded.
  */
 import { tickTimeMs } from '@boardsesh/profile-stats';
+import { Platform } from 'react-native';
 import data from '../data/changelog.generated.json';
 
 export type ChangelogCategory = 'new' | 'improved' | 'fixed';
@@ -24,9 +25,29 @@ export type ChangelogEntry = {
   prUrl: string;
 };
 
+export type NativePlatform = 'ios' | 'android';
+
+/**
+ * A native (store) release marker — a commit where a new native fingerprint
+ * shipped to the App Store / Play Store. Generated from the
+ * `fingerprint-<platform>-<hash>` git tags (see scripts/generate-changelog.ts) and
+ * woven into the timeline so the boundary between OTA-delivered and store-delivered
+ * changes is visible. The `kind` field discriminates it from a `ChangelogEntry`.
+ */
+export type NativeRelease = {
+  kind: 'native-release';
+  /** ISO committer date of the shipping commit. */
+  date: string;
+  sha: string;
+  platforms: NativePlatform[];
+  fingerprints?: { ios?: string; android?: string };
+};
+
 export type ChangelogData = {
   generatedAt: string;
   entries: ChangelogEntry[];
+  /** Optional so a pre-feature snapshot (no markers yet) still loads — defaults to []. */
+  nativeReleases?: NativeRelease[];
 };
 
 const rawData = data as ChangelogData;
@@ -36,13 +57,37 @@ const rawData = data as ChangelogData;
 // tickTimeMs (the same dayjs-backed parser the rest of the app uses) so an
 // unparseable date sorts last rather than poisoning the comparison. tickTimeMs
 // throws on an empty string, so guard that before calling it.
-function mergedAtMs(entry: ChangelogEntry): number {
-  if (!entry.mergedAt) return Number.NEGATIVE_INFINITY;
-  const parsed = tickTimeMs(entry.mergedAt);
+function isoDateMs(iso: string | undefined): number {
+  if (!iso) return Number.NEGATIVE_INFINITY;
+  const parsed = tickTimeMs(iso);
   return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
 }
 
-export const entries: ChangelogEntry[] = [...rawData.entries].sort((a, b) => mergedAtMs(b) - mergedAtMs(a));
+export const entries: ChangelogEntry[] = [...rawData.entries].sort(
+  (a, b) => isoDateMs(b.mergedAt) - isoDateMs(a.mergedAt),
+);
 
 /** The newest entry's `mergedAt`, or `null` when the changelog is empty. */
 export const latestEntryDate: string | null = entries.length > 0 ? entries[0].mergedAt : null;
+
+// Only show native-release markers for the running platform: a device cares about
+// store builds that changed *its* binary, not the other platform's. Platform.OS is
+// 'ios' | 'android' on the app (web/desktop never run this screen).
+const runningPlatform: NativePlatform = Platform.OS === 'android' ? 'android' : 'ios';
+const platformReleases: NativeRelease[] = (rawData.nativeReleases ?? []).filter((release) =>
+  release.platforms.includes(runningPlatform),
+);
+
+export type TimelineItem = ChangelogEntry | NativeRelease;
+
+/** True for a native-release marker; narrows the union for `renderItem`/`keyExtractor`. */
+export function isNativeRelease(item: TimelineItem): item is NativeRelease {
+  return 'kind' in item && item.kind === 'native-release';
+}
+
+function timelineMs(item: TimelineItem): number {
+  return isNativeRelease(item) ? isoDateMs(item.date) : isoDateMs(item.mergedAt);
+}
+
+/** PR entries + platform native-release markers, interleaved newest-first by date. */
+export const timeline: TimelineItem[] = [...entries, ...platformReleases].sort((a, b) => timelineMs(b) - timelineMs(a));

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -195,7 +195,29 @@
         "fixed": "Fixed"
       },
       "viewPr": "View on GitHub",
-      "empty": "No changes logged yet — we've been too busy climbing. Check back after the next send."
+      "empty": "No changes logged yet — we've been too busy climbing. Check back after the next send.",
+      "nativeRelease": {
+        "title": "App update",
+        "appStore": "A new version shipped to the App Store.",
+        "playStore": "A new version shipped to the Play Store."
+      },
+      "checkForUpdates": "Check for updates",
+      "checking": "Checking…",
+      "downloading": "Downloading…",
+      "upToDate": {
+        "title": "You're up to date",
+        "message": "You're already on the latest version."
+      },
+      "updateReady": {
+        "title": "Update ready",
+        "message": "Restart Boardsesh now to use the latest version?",
+        "restart": "Restart",
+        "later": "Later"
+      },
+      "checkError": {
+        "title": "Couldn't check for updates",
+        "message": "Something went wrong getting the latest version. Try again in a bit."
+      }
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -393,7 +393,29 @@
         "fixed": "Corregido"
       },
       "viewPr": "Ver en GitHub",
-      "empty": "Aún no hay cambios registrados: hemos estado escalando demasiado. Vuelve después del próximo encadene."
+      "empty": "Aún no hay cambios registrados: hemos estado escalando demasiado. Vuelve después del próximo encadene.",
+      "nativeRelease": {
+        "title": "Actualización de la app",
+        "appStore": "Una nueva versión llegó a la App Store.",
+        "playStore": "Una nueva versión llegó a la Play Store."
+      },
+      "checkForUpdates": "Buscar actualizaciones",
+      "checking": "Buscando…",
+      "downloading": "Descargando…",
+      "upToDate": {
+        "title": "Estás al día",
+        "message": "Ya tienes la última versión."
+      },
+      "updateReady": {
+        "title": "Actualización lista",
+        "message": "¿Reiniciar Boardsesh ahora para usar la última versión?",
+        "restart": "Reiniciar",
+        "later": "Más tarde"
+      },
+      "checkError": {
+        "title": "No se pudo buscar actualizaciones",
+        "message": "Algo salió mal al obtener la última versión. Inténtalo de nuevo en un rato."
+      }
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -195,7 +195,29 @@
         "fixed": "Corrigé"
       },
       "viewPr": "Voir sur GitHub",
-      "empty": "Aucun changement pour l'instant : on était trop occupés à grimper. Reviens après le prochain enchaînement."
+      "empty": "Aucun changement pour l'instant : on était trop occupés à grimper. Reviens après le prochain enchaînement.",
+      "nativeRelease": {
+        "title": "Mise à jour de l'app",
+        "appStore": "Une nouvelle version est arrivée sur l'App Store.",
+        "playStore": "Une nouvelle version est arrivée sur le Play Store."
+      },
+      "checkForUpdates": "Rechercher des mises à jour",
+      "checking": "Recherche…",
+      "downloading": "Téléchargement…",
+      "upToDate": {
+        "title": "Vous êtes à jour",
+        "message": "Vous avez déjà la dernière version."
+      },
+      "updateReady": {
+        "title": "Mise à jour prête",
+        "message": "Redémarrer Boardsesh maintenant pour utiliser la dernière version ?",
+        "restart": "Redémarrer",
+        "later": "Plus tard"
+      },
+      "checkError": {
+        "title": "Impossible de rechercher des mises à jour",
+        "message": "Une erreur s'est produite lors de la récupération de la dernière version. Réessayez dans un instant."
+      }
     }
   },
   "lightControl": {

--- a/scripts/__tests__/changelog-transform.test.ts
+++ b/scripts/__tests__/changelog-transform.test.ts
@@ -4,11 +4,14 @@ import {
   isNoReleaseNoteBoxChecked,
   categorize,
   buildEntries,
+  buildNativeReleases,
   isContentEqual,
   renderChangelogMarkdown,
   type RawPullRequest,
+  type RawFingerprintTag,
   type ChangelogData,
   type ChangelogEntry,
+  type NativeRelease,
 } from '../lib/changelog-transform';
 
 describe('extractReleaseNotes', () => {
@@ -208,6 +211,52 @@ describe('buildEntries', () => {
   });
 });
 
+describe('buildNativeReleases', () => {
+  const tag = (over: Partial<RawFingerprintTag>): RawFingerprintTag => ({
+    platform: 'ios',
+    hash: 'abc123',
+    sha: 'sha-1',
+    date: '2026-06-19T12:00:00Z',
+    ...over,
+  });
+
+  it('collapses iOS + Android tags on the same commit into one marker', () => {
+    const releases = buildNativeReleases([
+      tag({ platform: 'ios', hash: 'iosfp', sha: 'sha-1' }),
+      tag({ platform: 'android', hash: 'androidfp', sha: 'sha-1' }),
+    ]);
+    expect(releases).toHaveLength(1);
+    expect(releases[0]).toEqual({
+      kind: 'native-release',
+      date: '2026-06-19T12:00:00Z',
+      sha: 'sha-1',
+      platforms: ['android', 'ios'], // sorted, stable
+      fingerprints: { ios: 'iosfp', android: 'androidfp' },
+    });
+  });
+
+  it('keeps tags on different commits as separate markers, newest-first', () => {
+    const releases = buildNativeReleases([
+      tag({ sha: 'older', date: '2026-06-10T00:00:00Z' }),
+      tag({ sha: 'newer', date: '2026-06-18T00:00:00Z' }),
+    ]);
+    expect(releases.map((release) => release.sha)).toEqual(['newer', 'older']);
+  });
+
+  it('takes the first hash per platform for a commit', () => {
+    const releases = buildNativeReleases([
+      tag({ platform: 'ios', hash: 'first', sha: 'sha-1' }),
+      tag({ platform: 'ios', hash: 'second', sha: 'sha-1' }),
+    ]);
+    expect(releases[0].platforms).toEqual(['ios']);
+    expect(releases[0].fingerprints).toEqual({ ios: 'first' });
+  });
+
+  it('returns [] for no tags', () => {
+    expect(buildNativeReleases([])).toEqual([]);
+  });
+});
+
 describe('isContentEqual', () => {
   const entries = [
     {
@@ -218,16 +267,25 @@ describe('isContentEqual', () => {
       prUrl: 'u',
     },
   ];
+  const nativeReleases: NativeRelease[] = [
+    { kind: 'native-release', date: '2026-06-10T10:00:00Z', sha: 's', platforms: ['ios'], fingerprints: { ios: 'fp' } },
+  ];
 
   it('is true when only generatedAt differs', () => {
-    const first: ChangelogData = { generatedAt: '2026-06-10T00:00:00Z', entries };
-    const second: ChangelogData = { generatedAt: '2026-06-19T00:00:00Z', entries };
+    const first: ChangelogData = { generatedAt: '2026-06-10T00:00:00Z', entries, nativeReleases };
+    const second: ChangelogData = { generatedAt: '2026-06-19T00:00:00Z', entries, nativeReleases };
     expect(isContentEqual(first, second)).toBe(true);
   });
 
   it('is false when entries differ', () => {
-    const first: ChangelogData = { generatedAt: 'x', entries };
-    const second: ChangelogData = { generatedAt: 'x', entries: [] };
+    const first: ChangelogData = { generatedAt: 'x', entries, nativeReleases };
+    const second: ChangelogData = { generatedAt: 'x', entries: [], nativeReleases };
+    expect(isContentEqual(first, second)).toBe(false);
+  });
+
+  it('is false when native releases differ', () => {
+    const first: ChangelogData = { generatedAt: 'x', entries, nativeReleases };
+    const second: ChangelogData = { generatedAt: 'x', entries, nativeReleases: [] };
     expect(isContentEqual(first, second)).toBe(false);
   });
 });
@@ -277,5 +335,39 @@ describe('renderChangelogMarkdown', () => {
   it('is deterministic (same entries → byte-identical output)', () => {
     const entries = [entry({ prNumber: 3 }), entry({ prNumber: 4, category: 'fixed' })];
     expect(renderChangelogMarkdown(entries)).toBe(renderChangelogMarkdown(entries));
+  });
+
+  const nativeRelease = (over: Partial<NativeRelease>): NativeRelease => ({
+    kind: 'native-release',
+    date: '2026-06-19T12:00:00Z',
+    sha: 'sha-1',
+    platforms: ['ios', 'android'],
+    fingerprints: {},
+    ...over,
+  });
+
+  it('leads a day with an App update note labelled by the platforms present', () => {
+    const md = renderChangelogMarkdown(
+      [entry({ prNumber: 11, category: 'new', title: 'Day feature', mergedAt: '2026-06-19T10:00:00Z' })],
+      [nativeRelease({ platforms: ['ios', 'android'] })],
+    );
+    expect(md).toContain('### App update\n\nA new version shipped to the App Store and Play Store.');
+    // The App update note precedes the New subsection within the same date.
+    const day = md.slice(md.indexOf('## 2026-06-19'));
+    expect(day.indexOf('### App update')).toBeLessThan(day.indexOf('### New'));
+  });
+
+  it('labels a single-platform release with just that store', () => {
+    const iosOnly = renderChangelogMarkdown([], [nativeRelease({ platforms: ['ios'] })]);
+    expect(iosOnly).toContain('A new version shipped to the App Store.');
+    const androidOnly = renderChangelogMarkdown([], [nativeRelease({ platforms: ['android'] })]);
+    expect(androidOnly).toContain('A new version shipped to the Play Store.');
+  });
+
+  it('renders a native-only date as its own section', () => {
+    const md = renderChangelogMarkdown([], [nativeRelease({ date: '2026-06-15T00:00:00Z' })]);
+    expect(md).toContain('## 2026-06-15');
+    expect(md).toContain('### App update');
+    expect(md).not.toContain('### New');
   });
 });

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -30,9 +30,12 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   buildEntries,
+  buildNativeReleases,
   isContentEqual,
   renderChangelogMarkdown,
   type ChangelogData,
+  type NativePlatform,
+  type RawFingerprintTag,
   type RawPullRequest,
 } from './lib/changelog-transform';
 
@@ -58,12 +61,60 @@ function gh(args: string[]): string {
   return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 }
 
+function git(args: string[]): string {
+  return execFileSync('git', args, { cwd: here, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+}
+
 function readExisting(): ChangelogData {
   try {
-    return JSON.parse(readFileSync(OUTPUT_PATH, 'utf8')) as ChangelogData;
+    const parsed = JSON.parse(readFileSync(OUTPUT_PATH, 'utf8')) as Partial<ChangelogData>;
+    return {
+      generatedAt: parsed.generatedAt ?? '',
+      entries: parsed.entries ?? [],
+      nativeReleases: parsed.nativeReleases ?? [],
+    };
   } catch {
-    return { generatedAt: '', entries: [] };
+    return { generatedAt: '', entries: [], nativeReleases: [] };
   }
+}
+
+// Each native build workflow pushes a lightweight tag `fingerprint-<platform>-<hash>`
+// onto the shipping commit after a successful store upload (see
+// ios-testflight-rn.yml / android-apk-rn.yml). Reading them tells us which commits
+// crossed a native-fingerprint boundary, i.e. shipped a store update. Degrades to
+// none on any git failure (not a repo, shallow clone, tags not fetched) so the
+// changelog still generates from PR entries alone.
+const FINGERPRINT_TAG = /^fingerprint-(ios|android)-([0-9a-f]+)$/;
+
+function gatherFingerprintTags(): RawFingerprintTag[] {
+  let raw: string;
+  try {
+    // Lightweight tags point straight at the shipping commit, so `%(objectname)`
+    // is that commit SHA; we resolve its committer date below.
+    raw = git(['for-each-ref', '--format=%(refname:short) %(objectname)', 'refs/tags/fingerprint-*']);
+  } catch (error) {
+    console.warn(`[changelog] could not read fingerprint tags, skipping native-release markers: ${String(error)}`);
+    return [];
+  }
+
+  const tags: RawFingerprintTag[] = [];
+  for (const line of raw.split('\n')) {
+    const [refName, sha] = line.trim().split(/\s+/);
+    const match = refName ? FINGERPRINT_TAG.exec(refName) : null;
+    if (!match || !sha) continue;
+
+    let date: string;
+    try {
+      date = git(['log', '-1', '--format=%cI', sha]).trim();
+    } catch {
+      // Tag points at a commit not in this (possibly shallow) clone — skip it.
+      continue;
+    }
+    if (!date) continue;
+
+    tags.push({ platform: match[1] as NativePlatform, hash: match[2], sha, date });
+  }
+  return tags;
 }
 
 // Merged PRs against main, newest-updated first so the crawl can stop early once
@@ -175,14 +226,15 @@ function main(): void {
   }
 
   const entries = buildEntries(pullRequests);
-  const candidate: ChangelogData = { generatedAt: existing.generatedAt, entries };
-  const entriesUnchanged = isContentEqual(candidate, existing);
+  const nativeReleases = buildNativeReleases(gatherFingerprintTags());
+  const candidate: ChangelogData = { generatedAt: existing.generatedAt, entries, nativeReleases };
+  const contentUnchanged = isContentEqual(candidate, existing);
 
   if (isCheckMode) {
-    // Compare entries only: the committed seed ships with an empty `generatedAt`,
-    // so a matching-but-unstamped snapshot is up to date, not stale.
-    if (entriesUnchanged) {
-      console.log(`[changelog] up to date (${entries.length} entries).`);
+    // Compare entries + native releases only: the committed seed ships with an
+    // empty `generatedAt`, so a matching-but-unstamped snapshot is up to date.
+    if (contentUnchanged) {
+      console.log(`[changelog] up to date (${entries.length} entries, ${nativeReleases.length} native releases).`);
       return;
     }
     console.error(
@@ -192,16 +244,18 @@ function main(): void {
     return;
   }
 
-  // Keep the timestamp stable when the entries are unchanged AND already stamped;
+  // Keep the timestamp stable when the content is unchanged AND already stamped;
   // stamp a real time on the first write (the seed's `generatedAt` is empty).
-  const generatedAt = entriesUnchanged && existing.generatedAt ? existing.generatedAt : new Date().toISOString();
-  const data: ChangelogData = { generatedAt, entries };
+  const generatedAt = contentUnchanged && existing.generatedAt ? existing.generatedAt : new Date().toISOString();
+  const data: ChangelogData = { generatedAt, entries, nativeReleases };
   mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
   writeFileSync(OUTPUT_PATH, `${JSON.stringify(data, null, 2)}\n`);
-  // CHANGELOG.md is a pure function of the entries (no timestamp), so it's
-  // deterministic — the same entries always produce a byte-identical file.
-  writeFileSync(CHANGELOG_PATH, renderChangelogMarkdown(entries));
-  console.log(`[changelog] wrote ${entries.length} entries (changelog.generated.json + CHANGELOG.md)`);
+  // CHANGELOG.md is a pure function of the inputs (no timestamp), so it's
+  // deterministic — the same entries + releases always produce a byte-identical file.
+  writeFileSync(CHANGELOG_PATH, renderChangelogMarkdown(entries, nativeReleases));
+  console.log(
+    `[changelog] wrote ${entries.length} entries + ${nativeReleases.length} native releases (changelog.generated.json + CHANGELOG.md)`,
+  );
 }
 
 main();

--- a/scripts/lib/changelog-transform.ts
+++ b/scripts/lib/changelog-transform.ts
@@ -25,10 +25,42 @@ export type ChangelogEntry = {
   prUrl: string;
 };
 
+export type NativePlatform = 'ios' | 'android';
+
+/**
+ * A native (store) release marker: a commit where a new native fingerprint
+ * shipped to the App Store / Play Store. Built from the
+ * `fingerprint-<platform>-<hash>` git tags the native build workflows push after a
+ * successful store upload. Woven into the changelog timeline so a user can see the
+ * boundary between changes they already have over the air and ones that needed a
+ * store update.
+ */
+export type NativeRelease = {
+  kind: 'native-release';
+  /** ISO 8601 committer date of the shipping commit. */
+  date: string;
+  /** The shipping commit SHA (markers are deduped by it). */
+  sha: string;
+  /** Platforms whose native build shipped at this commit (sorted, stable). */
+  platforms: NativePlatform[];
+  /** Per-platform fingerprint hash (for an optional runtime-aware "you're behind" highlight). */
+  fingerprints: { ios?: string; android?: string };
+};
+
+/** One `fingerprint-<platform>-<hash>` git tag, resolved to its commit by the I/O shell. */
+export type RawFingerprintTag = {
+  platform: NativePlatform;
+  hash: string;
+  sha: string;
+  /** ISO 8601 committer date of `sha`. */
+  date: string;
+};
+
 export type ChangelogData = {
-  /** ISO 8601; only moves when `entries` changes (idempotent). */
+  /** ISO 8601; only moves when `entries` or `nativeReleases` changes (idempotent). */
   generatedAt: string;
   entries: ChangelogEntry[];
+  nativeReleases: NativeRelease[];
 };
 
 /** A merged pull request as selected from the GitHub GraphQL API. */
@@ -187,12 +219,45 @@ export function buildEntries(pullRequests: RawPullRequest[]): ChangelogEntry[] {
 }
 
 /**
+ * Builds native-release markers from the `fingerprint-<platform>-<hash>` tags:
+ * groups tags by their shipping commit (so an iOS + Android build on the same push
+ * collapse to one marker carrying both platforms), records the per-platform
+ * fingerprint, and sorts newest-first by commit date. A second key (sha) keeps the
+ * order stable when two commits share a date. First hash wins per platform — a
+ * commit resolves to exactly one fingerprint per platform.
+ */
+export function buildNativeReleases(tags: RawFingerprintTag[]): NativeRelease[] {
+  const bySha = new Map<string, NativeRelease>();
+
+  for (const tag of tags) {
+    let release = bySha.get(tag.sha);
+    if (!release) {
+      release = { kind: 'native-release', date: tag.date, sha: tag.sha, platforms: [], fingerprints: {} };
+      bySha.set(tag.sha, release);
+    }
+    if (!release.platforms.includes(tag.platform)) release.platforms.push(tag.platform);
+    if (release.fingerprints[tag.platform] === undefined) release.fingerprints[tag.platform] = tag.hash;
+  }
+
+  for (const release of bySha.values()) release.platforms.sort();
+
+  return [...bySha.values()].sort((first, second) => {
+    if (first.date !== second.date) return first.date < second.date ? 1 : -1;
+    return first.sha < second.sha ? 1 : first.sha > second.sha ? -1 : 0;
+  });
+}
+
+/**
  * Compares two changelog payloads ignoring `generatedAt`, so a re-run that
- * produces the same entries leaves the committed file (and its timestamp)
- * untouched. Mirrors the churn-free idempotency in fetch-acknowledgements.ts.
+ * produces the same entries + native releases leaves the committed file (and its
+ * timestamp) untouched. Mirrors the churn-free idempotency in
+ * fetch-acknowledgements.ts.
  */
 export function isContentEqual(first: ChangelogData, second: ChangelogData): boolean {
-  return JSON.stringify(first.entries) === JSON.stringify(second.entries);
+  return (
+    JSON.stringify(first.entries) === JSON.stringify(second.entries) &&
+    JSON.stringify(first.nativeReleases ?? []) === JSON.stringify(second.nativeReleases ?? [])
+  );
 }
 
 // Human-readable labels + fixed render order for the markdown category
@@ -210,42 +275,70 @@ Notes" section of merged pull requests — do not edit by hand (a CI check rejec
 manual changes). See docs/mobile-ota-updates.md.
 `;
 
-/**
- * Renders the changelog entries as a human-readable, Keep a Changelog-style
- * CHANGELOG.md: `## <YYYY-MM-DD>` sections newest-first, each with `### New /
- * Improved / Fixed` subsections of PR-linked bullets. A pure function of the
- * entries with no timestamps, so the same entries always produce a byte-identical
- * file. `entries` is expected newest-first (as `buildEntries` returns).
- */
-export function renderChangelogMarkdown(entries: ChangelogEntry[]): string {
-  if (entries.length === 0) return CHANGELOG_PREAMBLE;
+// The store(s) a native release shipped to, for the CHANGELOG.md "App update" note.
+function storeLabel(platforms: NativePlatform[]): string {
+  const ios = platforms.includes('ios');
+  const android = platforms.includes('android');
+  if (ios && android) return 'the App Store and Play Store';
+  if (ios) return 'the App Store';
+  return 'the Play Store';
+}
 
-  // Group by UTC date, keeping the newest-first order in which each date first
-  // appears (entries are already sorted newest-first by mergedAt).
-  const dateOrder: string[] = [];
-  const byDate = new Map<string, ChangelogEntry[]>();
+/**
+ * Renders the changelog as a human-readable, Keep a Changelog-style CHANGELOG.md:
+ * `## <YYYY-MM-DD>` sections newest-first. Each day leads with an `### App update`
+ * note when a native build shipped that day (from `nativeReleases`), then `### New
+ * / Improved / Fixed` subsections of PR-linked bullets. A pure function with no
+ * timestamps, so the same inputs always produce a byte-identical file. `entries` is
+ * expected newest-first (as `buildEntries` returns).
+ */
+export function renderChangelogMarkdown(entries: ChangelogEntry[], nativeReleases: NativeRelease[] = []): string {
+  if (entries.length === 0 && nativeReleases.length === 0) return CHANGELOG_PREAMBLE;
+
+  // Group entries by UTC date.
+  const entriesByDate = new Map<string, ChangelogEntry[]>();
   for (const entry of entries) {
     const date = entry.mergedAt.slice(0, 10); // ISO 8601 → YYYY-MM-DD (UTC)
-    let group = byDate.get(date);
-    if (!group) {
-      group = [];
-      byDate.set(date, group);
-      dateOrder.push(date);
-    }
+    const group = entriesByDate.get(date) ?? [];
     group.push(entry);
+    entriesByDate.set(date, group);
   }
 
-  const sections = dateOrder.map((date) => {
-    const dayEntries = byDate.get(date) ?? [];
-    const blocks = CATEGORY_LABELS.flatMap(([category, label]) => {
+  // Group native-release markers by the same UTC date key.
+  const releasesByDate = new Map<string, NativeRelease[]>();
+  for (const release of nativeReleases) {
+    const date = release.date.slice(0, 10);
+    const group = releasesByDate.get(date) ?? [];
+    group.push(release);
+    releasesByDate.set(date, group);
+  }
+
+  // Newest-first union of every date. ISO YYYY-MM-DD sorts lexicographically.
+  const allDates = [...new Set([...entriesByDate.keys(), ...releasesByDate.keys()])].sort((first, second) =>
+    first < second ? 1 : first > second ? -1 : 0,
+  );
+
+  const sections = allDates.map((date) => {
+    const blocks: string[] = [];
+
+    // The "App update" note leads the day so the store-build boundary is obvious.
+    const dayReleases = releasesByDate.get(date) ?? [];
+    if (dayReleases.length > 0) {
+      const platforms = [...new Set(dayReleases.flatMap((release) => release.platforms))].sort();
+      blocks.push(`### App update\n\nA new version shipped to ${storeLabel(platforms)}.`);
+    }
+
+    const dayEntries = entriesByDate.get(date) ?? [];
+    for (const [category, label] of CATEGORY_LABELS) {
       const inCategory = dayEntries.filter((entry) => entry.category === category);
-      if (inCategory.length === 0) return [];
+      if (inCategory.length === 0) continue;
       const bullets = inCategory.map((entry) => {
         const line = `- ${entry.title} ([#${entry.prNumber}](${entry.prUrl}))`;
         return entry.body ? `${line}\n  ${entry.body.replace(/\n/g, '\n  ')}` : line;
       });
-      return [`### ${label}\n\n${bullets.join('\n')}`];
-    });
+      blocks.push(`### ${label}\n\n${bullets.join('\n')}`);
+    }
+
     return `## ${date}\n\n${blocks.join('\n\n')}`;
   });
 


### PR DESCRIPTION
## Summary

Two changelog improvements for the mobile "What's New" screen, building on the now-working self-hosted OTA pipeline.

**Native-release markers.** The changelog generator (`scripts/generate-changelog.ts`) now reads the `fingerprint-<platform>-<hash>` git tags the native build workflows push after a successful store upload, and emits a `nativeReleases` array alongside `entries`. Both `CHANGELOG.md` and the in-app feed weave these in as a dated **App update** divider, so the boundary between OTA-delivered and store-delivered changes is visible. The app filters markers to the running platform (a device only cares about store builds that changed its own binary). The OTA publish workflow checks out with `fetch-tags: true` so the tags are present when the generator runs.

**Check for updates.** The changelog screen gains a **Check for updates** button (shown only when `Updates.isEnabled`, i.e. production OTA builds) that pulls an OTA on demand: `checkForUpdateAsync` → `fetchUpdateAsync` → "restart now?" → `reloadAsync`, mirroring the existing `BranchSwitcherScreen` flow.

The generated `changelog.generated.json` / `CHANGELOG.md` are untouched here — they're owned solely by the OTA workflow (`changelog-owned` guard), which regenerates them with the new `nativeReleases` field on the next run. The app defaults `nativeReleases` to `[]` so the pre-feature snapshot still loads.

### Known limitation

A fingerprint tag is pushed only after the native build + store upload completes (~60 min for iOS), so a marker appears on the _next_ changelog regeneration, not the same push that triggered the native build. Acceptable for a changelog (eventually consistent).

## Release Notes

- See when a new app version landed — What's New now flags store updates, so you can tell what arrived over the air from what needs an app update.
- Tap "Check for updates" in What's New to grab the latest fixes on the spot.

## Test plan

- `vp test run --reporter=agent changelog-transform` — 37 pass (new `buildNativeReleases`, native-release markdown, idempotency coverage).
- `vp run typecheck:mobile`, `vp run typecheck` (all packages), plus a direct `tsc --noEmit` on the changed `scripts/` files — clean.
- `vp run test:mobile` — 2530 pass.
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp test run catalog-completeness` — i18n parity across en-US / es / fr holds (28 pass).
- `vp check` on all changed files — formatting + lint clean.
- End-to-end render harness against the repo's real `fingerprint-*` tags: markers build correctly (per-platform fingerprints, newest-first) and `CHANGELOG.md` renders the dated `### App update` sections with the right store label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fd63EEpwVrpfn41N5SbQRz