### PR TITLE
fix(mobile): keep board history fresh after reconnect, backgrounding & pull-to-refresh

### DIFF
--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -237,6 +237,12 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   historyCountRef.current = visibleHistory.length;
 
   const lastReceivedWallClimbRef = useRef<string | null>(null);
+  // `seq` rides along in the telemetry payload but must NOT trigger the effect —
+  // a same-uuid seq bump (e.g. a backfill merge) shouldn't re-evaluate the
+  // "new climb on the wall" event. Read it from a ref so the effect keys only on
+  // the climb uuid.
+  const currentClimbSeqRef = useRef(currentClimb?.seq);
+  currentClimbSeqRef.current = currentClimb?.seq;
   const actionClimbCacheRef = useRef(new Map<string, Climb>());
   const actionClimbRequestRef = useRef(new Map<string, Promise<Climb | null>>());
   const pendingActionKeysRef = useRef(new Set<string>());
@@ -251,9 +257,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       boardId: boardPresenceBoardIdRef.current ?? undefined,
       climbUuid: currentClimbUuid,
       // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
-      seq: currentClimb?.seq ?? undefined,
+      seq: currentClimbSeqRef.current ?? undefined,
     });
-  }, [currentClimb?.climbUuid, currentClimb?.seq]);
+  }, [currentClimb?.climbUuid]);
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
   const rowBoard = useMemo<BoardSheetRowBoard | null>(

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -12,7 +12,7 @@
 // sheet is only ever opened from the board glyph when the flag is on.
 
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { Platform, Pressable, StyleSheet, View, type ColorValue } from 'react-native';
+import { Platform, Pressable, RefreshControl, StyleSheet, View, type ColorValue } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetBackdrop,
@@ -22,7 +22,11 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
-import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
+import {
+  useBoardPresenceActions,
+  useBoardPresenceCurrent,
+  useBoardPresenceFeed,
+} from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardName, BoardPresenceClimb, BoardPresenceHardestSend, Climb } from '@boardsesh/shared-schema';
 import { GlassSheetBackground } from '../GlassSheetBackground';
@@ -194,9 +198,32 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
 
   const { currentClimb } = useBoardPresenceCurrent();
   const { history, stats } = useBoardPresenceFeed();
+  const { refresh } = useBoardPresenceActions();
   const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
   const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
   boardPresenceBoardIdRef.current = boardPresenceBoardId;
