### PR TITLE
fix(mobile): pin one fingerprint across native build + OTA publish

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -81,9 +81,10 @@ jobs:
   # Fingerprint gate: resolve the Android runtimeVersion fingerprint and skip the
   # native build when a binary with that fingerprint already shipped (a
   # fingerprint-android-<hash> tag exists). The OTA publish
-  # (mobile-ota-production.yml) still delivers the JS to matching binaries. The
-  # build job re-resolves and tags THAT value on success. Gate + build both run
-  # on Linux, so the fingerprints match exactly. See docs/mobile-ota-updates.md.
+  # (mobile-ota-production.yml) still delivers the JS to matching binaries. This
+  # gate is the ONE canonical resolution: the build embeds this exact value in the
+  # binary via EXPO_UPDATES_FINGERPRINT_OVERRIDE and tags it, so binary-rv == tag
+  # == the OTA-published rv by construction. See docs/mobile-ota-updates.md.
   gate:
     # Push is always on main; a manual dispatch (any branch) always builds, so
     # `workflow_dispatch` keeps producing an APK artifact off a feature branch.
@@ -168,6 +169,15 @@ jobs:
     # Shared EXPO_PUBLIC_* / EXPO_UPDATES_* / GOOGLE_MAPS_API_KEY env lives at the
     # workflow level (above) so the gate and build jobs resolve a byte-identical
     # fingerprint.
+    env:
+      # Pin the binary's runtimeVersion to the gate's canonical fingerprint.
+      # app.config.ts emits this as a LITERAL runtimeVersion, so `expo prebuild`
+      # bakes this exact value into the binary and the build never resolves its
+      # own. Android gate+build are both Linux, so this is belt-and-suspenders —
+      # but it keeps the invariant identical to iOS: binary-rv == the
+      # fingerprint-android-<hash> tag == the OTA-published rv by construction.
+      # See docs/mobile-ota-updates.md.
+      EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${{ needs.gate.outputs.fingerprint }}
 
     steps:
       - name: Checkout repository
@@ -233,21 +243,19 @@ jobs:
           echo "SENTRY_DISABLE_AUTO_UPLOAD=true" >> "$GITHUB_ENV"
           echo "::warning::Sentry source-map upload is disabled for Android release builds until the Gradle upload task is compatible with the generated Gradle version."
 
-      # Re-resolve the fingerprint (Linux, same runner class as the gate) before
-      # prebuild, and tag this value on a successful release (final tag step).
-      # GOOGLE_MAPS_API_KEY is inherited from the workflow env.
-      - name: Resolve fingerprint for tagging
+      # The binary embeds the gate's canonical fingerprint via
+      # EXPO_UPDATES_FINGERPRINT_OVERRIDE (job env above), so the build no longer
+      # re-resolves. Record the gate value so the tag step (final) tags exactly
+      # what the binary embeds: tag == binary-rv == OTA-published rv.
+      - name: Record fingerprint for tagging
         run: |
           set -uo pipefail
-          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform android 2>/dev/null || true)"
-          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
-          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
-            echo "::warning::Could not resolve the Android fingerprint on the build runner — the fingerprint tag will be skipped (the next push rebuilds)."
-          else
+          fp="${{ needs.gate.outputs.fingerprint }}"
+          if printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
             echo "FINGERPRINT_ANDROID=$fp" >> "$GITHUB_ENV"
-            if [ "$fp" != "${{ needs.gate.outputs.fingerprint }}" ]; then
-              echo "::warning::Android fingerprint differs between the gate (${{ needs.gate.outputs.fingerprint }}) and this build ($fp) — both run on Linux, so this is unexpected; investigate."
-            fi
+            echo "::notice::Android binary embeds gate fingerprint $fp (EXPO_UPDATES_FINGERPRINT_OVERRIDE); tagging that value on a successful release."
+          else
+            echo "::warning::Gate produced no usable fingerprint; the binary self-resolves and no fingerprint-android tag is pushed (next push rebuilds)."
           fi
 
       - name: Expo prebuild (generate android/)

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -62,10 +62,11 @@ jobs:
   # Fingerprint gate: resolve the iOS runtimeVersion fingerprint on a cheap Linux
   # runner and skip the ~60-min macOS build when a binary with that fingerprint
   # already shipped (a fingerprint-ios-<hash> tag exists). The OTA publish
-  # (mobile-ota-production.yml) still delivers the JS to matching binaries. The
-  # build job re-resolves on macOS and tags THAT value, so a Linux/macOS
-  # fingerprint divergence can only ever make iOS over-build, never wrongly skip.
-  # See docs/mobile-ota-updates.md.
+  # (mobile-ota-production.yml) still delivers the JS to matching binaries. This
+  # gate is the ONE canonical resolution: the build job embeds this exact value in
+  # the binary via EXPO_UPDATES_FINGERPRINT_OVERRIDE (no macOS re-resolve) and tags
+  # it, so binary-rv == tag == the OTA-published rv by construction — no cross-OS
+  # divergence to over-build around or strand OTAs over. See docs/mobile-ota-updates.md.
   gate:
     # main-only: the iOS build is main-only by design (it uploads to TestFlight),
     # so a dispatch forces a build only from main — there's no point running the
@@ -158,6 +159,13 @@ jobs:
       KEYCHAIN_PASSWORD: ${{ github.run_id }}
       # Shared EXPO_PUBLIC_* / EXPO_UPDATES_* env lives at the workflow level
       # (above) so the gate and build jobs resolve a byte-identical fingerprint.
+      #
+      # Pin the binary's runtimeVersion to the gate's canonical (Linux) fingerprint.
+      # app.config.ts reads this and emits it as a LITERAL runtimeVersion, so
+      # `expo prebuild` bakes this exact value into Expo.plist and the macOS runner
+      # never resolves its own (divergent) fingerprint. Job-level so it's live at
+      # prebuild AND the xcodebuild archive phase. See docs/mobile-ota-updates.md.
+      EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${{ needs.gate.outputs.fingerprint }}
 
     steps:
       - name: Checkout repository
@@ -182,22 +190,21 @@ jobs:
           EXPO_PUBLIC_POSTHOG_KEY=$EXPO_PUBLIC_POSTHOG_KEY
           EOF
 
