### PR TITLE
fix(mobile): recover transient null resolves in the OTA-compat check

### DIFF
--- a/scripts/mobile-ota-compat-check.test.ts
+++ b/scripts/mobile-ota-compat-check.test.ts
@@ -207,6 +207,12 @@ describe('confirmComparison (retry/confirmation logic)', () => {
     const pr = sequence([null, 'abc']);
     const base = sequence(['abc']);
     expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: 'abc', baseFingerprint: 'abc' });
+    expect(pr.calls()).toBe(2); // the retry actually happened
+  });
+
+  it('treats a real difference after a transient null as a native change', () => {
+    const pr = sequence([null, 'abc', 'abc']);
+    expect(confirmComparison(pr.resolve, () => 'xyz', 3)).toEqual({ prFingerprint: 'abc', baseFingerprint: 'xyz' });
   });
 
   it('falls through to a null result (→ unknown) when a side never resolves', () => {

--- a/scripts/mobile-ota-compat-check.test.ts
+++ b/scripts/mobile-ota-compat-check.test.ts
@@ -203,11 +203,17 @@ describe('confirmComparison (retry/confirmation logic)', () => {
     expect(base.calls()).toBe(1);
   });
 
-  it('returns early without retrying when a side is null', () => {
+  it('recovers from a transient null on the first read by retrying', () => {
     const pr = sequence([null, 'abc']);
     const base = sequence(['abc']);
-    expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: null, baseFingerprint: 'abc' });
-    expect(pr.calls()).toBe(1);
+    expect(confirmComparison(pr.resolve, base.resolve)).toEqual({ prFingerprint: 'abc', baseFingerprint: 'abc' });
+  });
+
+  it('falls through to a null result (→ unknown) when a side never resolves', () => {
+    const base = sequence(['abc']);
+    const result = confirmComparison(() => null, base.resolve, 3);
+    expect(result.prFingerprint).toBeNull();
+    expect(result.baseFingerprint).toBe('abc');
   });
 
   it('collapses a flake: a spurious difference that re-resolves to equal → equal', () => {

--- a/scripts/mobile-ota-compat-check.ts
+++ b/scripts/mobile-ota-compat-check.ts
@@ -51,10 +51,13 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 /**
  * `bunx expo-updates runtimeversion:resolve` is intermittently non-deterministic
  * (≈5% of invocations its autolinking step computes a hash off a different source
- * set), so a single resolve can't be trusted to mean "the fingerprint changed".
- * The check confirms a *difference* before reporting it: a real native change
- * stays different across re-resolves, a flake collapses back to equal. An "equal"
- * is trusted immediately (two independent trees won't collide on a wrong hash).
+ * set, or fails outright and yields null), so a single resolve can't be trusted
+ * to mean "the fingerprint changed". The check confirms a *difference* (and
+ * retries a *null*) before acting: a real native change stays different across
+ * re-resolves, a flake collapses back to equal, a transient null recovers. An
+ * "equal" is trusted immediately (two independent trees won't collide on a wrong
+ * hash). Worst case is MAX_DIFF_CONFIRMATIONS + 1 resolves per side per platform
+ * (≈12 total) — only when reads never settle; the common path is one each.
  */
 const MAX_DIFF_CONFIRMATIONS = 5;
 
@@ -133,16 +136,22 @@ export interface FingerprintPair {
 
 /**
  * PURE (given injected resolvers): resolve a platform's PR and baseline
- * fingerprints, confirming any difference so a flaky resolver can't surface as a
- * false "native change". Trusts an "equal" read immediately (two independent
- * trees won't collide on a wrong hash); on a difference, re-resolves both up to
- * `maxConfirmations` times — returns the equal pair the moment one agrees, or
- * stops early once the same differing pair repeats (a stable, real native change).
+ * fingerprints, smoothing over the resolver's intermittent flakiness so it can't
+ * surface as a false "native change" or a spurious "unknown".
+ *
+ * - An equal, non-null pair is trusted immediately (two independent trees won't
+ *   collide on a wrong hash).
+ * - A difference or a null on either side is retried, up to `maxConfirmations`
+ *   re-resolves: a flaky difference collapses back to equal, a transient null
+ *   recovers to a real hash. A genuine native change stays different — detected
+ *   when the same non-null differing pair repeats — and returns after one
+ *   confirmation. A side that is *persistently* null (or never settles) falls
+ *   through to a null result → an honest "unknown" verdict.
  *
  * `resolveBase` may be backed by a fixed value (the cache-hit path); then only
  * the PR side actually changes across retries, and the PR converging to that
- * constant is what confirms equality. Keep the two resolvers' side effects cheap
- * and idempotent — they're each called up to `maxConfirmations + 1` times.
+ * constant is what confirms equality. Keep the resolvers cheap and idempotent —
+ * each is called up to `maxConfirmations + 1` times.
  */
 export function confirmComparison(
   resolvePr: () => string | null,
@@ -151,23 +160,33 @@ export function confirmComparison(
 ): FingerprintPair {
   let prFingerprint = resolvePr();
   let baseFingerprint = resolveBase();
-
-  if (!prFingerprint || !baseFingerprint || prFingerprint === baseFingerprint) {
-    return { prFingerprint, baseFingerprint };
-  }
-
   let previousPr = prFingerprint;
   let previousBase = baseFingerprint;
+
   for (let attempt = 0; attempt < maxConfirmations; attempt += 1) {
+    if (prFingerprint && baseFingerprint && prFingerprint === baseFingerprint) {
+      return { prFingerprint, baseFingerprint };
+    }
+    // A non-null differing pair seen twice running → a stable, genuine native
+    // change (attempt > 0 so we never short-circuit before re-resolving once).
+    if (
+      attempt > 0 &&
+      prFingerprint &&
+      baseFingerprint &&
+      prFingerprint === previousPr &&
+      baseFingerprint === previousBase
+    ) {
+      break;
+    }
+    // Otherwise re-resolve: a difference may be a flake, a null may be a
+    // transient resolve failure — both can recover on re-read. Keep the last
+    // non-null reading so a later null doesn't erase a good hash.
+    previousPr = prFingerprint;
+    previousBase = baseFingerprint;
     const pr = resolvePr();
     const base = resolveBase();
     if (pr) prFingerprint = pr;
     if (base) baseFingerprint = base;
-    if (pr && base && pr === base) return { prFingerprint: pr, baseFingerprint: base };
-    // The same differing pair twice running → a stable, genuine native change.
-    if (pr && base && pr === previousPr && base === previousBase) break;
-    if (pr) previousPr = pr;
-    if (base) previousBase = base;
   }
   return { prFingerprint, baseFingerprint };
 }


### PR DESCRIPTION
## Summary

Final follow-up to #3106 / #3109 (both merged on green before this landed). Closes the last gap in the OTA-compatibility check's reliability.

`bunx expo-updates runtimeversion:resolve` is intermittently flaky in two ways: it returns a wrong hash (#3109 handles that with confirm-on-difference) **or fails outright and yields null**. The merged `confirmComparison` returned early on a first-read null → a spurious `unknown` on exactly the failure mode the check exists to smooth over.

**Fix:** fold null handling into the same retry loop. A transient null on either side now re-resolves and recovers to a real verdict; only a *persistently* null side falls through to an honest `unknown`. Worst-case resolve count is documented (≤ `MAX_DIFF_CONFIRMATIONS + 1` per side per platform).

This is the change I'd pushed to #3109 moments after it was merged, rebased onto current `main` (which now includes #3107's fingerprint pin — verified the check still resolves cleanly against the new `app.config.ts`).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 204 pass, incl. new `confirmComparison` cases (transient-null recovery, persistent-null → unknown) alongside the existing flake/native/equal paths.
- `vp check` — clean.
- End-to-end vs an `origin/main` worktree (post-#3107): both platforms `ota-compatible`.
- The check self-tests on this PR via `mobile-ota-check.yml` (the script is in its path filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfJ8E5QVxhWYbKRb4RGDbn