### PR TITLE
chore(mobile): Android-16 climb-list freeze — on-device bisection toggles

### DIFF
--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -32,12 +32,17 @@ concurrency:
 jobs:
   publish-update:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       INPUT_BRANCH: ${{ github.event.inputs.branch }}
       INPUT_PLATFORM: ${{ github.event.inputs.platform || 'all' }}
+      # NOTE: EXPO_UPDATES_URL is deliberately NOT set job-wide. app.config's
+      # resolveUpdatesConfig flips `updates.url` to the self-hosted server whenever
+      # EXPO_UPDATES_URL is present (+ the committed cert), which would make the EAS
+      # `eas update` step below fail ("expected the EAS url"). So it's set per-step
+      # ONLY on the self-hosted publish steps; the EAS step runs without it.
       # Build-time env inlined into the OTA JS bundle, matching the native build
       # workflows (ios-testflight-rn.yml / android-apk-rn.yml). Without these, an OTA
       # update ships a bundle that re-resolves EXPO_PUBLIC_* to its in-code fallbacks
@@ -55,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
 
       - uses: oven-sh/setup-bun@v2
 
@@ -104,6 +111,47 @@ jobs:
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.name }}
 
+      # ---- Self-hosted OTA (expo-open-ota) ----
+      # Publish the SAME JS to our own server under a channel named after the branch,
+      # so a tester on a TestFlight/store build can pull it via the in-app channel
+      # switcher (#3068) — those binaries point at the self-hosted server, never EAS.
+      # Skips gracefully until EXPO_UPDATES_URL is set repo-wide + the signing cert is
+      # committed (mirrors mobile-ota-production.yml's gate).
+      - name: Check self-hosted OTA is wired
+        id: selfhost_gate
+        env:
+          EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+        run: |
+          if [ -z "$EXPO_UPDATES_URL" ] || [ ! -f packages/mobile/certs/certificate.pem ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Self-hosted OTA not wired (EXPO_UPDATES_URL unset or certs/certificate.pem missing) — skipping self-hosted preview publish. See docs/mobile-ota-updates.md."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # iOS and Android publish SEPARATELY for fingerprint parity: GOOGLE_MAPS_API_KEY
+      # perturbs BOTH resolved fingerprints, and only the Android binary bakes it in
+      # (iOS uses Apple Maps). So iOS publishes WITHOUT the key and Android WITH it —
+      # a single `--platform all` publish could only ever match one side. Mirrors
+      # mobile-ota-production.yml. `--channel "$BRANCH_NAME"` maps to a same-named
+      # branch on the server (eoas); testers type that name in the channel switcher.
+      - name: Publish iOS OTA (self-hosted)
+        if: steps.selfhost_gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
+        run: vp run mobile:publish -- --channel "$BRANCH_NAME" --platform ios --message "$BRANCH_NAME (branch preview)"
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+
+      - name: Publish Android OTA (self-hosted)
+        if: steps.selfhost_gate.outputs.configured == 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
+        run: vp run mobile:publish -- --channel "$BRANCH_NAME" --platform android --message "$BRANCH_NAME (branch preview)"
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
+          # Must match the Android native prebuild so the resolved android.config +
+          # fingerprint agree with the installed binary.
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
       - name: Post update link to PR
         if: github.event_name == 'push'
         uses: actions/github-script@v7
@@ -135,11 +183,16 @@ jobs:
               `**Commit:** \`${sha}\``,
               `**Platform:** ${platform}`,
               '',
-              'Testers with the **preview** build installed will receive this update automatically',
-              'if their channel points to this branch.',
+              '**Tester on a TestFlight / store build** (self-hosted OTA): grant the `tester`',
+              'role, then in-app **More → OTA channel switcher → Custom Channel** and enter:',
+              '',
+              '```',
+              branch,
+              '```',
+              '',
+              '**EAS preview build** (branch switcher): point the preview channel at this branch:',
               '',
               '```bash',
-              `# Point the preview channel at this branch:`,
               `bunx eas-cli@16 channel:edit preview --branch "${branch}"`,
               '```',
             ].join('\n');

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback, useMemo, useRef, useEffect, type ComponentProps } from 'react';
-import { View, StyleSheet, RefreshControl, Keyboard, InteractionManager } from 'react-native';
+import { View, StyleSheet, RefreshControl, Keyboard, InteractionManager, FlatList } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -61,6 +61,7 @@ import { getFilterSummary, buildClimbFilterSummary } from '../../../src/lib/filt
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName, visibleSearchTextNeedsSync } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
+import { useFreezeDebugFlags } from '../../../src/lib/freeze-debug-store';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
@@ -872,6 +873,12 @@ function ClimbListInner() {
     [useNativeSearch, t, handleNativeSearchChange, handleSearchFocus, handleSearchBlur, handleNativeSearchCancel],
   );
 
