### PR TITLE
fix(mobile): make OTA-compat check reliable + apply #3106 review notes

### DIFF
--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -26,6 +26,8 @@ on:
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
       - '.github/workflows/mobile-ota-check.yml'
+      # The check's own logic — so changes to it re-run and self-validate.
+      - 'scripts/mobile-ota-compat-check.ts'
   workflow_dispatch:
 
 permissions:

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -143,6 +143,38 @@ Resolve the current fingerprint locally to predict what the gate will see: `cd p
 bunx expo-updates runtimeversion:resolve --platform ios` (add the production env to match CI
 exactly — see the parity check above).
 
+## PR-time OTA-compatibility signal
+
+The native gate above answers "should `main` rebuild?". `mobile-ota-check.yml` answers the same
+question one step earlier, on the PR: **does this change ride over-the-air, or does it force a new
+TestFlight/Play build?** It runs on every non-`main` push touching mobile code and posts a sticky
+comment plus a neutral **"OTA compatibility"** check-run. It is informational only — a native change
+is legitimate, so it never blocks merge.
+
+The verdict is a **fingerprint diff of the branch versus `origin/main`**, resolved in one job under
+identical env (`scripts/mobile-ota-compat-check.ts`, run via `vp run check:mobile-ota-compat`): the
+job checks out the PR, materializes `origin/main` as a sibling `git worktree` with its own
+`bun install`, then resolves both per platform and compares — equal fingerprint → ships OTA,
+different → needs a native build.
+
+It diffs against `main` rather than looking up a shipped `fingerprint-<platform>-<hash>` tag on
+purpose: the equality verdict is invariant to env imperfections. `GOOGLE_MAPS_API_KEY` is a
+Production-environment secret unavailable on feature-branch pushes, but a missing key shifts _both_
+sides of the comparison by the same constant, so the delta is still detected — the check needs no
+Production secret. The shipped-tag lookup survives only as a secondary "already on a released build"
+line, shown when confidently true (it matches the iOS tag in CI, and is suppressed for Android,
+whose tag was built with the maps key the branch push lacks).
+
+The workflow's fingerprint-affecting env is held byte-identical to the native builds + OTA publish by
+`scripts/mobile-ci-env-parity.test.ts` (which now guards four workflows, and asserts this one
+intentionally omits `GOOGLE_MAPS_API_KEY`). Reproduce a verdict locally:
+
+```bash
+git worktree add /tmp/main-baseline origin/main
+(cd /tmp/main-baseline && bun install --frozen-lockfile)
+vp run check:mobile-ota-compat -- --write-env --base-dir /tmp/main-baseline
+```
+
 ## One-time setup (infra — done outside this repo)
 
 `vp run mobile:ota-setup` scripts the in-repo phases (cert generation, the Railway env block, the

--- a/scripts/mobile-ota-compat-check.test.ts
+++ b/scripts/mobile-ota-compat-check.test.ts
@@ -121,7 +121,7 @@ describe('renderComment', () => {
       ctx,
     );
     expect(comment).toContain('Native change detected');
-    expect(comment).toContain('`1111111111aa` → `2222222222bb`');
+    expect(comment).toContain('PR `1111111111aa` · main `2222222222bb`');
   });
 
   it('states "already on a released build" only when shippedTagExists is true', () => {

--- a/scripts/mobile-ota-compat-check.test.ts
+++ b/scripts/mobile-ota-compat-check.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CHECK_TITLE,
   STICKY_MARKER,
+  confirmComparison,
   deriveOverall,
   deriveVerdict,
   parseArgs,
@@ -124,6 +125,26 @@ describe('renderComment', () => {
     expect(comment).toContain('PR `1111111111aa` · main `2222222222bb`');
   });
 
+  it('labels the unknown case "(no baseline)" rather than a bare em-dash pair', () => {
+    const comment = renderComment(
+      {
+        results: [
+          platformResult({ platform: 'ios', verdict: 'unknown', prFingerprint: 'abcdef123456', baseFingerprint: null }),
+          platformResult({
+            platform: 'android',
+            verdict: 'unknown',
+            prFingerprint: 'abcdef123456',
+            baseFingerprint: null,
+          }),
+        ],
+        overall: 'unknown',
+      },
+      ctx,
+    );
+    expect(comment).toContain('`abcdef123456` (no baseline)');
+    expect(comment).toContain('OTA compatibility unknown');
+  });
+
   it('states "already on a released build" only when shippedTagExists is true', () => {
     const comment = renderComment(
       {
@@ -160,6 +181,67 @@ describe('renderSummary', () => {
 describe('CHECK_TITLE covers every verdict', () => {
   it.each<Verdict>(['ota-compatible', 'native-change-required', 'unknown'])('has a title for %s', (verdict) => {
     expect(CHECK_TITLE[verdict]).toBeTruthy();
+  });
+});
+
+describe('confirmComparison (retry/confirmation logic)', () => {
+  // A resolver that yields a scripted sequence, repeating the last value once
+  // exhausted, and counts how many times it was called.
+  function sequence(values: readonly (string | null)[]): { resolve: () => string | null; calls: () => number } {
+    let index = 0;
+    return {
+      resolve: () => values[Math.min(index++, values.length - 1)],
+      calls: () => index,
+    };
+  }
+
+  it('trusts an equal first read without retrying', () => {
+    const pr = sequence(['abc', 'should-not-read']);
+    const base = sequence(['abc', 'should-not-read']);
+    expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: 'abc', baseFingerprint: 'abc' });
+    expect(pr.calls()).toBe(1);
+    expect(base.calls()).toBe(1);
+  });
+
+  it('returns early without retrying when a side is null', () => {
+    const pr = sequence([null, 'abc']);
+    const base = sequence(['abc']);
+    expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: null, baseFingerprint: 'abc' });
+    expect(pr.calls()).toBe(1);
+  });
+
+  it('collapses a flake: a spurious difference that re-resolves to equal → equal', () => {
+    const pr = sequence(['flake', 'abc', 'abc']);
+    const base = sequence(['abc', 'abc', 'abc']);
+    expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: 'abc', baseFingerprint: 'abc' });
+  });
+
+  it('confirms a stable native change and stops early on a repeated differing pair', () => {
+    const pr = sequence(['aaa']);
+    const base = sequence(['bbb']);
+    expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: 'aaa', baseFingerprint: 'bbb' });
+    // 1 initial read + 1 confirmation (which repeats the pair → break) = 2 each.
+    expect(pr.calls()).toBe(2);
+    expect(base.calls()).toBe(2);
+  });
+
+  it('exhausts retries when the differing pair never repeats nor agrees', () => {
+    let prIndex = 0;
+    let baseIndex = 0;
+    const result = confirmComparison(
+      () => `pr${prIndex++}`,
+      () => `base${baseIndex++}`,
+      3,
+    );
+    // 1 initial + 3 confirmations, all distinct → returns the last differing pair.
+    expect(prIndex).toBe(4);
+    expect(baseIndex).toBe(4);
+    expect(result).toEqual({ prFingerprint: 'pr3', baseFingerprint: 'base3' });
+  });
+
+  it('confirms equality against a fixed (constant) baseline when the PR converges', () => {
+    const pr = sequence(['flake', 'abc']);
+    expect(confirmComparison(pr.resolve, () => 'abc')).toEqual({ prFingerprint: 'abc', baseFingerprint: 'abc' });
   });
 });
 