+
+  // Pull-to-refresh: a manual catch-up for when a user notices the wall feed is
+  // stale. `refresh()` is fire-and-forget (the durable history merges back in
+  // via context), so show the spinner briefly, then clear it.
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleRefresh = useCallback(() => {
+    refresh('manual');
+    setIsRefreshing(true);
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+    }
+    refreshTimerRef.current = setTimeout(() => setIsRefreshing(false), 800);
+  }, [refresh]);
+  useEffect(
+    () => () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    },
+    [],
+  );
   const visibleHistory = useMemo(
     () =>
       currentClimb
@@ -223,8 +250,10 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     track(SHARED_EVENTS.BoardNowPlayingReceived, {
       boardId: boardPresenceBoardIdRef.current ?? undefined,
       climbUuid: currentClimbUuid,
+      // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
+      seq: currentClimb?.seq ?? undefined,
     });
-  }, [currentClimb?.climbUuid]);
+  }, [currentClimb?.climbUuid, currentClimb?.seq]);
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
   const rowBoard = useMemo<BoardSheetRowBoard | null>(
@@ -664,6 +693,9 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
         ListHeaderComponent={listHeader}
         ListEmptyComponent={listEmpty}
         contentContainerStyle={{ paddingBottom: spacing[4] }}
+        refreshControl={
+          <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />
+        }
       />
 
       <Pressable

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -8,6 +8,7 @@ const presence = vi.hoisted(() => ({
   currentClimb: null as BoardPresenceClimb | null,
   history: [] as BoardPresenceClimb[],
   stats: null as BoardPresenceStats | null,
+  refresh: vi.fn(),
 }));
 
 const presenceControls = vi.hoisted(() => ({
@@ -62,6 +63,9 @@ vi.mock('react-native', () => ({
     accessibilityLabel,
   }: ViewMockProps & { onPress?: () => void; accessibilityLabel?: string }) =>
     createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  // Surface onRefresh as a clickable element so the pull-to-refresh wiring is testable.
+  RefreshControl: ({ onRefresh }: { onRefresh?: () => void }) =>
+    createElement('button', { onClick: onRefresh, 'aria-label': 'refresh' }),
 }));
 
 vi.mock('@gorhom/bottom-sheet', () => ({
@@ -77,16 +81,19 @@ vi.mock('@gorhom/bottom-sheet', () => ({
     ListHeaderComponent,
     ListEmptyComponent,
     keyExtractor,
+    refreshControl,
   }: {
     data: BoardPresenceClimb[];
     renderItem: (info: { item: BoardPresenceClimb }) => ReactNode;
     ListHeaderComponent?: ReactNode;
     ListEmptyComponent?: ReactNode;
     keyExtractor: (item: BoardPresenceClimb) => string;
+    refreshControl?: ReactNode;
   }) =>
     createElement(
       'div',
       { 'data-list': 'true' },
+      refreshControl,
       ListHeaderComponent,
       data.length === 0
         ? ListEmptyComponent
@@ -117,6 +124,7 @@ vi.mock('@boardsesh/board-presence-react', () => ({
     isLive: true,
   }),
   useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
+  useBoardPresenceActions: () => ({ refresh: presence.refresh }),
 }));
 
 vi.mock('../../../providers/board-presence-provider', () => ({
@@ -278,6 +286,7 @@ describe('BoardSheet', () => {
     presence.history = [];
     presence.stats = null;
     presenceControls.boardId = 123;
+    presence.refresh.mockClear();
     analytics.track.mockClear();
     graphql.request.mockReset();
     toast.showToast.mockClear();
@@ -322,7 +331,23 @@ describe('BoardSheet', () => {
     expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardNowPlayingReceived, {
       boardId: 123,
       climbUuid: 'c1',
+      seq: 3,
     });
+  });
+
+  it('triggers a manual catch-up when the history list is pulled to refresh', () => {
+    presence.history = [makeClimb('c1', 3)];
+    const { getByLabelText } = render(
+      createElement(BoardSheet, {
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    fireEvent.click(getByLabelText('refresh'));
+    expect(presence.refresh).toHaveBeenCalledWith('manual');
   });
 
   it('tracks history views from the imperative present call', () => {

--- a/packages/mobile/src/lib/board-presence/board-presence-client.ts
+++ b/packages/mobile/src/lib/board-presence/board-presence-client.ts
@@ -102,6 +102,22 @@ export function createMobileBoardPresenceClient(getClient: () => Client): Mobile
       );
     },
 
+    onReconnect(callback) {
+      // graphql-ws fires `connected` on the first connect AND on every
+      // reconnect. Skip the first (the initial backfill already covers it) and
+      // fire on each reconnect so the hook can re-read the durable history for
+      // anything the Redis pub/sub feed dropped during the gap. Same mechanism
+      // the queue provider uses (queue-provider.tsx on('connected')). `on`
+      // returns its own unsubscribe.
+      let connectedOnce = false;
+      return getClient().on('connected', () => {
+        if (connectedOnce) {
+          callback();
+        }
+        connectedOnce = true;
+      });
+    },
+
     async fetchRecentClimbs(boardId) {
       const data = await execute<BoardRecentClimbsData>(getClient(), {
         query: BOARD_RECENT_CLIMBS,

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -20,7 +20,31 @@ const transport = vi.hoisted(() => ({
   ),
   reportClimb: vi.fn(async () => true),
 }));
-const sharedProvider = vi.hoisted(() => ({ lastBoardId: undefined as number | null | undefined }));
+const sharedProvider = vi.hoisted(() => ({
+  lastBoardId: undefined as number | null | undefined,
+  lastOnCatchUp: undefined as ((info: { reason: string; recoveredThroughSeqDelta: number }) => void) | undefined,
+}));
+// The refresh action exposed by the (mocked) shared actions context, and a track
+// spy — so we can assert the foreground sync and catch-up telemetry wiring.
+const refreshMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+// Capture the AppState 'change' handler so a test can fire 'active'/'background'.
+const appState = vi.hoisted(() => {
+  const ref: { handler: ((state: string) => void) | null } = { handler: null };
+  return {
+    addEventListener: vi.fn((_event: string, cb: (state: string) => void) => {
+      ref.handler = cb;
+      return { remove: vi.fn() };
+    }),
+    fire: (state: string) => ref.handler?.(state),
+  };
+});
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+
+vi.mock('../../lib/analytics', () => ({ track: trackMock }));
 
 // Board presence is always-on (the flag was removed); the provider no longer
 // reads useFeatureFlag, but stub the module so nothing transitively loads the
@@ -54,10 +78,21 @@ vi.mock('../../components/board-discovery/BoardDisambiguationSheet', () => ({
 // Capture the boardId handed to the shared provider so we can assert it updates
 // after resolve.
 vi.mock('@boardsesh/board-presence-react', () => ({
-  BoardPresenceProvider: ({ boardId, children }: { boardId: number | null; children: ReactNode }) => {
+  BoardPresenceProvider: ({
+    boardId,
+    onCatchUp,
+    children,
+  }: {
+    boardId: number | null;
+    onCatchUp?: (info: { reason: string; recoveredThroughSeqDelta: number }) => void;
+    children: ReactNode;
+  }) => {
     sharedProvider.lastBoardId = boardId;
+    sharedProvider.lastOnCatchUp = onCatchUp;
     return createElement('div', { 'data-board-id': String(boardId) }, children);
   },
+  // BoardPresenceForegroundSync (rendered inside the provider) reads this.
+  useBoardPresenceActions: () => ({ refresh: refreshMock }),
 }));
 
 import { MobileBoardPresenceProvider, useBoardPresenceControls } from '../board-presence-provider';
@@ -105,6 +140,10 @@ describe('MobileBoardPresenceProvider', () => {
     transport.reportClimb.mockClear();
     transport.reportClimb.mockResolvedValue(true);
     sharedProvider.lastBoardId = undefined;
+    sharedProvider.lastOnCatchUp = undefined;
+    refreshMock.mockClear();
+    trackMock.mockClear();
+    appState.addEventListener.mockClear();
     capturedControls = null;
   });
 
@@ -441,5 +480,44 @@ describe('MobileBoardPresenceProvider', () => {
     });
 
     expect(transport.reportClimb).toHaveBeenCalledWith(42, { uuid: 'queue-1', climb: { uuid: 'climb-1' } }, 40);
+  });
+
+  it('catches up the wall feed when the app returns to the foreground', () => {
+    renderProvider();
+    expect(appState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    refreshMock.mockClear();
+    act(() => appState.fire('active'));
+    expect(refreshMock).toHaveBeenCalledWith('foreground');
+  });
+
+  it('does not catch up when the app goes to the background', () => {
+    renderProvider();
+    refreshMock.mockClear();
+    act(() => appState.fire('background'));
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('tracks a catch-up telemetry event with the active boardId, reason, and recovered delta', async () => {
+    renderProvider();
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoard({
+        serial: 'SERIAL-1',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+    await waitFor(() => expect(sharedProvider.lastBoardId).toBe(42));
+
+    trackMock.mockClear();
+    act(() => sharedProvider.lastOnCatchUp?.({ reason: 'reconnect', recoveredThroughSeqDelta: 2 }));
+
+    expect(trackMock).toHaveBeenCalledWith('Board History Catch Up', {
+      boardId: 42,
+      reason: 'reconnect',
+      recoveredThroughSeqDelta: 2,
+    });
   });
 });

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -20,14 +20,21 @@
 // (b) report a freshly-lit climb on wall-confirm. Reads of the wall's current
 // climb go through `@boardsesh/board-presence-react`'s split contexts.
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
-import { BoardPresenceProvider } from '@boardsesh/board-presence-react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { AppState } from 'react-native';
+import {
+  BoardPresenceProvider,
+  useBoardPresenceActions,
+  type BoardPresenceCatchUpInfo,
+} from '@boardsesh/board-presence-react';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardCandidate, ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
 import {
   createMobileBoardPresenceClient,
   type MobileBoardPresenceClient,
 } from '../lib/board-presence/board-presence-client';
 import { getWsClient } from '../lib/graphql/ws-client';
+import { track } from '../lib/analytics';
 import { BoardDisambiguationSheet } from '../components/board-discovery/BoardDisambiguationSheet';
 
 /** Board config needed to find-or-bind the shared board on first sighting. */
@@ -298,6 +305,18 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     setPendingDisambiguation(null);
   }, []);
 
+  // Telemetry for every catch-up. `recoveredThroughSeqDelta > 0` means the live
+  // feed silently dropped pushes (Redis pub/sub has no replay) and we just
+  // recovered them — the measurable "history was slow to update" signal. Stable
+  // identity (reads boardIdRef) so it never re-binds the presence subscription.
+  const handleCatchUp = useCallback((info: BoardPresenceCatchUpInfo) => {
+    track(SHARED_EVENTS.BoardHistoryCatchUp, {
+      boardId: boardIdRef.current ?? undefined,
+      reason: info.reason,
+      recoveredThroughSeqDelta: info.recoveredThroughSeqDelta,
+    });
+  }, []);
+
   const controls = useMemo<BoardPresenceControlsValue>(
     () => ({
       enabled,
@@ -323,7 +342,8 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
 
   return (
     <BoardPresenceControlsContext.Provider value={controls}>
-      <BoardPresenceProvider boardId={boardId} client={client}>
+      <BoardPresenceProvider boardId={boardId} client={client} onCatchUp={handleCatchUp}>
+        <BoardPresenceForegroundSync />
         {children}
       </BoardPresenceProvider>
       <BoardDisambiguationSheet
@@ -334,6 +354,28 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
       />
     </BoardPresenceControlsContext.Provider>
   );
+}
+
+/**
+ * Refetch the wall feed when the app returns to the foreground. iOS can suspend
+ * the WebSocket while the app is backgrounded without emitting a clean
+ * reconnect, so climbs pushed in the meantime are dropped (Redis pub/sub has no
+ * replay) and the seq-gap detector only recovers them if a *later* event
+ * arrives. A foreground catch-up pulls them from the durable history right away.
+ * Rendered inside `BoardPresenceProvider` so it can read the `refresh` action;
+ * the catch-up coalescer dedups it against any reconnect/gap catch-up.
+ */
+function BoardPresenceForegroundSync(): null {
+  const { refresh } = useBoardPresenceActions();
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState === 'active') {
+        refresh('foreground');
+      }
+    });
+    return () => subscription.remove();
+  }, [refresh]);
+  return null;
 }
 
 /**

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -116,6 +116,12 @@ export const SHARED_EVENTS = {
   BoardSheetOpened: 'Board Sheet Opened',
   BoardHistoryViewed: 'Board History Viewed',
   BoardSwapInvokedFromSheet: 'Board Swap Invoked From Sheet',
+  // Fired after a board-history catch-up completes. Props:
+  // { boardId?, reason: 'gap' | 'reconnect' | 'foreground' | 'manual',
+  //   recoveredThroughSeqDelta }. `recoveredThroughSeqDelta > 0` means live
+  //   events were silently dropped (Redis pub/sub has no replay) and just
+  //   recovered — the signal for "history was slow/stale to update".
+  BoardHistoryCatchUp: 'Board History Catch Up',
   // External platform integrations (Apple Health, Strava). Props:
   // { integration: 'apple_health' | 'strava', trigger?: 'auto' | 'manual',
   //   enabled?: boolean }

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -136,6 +136,15 @@ function makeClient() {
   const fetchRecentClimbs = vi.fn((boardId: number) => pushDeferred(recentByBoard, boardId).promise);
   const fetchStats = vi.fn((boardId: number) => pushDeferred(statsByBoard, boardId).promise);
   const fetchConnection = vi.fn((boardId: number) => pushDeferred(connectionByBoard, boardId).promise);
+
+  // Transport reconnect registration. `triggerReconnect` fires the registered
+  // callback the way graphql-ws `on('connected')` would on a reconnect.
+  let reconnectCallback: (() => void) | null = null;
+  const onReconnectUnsubscribe = vi.fn();
+  const onReconnect = vi.fn((callback: () => void) => {
+    reconnectCallback = callback;
+    return onReconnectUnsubscribe;
+  });
   const subscribeNowPlaying = vi.fn(
     (
       boardId: number,
@@ -158,6 +167,7 @@ function makeClient() {
     fetchConnection,
     reportClimb,
     reportDisconnect,
+    onReconnect,
     resolveBoardForSerial: vi.fn(),
   };
 
@@ -170,6 +180,9 @@ function makeClient() {
     fetchStats,
     fetchConnection,
     subscribeNowPlaying,
+    onReconnect,
+    onReconnectUnsubscribe,
+    triggerReconnect: () => reconnectCallback?.(),
     emit: (event: BoardPresenceEvent) => onEvent?.(event),
     emitError: (err: unknown) => onError?.(err),
     emitComplete: () => onComplete?.(),
@@ -500,6 +513,122 @@ describe('useBoardPresence — sequence gap recovery', () => {
     });
 
     expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('useBoardPresence — reconnect / foreground / manual catch-up', () => {
+  // Seed a board with one climb (seq 1) so observedSeq is a non-zero baseline.
+  async function mountSeeded(onCatchUp?: (info: { reason: string; recoveredThroughSeqDelta: number }) => void) {
+    const harness = makeClient();
+    const view = renderHook(() => useBoardPresence(1, harness.client, onCatchUp));
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+    return { harness, view };
+  }
+
+  it('registers a reconnect listener and catches up when the transport reconnects', async () => {
+    const onCatchUp = vi.fn();
+    const { harness } = await mountSeeded(onCatchUp);
+    expect(harness.onReconnect).toHaveBeenCalledTimes(1);
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+
+    // A reconnect must re-read the durable history WITHOUT waiting for a later
+    // live event to reveal the gap (the whole point of the fix).
+    act(() => harness.triggerReconnect());
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+    expect(harness.fetchStats).toHaveBeenCalledTimes(2);
+    expect(harness.fetchConnection).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('missed-while-offline', 3), climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 2 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+
+    // seq advanced 1 → 3 ⇒ ~2 events were silently dropped and just recovered.
+    expect(onCatchUp).toHaveBeenCalledWith({ reason: 'reconnect', recoveredThroughSeqDelta: 2 });
+  });
+
+  it('refresh() runs a manual catch-up and reports the manual reason', async () => {
+    const onCatchUp = vi.fn();
+    const { harness, view } = await mountSeeded(onCatchUp);
+
+    act(() => view.result.current.refresh());
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('newer', 4), climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+
+    expect(onCatchUp).toHaveBeenCalledWith({ reason: 'manual', recoveredThroughSeqDelta: 3 });
+  });
+
+  it('refresh("foreground") reports the foreground reason', async () => {
+    const onCatchUp = vi.fn();
+    const { harness, view } = await mountSeeded(onCatchUp);
+
+    act(() => view.result.current.refresh('foreground'));
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats, climbsSentCount: 1 });
+      await harness.resolveConnection(1, holder({ userId: 'seed' }));
+    });
+
+    // Nothing newer arrived ⇒ delta 0, but the trigger is still reported.
+    expect(onCatchUp).toHaveBeenCalledWith({ reason: 'foreground', recoveredThroughSeqDelta: 0 });
+  });
+
+  it('reports a zero delta for a cold-start catch-up (no false "dropped events" signal)', async () => {
+    const onCatchUp = vi.fn();
+    const harness = makeClient();
+    renderHook(() => useBoardPresence(1, harness.client, onCatchUp));
+
+    // Reconnect fires before any baseline exists (observedSeq still 0). Even if
+    // the catch-up pulls climbs, the delta must be 0 — that's the cold-start
+    // seed, not a recovery of dropped events.
+    act(() => harness.triggerReconnect());
+    await act(async () => {
+      // The mount backfill + the reconnect catch-up each issued a fetch; resolve
+      // both rounds so the catch-up's allSettled chain completes.
+      await harness.resolveRecent(1, [climb('a', 5)]);
+      await harness.resolveStats(1, { ...emptyStats });
+      await harness.resolveConnection(1, null);
+      await harness.resolveRecent(1, [climb('a', 5)]);
+      await harness.resolveStats(1, { ...emptyStats });
+      await harness.resolveConnection(1, null);
+    });
+
+    expect(onCatchUp).toHaveBeenCalledWith({ reason: 'reconnect', recoveredThroughSeqDelta: 0 });
+  });
+
+  it('unsubscribes the reconnect listener on unmount', () => {
+    const harness = makeClient();
+    const { unmount } = renderHook(() => useBoardPresence(1, harness.client));
+    expect(harness.onReconnect).toHaveBeenCalledTimes(1);
+    expect(harness.onReconnectUnsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(harness.onReconnectUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('still functions when the client does not implement onReconnect (web/read-only)', async () => {
+    const harness = makeClient();
+    const clientWithoutReconnect: BoardPresenceClient = { ...harness.client, onReconnect: undefined };
+    const { result } = renderHook(() => useBoardPresence(1, clientWithoutReconnect));
+
+    await act(async () => {
+      await harness.resolveRecent(1, [climb('first', 1)]);
+      await harness.resolveStats(1, { ...emptyStats });
+      await harness.resolveConnection(1, null);
+    });
+
+    // refresh() still drives a catch-up even with no reconnect hook available.
+    act(() => result.current.refresh());
+    expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -529,11 +529,21 @@ describe('useBoardPresence — reconnect / foreground / manual catch-up', () => 
     return { harness, view };
   }
 
+  it('does not fire catch-up telemetry on the initial mount/backfill', async () => {
+    const onCatchUp = vi.fn();
+    // Seeding goes through the direct backfill path, NOT runCatchUp — so no
+    // telemetry should fire on mount. Guards a future refactor that routes the
+    // initial backfill through runCatchUp from silently emitting spurious events.
+    await mountSeeded(onCatchUp);
+    expect(onCatchUp).not.toHaveBeenCalled();
+  });
+
   it('registers a reconnect listener and catches up when the transport reconnects', async () => {
     const onCatchUp = vi.fn();
     const { harness } = await mountSeeded(onCatchUp);
     expect(harness.onReconnect).toHaveBeenCalledTimes(1);
     expect(harness.fetchRecentClimbs).toHaveBeenCalledTimes(1);
+    expect(onCatchUp).not.toHaveBeenCalled();
 
     // A reconnect must re-read the durable history WITHOUT waiting for a later
     // live event to reveal the gap (the whole point of the fix).

--- a/packages/shared/board-presence-react/src/board-presence-provider.tsx
+++ b/packages/shared/board-presence-react/src/board-presence-provider.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import {
   useBoardPresence,
   type BoardPresenceActions,
+  type BoardPresenceCatchUpInfo,
   type BoardPresenceCurrentState,
   type BoardPresenceFeedState,
   type UseBoardPresenceResult,
@@ -27,21 +28,30 @@ const BoardPresenceHasClimbContext = createContext<boolean | undefined>(undefine
 export function BoardPresenceProvider({
   boardId,
   client,
+  onCatchUp,
   children,
 }: {
   boardId: number | null;
   client: BoardPresenceClient | null;
+  /**
+   * Optional telemetry hook fired after a catch-up (reconnect / foreground /
+   * gap / manual) completes — lets the platform measure how often live events
+   * are silently dropped and recovered, without pulling analytics into this
+   * renderer-agnostic package.
+   */
+  onCatchUp?: (info: BoardPresenceCatchUpInfo) => void;
   children: ReactNode;
 }) {
-  const value = useBoardPresence(boardId, client);
+  const value = useBoardPresence(boardId, client, onCatchUp);
   const actions = useMemo<BoardPresenceActions>(
     () => ({
       reportClimb: value.reportClimb,
       reportClimbWithUndoTarget: value.reportClimbWithUndoTarget,
       reportDisconnect: value.reportDisconnect,
       getUndoTarget: value.getUndoTarget,
+      refresh: value.refresh,
     }),
-    [value.reportClimb, value.reportClimbWithUndoTarget, value.reportDisconnect, value.getUndoTarget],
+    [value.reportClimb, value.reportClimbWithUndoTarget, value.reportDisconnect, value.getUndoTarget, value.refresh],
   );
   const current = useMemo<BoardPresenceCurrentState>(
     () => ({

--- a/packages/shared/board-presence-react/src/index.ts
+++ b/packages/shared/board-presence-react/src/index.ts
@@ -9,6 +9,8 @@
 export { useBoardPresence } from './use-board-presence';
 export type {
   BoardPresenceActions,
+  BoardPresenceCatchUpInfo,
+  BoardPresenceCatchUpReason,
   BoardPresenceCurrentState,
   BoardPresenceFeedState,
   BoardPresenceReportResult,

--- a/packages/shared/board-presence-react/src/types.ts
+++ b/packages/shared/board-presence-react/src/types.ts
@@ -42,6 +42,17 @@ export interface BoardPresenceClient {
     onComplete?: () => void,
   ): () => void;
 
+  /**
+   * Register a callback fired whenever the underlying transport reconnects
+   * (i.e. on every reconnect, not the first connect). The hook uses this to
+   * catch up the durable history after a dropped socket — live events ride
+   * Redis pub/sub with no replay, so anything pushed during the reconnect
+   * window is otherwise lost for this client. Returns an unsubscribe function.
+   * Optional so read-only / web clients that don't expose reconnect events
+   * still satisfy the interface (their feed self-heals on the next live event).
+   */
+  onReconnect?(callback: () => void): () => void;
+
   /** Newest-first recent climbs, used to backfill history for a late joiner. */
   fetchRecentClimbs(boardId: number): Promise<BoardPresenceClimb[]>;
 

--- a/packages/shared/board-presence-react/src/use-board-presence.ts
+++ b/packages/shared/board-presence-react/src/use-board-presence.ts
@@ -30,6 +30,30 @@ import type {
 } from '@boardsesh/shared-schema';
 import type { BoardPresenceClient } from './types';
 
+/**
+ * Why a catch-up (re-fetch of recent climbs + stats + connection) ran. Live
+ * events ride Redis pub/sub, which has no replay — so anything published while
+ * this client's socket was mid-reconnect is gone, and the durable Redis history
+ * list is the only recovery source. These are the four triggers that pull it:
+ * - `gap`: a live event arrived with a seq jump (we already missed something).
+ * - `reconnect`: the WebSocket reconnected (events in the gap window are lost).
+ * - `foreground`: the app returned to the foreground (socket may have been
+ *   suspended by the OS without a clean reconnect).
+ * - `manual`: an explicit user refresh (pull-to-refresh).
+ */
+export type BoardPresenceCatchUpReason = 'gap' | 'reconnect' | 'foreground' | 'manual';
+
+/** Telemetry payload emitted after a catch-up completes. */
+export type BoardPresenceCatchUpInfo = {
+  reason: BoardPresenceCatchUpReason;
+  /**
+   * How far the catch-up advanced the observed seq beyond what we'd seen when
+   * it started — a proxy for the number of live events that had been silently
+   * missed and were just recovered. `0` means the catch-up found nothing new.
+   */
+  recoveredThroughSeqDelta: number;
+};
+
 export type UseBoardPresenceResult = {
   currentClimb: BoardPresenceCurrentState['currentClimb'];
   previousClimb: BoardPresenceCurrentState['previousClimb'];
@@ -42,6 +66,7 @@ export type UseBoardPresenceResult = {
   reportClimbWithUndoTarget: BoardPresenceActions['reportClimbWithUndoTarget'];
   reportDisconnect: BoardPresenceActions['reportDisconnect'];
   getUndoTarget: BoardPresenceActions['getUndoTarget'];
+  refresh: BoardPresenceActions['refresh'];
 };
 
 export type BoardPresenceReportResult = {
@@ -91,6 +116,13 @@ export type BoardPresenceActions = {
   reportDisconnect: () => Promise<boolean>;
   /** Latest captured undo target for action-only consumers that need a ref-like read. */
   getUndoTarget: () => BoardPresenceClimb | null;
+  /**
+   * Force a catch-up: re-fetch recent climbs + stats + connection from the
+   * durable Redis-backed source and merge them in (deduped by seq). Use for
+   * pull-to-refresh (`manual`) and app-foreground recovery (`foreground`). A
+   * no-op while inert; coalesced with any in-flight catch-up.
+   */
+  refresh: (reason?: BoardPresenceCatchUpReason) => void;
 };
 
 function boardPresenceEventSeq(event: BoardPresenceEvent): number | null {
@@ -110,7 +142,11 @@ function highestClimbSeq(climbs: BoardPresenceClimb[]): number {
   return climbs.reduce((highestSeq, climb) => Math.max(highestSeq, climb.seq), 0);
 }
 
-export function useBoardPresence(boardId: number | null, client: BoardPresenceClient | null): UseBoardPresenceResult {
+export function useBoardPresence(
+  boardId: number | null,
+  client: BoardPresenceClient | null,
+  onCatchUp?: (info: BoardPresenceCatchUpInfo) => void,
+): UseBoardPresenceResult {
   const [state, dispatch] = useReducer(boardPresenceReducer, initialBoardPresenceState);
   const [isLive, setIsLive] = useState(false);
   const [undoTarget, setUndoTarget] = useState<BoardPresenceClimb | null>(null);
@@ -126,6 +162,14 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
   const undoTargetRef = useRef<BoardPresenceClimb | null>(undoTarget);
   undoTargetRef.current = undoTarget;
   const observedSeqRef = useRef(0);
+  // Keep the telemetry callback in a ref so it can change without forcing the
+  // subscription effect (keyed on [boardId, client]) to tear down and re-attach.
+  const onCatchUpRef = useRef(onCatchUp);
+  onCatchUpRef.current = onCatchUp;
+  // Points at the active effect-run's `runCatchUp`, so the stable `refresh()`
+  // action and the AppState/reconnect triggers can invoke it without being
+  // listed in the effect deps. Null while inert.
+  const catchUpRef = useRef<((reason: BoardPresenceCatchUpReason) => void) | null>(null);
 
   useEffect(() => {
     // No board or no transport: collapse to the initial state and stay inert.
@@ -135,6 +179,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       setIsLive(false);
       setUndoTarget(null);
       observedSeqRef.current = 0;
+      catchUpRef.current = null;
       return;
     }
 
@@ -147,6 +192,9 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     let isActive = true;
     let catchUpInFlight = false;
     let catchUpRequested = false;
+    // Reason for a catch-up requested while another was already in flight; the
+    // coalesced follow-up run reports the most recent trigger.
+    let catchUpRequestedReason: BoardPresenceCatchUpReason = 'gap';
     // Once a baseline exists, a live gap may trigger catch-up even while the
     // initial backfill is still resolving. That overlap is safe: both paths
     // merge through BACKFILL_HISTORY, which dedups by (climbUuid, seq).
@@ -155,12 +203,13 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     // ignored by comparing against the ref, which the cleanup flips off.
     const subscribedBoardId = boardId;
 
-    const runCatchUp = () => {
+    const runCatchUp = (reason: BoardPresenceCatchUpReason) => {
       if (!isActive || boardIdRef.current !== subscribedBoardId) {
         return;
       }
       if (catchUpInFlight) {
         catchUpRequested = true;
+        catchUpRequestedReason = reason;
         return;
       }
 
@@ -203,6 +252,13 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
               payload: { holder: connectionResult.value ?? null, upToSeq: repairedThroughSeq },
             });
           }
+
+          // Emit telemetry: how far this catch-up advanced past what we'd seen
+          // when it started ≈ the live events that had been silently dropped and
+          // were just recovered. Drop the first backfill's apparent "gap" from a
+          // zero baseline — that's the normal cold-start seed, not a recovery.
+          const recoveredThroughSeqDelta = startedAtSeq > 0 ? Math.max(0, repairedThroughSeq - startedAtSeq) : 0;
+          onCatchUpRef.current?.({ reason, recoveredThroughSeqDelta });
         })
         .finally(() => {
           if (!isActive) {
@@ -211,10 +267,11 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
           catchUpInFlight = false;
           if (catchUpRequested) {
             catchUpRequested = false;
-            runCatchUp();
+            runCatchUp(catchUpRequestedReason);
           }
         });
     };
+    catchUpRef.current = runCatchUp;
 
     // 1) Subscribe FIRST. Events arriving during the catch-up fetches below are
     //    buffered straight into the reducer; the reducer's seq-dedup then keeps
@@ -230,7 +287,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
           const previousObservedSeq = observedSeqRef.current;
           observedSeqRef.current = Math.max(previousObservedSeq, eventSeq);
           if (hasSequenceBaseline && eventSeq > previousObservedSeq + 1) {
-            runCatchUp();
+            runCatchUp('gap');
           }
           hasSequenceBaseline = true;
         }
@@ -251,6 +308,15 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       },
     );
     setIsLive(true);
+
+    // 1b) Catch up on every reconnect. graphql-ws transparently re-subscribes
+    //     after a dropped socket, but the live feed rides Redis pub/sub (no
+    //     replay), so any climb pushed during the gap window is lost for this
+    //     client and the seq-gap detector above only fires if a *later* event
+    //     happens to arrive. Proactively re-read the durable Redis history on
+    //     reconnect so a just-missed send shows up without waiting for the next
+    //     one. Optional on the client (web omits it); returns an unsubscribe.
+    const unsubscribeReconnect = client.onReconnect?.(() => runCatchUp('reconnect'));
 
     // 2) Backfill recent history, then 3) seed stats. Both guarded against
     //    unmount and against a board switch (a late resolve for the previous
@@ -303,9 +369,18 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
     return () => {
       isActive = false;
       setIsLive(false);
+      catchUpRef.current = null;
+      unsubscribeReconnect?.();
       unsubscribe();
     };
   }, [boardId, client]);
+
+  // Stable manual catch-up trigger. Defaults to `manual` (pull-to-refresh);
+  // callers pass `foreground` for app-resume recovery. Reads the live
+  // `catchUpRef` so it never re-binds the subscription effect.
+  const refresh = useCallback((reason: BoardPresenceCatchUpReason = 'manual') => {
+    catchUpRef.current?.(reason);
+  }, []);
 
   const reportClimbWithUndoTarget = useCallback(
     async (climb: ClimbQueueItemInput, angle: number | null): Promise<BoardPresenceReportResult> => {
@@ -360,6 +435,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       reportClimbWithUndoTarget,
       reportDisconnect,
       getUndoTarget,
+      refresh,
     }),
     [
       state.currentClimb,
@@ -373,6 +449,7 @@ export function useBoardPresence(boardId: number | null, client: BoardPresenceCl
       reportClimbWithUndoTarget,
       reportDisconnect,
       getUndoTarget,
+      refresh,
     ],
   );
 }


### PR DESCRIPTION
## What & why

While climbing a shared board with friends, the new mobile board-history feature felt slow to update — the hunch was that messages get dropped. They do, and the architecture explains it:

- Live "now on the wall" events ride **Redis pub/sub, which has no replay**. Any climb pushed while a phone's WebSocket is mid-reconnect (app backgrounded, network blip, the WS-1006 churn) is gone for that client.
- The durable Redis history (`fetchRecentClimbs`) *does* persist, but today it's only re-read when a **later** live event reveals a sequence gap (`use-board-presence.ts`). So a dropped event with no successor — the last send in a burst, or anything missed while backgrounded — stays invisible until the board sheet is fully reopened.

There was no catch-up on reconnect, no refetch on app-foreground, and no pull-to-refresh. The queue provider already solved this class of bug with a `wsClient.on('connected')` re-sync; board-presence just never got the same treatment.

## Changes

Trigger the existing `runCatchUp` (re-fetch recent climbs + stats + connection from the durable Redis source, deduped by seq) on three more signals, all funneled through its existing coalescer so they can't stampede the backend:

- **WS reconnect** — new optional `BoardPresenceClient.onReconnect`, implemented on mobile via graphql-ws `on('connected')` (skips the first connect). Web omits it (optional).
- **App foreground** — `AppState` `active` in `MobileBoardPresenceProvider`, for the case where iOS suspended the socket without a clean reconnect.
- **Pull-to-refresh** on the history list — a manual escape hatch.

Plus lightweight telemetry so the drop rate is measurable in PostHog: a `Board History Catch Up` event (`{ reason: gap | reconnect | foreground | manual, recoveredThroughSeqDelta }`) and `seq` added to `Board Now Playing Received`. The shared package stays analytics-free — the callback is injected.

No backend, schema, or DB changes. Web behaviour is unchanged.

## Tests

- `use-board-presence` (shared): reconnect → catch-up, `refresh()`/foreground → catch-up, `onCatchUp` reason + recovered-delta, cold-start delta = 0, listener unsubscribe, and the no-`onReconnect` (web) path.
- `MobileBoardPresenceProvider`: foreground triggers refresh, background does not, catch-up telemetry fires with boardId/reason/delta.
- `BoardSheet`: pull-to-refresh triggers a manual catch-up; `seq` on the now-playing event.
- Full mobile suite (2540), shared suites, `vp check`, `vp run typecheck:mobile`, `vp run check:mobile-bundle` all green.

## How to verify

On a sim/device against a local backend (point `EXPO_PUBLIC_BACKEND_URL`/`WS_URL` at it so you can drive `reportBoardClimb`):
- **Foreground:** open the board sheet, background the app, push a climb from another client, foreground → the climb appears within a second or two (was: stayed stale).
- **Reconnect:** toggle airplane mode briefly while a climb is pushed, restore → catch-up pulls it in without needing a *later* climb.
- **Pull-to-refresh:** swipe down on the history list → refetches.

After release, trend `Board History Catch Up` by `reason` and watch `recoveredThroughSeqDelta` to quantify how many silent drops are being recovered.

## Release Notes

The wall history keeps up with your crew now — sends from friends show up right away, even after your phone's been in your pocket or your signal dropped for a moment. Pull down on the history list any time to refresh it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)