### PR TITLE
ci(mobile): add PR OTA-compatibility fingerprint check

### DIFF
--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -1,0 +1,164 @@
+name: Mobile OTA Compatibility (PR Signal)
+
+# A fast, reliable PR signal: does this mobile change ride over-the-air on
+# existing app binaries, or does it force a new TestFlight/Play build? It resolves
+# the Expo runtimeVersion `fingerprint` for iOS + Android on the branch AND on
+# origin/main (in one job, under identical env), then compares per platform —
+# equal = JS-only (ships OTA), different = native change (needs a new binary).
+# Informational only: a native change is legitimate, so the check stays neutral
+# and never blocks merge. Verdict lands as a sticky PR comment + a neutral
+# "OTA compatibility" check-run. See docs/mobile-ota-updates.md.
+#
+# Push-on-branch (not pull_request) so it has the token to comment + post a check
+# and — unlike a workflow_dispatch-only file — runs on its own feature branch
+# immediately, self-testing on its own PR.
+
+on:
+  push:
+    branches-ignore: [main]
+    # Mirror the native build / OTA-publish triggers (ios-testflight-rn.yml /
+    # android-apk-rn.yml / mobile-ota-production.yml) so the signal reacts to
+    # exactly what moves the fingerprint. packages/shared/** already covers
+    # queue / board-config / ble-protocol.
+    paths:
+      - 'packages/mobile/**'
+      - 'packages/shared/**'
+      - 'packages/board-constants/**'
+      - 'packages/shared-schema/**'
+      - '.github/workflows/mobile-ota-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # sticky comment
+  checks: write # neutral check-run
+
+concurrency:
+  group: mobile-ota-check-${{ github.ref }}
+  cancel-in-progress: true
+
+# ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
+# Byte-identical to ios-testflight-rn.yml / android-apk-rn.yml /
+# mobile-ota-production.yml — scripts/mobile-ci-env-parity.test.ts fails the build
+# if these drift. The fingerprint hashes the resolved Expo config + the written
+# .env, so the verdict is only meaningful if this check resolves under the same
+# env the native builds bake in. GOOGLE_MAPS_API_KEY is deliberately NOT set here:
+# it's a Production-environment secret unavailable on feature-branch pushes, and
+# the diff-vs-main verdict doesn't need it (a missing key shifts BOTH sides of the
+# comparison equally). The parity test guards that omission too.
+env:
+  EXPO_PUBLIC_BACKEND_URL: https://ws.boardsesh.com
+  EXPO_PUBLIC_WS_URL: wss://ws.boardsesh.com/graphql
+  EXPO_PUBLIC_WEB_URL: https://www.boardsesh.com
+  EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: 401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: 401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com
+  EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: 401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com
+  EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
+  EXPO_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+  EXPO_UPDATES_CHANNEL: production
+  EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+
+jobs:
+  ota-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Need origin/main reachable for the baseline worktree, and the tags for
+          # the secondary "already on a released build" lookup.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: voidzero-dev/setup-vp@v1
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies (PR tree)
+        run: bun install --frozen-lockfile
+
+      # Materialize origin/main as a sibling worktree with its OWN node_modules so
+      # the baseline resolves against main's exact dependency tree. The verdict is
+      # the PR-vs-main fingerprint diff; resolving both here, same job + same env,
+      # is what makes that diff robust to env imperfections.
+      - name: Materialize origin/main baseline
+        run: |
+          git fetch origin main --depth=1
+          git worktree add "$RUNNER_TEMP/main-baseline" origin/main
+
+      - name: Install dependencies (main baseline)
+        working-directory: ${{ runner.temp }}/main-baseline
+        run: bun install --frozen-lockfile
+
+      - name: Resolve fingerprints and compare vs main
+        id: ota
+        run: |
+          vp run check:mobile-ota-compat -- \
+            --write-env \
+            --check-shipped-tags \
+            --base-dir "$RUNNER_TEMP/main-baseline"
+
+      - name: Comment OTA compatibility on the PR
+        if: github.event_name == 'push' && steps.ota.outputs.comment_b64 != ''
+        uses: actions/github-script@v7
+        env:
+          COMMENT_B64: ${{ steps.ota.outputs.comment_b64 }}
+        with:
+          script: |
+            const body = Buffer.from(process.env.COMMENT_B64, 'base64').toString('utf8');
+            const marker = '<!-- mobile-ota-check -->';
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${context.payload.ref.replace('refs/heads/', '')}`,
+              state: 'open',
+            });
+            if (prs.length === 0) return;
+
+            const pr = prs[0];
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }
+
+      - name: Publish neutral check-run
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          # Falls back to "unknown" if an earlier step failed before the script
+          # produced an output (e.g. install died), so the check always posts.
+          CHECK_TITLE: ${{ steps.ota.outputs.check_title || 'OTA compatibility unknown (no baseline)' }}
+        with:
+          script: |
+            const title = process.env.CHECK_TITLE;
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'OTA compatibility',
+              head_sha: context.sha,
+              status: 'completed',
+              // Always neutral — informational, never a merge gate.
+              conclusion: 'neutral',
+              output: { title, summary: title },
+            });

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -31,6 +31,10 @@ const WORKFLOW_DIR = resolve(REPO_ROOT, '.github/workflows');
 const NATIVE_IOS = 'ios-testflight-rn.yml';
 const NATIVE_ANDROID = 'android-apk-rn.yml';
 const OTA = 'mobile-ota-production.yml';
+// The PR-time OTA-compatibility check (mobile-ota-check.yml) resolves the same
+// fingerprint, so its fingerprint-affecting env must stay locked to the native
+// builds — or it would report a verdict against an env the binaries never had.
+const OTA_CHECK = 'mobile-ota-check.yml';
 
 // Workflow-level env keys that feed the resolved config (fingerprint) and/or the
 // inlined JS bundle (runtime correctness). Every one must be declared identically
@@ -61,9 +65,11 @@ function workflowEnvValue(source: string, key: string): string | null {
 }
 
 describe('mobile CI env parity (OTA fingerprint invariant)', () => {
-  const workflows = [NATIVE_IOS, NATIVE_ANDROID, OTA];
+  // The PR-time OTA-compat check resolves the same fingerprint as the native
+  // builds + OTA publish, so it must share the same fingerprint-affecting env.
+  const workflows = [NATIVE_IOS, NATIVE_ANDROID, OTA, OTA_CHECK];
 
-  it.each(SHARED_ENV_KEYS)('declares %s identically across all three workflows', (key) => {
+  it.each(SHARED_ENV_KEYS)('declares %s identically across all mobile fingerprint workflows', (key) => {
     const values = workflows.map((name) => ({ name, value: workflowEnvValue(readWorkflow(name), key) }));
 
     for (const { name, value } of values) {
@@ -76,8 +82,18 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
       `${key} drifted across the mobile workflows: ${JSON.stringify(values)}. For a ` +
         `config-affecting var this desyncs the fingerprint runtimeVersion (the OTA never reaches ` +
         `the binary); for a bundle-only var it ships an OTA pointing at the wrong backend/analytics. ` +
-        `Keep all three workflows in lockstep.`,
+        `Keep all the mobile fingerprint workflows in lockstep.`,
     ).toBe(1);
+  });
+
+  it('keeps GOOGLE_MAPS_API_KEY out of the PR OTA-compat check (it diffs vs main without the key)', () => {
+    // mobile-ota-check.yml intentionally omits GOOGLE_MAPS_API_KEY: it's a
+    // Production-environment secret, unavailable on feature-branch pushes, and the
+    // diff-vs-main verdict doesn't need it — a missing key shifts BOTH sides of
+    // the comparison equally. Re-adding it here would reintroduce a Production
+    // dependency the branch push can't satisfy, so guard the omission.
+    const otaCheck = readWorkflow(OTA_CHECK);
+    expect(otaCheck).not.toMatch(/^\s*GOOGLE_MAPS_API_KEY:/m);
   });
 
   it('publishes the Android OTA with the same GOOGLE_MAPS_API_KEY the Android build bakes in', () => {

--- a/scripts/mobile-ota-compat-check.test.ts
+++ b/scripts/mobile-ota-compat-check.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHECK_TITLE,
+  STICKY_MARKER,
+  deriveOverall,
+  deriveVerdict,
+  parseArgs,
+  parseRuntimeVersion,
+  renderComment,
+  renderSummary,
+  type PlatformResult,
+  type Verdict,
+} from './mobile-ota-compat-check';
+
+function platformResult(
+  overrides: Partial<PlatformResult> & Pick<PlatformResult, 'platform' | 'verdict'>,
+): PlatformResult {
+  return {
+    prFingerprint: 'aaaaaaaaaaaa',
+    baseFingerprint: 'aaaaaaaaaaaa',
+    shippedTagExists: null,
+    ...overrides,
+  };
+}
+
+describe('deriveVerdict', () => {
+  it('equal fingerprints → ota-compatible', () => {
+    expect(deriveVerdict('abc12345', 'abc12345')).toBe('ota-compatible');
+  });
+
+  it('different fingerprints → native-change-required', () => {
+    expect(deriveVerdict('abc12345', 'def67890')).toBe('native-change-required');
+  });
+
+  it('missing baseline → unknown', () => {
+    expect(deriveVerdict('abc12345', null)).toBe('unknown');
+  });
+
+  it('missing PR fingerprint → unknown', () => {
+    expect(deriveVerdict(null, 'abc12345')).toBe('unknown');
+  });
+
+  it('both missing → unknown', () => {
+    expect(deriveVerdict(null, null)).toBe('unknown');
+  });
+});
+
+describe('deriveOverall precedence (native > unknown > compatible)', () => {
+  it('a native verdict on one platform wins even if the other is compatible', () => {
+    const results = [
+      platformResult({ platform: 'ios', verdict: 'ota-compatible' }),
+      platformResult({ platform: 'android', verdict: 'native-change-required' }),
+    ];
+    expect(deriveOverall(results)).toBe('native-change-required');
+  });
+
+  it('a native verdict is never masked by an unknown', () => {
+    const results = [
+      platformResult({ platform: 'ios', verdict: 'unknown' }),
+      platformResult({ platform: 'android', verdict: 'native-change-required' }),
+    ];
+    expect(deriveOverall(results)).toBe('native-change-required');
+  });
+
+  it('a single unknown downgrades an otherwise-compatible headline', () => {
+    const results = [
+      platformResult({ platform: 'ios', verdict: 'ota-compatible' }),
+      platformResult({ platform: 'android', verdict: 'unknown' }),
+    ];
+    expect(deriveOverall(results)).toBe('unknown');
+  });
+
+  it('all compatible → ota-compatible', () => {
+    const results = [
+      platformResult({ platform: 'ios', verdict: 'ota-compatible' }),
+      platformResult({ platform: 'android', verdict: 'ota-compatible' }),
+    ];
+    expect(deriveOverall(results)).toBe('ota-compatible');
+  });
+
+  it('no platforms → unknown', () => {
+    expect(deriveOverall([])).toBe('unknown');
+  });
+});
+
+describe('renderComment', () => {
+  const ctx = { sha: 'deadbeefcafef00d', branch: 'feat/x' };
+
+  it('carries the sticky marker, branch, and short SHA', () => {
+    const comment = renderComment(
+      {
+        results: [
+          platformResult({ platform: 'ios', verdict: 'ota-compatible' }),
+          platformResult({ platform: 'android', verdict: 'ota-compatible' }),
+        ],
+        overall: 'ota-compatible',
+      },
+      ctx,
+    );
+    expect(comment.startsWith(STICKY_MARKER)).toBe(true);
+    expect(comment).toContain('feat/x');
+    expect(comment).toContain('deadbee'); // 7-char short SHA
+    expect(comment).toContain('Ships over-the-air');
+  });
+
+  it('shows pr → main hashes for a native change', () => {
+    const comment = renderComment(
+      {
+        results: [
+          platformResult({ platform: 'ios', verdict: 'ota-compatible' }),
+          platformResult({
+            platform: 'android',
+            verdict: 'native-change-required',
+            prFingerprint: '1111111111aa',
+            baseFingerprint: '2222222222bb',
+          }),
+        ],
+        overall: 'native-change-required',
+      },
+      ctx,
+    );
+    expect(comment).toContain('Native change detected');
+    expect(comment).toContain('`1111111111aa` → `2222222222bb`');
+  });
+
+  it('states "already on a released build" only when shippedTagExists is true', () => {
+    const comment = renderComment(
+      {
+        results: [
+          platformResult({ platform: 'ios', verdict: 'ota-compatible', shippedTagExists: true }),
+          platformResult({ platform: 'android', verdict: 'ota-compatible', shippedTagExists: false }),
+        ],
+        overall: 'ota-compatible',
+      },
+      ctx,
+    );
+    expect(comment).toContain('already on a released build');
+    // Never makes a negative "not shipped" claim (ambiguous when the maps key is absent on Android).
+    expect(comment.toLowerCase()).not.toContain('not shipped');
+    expect(comment.toLowerCase()).not.toContain('no released build');
+  });
+});
+
+describe('renderSummary', () => {
+  it('includes a table row per platform', () => {
+    const summary = renderSummary({
+      results: [
+        platformResult({ platform: 'ios', verdict: 'ota-compatible' }),
+        platformResult({ platform: 'android', verdict: 'native-change-required', baseFingerprint: 'bbbbbbbbbbbb' }),
+      ],
+      overall: 'native-change-required',
+    });
+    expect(summary).toContain('## OTA compatibility');
+    expect(summary).toContain('| iOS |');
+    expect(summary).toContain('| Android |');
+  });
+});
+
+describe('CHECK_TITLE covers every verdict', () => {
+  it.each<Verdict>(['ota-compatible', 'native-change-required', 'unknown'])('has a title for %s', (verdict) => {
+    expect(CHECK_TITLE[verdict]).toBeTruthy();
+  });
+});
+
+describe('parseArgs', () => {
+  it('skips a leading `--` (vp run <task> -- <args> forwards it as argv[0])', () => {
+    const options = parseArgs(['--', '--write-env', '--base-dir', '/tmp/base'], '/repo');
+    expect(options.writeEnvFiles).toBe(true);
+    expect(options.baseMobileDir).toBe('/tmp/base/packages/mobile');
+  });
+
+  it('reads base fingerprints and the shipped-tags flag', () => {
+    const options = parseArgs(
+      ['--base-fingerprint-ios', 'abc12345', '--base-fingerprint-android', 'def67890', '--check-shipped-tags'],
+      '/repo',
+    );
+    expect(options.baseFingerprints).toEqual({ ios: 'abc12345', android: 'def67890' });
+    expect(options.checkShippedTags).toBe(true);
+  });
+
+  it('throws on an unknown argument', () => {
+    expect(() => parseArgs(['--nope'], '/repo')).toThrow(/unknown argument/);
+  });
+});
+
+describe('parseRuntimeVersion', () => {
+  it('extracts a valid hex runtimeVersion from JSON', () => {
+    expect(parseRuntimeVersion('{"runtimeVersion":"abc1234567"}')).toBe('abc1234567');
+  });
+
+  it('finds the JSON object amid surrounding log noise', () => {
+    expect(parseRuntimeVersion('resolving…\n{"runtimeVersion":"deadbeef","fingerprintSources":[]}\n')).toBe('deadbeef');
+  });
+
+  it('rejects a non-hex / too-short runtimeVersion', () => {
+    expect(parseRuntimeVersion('{"runtimeVersion":"1.0.0"}')).toBeNull();
+    expect(parseRuntimeVersion('{"runtimeVersion":"abc"}')).toBeNull();
+  });
+
+  it('returns null for empty or unparseable output', () => {
+    expect(parseRuntimeVersion('')).toBeNull();
+    expect(parseRuntimeVersion('not json at all')).toBeNull();
+  });
+});

--- a/scripts/mobile-ota-compat-check.ts
+++ b/scripts/mobile-ota-compat-check.ts
@@ -1,0 +1,386 @@
+/// <reference types="node" />
+
+/**
+ * Tells a PR reviewer, on every non-main branch push, whether a mobile change
+ * rides over-the-air on existing app binaries or forces a new TestFlight/Play
+ * build. It answers the one question the runtimeVersion `fingerprint` policy
+ * (packages/mobile/app.config.ts) makes load-bearing: an OTA update only reaches
+ * a binary whose fingerprint matches, so a JS-only change keeps the fingerprint
+ * (ships OTA in minutes) while a native change (deps, plugins, entitlements,
+ * config) moves it (needs a new binary first).
+ *
+ * Verdict = DIFF vs origin/main, resolved in ONE job under identical env:
+ *
+ *   fingerprint(PR tree, platform) === fingerprint(main tree, platform)
+ *     → ota-compatible            (no native delta vs main)
+ *   …differ                       → native-change-required
+ *   …either side unresolved       → unknown (neutral, never blocks)
+ *
+ * Why diff-vs-main and not "does a shipped fingerprint-<platform>-<hash> tag
+ * exist": the equality verdict is invariant to env imperfections. A missing
+ * GOOGLE_MAPS_API_KEY (a Production-environment secret, unavailable on
+ * feature-branch pushes — see .github/workflows/android-apk-rn.yml) shifts BOTH
+ * sides of the comparison by the same constant, so the PR-vs-main delta is still
+ * detected. The absolute hash never has to match production; only the relative
+ * diff matters. A tag lookup would instead need the branch push to reproduce the
+ * production hash exactly (maps key + cross-OS determinism) and would falsely
+ * report "native change" on every Android PR. The tag lookup is kept only as a
+ * SECONDARY, informational signal ("already on a released build"), surfaced only
+ * when confidently true.
+ *
+ * This never fails the PR: a native change is a legitimate outcome, not an error.
+ * The signal is the comment / step-summary / check-run content, not pass/fail.
+ *
+ * Usage:
+ *   vp run check:mobile-ota-compat -- --write-env --base-dir <main-worktree> [--check-shipped-tags]
+ *   vp run check:mobile-ota-compat -- --base-fingerprint-ios <h> --base-fingerprint-android <h>
+ *
+ * The CI workflow (.github/workflows/mobile-ota-check.yml) materializes the
+ * baseline as a git worktree of origin/main with its own `bun install`, then
+ * passes it via --base-dir. Run locally the same way:
+ *   git worktree add /tmp/main-baseline origin/main
+ *   (cd /tmp/main-baseline && bun install --frozen-lockfile)
+ *   vp run check:mobile-ota-compat -- --write-env --base-dir /tmp/main-baseline
+ */
+
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export type Platform = 'ios' | 'android';
+export type Verdict = 'ota-compatible' | 'native-change-required' | 'unknown';
+
+export const PLATFORMS: readonly Platform[] = ['ios', 'android'];
+
+/** The sticky-comment marker (matches the upsert logic in the workflow). */
+export const STICKY_MARKER = '<!-- mobile-ota-check -->';
+
+/**
+ * The .env keys whose values are hashed into the fingerprint (via the written
+ * .env file) — byte-identical to the heredoc the native build / gate jobs write.
+ * The script owns writing this into BOTH the PR and baseline trees so they can
+ * never diverge (a divergence would make every PR falsely read "native change").
+ */
+export const ENV_KEYS: readonly string[] = [
+  'EXPO_PUBLIC_BACKEND_URL',
+  'EXPO_PUBLIC_WS_URL',
+  'EXPO_PUBLIC_WEB_URL',
+  'EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID',
+  'EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID',
+  'EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID',
+  'EXPO_PUBLIC_SENTRY_DSN',
+  'EXPO_PUBLIC_POSTHOG_KEY',
+];
+
+/** Same shape the native gates accept: a lowercase hex hash, ≥8 chars. */
+const FINGERPRINT_RE = /^[0-9a-f]{8,}$/i;
+
+export interface PlatformResult {
+  platform: Platform;
+  /** Resolved fingerprint of the PR tree, or null if it couldn't be resolved. */
+  prFingerprint: string | null;
+  /** Resolved fingerprint of the origin/main baseline, or null if unavailable. */
+  baseFingerprint: string | null;
+  verdict: Verdict;
+  /** Secondary signal: a released binary already carries the PR fingerprint. null = not checked. */
+  shippedTagExists: boolean | null;
+}
+
+export interface OtaCompatResult {
+  results: PlatformResult[];
+  overall: Verdict;
+}
+
+export interface CommentContext {
+  sha: string;
+  branch: string;
+}
+
+/** PURE: a single platform verdict from the PR and baseline fingerprints. */
+export function deriveVerdict(prFingerprint: string | null, baseFingerprint: string | null): Verdict {
+  if (!prFingerprint || !baseFingerprint) return 'unknown';
+  return prFingerprint === baseFingerprint ? 'ota-compatible' : 'native-change-required';
+}
+
+/**
+ * PURE: fold per-platform verdicts into the headline. Precedence:
+ * native-change-required > unknown > ota-compatible — a confident native verdict
+ * on one platform is never masked by an "unknown" on the other, and a single
+ * "unknown" downgrades an otherwise-compatible headline to honest uncertainty.
+ */
+export function deriveOverall(results: readonly PlatformResult[]): Verdict {
+  if (results.some((entry) => entry.verdict === 'native-change-required')) return 'native-change-required';
+  if (results.some((entry) => entry.verdict === 'unknown')) return 'unknown';
+  if (results.length === 0) return 'unknown';
+  return 'ota-compatible';
+}
+
+function shortHash(fingerprint: string | null): string {
+  return fingerprint ? fingerprint.slice(0, 12) : '—';
+}
+
+const PLATFORM_LABEL: Record<Platform, string> = { ios: 'iOS', android: 'Android' };
+
+const VERDICT_CELL: Record<Verdict, string> = {
+  'ota-compatible': '✅ Compatible',
+  'native-change-required': '⚠️ Native change',
+  unknown: 'ℹ️ Unknown',
+};
+
+const HEADLINE: Record<Verdict, string> = {
+  'ota-compatible':
+    '✅ **Ships over-the-air.** No native change versus `main` — this lands on existing builds via OTA.',
+  'native-change-required':
+    "⚠️ **Native change detected.** This won't reach users over-the-air; it needs a new TestFlight/Play " +
+    'build before it ships. (Merge is not blocked — native changes are expected.)',
+  unknown: "ℹ️ **OTA compatibility unknown.** Couldn't establish a `main` baseline this run, so no verdict.",
+};
+
+/** A short title for the non-blocking GitHub check-run. */
+export const CHECK_TITLE: Record<Verdict, string> = {
+  'ota-compatible': 'OTA-compatible — rides existing builds',
+  'native-change-required': 'Native change — needs a new TestFlight/Play build',
+  unknown: 'OTA compatibility unknown (no baseline)',
+};
+
+/** PURE: the fingerprint cell for one platform, e.g. `abc123` (unchanged) or `pr` → `main`. */
+function fingerprintCell(entry: PlatformResult): string {
+  if (entry.verdict === 'ota-compatible') {
+    const cell = `\`${shortHash(entry.prFingerprint)}\` (unchanged)`;
+    // Secondary signal — only ever stated when confidently true.
+    return entry.shippedTagExists ? `${cell} · already on a released build` : cell;
+  }
+  if (entry.verdict === 'native-change-required') {
+    return `\`${shortHash(entry.prFingerprint)}\` → \`${shortHash(entry.baseFingerprint)}\``;
+  }
+  return `\`${shortHash(entry.prFingerprint)}\` (no baseline)`;
+}
+
+function table(results: readonly PlatformResult[]): string {
+  const rows = results.map(
+    (entry) => `| ${PLATFORM_LABEL[entry.platform]} | ${VERDICT_CELL[entry.verdict]} | ${fingerprintCell(entry)} |`,
+  );
+  return ['| Platform | Verdict | Fingerprint (PR → main) |', '| --- | --- | --- |', ...rows].join('\n');
+}
+
+/** PURE: render the sticky PR comment markdown. */
+export function renderComment(result: OtaCompatResult, ctx: CommentContext): string {
+  return [
+    STICKY_MARKER,
+    '### 📱 OTA compatibility',
+    '',
+    HEADLINE[result.overall],
+    '',
+    table(result.results),
+    '',
+    `Branch \`${ctx.branch}\` · commit \`${ctx.sha.slice(0, 7)}\`.`,
+    '',
+    '<sub>Fingerprint is resolved per platform against `main`. iOS native builds run on `main` ' +
+      'only, so the iOS verdict is computed versus `main`’s tree. See `docs/mobile-ota-updates.md`.</sub>',
+  ].join('\n');
+}
+
+/** PURE: render the `$GITHUB_STEP_SUMMARY` markdown. */
+export function renderSummary(result: OtaCompatResult): string {
+  return ['## OTA compatibility', '', HEADLINE[result.overall], '', table(result.results), ''].join('\n');
+}
+
+// ─── I/O (everything below shells out / touches the filesystem) ───────────────
+
+/** Pull the fingerprint hash out of `expo-updates runtimeversion:resolve` stdout. */
+export function parseRuntimeVersion(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  const candidates = [trimmed, trimmed.match(/\{[\s\S]*\}/)?.[0]].filter((value): value is string => Boolean(value));
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as { runtimeVersion?: unknown };
+      const value = parsed.runtimeVersion;
+      if (typeof value === 'string' && FINGERPRINT_RE.test(value)) return value;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+/** Write the byte-identical `.env` (the 8 EXPO_PUBLIC_* vars) into a mobile dir. */
+function writeEnv(mobileDir: string): void {
+  const body = ENV_KEYS.map((key) => `${key}=${process.env[key] ?? ''}`).join('\n');
+  writeFileSync(resolve(mobileDir, '.env'), `${body}\n`);
+}
+
+/**
+ * Resolve one platform's fingerprint by shelling the same CLI the native gates
+ * use. Returns null on any failure (mirrors the gates' `|| true` tolerance).
+ * iOS resolves WITHOUT GOOGLE_MAPS_API_KEY, Android WITH it — applied identically
+ * to PR and baseline so the equality verdict holds regardless of the key.
+ */
+function resolveFingerprint(mobileDir: string, platform: Platform): string | null {
+  const childEnv = { ...process.env };
+  if (platform === 'ios') delete childEnv.GOOGLE_MAPS_API_KEY;
+  try {
+    const stdout = execFileSync('bunx', ['expo-updates', 'runtimeversion:resolve', '--platform', platform], {
+      cwd: mobileDir,
+      env: childEnv,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return parseRuntimeVersion(stdout);
+  } catch {
+    return null;
+  }
+}
+
+/** Secondary signal: does a released binary already carry this fingerprint? */
+function shippedTagExists(platform: Platform, fingerprint: string): boolean {
+  try {
+    execFileSync(
+      'git',
+      ['ls-remote', '--exit-code', '--tags', 'origin', `refs/tags/fingerprint-${platform}-${fingerprint}`],
+      {
+        stdio: 'ignore',
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface Options {
+  prMobileDir: string;
+  baseMobileDir: string | null;
+  baseFingerprints: Partial<Record<Platform, string>>;
+  writeEnvFiles: boolean;
+  checkShippedTags: boolean;
+}
+
+export function parseArgs(argv: readonly string[], repoRoot: string): Options {
+  const options: Options = {
+    prMobileDir: resolve(repoRoot, 'packages', 'mobile'),
+    baseMobileDir: null,
+    baseFingerprints: {},
+    writeEnvFiles: false,
+    checkShippedTags: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const next = (): string => {
+      const value = argv[index + 1];
+      if (value === undefined) throw new Error(`missing value for ${flag}`);
+      index += 1;
+      return value;
+    };
+    switch (flag) {
+      case '--':
+        // `vp run <task> -- <args>` forwards a literal `--` separator as argv[0];
+        // it carries no meaning here, so skip it.
+        break;
+      case '--pr-dir':
+        options.prMobileDir = resolve(next(), 'packages', 'mobile');
+        break;
+      case '--base-dir':
+        options.baseMobileDir = resolve(next(), 'packages', 'mobile');
+        break;
+      case '--base-fingerprint-ios':
+        options.baseFingerprints.ios = next();
+        break;
+      case '--base-fingerprint-android':
+        options.baseFingerprints.android = next();
+        break;
+      case '--write-env':
+        options.writeEnvFiles = true;
+        break;
+      case '--check-shipped-tags':
+        options.checkShippedTags = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  return options;
+}
+
+function emitGithubOutputs(result: OtaCompatResult, ctx: CommentContext): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    const verdictFor = (platform: Platform): Verdict =>
+      result.results.find((entry) => entry.platform === platform)?.verdict ?? 'unknown';
+    const commentB64 = Buffer.from(renderComment(result, ctx), 'utf8').toString('base64');
+    appendFileSync(
+      outputPath,
+      [
+        `overall=${result.overall}`,
+        `verdict_ios=${verdictFor('ios')}`,
+        `verdict_android=${verdictFor('android')}`,
+        `check_title=${CHECK_TITLE[result.overall]}`,
+        `comment_b64=${commentB64}`,
+        '',
+      ].join('\n'),
+    );
+  }
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) appendFileSync(summaryPath, `${renderSummary(result)}\n`);
+}
+
+/** Wire the real filesystem / subprocesses and run the check. Returns the exit code. */
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const options = parseArgs(argv, repoRoot);
+
+  if (options.writeEnvFiles) {
+    writeEnv(options.prMobileDir);
+    if (options.baseMobileDir) writeEnv(options.baseMobileDir);
+  }
+
+  const results: PlatformResult[] = PLATFORMS.map((platform) => {
+    const prFingerprint = resolveFingerprint(options.prMobileDir, platform);
+    const baseFingerprint =
+      options.baseFingerprints[platform] ??
+      (options.baseMobileDir ? resolveFingerprint(options.baseMobileDir, platform) : null);
+
+    if (!prFingerprint) {
+      console.warn(
+        `::warning::Could not resolve the ${platform} fingerprint — reporting OTA compatibility as unknown.`,
+      );
+    }
+    if (!baseFingerprint) {
+      console.warn(`::warning::No ${platform} baseline fingerprint — reporting OTA compatibility as unknown.`);
+    }
+
+    const verdict = deriveVerdict(prFingerprint, baseFingerprint);
+    const tagExists =
+      options.checkShippedTags && prFingerprint && verdict === 'ota-compatible'
+        ? shippedTagExists(platform, prFingerprint)
+        : null;
+
+    return { platform, prFingerprint, baseFingerprint, verdict, shippedTagExists: tagExists };
+  });
+
+  const result: OtaCompatResult = { results, overall: deriveOverall(results) };
+
+  for (const entry of result.results) {
+    console.log(
+      `[mobile-ota-compat] ${PLATFORM_LABEL[entry.platform]}: ${entry.verdict} ` +
+        `(pr=${shortHash(entry.prFingerprint)} main=${shortHash(entry.baseFingerprint)})`,
+    );
+  }
+  console.log(`[mobile-ota-compat] overall: ${result.overall}`);
+
+  emitGithubOutputs(result, {
+    sha: process.env.GITHUB_SHA ?? 'local',
+    branch: process.env.GITHUB_REF_NAME ?? 'local',
+  });
+
+  // Never fail the PR — a native change is legitimate. The signal is the content.
+  return 0;
+}
+
+// Run only when executed directly (tsx scripts/mobile-ota-compat-check.ts), not
+// when imported by the unit test.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -511,6 +511,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-native-deps-check.ts',
         cache: false,
       },
+      'check:mobile-ota-compat': {
+        command: 'tsx scripts/mobile-ota-compat-check.ts',
+        cache: false,
+      },
       'check:mobile-patches': {
         command: 'tsx scripts/mobile-patches-check.ts',
         cache: false,


### PR DESCRIPTION
## Summary

On a mobile PR, there was no way to tell — while reviewing — whether the change ships to users **over-the-air** or forces a new TestFlight/Play build. The Expo `runtimeVersion: { policy: 'fingerprint' }` makes that the load-bearing question: a JS-only change keeps the fingerprint (OTA lands in minutes), any native change moves it (needs a new binary first). Until now the fingerprint was only resolved on `main`.

This adds a fast, **informational** PR signal:

- A new **"OTA compatibility"** check + sticky PR comment on every non-`main` push that touches mobile code, stating per-platform whether the PR is OTA-compatible.
- **Never blocks merge** — a native change is legitimate; the check stays `neutral`.

### How the verdict is computed

It resolves the iOS + Android fingerprint on the branch **and** on `origin/main` in one job under identical env, then compares for equality per platform — equal → ships OTA, different → needs a native build.

Comparing **PR-vs-main** (not "does a shipped `fingerprint-*` tag exist") is what makes it reliable: the equality verdict is invariant to env imperfections. A missing `GOOGLE_MAPS_API_KEY` (a Production-environment secret, unavailable on feature-branch pushes) shifts *both* sides of the comparison by the same constant, so the delta is still detected — no Production secret needed on branch pushes. A shipped-tag lookup is kept only as a secondary, "already on a released build" line.

### Changes

- `scripts/mobile-ota-compat-check.ts` — pure verdict/render logic + thin I/O. Reuses `bunx expo-updates runtimeversion:resolve` (no new dep), writes a byte-identical `.env` into both trees so they can't diverge, emits the comment body + `$GITHUB_STEP_SUMMARY`. Exit 0 for every verdict.
- `.github/workflows/mobile-ota-check.yml` — push-on-branch trigger, env mirrored from the native build workflows, `origin/main` worktree baseline, sticky comment + neutral check-run.
- `scripts/mobile-ci-env-parity.test.ts` — locks the new workflow's fingerprint env to the native builds; guards its intentional omission of `GOOGLE_MAPS_API_KEY`.
- `vite.config.ts` — registers `check:mobile-ota-compat`.

Push-trigger (not `workflow_dispatch`-only), so it **self-tests on this PR** — expect an "OTA compatibility" comment + check below.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 195 pass, incl. new verdict/precedence/render/parseArgs tests and the env-parity guard.
- `vp run typecheck` — clean. `vp check` — clean on changed files.
- Local end-to-end against an `origin/main` worktree:
  - JS/CI-only branch → **`ota-compatible`**, both platforms resolve to identical PR/main hashes under identical env (iOS `e02b48b0bbab`, Android `e3285fb8eb51`).
  - Perturbing a hashed native source (a plugin file) in the baseline → flips to **`native-change-required`** on both platforms (iOS `e02b…`→`ff9f…`, Android `e328…`→`9601…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfJ8E5QVxhWYbKRb4RGDbn