-      # Re-resolve the fingerprint on THIS (macOS) runner, before prebuild, and
-      # tag this value on a successful upload (final step). The gate checks the
-      # Linux value; tagging the build-runner value means a cross-OS divergence
-      # can only ever over-build, never wrongly skip.
-      - name: Resolve fingerprint for tagging
+      # The binary embeds the gate's canonical fingerprint via
+      # EXPO_UPDATES_FINGERPRINT_OVERRIDE (job env above), so the macOS runner no
+      # longer re-resolves its own value — that cross-OS divergence is what
+      # stranded iOS OTAs (binary on the macOS hash, publish on the Linux hash).
+      # Record the gate value here so the tag step (final) tags exactly what the
+      # binary embeds: tag == binary-rv == published-rv by construction.
+      - name: Record fingerprint for tagging
         run: |
           set -uo pipefail
-          raw="$(cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform ios 2>/dev/null || true)"
-          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
-          if ! printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
-            echo "::warning::Could not resolve the iOS fingerprint on the build runner — the fingerprint tag will be skipped (the next push rebuilds)."
-          else
+          fp="${{ needs.gate.outputs.fingerprint }}"
+          if printf '%s' "$fp" | grep -qiE '^[0-9a-f]{8,}$'; then
             echo "FINGERPRINT_IOS=$fp" >> "$GITHUB_ENV"
-            if [ "$fp" != "${{ needs.gate.outputs.fingerprint }}" ]; then
-              echo "::warning::iOS fingerprint differs between the Linux gate (${{ needs.gate.outputs.fingerprint }}) and this macOS build ($fp); the gate will conservatively keep building iOS until they agree. Investigate cross-OS @expo/fingerprint determinism."
-            fi
+            echo "::notice::iOS binary embeds gate fingerprint $fp (EXPO_UPDATES_FINGERPRINT_OVERRIDE); tagging that value on a successful upload."
+          else
+            echo "::warning::Gate produced no usable fingerprint; the binary self-resolves on macOS and no fingerprint-ios tag is pushed (next push rebuilds)."
           fi
 
       - name: Expo prebuild (generate ios/)

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -144,28 +144,6 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Pin each platform's OTA to the runtimeVersion the INSTALLED binaries embed
-      # = the most-recent ancestor fingerprint-<platform>-<hash> tag (pushed by the
-      # native build workflows when a store binary shipped). The publish steps below
-      # export this as EXPO_UPDATES_FINGERPRINT_OVERRIDE; app.config.ts turns it into
-      # a literal runtimeVersion that `eoas publish` resolves verbatim, so the bundle
-      # is served under exactly the binary's runtimeVersion — no Linux-vs-binary
-      # resolution mismatch can strand it. On a native-change commit the NEW
-      # fingerprint's tag may not exist yet (the native build runs as a separate,
-      # parallel workflow), so the publish pins to the PREVIOUS fingerprint: correct,
-      # since old binaries get matching JS and the fresh binary already carries this
-      # commit's JS embedded (it picks up its own fingerprint's OTA on the next push).
-      - name: Resolve OTA fingerprint pins from shipped native tags
-        id: pins
-        if: steps.gate.outputs.configured == 'true'
-        run: |
-          set -uo pipefail
-          ios_fp="$(git describe --tags --abbrev=0 --match 'fingerprint-ios-*' 2>/dev/null | sed 's/^fingerprint-ios-//' || true)"
-          android_fp="$(git describe --tags --abbrev=0 --match 'fingerprint-android-*' 2>/dev/null | sed 's/^fingerprint-android-//' || true)"
-          echo "ios_fp=$ios_fp" >> "$GITHUB_OUTPUT"
-          echo "android_fp=$android_fp" >> "$GITHUB_OUTPUT"
-          echo "::notice::OTA pins — iOS=${ios_fp:-<none>} Android=${android_fp:-<none>} (most-recent ancestor fingerprint tags)."
-
       - name: Write .env for Expo build-time inlining
         if: steps.gate.outputs.configured == 'true'
         working-directory: packages/mobile
@@ -229,16 +207,14 @@ jobs:
       - name: Publish iOS OTA
         id: publish_ios
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
-        env:
-          # Pin the published runtimeVersion to the last shipped iOS binary's
-          # fingerprint so the bundle actually reaches it. app.config.ts emits this
-          # as a literal runtimeVersion; eoas publishes under it verbatim.
-          EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${{ steps.pins.outputs.ios_fp }}
+        # No EXPO_UPDATES_FINGERPRINT_OVERRIDE here: the publish resolves the CURRENT
+        # commit's fingerprint (app.config's `fingerprint` policy) and serves the JS
+        # under it. That matches the shipped binary — which embeds the same Linux gate
+        # fingerprint (set at build time, ios-testflight-rn.yml) — for a JS-only
+        # commit, and on a native change it resolves the NEW fingerprint, so old
+        # binaries (still on the old one) never receive JS that needs the new native
+        # code. Pinning to the last tag instead would do exactly that — a crash.
         run: |
-          if [ -z "$EXPO_UPDATES_FINGERPRINT_OVERRIDE" ]; then
-            echo "::warning::No fingerprint-ios-* tag reachable — no shipped iOS binary to target; skipping iOS OTA."
-            exit 0
-          fi
           args=(--channel production --platform ios)
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"
@@ -247,19 +223,12 @@ jobs:
         id: publish_android
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
         env:
-          # Kept for env parity with the Android native prebuild (android-apk-rn.yml)
-          # so `expo export` sees the same resolved android.config the binary did.
-          # The runtimeVersion is now pinned by the override below (not derived from
-          # this key), but parity keeps the bundled config aligned with the binary.
+          # Must match the Android native prebuild (android-apk-rn.yml) so the
+          # resolved android.config.googleMaps block — and the freshly-resolved
+          # fingerprint — agree with the binary. (No fingerprint override: see the
+          # iOS publish step; the publish resolves the current commit's fingerprint.)
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          # Pin the published runtimeVersion to the last shipped Android binary's
-          # fingerprint so the bundle actually reaches it.
-          EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${{ steps.pins.outputs.android_fp }}
         run: |
