### PR TITLE
fix(mobile): make Find-a-gym a map-first, draggable screen

### DIFF
--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -28,6 +28,10 @@ import { spacing, borderRadius, shadows } from '../../src/theme/tokens';
 const REGION_DEBOUNCE_MS = 500;
 const MIN_MOVE_DEG = 0.04;
 
+// The floating close button is a fixed square; the "Showing <place>" pill aligns
+// under the search field by clearing the button + the row gap.
+const CLOSE_BUTTON_SIZE = 44;
+
 function movedEnough(a: Coords, b: Coords): boolean {
   const dLat = a.latitude - b.latitude;
   const dLng = a.longitude - b.longitude;
@@ -68,6 +72,18 @@ export default function GymDiscovery() {
 
   // A chosen view (searched or panned) wins; fall back to the device fix.
   const center = viewCenter ?? location.coords;
+
+  // Stable sheet chrome styles so they don't allocate a new object each render.
+  const sheetBackgroundStyle = useMemo(
+    () => ({ backgroundColor: systemColors.secondaryBackground }),
+    [systemColors.secondaryBackground],
+  );
+  const sheetHandleStyle = useMemo(
+    () => ({ backgroundColor: systemColors.tertiaryLabel }),
+    [systemColors.tertiaryLabel],
+  );
+  // Clear the home indicator / gesture bar at the bottom of the list.
+  const listContentStyle = useMemo(() => [styles.list, { paddingBottom: insets.bottom + spacing[6] }], [insets.bottom]);
 
   // Refs mirror state so the stable, debounced region handler reads fresh values
   // without being torn down and rebuilt on every pan.
@@ -238,7 +254,12 @@ export default function GymDiscovery() {
       />
       {isGeocoding ? <ActivityIndicator /> : null}
       {inputText.length > 0 || searchLabel ? (
-        <Pressable onPress={clearSearch} hitSlop={8} accessibilityLabel={t('mobile.gyms.clearSearch')}>
+        <Pressable
+          onPress={clearSearch}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.gyms.clearSearch')}
+        >
           <Icon name="close" size={18} color={systemColors.secondaryLabel} />
         </Pressable>
       ) : null}
@@ -263,7 +284,9 @@ export default function GymDiscovery() {
     </View>
   );
 
-  const screen = <Stack.Screen options={{ title: t('mobile.gyms.title'), headerShown: false }} />;
+  // The root stack hides headers globally; this screen draws its own floating
+  // top bar over the map. The title is kept for the back/breadcrumb affordance.
+  const screen = <Stack.Screen options={{ title: t('mobile.gyms.title') }} />;
 
   // No place to show yet: prompt for location (the search bar above still works
   // for browsing a typed place without granting it).
@@ -318,10 +341,10 @@ export default function GymDiscovery() {
         index={1}
         snapPoints={SNAP_POINTS}
         enablePanDownToClose={false}
-        backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
-        handleIndicatorStyle={{ backgroundColor: systemColors.tertiaryLabel }}
+        backgroundStyle={sheetBackgroundStyle}
+        handleIndicatorStyle={sheetHandleStyle}
       >
-        <BottomSheetScrollView contentContainerStyle={styles.list} showsVerticalScrollIndicator={false}>
+        <BottomSheetScrollView contentContainerStyle={listContentStyle} showsVerticalScrollIndicator={false}>
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
             {t('mobile.gyms.subtitle')}
           </Text>
@@ -433,8 +456,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   closeButton: {
-    width: 44,
-    height: 44,
+    width: CLOSE_BUTTON_SIZE,
+    height: CLOSE_BUTTON_SIZE,
     borderRadius: borderRadius.full,
     alignItems: 'center',
     justifyContent: 'center',
@@ -456,7 +479,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[1],
     borderRadius: borderRadius.full,
-    marginLeft: 44 + spacing[2],
+    marginLeft: CLOSE_BUTTON_SIZE + spacing[2],
   },
   center: {
     flex: 1,
@@ -473,7 +496,6 @@ const styles = StyleSheet.create({
   },
   list: {
     padding: spacing[4],
-    paddingBottom: spacing[8],
     gap: spacing[2],
   },
   sectionLabel: {

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Linking, Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { Linking, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { useNearbyBoards, useNearbyGyms } from '../../src/lib/graphql/hooks';
 import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
@@ -15,39 +17,68 @@ import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
 import { Button } from '../../src/components/Button';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
-import { GymMap, type GymMapMarker } from '../../src/components/gym-directory/GymMap';
-import { spacing, borderRadius } from '../../src/theme/tokens';
+import { GymMap, type GymMapHandle, type GymMapMarker } from '../../src/components/gym-directory/GymMap';
+import { spacing, borderRadius, shadows } from '../../src/theme/tokens';
+
+// How long the camera must be still after a pan before we re-query the new
+// viewport, and how far it must have moved to bother. The radius queried is
+// 50km, so a sub-~4km nudge isn't worth a refetch — and the threshold also
+// absorbs the programmatic camera settle after a place search so it doesn't
+// read as a user pan.
+const REGION_DEBOUNCE_MS = 500;
+const MIN_MOVE_DEG = 0.04;
+
+function movedEnough(a: Coords, b: Coords): boolean {
+  const dLat = a.latitude - b.latitude;
+  const dLng = a.longitude - b.longitude;
+  return dLat * dLat + dLng * dLng >= MIN_MOVE_DEG * MIN_MOVE_DEG;
+}
 
 /**
- * Gym-first board discovery: find a gym (or a standalone board) on the map / in
- * the list and pick its board. The location search bar geocodes a typed place
- * ("Blackheath NSW") so you can browse anywhere — not just your GPS fix — and
- * the same text filters gyms/boards by name. The list is the primary
- * interaction so the flow still works where the native map is blank (Android
- * without a Google Maps key). Selecting a board makes it the active named board.
+ * Gym-first board discovery: a full-screen map with a draggable gym list sheet.
+ * The floating search bar geocodes a typed place ("Blackheath NSW") so you can
+ * browse anywhere — not just your GPS fix — and the same text filters gyms/boards
+ * by name. Panning the map re-queries gyms for the new viewport (debounced, with
+ * the previous results kept on screen so pins/list don't flicker). The list is
+ * the primary interaction, so the flow still works where the native map is blank
+ * (Android without a Google Maps key). Selecting a board makes it active.
  */
 export default function GymDiscovery() {
   const router = useRouter();
   const { t } = useTranslation('boards');
   const { showToast } = useToast();
   const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
   const location = useDeviceLocation();
   const { geocode, isGeocoding } = useGeocodePlace();
   const setActiveBoard = useSetActiveBoard();
   const { returnTo } = useLocalSearchParams<{ returnTo?: string }>();
   const boardReturnTo = resolveBoardReturnTo(returnTo);
   const [expandedGymUuid, setExpandedGymUuid] = useState<string | null>(null);
+  const mapRef = useRef<GymMapHandle>(null);
 
-  // The text in the field vs. the applied filters. `query` is the name filter
-  // sent to the backend; `searchCenter`/`searchLabel` track a geocoded relocate.
-  // Both apply on submit so typing doesn't fire a request per keystroke.
+  // `inputText` is the field; `query` is the applied name filter sent to the
+  // backend; `viewCenter` is the authoritative map/query center (a searched place
+  // or a panned location); `searchLabel` drives the "Showing X" caption. Both
+  // filters apply on submit so typing doesn't fire a request per keystroke.
   const [inputText, setInputText] = useState('');
   const [query, setQuery] = useState('');
-  const [searchCenter, setSearchCenter] = useState<Coords | null>(null);
+  const [viewCenter, setViewCenter] = useState<Coords | null>(null);
   const [searchLabel, setSearchLabel] = useState<string | null>(null);
 
-  // A searched place wins over the device fix; fall back to GPS otherwise.
-  const center = searchCenter ?? location.coords;
+  // A chosen view (searched or panned) wins; fall back to the device fix.
+  const center = viewCenter ?? location.coords;
+
+  // Refs mirror state so the stable, debounced region handler reads fresh values
+  // without being torn down and rebuilt on every pan.
+  const viewCenterRef = useRef(viewCenter);
+  viewCenterRef.current = viewCenter;
+  const locationCoordsRef = useRef(location.coords);
+  locationCoordsRef.current = location.coords;
+  // The target of the last programmatic camera move (place search / reset). The
+  // resulting onCameraMove settle near this point must NOT be read as a user pan.
+  const programmaticTargetRef = useRef<Coords | null>(null);
+  const regionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Ask for location once on mount — the map + nearby queries default to it.
   // Read `request` through a ref so this fires exactly once (the hook is
@@ -57,6 +88,13 @@ export default function GymDiscovery() {
   useEffect(() => {
     void requestLocationRef.current();
   }, []);
+
+  useEffect(
+    () => () => {
+      if (regionTimerRef.current) clearTimeout(regionTimerRef.current);
+    },
+    [],
+  );
 
   const { data: gymConnection, isLoading: gymsLoading } = useNearbyGyms(center, 50, query);
   const { data: boardConnection } = useNearbyBoards(center, 50, query, 50);
@@ -94,6 +132,33 @@ export default function GymDiscovery() {
 
   const boardsForGym = useCallback((gymUuid: string) => boards.filter((board) => board.gymUuid === gymUuid), [boards]);
 
+  // Move the camera to a point we chose (search result / reset) and remember the
+  // target so its settle is ignored by the pan handler.
+  const moveCameraTo = useCallback((coords: Coords) => {
+    programmaticTargetRef.current = coords;
+    mapRef.current?.setCenter(coords);
+  }, []);
+
+  // Debounced: after the map stops moving, decide whether it was a real user pan
+  // (re-query that area) or just the settle from a programmatic move (ignore).
+  const handleRegionChange = useCallback((next: Coords) => {
+    if (regionTimerRef.current) clearTimeout(regionTimerRef.current);
+    regionTimerRef.current = setTimeout(() => {
+      const target = programmaticTargetRef.current;
+      if (target && !movedEnough(next, target)) {
+        programmaticTargetRef.current = null;
+        return; // the camera just settled where we sent it
+      }
+      const effective = viewCenterRef.current ?? locationCoordsRef.current;
+      if (effective && !movedEnough(next, effective)) return; // tiny nudge / mount echo
+      programmaticTargetRef.current = null;
+      // A real pan takes over: this is now where we're browsing, so drop any
+      // "Showing <place>" label and re-query around the new center.
+      setViewCenter(next);
+      setSearchLabel(null);
+    }, REGION_DEBOUNCE_MS);
+  }, []);
+
   const activate = useCallback(
     async (board: UserBoard) => {
       hapticSelection();
@@ -110,75 +175,104 @@ export default function GymDiscovery() {
   // One bar, two jobs: if the text resolves to a place, relocate there and show
   // everything nearby; otherwise treat it as a name filter at the current spot.
   // We deliberately don't AND the two — a place name ("Tokyo") would otherwise
-  // hide every gym not literally named after it. State is set together per
-  // branch (after the await) so the map + queries never flash at a stale center.
+  // hide every gym not literally named after it.
   const onSubmitSearch = useCallback(async () => {
     const text = inputText.trim();
     setExpandedGymUuid(null);
     if (!text) {
-      setSearchCenter(null);
       setSearchLabel(null);
       setQuery('');
       return;
     }
     const coords = await geocode(text);
     if (coords) {
-      setSearchCenter(coords);
+      setViewCenter(coords);
       setSearchLabel(text);
       setQuery('');
+      moveCameraTo(coords);
     } else {
       setQuery(text);
     }
-  }, [inputText, geocode]);
+  }, [inputText, geocode, moveCameraTo]);
 
   // Clear everything and snap back to the device location.
   const clearSearch = useCallback(() => {
     setInputText('');
     setQuery('');
-    setSearchCenter(null);
     setSearchLabel(null);
+    setViewCenter(null);
     setExpandedGymUuid(null);
-  }, []);
+    const deviceCoords = locationCoordsRef.current;
+    if (deviceCoords) moveCameraTo(deviceCoords);
+  }, [moveCameraTo]);
 
-  const screen = <Stack.Screen options={{ title: t('mobile.gyms.title') }} />;
+  const closeScreen = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.dismissTo(boardReturnTo);
+  }, [router, boardReturnTo]);
 
-  const searchBar = (
-    <View style={styles.searchWrap}>
-      <View style={[styles.searchField, { backgroundColor: systemColors.secondaryBackground }]}>
-        <Icon name="search" size={18} color={systemColors.secondaryLabel} />
-        <TextInput
-          value={inputText}
-          onChangeText={setInputText}
-          onSubmitEditing={() => void onSubmitSearch()}
-          placeholder={t('mobile.gyms.searchPlaceholder')}
-          placeholderTextColor={systemColors.tertiaryLabel}
-          style={[styles.searchInput, { color: systemColors.label }]}
-          autoCorrect={false}
-          returnKeyType="search"
-        />
-        {isGeocoding ? <ActivityIndicator /> : null}
-        {inputText.length > 0 || searchLabel ? (
-          <Pressable onPress={clearSearch} hitSlop={8} accessibilityLabel={t('mobile.gyms.clearSearch')}>
-            <Icon name="close" size={18} color={systemColors.secondaryLabel} />
-          </Pressable>
-        ) : null}
-      </View>
-      {searchLabel ? (
-        <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.showingPlace}>
-          {t('mobile.gyms.showingPlace', { place: searchLabel })}
-        </Text>
+  const closeButton = (
+    <Pressable
+      onPress={closeScreen}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={t('mobile.gyms.closeMap')}
+      style={[styles.closeButton, shadows.sm, { backgroundColor: systemColors.secondaryBackground }]}
+    >
+      <Icon name="close" size={20} color={systemColors.label} />
+    </Pressable>
+  );
+
+  const searchField = (
+    <View style={[styles.searchField, shadows.sm, { backgroundColor: systemColors.secondaryBackground }]}>
+      <Icon name="search" size={18} color={systemColors.secondaryLabel} />
+      <TextInput
+        value={inputText}
+        onChangeText={setInputText}
+        onSubmitEditing={() => void onSubmitSearch()}
+        placeholder={t('mobile.gyms.searchPlaceholder')}
+        placeholderTextColor={systemColors.tertiaryLabel}
+        style={[styles.searchInput, { color: systemColors.label }]}
+        autoCorrect={false}
+        returnKeyType="search"
+      />
+      {isGeocoding ? <ActivityIndicator /> : null}
+      {inputText.length > 0 || searchLabel ? (
+        <Pressable onPress={clearSearch} hitSlop={8} accessibilityLabel={t('mobile.gyms.clearSearch')}>
+          <Icon name="close" size={18} color={systemColors.secondaryLabel} />
+        </Pressable>
       ) : null}
     </View>
   );
+
+  // Floating top chrome over the map: close button + search field + place caption.
+  // `box-none` lets pans land on the map in the gaps around the controls.
+  const topBar = (
+    <View style={[styles.topBar, { paddingTop: insets.top + spacing[2] }]} pointerEvents="box-none">
+      <View style={styles.topRow} pointerEvents="box-none">
+        {closeButton}
+        <View style={styles.searchColumn}>{searchField}</View>
+      </View>
+      {searchLabel ? (
+        <View style={[styles.placePill, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('mobile.gyms.showingPlace', { place: searchLabel })}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+
+  const screen = <Stack.Screen options={{ title: t('mobile.gyms.title'), headerShown: false }} />;
 
   // No place to show yet: prompt for location (the search bar above still works
   // for browsing a typed place without granting it).
   if (!center) {
     const waiting = location.status === 'idle' || location.status === 'loading';
     return (
-      <View style={styles.flex}>
+      <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
         {screen}
-        {searchBar}
+        {topBar}
         <View style={styles.center}>
           {waiting ? (
             <ActivityIndicator size="large" />
@@ -210,106 +304,140 @@ export default function GymDiscovery() {
   }
 
   return (
-    <View style={styles.flex}>
+    <View style={[styles.flex, { backgroundColor: systemColors.background }]}>
       {screen}
-      {searchBar}
-      <View style={styles.mapContainer}>
-        <GymMap center={center} markers={markers} />
-      </View>
+      <GymMap
+        ref={mapRef}
+        center={center}
+        markers={markers}
+        onRegionChange={handleRegionChange}
+        style={StyleSheet.absoluteFill}
+      />
 
-      <ScrollView contentContainerStyle={styles.list} showsVerticalScrollIndicator={false}>
-        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
-          {t('mobile.gyms.subtitle')}
-        </Text>
-
-        {gymsLoading && gyms.length === 0 ? <ActivityIndicator style={styles.listSpinner} /> : null}
-
-        {!gymsLoading && gyms.length === 0 ? (
-          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.empty}>
-            {t('mobile.gyms.empty')}
+      <BottomSheet
+        index={1}
+        snapPoints={SNAP_POINTS}
+        enablePanDownToClose={false}
+        backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
+        handleIndicatorStyle={{ backgroundColor: systemColors.tertiaryLabel }}
+      >
+        <BottomSheetScrollView contentContainerStyle={styles.list} showsVerticalScrollIndicator={false}>
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
+            {t('mobile.gyms.subtitle')}
           </Text>
-        ) : null}
 
-        {gyms.map((gym) => {
-          const expanded = expandedGymUuid === gym.uuid;
-          const gymBoards = boardsForGym(gym.uuid);
-          return (
-            <View key={gym.uuid} style={[styles.gymBlock, { borderColor: systemColors.separator }]}>
-              <Pressable onPress={() => setExpandedGymUuid(expanded ? null : gym.uuid)} style={styles.gymRow}>
-                <Icon name="pin" size={20} color={systemColors.label} />
-                <View style={styles.gymText}>
-                  <Text variant="headline">{gym.name}</Text>
-                  <Text variant="subheadline" color={systemColors.secondaryLabel}>
-                    {gym.address ?? t('mobile.gyms.boardCount', { count: gym.boardCount ?? gymBoards.length })}
-                  </Text>
-                </View>
-                <Icon name={expanded ? 'minus' : 'add'} size={20} color={systemColors.tertiaryLabel} />
-              </Pressable>
+          {gymsLoading && gyms.length === 0 ? <ActivityIndicator style={styles.listSpinner} /> : null}
 
-              {expanded ? (
-                gymBoards.length > 0 ? (
-                  gymBoards.map((board) => (
-                    <Pressable
-                      key={board.uuid}
-                      onPress={() => void activate(board)}
-                      style={[styles.boardRow, { borderTopColor: systemColors.separator }]}
-                    >
-                      <Icon name="boards" size={18} color={systemColors.secondaryLabel} />
-                      <View style={styles.gymText}>
-                        <Text variant="subheadline">{board.name}</Text>
-                        <Text variant="caption1" color={systemColors.tertiaryLabel}>
-                          {board.boardType}
-                        </Text>
-                      </View>
-                    </Pressable>
-                  ))
-                ) : (
-                  <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.noBoards}>
-                    {t('mobile.gyms.noBoards')}
-                  </Text>
-                )
-              ) : null}
-            </View>
-          );
-        })}
-
-        {standaloneBoards.length > 0 ? (
-          <>
-            <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
-              {t('mobile.gyms.otherBoardsTitle')}
+          {!gymsLoading && gyms.length === 0 ? (
+            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.empty}>
+              {t('mobile.gyms.empty')}
             </Text>
-            {standaloneBoards.map((board) => (
-              <Pressable
-                key={board.uuid}
-                onPress={() => void activate(board)}
-                style={[styles.gymBlock, styles.standaloneRow, { borderColor: systemColors.separator }]}
-              >
-                <Icon name="boards" size={20} color={systemColors.label} />
-                <View style={styles.gymText}>
-                  <Text variant="headline">{board.name}</Text>
-                  <Text variant="subheadline" color={systemColors.secondaryLabel}>
-                    {board.locationName ?? board.boardType}
-                  </Text>
-                </View>
-                <Icon name="chevron.right" size={18} color={systemColors.tertiaryLabel} />
-              </Pressable>
-            ))}
-          </>
-        ) : null}
-      </ScrollView>
+          ) : null}
+
+          {gyms.map((gym) => {
+            const expanded = expandedGymUuid === gym.uuid;
+            const gymBoards = boardsForGym(gym.uuid);
+            return (
+              <View key={gym.uuid} style={[styles.gymBlock, { borderColor: systemColors.separator }]}>
+                <Pressable onPress={() => setExpandedGymUuid(expanded ? null : gym.uuid)} style={styles.gymRow}>
+                  <Icon name="pin" size={20} color={systemColors.label} />
+                  <View style={styles.gymText}>
+                    <Text variant="headline">{gym.name}</Text>
+                    <Text variant="subheadline" color={systemColors.secondaryLabel}>
+                      {gym.address ?? t('mobile.gyms.boardCount', { count: gym.boardCount ?? gymBoards.length })}
+                    </Text>
+                  </View>
+                  <Icon name={expanded ? 'minus' : 'add'} size={20} color={systemColors.tertiaryLabel} />
+                </Pressable>
+
+                {expanded ? (
+                  gymBoards.length > 0 ? (
+                    gymBoards.map((board) => (
+                      <Pressable
+                        key={board.uuid}
+                        onPress={() => void activate(board)}
+                        style={[styles.boardRow, { borderTopColor: systemColors.separator }]}
+                      >
+                        <Icon name="boards" size={18} color={systemColors.secondaryLabel} />
+                        <View style={styles.gymText}>
+                          <Text variant="subheadline">{board.name}</Text>
+                          <Text variant="caption1" color={systemColors.tertiaryLabel}>
+                            {board.boardType}
+                          </Text>
+                        </View>
+                      </Pressable>
+                    ))
+                  ) : (
+                    <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.noBoards}>
+                      {t('mobile.gyms.noBoards')}
+                    </Text>
+                  )
+                ) : null}
+              </View>
+            );
+          })}
+
+          {standaloneBoards.length > 0 ? (
+            <>
+              <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
+                {t('mobile.gyms.otherBoardsTitle')}
+              </Text>
+              {standaloneBoards.map((board) => (
+                <Pressable
+                  key={board.uuid}
+                  onPress={() => void activate(board)}
+                  style={[styles.gymBlock, styles.standaloneRow, { borderColor: systemColors.separator }]}
+                >
+                  <Icon name="boards" size={20} color={systemColors.label} />
+                  <View style={styles.gymText}>
+                    <Text variant="headline">{board.name}</Text>
+                    <Text variant="subheadline" color={systemColors.secondaryLabel}>
+                      {board.locationName ?? board.boardType}
+                    </Text>
+                  </View>
+                  <Icon name="chevron.right" size={18} color={systemColors.tertiaryLabel} />
+                </Pressable>
+              ))}
+            </>
+          ) : null}
+        </BottomSheetScrollView>
+      </BottomSheet>
+
+      {topBar}
     </View>
   );
 }
+
+// Drag the sheet down to ~a quarter to see a big map; mid is the default; up
+// covers most of the screen for browsing a long list.
+const SNAP_POINTS = ['25%', '55%', '90%'];
 
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
-  searchWrap: {
+  topBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
     paddingHorizontal: spacing[4],
-    paddingTop: spacing[2],
-    paddingBottom: spacing[1],
-    gap: spacing[1],
+    gap: spacing[2],
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  searchColumn: {
+    flex: 1,
+  },
+  closeButton: {
+    width: 44,
+    height: 44,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   searchField: {
     flexDirection: 'row',
@@ -323,8 +451,12 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
   },
-  showingPlace: {
-    paddingHorizontal: spacing[1],
+  placePill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1],
+    borderRadius: borderRadius.full,
+    marginLeft: 44 + spacing[2],
   },
   center: {
     flex: 1,
@@ -338,9 +470,6 @@ const styles = StyleSheet.create({
   },
   centerButton: {
     marginTop: spacing[2],
-  },
-  mapContainer: {
-    height: 260,
   },
   list: {
     padding: spacing[4],

--- a/packages/mobile/src/components/gym-directory/GymMap.tsx
+++ b/packages/mobile/src/components/gym-directory/GymMap.tsx
@@ -1,4 +1,4 @@
-import { Component, forwardRef, memo, useCallback, useImperativeHandle, useRef, type ReactNode } from 'react';
+import { Component, forwardRef, memo, useCallback, useImperativeHandle, useMemo, useRef, type ReactNode } from 'react';
 import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 export type GymMapMarker = {
@@ -89,6 +89,17 @@ const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap
     nativeRef.current = (instance as NativeMapHandle | null) ?? null;
   }, []);
 
+  // Markers only change on a refetch; rebuild the native marker array then, not
+  // on the re-renders a changing `center` prop triggers during a pan.
+  const mapMarkers = useMemo(
+    () =>
+      markers.map((marker) => ({
+        coordinates: { latitude: marker.latitude, longitude: marker.longitude },
+        title: marker.name,
+      })),
+    [markers],
+  );
+
   if (!Maps) return null;
   // requireNativeView can hand back a component that exists in JS but throws on
   // mount when the native side is absent — the boundary above is the real guard;
@@ -100,10 +111,6 @@ const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap
     coordinates: initialCameraRef.current,
     zoom: DEFAULT_ZOOM,
   };
-  const mapMarkers = markers.map((marker) => ({
-    coordinates: { latitude: marker.latitude, longitude: marker.longitude },
-    title: marker.name,
-  }));
 
   // expo-maps types the camera coordinates as optional; only forward a complete
   // pair so the screen never re-queries around a half-defined center.

--- a/packages/mobile/src/components/gym-directory/GymMap.tsx
+++ b/packages/mobile/src/components/gym-directory/GymMap.tsx
@@ -1,4 +1,4 @@
-import { Component, memo, type ReactNode } from 'react';
+import { Component, forwardRef, memo, useCallback, useImperativeHandle, useRef, type ReactNode } from 'react';
 import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 export type GymMapMarker = {
@@ -8,11 +8,30 @@ export type GymMapMarker = {
   name: string;
 };
 
+type LatLng = { latitude: number; longitude: number };
+
+/** Imperative handle so the screen can recenter the camera on a place search. */
+export type GymMapHandle = {
+  setCenter: (coords: LatLng) => void;
+};
+
 type GymMapProps = {
-  center: { latitude: number; longitude: number };
+  center: LatLng;
   markers: GymMapMarker[];
+  // Fired (already debounced upstream) when the user pans/zooms the map, so the
+  // screen can re-query gyms for the new viewport.
+  onRegionChange?: (center: LatLng) => void;
   style?: StyleProp<ViewStyle>;
 };
+
+// The slice of the native expo-maps view ref we use. Both AppleMaps.View and
+// GoogleMaps.View expose `setCameraPosition`; typing it narrowly avoids leaking
+// platform-specific handle types up to callers.
+type NativeMapHandle = {
+  setCameraPosition?: (config: { coordinates: LatLng; zoom?: number }) => void;
+};
+
+const DEFAULT_ZOOM = 10;
 
 // Lazy-require so a native build that predates the expo-maps module degrades to
 // "no map" instead of crashing. The gym list is the primary interaction, so a
@@ -43,7 +62,33 @@ class MapErrorBoundary extends Component<{ children: ReactNode }, { failed: bool
   }
 }
 
-function NativeGymMap({ center, markers, style }: GymMapProps) {
+const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap(
+  { center, markers, onRegionChange, style },
+  ref,
+) {
+  // Keep a ref to the native view so the imperative handle can drive the camera.
+  const nativeRef = useRef<NativeMapHandle | null>(null);
+  // The camera position is *initial-only*: capture the first center so parent
+  // re-renders (and the panned query center) never snap the camera back while
+  // the user is dragging. Search relocations go through the imperative handle.
+  const initialCameraRef = useRef(center);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setCenter: (coords: LatLng) => {
+        nativeRef.current?.setCameraPosition?.({ coordinates: coords, zoom: DEFAULT_ZOOM });
+      },
+    }),
+    [],
+  );
+
+  // A callback ref typed against `unknown` is assignable to either platform
+  // view's ref slot (params are contravariant) without an explicit cast.
+  const assignNativeRef = useCallback((instance: unknown) => {
+    nativeRef.current = (instance as NativeMapHandle | null) ?? null;
+  }, []);
+
   if (!Maps) return null;
   // requireNativeView can hand back a component that exists in JS but throws on
   // mount when the native side is absent — the boundary above is the real guard;
@@ -52,31 +97,52 @@ function NativeGymMap({ center, markers, style }: GymMapProps) {
   if (!MapView) return null;
 
   const cameraPosition = {
-    coordinates: { latitude: center.latitude, longitude: center.longitude },
-    zoom: 10,
+    coordinates: initialCameraRef.current,
+    zoom: DEFAULT_ZOOM,
   };
   const mapMarkers = markers.map((marker) => ({
     coordinates: { latitude: marker.latitude, longitude: marker.longitude },
     title: marker.name,
   }));
 
-  return <MapView style={[styles.map, style]} cameraPosition={cameraPosition} markers={mapMarkers} />;
-}
+  // expo-maps types the camera coordinates as optional; only forward a complete
+  // pair so the screen never re-queries around a half-defined center.
+  const handleCameraMove = onRegionChange
+    ? (event: { coordinates: { latitude?: number; longitude?: number } }) => {
+        const { latitude, longitude } = event.coordinates;
+        if (latitude != null && longitude != null) onRegionChange({ latitude, longitude });
+      }
+    : undefined;
+
+  return (
+    <MapView
+      ref={assignNativeRef}
+      style={[styles.map, style]}
+      cameraPosition={cameraPosition}
+      markers={mapMarkers}
+      onCameraMove={handleCameraMove}
+    />
+  );
+});
 
 /**
  * Renders nearby gyms as pins on the platform map (Apple Maps on iOS, Google
  * Maps on Android — the latter needs GOOGLE_MAPS_API_KEY + a native build, else
  * blank). Marker taps aren't wired: selection happens in the gym list so the
  * flow works identically whether or not the map renders, and a missing/broken
- * native map never crashes the screen.
+ * native map never crashes the screen. Panning the map fires `onRegionChange`;
+ * a place search drives the camera via the {@link GymMapHandle} ref. Both no-op
+ * when the native map is unavailable, so the list-only fallback still works.
  */
-export const GymMap = memo(function GymMap({ center, markers, style }: GymMapProps) {
-  return (
-    <MapErrorBoundary>
-      <NativeGymMap center={center} markers={markers} style={style} />
-    </MapErrorBoundary>
-  );
-});
+export const GymMap = memo(
+  forwardRef<GymMapHandle, GymMapProps>(function GymMap({ center, markers, onRegionChange, style }, ref) {
+    return (
+      <MapErrorBoundary>
+        <NativeGymMap ref={ref} center={center} markers={markers} onRegionChange={onRegionChange} style={style} />
+      </MapErrorBoundary>
+    );
+  }),
+);
 
 const styles = StyleSheet.create({
   map: {

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -8,6 +8,7 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 const cfg = vi.hoisted(() => ({
   onClimbsTab: true,
   insideTabs: true,
+  onGymDiscovery: false,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
   wallClimb: null as null | { uuid: string; angle: number },
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
@@ -47,6 +48,7 @@ vi.mock('expo-router', () => ({ useSegments: () => [] }));
 vi.mock('../../../lib/route-segments', () => ({
   isClimbsTabRoute: () => cfg.onClimbsTab,
   isTabsRoute: () => cfg.insideTabs,
+  isGymDiscoveryRoute: () => cfg.onGymDiscovery,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
@@ -131,6 +133,7 @@ describe('PersistentQueueBar', () => {
   beforeEach(() => {
     cfg.onClimbsTab = true;
     cfg.insideTabs = true;
+    cfg.onGymDiscovery = false;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
     cfg.wallClimb = null;
     cfg.variant = 'liquidGlass';
@@ -149,6 +152,15 @@ describe('PersistentQueueBar', () => {
     const { container } = render(<PersistentQueueBar />);
     expect(container.querySelector('[data-capsule]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).not.toBeNull();
+  });
+
+  it('renders nothing on the gym-discovery map route', () => {
+    // The /gyms screen is a full-bleed map with its own bottom sheet, so the
+    // climb accessory is suppressed there even with a current climb.
+    cfg.onGymDiscovery = true;
+    const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
   });
 
   it('does not render the JS toolbar when the native bottom accessory is active', () => {

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -16,10 +16,12 @@
  * pair, so `jsQueueToolbarVisible` is false here and this returns null.
  */
 
+import { useSegments } from 'expo-router';
 import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, glassSize } from '../../theme/layout';
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
+import { isGymDiscoveryRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
@@ -34,11 +36,15 @@ export { TOOLBAR_RESERVE, TAB_BAR_HEIGHT };
 export function PersistentQueueBar() {
   const { state } = useQueue();
   const { variant } = useTheme();
+  const segments = useSegments();
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
 
   if (!currentClimb) return null;
+  // The gym-discovery screen is a full-bleed map with its own bottom sheet — the
+  // climb accessory would overlap it, so suppress it there.
+  if (isGymDiscoveryRoute(segments)) return null;
   if (!bottomChrome.jsQueueToolbarVisible && bottomChrome.nativeAccessoryMounted) return null;
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import type {
   UserBoard,
   UserBoardConnection,
@@ -236,6 +236,11 @@ export function useNearbyBoards(
       }),
     select: (data) => data.searchBoards,
     enabled: coords !== null,
+    // Keep the previous boards visible while a new center/filter loads so the
+    // gym-finder map doesn't blank its pins/list on every pan (the queryKey
+    // changes when `coords` moves). Harmless for the "Near you" carousel, whose
+    // key rarely changes.
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -249,6 +254,9 @@ export function useNearbyGyms(coords: { latitude: number; longitude: number } | 
       }),
     select: (data) => data.searchGyms,
     enabled: coords !== null,
+    // See useNearbyBoards: keep prior gyms on screen while a panned center
+    // refetches so markers/list don't flicker.
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -11,6 +11,7 @@ type Segments = readonly string[];
 
 const TABS_GROUP = '(tabs)';
 const CLIMBS_TAB = 'climbs';
+const GYMS_ROUTE = 'gyms';
 
 /** True when the focused route lives inside the bottom-tab navigator. */
 export function isTabsRoute(segments: Segments): boolean {
@@ -20,4 +21,13 @@ export function isTabsRoute(segments: Segments): boolean {
 /** True when the focused route is the Climbs tab (or one of its sub-routes). */
 export function isClimbsTabRoute(segments: Segments): boolean {
   return segments[0] === TABS_GROUP && segments[1] === CLIMBS_TAB;
+}
+
+/**
+ * True when the focused route is the gym-discovery map screen (`/gyms`). The
+ * map owns the whole screen there, so the persistent climb accessory is hidden
+ * to keep it from overlapping the map + bottom sheet.
+ */
+export function isGymDiscoveryRoute(segments: Segments): boolean {
+  return segments[0] === GYMS_ROUTE;
 }

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -140,6 +140,7 @@
       "searchPlaceholder": "Search a city, gym, or board",
       "showingPlace": "Showing {{place}}",
       "clearSearch": "Clear search",
+      "closeMap": "Close",
       "otherBoardsTitle": "Boards nearby"
     }
   },

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -140,6 +140,7 @@
       "searchPlaceholder": "Busca una ciudad, gimnasio o tabla",
       "showingPlace": "Mostrando {{place}}",
       "clearSearch": "Borrar búsqueda",
+      "closeMap": "Cerrar",
       "otherBoardsTitle": "Tablas cercanas"
     }
   },

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -140,6 +140,7 @@
       "searchPlaceholder": "Rechercher une ville, une salle ou un mur",
       "showingPlace": "Résultats pour {{place}}",
       "clearSearch": "Effacer la recherche",
+      "closeMap": "Fermer",
       "otherBoardsTitle": "Murs à proximité"
     }
   },


### PR DESCRIPTION
## Summary

Rebuilds the **Find a gym** screen (`/gyms`) around the map and fixes the Android problems reported on it (search bar unreachable under the status bar, no way to close it, panning didn't update results, the climb bar overlapped, fixed-height map).

- **Search bar reachable on Android.** The screen has no native header (`headerShown: false` globally), so the search field sat in the status-bar unsafe area. It now floats over the map in a top bar padded by the top safe-area inset, alongside a round close button.
- **Pan to explore.** `GymMap` reports camera moves (`onCameraMove`, debounced with a distance threshold and a programmatic-move guard so a place search doesn't loop back into a re-query). The nearby hooks use `placeholderData: keepPreviousData`, so pins and the list stay on screen while the new area loads — no flicker.
- **Draggable map.** The gym list moved into a `@gorhom/bottom-sheet` over a full-screen map (snap 25% / 55% / 90%); dragging the sheet down enlarges the map.
- **No climb accessory here.** `PersistentQueueBar` is suppressed on the gyms route via a new `isGymDiscoveryRoute` helper, so it no longer overlaps the map + sheet.

Search-as-name-filter, place geocoding, the "Showing <place>" caption, the location-permission empty state, and board activation all keep working.

## Release Notes

- Find a gym on a full-screen map you can drag to resize, pan to explore new areas, and search by city — board picking right from the map.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp check` — format + lint clean (changed files)
- `vp run test:mobile` — 2552 passed (added a case asserting the climb bar hides on `/gyms`)
- `vp run check:mobile-bundle` — Android bundle OK (11.1 MB)
- Manual QA on Android via Metro: search bar tappable below the status bar; close button dismisses; pan re-queries without flicker; place search flies the camera and the caption clears on pan; sheet drag resizes the map; climb accessory absent on this screen; gym → board activation still dismisses to the return tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP1ZYq4gX8TzpFniQKACBz