### PR TITLE
fix(mobile): stop counting OAuth cancels & recoverable throws as login failures

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -186,13 +186,21 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
     expect(trackedEvents()).toContainEqual({ event: 'Login Succeeded', flow: 'web_fallback', reason: undefined });
   });
 
-  it('does NOT fall back when the user cancels native Apple', async () => {
+  it('does NOT fall back when the user cancels native Apple, and logs a cancel (not a failure)', async () => {
     signInWithAppleMock.mockResolvedValue({ success: false, cancelled: true });
 
     await runSignIn('apple');
 
     expect(signInWithAppleWebMock).not.toHaveBeenCalled();
     expect(reportErrorMock).not.toHaveBeenCalled();
+    const events = trackedEvents();
+    expect(events).toContainEqual({
+      event: 'Login Cancelled',
+      flow: 'native',
+      reason: undefined,
+      recoverable: undefined,
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed' }));
   });
 
   it('stays silent (no error, no report) when the browser Apple sheet is cancelled', async () => {

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -36,12 +36,13 @@ vi.mock('react-native', () => ({ Platform: platform }));
 
 const { useNativeOAuthSignIn } = await import('../use-native-oauth-sign-in');
 
-type TrackedEvent = { event: unknown; flow: unknown; reason: unknown };
+type TrackedEvent = { event: unknown; flow: unknown; reason: unknown; recoverable: unknown };
 function trackedEvents(): TrackedEvent[] {
   return trackMock.mock.calls.map(([event, props]) => ({
     event,
     flow: (props as { flow?: unknown })?.flow,
     reason: (props as { failure_reason?: unknown })?.failure_reason,
+    recoverable: (props as { recoverable?: unknown })?.recoverable,
   }));
 }
 
@@ -75,8 +76,20 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
     expect(reportErrorMock).not.toHaveBeenCalled();
     expect(setError).toHaveBeenLastCalledWith(null);
     const events = trackedEvents();
-    expect(events).toContainEqual({ event: 'Login Attempted', flow: 'web_fallback', reason: undefined });
-    expect(events).toContainEqual({ event: 'Login Succeeded', flow: 'web_fallback', reason: undefined });
+    expect(events).toContainEqual({
+      event: 'Login Attempted',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+    });
+    expect(events).toContainEqual({
+      event: 'Login Succeeded',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+    });
+    // The native throw is logged recoverable on iOS so the failure metric excludes it.
+    expect(events).toContainEqual({ event: 'Login Failed', flow: 'native', reason: 'exception', recoverable: true });
   });
 
   it('falls back when native Google returns a non-cancel failure', async () => {
@@ -86,15 +99,30 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
     await runSignIn('google');
 
     expect(signInWithGoogleWebMock).toHaveBeenCalledTimes(1);
+    // The native backend failure is recoverable on iOS (the fallback runs next).
+    expect(trackedEvents()).toContainEqual({
+      event: 'Login Failed',
+      flow: 'native',
+      reason: 'invalid_oauth_token',
+      recoverable: true,
+    });
   });
 
-  it('does NOT fall back when the user cancels native Google', async () => {
+  it('does NOT fall back when the user cancels native Google, and logs a cancel (not a failure)', async () => {
     signInWithGoogleMock.mockResolvedValue({ success: false, cancelled: true });
 
     await runSignIn('google');
 
     expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
     expect(reportErrorMock).not.toHaveBeenCalled();
+    const events = trackedEvents();
+    expect(events).toContainEqual({
+      event: 'Login Cancelled',
+      flow: 'native',
+      reason: undefined,
+      recoverable: undefined,
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed' }));
   });
 
   it('surfaces an error and reports once when the web fallback also fails', async () => {
@@ -179,7 +207,15 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
     expect(reportErrorMock).not.toHaveBeenCalled();
     // setError(null) at the start; never set to an error message.
     expect(setError).not.toHaveBeenCalledWith('nativeStart.oauthError');
-    expect(trackedEvents()).toContainEqual({ event: 'Login Failed', flow: 'web_fallback', reason: 'cancel' });
+    // A browser cancel is logged as a distinct event, not a LoginFailed.
+    const events = trackedEvents();
+    expect(events).toContainEqual({
+      event: 'Login Cancelled',
+      flow: 'web_fallback',
+      reason: undefined,
+      recoverable: undefined,
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed', flow: 'web_fallback' }));
   });
 
   it('surfaces an error and reports once when the Apple web fallback also fails', async () => {
@@ -228,6 +264,13 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
       }),
     );
     expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
+    // No fallback on Android, so the native throw is terminal, not recoverable.
+    expect(trackedEvents()).toContainEqual({
+      event: 'Login Failed',
+      flow: 'native',
+      reason: 'exception',
+      recoverable: false,
+    });
   });
 
   it('surfaces the native error (no fallback) when Google returns a non-cancel failure', async () => {
@@ -240,13 +283,21 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
     expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
   });
 
-  it('does NOT fall back or error when the user cancels native Google', async () => {
+  it('does NOT fall back or error when the user cancels native Google, and logs a cancel', async () => {
     signInWithGoogleMock.mockResolvedValue({ success: false, cancelled: true });
 
     await runSignIn('google');
 
     expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
     expect(reportErrorMock).not.toHaveBeenCalled();
+    const events = trackedEvents();
+    expect(events).toContainEqual({
+      event: 'Login Cancelled',
+      flow: 'native',
+      reason: undefined,
+      recoverable: undefined,
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed' }));
   });
 
   it('does not run the Apple web fallback on Android (the iOS gate holds)', async () => {

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -91,11 +91,11 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           return;
         }
         if ('cancelled' in fallback) {
-          // The user dismissed the browser — not an error, no message shown.
-          track(SHARED_EVENTS.LoginFailed, {
+          // The user dismissed the browser — intent, not a failure. A distinct
+          // event keeps it out of the LoginFailed count.
+          track(SHARED_EVENTS.LoginCancelled, {
             auth_method: provider,
             flow: 'web_fallback',
-            failure_reason: 'cancel',
             duration_ms: Date.now() - fallbackStartedAt,
             ...registrationProps,
           });
@@ -126,23 +126,27 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           return;
         }
         if ('cancelled' in result) {
-          // The user dismissed the provider sheet — not an error, no message shown.
-          track(SHARED_EVENTS.LoginFailed, {
+          // The user dismissed the provider sheet — intent, not a failure. A
+          // distinct event keeps it out of the LoginFailed count.
+          track(SHARED_EVENTS.LoginCancelled, {
             auth_method: provider,
             flow: 'native',
-            failure_reason: 'cancel',
             duration_ms: Date.now() - attemptStartedAt,
             ...registrationProps,
           });
           return;
         }
-        // A real backend/token failure carrying the server's status + error.
+        // A real backend/token failure carrying the server's status + error. On
+        // iOS the browser fallback runs next, so this native failure is
+        // recoverable and shouldn't count toward the terminal failure metric;
+        // on Android it dead-ends and is terminal.
         const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
           flow: 'native',
           failure_reason: oauthFailureReason,
           failure_detail: result.error,
+          recoverable: Platform.OS === 'ios',
           duration_ms: Date.now() - attemptStartedAt,
           ...registrationProps,
         });
@@ -168,11 +172,14 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
         // signing/client-id mismatch, …). Prefer the native `.code` for
         // failure_detail — far more actionable than the opaque message.
         const nativeErrorCode = nativeSignInErrorCode(oauthError);
+        // On iOS the browser fallback runs next (recoverable); on Android the
+        // native throw dead-ends and is terminal.
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
           flow: 'native',
           failure_reason: 'exception',
           failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
+          recoverable: Platform.OS === 'ios',
           duration_ms: Date.now() - attemptStartedAt,
           ...registrationProps,
         });

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -12,6 +12,9 @@ export const SHARED_EVENTS = {
   LoginAttempted: 'Login Attempted',
   LoginSucceeded: 'Login Succeeded',
   LoginFailed: 'Login Failed',
+  // A user dismissing the provider sheet or the browser is intent, not a failure.
+  // Kept distinct from LoginFailed so the failure metric isn't inflated by cancels.
+  LoginCancelled: 'Login Cancelled',
   Logout: 'Logout',
   // Queue / session
   AddToQueue: 'Add to Queue',


### PR DESCRIPTION
## Summary

The React Native **"Login Failed"** PostHog metric spiked to ~200/day starting 2026-06-14, but **no user reported a login problem**. Investigation (PostHog project 412845 + the code) found the metric counts **events, not users**, and a single broken-or-cancelled iOS OAuth tap fires **2–3** `Login Failed` events:

- In the 06-14 week, **246 unique users attempted, 189 (77%) succeeded**, yet only **35 unique users** produced the **~339 `exception` events** (~10 retries each).
- Inflators: (1) iOS 26.5.1 native Google/Apple OAuth throws on app 2.0.0 — each logs a `Login Failed (exception)`; (2) the iOS browser fallback meant to rescue them has a **0% success rate** (0/124), logging a second `Login Failed (cancel)`; (3) user cancellations (dismissing the sheet/browser) are logged as `Login Failed (cancel)`, ~157/week.

This PR makes the metric honest **without changing login behaviour**:

- **Cancels are no longer failures.** Dismissing the provider sheet or the browser fallback now fires a distinct **`Login Cancelled`** event (`@boardsesh/analytics` `SHARED_EVENTS`), not `Login Failed (cancel)`.
- **Recoverable native throws are tagged.** iOS native OAuth failures/throws (which the browser fallback handles next) carry `recoverable: true`; on Android they stay terminal (`recoverable: false`). The failure metric can then exclude `recoverable = true`.

The PostHog reliability insights (`[Reliability] Login outcomes per day` `1LQgqVWM` and its sibling `1vWdXf5k` on dashboard `1693744`) will be rebuilt to a unique-user funnel that separates terminal failures from cancels/recoverable throws — done in PostHog, no code dependency.

**Out of scope (tracked separately):** the real iOS 26.5.1 native OAuth break and the 0%-success browser fallback (`auth.ts` `signInWithProviderWeb`) — that's the genuine user-facing degradation. Expected user errors (`invalid_credentials`, registration 409) still emit `Login Failed`; they can be excluded at the insight level later.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2552 tests pass; `use-native-oauth-sign-in.test.tsx` updated to assert `Login Cancelled` on sheet/browser dismissal and `recoverable: true/false` on native throws (iOS/Android)
- `vp check` — lint/format clean on changed files
- `vp run check:mobile-bundle` — Metro bundle OK
- Ships JS-only via the production OTA pipeline on merge to `main`; the new `Login Cancelled` / `recoverable` signals appear once the OTA lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCUotBVjLgFyBZkBhYeYGF