### PR TITLE
ci(mobile): trigger native builds + OTA on root patches/ changes

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -16,6 +16,7 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/android-apk-rn.yml'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -8,6 +8,7 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/ios-testflight-rn.yml'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -21,6 +21,7 @@ on:
       - 'packages/shared/**'
       - 'packages/board-constants/**'
       - 'packages/shared-schema/**'
+      - 'patches/**' # bun patches to mobile deps live in root patches/, not under packages/mobile/**
       - '.github/workflows/mobile-ota-production.yml'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What & why

The three mobile delivery workflows — `android-apk-rn.yml`, `ios-testflight-rn.yml`, `mobile-ota-production.yml` — filter `push` to `packages/mobile/**` + the shared packages. A **bun patch** to a mobile dependency lives in root `patches/` (plus `package.json` `patchedDependencies` / `bun.lock`), which none of those globs match. So a dependency-level mobile fix can merge to `main` and **publish nothing**.

This just bit **#3108** — the `@gorhom/bottom-sheet` backdrop patch (the Android scroll/bars freeze fix). It merged but did **not** auto-publish an OTA; I had to dispatch `mobile-ota-production.yml` by hand to actually deliver it.

## The fix

Add `patches/**` to all three workflows' `paths:` filters, so a patched dependency triggers the same native-build + OTA path a `packages/mobile/**` change does. The native workflows' fingerprint gate still decides native-build-vs-OTA, so a JS-only patch (like the gorhom one) just rides OTA with no native build.

`patches/**` is the precise trigger — patches are rare and always a runtime-behaviour change — so it won't over-fire the way root `package.json` / `bun.lock` would (those move on every monorepo dep bump, including web/backend-only ones).

## Validation

- `scripts/mobile-ci-env-parity.test.ts` + `scripts/mobile-ota-compat-check.test.ts` — 39 tests pass (the three workflows stay in parity; `patches/**` added to all three identically).
- This PR edits the workflow files themselves, which each workflow already watches — so merging it is its own smoke test (the fingerprint gate will skip native builds, OTA republishes the current bundle).

## Release Notes

none