### PR TITLE
fix(backend): require activeBoardName and activeAngle together for playlist climbs

### DIFF
--- a/packages/backend/src/__tests__/playlist-queries.test.ts
+++ b/packages/backend/src/__tests__/playlist-queries.test.ts
@@ -317,6 +317,14 @@ describe('playlistClimbs resolver', () => {
     expect(byUuid['climb-tension'].angle).toBe(25);
   });
 
+  it('rejects activeBoardName without activeAngle (they must be provided together)', async () => {
+    const ctx = makeCtx();
+    // Validation runs before any DB access, so no select mocks are needed.
+    await expect(
+      playlistQueries.playlistClimbs(null, { input: { playlistId: 'test-pl', activeBoardName: 'kilter' } }, ctx),
+    ).rejects.toThrow();
+  });
+
   it('should return climbs in specific-board mode when boardName is provided', async () => {
     const ctx = makeCtx();
 

--- a/packages/backend/src/__tests__/playlist-queries.test.ts
+++ b/packages/backend/src/__tests__/playlist-queries.test.ts
@@ -317,12 +317,17 @@ describe('playlistClimbs resolver', () => {
     expect(byUuid['climb-tension'].angle).toBe(25);
   });
 
-  it('rejects activeBoardName without activeAngle (they must be provided together)', async () => {
+  it('rejects either activeBoardName or activeAngle alone — they must be provided together', async () => {
     const ctx = makeCtx();
-    // Validation runs before any DB access, so no select mocks are needed.
+    // Validation runs before any DB access, so no select mocks are needed. Assert
+    // the specific refine message (not just "throws") so an unrelated DB/resolver
+    // failure can't make this pass, and cover both directions of the refine.
     await expect(
       playlistQueries.playlistClimbs(null, { input: { playlistId: 'test-pl', activeBoardName: 'kilter' } }, ctx),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/must be provided together/);
+    await expect(
+      playlistQueries.playlistClimbs(null, { input: { playlistId: 'test-pl', activeAngle: 40 } }, ctx),
+    ).rejects.toThrow(/must be provided together/);
   });
 
   it('should return climbs in specific-board mode when boardName is provided', async () => {

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -86,20 +86,26 @@ export const GetPlaylistsForClimbsInputSchema = z.object({
   climbUuids: z.array(ExternalUUIDSchema).min(1).max(500),
 });
 
-export const GetPlaylistClimbsInputSchema = z.object({
-  playlistId: z.string().min(1),
-  boardName: BoardNameSchema.optional(),
-  layoutId: z.number().int().positive().optional(),
-  sizeId: z.number().int().positive().optional(),
-  setIds: z.string().min(1).optional(),
-  angle: z.number().int().optional(),
-  // All-boards mode only: render on-active-board climbs' grades at the user's
-  // selected angle instead of the added-at / most-ascents fallback.
-  activeBoardName: BoardNameSchema.optional(),
-  activeAngle: z.number().int().min(0).max(90).optional(),
-  page: z.number().int().min(0).optional(),
-  pageSize: z.number().int().min(1).max(100).optional(),
-});
+export const GetPlaylistClimbsInputSchema = z
+  .object({
+    playlistId: z.string().min(1),
+    boardName: BoardNameSchema.optional(),
+    layoutId: z.number().int().positive().optional(),
+    sizeId: z.number().int().positive().optional(),
+    setIds: z.string().min(1).optional(),
+    angle: z.number().int().optional(),
+    // All-boards mode only: render on-active-board climbs' grades at the user's
+    // selected angle instead of the added-at / most-ascents fallback. Both are
+    // required together — one without the other would silently no-op.
+    activeBoardName: BoardNameSchema.optional(),
+    activeAngle: z.number().int().min(0).max(90).optional(),
+    page: z.number().int().min(0).optional(),
+    pageSize: z.number().int().min(1).max(100).optional(),
+  })
+  .refine((input) => (input.activeBoardName == null) === (input.activeAngle == null), {
+    message: 'activeBoardName and activeAngle must be provided together',
+    path: ['activeAngle'],
+  });
 
 export const DiscoverPlaylistsInputSchema = z.object({
   boardType: BoardNameSchema.optional(),


### PR DESCRIPTION
## Summary

Follow-up to #3090 (the #1596 grade-angle fix). That PR added optional `activeBoardName` / `activeAngle` to the all-boards `playlistClimbs` input. The resolver only applies the active-angle override when **both** are set, so a request with one but not the other silently no-ops. This adds a zod `refine` so the API contract requires them together (both-or-neither) and rejects the half-specified case instead of quietly ignoring it.

Surfaced by the automated review on #3090; flagged non-blocking, and the commit landed seconds after that PR was merged, so it missed the train.

- `GetPlaylistClimbsInputSchema` gains a `refine` requiring `activeBoardName` and `activeAngle` to both be present or both absent.
- Resolver test asserts the half-specified request is rejected.
- Our clients (mobile all-boards list) always send both or neither, so no client change is needed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:backend` — green
- `vp test run --project backend playlist-queries` — 10 passed (incl. the new rejection case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157PsyHaLfWs8aXxN1T3No9
