### PR TITLE
fix(mobile): drop ActiveContextBar entering animation on Android (frozen bars)

### DIFF
--- a/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
+++ b/packages/mobile/src/components/queue-control/ActiveContextBar.tsx
@@ -13,7 +13,7 @@
  */
 
 import { type ReactNode } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { timing } from '../../theme/animations';
 import {
@@ -88,7 +88,13 @@ export function ActiveContextBar({
         },
       ]}
     >
-      <Animated.View entering={reduceMotion ? undefined : FadeIn.duration(timing.normal)}>
+      {/* Android: drop the `entering` animation entirely. Even this content-sized inner
+          Animated.View absorbs touches once it runs an `entering` layout animation —
+          Reanimated #5728 ignores pointerEvents on API 36, and in the full-width Material
+          variant (fillPrimary) the band spans the screen, freezing the top + bottom bars
+          the moment a climb is selected and the bar mounts. iOS honors pointerEvents, so
+          it keeps the fade. (#3060 split the outer View out but kept this inner fade.) */}
+      <Animated.View entering={reduceMotion || Platform.OS === 'android' ? undefined : FadeIn.duration(timing.normal)}>
         {fillPrimary ? (
           <View style={styles.fillRow} pointerEvents="box-none" importantForAccessibility="auto">
             {primary}


### PR DESCRIPTION
## Summary

Fixes the Android freeze where the **top and bottom bars go dead the moment a climb is selected** — confirmed live on build `2000363`, which already carries #3060 *and* the Phase 1 board-prewarm deferral, yet still froze.

`ActiveContextBar`'s inner `Animated.View` still runs `entering={FadeIn}`. On Android 16 a Reanimated `entering` layout animation **absorbs touches across the view's bounds and ignores `pointerEvents`** (Reanimated #5728), and in the Material `fillPrimary` variant that inner view is **full-width** — so selecting a climb (which mounts the bar) freezes the top + bottom bars while the climb list in the middle still scrolls/taps. #3060 split the *outer* positioning View out but **kept this inner fade**, so the bug persisted on the Android Material variant.

Fix: drop the `entering` animation on Android entirely (the inner view renders with no layout animation). iOS honors `pointerEvents`, so it keeps the fade.

## Release Notes

Fixed an Android freeze where the top and bottom bars stopped responding right after you picked a climb.

- [ ] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` + `vp run test:mobile` — 342 files / 2536 tests green.
- Diagnosed from PostHog: a user on `2000363` froze (rage-relaunch + repeated Play Drawer opens) immediately after `Set Active Climb`; symptom confirmed as "only the bars dead, the list still scrolls."
- Device verify pending: Android 16, select a climb → top + bottom bars stay responsive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ny9KuZRymZJ7g2XF92mgxk