--- a/scripts/mobile-ota-compat-check.ts
+++ b/scripts/mobile-ota-compat-check.ts
@@ -48,6 +48,16 @@ import { execFileSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+/**
+ * `bunx expo-updates runtimeversion:resolve` is intermittently non-deterministic
+ * (≈5% of invocations its autolinking step computes a hash off a different source
+ * set), so a single resolve can't be trusted to mean "the fingerprint changed".
+ * The check confirms a *difference* before reporting it: a real native change
+ * stays different across re-resolves, a flake collapses back to equal. An "equal"
+ * is trusted immediately (two independent trees won't collide on a wrong hash).
+ */
+const MAX_DIFF_CONFIRMATIONS = 5;
+
 export type Platform = 'ios' | 'android';
 export type Verdict = 'ota-compatible' | 'native-change-required' | 'unknown';
 
@@ -110,9 +120,9 @@ export function deriveVerdict(prFingerprint: string | null, baseFingerprint: str
  * "unknown" downgrades an otherwise-compatible headline to honest uncertainty.
  */
 export function deriveOverall(results: readonly PlatformResult[]): Verdict {
+  if (results.length === 0) return 'unknown';
   if (results.some((entry) => entry.verdict === 'native-change-required')) return 'native-change-required';
   if (results.some((entry) => entry.verdict === 'unknown')) return 'unknown';
-  if (results.length === 0) return 'unknown';
   return 'ota-compatible';
 }
 
@@ -144,24 +154,27 @@ export const CHECK_TITLE: Record<Verdict, string> = {
   unknown: 'OTA compatibility unknown (no baseline)',
 };
 
-/** PURE: the fingerprint cell for one platform, e.g. `abc123` (unchanged) or `pr` → `main`. */
+/**
+ * PURE: the fingerprint cell for one platform. Each hash is labelled (no bare
+ * arrow) so it reads as two static snapshots, not a state transition:
+ *   compatible → `abc` (matches main)
+ *   native     → PR `abc` · main `def`
+ *   unknown    → PR `abc` · main —
+ */
 function fingerprintCell(entry: PlatformResult): string {
   if (entry.verdict === 'ota-compatible') {
-    const cell = `\`${shortHash(entry.prFingerprint)}\` (unchanged)`;
+    const cell = `\`${shortHash(entry.prFingerprint)}\` (matches \`main\`)`;
     // Secondary signal — only ever stated when confidently true.
     return entry.shippedTagExists ? `${cell} · already on a released build` : cell;
   }
-  if (entry.verdict === 'native-change-required') {
-    return `\`${shortHash(entry.prFingerprint)}\` → \`${shortHash(entry.baseFingerprint)}\``;
-  }
-  return `\`${shortHash(entry.prFingerprint)}\` (no baseline)`;
+  return `PR \`${shortHash(entry.prFingerprint)}\` · main \`${shortHash(entry.baseFingerprint)}\``;
 }
 
 function table(results: readonly PlatformResult[]): string {
   const rows = results.map(
     (entry) => `| ${PLATFORM_LABEL[entry.platform]} | ${VERDICT_CELL[entry.verdict]} | ${fingerprintCell(entry)} |`,
   );
-  return ['| Platform | Verdict | Fingerprint (PR → main) |', '| --- | --- | --- |', ...rows].join('\n');
+  return ['| Platform | Verdict | Fingerprint |', '| --- | --- | --- |', ...rows].join('\n');
 }
 
 /** PURE: render the sticky PR comment markdown. */
@@ -216,6 +229,9 @@ function writeEnv(mobileDir: string): void {
  * use. Returns null on any failure (mirrors the gates' `|| true` tolerance).
  * iOS resolves WITHOUT GOOGLE_MAPS_API_KEY, Android WITH it — applied identically
  * to PR and baseline so the equality verdict holds regardless of the key.
+ *
+ * May intermittently return a wrong hash (see MAX_DIFF_CONFIRMATIONS) — callers
+ * must confirm a difference, never act on a single differing read.
  */
 function resolveFingerprint(mobileDir: string, platform: Platform): string | null {
   const childEnv = { ...process.env };
@@ -232,6 +248,41 @@ function resolveFingerprint(mobileDir: string, platform: Platform): string | nul
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve a platform's PR and baseline fingerprints, confirming any difference so
+ * a flaky resolve can't surface as a false "native change". Trusts an "equal"
+ * read immediately; on a difference, re-resolves both up to MAX_DIFF_CONFIRMATIONS
+ * times — returns the equal pair the moment one agrees, or stops early once the
+ * same differing pair repeats (a stable, real native change).
+ */
+function comparePlatform(
+  platform: Platform,
+  prMobileDir: string,
+  readBaseFingerprint: () => string | null,
+): { prFingerprint: string | null; baseFingerprint: string | null } {
+  let prFingerprint = resolveFingerprint(prMobileDir, platform);
+  let baseFingerprint = readBaseFingerprint();
+
+  if (!prFingerprint || !baseFingerprint || prFingerprint === baseFingerprint) {
+    return { prFingerprint, baseFingerprint };
+  }
+
+  let previousPr = prFingerprint;
+  let previousBase = baseFingerprint;
+  for (let attempt = 0; attempt < MAX_DIFF_CONFIRMATIONS; attempt += 1) {
+    const pr = resolveFingerprint(prMobileDir, platform);
+    const base = readBaseFingerprint();
+    if (pr) prFingerprint = pr;
+    if (base) baseFingerprint = base;
+    if (pr && base && pr === base) return { prFingerprint: pr, baseFingerprint: base };
+    // The same differing pair twice running → a stable, genuine native change.
+    if (pr && base && pr === previousPr && base === previousBase) break;
+    if (pr) previousPr = pr;
+    if (base) previousBase = base;
+  }
+  return { prFingerprint, baseFingerprint };
 }
 
 /** Secondary signal: does a released binary already carry this fingerprint? */
@@ -337,10 +388,13 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   }
 
   const results: PlatformResult[] = PLATFORMS.map((platform) => {
-    const prFingerprint = resolveFingerprint(options.prMobileDir, platform);
-    const baseFingerprint =
+    // Re-read the baseline the same way each attempt: a provided value is fixed,
+    // a worktree is re-resolved so a flaky baseline read can also self-correct.
+    const readBaseFingerprint = (): string | null =>
       options.baseFingerprints[platform] ??
       (options.baseMobileDir ? resolveFingerprint(options.baseMobileDir, platform) : null);
+
+    const { prFingerprint, baseFingerprint } = comparePlatform(platform, options.prMobileDir, readBaseFingerprint);
 
     if (!prFingerprint) {
       console.warn(

--- a/scripts/mobile-ota-compat-check.ts
+++ b/scripts/mobile-ota-compat-check.ts
@@ -126,6 +126,52 @@ export function deriveOverall(results: readonly PlatformResult[]): Verdict {
   return 'ota-compatible';
 }
 
+export interface FingerprintPair {
+  prFingerprint: string | null;
+  baseFingerprint: string | null;
+}
+
+/**
+ * PURE (given injected resolvers): resolve a platform's PR and baseline
+ * fingerprints, confirming any difference so a flaky resolver can't surface as a
+ * false "native change". Trusts an "equal" read immediately (two independent
+ * trees won't collide on a wrong hash); on a difference, re-resolves both up to
+ * `maxConfirmations` times — returns the equal pair the moment one agrees, or
+ * stops early once the same differing pair repeats (a stable, real native change).
+ *
+ * `resolveBase` may be backed by a fixed value (the cache-hit path); then only
+ * the PR side actually changes across retries, and the PR converging to that
+ * constant is what confirms equality. Keep the two resolvers' side effects cheap
+ * and idempotent — they're each called up to `maxConfirmations + 1` times.
+ */
+export function confirmComparison(
+  resolvePr: () => string | null,
+  resolveBase: () => string | null,
+  maxConfirmations: number = MAX_DIFF_CONFIRMATIONS,
+): FingerprintPair {
+  let prFingerprint = resolvePr();
+  let baseFingerprint = resolveBase();
+
+  if (!prFingerprint || !baseFingerprint || prFingerprint === baseFingerprint) {
+    return { prFingerprint, baseFingerprint };
+  }
+
+  let previousPr = prFingerprint;
+  let previousBase = baseFingerprint;
+  for (let attempt = 0; attempt < maxConfirmations; attempt += 1) {
+    const pr = resolvePr();
+    const base = resolveBase();
+    if (pr) prFingerprint = pr;
+    if (base) baseFingerprint = base;
+    if (pr && base && pr === base) return { prFingerprint: pr, baseFingerprint: base };
+    // The same differing pair twice running → a stable, genuine native change.
+    if (pr && base && pr === previousPr && base === previousBase) break;
+    if (pr) previousPr = pr;
+    if (base) previousBase = base;
+  }
+  return { prFingerprint, baseFingerprint };
+}
+
 function shortHash(fingerprint: string | null): string {
   return fingerprint ? fingerprint.slice(0, 12) : '—';
 }
@@ -159,7 +205,7 @@ export const CHECK_TITLE: Record<Verdict, string> = {
  * arrow) so it reads as two static snapshots, not a state transition:
  *   compatible → `abc` (matches main)
  *   native     → PR `abc` · main `def`
- *   unknown    → PR `abc` · main —
+ *   unknown    → `abc` (no baseline)  /  `—` (unresolved)
  */
 function fingerprintCell(entry: PlatformResult): string {
   if (entry.verdict === 'ota-compatible') {
@@ -167,7 +213,13 @@ function fingerprintCell(entry: PlatformResult): string {
     // Secondary signal — only ever stated when confidently true.
     return entry.shippedTagExists ? `${cell} · already on a released build` : cell;
   }
-  return `PR \`${shortHash(entry.prFingerprint)}\` · main \`${shortHash(entry.baseFingerprint)}\``;
+  if (entry.verdict === 'native-change-required') {
+    return `PR \`${shortHash(entry.prFingerprint)}\` · main \`${shortHash(entry.baseFingerprint)}\``;
+  }
+  // unknown — name why we couldn't compare rather than show a bare em-dash pair.
+  return entry.baseFingerprint
+    ? `\`${shortHash(entry.prFingerprint)}\` (unresolved)`
+    : `\`${shortHash(entry.prFingerprint)}\` (no baseline)`;
 }
 
 function table(results: readonly PlatformResult[]): string {
@@ -248,41 +300,6 @@ function resolveFingerprint(mobileDir: string, platform: Platform): string | nul
   } catch {
     return null;
   }
-}
-
-/**
- * Resolve a platform's PR and baseline fingerprints, confirming any difference so
- * a flaky resolve can't surface as a false "native change". Trusts an "equal"
- * read immediately; on a difference, re-resolves both up to MAX_DIFF_CONFIRMATIONS
- * times — returns the equal pair the moment one agrees, or stops early once the
- * same differing pair repeats (a stable, real native change).
- */
-function comparePlatform(
-  platform: Platform,
-  prMobileDir: string,
-  readBaseFingerprint: () => string | null,
-): { prFingerprint: string | null; baseFingerprint: string | null } {
-  let prFingerprint = resolveFingerprint(prMobileDir, platform);
-  let baseFingerprint = readBaseFingerprint();
-
-  if (!prFingerprint || !baseFingerprint || prFingerprint === baseFingerprint) {
-    return { prFingerprint, baseFingerprint };
-  }
-
-  let previousPr = prFingerprint;
-  let previousBase = baseFingerprint;
-  for (let attempt = 0; attempt < MAX_DIFF_CONFIRMATIONS; attempt += 1) {
-    const pr = resolveFingerprint(prMobileDir, platform);
-    const base = readBaseFingerprint();
-    if (pr) prFingerprint = pr;
-    if (base) baseFingerprint = base;
-    if (pr && base && pr === base) return { prFingerprint: pr, baseFingerprint: base };
-    // The same differing pair twice running → a stable, genuine native change.
-    if (pr && base && pr === previousPr && base === previousBase) break;
-    if (pr) previousPr = pr;
-    if (base) previousBase = base;
-  }
-  return { prFingerprint, baseFingerprint };
 }
 
 /** Secondary signal: does a released binary already carry this fingerprint? */
@@ -394,7 +411,10 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
       options.baseFingerprints[platform] ??
       (options.baseMobileDir ? resolveFingerprint(options.baseMobileDir, platform) : null);
 
-    const { prFingerprint, baseFingerprint } = comparePlatform(platform, options.prMobileDir, readBaseFingerprint);
+    const { prFingerprint, baseFingerprint } = confirmComparison(
+      () => resolveFingerprint(options.prMobileDir, platform),
+      readBaseFingerprint,
+    );
 
     if (!prFingerprint) {
       console.warn(


### PR DESCRIPTION
## Summary

Follow-up to #3106 (merged before these landed). The headline fix closes a real reliability hole in the OTA-compatibility check that #3106 added.

**The bug:** `bunx expo-updates runtimeversion:resolve` is intermittently non-deterministic — roughly 5% of invocations its autolinking step hashes a different source set (the same instability that motivates #3107's cross-OS pin). The merged check acted on a *single* resolve per tree, so a flake on one side surfaced as a **false "native change"**. Stress-testing a JS-only branch reproduced it in ~2/10 runs — exactly the kind of unreliable signal the feature was meant to avoid.

**The fix** (`scripts/mobile-ota-compat-check.ts`): confirm a difference before reporting it. An "equal" read is trusted immediately (two independent trees won't collide on a wrong hash), but on a difference both sides are re-resolved up to 5×, returning the equal pair the moment one agrees and stopping early once the same differing pair repeats (a stable, real native change). A genuine native change stays different across re-resolves; a flake collapses back to equal.

**Result:** a JS-only branch now reads `ota-compatible` **14/14** stress runs (was ~12/14).

### Also addresses the #3106 Claude review

- **Docs**: `docs/mobile-ota-updates.md` now documents the PR-time signal (the rendered comment points readers there).
- **`deriveOverall`**: empty-array guard moved first, for clarity.
- **Comment table**: each hash is labelled (`PR x · main y`) instead of an ambiguous `x → main` arrow under a "(PR → main)" header.

(The fourth review note — parallelizing the resolves — was the thing that surfaced this bug: concurrent resolves in one tree make the flake worse, so resolution stays sequential by design.)

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 195 pass (incl. updated table assertion + `parseArgs` tests).
- `vp run typecheck:mobile`, `vp check` — clean.
- Stress test, JS-only branch vs an `origin/main` worktree, 14 runs → **14/14 `ota-compatible`** (pre-fix: intermittent false `native-change-required`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfJ8E5QVxhWYbKRb4RGDbn