### PR TITLE
feat(mobile): refresh button and loading skeleton for the board-history sheet

### DIFF
--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -22,7 +22,11 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import { useBoardPresenceActions, useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
+import {
+  useBoardPresenceActions,
+  useBoardPresenceCurrent,
+  useBoardPresenceFeed,
+} from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardName, BoardPresenceClimb, BoardPresenceHardestSend, Climb } from '@boardsesh/shared-schema';
 import { GlassSheetBackground } from '../GlassSheetBackground';

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -22,7 +22,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
+import { useBoardPresenceActions, useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardName, BoardPresenceClimb, BoardPresenceHardestSend, Climb } from '@boardsesh/shared-schema';
 import { GlassSheetBackground } from '../GlassSheetBackground';
@@ -32,6 +32,7 @@ import { ActivityIndicator } from '../ActivityIndicator';
 import { ClimbListRow, type ClimbListRowRenderContentArgs } from '../ClimbListRow';
 import { PressableAvatar } from '../PressableAvatar';
 import { BoardDriverAvatar } from './BoardDriverAvatar';
+import { BoardSheetHistorySkeleton, BoardSheetStatsSkeleton } from './BoardSheetSkeleton';
 import { AccessoryClimbThumbnail } from '../queue-control/AccessoryClimbThumbnail';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -193,7 +194,11 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   boardConfigSignatureRef.current = boardConfigSignature;
 
   const { currentClimb } = useBoardPresenceCurrent();
-  const { history, stats } = useBoardPresenceFeed();
+  const { history, stats, isHydrating, isRefreshing } = useBoardPresenceFeed();
+  const { refresh } = useBoardPresenceActions();
+  // Show skeleton content on first open (before the backfill settles) and while a
+  // manual refresh is in flight.
+  const isLoading = isHydrating || isRefreshing;
   const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
   const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
   boardPresenceBoardIdRef.current = boardPresenceBoardId;
@@ -533,7 +538,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             gradeColor={getGradeColor(currentClimb?.grade ?? '') ?? DEFAULT_GRADE_COLOR}
           />
         )}
-        {stats ? (
+        {isLoading ? (
+          <BoardSheetStatsSkeleton />
+        ) : stats ? (
           <View style={styles.statsBlock}>
             <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
               {t('mobile.boardPresence.statsHeader')}
@@ -581,7 +588,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             ) : null}
           </View>
         ) : null}
