### PR TITLE
feat(mobile): glow the accessory bar when you have board control + connect from it

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -25,6 +25,7 @@ import { ToastProvider } from '../src/providers/toast-provider';
 import { QueueProvider } from '../src/providers/queue-provider';
 import { QueueSnackbarProvider } from '../src/providers/queue-snackbar-provider';
 import { DrawerHostProvider } from '../src/providers/drawer-host-provider';
+import { BleControlSheetProvider } from '../src/providers/ble-control-sheet-provider';
 import { DeepLinkProvider } from '../src/providers/deep-link-provider';
 import { ShareTargetProvider } from '../src/providers/share-target-provider';
 import { TabBarHeightProvider } from '../src/providers/tab-bar-height-provider';
@@ -334,90 +335,98 @@ function RootLayout() {
                                         <MobileBoardPresenceProvider>
                                           <BottomSheetModalProvider>
                                             <BluetoothProviderWrapper>
-                                              <DrawerHostProvider>
-                                                <DeepLinkProvider>
-                                                  <ShareTargetProvider>
-                                                    <TabBarHeightProvider>
-                                                      <UserDrawerProvider>
-                                                        <ThemedNavigation>
-                                                          <Stack
-                                                            // Root scenes keep the opaque, theme-aware nav background so a dark
-                                                            // backstop sits behind the tab screens (the tab stacks paint their own
-                                                            // transparent content over it). glassStackScreenOptions' transparent
-                                                            // contentStyle would expose the light window background at the top of the
-                                                            // screen in dark mode, where the floating chrome leaves it uncovered.
-                                                            // The header props still apply to root-level pushed screens (session, about).
-                                                            screenOptions={{
-                                                              ...glassStackScreenOptions,
-                                                              headerShown: false,
-                                                              contentStyle: undefined,
-                                                            }}
-                                                            initialRouteName="index"
-                                                          >
-                                                            <Stack.Screen name="index" />
-                                                            <Stack.Screen name="(tabs)" />
-                                                            <Stack.Screen
-                                                              name="auth"
-                                                              options={{ headerShown: false, gestureEnabled: false }}
-                                                            />
-                                                            {/* Public climber profiles + climber search, pushed from any
+                                              {/* One BLE controls sheet (Re-light / Turn off /
+                                                  Disconnect) shared by the play-drawer lightbulb and
+                                                  the persistent bar's board control. Wraps
+                                                  DrawerHostProvider (which renders PlayDrawer as a
+                                                  sibling of its children) so both the drawer and the
+                                                  bar descend from it. */}
+                                              <BleControlSheetProvider>
+                                                <DrawerHostProvider>
+                                                  <DeepLinkProvider>
+                                                    <ShareTargetProvider>
+                                                      <TabBarHeightProvider>
+                                                        <UserDrawerProvider>
+                                                          <ThemedNavigation>
+                                                            <Stack
+                                                              // Root scenes keep the opaque, theme-aware nav background so a dark
+                                                              // backstop sits behind the tab screens (the tab stacks paint their own
+                                                              // transparent content over it). glassStackScreenOptions' transparent
+                                                              // contentStyle would expose the light window background at the top of the
+                                                              // screen in dark mode, where the floating chrome leaves it uncovered.
+                                                              // The header props still apply to root-level pushed screens (session, about).
+                                                              screenOptions={{
+                                                                ...glassStackScreenOptions,
+                                                                headerShown: false,
+                                                                contentStyle: undefined,
+                                                              }}
+                                                              initialRouteName="index"
+                                                            >
+                                                              <Stack.Screen name="index" />
+                                                              <Stack.Screen name="(tabs)" />
+                                                              <Stack.Screen
+                                                                name="auth"
+                                                                options={{ headerShown: false, gestureEnabled: false }}
+                                                              />
+                                                              {/* Public climber profiles + climber search, pushed from any
                                                           tab (tappable avatars, the Home search action). */}
-                                                            <Stack.Screen name="users/[userId]/index" />
-                                                            {/* A climber's full beta-video grid — the "See all" target of
+                                                              <Stack.Screen name="users/[userId]/index" />
+                                                              {/* A climber's full beta-video grid — the "See all" target of
                                                           the profile beta shelf. Sets its own solid header. */}
-                                                            <Stack.Screen name="users/[userId]/beta" />
-                                                            {/* Headerless push — hides the tab bar like the other pushed
+                                                              <Stack.Screen name="users/[userId]/beta" />
+                                                              {/* Headerless push — hides the tab bar like the other pushed
                                                           screens, with its own in-body search bar. NOT a modal: a native
                                                           modal presentation traps the root play drawer beneath it when a
                                                           climb is opened from a profile pushed off search. */}
-                                                            <Stack.Screen
-                                                              name="users/search"
-                                                              options={{ headerShown: false }}
-                                                            />
-                                                            <Stack.Screen name="users/connections" />
-                                                            <Stack.Screen
-                                                              name="join/[sessionId]"
-                                                              options={{ presentation: 'modal', headerShown: false }}
-                                                            />
-                                                            <Stack.Screen
-                                                              name="share-beta"
-                                                              options={{ presentation: 'modal', headerShown: false }}
-                                                            />
-                                                            {/* Board selection is a modal off the Climbs capsule /
+                                                              <Stack.Screen
+                                                                name="users/search"
+                                                                options={{ headerShown: false }}
+                                                              />
+                                                              <Stack.Screen name="users/connections" />
+                                                              <Stack.Screen
+                                                                name="join/[sessionId]"
+                                                                options={{ presentation: 'modal', headerShown: false }}
+                                                              />
+                                                              <Stack.Screen
+                                                                name="share-beta"
+                                                                options={{ presentation: 'modal', headerShown: false }}
+                                                              />
+                                                              {/* Board selection is a modal off the Climbs capsule /
                                                       no-board CTA — board switching is rare, so it doesn't
                                                       earn a tab. Its own _layout owns the headers. */}
-                                                            <Stack.Screen
-                                                              name="boards"
-                                                              options={{ presentation: 'modal', headerShown: false }}
-                                                            />
-                                                            {/* First-run welcome walkthrough. Full-screen cover
+                                                              <Stack.Screen
+                                                                name="boards"
+                                                                options={{ presentation: 'modal', headerShown: false }}
+                                                              />
+                                                              {/* First-run welcome walkthrough. Full-screen cover
                                                       over the Climbs tab; gesture disabled so the user
                                                       leaves only via Skip / finish / the final CTA, never
                                                       an accidental swipe-dismiss. */}
-                                                            <Stack.Screen
-                                                              name="onboarding"
-                                                              options={{
-                                                                presentation: 'fullScreenModal',
-                                                                headerShown: false,
-                                                                gestureEnabled: false,
-                                                                animation: 'fade',
-                                                              }}
-                                                            />
-                                                          </Stack>
-                                                        </ThemedNavigation>
-                                                        <PersistentQueueBar />
-                                                        {/* One-time tip floating above the tab bar / accessory bar,
+                                                              <Stack.Screen
+                                                                name="onboarding"
+                                                                options={{
+                                                                  presentation: 'fullScreenModal',
+                                                                  headerShown: false,
+                                                                  gestureEnabled: false,
+                                                                  animation: 'fade',
+                                                                }}
+                                                              />
+                                                            </Stack>
+                                                          </ThemedNavigation>
+                                                          <PersistentQueueBar />
+                                                          {/* One-time tip floating above the tab bar / accessory bar,
                                                             mounted next to PersistentQueueBar so it watches climb
                                                             presence globally and overlays both the native (iOS 26) and
                                                             JS bottom-bar variants. */}
-                                                        <AccessoryOnboardingTip />
-                                                        <OnboardingGate ready={authReady && fontsReady} />
-                                                      </UserDrawerProvider>
-                                                    </TabBarHeightProvider>
-                                                    <AnalyticsScreenTracker />
-                                                  </ShareTargetProvider>
-                                                </DeepLinkProvider>
-                                              </DrawerHostProvider>
+                                                          <AccessoryOnboardingTip />
+                                                          <OnboardingGate ready={authReady && fontsReady} />
+                                                        </UserDrawerProvider>
+                                                      </TabBarHeightProvider>
+                                                      <AnalyticsScreenTracker />
+                                                    </ShareTargetProvider>
+                                                  </DeepLinkProvider>
+                                                </DrawerHostProvider>
+                                              </BleControlSheetProvider>
                                             </BluetoothProviderWrapper>
                                           </BottomSheetModalProvider>
                                         </MobileBoardPresenceProvider>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -31,8 +31,7 @@ import { computeFirstScreenHeight } from './play-drawer-layout';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { AddBetaVideoSheet } from '../AddBetaVideoSheet';
-import { BleControlSheet } from '../ble/BleControlSheet';
-import { disconnectAllBluetooth } from '../../lib/ble/bluetooth-status-store';
+import { useBleControlSheet } from '../../providers/ble-control-sheet-provider';
 import { GlassSheetBackground } from '../GlassSheetBackground';
 import { Icon } from '../Icon';
 import { usePlaylistSuggestionSource, useQueue } from '../../providers/queue-provider';
@@ -168,7 +167,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const [isTickBarActive, setIsTickBarActive] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [activeSubDrawer, setActiveSubDrawer] = useState<ActiveSubDrawer>('none');
-  const [bleControlOpen, setBleControlOpen] = useState(false);
   const [addBetaVideoOpen, setAddBetaVideoOpen] = useState(false);
   const [belowFoldContentRequested, setBelowFoldContentRequested] = useState(false);
   const resetZoomRef = useRef<(() => void) | null>(null);
@@ -189,9 +187,9 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
   const { isAuthenticated } = useAuth();
 
   const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
-  const bluetoothArmUndoWallChangeToast = bluetooth?.armUndoWallChangeToast;
-  const bluetoothReassertWall = bluetooth?.reassertWall;
-  const bluetoothClearBoard = bluetooth?.clearBoard;
+  // Opens the shared, app-root BLE controls sheet (same instance the persistent
+  // bar's board control uses), so there's one Re-light / Disconnect menu.
+  const { open: openBleControlSheet } = useBleControlSheet();
 
   usePlayDrawerWakeLock(isSheetOpen);
 
@@ -490,29 +488,10 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
 
   const handleLightbulbLongPress = useCallback(() => {
     if (!bluetooth?.isConnected) return;
-    // Reveal the BLE controls (Re-light / Disconnect) rather than disconnecting
-    // blind — keeps the destructive action behind a labelled menu.
-    setBleControlOpen(true);
-  }, [bluetooth]);
-
-  const handleBleReassert = useCallback(() => {
-    bluetoothArmUndoWallChangeToast?.();
-    bluetoothReassertWall?.();
-  }, [bluetoothArmUndoWallChangeToast, bluetoothReassertWall]);
-
-  const handleBleClearLights = useCallback(() => {
-    void bluetoothClearBoard?.();
-  }, [bluetoothClearBoard]);
-
-  const handleBleControlClose = useCallback(() => {
-    setBleControlOpen(false);
-  }, []);
-
-  // Close the BLE controls sheet if the link drops while it's open — otherwise
-  // it lingers showing Re-light / Disconnect actions that no-op on a dead link.
-  useEffect(() => {
-    if (!bluetoothConnected) setBleControlOpen(false);
-  }, [bluetoothConnected]);
+    // Reveal the shared BLE controls (Re-light / Disconnect) rather than
+    // disconnecting blind — keeps the destructive action behind a labelled menu.
+    openBleControlSheet();
+  }, [bluetooth, openBleControlSheet]);
 
   const handleOpenActions = useCallback(() => {
     // iOS: open the floating reaction menu (over the drawer) instead of the in-drawer
@@ -860,18 +839,6 @@ export const PlayDrawer = forwardRef<PlayDrawerHandle, PlayDrawerProps>(function
           setIds={setIds}
           sessionId={sessionId}
           consensusGradeName={displayedClimb.difficulty}
-        />
-      )}
-
-      {/* BLE controls revealed by long-pressing the lightbulb. */}
-      {bluetooth && (
-        <BleControlSheet
-          visible={bleControlOpen}
-          onReassert={handleBleReassert}
-          onClearLights={handleBleClearLights}
-          supportsClearLights={boardName !== 'moonboard'}
-          onDisconnect={disconnectAllBluetooth}
-          onClose={handleBleControlClose}
         />
       )}
     </>

--- a/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
@@ -4,8 +4,12 @@ import { GlassSurface } from '../GlassSurface';
 import { useTheme } from '../../providers/theme-provider';
 import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
 import { shadows } from '../../theme/tokens';
+import { withAlpha } from '../../theme/colors';
 
 export type AccessoryBarSurfaceTreatment = 'floating' | 'docked';
+
+/** Visual emphasis: `connected` lights the bar up when you're driving the wall. */
+export type AccessoryBarSurfaceEmphasis = 'none' | 'connected';
 
 type AccessoryBarSurfaceProps = {
   /** Surface height; the default radius is a full pill (`height / 2`). */
@@ -13,6 +17,13 @@ type AccessoryBarSurfaceProps = {
   borderRadius?: number;
   /** Material can dock the surface to the tab bar instead of rendering a floating pill. */
   treatment?: AccessoryBarSurfaceTreatment;
+  /**
+   * `connected` = this device holds the board's BLE link. Expressed per platform:
+   * a violet M3 tonal container + a level-3 cast on Material (matching the active
+   * tab pill), a soft warm tint on the iOS glass/blur/solid capsule. Never on the
+   * iOS 26 native platter (UIKit-owned — handled in the content layer instead).
+   */
+  emphasis?: AccessoryBarSurfaceEmphasis;
   style?: StyleProp<ViewStyle>;
   children: ReactNode;
 };
@@ -34,13 +45,19 @@ export function AccessoryBarSurface({
   height,
   borderRadius,
   treatment = 'floating',
+  emphasis = 'none',
   style,
   children,
 }: AccessoryBarSurfaceProps) {
   const mode = useEffectiveSurfaceMode();
-  const { systemColors, variant, m3SurfaceContainers, materialElevation } = useTheme();
+  const { systemColors, variant, m3, m3SurfaceContainers, materialElevation, brandColors } = useTheme();
   const radius = treatment === 'docked' ? 0 : (borderRadius ?? height / 2);
   const shape: ViewStyle = { height, borderRadius: radius };
+  const connected = emphasis === 'connected';
+  // A soft warm tint for the iOS glass/blur/solid capsule when you hold control —
+  // deliberately gentler than the lightbulb's own halo so a large surface doesn't
+  // read as "tap me". Composited via GlassSurface's pointerEvents-none tint layer.
+  const warmTint = connected ? withAlpha(brandColors.warning, 0.12) : undefined;
 
   // Native Liquid Glass draws its own refractive edge + lift.
   if (mode === 'glass') {
@@ -48,6 +65,7 @@ export function AccessoryBarSurface({
       <View style={[shape, style]}>
         <GlassSurface
           glassEffectStyle="regular"
+          tintColor={warmTint}
           borderRadius={radius}
           style={StyleSheet.absoluteFill}
           pointerEvents="none"
@@ -65,26 +83,41 @@ export function AccessoryBarSurface({
     // canonical nav/bottom-bar role). Docked adds a hairline top separator;
     // floating is the same tone as a lifted pill. The grade colour lives in the
     // bar's leading accent, not here. No clip on this View, so the cast shows.
+    // When you hold control, swap to the violet `secondaryContainer` tonal (the
+    // same tone the active tab pill uses) and step the cast to level-3 — M3
+    // expresses "active" through tone + elevation, not a drop-shadow glow.
+    const surfaceBackground = connected ? m3.secondaryContainer : m3SurfaceContainers.base;
+    const surfaceElevation = connected ? materialElevation.level3 : materialElevation.level2;
     const materialSurfaceStyle: ViewStyle =
       treatment === 'docked'
         ? {
-            backgroundColor: m3SurfaceContainers.base,
+            backgroundColor: surfaceBackground,
             borderTopWidth: StyleSheet.hairlineWidth,
             borderTopColor: systemColors.separator,
-            ...materialElevation.level2,
+            ...surfaceElevation,
           }
-        : { backgroundColor: m3SurfaceContainers.base, ...materialElevation.level2 };
+        : { backgroundColor: surfaceBackground, ...surfaceElevation };
     return <View style={[shape, materialSurfaceStyle, style]}>{children}</View>;
   }
 
   // Blur / solid fallback: the surface has no intrinsic edge, so add the hairline
-  // border and separation shadow.
+  // border and separation shadow. When you hold control, warm the edge and tint
+  // the fill amber.
   return (
     <View
-      style={[shape, shadows.sm, { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator }, style]}
+      style={[
+        shape,
+        shadows.sm,
+        {
+          borderWidth: StyleSheet.hairlineWidth,
+          borderColor: connected ? withAlpha(brandColors.warning, 0.4) : systemColors.separator,
+        },
+        style,
+      ]}
     >
       <GlassSurface
         fallbackColor={systemColors.elevatedSurface}
+        tintColor={warmTint}
         borderRadius={radius}
         style={StyleSheet.absoluteFill}
         pointerEvents="none"

--- a/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryBarSurface.tsx
@@ -83,21 +83,32 @@ export function AccessoryBarSurface({
     // canonical nav/bottom-bar role). Docked adds a hairline top separator;
     // floating is the same tone as a lifted pill. The grade colour lives in the
     // bar's leading accent, not here. No clip on this View, so the cast shows.
-    // When you hold control, swap to the violet `secondaryContainer` tonal (the
-    // same tone the active tab pill uses) and step the cast to level-3 — M3
-    // expresses "active" through tone + elevation, not a drop-shadow glow.
-    const surfaceBackground = connected ? m3.secondaryContainer : m3SurfaceContainers.base;
+    // When you hold control, step the cast to level-3 and composite the violet
+    // `secondaryContainer` tone OVER the opaque base (this codebase maps that role
+    // to a low-alpha violet meant to layer, so painting it as the sole background
+    // would let the list bleed through). M3 expresses "active" through tone +
+    // elevation, not a drop-shadow glow.
     const surfaceElevation = connected ? materialElevation.level3 : materialElevation.level2;
     const materialSurfaceStyle: ViewStyle =
       treatment === 'docked'
         ? {
-            backgroundColor: surfaceBackground,
+            backgroundColor: m3SurfaceContainers.base,
             borderTopWidth: StyleSheet.hairlineWidth,
             borderTopColor: systemColors.separator,
             ...surfaceElevation,
           }
-        : { backgroundColor: surfaceBackground, ...surfaceElevation };
-    return <View style={[shape, materialSurfaceStyle, style]}>{children}</View>;
+        : { backgroundColor: m3SurfaceContainers.base, ...surfaceElevation };
+    return (
+      <View style={[shape, materialSurfaceStyle, style]}>
+        {connected ? (
+          <View
+            pointerEvents="none"
+            style={[StyleSheet.absoluteFill, { backgroundColor: m3.secondaryContainer, borderRadius: radius }]}
+          />
+        ) : null}
+        {children}
+      </View>
+    );
   }
 
   // Blur / solid fallback: the surface has no intrinsic edge, so add the hairline

--- a/packages/mobile/src/components/queue-control/BoardControlIndicator.tsx
+++ b/packages/mobile/src/components/queue-control/BoardControlIndicator.tsx
@@ -1,0 +1,159 @@
+// The accessory bar's leading board-control element. It is both the connection
+// STATUS (so a climber can tell at a glance whether they're driving the wall —
+// the user-testing gap) and the connect CONTROL, mirroring the in-drawer
+// lightbulb so the two surfaces share one vocabulary and one connect path.
+//
+// Tap, per connection state:
+//   disconnected   → connect (relight the remembered board; shared connect path)
+//   connectedByMe  → open the labelled BleControlSheet (Re-light / Turn off /
+//                    Disconnect) — destructive Disconnect stays behind a label,
+//                    never a stray tap on this large surface
+//   heldByPeer     → open the read-only "Now on the wall" view (a teammate drives)
+//
+// Long-press (JS bar only — never the iOS 26 UIKit platter, where a custom
+// recognizer would fight system gestures) is a power-user shortcut into the same
+// BleControlSheet. State is read from the single `useBoardConnectionState` source,
+// so the bar can never disagree with the drawer bulb or the Live Activity.
+
+import { useCallback } from 'react';
+import { Pressable, StyleSheet, type AccessibilityActionEvent } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '../Icon';
+import { useTheme } from '../../providers/theme-provider';
+import { useBleControlSheet } from '../../providers/ble-control-sheet-provider';
+import { useBoardConnectionState } from '../ble/use-board-connection-state';
+import { useLightbulbControl } from '../ble/use-lightbulb-control';
+import { hapticMedium } from '../../lib/haptics';
+import { glassSize } from '../../theme/layout';
+import { getBoardControlIndicatorVisual } from './board-control-indicator-state';
+import { useAccessoryClimbTap } from './use-accessory-climb-tap';
+
+type BoardControlIndicatorProps = {
+  /** Container (tap target) size; defaults to the 44pt control floor. */
+  size?: number;
+  /** Glyph size. */
+  iconSize?: number;
+  /**
+   * Enable the long-press → controls-sheet shortcut. JS bar only — left off on
+   * the iOS 26 native accessory platter to avoid colliding with UIKit's own
+   * press/highlight gestures.
+   */
+  enableLongPress?: boolean;
+};
+
+export function BoardControlIndicator({
+  size = glassSize.inline,
+  iconSize = 22,
+  enableLongPress = false,
+}: BoardControlIndicatorProps) {
+  const { t } = useTranslation('settings');
+  const { systemColors, brandColors } = useTheme();
+  const { boardConnection, holderDisplayName, bluetooth } = useBoardConnectionState();
+  const { open: openBoardControls } = useBleControlSheet();
+  // Reuse the shared connect path so analytics + undo-arming match the lightbulb.
+  // Only invoked from `disconnected` (where it connects); never from the
+  // connected state, so it never disconnects on a stray tap.
+  const { onPress: connectFromShared } = useLightbulbControl({ source: 'lightbulb_toolbar' });
+  const { openPlay } = useAccessoryClimbTap();
+
+  const handlePress = useCallback(() => {
+    if (boardConnection === 'connectedByMe') {
+      hapticMedium();
+      openBoardControls();
+      return;
+    }
+    if (boardConnection === 'heldByPeer') {
+      openPlay();
+      return;
+    }
+    connectFromShared();
+  }, [boardConnection, openBoardControls, openPlay, connectFromShared]);
+
+  const handleLongPress = useCallback(() => {
+    // Only meaningful when this device holds the link — the sheet self-guards too.
+    if (boardConnection !== 'connectedByMe') return;
+    hapticMedium();
+    openBoardControls();
+  }, [boardConnection, openBoardControls]);
+
+  const handleAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (event.nativeEvent.actionName === 'longpress') handleLongPress();
+    },
+    [handleLongPress],
+  );
+
+  // No board bound yet → nothing to indicate or connect to.
+  if (!bluetooth) return null;
+
+  const visual = getBoardControlIndicatorVisual({
+    boardConnection,
+    connectedColor: brandColors.warning,
+    peerColor: systemColors.secondaryLabel,
+    disconnectedColor: systemColors.secondaryLabel,
+  });
+
+  const accessibilityLabel =
+    boardConnection === 'connectedByMe'
+      ? t('ble.barControl.connectedLabel')
+      : boardConnection === 'heldByPeer'
+        ? holderDisplayName
+          ? t('ble.barControl.peerLabel', { name: holderDisplayName })
+          : t('ble.barControl.peerLabelAnonymous')
+        : t('ble.barControl.disconnectedLabel');
+
+  const accessibilityHint =
+    boardConnection === 'connectedByMe'
+      ? t('ble.barControl.connectedHint')
+      : boardConnection === 'heldByPeer'
+        ? t('ble.barControl.peerHint')
+        : t('ble.barControl.disconnectedHint');
+
+  // Surface the long-press shortcut to assistive tech without overriding the
+  // default activate (so a VoiceOver/TalkBack double-tap still fires the tap).
+  const accessibilityActions =
+    enableLongPress && boardConnection === 'connectedByMe'
+      ? [{ name: 'longpress', label: t('ble.holdForControls') }]
+      : undefined;
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      onLongPress={enableLongPress ? handleLongPress : undefined}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ selected: boardConnection === 'connectedByMe' }}
+      accessibilityActions={accessibilityActions}
+      onAccessibilityAction={accessibilityActions ? handleAccessibilityAction : undefined}
+      hitSlop={8}
+      style={({ pressed }) => [
+        styles.container,
+        { width: size, height: size, borderRadius: size / 2 },
+        visual.haloColor ? { backgroundColor: visual.haloColor, shadowColor: visual.iconColor as string } : null,
+        visual.haloColor ? styles.connected : null,
+        pressed ? styles.pressed : null,
+      ]}
+    >
+      <Icon name={visual.iconName} size={iconSize} color={visual.iconColor} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Soft warm glow, matching the in-drawer lightbulb's connected halo + shadow.
+  connected: {
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.35,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  pressed: {
+    opacity: 0.6,
+    transform: [{ scale: 0.92 }],
+  },
+});

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -9,7 +9,7 @@ import { View, StyleSheet, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { Climb } from '@boardsesh/queue';
-import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH } from '../../theme/layout';
+import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH, glassSize } from '../../theme/layout';
 import { spacing } from '../../theme/tokens';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
@@ -20,6 +20,8 @@ import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './Access
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
+import { useBoardConnectionState } from '../ble/use-board-connection-state';
+import { BoardControlIndicator } from './BoardControlIndicator';
 
 type ClimbLabelProps = {
   climb: Climb;
@@ -76,16 +78,23 @@ export function ClimbCapsule({
   endActionSize = 0,
   surfaceTreatment = 'floating',
 }: ClimbCapsuleProps) {
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { boardConfig } = useDrawerHost();
   const { formatGrade } = useGradeFormat();
   const { openGesture, currentItem } = useAccessoryClimbTap();
+  // Connection state drives the leading control + the "you have control" glow.
+  // Read from the single source so the bar can't disagree with the drawer bulb.
+  const { boardConnection, bluetooth } = useBoardConnectionState();
 
   // Source-of-truth flip: show the wall's lit climb when a board feed is live
   // (flag-gated), else the local queue head.
   const currentClimb = useWallOrQueueCurrentClimb(currentItem?.climb ?? null);
   // Board art needs the active board config; matches the iOS 26 native accessory.
   const showThumbnail = boardConfig != null;
+  // Show the connect control once a board is bound (the BLE context exists).
+  const hasBoardControl = bluetooth != null;
+  // Only "you are driving the wall" lights the bar up.
+  const connected = boardConnection === 'connectedByMe';
 
   const grades = useMemo(() => {
     const currentColor = currentClimb
@@ -103,25 +112,32 @@ export function ClimbCapsule({
   // Reserve room on the right so the name/grade never slide under the inline tick.
   const endActionReservedWidth = endAction ? endActionSize + spacing[2] : 0;
   const labelRight = spacing[4] + endActionReservedWidth;
+  // Reserve room on the LEFT for the board control, symmetric to the tick, so the
+  // climb name never slides under it.
+  const leadingReservedWidth = hasBoardControl ? glassSize.inline + spacing[2] : 0;
+  const labelLeft = spacing[4] + leadingReservedWidth;
 
   // The docked Material bar stays on a neutral M3 surface (a step above the tab bar
   // via elevation) and marks the grade with a vivid leading colour stripe — distinct
   // from the tab bar without painting a full grade-coloured band. The grade number
-  // keeps its per-grade colour, matching the list rows.
+  // keeps its per-grade colour, matching the list rows. When you hold control the
+  // stripe recolors to the brand violet so it reads as a control-on edge marker.
   const showGradeAccent = surfaceTreatment === 'docked';
+  const gradeAccentColor = connected ? brandColors.primary : grades.currentColor;
 
   return (
     <AccessoryBarSurface
       height={height}
       borderRadius={capsuleRadius}
       treatment={surfaceTreatment}
+      emphasis={connected ? 'connected' : 'none'}
       style={[styles.capsule, fillWidth ? null : styles.capsuleCap]}
     >
       {showGradeAccent ? (
         <View
           testID="grade-accent"
           pointerEvents="none"
-          style={[styles.gradeAccent, { backgroundColor: grades.currentColor }]}
+          style={[styles.gradeAccent, { backgroundColor: gradeAccentColor }]}
         />
       ) : null}
       <GestureDetector gesture={openGesture}>
@@ -130,7 +146,7 @@ export function ClimbCapsule({
           accessibilityRole="button"
           accessibilityLabel={currentClimb.name}
         >
-          <View style={[styles.labelSlot, { right: labelRight }]}>
+          <View style={[styles.labelSlot, { left: labelLeft, right: labelRight }]}>
             <ClimbLabel
               climb={currentClimb}
               labelColor={systemColors.label}
@@ -142,6 +158,13 @@ export function ClimbCapsule({
           </View>
         </View>
       </GestureDetector>
+      {/* Leading board control — outside the tap target so it never opens the
+          drawer. Sits over the bar's left edge, symmetric to the trailing tick. */}
+      {hasBoardControl ? (
+        <View style={[styles.leadingActionSlot, { height }]}>
+          <BoardControlIndicator size={glassSize.inline} enableLongPress />
+        </View>
+      ) : null}
       {endAction ? <View style={[styles.endActionSlot, { width: endActionSize, height }]}>{endAction}</View> : null}
     </AccessoryBarSurface>
   );
@@ -181,6 +204,13 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     right: spacing[2],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  leadingActionSlot: {
+    position: 'absolute',
+    top: 0,
+    left: spacing[2],
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -11,6 +11,7 @@ import { Text } from '../Text';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
+import { BoardControlIndicator } from './BoardControlIndicator';
 
 type AccessoryPlacement = 'regular' | 'inline';
 
@@ -82,6 +83,10 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
 
   return (
     <View style={[styles.row, { width, height: rowHeight }]}>
+      {/* Leading board control as a content-layer element (the platter is
+          UIKit-owned, so the glow lives here, not on the glass). Static state
+          swap; no long-press recognizer — it would fight UIKit's own gestures. */}
+      <BoardControlIndicator size={glassSize.inline} iconSize={22} />
       <GestureDetector gesture={openGesture}>
         <View style={styles.tapClip} accessibilityRole="button" accessibilityLabel={climb.name}>
           <View style={styles.labelSlot}>

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -22,7 +22,8 @@ type NativeAccessoryClimbRowProps = {
 };
 
 const ACCESSORY_LEADING_INSET = spacing[1];
-const ACCESSORY_TRAILING_INSET = spacing[3];
+// Pull the tick ~20pt off the platter's right edge so it doesn't sit flush.
+const ACCESSORY_TRAILING_INSET = spacing[8];
 
 type ClimbLabelProps = {
   climb: Climb;

--- a/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
@@ -88,17 +88,25 @@ describe('AccessoryBarSurface', () => {
     expect(container.querySelector('[data-view]')?.getAttribute('data-style')).toContain('"backgroundColor":"#2A2138"');
   });
 
-  it('lights the Material docked bar with the violet secondaryContainer + a higher elevation when connected', () => {
-    // "You have control" reads as the active-tab violet tonal + a level-3 cast,
-    // not a drop-shadow glow — the M3 way to say "active".
+  it('lights the Material docked bar: opaque base + a violet tint overlay + a higher elevation when connected', () => {
+    // "You have control" reads as the active-tab violet tonal + a level-3 cast.
+    // The base stays OPAQUE so the list never bleeds through; the violet (a
+    // low-alpha role here) is composited as an overlay on top.
     const { container } = render(
       <AccessoryBarSurface height={48} treatment="docked" emphasis="connected">
         child
       </AccessoryBarSurface>,
     );
 
-    const style = container.querySelector('[data-view]')?.getAttribute('data-style') ?? '';
-    expect(style).toContain('"backgroundColor":"#5A4A90"');
-    expect(style).toContain('"elevation":3');
+    const views = Array.from(container.querySelectorAll('[data-view]'));
+    const outerStyle = views[0]?.getAttribute('data-style') ?? '';
+    // Opaque base (NOT the translucent secondaryContainer) + the level-3 cast.
+    expect(outerStyle).toContain('"backgroundColor":"#2A2138"');
+    expect(outerStyle).toContain('"elevation":3');
+    // A separate violet overlay carries the "active" tone over the opaque base.
+    const overlay = views.find((view) =>
+      (view.getAttribute('data-style') ?? '').includes('"backgroundColor":"#5A4A90"'),
+    );
+    expect(overlay).toBeTruthy();
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/accessory-bar-surface.test.tsx
@@ -29,15 +29,22 @@ vi.mock('../../../providers/theme-provider', () => ({
       elevatedSurface: '#FFFFFF',
       separator: '#CCCCCC',
     },
+    m3: { secondaryContainer: '#5A4A90' },
+    brandColors: { warning: '#FBBF24' },
     m3SurfaceContainers: { lowest: '#101018', low: '#202028', base: '#2A2138', high: '#33293F', highest: '#3B2F49' },
     materialElevation: {
       level2: { elevation: 2, shadowOpacity: 0.12, shadowRadius: 3, shadowOffset: { width: 0, height: 1 } },
+      level3: { elevation: 3, shadowOpacity: 0.14, shadowRadius: 5, shadowOffset: { width: 0, height: 2 } },
     },
   }),
 }));
 
 vi.mock('../../../theme/tokens', () => ({
   shadows: { sm: { elevation: 2 } },
+}));
+
+vi.mock('../../../theme/colors', () => ({
+  withAlpha: (color: string, alpha: number) => `${color}-${alpha}`,
 }));
 
 import { AccessoryBarSurface } from '../AccessoryBarSurface';
@@ -79,5 +86,19 @@ describe('AccessoryBarSurface', () => {
 
     expect(container.querySelector('[data-glass]')).toBeNull();
     expect(container.querySelector('[data-view]')?.getAttribute('data-style')).toContain('"backgroundColor":"#2A2138"');
+  });
+
+  it('lights the Material docked bar with the violet secondaryContainer + a higher elevation when connected', () => {
+    // "You have control" reads as the active-tab violet tonal + a level-3 cast,
+    // not a drop-shadow glow — the M3 way to say "active".
+    const { container } = render(
+      <AccessoryBarSurface height={48} treatment="docked" emphasis="connected">
+        child
+      </AccessoryBarSurface>,
+    );
+
+    const style = container.querySelector('[data-view]')?.getAttribute('data-style') ?? '';
+    expect(style).toContain('"backgroundColor":"#5A4A90"');
+    expect(style).toContain('"elevation":3');
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/board-control-indicator-state.test.ts
+++ b/packages/mobile/src/components/queue-control/__tests__/board-control-indicator-state.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getBoardControlIndicatorVisual } from '../board-control-indicator-state';
+
+const colors = {
+  connectedColor: '#FBBF24',
+  peerColor: '#8E8898',
+  disconnectedColor: '#8E8898',
+};
+
+describe('getBoardControlIndicatorVisual', () => {
+  it('glows: a warm filled bulb with a halo only when this device has control', () => {
+    const visual = getBoardControlIndicatorVisual({ boardConnection: 'connectedByMe', ...colors });
+    expect(visual.iconName).toBe('lightbulb.fill');
+    expect(visual.iconColor).toBe('#FBBF24');
+    // ~14% alpha halo, mirroring the in-drawer lightbulb's `${connectedColor}24`.
+    expect(visual.haloColor).toBe('#FBBF2424');
+  });
+
+  it('does not glow: a neutral person glyph (no halo) when a teammate drives the wall', () => {
+    const visual = getBoardControlIndicatorVisual({ boardConnection: 'heldByPeer', ...colors });
+    expect(visual.iconName).toBe('person.fill');
+    expect(visual.iconColor).toBe('#8E8898');
+    expect(visual.haloColor).toBeUndefined();
+  });
+
+  it('does not glow: a neutral outline bulb (no halo) when disconnected', () => {
+    const visual = getBoardControlIndicatorVisual({ boardConnection: 'disconnected', ...colors });
+    expect(visual.iconName).toBe('lightbulb');
+    expect(visual.iconColor).toBe('#8E8898');
+    expect(visual.haloColor).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -115,7 +115,17 @@ vi.mock('../../GlassSurface', () => ({
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#111111', separator: '#cccccc', elevatedSurface: '#f0f0f0' },
+    brandColors: { primary: '#6D28D9', warning: '#FBBF24' },
   }),
+}));
+
+// The leading board control drags in the BLE stack + Icon (@expo/vector-icons);
+// these layout tests don't exercise it, so stub it (it has its own unit test).
+vi.mock('../BoardControlIndicator', () => ({ BoardControlIndicator: () => null }));
+
+// No board bound by default → no control rendered, disconnected glow state.
+vi.mock('../../ble/use-board-connection-state', () => ({
+  useBoardConnectionState: () => ({ boardConnection: 'disconnected', bluetooth: null }),
 }));
 
 vi.mock('../../../providers/queue-provider', () => ({

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -122,6 +122,10 @@ vi.mock('react-native-gesture-handler', () => {
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
+// The leading board control drags in the BLE stack + Icon (@expo/vector-icons);
+// the row's layout tests don't exercise it, so stub it (it has its own unit test).
+vi.mock('../BoardControlIndicator', () => ({ BoardControlIndicator: () => null }));
+
 type TextMockProps = {
   children?: ReactNode;
   color?: string;

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -187,7 +187,7 @@ vi.mock('../../../hooks/use-grade-format', () => ({
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 
 vi.mock('../../../theme/tokens', () => ({
-  spacing: { 1: 4, 2: 8, 3: 12, 10: 40 },
+  spacing: { 1: 4, 2: 8, 3: 12, 8: 32, 10: 40 },
   borderRadius: { md: 8 },
 }));
 
@@ -335,7 +335,7 @@ describe('NativeAccessoryClimbRow', () => {
     expect(container.querySelector('[data-tick-size="44"]')).not.toBeNull();
     expect(container.querySelector('[data-icon-size="24"]')).not.toBeNull();
     expect(container.querySelector('[data-height="48"]')).not.toBeNull();
-    expect(container.querySelector('[data-padding-right="12"]')).not.toBeNull();
+    expect(container.querySelector('[data-padding-right="32"]')).not.toBeNull();
 
     const thumbnail = getCurrentThumbnail(container);
     const thumbnailSlot = thumbnail.closest('[data-width="40"][data-height="40"]');

--- a/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../../../providers/queue-provider', () => ({
 }));
 vi.mock('../../../theme/layout', () => ({
   glassSize: { standard: 56, inline: 44, capsule: 52 },
-  NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH: 344,
+  NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH: 420,
   NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER: 32,
 }));
 // Stub the row so the test sees exactly what QueueBottomAccessory hands down, and
@@ -76,7 +76,7 @@ describe('QueueBottomAccessory', () => {
   });
 
   it('passes the inline placement through at the same width as regular', () => {
-    // max(56*2=112, min(344, 402-32=370)) = 344, independent of placement.
+    // max(56*2=112, min(420, 402-32=370)) = 370, independent of placement.
     const regular = render(<QueueBottomAccessory />);
     const regularRowWidth = regular.container.querySelector('[data-native-row]')?.getAttribute('data-row-width');
     regular.unmount();
@@ -87,7 +87,7 @@ describe('QueueBottomAccessory', () => {
 
     expect(inlineRow?.getAttribute('data-placement')).toBe('inline');
     expect(inlineRow?.getAttribute('data-row-width')).toBe(regularRowWidth);
-    expect(inlineRow?.getAttribute('data-row-width')).toBe('344');
+    expect(inlineRow?.getAttribute('data-row-width')).toBe('370');
   });
 
   it('renders nothing without a current climb', () => {

--- a/packages/mobile/src/components/queue-control/board-control-indicator-state.ts
+++ b/packages/mobile/src/components/queue-control/board-control-indicator-state.ts
@@ -1,0 +1,50 @@
+import type { OpaqueColorValue } from 'react-native';
+import type { IconName } from '../icon-map';
+import type { BoardConnection } from '../play-drawer/lightbulb-control';
+
+export type BoardControlIndicatorVisual = {
+  iconName: IconName;
+  iconColor: string | OpaqueColorValue;
+  /**
+   * Circular halo behind the glyph. Only the "you have control" state glows —
+   * the peer and disconnected states are intentionally flat so the bar never
+   * tells a climber their Prev/Next drive the wall when a teammate holds it.
+   */
+  haloColor?: string;
+};
+
+type BoardControlIndicatorVisualInput = {
+  boardConnection: BoardConnection;
+  /** Warm "wall is lit / you're driving" tone (brandColors.warning). */
+  connectedColor: string;
+  /** Neutral tone for a teammate-driven wall (systemColors.secondaryLabel). */
+  peerColor: string | OpaqueColorValue;
+  /** Neutral tone for "tap to connect" (systemColors.secondaryLabel). */
+  disconnectedColor: string | OpaqueColorValue;
+};
+
+/**
+ * Maps the board-connection tri-state to the accessory bar's leading control
+ * visual. Mirrors the in-drawer lightbulb vocabulary (`getBleLightbulbVisualState`)
+ * so the bar and the bulb can never disagree, and carries each state by SHAPE
+ * (filled bulb / person / outline bulb) as well as colour, so it reads without
+ * relying on hue (colour-blind / Differentiate Without Color).
+ */
+export function getBoardControlIndicatorVisual({
+  boardConnection,
+  connectedColor,
+  peerColor,
+  disconnectedColor,
+}: BoardControlIndicatorVisualInput): BoardControlIndicatorVisual {
+  switch (boardConnection) {
+    case 'connectedByMe':
+      // Warm filled bulb + halo, matching the lightbulb's connected look.
+      return { iconName: 'lightbulb.fill', iconColor: connectedColor, haloColor: `${connectedColor}24` };
+    case 'heldByPeer':
+      // A teammate drives the wall — neutral person glyph, no glow.
+      return { iconName: 'person.fill', iconColor: peerColor };
+    case 'disconnected':
+      // Tap to take control — neutral outline bulb, no glow.
+      return { iconName: 'lightbulb', iconColor: disconnectedColor };
+  }
+}

--- a/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
@@ -18,6 +18,12 @@ import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 export type AccessoryClimbTap = {
   /** Tap → open the play drawer for the displayed climb. */
   openGesture: GestureType;
+  /**
+   * The same open-the-displayed-climb action as a plain callback, for non-gesture
+   * callers (e.g. the bar's board control opening the read-only "Now on the wall"
+   * view when a teammate drives).
+   */
+  openPlay: () => void;
   /** Local queue head; the wrappers re-apply `useWallOrQueueCurrentClimb` for display. */
   currentItem: ClimbQueueItem | null | undefined;
 };
@@ -65,5 +71,5 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
     [handleOpenPlay],
   );
 
-  return { openGesture, currentItem: currentClimbQueueItem };
+  return { openGesture, openPlay: handleOpenPlay, currentItem: currentClimbQueueItem };
 }

--- a/packages/mobile/src/providers/ble-control-sheet-provider.tsx
+++ b/packages/mobile/src/providers/ble-control-sheet-provider.tsx
@@ -1,0 +1,83 @@
+// Hosts a single BLE controls sheet (Re-light / Turn off all lights /
+// Disconnect) at app root so every surface opens the SAME labelled menu — the
+// play-drawer lightbulb and the persistent accessory bar's board control — and
+// the destructive Disconnect always stays behind a label. Wraps
+// DrawerHostProvider (which renders PlayDrawer as a sibling of its children) so
+// both the drawer and the bar descend from it, and sits inside
+// BluetoothProviderWrapper for the BLE callbacks. The active board (for
+// supportsClearLights) comes from useActiveBoard, since this is above the
+// drawer host.
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { toBoardName } from '@boardsesh/board-config';
+import { useOptionalBluetoothContext } from './bluetooth-provider';
+import { useActiveBoard } from '../lib/graphql/use-active-board';
+import { disconnectAllBluetooth } from '../lib/ble/bluetooth-status-store';
+import { BleControlSheet } from '../components/ble/BleControlSheet';
+
+type BleControlSheetContextValue = {
+  /** Reveal the BLE controls. No-ops unless this device holds the BLE link. */
+  open: () => void;
+  close: () => void;
+};
+
+const BleControlSheetContext = createContext<BleControlSheetContextValue | null>(null);
+
+export function BleControlSheetProvider({ children }: { children: ReactNode }) {
+  const bluetooth = useOptionalBluetoothContext();
+  const { data: activeBoard } = useActiveBoard();
+  const [visible, setVisible] = useState(false);
+
+  const isConnected = bluetooth?.isConnected ?? false;
+
+  const open = useCallback(() => {
+    // Nothing to control unless this device holds the link.
+    if (!isConnected) return;
+    setVisible(true);
+  }, [isConnected]);
+
+  const close = useCallback(() => setVisible(false), []);
+
+  // Close if the link drops while the sheet is open — otherwise it lingers
+  // showing Re-light / Disconnect actions that no-op on a dead link (mirrors the
+  // old in-drawer close-on-disconnect effect).
+  useEffect(() => {
+    if (!isConnected) setVisible(false);
+  }, [isConnected]);
+
+  const handleReassert = useCallback(() => {
+    bluetooth?.armUndoWallChangeToast();
+    bluetooth?.reassertWall();
+  }, [bluetooth]);
+
+  const handleClearLights = useCallback(() => {
+    void bluetooth?.clearBoard();
+  }, [bluetooth]);
+
+  const value = useMemo<BleControlSheetContextValue>(() => ({ open, close }), [open, close]);
+
+  return (
+    <BleControlSheetContext value={value}>
+      {children}
+      {bluetooth ? (
+        <BleControlSheet
+          visible={visible}
+          onReassert={handleReassert}
+          onClearLights={handleClearLights}
+          // MoonBoard's protocol has no clear-all frame; hide the row there.
+          supportsClearLights={toBoardName(activeBoard?.boardType) !== 'moonboard'}
+          onDisconnect={disconnectAllBluetooth}
+          onClose={close}
+        />
+      ) : null}
+    </BleControlSheetContext>
+  );
+}
+
+export function useBleControlSheet(): BleControlSheetContextValue {
+  const value = useContext(BleControlSheetContext);
+  if (value === null) {
+    throw new Error('useBleControlSheet must be used within a BleControlSheetProvider');
+  }
+  return value;
+}

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -67,7 +67,7 @@ export const TOOLBAR_SIDE_MARGIN = 16;
 export const TOOLBAR_GAP = 8;
 
 /** Max readable width for UIKit's iOS 26 bottom accessory content. */
-export const NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH = 344;
+export const NATIVE_BOTTOM_ACCESSORY_MAX_WIDTH = 420;
 
 /** Total horizontal screen gutter reserved around UIKit's iOS 26 bottom accessory. */
 export const NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER = 32;

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -416,7 +416,16 @@
     "permissionRequired": "Bluetooth permission required",
     "errorPermissionDenied": "Allow Bluetooth permissions to connect a board.",
     "errorLedMissing": "Could not send to board — LED data missing for this board configuration.",
-    "errorIncompatible": "This climb is for a different board configuration."
+    "errorIncompatible": "This climb is for a different board configuration.",
+    "barControl": {
+      "connectedLabel": "Board connected, you have control",
+      "connectedHint": "Opens board controls",
+      "peerLabel": "On {{name}}'s wall",
+      "peerLabelAnonymous": "On the wall",
+      "peerHint": "Opens the climb on the wall",
+      "disconnectedLabel": "Board disconnected",
+      "disconnectedHint": "Connect to the board"
+    }
   },
   "integrations": {
     "title": "Connected apps",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -416,7 +416,16 @@
     "permissionRequired": "Permiso de Bluetooth necesario",
     "errorPermissionDenied": "Permite los permisos de Bluetooth para conectar un tablero.",
     "errorLedMissing": "No se pudo enviar al tablero — faltan datos LED para esta configuración.",
-    "errorIncompatible": "Este boulder es para una configuración de tablero diferente."
+    "errorIncompatible": "Este boulder es para una configuración de tablero diferente.",
+    "barControl": {
+      "connectedLabel": "Tablero conectado, tienes el control",
+      "connectedHint": "Abre los controles del tablero",
+      "peerLabel": "En el muro de {{name}}",
+      "peerLabelAnonymous": "En el muro",
+      "peerHint": "Abre la vía en el muro",
+      "disconnectedLabel": "Tablero desconectado",
+      "disconnectedHint": "Conéctate al tablero"
+    }
   },
   "integrations": {
     "title": "Aplicaciones conectadas",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -416,7 +416,16 @@
     "permissionRequired": "Autorisation Bluetooth requise",
     "errorPermissionDenied": "Autorisez le Bluetooth pour connecter un panneau.",
     "errorLedMissing": "Impossible d'envoyer au panneau — données LED manquantes pour cette configuration.",
-    "errorIncompatible": "Ce bloc est pour une configuration de panneau différente."
+    "errorIncompatible": "Ce bloc est pour une configuration de panneau différente.",
+    "barControl": {
+      "connectedLabel": "Panneau connecté, vous avez le contrôle",
+      "connectedHint": "Ouvre les commandes du panneau",
+      "peerLabel": "Sur le mur de {{name}}",
+      "peerLabelAnonymous": "Sur le mur",
+      "peerHint": "Ouvre la voie sur le mur",
+      "disconnectedLabel": "Panneau déconnecté",
+      "disconnectedHint": "Se connecter au panneau"
+    }
   },
   "integrations": {
     "title": "Applications connectées",


### PR DESCRIPTION
## What & why

User testing surfaced two bits of feedback about the persistent accessory bar (the always-visible bottom climb bar):

1. Climbers often **couldn't tell they had live control of the board** — they suggested the bar could "glow" when they have control.
2. They wanted a way to **connect/disconnect from the bar**.

A design panel (Material 3 + Apple HIG/Liquid-Glass + interaction/a11y) found both are symptoms of one root cause: the board-connection state lived only on the play-drawer lightbulb, never on the bar climbers were actually looking at. So this adds a leading **board-control element** to the bar that is both the connection *status* and the connect *control*, reading from the single shared `useBoardConnectionState` source so it can never disagree with the drawer bulb or the Live Activity.

## Behaviour, per connection state

| State | Look | Tap |
|---|---|---|
| You're driving (`connectedByMe`) | **Bar lights up.** iOS: amber filled `lightbulb.fill` on the content layer + a soft warm tint on the JS capsule. Android (Material): the violet `secondaryContainer` tonal + a level-3 cast, matching the active tab pill. | Opens the labelled board-controls sheet (Re-light / Turn off / Disconnect). Long-press is a shortcut into it (JS bar only). |
| A teammate's driving (`heldByPeer`) | A neutral **person** glyph, **no glow** — so it never reads as "you have control" when your Prev/Next won't write to the wall. | Opens the read-only "Now on the wall" view. |
| Disconnected | A neutral outline bulb. | Connects. |

## Platform notes (this app keeps platform-specific UX)

- The iOS 26 native accessory is a **UIKit-owned glass platter** we can't restyle, so the iOS glow lives in the content layer, with **no custom long-press** there (it would fight system gestures).
- The indicator is a **static state swap** — no animation on the bar's interactive layer, so the recent Android touch-block fix stands. Honors Reduce Motion / Reduce Transparency by construction.
- Disconnect always stays behind the **labelled sheet**, never a stray tap/hold — the bar's existing tap-to-open-drawer is untouched (the control is a separate hit target).
- The BLE controls sheet is lifted into an app-root `BleControlSheetProvider` so the play-drawer lightbulb and the bar open **one shared instance**.

## Tests

- New unit test for the state→visual mapper (`board-control-indicator-state`).
- New Material "connected" emphasis test on `AccessoryBarSurface`.
- Updated the `ClimbCapsule` / `AccessoryBarSurface` / `NativeAccessoryClimbRow` unit tests for the new dependencies.
- Full mobile suite (2540), i18n catalog-completeness + orphans, and the Metro bundle check all green.

## Release Notes

You can now see at a glance when you're driving the board: the bar lights up when you have control, shows who's driving when a crewmate has it, and lets you connect or open board controls right from the bar — no digging into the climb view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UAyXSzY83s3FQQLuC2Fj8