### PR TITLE
fix(mobile): restore Android Google web-OAuth fallback so native failures don't dead-end login

### DIFF
--- a/docs/android-sideload-build.md
+++ b/docs/android-sideload-build.md
@@ -188,9 +188,8 @@ signed the running APK** is registered as an Android OAuth client, in the same
 Google Cloud project as the `webClientId` the app ships
 (`401523882502-…`, project **401523882502**).
 
-If it isn't, `GoogleSignin.signIn()` fails **before any network call** — so the
-backend never logs anything, and the login screen shows the generic "Sign in
-didn't complete." (The classic Play Services flow reported this as
+If it isn't, `GoogleSignin.signIn()` fails **before any network call**, so the
+backend never logs anything. (The classic Play Services flow reported this as
 `DEVELOPER_ERROR` / status 10; the Credential Manager flow in current
 `@react-native-google-signin` surfaces an unmapped error instead, which is why
 the code below keys off "not a known status code" rather than a specific code.)
@@ -198,16 +197,26 @@ the code below keys off "not a known status code" rather than a specific code.)
 `native_error_code`, and a local dev build prints a hint — see
 `nativeSignInErrorCode` in `packages/mobile/src/lib/native-auth-analytics.ts`.
 
-**Spotting it in PostHog.** This lands in error tracking as a handled exception
-tagged `source: native-auth`, `provider: google` — message `DEVELOPER_ERROR` on
-the classic flow, or a generic `Error` with the troubleshooting URL on the
-Credential Manager flow. It was the single highest-volume mobile issue in June
-2026 (163 occurrences, 11 users). A spike here is almost always an unregistered
-signing key, not a code regression — it can't be fixed in-repo. Work the table
-below: enumerate every key currently shipping `com.boardsesh.app`, confirm each
-SHA-1 has an Android OAuth client in project **401523882502**, and add any that's
-missing. (Because handled exceptions without a JS stack group together, that same
-PostHog issue can also absorb unrelated handled errors — filter to
+The native failure no longer dead-ends the user: `useNativeOAuthSignIn` then runs
+the browser-OAuth fallback (the web NextAuth handoff, which doesn't touch the
+native SDK and so isn't affected by the SHA-1 gap), and only shows "Sign in didn't
+complete" if that also fails. Registering the SHA-1 is still the real fix — the
+fallback is recovery, not a substitute.
+
+**Spotting it in PostHog.** The native failure always lands as a `Login Failed`
+analytics event tagged `flow: native`, `auth_method: google`, with the native code
+in `failure_detail` (`DEVELOPER_ERROR` on the classic flow, an unmapped `Error` on
+the Credential Manager flow) — so a spike is visible there even when the browser
+fallback recovers the user. It only reaches **error tracking** as a handled
+exception when the fallback _also_ fails, and then it's tagged `flow: web_fallback`,
+`source: native-auth`, `provider: google` (before #3083/#3100 the native throw was
+reported directly under `flow: native`). It was the single highest-volume mobile
+issue in June 2026 (163 occurrences, 11 users). A spike is almost always an
+unregistered signing key, not a code regression — it can't be fixed in-repo. Work
+the table below: enumerate every key currently shipping `com.boardsesh.app`,
+confirm each SHA-1 has an Android OAuth client in project **401523882502**, and add
+any that's missing. (Because handled exceptions without a JS stack group together,
+that same PostHog issue can also absorb unrelated handled errors — filter to
 `source = native-auth` rather than reading the whole bucket as Google Sign-In.)
 
 `com.boardsesh.app` is signed by up to three different keys, each needing its own

--- a/packages/mobile/app/+native-intent.ts
+++ b/packages/mobile/app/+native-intent.ts
@@ -9,6 +9,22 @@ import { getShareExtensionKey } from 'expo-share-intent';
 // through an ACTION_SEND intent (no deep-link path), so it falls through here
 // unchanged and the provider handles it the same way.
 export function redirectSystemPath({ path, initial }: { path: string; initial: boolean }): string {
+  // The browser-OAuth fallback (signInWithProviderWeb) redirects to
+  // com.boardsesh.app://auth/callback?… On Android that redirect arrives as a real
+  // OS deep link *in addition to* being captured by openAuthSessionAsync's own
+  // Linking listener, and the fallback handler already owns the result inline (token
+  // exchange on success, a translated error on the login/register screen on
+  // failure). If Expo Router also routes it, the unmatched path hits +not-found and
+  // redirects to home — tearing the auth screen down before the error can show.
+  // Return '' so Expo Router skips that navigation: success still lands on home (the
+  // auth state flips and the root layout redirects), and failure surfaces on the
+  // still-mounted screen — exactly how iOS behaves, where ASWebAuthenticationSession
+  // consumes the redirect and it never becomes a deep link. The fallback only runs
+  // with the app foregrounded, so this is always a warm intent; a stale cold-start
+  // intent (initial) falls through to the app's normal initial route.
+  if (path.includes('auth/callback')) {
+    return '';
+  }
   try {
     if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
       // Cold start (initial): bootstrap to the home route — the ShareTargetProvider

--- a/packages/mobile/app/+native-intent.ts
+++ b/packages/mobile/app/+native-intent.ts
@@ -1,5 +1,10 @@
 import { getShareExtensionKey } from 'expo-share-intent';
 
+// The OAuth fallback callback — com.boardsesh.app://auth/callback?… or the
+// normalized /auth/callback?… form — anchored to the path segment so it can't catch
+// an unrelated route that merely contains the substring (e.g. /admin/auth/callback-debug).
+const OAUTH_CALLBACK_PATH = /(^|\/)auth\/callback(\?|$)/;
+
 // Expo Router's redirect hook for OS-level deep links. The iOS Share Extension
 // (expo-share-intent) opens the app via a synthetic `com.boardsesh.app://...
 // dataUrl=<key>` URL; without this redirect Expo Router treats that as an
@@ -19,10 +24,12 @@ export function redirectSystemPath({ path, initial }: { path: string; initial: b
   // Return '' so Expo Router skips that navigation: success still lands on home (the
   // auth state flips and the root layout redirects), and failure surfaces on the
   // still-mounted screen — exactly how iOS behaves, where ASWebAuthenticationSession
-  // consumes the redirect and it never becomes a deep link. The fallback only runs
-  // with the app foregrounded, so this is always a warm intent; a stale cold-start
-  // intent (initial) falls through to the app's normal initial route.
-  if (path.includes('auth/callback')) {
+  // consumes the redirect and it never becomes a deep link. Only for a *warm* intent:
+  // the fallback always runs foregrounded, and '' isn't a safe cold-start
+  // destination (the share branch returns '/' on cold start for the same reason). A
+  // stale cold-start auth/callback intent (no exchange in flight) falls through to
+  // normal routing → +not-found → home instead.
+  if (!initial && OAUTH_CALLBACK_PATH.test(path)) {
     return '';
   }
   try {

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -27,12 +27,8 @@ vi.mock('../../lib/error-reporting', () => ({ reportError: (...args: unknown[]) 
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-// The hook reads Platform.OS to gate the browser web fallback (Google + Apple)
-// to iOS. A mutable hoisted ref lets each test flip the platform (default iOS,
-// where the fallback lives); the real react-native module is too heavy to load
-// under jsdom.
-const { platform } = vi.hoisted(() => ({ platform: { OS: 'ios' } as { OS: string } }));
-vi.mock('react-native', () => ({ Platform: platform }));
+// The browser web fallback is the recovery path on every platform (it used to be
+// iOS-only), so the hook no longer reads Platform.OS — no react-native mock needed.
 
 const { useNativeOAuthSignIn } = await import('../use-native-oauth-sign-in');
 
@@ -46,6 +42,12 @@ function trackedEvents(): TrackedEvent[] {
   }));
 }
 
+// The full props of every tracked event — for assertions that need a field
+// trackedEvents() doesn't surface, like failure_detail.
+function trackedProps(): Record<string, unknown>[] {
+  return trackMock.mock.calls.map(([, props]) => props as Record<string, unknown>);
+}
+
 async function runSignIn(provider: 'google' | 'apple', setError = vi.fn()) {
   const { result } = renderHook(() => useNativeOAuthSignIn({ setError }));
   await act(async () => {
@@ -54,9 +56,8 @@ async function runSignIn(provider: 'google' | 'apple', setError = vi.fn()) {
   return setError;
 }
 
-describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
+describe('useNativeOAuthSignIn — Google web fallback', () => {
   beforeEach(() => {
-    platform.OS = 'ios';
     trackMock.mockReset();
     reportErrorMock.mockReset();
     signInWithAppleMock.mockReset();
@@ -145,9 +146,8 @@ describe('useNativeOAuthSignIn — Google web fallback (iOS)', () => {
   });
 });
 
-describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
+describe('useNativeOAuthSignIn — Apple web fallback', () => {
   beforeEach(() => {
-    platform.OS = 'ios';
     trackMock.mockReset();
     reportErrorMock.mockReset();
     signInWithAppleMock.mockReset();
@@ -246,9 +246,13 @@ describe('useNativeOAuthSignIn — Apple web fallback (iOS)', () => {
   });
 });
 
-describe('useNativeOAuthSignIn — Android has no web fallback', () => {
+// The Android-specific failure mode #3100 fixes: a native Google
+// DEVELOPER_ERROR (the running build's signing-cert SHA-1 isn't registered) used
+// to dead-end login after #3083 gated the browser fallback to iOS. The fallback
+// now runs on Android too, so the user recovers — while the native failure stays
+// visible in analytics so the underlying SHA-1 misconfig is still measurable.
+describe('useNativeOAuthSignIn — Android Google web fallback (DEVELOPER_ERROR recovery)', () => {
   beforeEach(() => {
-    platform.OS = 'android';
     trackMock.mockReset();
     reportErrorMock.mockReset();
     signInWithAppleMock.mockReset();
@@ -257,38 +261,43 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
     signInWithAppleWebMock.mockReset();
   });
 
-  it('surfaces the native error (no fallback) when Google throws — the SHA-1/DEVELOPER_ERROR case', async () => {
+  it('recovers via the web flow when native Google throws DEVELOPER_ERROR — and still records it', async () => {
     signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('developer error'), { code: 'DEVELOPER_ERROR' }));
+    signInWithGoogleWebMock.mockResolvedValue({ success: true });
 
     const setError = await runSignIn('google');
 
-    expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
-    // Reported once, tagged with the native code so PostHog records DEVELOPER_ERROR.
-    expect(reportErrorMock).toHaveBeenCalledTimes(1);
-    expect(reportErrorMock).toHaveBeenCalledWith(
-      expect.any(Error),
-      expect.objectContaining({
-        tags: expect.objectContaining({ provider: 'google', flow: 'native', native_error_code: 'DEVELOPER_ERROR' }),
-      }),
+    expect(signInWithGoogleWebMock).toHaveBeenCalledTimes(1);
+    // The browser recovered the user — no dead-end exception report.
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenLastCalledWith(null);
+    const events = trackedEvents();
+    expect(events).toContainEqual({ event: 'Login Succeeded', flow: 'web_fallback', reason: undefined });
+    // The native failure is still tracked (flow: 'native') with the native code as
+    // failure_detail, so DEVELOPER_ERROR / the SHA-1 misconfig stays visible in PostHog.
+    const nativeFailure = trackedProps().find(
+      (props) => props.flow === 'native' && props.failure_reason === 'exception',
     );
-    expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
-    // No fallback on Android, so the native throw is terminal, not recoverable.
-    expect(trackedEvents()).toContainEqual({
+    expect(nativeFailure?.failure_detail).toBe('DEVELOPER_ERROR');
+    // Android now recovers via the fallback too, so the native throw is tagged
+    // recoverable (matches iOS) and the terminal-failure metric excludes it.
+    expect(events).toContainEqual({
       event: 'Login Failed',
       flow: 'native',
       reason: 'exception',
-      recoverable: false,
+      recoverable: true,
     });
   });
 
-  it('surfaces the native error (no fallback) when Google returns a non-cancel failure', async () => {
+  it('recovers via the web flow when native Google returns a non-cancel failure', async () => {
     signInWithGoogleMock.mockResolvedValue({ success: false, status: 401, error: 'invalid' });
+    signInWithGoogleWebMock.mockResolvedValue({ success: true });
 
     const setError = await runSignIn('google');
 
-    expect(signInWithGoogleWebMock).not.toHaveBeenCalled();
-    expect(reportErrorMock).toHaveBeenCalledTimes(1);
-    expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
+    expect(signInWithGoogleWebMock).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenLastCalledWith(null);
   });
 
   it('does NOT fall back or error when the user cancels native Google, and logs a cancel', async () => {
@@ -308,15 +317,23 @@ describe('useNativeOAuthSignIn — Android has no web fallback', () => {
     expect(events).not.toContainEqual(expect.objectContaining({ event: 'Login Failed' }));
   });
 
-  it('does not run the Apple web fallback on Android (the iOS gate holds)', async () => {
-    // Apple sign-in isn't offered on Android, but guard the gate anyway: a native
-    // throw must surface the real error, not silently open a browser fallback.
-    signInWithAppleMock.mockRejectedValue(Object.assign(new Error('unknown'), { code: 1000 }));
+  it('surfaces an error and reports once when the web fallback also fails (SHA-1 still unfixed)', async () => {
+    signInWithGoogleMock.mockRejectedValue(Object.assign(new Error('developer error'), { code: 'DEVELOPER_ERROR' }));
+    signInWithGoogleWebMock.mockResolvedValue({
+      success: false,
+      status: 401,
+      error: 'Invalid or expired transfer token',
+    });
 
-    const setError = await runSignIn('apple');
+    const setError = await runSignIn('google');
 
-    expect(signInWithAppleWebMock).not.toHaveBeenCalled();
+    // A genuine failure still reaches error tracking — re-tagged under flow: 'web_fallback'.
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
     expect(setError).toHaveBeenLastCalledWith('nativeStart.oauthError');
+    expect(trackedEvents()).toContainEqual({
+      event: 'Login Failed',
+      flow: 'web_fallback',
+      reason: 'invalid_oauth_token',
+    });
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-oauth-sign-in.test.tsx
@@ -336,4 +336,19 @@ describe('useNativeOAuthSignIn — Android Google web fallback (DEVELOPER_ERROR 
       reason: 'invalid_oauth_token',
     });
   });
+
+  it('opens the Apple web fallback on Android too — the hook is platform-agnostic now', async () => {
+    // Apple sign-in isn't offered in the Android UI, but the gate that used to keep
+    // the fallback iOS-only is gone (#3083 → #3100). Locking the deliberate behavior:
+    // if a caller ever passes 'apple', it recovers in the browser rather than
+    // silently dead-ending — so a future regression that re-gates it is caught here.
+    signInWithAppleMock.mockRejectedValue(Object.assign(new Error('unknown'), { code: 1000 }));
+    signInWithAppleWebMock.mockResolvedValue({ success: true });
+
+    const setError = await runSignIn('apple');
+
+    expect(signInWithAppleWebMock).toHaveBeenCalledTimes(1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenLastCalledWith(null);
+  });
 });

--- a/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
+++ b/packages/mobile/src/hooks/use-native-oauth-sign-in.ts
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react';
-import { Platform } from 'react-native';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useAuth } from '../providers/auth-provider';
 import { track } from '../lib/analytics';
@@ -42,20 +41,24 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
       // the flow dying programmatically (sub-second).
       const attemptStartedAt = Date.now();
 
-      // Browser-OAuth fallback, iOS-only, for both Google and Apple. The native
-      // SDK can fail before any network call — Google on iOS 26.5.1 (GIDSignIn
-      // "Unable to open Safari"), Apple on ASAuthorizationError.unknown (code
-      // 1000: device not signed into iCloud, 2FA disabled, transient Apple ID
-      // issues) — and that failure isn't fatal: the web NextAuth handoff completes
-      // sign-in without the native SDK. Reports its own telemetry under
-      // flow: 'web_fallback' so we can measure how often it rescues a native
-      // failure, and fully owns the outcome (success returns, a browser cancel
-      // stays silent, a real failure reaches error tracking + the error region).
-      // Not used on Android: the redirect to com.boardsesh.app://auth/callback
-      // doesn't reliably return through openAuthSessionAsync there, an Android
-      // native Google failure is almost always an unregistered signing-cert SHA-1
-      // (a Google Cloud fix), and Apple sign-in isn't offered on Android at all —
-      // so we surface the real error instead (see auth.ts).
+      // Browser-OAuth fallback, for both Google and Apple, on every platform. The
+      // native SDK can fail before any network call — Google on iOS 26.5.1
+      // (GIDSignIn "Unable to open Safari") or on Android when the running build's
+      // signing-cert SHA-1 isn't registered against the OAuth client
+      // (DEVELOPER_ERROR), Apple on ASAuthorizationError.unknown (code 1000: device
+      // not signed into iCloud, 2FA disabled, transient Apple ID issues) — and that
+      // failure isn't fatal: the web NextAuth handoff completes sign-in without the
+      // native SDK, and its com.boardsesh.app://auth/callback redirect returns
+      // through the scheme the app registers on both platforms (app.config.ts).
+      // Reports its own telemetry under flow: 'web_fallback' so we can measure how
+      // often it rescues a native failure, and fully owns the outcome (success
+      // returns, a browser cancel stays silent, a real failure reaches error
+      // tracking + the error region). The native failure is tracked separately
+      // under flow: 'native' before this runs, so a config bug like an unregistered
+      // Android SHA-1 stays visible in analytics even when the browser recovers the
+      // user — the real fix is still registering the SHA-1 (see
+      // docs/android-sideload-build.md). Apple isn't offered on Android, so that
+      // branch of the map is unreachable there.
       // Keyed by provider so the map is exhaustive: extending Provider without a
       // web fn here is a type error, rather than silently routing the new provider
       // to the Google flow.
@@ -136,75 +139,50 @@ export function useNativeOAuthSignIn({ isRegistration = false, setError }: Optio
           });
           return;
         }
-        // A real backend/token failure carrying the server's status + error. On
-        // iOS the browser fallback runs next, so this native failure is
-        // recoverable and shouldn't count toward the terminal failure metric;
-        // on Android it dead-ends and is terminal.
+        // A real backend/token failure carrying the server's status + error. The
+        // browser fallback runs next on every platform, so this native failure is
+        // recoverable and shouldn't count toward the terminal failure metric — the
+        // terminal event is the web_fallback one below if the browser also fails.
         const oauthFailureReason = classifyNativeAuthFailureReason(result, 'oauth');
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
           flow: 'native',
           failure_reason: oauthFailureReason,
           failure_detail: result.error,
-          recoverable: Platform.OS === 'ios',
+          recoverable: true,
           duration_ms: Date.now() - attemptStartedAt,
           ...registrationProps,
         });
-        // On iOS, Google and Apple native failures are recoverable in the browser
-        // — the fallback owns the user-facing outcome and error tracking from
-        // here. Android has no working browser fallback and falls through to the
-        // real-error path below.
-        if (Platform.OS === 'ios') {
-          await runWebFallback();
-          return;
-        }
-        // Surface to error tracking too: an OAuth 401 / no_id_token is a config
-        // bug (client-id audience mismatch, unconfigured backend) rather than a
-        // user typo. Network blips downgrade to a warning.
-        reportError(new Error(`Native ${provider} sign-in failed: ${result.error}`), {
-          level: result.error === 'network' ? 'warning' : 'error',
-          tags: { source: 'native-auth', provider, flow: 'native', failure_reason: oauthFailureReason },
-          extra: { status: result.status, server_error: result.error },
-        });
-        setError(result.error === 'network' ? t('nativeStart.networkError') : t('nativeStart.oauthError'));
+        // Google and Apple native failures are recoverable in the browser — the
+        // fallback owns the user-facing outcome and error tracking from here. The
+        // native failure above is already recorded (flow: 'native'); if the browser
+        // recovers the user nothing more is reported, and if it also fails
+        // runWebFallback reports it under flow: 'web_fallback'.
+        await runWebFallback();
       } catch (oauthError) {
         // The native module threw (Play Services missing, no presenter, a
         // signing/client-id mismatch, …). Prefer the native `.code` for
         // failure_detail — far more actionable than the opaque message.
         const nativeErrorCode = nativeSignInErrorCode(oauthError);
-        // On iOS the browser fallback runs next (recoverable); on Android the
-        // native throw dead-ends and is terminal.
+        // The browser fallback runs next on every platform, so the native throw is
+        // recoverable and excluded from the terminal failure metric.
         track(SHARED_EVENTS.LoginFailed, {
           auth_method: provider,
           flow: 'native',
           failure_reason: 'exception',
           failure_detail: nativeErrorCode ?? (oauthError instanceof Error ? oauthError.message : undefined),
-          recoverable: Platform.OS === 'ios',
+          recoverable: true,
           duration_ms: Date.now() - attemptStartedAt,
           ...registrationProps,
         });
-        // Native throws land here — on iOS, recover via the browser flow instead
-        // of reporting and dead-ending the user. Google's is the iOS 26.5.1
-        // "Unable to open Safari" GIDSignIn throw; Apple's is
-        // ASAuthorizationError.unknown (code 1000). On Android a Google throw is
-        // almost always an unregistered signing-cert SHA-1 (DEVELOPER_ERROR) and
-        // Apple isn't offered, so fall through and let reportError tag it with
-        // native_error_code for PostHog rather than hide it behind a fallback that
-        // can't complete.
-        if (Platform.OS === 'ios') {
-          await runWebFallback();
-          return;
-        }
-        reportError(oauthError, {
-          tags: {
-            source: 'native-auth',
-            provider,
-            flow: 'native',
-            mechanism: 'exception',
-            native_error_code: nativeErrorCode,
-          },
-        });
-        setError(t('nativeStart.oauthError'));
+        // Native throws land here — recover via the browser flow instead of
+        // dead-ending the user. Google's is the iOS 26.5.1 "Unable to open Safari"
+        // GIDSignIn throw or an Android DEVELOPER_ERROR (unregistered signing-cert
+        // SHA-1); Apple's is ASAuthorizationError.unknown (code 1000). The throw is
+        // already tracked above (flow: 'native', failure_detail: native_error_code),
+        // so it stays visible in analytics; runWebFallback owns recovery and reports
+        // under flow: 'web_fallback' if the browser flow also fails.
+        await runWebFallback();
       } finally {
         setInProgress(false);
       }

--- a/packages/mobile/src/lib/__tests__/native-intent.test.ts
+++ b/packages/mobile/src/lib/__tests__/native-intent.test.ts
@@ -27,7 +27,7 @@ describe('redirectSystemPath', () => {
     expect(redirectSystemPath({ path: 'com.boardsesh.app://share?dataUrl=SHAREKEY', initial: false })).toBe('');
   });
 
-  it('suppresses navigation for the OAuth fallback callback so the result handler owns it', () => {
+  it('suppresses navigation for a warm OAuth fallback callback so the result handler owns it', () => {
     // On Android the browser fallback's com.boardsesh.app://auth/callback redirect
     // is delivered as a real deep link; routing it would hit +not-found and navigate
     // the auth screen to home before runWebFallback can show its error. '' skips that.
@@ -36,6 +36,23 @@ describe('redirectSystemPath', () => {
     );
     // A ?error= callback is the case the suppression protects (must not navigate away).
     expect(redirectSystemPath({ path: '/auth/callback?error=session_missing', initial: false })).toBe('');
+  });
+
+  it('does NOT suppress a cold-start auth/callback (stale intent) — falls through to normal routing', () => {
+    // '' is not a safe cold-start destination. A stale queued auth/callback intent
+    // (no exchange in flight) must fall through to +not-found → home, not be swallowed.
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: '/auth/callback?error=session_missing', initial: true })).toBe(
+      '/auth/callback?error=session_missing',
+    );
+  });
+
+  it('only matches the auth/callback path segment, not routes that merely contain it', () => {
+    // The match is anchored so an unrelated route isn't silently suppressed.
+    getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
+    expect(redirectSystemPath({ path: '/admin/auth/callback-debug', initial: false })).toBe(
+      '/admin/auth/callback-debug',
+    );
   });
 
   it('leaves ordinary deep links untouched', () => {

--- a/packages/mobile/src/lib/__tests__/native-intent.test.ts
+++ b/packages/mobile/src/lib/__tests__/native-intent.test.ts
@@ -27,6 +27,17 @@ describe('redirectSystemPath', () => {
     expect(redirectSystemPath({ path: 'com.boardsesh.app://share?dataUrl=SHAREKEY', initial: false })).toBe('');
   });
 
+  it('suppresses navigation for the OAuth fallback callback so the result handler owns it', () => {
+    // On Android the browser fallback's com.boardsesh.app://auth/callback redirect
+    // is delivered as a real deep link; routing it would hit +not-found and navigate
+    // the auth screen to home before runWebFallback can show its error. '' skips that.
+    expect(redirectSystemPath({ path: 'com.boardsesh.app://auth/callback?transferToken=abc', initial: false })).toBe(
+      '',
+    );
+    // A ?error= callback is the case the suppression protects (must not navigate away).
+    expect(redirectSystemPath({ path: '/auth/callback?error=session_missing', initial: false })).toBe('');
+  });
+
   it('leaves ordinary deep links untouched', () => {
     getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
     expect(redirectSystemPath({ path: JOIN_LINK, initial: true })).toBe(JOIN_LINK);


### PR DESCRIPTION
## Summary

Android Google Sign-In was dead-ending login. PR #3083 gated the browser-OAuth fallback to iOS so Android would "surface native errors", but on Android a native Google failure is almost always an unregistered signing-cert SHA-1 (`DEVELOPER_ERROR`), and with the fallback gone there was no way to recover — the user simply couldn't sign in with Google. The 2.0 rollout spiked Android `Login Failed` from ~1–7/day to **50 (12 users) on 06‑19**, almost all Google Sign-In (PostHog 412845, `$os=Android`, `$app_version=2.0.0`).

This restores the browser fallback on Android. The fallback's premise against Android — that `com.boardsesh.app://auth/callback` "doesn't reliably return through `openAuthSessionAsync`" — doesn't hold: the scheme is registered on **both** platforms (`app.config.ts`) and the web NextAuth handoff is provider- and platform-agnostic. So the `Platform.OS === 'ios'` guard is removed at both fallback sites and the browser flow now recovers the user on Android too.

Crucially, the native failure is still tracked under `flow: 'native'` (with the native code as `failure_detail`) **before** the fallback runs, so a `DEVELOPER_ERROR` / SHA-1 misconfig stays visible in analytics. **Registering the SHA-1 against the Google Cloud OAuth client is still the real fix** (`docs/android-sideload-build.md`) — this fallback is recovery, not a substitute.

Refs #3100. Defers the `google/cancel`-recorded-as-failure hygiene to #3088.

## Release Notes

- Signing in with Google on Android now recovers in the browser instead of dead-ending when the native sign-in can't complete.

## Test plan

- `vp run typecheck:mobile` — green
- `vp run test:mobile` — 2552 passed; `use-native-oauth-sign-in.test.tsx` reworked so the Android cases assert recovery via the web fallback (DEVELOPER_ERROR throw recovers **and** is still tracked under `flow: 'native'`; non-cancel failure recovers; cancel still no-ops; web-fallback-also-fails still reports once)
- `vp run check:mobile-bundle` — OK (11.1 MB)
- ⚠️ **Pending real-device check:** full Google OAuth through the browser fallback needs a real Google account on the device (our `test@boardsesh.com` is email/password). The deep-link return mechanism is the same registered scheme the iOS fallback already uses, but the end-to-end Android Google sign-in should be confirmed on a real device via a preview OTA before this rides to production.

## Out of scope

- **SHA-1 registration** (Google Cloud / Play Console) — the actual root-cause fix; ops task tracked in #3100, can't be done in-repo.
- **`google/cancel` counted as a failure** — deferred to #3088 (P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqmyMjGzWkdpQVCL9NUBXT