-        {visibleHistory.length > 0 ? (
+        {!isLoading && visibleHistory.length > 0 ? (
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionHeader}>
             {t('mobile.boardPresence.historyHeader')}
           </Text>
@@ -592,6 +599,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       currentClimb,
       boardConfig,
       stats,
+      isLoading,
       visibleHistory.length,
       systemColors,
       brandColors.warning,
@@ -654,15 +662,28 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
         <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
           {boardLabel ?? t('mobile.boardPresence.title')}
         </Text>
-        <View pointerEvents="none" style={styles.headerAction} />
+        <Pressable
+          onPress={() => void refresh()}
+          disabled={isRefreshing}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.boardPresence.refresh')}
+          style={styles.headerAction}
+        >
+          {isRefreshing ? (
+            <ActivityIndicator size="small" style={styles.actionSpinner} />
+          ) : (
+            <Icon name="refresh" size={20} color={systemColors.secondaryLabel} />
+          )}
+        </Pressable>
       </View>
 
       <BottomSheetFlatList
-        data={visibleHistory}
+        data={isLoading ? [] : visibleHistory}
         keyExtractor={boardPresenceHistoryKeyExtractor}
         renderItem={renderHistoryItem}
         ListHeaderComponent={listHeader}
-        ListEmptyComponent={listEmpty}
+        ListEmptyComponent={isLoading ? <BoardSheetHistorySkeleton /> : listEmpty}
         contentContainerStyle={{ paddingBottom: spacing[4] }}
       />
 

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -668,7 +668,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
         </Text>
         <Pressable
           onPress={() => void refresh()}
-          disabled={isRefreshing}
+          disabled={isLoading}
           hitSlop={8}
           accessibilityRole="button"
           accessibilityLabel={t('mobile.boardPresence.refresh')}

--- a/packages/mobile/src/components/board-presence/BoardSheetSkeleton.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheetSkeleton.tsx
@@ -1,0 +1,131 @@
+// Skeleton ("shadow") placeholders for the board-presence sheet. Shown while the
+// feed is hydrating on first open and while a manual refresh is in flight, so the
+// stats tiles and history list don't pop in (or show the empty state) before data
+// lands. Static-opacity blocks tinted with `systemColors.fill`, matching
+// ClimbListRowSkeleton — no shimmer dependency. Dimensions mirror the real stat
+// tiles (styles.statTiles / statTile) and history rows (styles.historyRow).
+
+import { View, StyleSheet } from 'react-native';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+const STAT_TILE_COUNT = 4;
+const HISTORY_ROW_COUNT = 5;
+
+export function BoardSheetStatsSkeleton() {
+  const { systemColors } = useTheme();
+  const blockColor = systemColors.fill;
+
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      testID="board-sheet-stats-skeleton"
+      style={styles.statsBlock}
+    >
+      <View style={[styles.sectionHeaderBlock, { backgroundColor: blockColor }]} />
+      <View style={styles.statTiles}>
+        {Array.from({ length: STAT_TILE_COUNT }, (_, tileIndex) => (
+          <View key={tileIndex} style={[styles.statTile, { backgroundColor: systemColors.secondaryBackground }]}>
+            <View style={[styles.statValueBlock, { backgroundColor: blockColor }]} />
+            <View style={[styles.statLabelBlock, { backgroundColor: blockColor }]} />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+export function BoardSheetHistorySkeleton() {
+  const { systemColors } = useTheme();
+  const blockColor = systemColors.fill;
+
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      testID="board-sheet-history-skeleton"
+    >
+      <View style={[styles.sectionHeaderBlock, { backgroundColor: blockColor }]} />
+      {Array.from({ length: HISTORY_ROW_COUNT }, (_, rowIndex) => (
+        <View key={rowIndex} style={styles.historyRow}>
+          <View style={styles.historyBody}>
+            <View style={[styles.historyNameBlock, { backgroundColor: blockColor }]} />
+            <View style={[styles.historySubBlock, { backgroundColor: blockColor }]} />
+          </View>
+          <View style={[styles.historyGradeBlock, { backgroundColor: blockColor }]} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionHeaderBlock: {
+    width: 96,
+    height: 12,
+    borderRadius: borderRadius.full,
+    opacity: 0.4,
+    marginHorizontal: spacing[4],
+    marginTop: spacing[3],
+    marginBottom: spacing[2],
+  },
+  statsBlock: {
+    paddingBottom: spacing[2],
+  },
+  statTiles: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+  },
+  statTile: {
+    flexGrow: 1,
+    flexBasis: '47%',
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+    gap: 6,
+  },
+  statValueBlock: {
+    width: 40,
+    height: 22,
+    borderRadius: borderRadius.full,
+    opacity: 0.55,
+  },
+  statLabelBlock: {
+    width: 56,
+    height: 11,
+    borderRadius: borderRadius.full,
+    opacity: 0.4,
+  },
+  historyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  historyBody: {
+    flex: 1,
+    gap: 6,
+  },
+  historyNameBlock: {
+    width: '62%',
+    height: 16,
+    borderRadius: borderRadius.full,
+    opacity: 0.55,
+  },
+  historySubBlock: {
+    width: '40%',
+    height: 11,
+    borderRadius: borderRadius.full,
+    opacity: 0.4,
+  },
+  historyGradeBlock: {
+    width: 34,
+    height: 18,
+    borderRadius: borderRadius.full,
+    opacity: 0.5,
+  },
+});

--- a/packages/mobile/src/components/board-presence/BoardSheetSkeleton.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheetSkeleton.tsx
@@ -85,7 +85,8 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[3],
     paddingHorizontal: spacing[3],
     borderRadius: borderRadius.md,
-    gap: 6,
+    // Match styles.statTile in BoardSheet so tiles don't jump when real data lands.
+    gap: 2,
   },
   statValueBlock: {
     width: 40,
@@ -108,7 +109,8 @@ const styles = StyleSheet.create({
   },
   historyBody: {
     flex: 1,
-    gap: 6,
+    // Match styles.historyBody in BoardSheet so rows don't jump when real data lands.
+    gap: 2,
   },
   historyNameBlock: {
     width: '62%',

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -66,8 +66,9 @@ vi.mock('react-native', () => ({
     children,
     onPress,
     accessibilityLabel,
-  }: ViewMockProps & { onPress?: () => void; accessibilityLabel?: string }) =>
-    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+    disabled,
+  }: ViewMockProps & { onPress?: () => void; accessibilityLabel?: string; disabled?: boolean }) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel, disabled }, children),
 }));
 
 vi.mock('@gorhom/bottom-sheet', () => ({
@@ -956,7 +957,7 @@ describe('BoardSheet', () => {
   it('shows skeleton placeholders instead of history while hydrating', () => {
     presence.isHydrating = true;
     presence.history = [makeClimb('hidden-while-loading', 1)];
-    const { container } = render(
+    const { container, getByLabelText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose: noop,
@@ -967,8 +968,10 @@ describe('BoardSheet', () => {
     );
     // The real history rows are withheld while the skeleton is up.
     expect(container.textContent).not.toContain('hidden-while-loading');
-    // The header refresh control is still rendered (disabled) during the hydrate.
+    // The header refresh control is rendered but disabled during the hydrate, so a
+    // tap can't kick off a redundant fetch alongside the initial seeds.
     expect(container.querySelector('[data-icon="refresh"]')).not.toBeNull();
+    expect((getByLabelText('mobile.boardPresence.refresh') as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('shows skeleton placeholders and a spinning refresh control while refreshing', () => {

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -967,7 +967,26 @@ describe('BoardSheet', () => {
     );
     // The real history rows are withheld while the skeleton is up.
     expect(container.textContent).not.toContain('hidden-while-loading');
-    // The header refresh control stays available during the initial hydrate.
+    // The header refresh control is still rendered (disabled) during the hydrate.
     expect(container.querySelector('[data-icon="refresh"]')).not.toBeNull();
+  });
+
+  it('shows skeleton placeholders and a spinning refresh control while refreshing', () => {
+    presence.isRefreshing = true;
+    presence.history = [makeClimb('hidden-while-refreshing', 1)];
+    const { container } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+    // Same skeleton path as hydration: real rows withheld while refreshing.
+    expect(container.textContent).not.toContain('hidden-while-refreshing');
+    // The refresh control swaps its icon for a spinner mid-refresh.
+    expect(container.querySelector('[data-icon="refresh"]')).toBeNull();
+    expect(container.querySelector('[data-loading="true"]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -8,6 +8,12 @@ const presence = vi.hoisted(() => ({
   currentClimb: null as BoardPresenceClimb | null,
   history: [] as BoardPresenceClimb[],
   stats: null as BoardPresenceStats | null,
+  isHydrating: false,
+  isRefreshing: false,
+}));
+
+const presenceActions = vi.hoisted(() => ({
+  refresh: vi.fn(async () => {}),
 }));
 
 const presenceControls = vi.hoisted(() => ({
@@ -116,7 +122,13 @@ vi.mock('@boardsesh/board-presence-react', () => ({
     undoTarget: null,
     isLive: true,
   }),
-  useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
+  useBoardPresenceFeed: () => ({
+    history: presence.history,
+    stats: presence.stats,
+    isHydrating: presence.isHydrating,
+    isRefreshing: presence.isRefreshing,
+  }),
+  useBoardPresenceActions: () => ({ refresh: presenceActions.refresh }),
 }));
 
 vi.mock('../../../providers/board-presence-provider', () => ({
@@ -277,6 +289,9 @@ describe('BoardSheet', () => {
     presence.currentClimb = null;
     presence.history = [];
     presence.stats = null;
+    presence.isHydrating = false;
+    presence.isRefreshing = false;
+    presenceActions.refresh.mockClear();
     presenceControls.boardId = 123;
     analytics.track.mockClear();
     graphql.request.mockReset();
@@ -921,5 +936,38 @@ describe('BoardSheet', () => {
     expect(container.querySelector('[data-icon="close"]')).toBeNull();
     fireEvent.click(getByLabelText('mobile.boardPresence.close'));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('forces a refresh from the header refresh control', () => {
+    const { container, getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+    expect(container.querySelector('[data-icon="refresh"]')).not.toBeNull();
+    fireEvent.click(getByLabelText('mobile.boardPresence.refresh'));
+    expect(presenceActions.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows skeleton placeholders instead of history while hydrating', () => {
+    presence.isHydrating = true;
+    presence.history = [makeClimb('hidden-while-loading', 1)];
+    const { container } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onDismissed: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+    // The real history rows are withheld while the skeleton is up.
+    expect(container.textContent).not.toContain('hidden-while-loading');
+    // The header refresh control stays available during the initial hydrate.
+    expect(container.querySelector('[data-icon="refresh"]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -61,7 +61,8 @@ type ClimbListRowMockProps = {
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
-  View: ({ children }: ViewMockProps) => createElement('div', null, children),
+  View: ({ children, testID }: ViewMockProps & { testID?: string }) =>
+    createElement('div', { 'data-testid': testID }, children),
   Pressable: ({
     children,
     onPress,
@@ -968,6 +969,9 @@ describe('BoardSheet', () => {
     );
     // The real history rows are withheld while the skeleton is up.
     expect(container.textContent).not.toContain('hidden-while-loading');
+    // The stats and history skeletons actually render in place of the real content.
+    expect(container.querySelector('[data-testid="board-sheet-stats-skeleton"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="board-sheet-history-skeleton"]')).not.toBeNull();
     // The header refresh control is rendered but disabled during the hydrate, so a
     // tap can't kick off a redundant fetch alongside the initial seeds.
     expect(container.querySelector('[data-icon="refresh"]')).not.toBeNull();
@@ -986,8 +990,10 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
-    // Same skeleton path as hydration: real rows withheld while refreshing.
+    // Same skeleton path as hydration: real rows withheld, skeletons shown.
     expect(container.textContent).not.toContain('hidden-while-refreshing');
+    expect(container.querySelector('[data-testid="board-sheet-stats-skeleton"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="board-sheet-history-skeleton"]')).not.toBeNull();
     // The refresh control swaps its icon for a spinner mid-refresh.
     expect(container.querySelector('[data-icon="refresh"]')).toBeNull();
     expect(container.querySelector('[data-loading="true"]')).not.toBeNull();

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -684,7 +684,7 @@ describe('useBoardPresence — hydrating & refresh', () => {
   it('re-raises isHydrating synchronously on a board switch (no empty-state frame)', async () => {
     const harness = makeClient();
     const { result, rerender } = renderHook(({ boardId }) => useBoardPresence(boardId, harness.client), {
-      initialProps: { boardId: 1 },
+      initialProps: { boardId: 1 as number | null },
     });
 
     await act(async () => {

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -814,6 +814,36 @@ describe('useBoardPresence — hydrating & refresh', () => {
     expect(result.current.isRefreshing).toBe(false);
   });
 
+  it('refresh applies the successful fetches even when one (stats) fails', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('second', 2), climb('first', 1)]);
+      await harness.rejectStats(1, new Error('stats 503')).catch(() => undefined);
+      await harness.resolveConnection(1, holder({ userId: 'after' }));
+      await refreshPromise;
+    });
+
+    // History and holder update from the fulfilled fetches; stats keeps its prior
+    // value rather than clobbering it with a half-failed snapshot.
+    expect(result.current.history.map((entry) => entry.seq)).toEqual([2, 1]);
+    expect(result.current.stats?.climbsSentCount).toBe(1);
+    expect(result.current.holder?.userId).toBe('after');
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
   it('refresh is a no-op while the initial hydration is still in flight', async () => {
     const harness = makeClient();
     const { result } = renderHook(() => useBoardPresence(1, harness.client));

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -808,6 +808,43 @@ describe('useBoardPresence — hydrating & refresh', () => {
     expect(result.current.holder).toBeNull();
   });
 
+  it('ignores a refresh from a superseded binding after an A→B→A switch', async () => {
+    const harness = makeClient();
+    const { result, rerender } = renderHook(({ boardId }) => useBoardPresence(boardId, harness.client), {
+      initialProps: { boardId: 1 as number | null },
+    });
+
+    // Hydrate board 1 — settle all three seeds so the refresh's own fetches are the
+    // next pending deferreds (the fake resolves them in FIFO order per board).
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('board1-initial', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'board1-seed' }));
+    });
+    expect(result.current.isHydrating).toBe(false);
+
+    // Start a refresh on board 1, then switch away and BACK before it settles.
+    let stalePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      stalePromise = result.current.refresh();
+    });
+    rerender({ boardId: 2 });
+    rerender({ boardId: 1 });
+
+    // Resolve the original (now superseded) refresh's fetches. The board id matches
+    // again, but the bind generation moved on, so nothing is applied.
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('STALE', 9)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 999 });
+      await harness.resolveConnection(1, holder({ userId: 'stale-holder' }));
+      await stalePromise;
+    });
+
+    expect(result.current.history).toEqual([]);
+    expect(result.current.stats).toBeNull();
+    expect(result.current.holder).toBeNull();
+  });
+
   it('refresh is a no-op when inert', async () => {
     const { result } = renderHook(() => useBoardPresence(null, null));
     await expect(result.current.refresh()).resolves.toBeUndefined();

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -662,6 +662,131 @@ describe('useBoardPresence — actions', () => {
   });
 });
 
+describe('useBoardPresence — hydrating & refresh', () => {
+  it('reports isHydrating until both the recent-climbs and stats seeds settle', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+    // Skeleton flag is up from the moment the board binds.
+    expect(result.current.isHydrating).toBe(true);
+
+    // Only the recent fetch settled — stats still pending keeps hydration up.
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('a', 2)]);
+    });
+    expect(result.current.isHydrating).toBe(true);
+
+    await act(async () => {
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+    });
+    await waitFor(() => expect(result.current.isHydrating).toBe(false));
+  });
+
+  it('refresh re-fetches and merges recent climbs, stats, and holder while toggling isRefreshing', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+    expect(result.current.isRefreshing).toBe(false);
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+    // The synchronous part of refresh sets the flag and fires the fetches.
+    expect(result.current.isRefreshing).toBe(true);
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+    expect(harness.fetchStats).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('second', 2), climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 5, hardestGrade: 'V5' });
+      await harness.resolveConnection(1, holder({ userId: 'after-refresh' }));
+      await refreshPromise;
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+    expect(result.current.history.map((entry) => entry.seq)).toEqual([2, 1]);
+    expect(result.current.stats?.climbsSentCount).toBe(5);
+    expect(result.current.holder?.userId).toBe('after-refresh');
+  });
+
+  it('coalesces a refresh requested while one is already in flight (no double fetch)', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+
+    let firstRefresh: Promise<void> = Promise.resolve();
+    act(() => {
+      firstRefresh = result.current.refresh();
+    });
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+
+    // A second tap while the first is in flight is a no-op (guarded by the ref).
+    act(() => {
+      void result.current.refresh();
+    });
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+      await firstRefresh;
+    });
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it('ignores a refresh result for a board that was switched away mid-flight', async () => {
+    const harness = makeClient();
+    const { result, rerender } = renderHook(({ boardId }) => useBoardPresence(boardId, harness.client), {
+      initialProps: { boardId: 1 },
+    });
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('b1', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'b1' }));
+    });
+
+    let refreshPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+
+    // Switch boards before board 1's refresh resolves.
+    rerender({ boardId: 2 });
+    expect(result.current.history).toEqual([]);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('b1-late', 9)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 99 });
+      await harness.resolveConnection(1, holder({ userId: 'b1-late' }));
+      await refreshPromise;
+    });
+
+    // The stale board-1 refresh must not write into board 2's state.
+    expect(result.current.history).toEqual([]);
+    expect(result.current.stats).toBeNull();
+    expect(result.current.holder).toBeNull();
+  });
+
+  it('refresh is a no-op when inert', async () => {
+    const { result } = renderHook(() => useBoardPresence(null, null));
+    await expect(result.current.refresh()).resolves.toBeUndefined();
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});
+
 describe('useBoardPresence — connection holder', () => {
   it('seeds the holder from fetchConnection for a late joiner', async () => {
     const harness = makeClient();

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -813,6 +813,23 @@ describe('useBoardPresence — hydrating & refresh', () => {
     await expect(result.current.refresh()).resolves.toBeUndefined();
     expect(result.current.isRefreshing).toBe(false);
   });
+
+  it('refresh is a no-op while the initial hydration is still in flight', async () => {
+    const harness = makeClient();
+    const { result } = renderHook(() => useBoardPresence(1, harness.client));
+    // Seeds are still pending, so the board is hydrating.
+    expect(result.current.isHydrating).toBe(true);
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    // The refresh bailed: no extra fetches piled on top of the in-flight seeds.
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+    expect(harness.fetchStats).toHaveBeenCalledTimes(1);
+    expect(result.current.isRefreshing).toBe(false);
+  });
 });
 
 describe('useBoardPresence — connection holder', () => {

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -681,6 +681,34 @@ describe('useBoardPresence — hydrating & refresh', () => {
     await waitFor(() => expect(result.current.isHydrating).toBe(false));
   });
 
+  it('re-raises isHydrating synchronously on a board switch (no empty-state frame)', async () => {
+    const harness = makeClient();
+    const { result, rerender } = renderHook(({ boardId }) => useBoardPresence(boardId, harness.client), {
+      initialProps: { boardId: 1 },
+    });
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('a', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+    });
+    await waitFor(() => expect(result.current.isHydrating).toBe(false));
+
+    // Switching boards shows the skeleton again immediately — the render-phase
+    // reset raises it before the bind effect runs, so no empty-state flash.
+    rerender({ boardId: 2 });
+    expect(result.current.isHydrating).toBe(true);
+
+    await act(async () => {
+      await harness.resolveRecent(2, [climb('b', 1)]);
+      await harness.resolveStats(2, { ...emptyStats, climbsSentCount: 1 });
+    });
+    await waitFor(() => expect(result.current.isHydrating).toBe(false));
+
+    // Unbinding (null board) drops the skeleton too.
+    rerender({ boardId: null });
+    expect(result.current.isHydrating).toBe(false);
+  });
+
   it('refresh re-fetches and merges recent climbs, stats, and holder while toggling isRefreshing', async () => {
     const harness = makeClient();
     const { result } = renderHook(() => useBoardPresence(1, harness.client));

--- a/packages/shared/board-presence-react/src/board-presence-provider.tsx
+++ b/packages/shared/board-presence-react/src/board-presence-provider.tsx
@@ -40,8 +40,9 @@ export function BoardPresenceProvider({
       reportClimbWithUndoTarget: value.reportClimbWithUndoTarget,
       reportDisconnect: value.reportDisconnect,
       getUndoTarget: value.getUndoTarget,
+      refresh: value.refresh,
     }),
-    [value.reportClimb, value.reportClimbWithUndoTarget, value.reportDisconnect, value.getUndoTarget],
+    [value.reportClimb, value.reportClimbWithUndoTarget, value.reportDisconnect, value.getUndoTarget, value.refresh],
   );
   const current = useMemo<BoardPresenceCurrentState>(
     () => ({
@@ -57,8 +58,10 @@ export function BoardPresenceProvider({
     () => ({
       history: value.history,
       stats: value.stats,
+      isHydrating: value.isHydrating,
+      isRefreshing: value.isRefreshing,
     }),
-    [value.history, value.stats],
+    [value.history, value.stats, value.isHydrating, value.isRefreshing],
   );
   // Bare primitive on purpose — no useMemo. A boolean is compared by value, so
   // the context only re-renders consumers when it actually flips (not on every

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -222,10 +222,14 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   currentClimbRef.current = state.currentClimb;
   const undoTargetRef = useRef<BoardPresenceClimb | null>(undoTarget);
   undoTargetRef.current = undoTarget;
+  const isHydratingRef = useRef(isHydrating);
+  isHydratingRef.current = isHydrating;
   const observedSeqRef = useRef(0);
 
   // Tracks mount so async tails (e.g. a refresh resolving after unmount) can skip
   // their trailing state updates, matching the bind effect's per-run `isActive`.
+  // The mount assignment is not redundant with `useRef(true)`: under StrictMode's
+  // mount→cleanup→mount cycle the cleanup flips it false, so we must re-set it true.
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -438,19 +442,21 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   const refresh = useCallback(async (): Promise<void> => {
     const activeBoardId = boardIdRef.current;
     const activeClient = clientRef.current;
-    if (activeBoardId === null || activeClient === null || isRefreshingRef.current) {
+    // Skip while inert, already refreshing, or still doing the initial hydrate —
+    // the seeds are already fetching the same data, so a refresh would just pile on.
+    if (activeBoardId === null || activeClient === null || isRefreshingRef.current || isHydratingRef.current) {
       return;
     }
     isRefreshingRef.current = true;
     setIsRefreshing(true);
     try {
-      // Ignore a late result if the board was switched out mid-flight.
+      // Ignore a late result after unmount or a board switch mid-flight.
       await applyBoardPresenceCatchUp(
         activeClient,
         activeBoardId,
         dispatch,
         observedSeqRef,
-        () => boardIdRef.current === activeBoardId,
+        () => mountedRef.current && boardIdRef.current === activeBoardId,
       );
     } finally {
       // Only clear the flags if still mounted and on the board this refresh was

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -14,7 +14,16 @@
 // reducer). We also guard every async result against unmount and against a
 // board switch (late results for a previous board are ignored).
 
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type Dispatch, type MutableRefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+} from 'react';
 import {
   boardPresenceReducer,
   initialBoardPresenceState,

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -191,15 +191,28 @@ async function applyBoardPresenceCatchUp(
   }
 }
 
+type HydrationBindKey = { boardId: number | null; client: BoardPresenceClient | null };
+
 export function useBoardPresence(boardId: number | null, client: BoardPresenceClient | null): UseBoardPresenceResult {
   const [state, dispatch] = useReducer(boardPresenceReducer, initialBoardPresenceState);
   const [isLive, setIsLive] = useState(false);
-  // Seed true when there's a board to hydrate so the first paint already shows the
-  // skeleton (the bind effect, which sets it, only runs after the first render).
-  const [isHydrating, setIsHydrating] = useState(() => boardId !== null && client !== null);
+  const [isHydrating, setIsHydrating] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [undoTarget, setUndoTarget] = useState<BoardPresenceClimb | null>(null);
   const isRefreshingRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  // Raise the skeleton synchronously during render whenever the bound board (or
+  // client) changes — including the first render. Doing it here (not in the bind
+  // effect, which runs after render) avoids flashing the empty state for one frame
+  // before the skeleton appears on a fresh bind or a board switch. The seed-settle
+  // in the effect lowers it again. Mirrors the effect's `[boardId, client]` deps;
+  // the guard keeps the render-phase update from looping.
+  const [hydrationBindKey, setHydrationBindKey] = useState<HydrationBindKey | null>(null);
+  if (hydrationBindKey === null || hydrationBindKey.boardId !== boardId || hydrationBindKey.client !== client) {
+    setHydrationBindKey({ boardId, client });
+    setIsHydrating(boardId !== null && client !== null);
+  }
 
   // Live refs so the action callbacks stay identity-stable while still reading
   // the current board, client, and restore target.
@@ -213,17 +226,26 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   undoTargetRef.current = undoTarget;
   const observedSeqRef = useRef(0);
 
+  // Tracks mount so async tails (e.g. a refresh resolving after unmount) can skip
+  // their trailing state updates, matching the bind effect's per-run `isActive`.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   useEffect(() => {
     // No board or no transport: collapse to the initial state and stay inert.
     // RESET clears stats too (they live in the reducer now).
     if (boardId === null || client === null) {
       dispatch({ type: 'RESET' });
       setIsLive(false);
-      setIsHydrating(false);
       setIsRefreshing(false);
       isRefreshingRef.current = false;
       setUndoTarget(null);
       observedSeqRef.current = 0;
+      // isHydrating is driven by the render-phase bind-key reset above.
       return;
     }
 
@@ -232,11 +254,10 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     dispatch({ type: 'RESET' });
     setUndoTarget(null);
     observedSeqRef.current = 0;
-    // Drop any in-flight refresh from the previous board and show the skeleton
-    // until the initial backfill below settles for THIS board.
+    // Drop any in-flight refresh from the previous board. The skeleton is raised
+    // by the render-phase bind-key reset above; the seed-settle below lowers it.
     isRefreshingRef.current = false;
     setIsRefreshing(false);
-    setIsHydrating(true);
 
     let isActive = true;
     let catchUpInFlight = false;
@@ -434,9 +455,9 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
         () => boardIdRef.current === activeBoardId,
       );
     } finally {
-      // Only clear the flags if we're still on the board this refresh was for —
-      // a board switch already reset them and may have started a fresh refresh.
-      if (boardIdRef.current === activeBoardId) {
+      // Only clear the flags if still mounted and on the board this refresh was
+      // for — a board switch already reset them and may have started a fresh one.
+      if (mountedRef.current && boardIdRef.current === activeBoardId) {
         isRefreshingRef.current = false;
         setIsRefreshing(false);
       }

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -194,7 +194,9 @@ async function applyBoardPresenceCatchUp(
 export function useBoardPresence(boardId: number | null, client: BoardPresenceClient | null): UseBoardPresenceResult {
   const [state, dispatch] = useReducer(boardPresenceReducer, initialBoardPresenceState);
   const [isLive, setIsLive] = useState(false);
-  const [isHydrating, setIsHydrating] = useState(false);
+  // Seed true when there's a board to hydrate so the first paint already shows the
+  // skeleton (the bind effect, which sets it, only runs after the first render).
+  const [isHydrating, setIsHydrating] = useState(() => boardId !== null && client !== null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [undoTarget, setUndoTarget] = useState<BoardPresenceClimb | null>(null);
   const isRefreshingRef = useRef(false);
@@ -263,17 +265,16 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
         dispatch,
         observedSeqRef,
         () => isActive && boardIdRef.current === subscribedBoardId,
-      )
-        .finally(() => {
-          if (!isActive) {
-            return;
-          }
-          catchUpInFlight = false;
-          if (catchUpRequested) {
-            catchUpRequested = false;
-            runCatchUp();
-          }
-        });
+      ).finally(() => {
+        if (!isActive) {
+          return;
+        }
+        catchUpInFlight = false;
+        if (catchUpRequested) {
+          catchUpRequested = false;
+          runCatchUp();
+        }
+      });
     };
 
     // 1) Subscribe FIRST. Events arriving during the catch-up fetches below are

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -14,11 +14,12 @@
 // reducer). We also guard every async result against unmount and against a
 // board switch (late results for a previous board are ignored).
 
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type Dispatch, type MutableRefObject } from 'react';
 import {
   boardPresenceReducer,
   initialBoardPresenceState,
   mapBoardPresenceEnvelopeToAction,
+  type BoardPresenceAction,
   type BoardPresenceState,
 } from '@boardsesh/board-presence';
 import type {
@@ -37,11 +38,14 @@ export type UseBoardPresenceResult = {
   holder: BoardPresenceCurrentState['holder'];
   history: BoardPresenceFeedState['history'];
   stats: BoardPresenceFeedState['stats'];
+  isHydrating: BoardPresenceFeedState['isHydrating'];
+  isRefreshing: BoardPresenceFeedState['isRefreshing'];
   isLive: BoardPresenceCurrentState['isLive'];
   reportClimb: BoardPresenceActions['reportClimb'];
   reportClimbWithUndoTarget: BoardPresenceActions['reportClimbWithUndoTarget'];
   reportDisconnect: BoardPresenceActions['reportDisconnect'];
   getUndoTarget: BoardPresenceActions['getUndoTarget'];
+  refresh: BoardPresenceActions['refresh'];
 };
 
 export type BoardPresenceReportResult = {
@@ -71,6 +75,14 @@ export type BoardPresenceCurrentState = {
 export type BoardPresenceFeedState = {
   history: BoardPresenceState['history'];
   stats: BoardPresenceStats | null;
+  /**
+   * True from the moment a board binds until the initial backfill (recent climbs
+   * + stats) settles. Lets the feed surface a skeleton on first open instead of
+   * the empty state, which is otherwise indistinguishable from a quiet board.
+   */
+  isHydrating: boolean;
+  /** True while a user-triggered `refresh()` is in flight. */
+  isRefreshing: boolean;
 };
 
 export type BoardPresenceActions = {
@@ -91,6 +103,12 @@ export type BoardPresenceActions = {
   reportDisconnect: () => Promise<boolean>;
   /** Latest captured undo target for action-only consumers that need a ref-like read. */
   getUndoTarget: () => BoardPresenceClimb | null;
+  /**
+   * Force a re-fetch of the active board's recent climbs, stats, and connection
+   * holder, dispatching the same catch-up actions the live-gap path uses. Resolves
+   * when the fetch settles; no-op when inert or already refreshing.
+   */
+  refresh: () => Promise<void>;
 };
 
 function boardPresenceEventSeq(event: BoardPresenceEvent): number | null {
@@ -110,10 +128,67 @@ function highestClimbSeq(climbs: BoardPresenceClimb[]): number {
   return climbs.reduce((highestSeq, climb) => Math.max(highestSeq, climb.seq), 0);
 }
 
+/**
+ * Shared catch-up body for both the live-gap path and the user `refresh()`:
+ * re-fetch recent climbs + stats + connection holder for `boardId` and dispatch
+ * the seq-guarded merge actions. `observedSeqRef` is advanced past anything the
+ * recent fetch repaired so a later live event doesn't re-trigger catch-up for
+ * the same gap. `shouldApply` is re-checked AFTER the fetch settles — when it
+ * returns false (unmount or a board switch landed mid-flight) nothing is applied,
+ * so a late result for a superseded board can't clobber the new board's state.
+ * Callers own their own in-flight guarding.
+ */
+async function applyBoardPresenceCatchUp(
+  client: BoardPresenceClient,
+  boardId: number,
+  dispatch: Dispatch<BoardPresenceAction>,
+  observedSeqRef: MutableRefObject<number>,
+  shouldApply: () => boolean,
+): Promise<void> {
+  const startedAtSeq = observedSeqRef.current;
+  const connectionFetch = client.fetchConnection;
+  const connectionPromise =
+    connectionFetch === undefined
+      ? Promise.resolve<BoardConnectionHolder | null | undefined>(undefined)
+      : connectionFetch(boardId);
+
+  const [recentResult, statsResult, connectionResult] = await Promise.allSettled([
+    client.fetchRecentClimbs(boardId),
+    client.fetchStats(boardId),
+    connectionPromise,
+  ] as const);
+
+  if (!shouldApply()) {
+    return;
+  }
+
+  let repairedThroughSeq = startedAtSeq;
+  if (recentResult.status === 'fulfilled') {
+    const recentClimbs = recentResult.value;
+    repairedThroughSeq = Math.max(repairedThroughSeq, highestClimbSeq(recentClimbs));
+    observedSeqRef.current = Math.max(observedSeqRef.current, repairedThroughSeq);
+    dispatch({ type: 'BACKFILL_HISTORY', payload: recentClimbs });
+  }
+
+  if (statsResult.status === 'fulfilled') {
+    dispatch({ type: 'REFRESH_STATS', payload: { stats: statsResult.value, upToSeq: repairedThroughSeq } });
+  }
+
+  if (connectionFetch !== undefined && connectionResult.status === 'fulfilled') {
+    dispatch({
+      type: 'REFRESH_CONNECTION',
+      payload: { holder: connectionResult.value ?? null, upToSeq: repairedThroughSeq },
+    });
+  }
+}
+
 export function useBoardPresence(boardId: number | null, client: BoardPresenceClient | null): UseBoardPresenceResult {
   const [state, dispatch] = useReducer(boardPresenceReducer, initialBoardPresenceState);
   const [isLive, setIsLive] = useState(false);
+  const [isHydrating, setIsHydrating] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [undoTarget, setUndoTarget] = useState<BoardPresenceClimb | null>(null);
+  const isRefreshingRef = useRef(false);
 
   // Live refs so the action callbacks stay identity-stable while still reading
   // the current board, client, and restore target.
@@ -133,6 +208,9 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     if (boardId === null || client === null) {
       dispatch({ type: 'RESET' });
       setIsLive(false);
+      setIsHydrating(false);
+      setIsRefreshing(false);
+      isRefreshingRef.current = false;
       setUndoTarget(null);
       observedSeqRef.current = 0;
       return;
@@ -143,6 +221,11 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     dispatch({ type: 'RESET' });
     setUndoTarget(null);
     observedSeqRef.current = 0;
+    // Drop any in-flight refresh from the previous board and show the skeleton
+    // until the initial backfill below settles for THIS board.
+    isRefreshingRef.current = false;
+    setIsRefreshing(false);
+    setIsHydrating(true);
 
     let isActive = true;
     let catchUpInFlight = false;
@@ -165,45 +248,13 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       }
 
       catchUpInFlight = true;
-      const startedAtSeq = observedSeqRef.current;
-      const connectionFetch = client.fetchConnection;
-      const connectionPromise =
-        connectionFetch === undefined
-          ? Promise.resolve<BoardConnectionHolder | null | undefined>(undefined)
-          : connectionFetch(boardId);
-
-      void Promise.allSettled([
-        client.fetchRecentClimbs(boardId),
-        client.fetchStats(boardId),
-        connectionPromise,
-      ] as const)
-        .then(([recentResult, statsResult, connectionResult]) => {
-          if (!isActive || boardIdRef.current !== subscribedBoardId) {
-            return;
-          }
-
-          let repairedThroughSeq = startedAtSeq;
-          if (recentResult.status === 'fulfilled') {
-            const recentClimbs = recentResult.value;
-            repairedThroughSeq = Math.max(repairedThroughSeq, highestClimbSeq(recentClimbs));
-            observedSeqRef.current = Math.max(observedSeqRef.current, repairedThroughSeq);
-            dispatch({ type: 'BACKFILL_HISTORY', payload: recentClimbs });
-          }
-
-          if (statsResult.status === 'fulfilled') {
-            dispatch({
-              type: 'REFRESH_STATS',
-              payload: { stats: statsResult.value, upToSeq: repairedThroughSeq },
-            });
-          }
-
-          if (connectionFetch !== undefined && connectionResult.status === 'fulfilled') {
-            dispatch({
-              type: 'REFRESH_CONNECTION',
-              payload: { holder: connectionResult.value ?? null, upToSeq: repairedThroughSeq },
-            });
-          }
-        })
+      void applyBoardPresenceCatchUp(
+        client,
+        boardId,
+        dispatch,
+        observedSeqRef,
+        () => isActive && boardIdRef.current === subscribedBoardId,
+      )
         .finally(() => {
           if (!isActive) {
             return;
@@ -259,7 +310,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     //    fresh `BoardStatsUpdated` over the subscription above (handled by the
     //    reducer), so the tiles update live without re-fetching. SEED_STATS is a
     //    no-op once any live push has landed, so it can't clobber fresher data.
-    void client
+    const recentSeed = client
       .fetchRecentClimbs(boardId)
       .then((recentClimbs) => {
         if (isActive && boardIdRef.current === subscribedBoardId) {
@@ -273,7 +324,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
         hasSequenceBaseline = observedSeqRef.current > 0;
       });
 
-    void client
+    const statsSeed = client
       .fetchStats(boardId)
       .then((nextStats) => {
         if (isActive && boardIdRef.current === subscribedBoardId) {
@@ -283,6 +334,14 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       .catch(() => {
         // Stats are best-effort; absence renders as "no stats yet".
       });
+
+    // Skeleton stays up until both seeds settle for this board; after that the
+    // real history/stats (or the empty state) render.
+    void Promise.allSettled([recentSeed, statsSeed]).then(() => {
+      if (isActive && boardIdRef.current === subscribedBoardId) {
+        setIsHydrating(false);
+      }
+    });
 
     // 4) Seed the current connection holder for a late joiner. `fetchConnection`
     //    is optional — `?.` skips clients that don't implement it (returns
@@ -347,6 +406,33 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     return activeClient.reportDisconnect(activeBoardId);
   }, []);
 
+  const refresh = useCallback(async (): Promise<void> => {
+    const activeBoardId = boardIdRef.current;
+    const activeClient = clientRef.current;
+    if (activeBoardId === null || activeClient === null || isRefreshingRef.current) {
+      return;
+    }
+    isRefreshingRef.current = true;
+    setIsRefreshing(true);
+    try {
+      // Ignore a late result if the board was switched out mid-flight.
+      await applyBoardPresenceCatchUp(
+        activeClient,
+        activeBoardId,
+        dispatch,
+        observedSeqRef,
+        () => boardIdRef.current === activeBoardId,
+      );
+    } finally {
+      // Only clear the flags if we're still on the board this refresh was for —
+      // a board switch already reset them and may have started a fresh refresh.
+      if (boardIdRef.current === activeBoardId) {
+        isRefreshingRef.current = false;
+        setIsRefreshing(false);
+      }
+    }
+  }, []);
+
   return useMemo<UseBoardPresenceResult>(
     () => ({
       currentClimb: state.currentClimb,
@@ -355,11 +441,14 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       holder: state.holder,
       history: state.history,
       stats: state.stats,
+      isHydrating,
+      isRefreshing,
       isLive,
       reportClimb,
       reportClimbWithUndoTarget,
       reportDisconnect,
       getUndoTarget,
+      refresh,
     }),
     [
       state.currentClimb,
@@ -368,11 +457,14 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       state.holder,
       state.history,
       state.stats,
+      isHydrating,
+      isRefreshing,
       isLive,
       reportClimb,
       reportClimbWithUndoTarget,
       reportDisconnect,
       getUndoTarget,
+      refresh,
     ],
   );
 }

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -155,11 +155,9 @@ async function applyBoardPresenceCatchUp(
   shouldApply: () => boolean,
 ): Promise<void> {
   const startedAtSeq = observedSeqRef.current;
-  const connectionFetch = client.fetchConnection;
-  const connectionPromise =
-    connectionFetch === undefined
-      ? Promise.resolve<BoardConnectionHolder | null | undefined>(undefined)
-      : connectionFetch(boardId);
+  // Optional call (not a bare `client.fetchConnection` reference) so we don't trip
+  // typescript/unbound-method; `??` supplies the no-op for clients without it.
+  const connectionPromise = client.fetchConnection?.(boardId) ?? Promise.resolve(undefined);
 
   const [recentResult, statsResult, connectionResult] = await Promise.allSettled([
     client.fetchRecentClimbs(boardId),
@@ -183,7 +181,7 @@ async function applyBoardPresenceCatchUp(
     dispatch({ type: 'REFRESH_STATS', payload: { stats: statsResult.value, upToSeq: repairedThroughSeq } });
   }
 
-  if (connectionFetch !== undefined && connectionResult.status === 'fulfilled') {
+  if (client.fetchConnection !== undefined && connectionResult.status === 'fulfilled') {
     dispatch({
       type: 'REFRESH_CONNECTION',
       payload: { holder: connectionResult.value ?? null, upToSeq: repairedThroughSeq },

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -205,7 +205,8 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   // effect, which runs after render) avoids flashing the empty state for one frame
   // before the skeleton appears on a fresh bind or a board switch. The seed-settle
   // in the effect lowers it again. Mirrors the effect's `[boardId, client]` deps;
-  // the guard keeps the render-phase update from looping.
+  // the guard keeps the render-phase update from looping (and, like the effect,
+  // assumes `client` is identity-stable — an inline client would re-bind anyway).
   const [hydrationBindKey, setHydrationBindKey] = useState<HydrationBindKey | null>(null);
   if (hydrationBindKey === null || hydrationBindKey.boardId !== boardId || hydrationBindKey.client !== client) {
     setHydrationBindKey({ boardId, client });

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -226,6 +226,11 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   const isHydratingRef = useRef(isHydrating);
   isHydratingRef.current = isHydrating;
   const observedSeqRef = useRef(0);
+  // Monotonic token bumped on every bind (board/client change). A manual refresh
+  // captures it and only applies its result if it still matches — so a refresh
+  // whose binding was torn down and later re-created for the SAME board (an A→B→A
+  // switch) is still treated as stale, which a plain boardId check would miss.
+  const bindGenerationRef = useRef(0);
 
   // Tracks mount so async tails (e.g. a refresh resolving after unmount) can skip
   // their trailing state updates, matching the bind effect's per-run `isActive`.
@@ -239,6 +244,8 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   }, []);
 
   useEffect(() => {
+    // Every (re)bind supersedes any in-flight manual refresh from a prior binding.
+    bindGenerationRef.current += 1;
     // No board or no transport: collapse to the initial state and stay inert.
     // RESET clears stats too (they live in the reducer now).
     if (boardId === null || client === null) {
@@ -448,21 +455,19 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     if (activeBoardId === null || activeClient === null || isRefreshingRef.current || isHydratingRef.current) {
       return;
     }
+    // Capture the binding this refresh belongs to; any (re)bind bumps the token,
+    // so an A→B→A switch invalidates this run even though the board id matches again.
+    const refreshGeneration = bindGenerationRef.current;
+    const isCurrentBinding = () => mountedRef.current && bindGenerationRef.current === refreshGeneration;
     isRefreshingRef.current = true;
     setIsRefreshing(true);
     try {
-      // Ignore a late result after unmount or a board switch mid-flight.
-      await applyBoardPresenceCatchUp(
-        activeClient,
-        activeBoardId,
-        dispatch,
-        observedSeqRef,
-        () => mountedRef.current && boardIdRef.current === activeBoardId,
-      );
+      // Ignore a late result after unmount or a (re)bind mid-flight.
+      await applyBoardPresenceCatchUp(activeClient, activeBoardId, dispatch, observedSeqRef, isCurrentBinding);
     } finally {
-      // Only clear the flags if still mounted and on the board this refresh was
-      // for — a board switch already reset them and may have started a fresh one.
-      if (mountedRef.current && boardIdRef.current === activeBoardId) {
+      // Only clear the flags if this refresh's binding is still the live one — a
+      // rebind already reset them and may have started a fresh refresh.
+      if (isCurrentBinding()) {
         isRefreshingRef.current = false;
         setIsRefreshing(false);
       }

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -389,6 +389,7 @@
       "switchBoard": "Switch board",
       "switchBoardAria": "Switch to a different board",
       "close": "Close",
+      "refresh": "Refresh",
       "setByLine": "Set by {{setter}}",
       "drivenByA11y": "{{name}} is lighting the wall. Open profile.",
       "drivenByAnonA11y": "Someone is lighting the wall.",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -389,6 +389,7 @@
       "switchBoard": "Cambiar de muro",
       "switchBoardAria": "Cambiar a otro muro",
       "close": "Cerrar",
+      "refresh": "Actualizar",
       "setByLine": "Abierto por {{setter}}",
       "drivenByA11y": "{{name}} está encendiendo el muro. Abre el perfil.",
       "drivenByAnonA11y": "Alguien está encendiendo el muro.",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -389,6 +389,7 @@
       "switchBoard": "Changer de mur",
       "switchBoardAria": "Passer à un autre mur",
       "close": "Fermer",
+      "refresh": "Actualiser",
       "setByLine": "Ouvert par {{setter}}",
       "drivenByA11y": "{{name}} allume le mur. Ouvre le profil.",
       "drivenByAnonA11y": "Quelqu'un allume le mur.",


### PR DESCRIPTION
## Summary

The board-presence "Now on the wall" sheet on mobile is driven by a live GraphQL-WS subscription with an initial backfill on bind. When the live stream lags, the history and stats could sit stale with no way to force an update. On first open the sheet also jumped straight to the empty state before data landed — indistinguishable from a genuinely quiet board.

This adds a manual refresh and proper loading placeholders:

- **Shared hook (`@boardsesh/board-presence-react`):** expose a `refresh()` action plus `isHydrating` / `isRefreshing` flags from `useBoardPresence`, routed through the actions and feed contexts. `refresh()` reuses the existing catch-up fetch path (recent climbs + stats + connection holder), extracted into a shared `applyBoardPresenceCatchUp` helper so the live-gap path and the manual refresh share one implementation — same seq-dedup and board-switch guards. `refresh()` is a no-op while inert, already refreshing, or still hydrating, and skips its trailing state updates after unmount or a board switch.
- **Header refresh button:** fills the previously-empty top-right slot of the sheet header; shows a spinner while a refresh is in flight and is disabled while loading.
- **Skeleton ("shadow") content:** new `BoardSheetSkeleton` renders placeholder stat tiles and history rows (static-opacity blocks, matching `ClimbListRowSkeleton`). Shown while the feed is hydrating on first open and while a manual refresh runs; raised in a render-phase reset so a board switch shows the skeleton immediately rather than flashing the empty state. The live hero (current climb) keeps showing real data.

## Release Notes

- Pull up the board's "Now on the wall" sheet and tap refresh to grab the latest sends if the wall feed falls behind
- The history and stats now show loading placeholders while they catch up, instead of flashing an empty wall

## Test plan

Shared-hook tests (`use-board-presence.test.tsx`):
- `isHydrating` stays up until the recent-climbs + stats seeds settle, and re-raises synchronously on a board switch.
- `refresh()` re-fetches and merges history/stats/holder while toggling `isRefreshing`; a second tap mid-flight is coalesced; a board switch mid-refresh is ignored; a partial fetch failure (stats) keeps prior stats while history/holder still update; it's a no-op when inert or still hydrating.

Mobile sheet tests (`board-sheet.test.tsx`):
- The header refresh control calls `refresh()`; the stats/history skeletons render (asserted by testID) while hydrating and refreshing, replacing the real rows; the refresh control is disabled during hydration and swaps to a spinner while refreshing.

i18n: `refresh` key added to all three locale catalogs (`en-US`, `es`, `fr`).

Validated by CI (lint, typecheck, the full `vp` test suite, and the mobile Metro bundle check) — local `vp` runs weren't possible in this environment because the network policy blocks npm tarball downloads, so CI is the validation gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)