+  // Diagnostic toggles (preview/dev only) for the Android-16 climb-list touch
+  // freeze: swap FlashList→FlatList, drop the per-row swipe, and hide the top
+  // chrome to bisect the cause on a real device. All default OFF. See
+  // freeze-debug-store / FreezeDebugPanel.
+  const { flags: freezeDebug } = useFreezeDebugFlags();
+
   const renderClimbItem = useCallback(
     ({ item: climb }: { item: Climb }) => (
       <ActiveAwareClimbListRow
@@ -885,6 +892,7 @@ function ClimbListInner() {
         onOpenActions={openClimbActions}
         onOpenPlaylist={openAddToPlaylist}
         onAddToQueue={handleAddToQueue}
+        disableSwipe={freezeDebug.disableRowSwipe}
       />
     ),
     [
@@ -897,6 +905,7 @@ function ClimbListInner() {
       openClimbActions,
       openAddToPlaylist,
       handleAddToQueue,
+      freezeDebug.disableRowSwipe,
     ],
   );
 
@@ -944,77 +953,105 @@ function ClimbListInner() {
 
   const isEmpty = visibleClimbs.length === 0 && !isClimbsLoading;
 
+  // Extracted so the diagnostic FlatList swap (freezeDebug.useFlatList) renders the
+  // exact same refresh control and empty state as FlashList.
+  const refreshControl = (
+    <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={brandColors.primary} />
+  );
+  const listEmptyComponent = showInitialSkeletons ? (
+    <ClimbListSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />
+  ) : isEmpty ? (
+    <View style={styles.emptyContainer}>
+      <Icon name="search" size={48} color={iosSystemColors.systemGray4} />
+      <Text variant="headline" style={styles.emptyTitle}>
+        {name.length > 0 ? t('mobile.emptyState.noMatches.title') : t('mobile.emptyState.noClimbs.title')}
+      </Text>
+      <Text variant="subheadline" style={styles.emptySubtitle}>
+        {name.length > 0
+          ? t('mobile.emptyState.noMatches.description', { query: name })
+          : t('mobile.emptyState.noClimbs.subtitle')}
+      </Text>
+    </View>
+  ) : null;
+
   return (
     <View testID="climbs-screen" style={[styles.container, { backgroundColor: systemColors.background }]}>
       <Stack.Screen options={stackOptions} />
-      <FlashList
-        testID="climb-list"
-        data={visibleClimbs}
-        renderItem={renderClimbItem}
-        keyExtractor={keyExtractor}
-        onEndReached={handleEndReached}
-        onEndReachedThreshold={0.5}
-        // The header is transparent on every path now, so the chrome owns the top
-        // inset and the list pads manually by the measured chrome height. Leaving
-        // this 'automatic' would double-inset under the (invisible) native header.
-        contentInsetAdjustmentBehavior="never"
-        contentContainerStyle={{ paddingTop: searchBarHeight }}
-        scrollIndicatorInsets={{ top: searchBarHeight }}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="interactive"
-        refreshControl={
-          <RefreshControl refreshing={isRefetching} onRefresh={handleRefresh} tintColor={brandColors.primary} />
-        }
-        ListHeaderComponent={listHeader}
-        ListFooterComponent={listFooter}
-        ListEmptyComponent={
-          showInitialSkeletons ? (
-            <ClimbListSkeletonRows count={INITIAL_SKELETON_ROW_COUNT} />
-          ) : isEmpty ? (
-            <View style={styles.emptyContainer}>
-              <Icon name="search" size={48} color={iosSystemColors.systemGray4} />
-              <Text variant="headline" style={styles.emptyTitle}>
-                {name.length > 0 ? t('mobile.emptyState.noMatches.title') : t('mobile.emptyState.noClimbs.title')}
-              </Text>
-              <Text variant="subheadline" style={styles.emptySubtitle}>
-                {name.length > 0
-                  ? t('mobile.emptyState.noMatches.description', { query: name })
-                  : t('mobile.emptyState.noClimbs.subtitle')}
-              </Text>
-            </View>
-          ) : null
-        }
-      />
+      {/* Diagnostic (preview/dev only): swap to a plain RN FlatList to isolate a
+          FlashList v2 scroll/measure regression on Android 16 — same props on both. */}
+      {freezeDebug.useFlatList ? (
+        <FlatList
+          testID="climb-list"
+          data={visibleClimbs}
+          renderItem={renderClimbItem}
+          keyExtractor={keyExtractor}
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.5}
+          contentInsetAdjustmentBehavior="never"
+          contentContainerStyle={{ paddingTop: searchBarHeight }}
+          scrollIndicatorInsets={{ top: searchBarHeight }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+          refreshControl={refreshControl}
+          ListHeaderComponent={listHeader}
+          ListFooterComponent={listFooter}
+          ListEmptyComponent={listEmptyComponent}
+        />
+      ) : (
+        <FlashList
+          testID="climb-list"
+          data={visibleClimbs}
+          renderItem={renderClimbItem}
+          keyExtractor={keyExtractor}
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.5}
+          // The header is transparent on every path now, so the chrome owns the top
+          // inset and the list pads manually by the measured chrome height. Leaving
+          // this 'automatic' would double-inset under the (invisible) native header.
+          contentInsetAdjustmentBehavior="never"
+          contentContainerStyle={{ paddingTop: searchBarHeight }}
+          scrollIndicatorInsets={{ top: searchBarHeight }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+          refreshControl={refreshControl}
+          ListHeaderComponent={listHeader}
+          ListFooterComponent={listFooter}
+          ListEmptyComponent={listEmptyComponent}
+        />
+      )}
 
-      <ClimbTopChrome
-        searchMode={useNativeSearch ? 'native' : 'custom'}
-        title={searchTitle}
-        canCreate={isAuthenticated && hasBoardConfig}
-        onCreate={handleCreateClimb}
-        onOpenBoardDetail={handleOpenBoardDetail}
-        showBoardBadge={showRevealTip}
-        onHeightChange={setSearchBarHeight}
-        searchFieldRef={searchHeaderRef}
-        searchInitialValue={name}
-        searchPlaceholder={t('search.placeholders.climbs')}
-        onSearchChange={handleSearchChange}
-        onSearchFocus={handleSearchFocus}
-        onSearchBlur={handleSearchBlur}
-        onCloseGrade={handleDismissGrade}
-        activeFilterCount={activeFilterCount}
-        onOpenFilters={handleOpenFilters}
-        filterSummary={
-          features.filtersInTopChrome && filterSummary
-            ? { text: filterSummary, onClear: handleClearNonGradeFilters }
-            : undefined
-        }
-        gradeBound={gradeBound}
-        grades={grades}
-        gradeRailVisible={showGrade}
-        gradeChip={gradeChip}
-        onOpenGrade={handleOpenGrade}
-        onGradeChange={handleGradeChange}
-      />
+      {/* Diagnostic: hide the absolute top chrome to test whether it blocks the list. */}
+      {freezeDebug.hideTopChrome ? null : (
+        <ClimbTopChrome
+          searchMode={useNativeSearch ? 'native' : 'custom'}
+          title={searchTitle}
+          canCreate={isAuthenticated && hasBoardConfig}
+          onCreate={handleCreateClimb}
+          onOpenBoardDetail={handleOpenBoardDetail}
+          showBoardBadge={showRevealTip}
+          onHeightChange={setSearchBarHeight}
+          searchFieldRef={searchHeaderRef}
+          searchInitialValue={name}
+          searchPlaceholder={t('search.placeholders.climbs')}
+          onSearchChange={handleSearchChange}
+          onSearchFocus={handleSearchFocus}
+          onSearchBlur={handleSearchBlur}
+          onCloseGrade={handleDismissGrade}
+          activeFilterCount={activeFilterCount}
+          onOpenFilters={handleOpenFilters}
+          filterSummary={
+            features.filtersInTopChrome && filterSummary
+              ? { text: filterSummary, onClear: handleClearNonGradeFilters }
+              : undefined
+          }
+          gradeBound={gradeBound}
+          grades={grades}
+          gradeRailVisible={showGrade}
+          gradeChip={gradeChip}
+          onOpenGrade={handleOpenGrade}
+          onGradeChange={handleGradeChange}
+        />
+      )}
 
       {filterInTopChrome ? null : (
         <ClimbFilterFab

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
 import { borderRadius, spacing } from '../../../src/theme/tokens';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
+import { FreezeDebugPanel } from '../../../src/components/settings/FreezeDebugPanel';
 import { Icon } from '../../../src/components/Icon';
 import { Avatar } from '../../../src/components/Avatar';
 import { Text } from '../../../src/components/Text';
@@ -137,6 +138,7 @@ export default function MoreScreen() {
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container}>
       <DevMetadataPanel />
+      <FreezeDebugPanel />
 
       {profile?.id ? (
         <View style={styles.section}>

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -175,6 +175,10 @@ type ClimbListRowProps = {
   contentRowStyle?: StyleProp<ViewStyle>;
   separatorStyle?: StyleProp<ViewStyle>;
   showSeparator?: boolean;
+  /** Diagnostic (preview/dev only): render the row WITHOUT the ReanimatedSwipeable
+   *  wrapper, to test whether the per-row horizontal-pan gesture is stealing the
+   *  list's vertical scroll on Android 16. Default false. See freeze-debug-store. */
+  disableSwipe?: boolean;
 };
 
 const ClimbListRow = React.memo(function ClimbListRow({
@@ -195,6 +199,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   contentRowStyle,
   separatorStyle,
   showSeparator = true,
+  disableSwipe = false,
 }: ClimbListRowProps) {
   const { systemColors, brandColors: brand } = useTheme();
   // Active-row highlight colours, derived from the scheme-aware brand so the wash
@@ -370,43 +375,53 @@ const ClimbListRow = React.memo(function ClimbListRow({
     />
   );
 
+  const rowInner = (
+    <GestureDetector gesture={tapGesture}>
+      <View
+        testID="climb-row"
+        style={[climbListRowStyles.contentRow, { backgroundColor: systemColors.background }, contentRowStyle]}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={climb.name}
+        accessibilityState={{ selected: !!selected }}
+      >
+        {/* Active-climb highlight: violet wash + left accent bar */}
+        {selected ? (
+          <View style={[styles.selectedFill, { backgroundColor: highlight.fill }]} pointerEvents="none" />
+        ) : null}
+        {selected ? (
+          <View style={[styles.selectedAccent, { backgroundColor: highlight.accent }]} pointerEvents="none" />
+        ) : null}
+
+        {rowContent}
+      </View>
+    </GestureDetector>
+  );
+
   return (
     <View style={[styles.outerContainer, containerStyle, unsupported && styles.unsupported]}>
-      <ReanimatedSwipeable
-        ref={swipeableRef}
-        friction={SWIPE_FRICTION}
-        leftThreshold={COMMIT_THRESHOLD}
-        rightThreshold={COMMIT_THRESHOLD}
-        overshootLeft={false}
-        overshootRight={false}
-        renderLeftActions={onAddToQueue ? renderLeftActions : undefined}
-        renderRightActions={onOpenPlaylist ? renderRightActions : undefined}
-        onSwipeableOpenStartDrag={handleSwipeStartDrag}
-        onSwipeableWillOpen={handleSwipeWillOpen}
-        onSwipeableOpen={handleSwipeableOpened}
-        onSwipeableClose={handleSwipeableClosed}
-      >
-        <GestureDetector gesture={tapGesture}>
-          <View
-            testID="climb-row"
-            style={[climbListRowStyles.contentRow, { backgroundColor: systemColors.background }, contentRowStyle]}
-            accessible
-            accessibilityRole="button"
-            accessibilityLabel={climb.name}
-            accessibilityState={{ selected: !!selected }}
-          >
-            {/* Active-climb highlight: violet wash + left accent bar */}
-            {selected ? (
-              <View style={[styles.selectedFill, { backgroundColor: highlight.fill }]} pointerEvents="none" />
-            ) : null}
-            {selected ? (
-              <View style={[styles.selectedAccent, { backgroundColor: highlight.accent }]} pointerEvents="none" />
-            ) : null}
-
-            {rowContent}
-          </View>
-        </GestureDetector>
-      </ReanimatedSwipeable>
+      {/* Diagnostic: disableSwipe drops the ReanimatedSwipeable so a tester can check
+          whether the per-row horizontal pan is stealing the list's vertical scroll. */}
+      {disableSwipe ? (
+        rowInner
+      ) : (
+        <ReanimatedSwipeable
+          ref={swipeableRef}
+          friction={SWIPE_FRICTION}
+          leftThreshold={COMMIT_THRESHOLD}
+          rightThreshold={COMMIT_THRESHOLD}
+          overshootLeft={false}
+          overshootRight={false}
+          renderLeftActions={onAddToQueue ? renderLeftActions : undefined}
+          renderRightActions={onOpenPlaylist ? renderRightActions : undefined}
+          onSwipeableOpenStartDrag={handleSwipeStartDrag}
+          onSwipeableWillOpen={handleSwipeWillOpen}
+          onSwipeableOpen={handleSwipeableOpened}
+          onSwipeableClose={handleSwipeableClosed}
+        >
+          {rowInner}
+        </ReanimatedSwipeable>
+      )}
 
       {/* Separator — inset to start at the text column (after the thumbnail) */}
       {showSeparator ? (

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,6 +21,7 @@ import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useFreezeDebugFlag } from '../../lib/freeze-debug-store';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
@@ -37,7 +38,11 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  // Diagnostic (preview/dev only): force the bar off to test whether it's the
+  // touch-freeze culprit. Default false in production. See freeze-debug-store.
+  const hideQueueBar = useFreezeDebugFlag('hideQueueBar');
 
+  if (hideQueueBar) return null;
   if (!currentClimb) return null;
   if (!bottomChrome.jsQueueToolbarVisible && bottomChrome.nativeAccessoryMounted) return null;
 

--- a/packages/mobile/src/components/settings/FreezeDebugPanel.tsx
+++ b/packages/mobile/src/components/settings/FreezeDebugPanel.tsx
@@ -1,0 +1,91 @@
+import { View, StyleSheet } from 'react-native';
+import { SectionHeader } from '../SectionHeader';
+import { SwitchRow } from '../SwitchRow';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { borderRadius, spacing } from '../../theme/tokens';
+import { useProfile } from '../../lib/graphql/hooks';
+import { useFreezeDebugFlags, type FreezeDebugFlag } from '../../lib/freeze-debug-store';
+
+// Diagnostic-only panel for the Android-16 climb-list touch-freeze bug. Each
+// switch disables ONE suspected cause; a tester flips one at a time and reports
+// which makes the list scroll again. Gated on the admin-granted `tester` role (or
+// a dev build) — same audience as the OTA channel switcher (#3068), so a tester on
+// a store build who switches to the diagnostic channel sees it. Copy is
+// intentionally un-translated (matches the other tester/dev-only sections in
+// profile/more.tsx).
+
+const ROWS: { flag: FreezeDebugFlag; label: string; description: string }[] = [
+  {
+    flag: 'hideQueueBar',
+    label: 'Hide queue bar',
+    description: 'Removes the current-climb bar above the tab bar.',
+  },
+  {
+    flag: 'useFlatList',
+    label: 'Use FlatList (not FlashList)',
+    description: 'Renders the climb list with React Native FlatList instead of FlashList.',
+  },
+  {
+    flag: 'disableRowSwipe',
+    label: 'Disable row swipe',
+    description: 'Removes the swipe-to-queue/playlist gesture from each row.',
+  },
+  {
+    flag: 'unmountSheets',
+    label: 'Unmount bottom sheets',
+    description: 'Stops mounting the always-on queue/board sheets (those buttons stop opening).',
+  },
+  {
+    flag: 'hideTopChrome',
+    label: 'Hide top chrome',
+    description: 'Removes the search/filter bar overlay at the top of the list.',
+  },
+];
+
+export function FreezeDebugPanel() {
+  const { systemColors } = useTheme();
+  const { data: profile } = useProfile();
+  const { flags, setFlag } = useFreezeDebugFlags();
+
+  // Admin-granted tester, or a local dev build. Never a regular production user.
+  if (!profile?.isTester && !__DEV__) return null;
+
+  return (
+    <View style={styles.section}>
+      {/* i18n-ignore-next-line — tester/dev-only diagnostic panel */}
+      <SectionHeader title="Climb-list freeze debug" />
+      <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
+        {ROWS.map((row) => (
+          <SwitchRow
+            key={row.flag}
+            label={row.label}
+            description={row.description}
+            value={flags[row.flag]}
+            onValueChange={(next) => setFlag(row.flag, next)}
+          />
+        ))}
+      </View>
+      <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.hint}>
+        {/* i18n-ignore-next-line */}
+        Flip ONE switch, go to the Climbs tab, and check if you can scroll and tap. Tell us which switch helps.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    width: '100%',
+    marginBottom: spacing[6],
+  },
+  card: {
+    overflow: 'hidden',
+    borderRadius: borderRadius.lg,
+    marginHorizontal: spacing[4],
+  },
+  hint: {
+    marginTop: spacing[2],
+    paddingHorizontal: spacing[4],
+  },
+});

--- a/packages/mobile/src/lib/freeze-debug-store.ts
+++ b/packages/mobile/src/lib/freeze-debug-store.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+// Diagnostic toggles for the Android-16 / Pixel-10 climb-list touch-freeze
+// investigation. Each flag, when ON, disables or alters ONE suspected cause so a
+// tester can bisect on a real affected device which change restores scrolling —
+// the two ActiveContextBar fixes (#3060 split, #3104 drop-entering-on-Android)
+// both missed, so the culprit has to be pinned on-device, not guessed again.
+//
+// Surfaced only to admin-granted testers / dev builds via FreezeDebugPanel, and
+// this branch ships only to the diagnostic OTA channel (never production) — all
+// flags default OFF, so a regular user can never enter a diagnostic state.
+// Structure mirrors `session-recording-preference.ts`: a module-level store
+// read via `useSyncExternalStore` with a referentially-stable cached snapshot, plus
+// a promise-singleton one-time load.
+
+export type FreezeDebugFlag =
+  /** PersistentQueueBar returns null — rules the queue/ActiveContextBar in or out. */
+  | 'hideQueueBar'
+  /** Don't mount the always-on gorhom QueueSheet/BoardSheet — tests a closed-sheet
+   *  container swallowing touches on Android 16. */
+  | 'unmountSheets'
+  /** Render the climb list with a plain RN FlatList instead of FlashList v2 —
+   *  isolates a FlashList v2 scroll/measure regression. */
+  | 'useFlatList'
+  /** Drop the per-row ReanimatedSwipeable wrapper — tests a horizontal-pan gesture
+   *  stealing the vertical scroll ("horizontal swipe works, vertical dead"). */
+  | 'disableRowSwipe'
+  /** Skip the absolutely-positioned ClimbTopChrome overlay — tests the Material
+   *  top chrome / its measured search-bar padding. */
+  | 'hideTopChrome';
+
+export type FreezeDebugFlags = Record<FreezeDebugFlag, boolean>;
+
+const STORAGE_KEY = 'freezeDebugFlags';
+
+const DEFAULT_FLAGS: FreezeDebugFlags = {
+  hideQueueBar: false,
+  unmountSheets: false,
+  useFlatList: false,
+  disableRowSwipe: false,
+  hideTopChrome: false,
+};
+
+const FLAG_KEYS = Object.keys(DEFAULT_FLAGS) as FreezeDebugFlag[];
+
+type FreezeDebugSnapshot = { flags: FreezeDebugFlags; loaded: boolean };
+
+let current: FreezeDebugFlags = DEFAULT_FLAGS;
+let hasLoaded = false;
+let snapshot: FreezeDebugSnapshot = { flags: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: FreezeDebugSnapshot = { flags: DEFAULT_FLAGS, loaded: false };
+
+function notify(): void {
+  snapshot = { flags: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+// Keep only known keys and coerce to boolean so a malformed/stale payload can't
+// inject unexpected flags or non-boolean values.
+function sanitize(stored: Partial<FreezeDebugFlags> | null): FreezeDebugFlags {
+  const next: FreezeDebugFlags = { ...DEFAULT_FLAGS };
+  if (stored && typeof stored === 'object') {
+    for (const key of FLAG_KEYS) {
+      if (typeof stored[key] === 'boolean') next[key] = stored[key] as boolean;
+    }
+  }
+  return next;
+}
+
+export async function loadFreezeDebugFlags(): Promise<FreezeDebugFlags> {
+  if (hasLoaded) return current;
+  // This branch's JS only ships to the diagnostic OTA channel (testers) — never the
+  // production channel — and only the tester-gated panel ever writes a flag, so a
+  // non-tester's store is empty and this read returns the OFF defaults regardless.
+  const stored = await getPreference<Partial<FreezeDebugFlags>>(STORAGE_KEY);
+  // A `setFreezeDebugFlag` may have raced in while we awaited storage; honour the
+  // newer in-memory choice over the (now stale) persisted value.
+  if (hasLoaded) return current;
+  current = sanitize(stored);
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+export async function setFreezeDebugFlag(flag: FreezeDebugFlag, value: boolean): Promise<void> {
+  current = { ...current, [flag]: value };
+  hasLoaded = true;
+  notify();
+  await setPreference(STORAGE_KEY, current);
+}
+
+let loadPromise: Promise<FreezeDebugFlags> | null = null;
+function ensureFreezeDebugLoaded(): Promise<FreezeDebugFlags> {
+  if (!loadPromise) {
+    loadPromise = loadFreezeDebugFlags().catch((error: unknown) => {
+      // Don't cache a rejected promise — clear the singleton so a later mount
+      // retries instead of staying stuck at defaults until restart.
+      loadPromise = null;
+      throw error;
+    });
+  }
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): FreezeDebugSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): FreezeDebugSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useFreezeDebugFlags(): {
+  flags: FreezeDebugFlags;
+  loaded: boolean;
+  setFlag: (flag: FreezeDebugFlag, value: boolean) => void;
+} {
+  const { flags, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    ensureFreezeDebugLoaded().catch(() => {});
+  }, []);
+
+  const setFlag = useCallback((flag: FreezeDebugFlag, value: boolean) => {
+    void setFreezeDebugFlag(flag, value);
+  }, []);
+
+  return { flags, loaded, setFlag };
+}
+
+// Single-flag reader for consumers (queue bar, drawer host, list rows) that only
+// gate on one toggle and don't need the setter.
+export function useFreezeDebugFlag(flag: FreezeDebugFlag): boolean {
+  const { flags } = useFreezeDebugFlags();
+  return flags[flag];
+}

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -27,6 +27,7 @@ import type { QueueItemRowBoard } from '../components/QueueItemRow';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import { formatActiveBoardLabel } from '../lib/boards/active-board-label';
 import { track } from '../lib/analytics';
+import { useFreezeDebugFlag } from '../lib/freeze-debug-store';
 import { ClimbReactionMenu } from '../components/climb-actions/ClimbReactionMenu';
 import { AddBetaVideoSheet } from '../components/AddBetaVideoSheet';
 import { AddToPlaylistSheet } from '../components/AddToPlaylistSheet';
@@ -185,6 +186,10 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // menu so its mount-time enter animation uses the real value, not the hook's
   // conservative `true` default.
   const reduceMotion = useReduceMotion();
+  // Diagnostic (preview/dev only): stop mounting the always-on gorhom sheets to
+  // test whether a closed-sheet container swallows climb-list touches on Android
+  // 16. Default false in production. See freeze-debug-store.
+  const unmountSheets = useFreezeDebugFlag('unmountSheets');
 
   // Climb to open after the boardConfig override has committed. We can't
   // open synchronously inside openPlayDrawer when an override is supplied
@@ -648,7 +653,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onClose={closeAddToPlaylist}
         />
       ) : null}
-      {queueBoard ? (
+      {!unmountSheets && queueBoard ? (
         <QueueSheet
           ref={queueSheetRef}
           board={queueBoard}
@@ -659,17 +664,19 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
           onTickHistory={handleQueueTickHistory}
         />
       ) : null}
-      <BoardSheet
-        ref={boardSheetRef}
-        boardLabel={boardSheetLabel}
-        boardConfig={storedActiveBoardConfig}
-        onClose={requestCloseBoardSheet}
-        onSwitchBoard={handleSwitchBoardFromSheet}
-        onClimbPress={handleBoardSheetClimbPress}
-        onAddToQueue={handleBoardSheetAddToQueue}
-        onOpenPlaylist={handleBoardSheetOpenPlaylist}
-        onOpenActions={handleBoardSheetOpenActions}
-      />
+      {!unmountSheets ? (
+        <BoardSheet
+          ref={boardSheetRef}
+          boardLabel={boardSheetLabel}
+          boardConfig={storedActiveBoardConfig}
+          onClose={requestCloseBoardSheet}
+          onSwitchBoard={handleSwitchBoardFromSheet}
+          onClimbPress={handleBoardSheetClimbPress}
+          onAddToQueue={handleBoardSheetAddToQueue}
+          onOpenPlaylist={handleBoardSheetOpenPlaylist}
+          onOpenActions={handleBoardSheetOpenActions}
+        />
+      ) : null}
       {/* Rendered after the queue/board sheets so its iOS FullWindowOverlay mounts as a
           later sibling and floats above them when a row inside those sheets is
           long-pressed (RN-screens doesn't strictly guarantee cross-overlay z-order). */}


### PR DESCRIPTION
## What & why

The Android-16 / Pixel-10 **climb-list touch freeze** (vertical scroll + taps dead, only horizontal swipe works, split-screen momentarily unfreezes it) **survives both `ActiveContextBar` fixes** — #3060 (split the positioning View out) and #3104 (drop the `entering` animation on Android). So the queue bar's Reanimated animation is **not** the cause. It also doesn't reproduce on a Pixel 9, so those two fixes shipped unverified and both missed.

Rather than guess a third time, this adds a **tester/dev-only diagnostic panel** so an affected device can **bisect which suspect is actually blocking the list**. Not a fix — a probe. Do not merge to production.

## Delivery (uses the #3068 tester OTA channel switcher)

Gated on the admin-granted **`tester`** role (or a dev build) — the same audience as the channel switcher — so a tester on a **store/TestFlight build** sees it after switching channels. Delivery is the "missing upload": the EAS preview publish doesn't reach the self-hosted server, so publish this branch's JS to a self-hosted **`preview-1`** channel (Android only — the bug is Android):

```bash
EXPO_UPDATES_URL=https://ota.boardsesh.com/manifest \
GOOGLE_MAPS_API_KEY=<android key> \
EXPO_TOKEN=<expo token> \
  vp run mobile:publish -- --channel preview-1 --platform android --message "freeze debug"
```

(Android needs `GOOGLE_MAPS_API_KEY` so the published fingerprint matches the Android store build; mirrors `mobile-ota-production.yml`.)

## How to test (@alejandrosanchezcabana — Android 16, build 2000363)

1. **Grant Alex the `tester` role** (web admin → role management).
2. Alex: **More → OTA channel switcher → `preview-1`** (or the Custom Channel field) → confirm → app pulls the diagnostic update + restarts.
3. **More → "Climb-list freeze debug"** (now visible) → flip **one** toggle.
4. Go to **Climbs**, try to scroll/tap. Flip it back, try the next.
5. Report **which single toggle brings scrolling back** (or "none").

### What each toggle isolates

| Toggle | If this one fixes it, the cause is… |
|---|---|
| **Hide queue bar** | the `ActiveContextBar` / persistent queue bar after all (despite #3060 + #3104) |
| **Use FlatList (not FlashList)** | a **FlashList v2** scroll/measure regression on Android 16 |
| **Disable row swipe** | the per-row `ReanimatedSwipeable` horizontal pan **stealing the vertical scroll** |
| **Unmount bottom sheets** | an always-mounted gorhom Queue/Board sheet container swallowing touches |
| **Hide top chrome** | the absolute Material top chrome overlay / its measured padding |

(If **none** help, the cause is likely Android-16 edge-to-edge window metrics — `app/_layout.tsx` defers `react-native-edge-to-edge`'s `<SystemBars>` — and we'll instrument that next.)

## Safety

All flags **default OFF**, the panel is gated on `profile.isTester || __DEV__`, and this branch ships only to the diagnostic channel (never `production`). So a regular user never sees it. Store mirrors `session-recording-preference.ts`.

## Validation

`vp run typecheck:mobile` ✓ · `vp check` ✓ · `vp run test:mobile` ✓ · `vp run check:mobile-bundle` ✓

## Release Notes

- [x] No release note needed (internal diagnostic build — not user-facing, not for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
