### PR TITLE
fix: restore channel-switch mirror on reset revert and enforce global tester grants

### DIFF
--- a/packages/backend/src/__tests__/grant-role-validation.test.ts
+++ b/packages/backend/src/__tests__/grant-role-validation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { GrantRoleInputSchema } from '../validation/schemas';
+
+describe('GrantRoleInputSchema', () => {
+  it('accepts a global tester grant with null boardType', () => {
+    const result = GrantRoleInputSchema.safeParse({ userId: 'u1', role: 'tester', boardType: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a global tester grant with boardType omitted', () => {
+    const result = GrantRoleInputSchema.safeParse({ userId: 'u1', role: 'tester' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a board-scoped tester grant', () => {
+    const result = GrantRoleInputSchema.safeParse({ userId: 'u1', role: 'tester', boardType: 'kilter' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['boardType']);
+      expect(result.error.issues[0].message).toBe('Tester role is global and cannot be scoped to a board');
+    }
+  });
+
+  it('still allows a board-scoped admin grant', () => {
+    const result = GrantRoleInputSchema.safeParse({ userId: 'u1', role: 'admin', boardType: 'kilter' });
+    expect(result.success).toBe(true);
+  });
+
+  it('still allows a board-scoped community_leader grant', () => {
+    const result = GrantRoleInputSchema.safeParse({ userId: 'u1', role: 'community_leader', boardType: 'tension' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/__tests__/roles.test.ts
+++ b/packages/backend/src/graphql/resolvers/social/__tests__/roles.test.ts
@@ -1,0 +1,113 @@
+// Auth-gate unit tests for the communityRoles query: admin-only, with the db client mocked.
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+const { dbState } = vi.hoisted(() => ({
+  dbState: { queue: [] as unknown[][], selectCalls: 0 },
+}));
+
+// A minimal Drizzle-style chain: from/where/limit return the chain, and awaiting it
+// at any point dequeues the next seeded result set (one entry per db.select call).
+vi.mock('../../../../db/client', () => {
+  const makeChain = () => {
+    const chain = {
+      from: () => chain,
+      where: () => chain,
+      limit: () => chain,
+      // Deliberately thenable: emulate Drizzle's lazy builder so the queue is only
+      // dequeued when a query is awaited, not when an intermediate link is created.
+      // oxlint-disable-next-line unicorn/no-thenable
+      then: (onFulfilled: (rows: unknown[]) => unknown) =>
+        Promise.resolve(dbState.queue.shift() ?? []).then(onFulfilled),
+    };
+    return chain;
+  };
+  return {
+    db: {
+      select: () => {
+        dbState.selectCalls += 1;
+        return makeChain();
+      },
+    },
+  };
+});
+
+import { socialRoleQueries } from '../roles';
+
+function makeCtx(overrides: Partial<ConnectionContext>): ConnectionContext {
+  return { isAuthenticated: false, ...overrides } as unknown as ConnectionContext;
+}
+
+describe('communityRoles auth gate', () => {
+  beforeEach(() => {
+    dbState.queue = [];
+    dbState.selectCalls = 0;
+  });
+
+  it('rejects an unauthenticated caller before reading any rows', async () => {
+    await expect(socialRoleQueries.communityRoles(null, {}, makeCtx({ isAuthenticated: false }))).rejects.toThrow(
+      'Authentication required to perform this operation',
+    );
+    expect(dbState.selectCalls).toBe(0);
+  });
+
+  it('rejects an authenticated non-admin caller', async () => {
+    dbState.queue = [[]]; // requireAdmin finds no admin row for this user
+    await expect(
+      socialRoleQueries.communityRoles(null, {}, makeCtx({ isAuthenticated: true, userId: 'user-1' })),
+    ).rejects.toThrow('Admin role required for this operation');
+  });
+
+  it('returns the enriched role assignments for an admin caller', async () => {
+    dbState.queue = [
+      [{ role: 'admin', boardType: null }], // requireAdmin: caller is a global admin
+      [
+        {
+          id: 1,
+          userId: 'tester-1',
+          role: 'tester',
+          boardType: null,
+          grantedBy: null,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      ], // the role listing
+      [{ displayName: 'Tester One', avatarUrl: null }], // enrichRoleAssignment profile lookup
+    ];
+
+    const result = await socialRoleQueries.communityRoles(
+      null,
+      {},
+      makeCtx({ isAuthenticated: true, userId: 'admin-1' }),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ userId: 'tester-1', role: 'tester', userDisplayName: 'Tester One' });
+  });
+
+  it('still passes a board-type filter through for an admin caller', async () => {
+    dbState.queue = [
+      [{ role: 'admin', boardType: null }], // requireAdmin: caller is a global admin
+      [
+        {
+          id: 2,
+          userId: 'leader-1',
+          role: 'community_leader',
+          boardType: 'kilter',
+          grantedBy: null,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      ], // the board-scoped listing
+      [{ displayName: 'Kilter Leader', avatarUrl: null }], // enrichRoleAssignment profile lookup
+    ];
+
+    const result = await socialRoleQueries.communityRoles(
+      null,
+      { boardType: 'kilter' },
+      makeCtx({ isAuthenticated: true, userId: 'admin-1' }),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ userId: 'leader-1', role: 'community_leader', boardType: 'kilter' });
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/roles.ts
+++ b/packages/backend/src/graphql/resolvers/social/roles.ts
@@ -98,7 +98,11 @@ async function enrichRoleAssignment(role: typeof dbSchema.communityRoles.$inferS
 }
 
 export const socialRoleQueries = {
-  communityRoles: async (_: unknown, { boardType }: { boardType?: string }, _ctx: ConnectionContext) => {
+  communityRoles: async (_: unknown, { boardType }: { boardType?: string }, ctx: ConnectionContext) => {
+    // Role assignments (including who holds tester) are admin-only — the sole consumer is
+    // the admin role-management screen. Don't let unauthenticated callers enumerate them.
+    await requireAdmin(ctx);
+
     const conditions = boardType ? [eq(dbSchema.communityRoles.boardType, boardType)] : [];
 
     const roles =

--- a/packages/backend/src/validation/schemas/proposals.ts
+++ b/packages/backend/src/validation/schemas/proposals.ts
@@ -60,11 +60,19 @@ export const FreezeClimbInputSchema = z.object({
   reason: z.string().max(500).optional().nullable(),
 });
 
-export const GrantRoleInputSchema = z.object({
-  userId: z.string().min(1, 'User ID cannot be empty'),
-  role: CommunityRoleTypeSchema,
-  boardType: BoardNameSchema.optional().nullable(),
-});
+export const GrantRoleInputSchema = z
+  .object({
+    userId: z.string().min(1, 'User ID cannot be empty'),
+    role: CommunityRoleTypeSchema,
+    boardType: BoardNameSchema.optional().nullable(),
+  })
+  // Tester access is global (userIsTester ignores board scope), so a board-scoped
+  // tester row would be a misleading no-op. Enforce the global invariant here rather
+  // than relying on the admin UI hiding the board picker.
+  .refine((input) => input.role !== 'tester' || input.boardType == null, {
+    message: 'Tester role is global and cannot be scoped to a board',
+    path: ['boardType'],
+  });
 
 export const RevokeRoleInputSchema = z.object({
   userId: z.string().min(1, 'User ID cannot be empty'),

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -150,8 +150,12 @@ export function ChannelSwitcherScreen() {
       const result = await performChannelReset(previousOverride, makeDeps());
       if (result.status === 'failed') {
         hapticError();
+        // The override was re-applied on the failed reset, so the build is still on the
+        // previous channel (or the build channel if there was no override). Say so.
+        const stayedOn = previousOverride ?? buildChannel;
+        const reason = result.error instanceof Error ? result.error.message : 'Could not reset channel.';
         // i18n-ignore-next-line — tester-only screen
-        Alert.alert('Reset failed', result.error instanceof Error ? result.error.message : 'Could not reset channel.');
+        Alert.alert('Reset failed', `${reason} Stayed on "${stayedOn}".`);
       } else {
         setOverride(null);
         if (result.status === 'pending-restart') {

--- a/packages/mobile/src/lib/__tests__/channel-switch.test.ts
+++ b/packages/mobile/src/lib/__tests__/channel-switch.test.ts
@@ -102,14 +102,27 @@ describe('performChannelReset', () => {
     expect(deps.reload).toHaveBeenCalledOnce();
   });
 
-  it('pre-commit failure re-applies the previous override → failed', async () => {
+  it('pre-commit failure re-applies the previous override + mirror → failed', async () => {
     const deps = makeDeps({ checkForUpdate: vi.fn().mockRejectedValue(new Error('offline')) });
     const result = await performChannelReset('preview-2', deps);
 
     expect(result.status).toBe('failed');
     expect(deps.applyOverride).toHaveBeenNthCalledWith(1, null);
     expect(deps.applyOverride).toHaveBeenLastCalledWith('preview-2');
+    // the mirror is restored to the previous channel (not cleared), so display matches native.
+    expect(deps.writeMirror).toHaveBeenCalledWith('preview-2');
     expect(deps.clearMirror).not.toHaveBeenCalled();
+    expect(deps.reload).not.toHaveBeenCalled();
+  });
+
+  it('pre-commit failure with no previous override clears the mirror', async () => {
+    const deps = makeDeps({ checkForUpdate: vi.fn().mockRejectedValue(new Error('offline')) });
+    const result = await performChannelReset(null, deps);
+
+    expect(result.status).toBe('failed');
+    expect(deps.applyOverride).toHaveBeenLastCalledWith(null);
+    expect(deps.clearMirror).toHaveBeenCalledOnce();
+    expect(deps.writeMirror).not.toHaveBeenCalled();
     expect(deps.reload).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/channel-switch.ts
+++ b/packages/mobile/src/lib/channel-switch.ts
@@ -86,7 +86,8 @@ export type ChannelResetResult =
 /**
  * Clear the channel override and return to the build-time channel. Mirrors
  * performChannelSwitch's commit discipline: the mirror is only cleared once we're
- * committed to reloading, and a pre-commit failure re-applies the previous override.
+ * committed to reloading, and a pre-commit failure re-applies the previous override
+ * AND restores the mirror to it, so the display never diverges from the native state.
  */
 export async function performChannelReset(
   previousOverride: string | null,
@@ -109,6 +110,7 @@ export async function performChannelReset(
       return { status: 'pending-restart' };
     }
     deps.applyOverride(previousOverride);
+    await (previousOverride ? deps.writeMirror(previousOverride) : deps.clearMirror()).catch(deps.onMirrorError);
     return { status: 'failed', error };
   }
 }


### PR DESCRIPTION
## Summary

Closes four code-review findings on the tester OTA channel-switcher + community-roles path.

- **Mirror divergence on reset revert (Medium)** — `performChannelReset` re-applied the native expo-updates override on a pre-commit failure but left the AsyncStorage display mirror stale, so the switcher UI could show "no override" while the native side still overrode the channel. It now restores the mirror to the previous channel (or clears it), matching `performChannelSwitch`'s symmetric revert. The test that encoded the bug (`clearMirror not called`) now asserts mirror restoration, plus a new null-override case.
- **Tester grants weren't enforced global (Low)** — `userIsTester` ignores board scope, but a direct `grantRole` API call with `role: tester, boardType: kilter` happily inserted a misleading board-scoped row. `GrantRoleInputSchema` now rejects a non-null `boardType` for tester at the schema level. Board-scoped `admin`/`community_leader` grants are unaffected; `RevokeRoleInputSchema` is left untouched so any legacy rows stay revocable.
- **Misleading "Reset failed" copy (Low)** — the alert now names the channel the build stayed on, since the override is restored on a failed reset.
- **Unauthenticated role enumeration (Info)** — the `communityRoles` query had no auth check; anyone could list every role assignment, including who holds `tester`. It's now gated behind `requireAdmin` (its only consumer is the admin role-management screen, already admin-gated client-side).

## Release Notes

- [x] No release note needed (internal / technical change)

Tester-only dev tooling + backend security/integrity hardening; nothing climber-facing.

## Test plan

- `vp run typecheck:mobile` and `vp run typecheck:backend` — pass.
- `vp test run --project mobile channel-switch` — 12 passed (updated reset-revert + new null-override cases).
- `vp test run --project backend grant-role-validation` — 5 passed (board-scoped tester rejected; global tester + board-scoped admin/leader accepted).
- `vp check` on the changed files — clean (lint + format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018CM7ctsAUGz55zbxvqgauX)_