-          if [ -z "$EXPO_UPDATES_FINGERPRINT_OVERRIDE" ]; then
-            echo "::warning::No fingerprint-android-* tag reachable — no shipped Android binary to target; skipping Android OTA."
-            exit 0
-          fi
           args=(--channel production --platform android)
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -144,6 +144,28 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Pin each platform's OTA to the runtimeVersion the INSTALLED binaries embed
+      # = the most-recent ancestor fingerprint-<platform>-<hash> tag (pushed by the
+      # native build workflows when a store binary shipped). The publish steps below
+      # export this as EXPO_UPDATES_FINGERPRINT_OVERRIDE; app.config.ts turns it into
+      # a literal runtimeVersion that `eoas publish` resolves verbatim, so the bundle
+      # is served under exactly the binary's runtimeVersion — no Linux-vs-binary
+      # resolution mismatch can strand it. On a native-change commit the NEW
+      # fingerprint's tag may not exist yet (the native build runs as a separate,
+      # parallel workflow), so the publish pins to the PREVIOUS fingerprint: correct,
+      # since old binaries get matching JS and the fresh binary already carries this
+      # commit's JS embedded (it picks up its own fingerprint's OTA on the next push).
+      - name: Resolve OTA fingerprint pins from shipped native tags
+        id: pins
+        if: steps.gate.outputs.configured == 'true'
+        run: |
+          set -uo pipefail
+          ios_fp="$(git describe --tags --abbrev=0 --match 'fingerprint-ios-*' 2>/dev/null | sed 's/^fingerprint-ios-//' || true)"
+          android_fp="$(git describe --tags --abbrev=0 --match 'fingerprint-android-*' 2>/dev/null | sed 's/^fingerprint-android-//' || true)"
+          echo "ios_fp=$ios_fp" >> "$GITHUB_OUTPUT"
+          echo "android_fp=$android_fp" >> "$GITHUB_OUTPUT"
+          echo "::notice::OTA pins — iOS=${ios_fp:-<none>} Android=${android_fp:-<none>} (most-recent ancestor fingerprint tags)."
+
       - name: Write .env for Expo build-time inlining
         if: steps.gate.outputs.configured == 'true'
         working-directory: packages/mobile
@@ -207,7 +229,16 @@ jobs:
       - name: Publish iOS OTA
         id: publish_ios
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
+        env:
+          # Pin the published runtimeVersion to the last shipped iOS binary's
+          # fingerprint so the bundle actually reaches it. app.config.ts emits this
+          # as a literal runtimeVersion; eoas publishes under it verbatim.
+          EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${{ steps.pins.outputs.ios_fp }}
         run: |
+          if [ -z "$EXPO_UPDATES_FINGERPRINT_OVERRIDE" ]; then
+            echo "::warning::No fingerprint-ios-* tag reachable — no shipped iOS binary to target; skipping iOS OTA."
+            exit 0
+          fi
           args=(--channel production --platform ios)
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"
@@ -216,10 +247,19 @@ jobs:
         id: publish_android
         if: steps.gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
         env:
-          # Must match the Android native prebuild (android-apk-rn.yml) so the
-          # resolved android.config.googleMaps block — and the fingerprint — agree.
+          # Kept for env parity with the Android native prebuild (android-apk-rn.yml)
+          # so `expo export` sees the same resolved android.config the binary did.
+          # The runtimeVersion is now pinned by the override below (not derived from
+          # this key), but parity keeps the bundled config aligned with the binary.
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # Pin the published runtimeVersion to the last shipped Android binary's
+          # fingerprint so the bundle actually reaches it.
+          EXPO_UPDATES_FINGERPRINT_OVERRIDE: ${{ steps.pins.outputs.android_fp }}
         run: |
+          if [ -z "$EXPO_UPDATES_FINGERPRINT_OVERRIDE" ]; then
+            echo "::warning::No fingerprint-android-* tag reachable — no shipped Android binary to target; skipping Android OTA."
+            exit 0
+          fi
           args=(--channel production --platform android)
           if [ -n "$INPUT_MESSAGE" ]; then args+=(--message "$INPUT_MESSAGE"); fi
           vp run mobile:publish -- "${args[@]}"

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -73,34 +73,43 @@ so `EXPO_UPDATES_URL` must be present.
 ### Fingerprint parity — the one rule that matters
 
 The published runtimeVersion must equal the one the native build baked into the binary, or the OTA
