### PR TITLE
fix(mobile): patch gorhom backdrop so a closed sheet never freezes Android scroll + bars

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -771,6 +771,7 @@
   },
   "patchedDependencies": {
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
+    "@gorhom/bottom-sheet@5.2.14": "patches/@gorhom%2Fbottom-sheet@5.2.14.patch",
     "expo-dev-launcher@56.0.20": "patches/expo-dev-launcher@56.0.20.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {
     "react-native-screens@4.25.2": "patches/react-native-screens@4.25.2.patch",
-    "expo-dev-launcher@56.0.20": "patches/expo-dev-launcher@56.0.20.patch"
+    "expo-dev-launcher@56.0.20": "patches/expo-dev-launcher@56.0.20.patch",
+    "@gorhom/bottom-sheet@5.2.14": "patches/@gorhom%2Fbottom-sheet@5.2.14.patch"
   }
 }

--- a/patches/@gorhom%2Fbottom-sheet@5.2.14.patch
+++ b/patches/@gorhom%2Fbottom-sheet@5.2.14.patch
@@ -1,0 +1,21 @@
+diff --git a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+index a0345b013904e92e0c00ba55ff23ba191d96a395..0e20d4337ecf16a85e7834900cb1d5c996c587b6 100644
+--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
++++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+@@ -47,7 +47,15 @@ const BottomSheetBackdropComponent = ({
+ }: BottomSheetDefaultBackdropProps) => {
+   //#region hooks
+   const { snapToIndex, close } = useBottomSheet();
+-  const isMounted = useRef(false);
++  // Boardsesh patch: seed `true`, not `false`. This ref only guards setState after
++  // *unmount* (the cleanup below still flips it false). Seeding `false` also drops the
++  // very first `handleContainerTouchability(true)` flip when the useAnimatedReaction
++  // fires before the mount effect arms the ref — a scheduling-order race that Android 16
++  // / Samsung One UI loses, leaving a closed backdrop stuck at pointerEvents:'auto' that
++  // silently eats every touch below it (frozen scroll + bars; recovers only on
++  // background/resume). gorhom #2680. Seeding `true` lets the mount-time flip land while
++  // keeping the unmount guard intact.
++  const isMounted = useRef(true);
+   //#endregion
+ 
+   //#region defaults


### PR DESCRIPTION
## What & why

Several Android 16 users (Samsung One UI, and likely Pixel 10) reported the 2.0 app going **completely dead** after a couple of minutes — the climb list won't scroll, the top and bottom bars stop responding, but you can still tap the climbs you can already see. It only comes back if you background the app and reopen it. iOS and older Android (Pixel 8) are fine.

Root cause is a race inside **@gorhom/bottom-sheet 5.2.14's `BottomSheetBackdrop`**. The backdrop decides whether it's touchable with a `pointerEvents` flip that's gated behind an `isMounted` ref — seeded `false`, then armed `true` in a mount effect. The `useAnimatedReaction` that drives the flip fires **once on mount** and then **only on a change**. When that first `handleContainerTouchability(true)` lands *before* the mount effect arms the ref, the flip to `pointerEvents:'none'` is silently dropped — and since the reaction never re-fires for an unchanged value, the closed backdrop stays `pointerEvents:'auto'` forever. It's an invisible full-screen overlay eating every touch underneath.

Android 16 / One UI frame scheduling loses this race; Pixel 8 wins it. It's an OS/skin timing difference, **not** raw device speed. Background/resume forces a re-render, which is why the freeze "fixes itself" on resume — matches upstream [gorhom #2680](https://github.com/gorhom/react-native-bottom-sheet/issues/2680).

Because we mount persistent sheets at the root (`PlayDrawer`, `QueueSheet`, `BoardSheet`) under one shared `BottomSheetModalProvider` — wrapping both the climbs `Stack` and the bottom bar — a single stuck backdrop freezes the **entire** screen, not just one sheet. That's the "both bars + scroll are dead" report.

## The fix

One line, via a bun patch on `@gorhom/bottom-sheet@5.2.14`: seed `isMounted` to **`true`** instead of `false`, so the mount-time flip always lands. The ref's only real job is guarding `setState` after **unmount**, and the cleanup still flips it `false` — so that protection is untouched. The patch edits gorhom's `src/` (what Metro actually bundles).

## Delivery

JS-level only — no native change — so it rides **OTA** to users already on the current Android build, no new APK required.

## Validation

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2536 tests pass
- `vp check` — clean (the reported format issues are all pre-existing files this PR doesn't touch)
- `vp run check:mobile-bundle` — android bundle OK (11.0 MB), patched gorhom bundles fine

## Release Notes

Fixed an Android freeze where the app could stop responding after a couple of minutes — the climb list wouldn't scroll and both bars went dead until you reopened the app. It stays live now.