-silently never lands. **CI pins this explicitly** instead of trusting both sides to resolve the same
-hash: the `gate` resolves the canonical fingerprint once (on Linux), the native build embeds _that_
-value in the binary via `EXPO_UPDATES_FINGERPRINT_OVERRIDE` (`app.config.ts` emits it as a literal
-runtimeVersion), and the OTA publish pins each platform to the most-recent shipped
-`fingerprint-<platform>-<hash>` tag. So binary-rv == tag == published-rv by construction, and
-publish-time fingerprint _resolution_ is no longer a correctness input for the runtimeVersion. (This
-matters because `@expo/fingerprint` is not deterministic across Linux and macOS — the iOS binary,
-baked on macOS, used to embed a different hash than the Linux gate/publish resolved, which stranded
-iOS OTAs whenever the two disagreed.)
+silently never lands — and the publish must run the **`fingerprint` policy** (resolve the _current_
+commit's hash), never a fixed value, so a native change moves the runtimeVersion and old binaries are
+correctly excluded. Two things make that hold:
 
-The fingerprint hashes the **resolved Expo config** and native files — **not** the JS bundle. With
-the runtimeVersion now pinned, the remaining reason to keep config-affecting env in sync is **bundle
-correctness**: `expo export` still bundles the resolved config and inlines `EXPO_PUBLIC_*`, so
-`GOOGLE_MAPS_API_KEY` (drives `android.config`), `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID`,
-`EXPO_UPDATES_URL`/`EXPO_UPDATES_CHANNEL`, and the other `EXPO_PUBLIC_*` (backend/analytics) must
-still match the binary. Three mechanisms, all enforced/handled in CI:
+- **The binary embeds the _Linux_ fingerprint.** `@expo/fingerprint` is not deterministic across
+  Linux and macOS, but the iOS binary is baked on macOS while the gate and the publish run on Linux.
+  So the iOS build exports `EXPO_UPDATES_FINGERPRINT_OVERRIDE` set to the gate's Linux fingerprint;
+  `app.config.ts` emits it as a literal runtimeVersion, and prebuild bakes _that_ into the binary
+  instead of the macOS-resolved hash. (Android sets it too, for a uniform invariant.) This is what
+  previously stranded iOS OTAs: the binary embedded a macOS hash the Linux publish never published
+  under.
+- **The publish resolves fresh.** The OTA publish sets **no** override — it resolves the current
+  commit's fingerprint (`{ policy: 'fingerprint' }`) on Linux and serves the JS under it. For a
+  JS-only commit that equals the shipped binary's embedded Linux value (OTA lands); on a native
+  change it resolves the **new** hash, so old binaries (still on the old one) never receive JS that
+  needs the new native code. **Pinning the publish to a fixed value (e.g. the last shipped tag) would
+  do exactly that — a crash** — so `scripts/mobile-ci-env-parity.test.ts` asserts the publish never
+  sets the override.
 
-- **Explicit pin.** The native builds set `EXPO_UPDATES_FINGERPRINT_OVERRIDE` to the gate fingerprint;
-  the OTA publish sets it per-platform to the last shipped `fingerprint-<platform>-<hash>` tag (via
-  `git describe --match`). `scripts/mobile-ci-env-parity.test.ts` asserts this wiring across all three
-  workflows (and that no build-side re-resolve creeps back in).
+The fingerprint hashes the **resolved Expo config** and native files — **not** the JS bundle — so the
+publish must resolve `app.config.ts` to the same config the native `expo prebuild` did. The
+config-affecting env that must match is `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` (drives the google-signin
+plugin's native `iosUrlScheme`), `GOOGLE_MAPS_API_KEY` (drives `android.config`), and
+`EXPO_UPDATES_URL`/`EXPO_UPDATES_CHANNEL`. The other `EXPO_PUBLIC_*` are inlined into the JS bundle;
+they must still match so the OTA points at the right backend/analytics, but drift there is a runtime
+bug, not a delivery failure. Mechanisms, all enforced/handled in CI:
+
+- **Binary pin + fresh publish.** The native builds set `EXPO_UPDATES_FINGERPRINT_OVERRIDE` to the
+  gate fingerprint; the publish leaves it unset. `scripts/mobile-ci-env-parity.test.ts` asserts both
+  (and that no build-side re-resolve creeps back in).
 - **Env parity.** `mobile-ota-production.yml` declares the same `EXPO_PUBLIC_*` + `EXPO_UPDATES_*`
   env as `ios-testflight-rn.yml` / `android-apk-rn.yml`. The same parity test fails the build if they
   drift.
 - **Per-platform publish.** `GOOGLE_MAPS_API_KEY` is set only on the Android prebuild (iOS uses
-  Apple Maps) and it changes the resolved config for the Android bundle. So the workflow publishes
-  iOS **without** the key and Android **with** it, in separate steps, each pinned to its own
-  platform's tag. A single `--platform all` publish with one env could only ever match one side.
+  Apple Maps) and it changes the resolved config — hence the fingerprint — for the Android side. So
+  the workflow publishes iOS **without** the key and Android **with** it, in separate steps. A single
+  `--platform all` publish with one env could only ever match one side.
 
 ## Native-build gating (OTA-only when the fingerprint is unchanged)
 
@@ -120,22 +129,21 @@ runtimeversion:resolve` using the same **workflow-level** env the build uses (iO
 3. On a successful build + store upload, the build job pushes `fingerprint-<platform>-<hash>` — the
    gate value the binary embeds (see the pin below), not a re-resolved one.
 
-**Why a wrong skip — or a stranded OTA — is impossible.** The gate is the single canonical
-resolution. The native build embeds _that exact value_ in the binary via
+**Why a wrong skip is impossible.** The native build embeds the gate's exact value in the binary via
 `EXPO_UPDATES_FINGERPRINT_OVERRIDE` (the macOS runner no longer re-resolves its own, divergent hash)
 and tags it. So the tag, the binary's runtimeVersion, and the gate's skip-key are one value by
-construction: the gate can never skip a fingerprint the binary lacks, and the OTA publish (pinned to
-the tag) can never serve JS under a runtimeVersion no installed binary embeds. This replaces the
-older "tag the build-OS value and always-build on cross-OS divergence" scheme, which wasted iOS
-builds and — worse — let the Linux OTA publish strand JS under a runtimeVersion the macOS binary
-never had. Android builds on Linux like its gate, so it was never divergent; it pins the same way for
-a uniform invariant.
+construction — the gate can never skip a fingerprint the binary lacks. This replaces the older "tag
+the build-OS value and always-build on cross-OS divergence" scheme, which wasted iOS builds and —
+worse — let the Linux OTA publish strand JS under a runtimeVersion the macOS binary never had.
+Android builds on Linux like its gate, so it was never divergent; it pins the same way for a uniform
+invariant.
 
-> **Publish lag (by design).** The commit that ships a _new_ native fingerprint doesn't get its own
-> OTA under that fingerprint until the _next_ push. The OTA publish is a separate, parallel workflow,
-> so while a native build is in flight the last existing tag is still the _previous_ fingerprint, and
-> the publish pins to it. That's correct: old binaries get matching JS, and the fresh binary already
-> carries this commit's JS embedded — it picks up its own fingerprint's OTAs from the next push on.
+The OTA publish stays on the `fingerprint` policy (it does **not** read a tag or an override): it
+resolves the current commit's fingerprint and serves the JS under it. On a native-change commit it
+resolves the **new** fingerprint, so the new JS only reaches a binary built from that same commit —
+old binaries (still on the previous fingerprint) keep their embedded bundle until they store-update.
+That's the fingerprint policy working as intended; pinning the publish to the last shipped tag would
+instead serve native-dependent JS to old binaries and crash them.
 
 **Fail-safe.** If the gate can't resolve the fingerprint, it builds. A manual `workflow_dispatch`
 bypasses the tag check and always builds — for iOS that means dispatching on `main` (the iOS build
@@ -251,12 +259,13 @@ itself still ships). A fine-grained PAT from a user who's in the bypass list wor
 prebuild --platform ios --clean --no-install`, then confirm `ios/Boardsesh/Supporting/Expo.plist`
    has `EXUpdatesRequestHeaders` → `expo-channel-name=production` and an `EXUpdatesCodeSigning*`
    entry. Repeat `--platform android` and grep `AndroidManifest.xml`.
-2. **Pin parity (the critical check)** — the OTA server must serve an update under the exact
+2. **Fingerprint parity (the critical check)** — the OTA server must serve an update under the exact
    runtimeVersion the shipped binary embeds. The binary embeds the gate fingerprint (the
    `fingerprint-<platform>-<hash>` tag), baked as a literal `EXUpdatesRuntimeVersion` in `Expo.plist`
    because the build sets `EXPO_UPDATES_FINGERPRINT_OVERRIDE` (a local prebuild without that env var
    instead writes the `file:fingerprint` sentinel and computes the hash at archive time — expected).
-   Probe the manifest the way the app does, with the tag's hash as the runtime-version header:
+   The publish reaches it by resolving the same fingerprint fresh on Linux (no override). Probe the
+   manifest the way the app does, with the tag's hash as the runtime-version header:
 
    ```sh
    curl -sS -H 'expo-channel-name: production' -H 'expo-platform: ios' \

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -72,24 +72,35 @@ so `EXPO_UPDATES_URL` must be present.
 
 ### Fingerprint parity — the one rule that matters
 
-The published fingerprint must equal the one the native build baked into the binary, or the OTA
-silently never lands. The fingerprint hashes the **resolved Expo config** and native files — **not**
-the JS bundle — so the publish must resolve `app.config.ts` to the same config the native
-`expo prebuild` did. The config-affecting env that must match is `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID`
-(drives the google-signin plugin's native `iosUrlScheme`), `GOOGLE_MAPS_API_KEY` (drives
-`android.config`), and — once the committed cert activates the self-hosted `updates` block —
-`EXPO_UPDATES_URL` + `EXPO_UPDATES_CHANNEL`. The other `EXPO_PUBLIC_*` are inlined into the JS
-bundle (not the fingerprint); they must still match so the OTA points at the right backend and
-analytics, but drift there is a runtime bug, not a delivery failure. Two mechanisms, both
-enforced/handled in CI:
+The published runtimeVersion must equal the one the native build baked into the binary, or the OTA
+silently never lands. **CI pins this explicitly** instead of trusting both sides to resolve the same
+hash: the `gate` resolves the canonical fingerprint once (on Linux), the native build embeds _that_
+value in the binary via `EXPO_UPDATES_FINGERPRINT_OVERRIDE` (`app.config.ts` emits it as a literal
+runtimeVersion), and the OTA publish pins each platform to the most-recent shipped
+`fingerprint-<platform>-<hash>` tag. So binary-rv == tag == published-rv by construction, and
+publish-time fingerprint _resolution_ is no longer a correctness input for the runtimeVersion. (This
+matters because `@expo/fingerprint` is not deterministic across Linux and macOS — the iOS binary,
+baked on macOS, used to embed a different hash than the Linux gate/publish resolved, which stranded
+iOS OTAs whenever the two disagreed.)
 
+The fingerprint hashes the **resolved Expo config** and native files — **not** the JS bundle. With
+the runtimeVersion now pinned, the remaining reason to keep config-affecting env in sync is **bundle
+correctness**: `expo export` still bundles the resolved config and inlines `EXPO_PUBLIC_*`, so
+`GOOGLE_MAPS_API_KEY` (drives `android.config`), `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID`,
+`EXPO_UPDATES_URL`/`EXPO_UPDATES_CHANNEL`, and the other `EXPO_PUBLIC_*` (backend/analytics) must
+still match the binary. Three mechanisms, all enforced/handled in CI:
+
+- **Explicit pin.** The native builds set `EXPO_UPDATES_FINGERPRINT_OVERRIDE` to the gate fingerprint;
+  the OTA publish sets it per-platform to the last shipped `fingerprint-<platform>-<hash>` tag (via
+  `git describe --match`). `scripts/mobile-ci-env-parity.test.ts` asserts this wiring across all three
+  workflows (and that no build-side re-resolve creeps back in).
 - **Env parity.** `mobile-ota-production.yml` declares the same `EXPO_PUBLIC_*` + `EXPO_UPDATES_*`
-  env as `ios-testflight-rn.yml` / `android-apk-rn.yml`. `scripts/mobile-ci-env-parity.test.ts`
-  fails the build if they drift.
+  env as `ios-testflight-rn.yml` / `android-apk-rn.yml`. The same parity test fails the build if they
+  drift.
 - **Per-platform publish.** `GOOGLE_MAPS_API_KEY` is set only on the Android prebuild (iOS uses
-  Apple Maps) and it changes the resolved config — hence the fingerprint — for **both** platforms.
-  So the workflow publishes iOS **without** the key and Android **with** it, in separate steps. A
-  single `--platform all` publish with one env could only ever match one side.
+  Apple Maps) and it changes the resolved config for the Android bundle. So the workflow publishes
+  iOS **without** the key and Android **with** it, in separate steps, each pinned to its own
+  platform's tag. A single `--platform all` publish with one env could only ever match one side.
 
 ## Native-build gating (OTA-only when the fingerprint is unchanged)
 
@@ -106,17 +117,25 @@ runtimeversion:resolve` using the same **workflow-level** env the build uses (iO
    hashed into the fingerprint, so an absent or different one would resolve a different hash.
 2. If a git tag `fingerprint-<platform>-<hash>` already exists, a binary with that fingerprint has
    already shipped → the native build **skips** (the OTA delivers the JS). Otherwise it **runs**.
-3. On a successful build + store upload, the build job pushes `fingerprint-<platform>-<hash>`.
+3. On a successful build + store upload, the build job pushes `fingerprint-<platform>-<hash>` — the
+   gate value the binary embeds (see the pin below), not a re-resolved one.
 
-**Why a wrong skip is impossible.** The gate resolves on Linux, but the iOS binary is baked on
-macOS. Rather than trust cross-OS fingerprint determinism for correctness, the build job
-re-resolves the fingerprint **on its own runner** and tags _that_ value, while the gate checks the
-_Linux_ value. Tags therefore only ever hold build-OS fingerprints. If Linux and macOS ever
-disagree, the gate never finds a matching tag and iOS simply always builds (wasteful, but safe) —
-it can never wrongly skip and strand users on an old binary. The build emits a `::warning::` when
-the two fingerprints disagree, so the degraded "always build" mode is visible. Android builds on
-Linux like its gate, so they always agree. (Expo's own action trusts cross-OS determinism here;
-ours is strictly safer.)
+**Why a wrong skip — or a stranded OTA — is impossible.** The gate is the single canonical
+resolution. The native build embeds _that exact value_ in the binary via
+`EXPO_UPDATES_FINGERPRINT_OVERRIDE` (the macOS runner no longer re-resolves its own, divergent hash)
+and tags it. So the tag, the binary's runtimeVersion, and the gate's skip-key are one value by
+construction: the gate can never skip a fingerprint the binary lacks, and the OTA publish (pinned to
+the tag) can never serve JS under a runtimeVersion no installed binary embeds. This replaces the
+older "tag the build-OS value and always-build on cross-OS divergence" scheme, which wasted iOS
+builds and — worse — let the Linux OTA publish strand JS under a runtimeVersion the macOS binary
+never had. Android builds on Linux like its gate, so it was never divergent; it pins the same way for
+a uniform invariant.
+
+> **Publish lag (by design).** The commit that ships a _new_ native fingerprint doesn't get its own
+> OTA under that fingerprint until the _next_ push. The OTA publish is a separate, parallel workflow,
+> so while a native build is in flight the last existing tag is still the _previous_ fingerprint, and
+> the publish pins to it. That's correct: old binaries get matching JS, and the fresh binary already
+> carries this commit's JS embedded — it picks up its own fingerprint's OTAs from the next push on.
 
 **Fail-safe.** If the gate can't resolve the fingerprint, it builds. A manual `workflow_dispatch`
 bypasses the tag check and always builds — for iOS that means dispatching on `main` (the iOS build
@@ -232,14 +251,26 @@ itself still ships). A fine-grained PAT from a user who's in the bypass list wor
 prebuild --platform ios --clean --no-install`, then confirm `ios/Boardsesh/Supporting/Expo.plist`
    has `EXUpdatesRequestHeaders` → `expo-channel-name=production` and an `EXUpdatesCodeSigning*`
    entry. Repeat `--platform android` and grep `AndroidManifest.xml`.
-2. **Fingerprint parity (the critical check)** — the fingerprint the publish CI computes (Linux)
-   must equal the one the native build embedded (macOS for iOS). Resolve it the same way the build
-   does: `cd packages/mobile && bunx expo-updates runtimeversion:resolve --platform ios` with the
-   **same env the native build uses** (`EXPO_UPDATES_URL`, `EXPO_UPDATES_CHANNEL=production`, the
-   `EXPO_PUBLIC_*` set; no `GOOGLE_MAPS_API_KEY` for iOS, with it for android), and confirm it
-   matches the binary's `EXUpdatesRuntimeVersion`. If they differ, OTAs for that platform never
-   land — recheck env parity (`scripts/mobile-ci-env-parity.test.ts`) and the per-platform
-   `GOOGLE_MAPS_API_KEY` split.
+2. **Pin parity (the critical check)** — the OTA server must serve an update under the exact
+   runtimeVersion the shipped binary embeds. The binary embeds the gate fingerprint (the
+   `fingerprint-<platform>-<hash>` tag), baked as a literal `EXUpdatesRuntimeVersion` in `Expo.plist`
+   because the build sets `EXPO_UPDATES_FINGERPRINT_OVERRIDE` (a local prebuild without that env var
+   instead writes the `file:fingerprint` sentinel and computes the hash at archive time — expected).
+   Probe the manifest the way the app does, with the tag's hash as the runtime-version header:
+
+   ```sh
+   curl -sS -H 'expo-channel-name: production' -H 'expo-platform: ios' \
+        -H 'expo-runtime-version: <hash-from-fingerprint-ios-tag>' \
+        -H 'accept: application/expo+json,application/json' \
+        "$EXPO_UPDATES_URL"
+   ```
+
+   A `200` whose `manifest` part (not a `directive`/`noUpdateAvailable`) reports `runtimeVersion`
+   equal to the tag hash confirms binary-rv == published-rv. Repeat with `expo-platform: android` and
+   the `fingerprint-android-` tag. The publish pins to the same tag the binary embeds, so these match
+   by construction — a mismatch means the pin wiring broke (recheck
+   `scripts/mobile-ci-env-parity.test.ts`).
+
 3. Ship one native TestFlight build from `main` (bakes in the fingerprint runtimeVersion + server
    URL + cert). Existing `appVersion`-era installs won't receive fingerprint OTAs — they update
    from the store once.

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -221,19 +221,18 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
           // `appVersion` footgun where a native change without a `version` bump
           // could push JS to a binary lacking the native capability it needs.
           //
-          // CI pins ONE value end to end. The fingerprint gate resolves the
-          // canonical hash on Linux (`bunx expo-updates runtimeversion:resolve` —
-          // it sees `{ policy: 'fingerprint' }` here because the override is unset).
-          // The native build and the OTA publish then export
-          // EXPO_UPDATES_FINGERPRINT_OVERRIDE, so this returns that exact hash as a
-          // LITERAL runtimeVersion: baked into the binary's Expo.plist by prebuild,
-          // and returned verbatim to `eoas publish` by runtimeversion:resolve (the
-          // resolve CLI passes a string runtimeVersion straight through). That makes
-          // binary-rv == published-rv == the fingerprint-<platform>-<hash> tag by
-          // construction, instead of each side resolving its own (Linux gate vs
-          // macOS build vs Linux publish) value and silently diverging — which
-          // stranded iOS OTAs. Override unset => identical to before, so the gate's
-          // canonical fingerprint is unchanged. See docs/mobile-ota-updates.md.
+          // The NATIVE BUILD sets EXPO_UPDATES_FINGERPRINT_OVERRIDE to the gate's
+          // Linux fingerprint, so this returns it as a LITERAL runtimeVersion that
+          // prebuild bakes into the binary's Expo.plist. That forces the iOS binary
+          // onto the *Linux* fingerprint instead of the macOS one it would otherwise
+          // resolve at build time — `@expo/fingerprint` is not deterministic across
+          // Linux/macOS, and that divergence stranded iOS OTAs (the binary embedded a
+          // hash the Linux publish never published under). The OTA publish does NOT
+          // set the override: it resolves the CURRENT commit's fingerprint fresh (on
+          // Linux), which matches the binary's embedded Linux value for a JS-only
+          // commit, and on a native change resolves the NEW fingerprint so old
+          // binaries are correctly excluded. Override unset => identical to before, so
+          // the gate's canonical fingerprint is unchanged. See docs/mobile-ota-updates.md.
           runtimeVersion: process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE?.trim()
             ? process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE.trim()
             : { policy: 'fingerprint' as const },

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -220,9 +220,23 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
           // until a store build with the new fingerprint ships). This removes the
           // `appVersion` footgun where a native change without a `version` bump
           // could push JS to a binary lacking the native capability it needs.
-          // Resolved by Expo's bundled @expo/fingerprint; verify with
-          // `bunx expo-updates runtimeversion:resolve --platform ios|android`.
-          runtimeVersion: { policy: 'fingerprint' as const },
+          //
+          // CI pins ONE value end to end. The fingerprint gate resolves the
+          // canonical hash on Linux (`bunx expo-updates runtimeversion:resolve` —
+          // it sees `{ policy: 'fingerprint' }` here because the override is unset).
+          // The native build and the OTA publish then export
+          // EXPO_UPDATES_FINGERPRINT_OVERRIDE, so this returns that exact hash as a
+          // LITERAL runtimeVersion: baked into the binary's Expo.plist by prebuild,
+          // and returned verbatim to `eoas publish` by runtimeversion:resolve (the
+          // resolve CLI passes a string runtimeVersion straight through). That makes
+          // binary-rv == published-rv == the fingerprint-<platform>-<hash> tag by
+          // construction, instead of each side resolving its own (Linux gate vs
+          // macOS build vs Linux publish) value and silently diverging — which
+          // stranded iOS OTAs. Override unset => identical to before, so the gate's
+          // canonical fingerprint is unchanged. See docs/mobile-ota-updates.md.
+          runtimeVersion: process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE?.trim()
+            ? process.env.EXPO_UPDATES_FINGERPRINT_OVERRIDE.trim()
+            : { policy: 'fingerprint' as const },
           updates: resolveUpdatesConfig(EAS_PROJECT_ID, projectRoot),
         }
       : {}),

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -133,20 +133,18 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
     expect(android).toMatch(/fingerprint-android-/);
   });
 
-  it('pins ONE fingerprint end to end (gate value into the binaries, shipped-tag value into the OTA)', () => {
-    // The gate is the single canonical resolution. The native builds embed that
-    // exact value in the binary via EXPO_UPDATES_FINGERPRINT_OVERRIDE (app.config
-    // emits it as a literal runtimeVersion), and the OTA publish pins each platform
-    // to the most-recent shipped fingerprint-<platform>-<hash> tag. So binary-rv ==
-    // tag == published-rv by construction — no Linux/macOS resolution can diverge
-    // and strand an OTA. If any of these wires breaks, the OTA silently stops
-    // landing, so assert them all.
+  it('forces the binary onto the gate fingerprint, and the OTA publish resolves fresh (never pinned)', () => {
+    // The iOS binary is baked on macOS but the gate/publish run on Linux, and
+    // @expo/fingerprint is not deterministic across the two. The native builds set
+    // EXPO_UPDATES_FINGERPRINT_OVERRIDE to the gate's Linux fingerprint so the binary
+    // embeds the *Linux* value (app.config emits it as a literal runtimeVersion) —
+    // which the Linux publish then matches.
     const ios = readWorkflow(NATIVE_IOS);
     const android = readWorkflow(NATIVE_ANDROID);
     const ota = readWorkflow(OTA);
     const gatePin = /EXPO_UPDATES_FINGERPRINT_OVERRIDE:\s*\$\{\{\s*needs\.gate\.outputs\.fingerprint\s*\}\}/;
 
-    // Native builds embed the gate's canonical fingerprint.
+    // Native builds embed the gate's canonical (Linux) fingerprint.
     expect(ios, 'iOS build must pin the binary to the gate fingerprint').toMatch(gatePin);
     expect(android, 'Android build must pin the binary to the gate fingerprint').toMatch(gatePin);
 
@@ -156,13 +154,17 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
     expect(ios.match(/runtimeversion:resolve --platform ios/g)?.length ?? 0).toBe(1);
     expect(android.match(/runtimeversion:resolve --platform android/g)?.length ?? 0).toBe(1);
 
-    // The OTA publish pins each platform to its last shipped native tag.
-    expect(ota).toMatch(/git describe --tags --abbrev=0 --match 'fingerprint-ios-\*'/);
-    expect(ota).toMatch(/git describe --tags --abbrev=0 --match 'fingerprint-android-\*'/);
-    expect(ota).toMatch(/EXPO_UPDATES_FINGERPRINT_OVERRIDE:\s*\$\{\{\s*steps\.pins\.outputs\.ios_fp\s*\}\}/);
-    expect(ota).toMatch(/EXPO_UPDATES_FINGERPRINT_OVERRIDE:\s*\$\{\{\s*steps\.pins\.outputs\.android_fp\s*\}\}/);
-    // The publish needs local tags to resolve those pins.
-    expect(ota).toMatch(/fetch-tags:\s*true/);
+    // CRITICAL: the OTA publish must NEVER pin the fingerprint. It resolves the
+    // CURRENT commit's fingerprint fresh and publishes under it. Pinning to a fixed
+    // value (e.g. the last shipped tag) would, on a native-change commit, serve the
+    // new JS to OLD binaries under the old runtimeVersion — bypassing the fingerprint
+    // compatibility check and crashing installs that lack the new native code.
+    // Match a real YAML env-key line (`KEY:`), not a comment that names the var.
+    expect(
+      /^\s*EXPO_UPDATES_FINGERPRINT_OVERRIDE:/m.test(ota),
+      'The OTA publish must not set EXPO_UPDATES_FINGERPRINT_OVERRIDE — it resolves the current ' +
+        'fingerprint fresh. Pinning it would deliver native-dependent JS to incompatible old binaries.',
+    ).toBe(false);
   });
 
   it('resolves the iOS fingerprint without GOOGLE_MAPS_API_KEY and Android with it', () => {

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -133,6 +133,38 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
     expect(android).toMatch(/fingerprint-android-/);
   });
 
+  it('pins ONE fingerprint end to end (gate value into the binaries, shipped-tag value into the OTA)', () => {
+    // The gate is the single canonical resolution. The native builds embed that
+    // exact value in the binary via EXPO_UPDATES_FINGERPRINT_OVERRIDE (app.config
+    // emits it as a literal runtimeVersion), and the OTA publish pins each platform
+    // to the most-recent shipped fingerprint-<platform>-<hash> tag. So binary-rv ==
+    // tag == published-rv by construction — no Linux/macOS resolution can diverge
+    // and strand an OTA. If any of these wires breaks, the OTA silently stops
+    // landing, so assert them all.
+    const ios = readWorkflow(NATIVE_IOS);
+    const android = readWorkflow(NATIVE_ANDROID);
+    const ota = readWorkflow(OTA);
+    const gatePin = /EXPO_UPDATES_FINGERPRINT_OVERRIDE:\s*\$\{\{\s*needs\.gate\.outputs\.fingerprint\s*\}\}/;
+
+    // Native builds embed the gate's canonical fingerprint.
+    expect(ios, 'iOS build must pin the binary to the gate fingerprint').toMatch(gatePin);
+    expect(android, 'Android build must pin the binary to the gate fingerprint').toMatch(gatePin);
+
+    // The divergence source is gone: exactly one runtimeversion:resolve per native
+    // workflow (the gate). A second occurrence means a build-side re-resolve crept
+    // back in — the macOS/Linux split that stranded iOS OTAs.
+    expect(ios.match(/runtimeversion:resolve --platform ios/g)?.length ?? 0).toBe(1);
+    expect(android.match(/runtimeversion:resolve --platform android/g)?.length ?? 0).toBe(1);
+
+    // The OTA publish pins each platform to its last shipped native tag.
+    expect(ota).toMatch(/git describe --tags --abbrev=0 --match 'fingerprint-ios-\*'/);
+    expect(ota).toMatch(/git describe --tags --abbrev=0 --match 'fingerprint-android-\*'/);
+    expect(ota).toMatch(/EXPO_UPDATES_FINGERPRINT_OVERRIDE:\s*\$\{\{\s*steps\.pins\.outputs\.ios_fp\s*\}\}/);
+    expect(ota).toMatch(/EXPO_UPDATES_FINGERPRINT_OVERRIDE:\s*\$\{\{\s*steps\.pins\.outputs\.android_fp\s*\}\}/);
+    // The publish needs local tags to resolve those pins.
+    expect(ota).toMatch(/fetch-tags:\s*true/);
+  });
+
   it('resolves the iOS fingerprint without GOOGLE_MAPS_API_KEY and Android with it', () => {
     // GOOGLE_MAPS_API_KEY changes the resolved android.config — hence the
     // fingerprint — so the gate must mirror the per-platform split the native


### PR DESCRIPTION
## Summary

The mobile `runtimeVersion` `fingerprint` policy was resolved **independently on two OSes**: the **iOS binary** embeds the **macOS**-resolved value (Expo.plist, baked at `expo prebuild`), while the fingerprint **gate** and the **OTA publish** resolve on **Linux**. `@expo/fingerprint` isn't deterministic across Linux/macOS — build 399's log shows the same commit resolving `Linux 3982ea77…` vs `macOS 8f7bf0dd…`. So the binary's runtimeVersion could differ from what the OTA published under, and JS was served under a runtimeVersion **no installed binary embedded** → iOS OTAs silently stranded (they only landed when the two OSes coincided).

### The fix (two parts)

1. **Force the binary onto the Linux fingerprint.** The iOS/Android builds export `EXPO_UPDATES_FINGERPRINT_OVERRIDE` set to the **gate's Linux fingerprint**; `app.config.ts` emits it as a *literal* `runtimeVersion`, so prebuild bakes that into the binary instead of the macOS-resolved hash. The build-side re-resolve (the divergence source) is dropped; the binary embeds exactly the gate value the tag records.
2. **The OTA publish resolves fresh — never pinned.** It keeps the `fingerprint` policy (resolves the *current* commit's hash on Linux) and serves the JS under it. For a JS-only commit that equals the shipped binary's embedded Linux value (OTA lands); on a native change it resolves the **new** hash, so old binaries are correctly excluded.

> **Why not pin the publish to the last shipped tag (an earlier revision of this PR did):** on a native-change commit the new fingerprint's tag isn't pushed until the parallel native build finishes, so the publish would pin to the *previous* binary's fingerprint and serve the new (native-dependent) JS to **old** binaries — bypassing the fingerprint compatibility check and crashing installs. Caught in review; reverted. The parity test now asserts the publish never sets the override.

**Why drive the binary pin through `app.config` rather than the build-helper env:** `eoas publish` resolves via `expo-updates runtimeversion:resolve` → `createFingerprintAsync`, which doesn't read `EXPO_UPDATES_FINGERPRINT_OVERRIDE`, and has no `--runtimeVersion` flag. Emitting a literal from `app.config` is the mechanism that pins the binary; the publish stays on the fingerprint policy. (Verified against installed `expo-updates@56.0.19` + cached `eoas@2.3.19`.)

Side effect: eliminates the wasted iOS rebuilds the cross-OS noise triggered (e.g. build 399, identical to 398).

### Rebase / integration

Rebased onto `main` to fold in the newly-merged `mobile-ota-check.yml` (PR #3106, PR-time OTA-compat signal). That check resolves the fingerprint canonically (no override), so these changes don't perturb its verdict; the env-parity test now guards all four mobile fingerprint workflows in lockstep.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `scripts/mobile-ci-env-parity.test.ts` — **16/16 pass** (new assertions: binary pin set on both native builds, no build-side re-resolve, publish never pins; plus #3106's OTA-check coverage).
- `vp run typecheck:mobile`, `vp check` — clean.
- All workflow YAMLs validated.
- Static verification: `expo-updates` `resolveRuntimeVersionAsync` returns a string `runtimeVersion` verbatim; `getRuntimeVersionNullableAsync` writes the literal to Expo.plist; `eoas`/the OTA-compat script never set the override.

**Post-merge verification (real CI run):**
1. Next iOS TestFlight log: binary embeds the gate fingerprint; `fingerprint-ios-<gate>` tag pushed; no `runtimeversion:resolve` in the build job.
2. Probe `ota.boardsesh.com` with `expo-runtime-version: <tag hash>` per platform → `200` manifest whose `runtimeVersion` equals the tag (binary-rv == published-rv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf3d3dUQfNeN6G2uYaZ821
