### PR TITLE
feat(mobile): OTA adoption telemetry + force-native build escape hatch (#3098)

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -24,6 +24,18 @@ on:
         description: 'Added to GH run_number for versionCode (raise to clear collisions / always supersede the Capacitor app)'
         required: false
         default: '2000000'
+      # The canonical "ship an urgent JS-only fix to binaries that can no longer
+      # receive an OTA" lever (issue #3098). A JS fix merged to main is delivered
+      # OTA-only and skips the native build when its fingerprint already shipped —
+      # but a binary whose fingerprint has since drifted is orphaned from the OTA.
+      # Dispatching this workflow with force_native on rebuilds the native app so
+      # those installs get the fix via a store update. Defaults on, so a manual
+      # dispatch keeps building as before; uncheck to honour the fingerprint gate.
+      force_native:
+        description: 'Force a native build even if this fingerprint already shipped (push an urgent JS-only fix to orphaned binaries). Uncheck to honour the fingerprint gate.'
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: android-apk-rn-${{ github.ref }}
@@ -144,9 +156,15 @@ jobs:
             exit 0
           fi
           echo "fingerprint=$fp" >> "$GITHUB_OUTPUT"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # A manual dispatch with force_native on (the default) builds regardless
+          # of the fingerprint — the escape hatch for shipping an urgent JS-only
+          # fix to OTA-orphaned binaries (issue #3098). With force_native off it
+          # falls through to the same fingerprint-tag check as a push, so a
+          # dispatch can also be a no-op rebuild when the fingerprint already
+          # shipped.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force_native }}" = "true" ]; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Manual dispatch — building Android regardless of fingerprint $fp."
+            echo "::notice::Manual dispatch with force_native — building Android regardless of fingerprint $fp."
             exit 0
           fi
           tag="fingerprint-android-$fp"

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -150,12 +150,20 @@ That's the fingerprint policy working as intended; pinning the publish to the la
 instead serve native-dependent JS to old binaries and crash them.
 
 **Fail-safe.** If the gate can't resolve the fingerprint, it builds. A manual `workflow_dispatch`
-bypasses the tag check and always builds — for iOS that means dispatching on `main` (the iOS build
-is `main`-only by design, since it uploads to TestFlight); the Android workflow additionally builds
-from a `workflow_dispatch` on any branch (artifact-only, matching its pre-existing behavior).
+bypasses the tag check and builds — for iOS that means dispatching on `main` (the iOS build is
+`main`-only by design, since it uploads to TestFlight). The Android workflow drives this with a
+`force_native` input (default **on**): on, it builds regardless of the fingerprint (the urgent-fix
+escape hatch below); off, it falls through to the same tag check as a push, so a dispatch can also be
+a no-op rebuild. A dispatch on any branch still produces an artifact-only APK, matching its
+pre-existing behavior.
 
 **Manual overrides.**
 
+- **Ship an urgent JS-only fix to OTA-orphaned binaries.** A JS fix merged to `main` is delivered
+  OTA-only and skips the native build when its fingerprint already shipped — but a binary whose
+  fingerprint has since drifted (heavy native churn orphans older binaries, the root cause behind
+  issue #3098) can't pull that OTA. Dispatch `android-apk-rn.yml` with `force_native` on to rebuild
+  the native app so those installs get the fix via a store update.
 - Force a rebuild of a fingerprint that already has a tag:
   `git push --delete origin fingerprint-<platform>-<hash>`, then re-push to `main` (or run the
   workflow via dispatch).
@@ -173,6 +181,29 @@ from a `workflow_dispatch` on any branch (artifact-only, matching its pre-existi
 Resolve the current fingerprint locally to predict what the gate will see: `cd packages/mobile &&
 bunx expo-updates runtimeversion:resolve --platform ios` (add the production env to match CI
 exactly — see the parity check above).
+
+## OTA observability (adoption + funnel)
+
+A JS-only fix lands OTA-only, so "did it actually reach users?" needs telemetry — without it an
+inert or broken OTA is silent (the gap that motivated issue #3098). The app reports two PostHog
+events from `OtaUpdateTracker` (`packages/mobile/src/components/analytics/OtaUpdateTracker.tsx`),
+mounted once near the root beside `AnalyticsScreenTracker`:
+
+- **`OTA Update Status`** — fired once per launch with the running bundle:
+  `{ isEnabled, isEmbeddedLaunch, updateId, channel, runtimeVersion, createdAtIso, isEmergencyLaunch,
+emergencyLaunchReason }`. `isEmbeddedLaunch === false` means the install is running an **OTA'd**
+  bundle (not the one baked into the binary); group by `updateId` to size the rollout of a specific
+  JS-only fix; `runtimeVersion` is the fingerprint cohort that can receive OTAs at all. The same
+  cohort is also registered as PostHog **super properties** (`ota_update_id`, `ota_is_embedded`,
+  `ota_runtime_version`) so any existing funnel can be sliced by OTA-vs-embedded.
+- **`OTA Update Downloaded`** — fired when a newer bundle finishes downloading in-session
+  (`{ updateId, createdAtIso }`). It applies on the **next** launch, which the following
+  `OTA Update Status` records — together they form the published → downloaded → applied funnel.
+
+Both no-op in dev / Expo Go (analytics disabled, `Updates.isEnabled` false); the `__DEV__` debug hook
+still logs `[analytics] OTA Update Status …` to Metro so you can confirm the tracker fires locally.
+In PostHog (project 412845), count distinct installs with `isEmbeddedLaunch = false` per `updateId` to
+measure how many pulled a given OTA.
 
 ## PR-time OTA-compatibility signal
 

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -190,8 +190,8 @@ events from `OtaUpdateTracker` (`packages/mobile/src/components/analytics/OtaUpd
 mounted once near the root beside `AnalyticsScreenTracker`:
 
 - **`OTA Update Status`** — fired once per launch with the running bundle:
-  `{ isEnabled, isEmbeddedLaunch, updateId, channel, runtimeVersion, createdAtIso, isEmergencyLaunch,
-emergencyLaunchReason }`. `isEmbeddedLaunch === false` means the install is running an **OTA'd**
+  `{ isEnabled, isEmbeddedLaunch, updateId, channel, runtimeVersion, createdAtIso, isEmergencyLaunch, emergencyLaunchReason }`.
+  `isEmbeddedLaunch === false` means the install is running an **OTA'd**
   bundle (not the one baked into the binary); group by `updateId` to size the rollout of a specific
   JS-only fix; `runtimeVersion` is the fingerprint cohort that can receive OTAs at all. The same
   cohort is also registered as PostHog **super properties** (`ota_update_id`, `ota_is_embedded`,

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -59,6 +59,7 @@ import { reportError } from '../src/lib/error-reporting';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
+import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
@@ -434,6 +435,7 @@ function RootLayout() {
                                                         </UserDrawerProvider>
                                                       </TabBarHeightProvider>
                                                       <AnalyticsScreenTracker />
+                                                      <OtaUpdateTracker />
                                                     </ShareTargetProvider>
                                                   </DeepLinkProvider>
                                                 </DrawerHostProvider>

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -37,6 +37,8 @@ export function OtaUpdateTracker(): null {
   // from the imperative Updates.* constants because useUpdates()' currentlyRunning
   // omits runtimeVersion.
   useEffect(() => {
+    if (hasReportedStatus) return;
+    hasReportedStatus = true;
     const properties = buildOtaStatusProperties({
       isEnabled: Updates.isEnabled,
       isEmbeddedLaunch: Updates.isEmbeddedLaunch,
@@ -47,8 +49,6 @@ export function OtaUpdateTracker(): null {
       isEmergencyLaunch: Updates.isEmergencyLaunch,
       emergencyLaunchReason: Updates.emergencyLaunchReason,
     });
-    if (hasReportedStatus) return;
-    hasReportedStatus = true;
     track(OTA_UPDATE_STATUS_EVENT, properties);
     registerSuperProperties({
       ota_update_id: properties.updateId,

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -19,12 +19,12 @@ import {
 // per launch) even if this subtree is ever torn down and recreated. The tracker
 // lives at the root layout and won't remount in practice, but this makes the
 // "once per launch" intent hold regardless. An OTA reload restarts the runtime,
-// clearing this, so the next launch re-reports under the new bundle's updateId.
-const reportedStatusKeys = new Set<string>();
+// clearing this, so the next launch re-reports the new bundle.
+let hasReportedStatus = false;
 
 // Test-only: resets the once-per-launch guard so each render starts clean.
 export function resetOtaStatusReportedForTests(): void {
-  reportedStatusKeys.clear();
+  hasReportedStatus = false;
 }
 
 export function OtaUpdateTracker(): null {
@@ -47,9 +47,8 @@ export function OtaUpdateTracker(): null {
       isEmergencyLaunch: Updates.isEmergencyLaunch,
       emergencyLaunchReason: Updates.emergencyLaunchReason,
     });
-    const statusKey = properties.updateId ?? 'embedded';
-    if (reportedStatusKeys.has(statusKey)) return;
-    reportedStatusKeys.add(statusKey);
+    if (hasReportedStatus) return;
+    hasReportedStatus = true;
     track(OTA_UPDATE_STATUS_EVENT, properties);
     registerSuperProperties({
       ota_update_id: properties.updateId,

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -14,6 +14,19 @@ import {
 // bundle (the "fetched, applies next launch" step of the funnel). Renders
 // nothing — mounted once near the app root beside AnalyticsScreenTracker. See
 // docs/mobile-ota-updates.md.
+
+// Module-scoped so the launch status fires at most once per JS runtime (= once
+// per launch) even if this subtree is ever torn down and recreated. The tracker
+// lives at the root layout and won't remount in practice, but this makes the
+// "once per launch" intent hold regardless. An OTA reload restarts the runtime,
+// clearing this, so the next launch re-reports under the new bundle's updateId.
+const reportedStatusKeys = new Set<string>();
+
+// Test-only: resets the once-per-launch guard so each render starts clean.
+export function resetOtaStatusReportedForTests(): void {
+  reportedStatusKeys.clear();
+}
+
 export function OtaUpdateTracker(): null {
   const { isUpdatePending, downloadedUpdate } = Updates.useUpdates();
   const reportedDownloadIdRef = useRef<string | null>(null);
@@ -34,6 +47,9 @@ export function OtaUpdateTracker(): null {
       isEmergencyLaunch: Updates.isEmergencyLaunch,
       emergencyLaunchReason: Updates.emergencyLaunchReason,
     });
+    const statusKey = properties.updateId ?? 'embedded';
+    if (reportedStatusKeys.has(statusKey)) return;
+    reportedStatusKeys.add(statusKey);
     track(OTA_UPDATE_STATUS_EVENT, properties);
     registerSuperProperties({
       ota_update_id: properties.updateId,

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import * as Updates from 'expo-updates';
+import { registerSuperProperties, track } from '../../lib/analytics';
+import {
+  OTA_UPDATE_DOWNLOADED_EVENT,
+  OTA_UPDATE_STATUS_EVENT,
+  buildOtaStatusProperties,
+} from '../../lib/ota-telemetry';
+
+// Emits OTA-adoption telemetry so a JS-only rollout is measurable (we previously
+// had no way to tell how many installs pulled an OTA — issue #3098). On mount it
+// reports the running bundle once and stamps the OTA cohort onto every later
+// event as super properties; while mounted it reports a freshly-downloaded
+// bundle (the "fetched, applies next launch" step of the funnel). Renders
+// nothing — mounted once near the app root beside AnalyticsScreenTracker. See
+// docs/mobile-ota-updates.md.
+export function OtaUpdateTracker(): null {
+  const { isUpdatePending, downloadedUpdate } = Updates.useUpdates();
+  const reportedDownloadIdRef = useRef<string | null>(null);
+
+  // Report the running bundle once. track() no-ops when analytics is disabled
+  // (dev / no key) but still logs via its __DEV__ debug hook, so this is
+  // observable in Metro without sending anything. updateId / runtimeVersion come
+  // from the imperative Updates.* constants because useUpdates()' currentlyRunning
+  // omits runtimeVersion.
+  useEffect(() => {
+    const properties = buildOtaStatusProperties({
+      isEnabled: Updates.isEnabled,
+      isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+      updateId: Updates.updateId,
+      channel: Updates.channel,
+      runtimeVersion: Updates.runtimeVersion,
+      createdAt: Updates.createdAt,
+      isEmergencyLaunch: Updates.isEmergencyLaunch,
+      emergencyLaunchReason: Updates.emergencyLaunchReason,
+    });
+    track(OTA_UPDATE_STATUS_EVENT, properties);
+    registerSuperProperties({
+      ota_update_id: properties.updateId,
+      ota_is_embedded: properties.isEmbeddedLaunch,
+      ota_runtime_version: properties.runtimeVersion,
+    });
+  }, []);
+
+  // A newer bundle finished downloading this session; it applies on the next
+  // launch (whose OTA Update Status event records the switch to isEmbeddedLaunch
+  // false with this updateId). Dedupe on updateId so a repeated pending state
+  // doesn't double-count the same download.
+  useEffect(() => {
+    if (!isUpdatePending || !downloadedUpdate) return;
+    const downloadedUpdateId = downloadedUpdate.updateId ?? null;
+    if (reportedDownloadIdRef.current === downloadedUpdateId) return;
+    reportedDownloadIdRef.current = downloadedUpdateId;
+    track(OTA_UPDATE_DOWNLOADED_EVENT, {
+      updateId: downloadedUpdateId,
+      createdAtIso: downloadedUpdate.createdAt ? downloadedUpdate.createdAt.toISOString() : null,
+    });
+  }, [isUpdatePending, downloadedUpdate]);
+
+  return null;
+}

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -121,4 +121,10 @@ describe('OtaUpdateTracker', () => {
     render(createElement(OtaUpdateTracker));
     expect(trackCallsFor('OTA Update Downloaded')).toHaveLength(0);
   });
+
+  it('does not report a download when pending but no bundle is downloaded yet', () => {
+    updates.current = { isUpdatePending: true, downloadedUpdate: undefined };
+    render(createElement(OtaUpdateTracker));
+    expect(trackCallsFor('OTA Update Downloaded')).toHaveLength(0);
+  });
 });

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analytics = vi.hoisted(() => ({ track: vi.fn(), registerSuperProperties: vi.fn() }));
+
+// Drives Updates.useUpdates() per test. The constants below mirror an OTA'd
+// production launch; `current` is swapped to exercise the downloaded-bundle
+// branch (a newer bundle fetched but not yet applied).
+const updates = vi.hoisted(() => ({
+  current: {
+    isUpdatePending: false,
+    downloadedUpdate: undefined as undefined | { updateId?: string; createdAt: Date },
+  },
+}));
+
+vi.mock('../../../lib/analytics', () => ({
+  track: analytics.track,
+  registerSuperProperties: analytics.registerSuperProperties,
+}));
+
+vi.mock('expo-updates', () => ({
+  isEnabled: true,
+  isEmbeddedLaunch: false,
+  updateId: 'a1b2c3d4-0000-0000-0000-000000000000',
+  channel: 'production',
+  runtimeVersion: 'abcdef123456',
+  createdAt: new Date('2026-06-20T07:53:51.000Z'),
+  isEmergencyLaunch: false,
+  emergencyLaunchReason: null,
+  useUpdates: () => updates.current,
+}));
+
+// Imported after the mocks (vi.mock is hoisted above imports).
+import { OtaUpdateTracker } from '../OtaUpdateTracker';
+
+function trackCallsFor(eventName: string) {
+  return analytics.track.mock.calls.filter(([name]) => name === eventName);
+}
+
+beforeEach(() => {
+  analytics.track.mockClear();
+  analytics.registerSuperProperties.mockClear();
+  updates.current = { isUpdatePending: false, downloadedUpdate: undefined };
+});
+
+describe('OtaUpdateTracker', () => {
+  it('reports the running bundle once and registers the OTA cohort', () => {
+    render(createElement(OtaUpdateTracker));
+
+    const statusCalls = trackCallsFor('OTA Update Status');
+    expect(statusCalls).toHaveLength(1);
+    expect(statusCalls[0][1]).toMatchObject({
+      isEnabled: true,
+      isEmbeddedLaunch: false,
+      updateId: 'a1b2c3d4-0000-0000-0000-000000000000',
+      channel: 'production',
+      runtimeVersion: 'abcdef123456',
+      createdAtIso: '2026-06-20T07:53:51.000Z',
+    });
+    expect(analytics.registerSuperProperties).toHaveBeenCalledWith({
+      ota_update_id: 'a1b2c3d4-0000-0000-0000-000000000000',
+      ota_is_embedded: false,
+      ota_runtime_version: 'abcdef123456',
+    });
+  });
+
+  it('reports a freshly downloaded bundle, deduped on updateId', () => {
+    updates.current = {
+      isUpdatePending: true,
+      downloadedUpdate: { updateId: 'next-update-id', createdAt: new Date('2026-06-21T00:00:00.000Z') },
+    };
+    const { rerender } = render(createElement(OtaUpdateTracker));
+
+    // A new object with the same updateId — the ref dedup must suppress a second
+    // event even though the effect re-runs on the changed reference.
+    updates.current = {
+      isUpdatePending: true,
+      downloadedUpdate: { updateId: 'next-update-id', createdAt: new Date('2026-06-21T00:00:00.000Z') },
+    };
+    rerender(createElement(OtaUpdateTracker));
+
+    const downloadedCalls = trackCallsFor('OTA Update Downloaded');
+    expect(downloadedCalls).toHaveLength(1);
+    expect(downloadedCalls[0][1]).toEqual({
+      updateId: 'next-update-id',
+      createdAtIso: '2026-06-21T00:00:00.000Z',
+    });
+  });
+
+  it('does not report a download when none is pending', () => {
+    render(createElement(OtaUpdateTracker));
+    expect(trackCallsFor('OTA Update Downloaded')).toHaveLength(0);
+  });
+});

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -11,7 +11,7 @@ const analytics = vi.hoisted(() => ({ track: vi.fn(), registerSuperProperties: v
 const updates = vi.hoisted(() => ({
   current: {
     isUpdatePending: false,
-    downloadedUpdate: undefined as undefined | { updateId?: string; createdAt: Date },
+    downloadedUpdate: undefined as undefined | { updateId?: string; createdAt?: Date },
   },
 }));
 
@@ -33,7 +33,7 @@ vi.mock('expo-updates', () => ({
 }));
 
 // Imported after the mocks (vi.mock is hoisted above imports).
-import { OtaUpdateTracker } from '../OtaUpdateTracker';
+import { OtaUpdateTracker, resetOtaStatusReportedForTests } from '../OtaUpdateTracker';
 
 function trackCallsFor(eventName: string) {
   return analytics.track.mock.calls.filter(([name]) => name === eventName);
@@ -43,6 +43,9 @@ beforeEach(() => {
   analytics.track.mockClear();
   analytics.registerSuperProperties.mockClear();
   updates.current = { isUpdatePending: false, downloadedUpdate: undefined };
+  // The status guard is module-scoped (once per launch); reset it so each test
+  // starts from a clean "nothing reported yet" state.
+  resetOtaStatusReportedForTests();
 });
 
 describe('OtaUpdateTracker', () => {
@@ -86,6 +89,31 @@ describe('OtaUpdateTracker', () => {
     expect(downloadedCalls[0][1]).toEqual({
       updateId: 'next-update-id',
       createdAtIso: '2026-06-21T00:00:00.000Z',
+    });
+  });
+
+  it('reports the launch status only once across a remount (same launch)', () => {
+    const first = render(createElement(OtaUpdateTracker));
+    first.unmount();
+    render(createElement(OtaUpdateTracker));
+
+    // Same JS runtime ⇒ same updateId ⇒ the module-scoped guard suppresses the
+    // second report.
+    expect(trackCallsFor('OTA Update Status')).toHaveLength(1);
+  });
+
+  it('coalesces a downloaded bundle with no createdAt to null', () => {
+    updates.current = {
+      isUpdatePending: true,
+      downloadedUpdate: { updateId: 'rollback-or-undated', createdAt: undefined },
+    };
+    render(createElement(OtaUpdateTracker));
+
+    const downloadedCalls = trackCallsFor('OTA Update Downloaded');
+    expect(downloadedCalls).toHaveLength(1);
+    expect(downloadedCalls[0][1]).toEqual({
+      updateId: 'rollback-or-undated',
+      createdAtIso: null,
     });
   });
 

--- a/packages/mobile/src/lib/__tests__/ota-telemetry.test.ts
+++ b/packages/mobile/src/lib/__tests__/ota-telemetry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { OTA_UPDATE_DOWNLOADED_EVENT, OTA_UPDATE_STATUS_EVENT, buildOtaStatusProperties } from '../ota-telemetry';
+
+describe('buildOtaStatusProperties', () => {
+  it('maps a downloaded-bundle launch to flat PostHog props', () => {
+    const createdAt = new Date('2026-06-20T07:53:51.000Z');
+    expect(
+      buildOtaStatusProperties({
+        isEnabled: true,
+        isEmbeddedLaunch: false,
+        updateId: 'a1b2c3d4-0000-0000-0000-000000000000',
+        channel: 'production',
+        runtimeVersion: 'abcdef123456',
+        createdAt,
+        isEmergencyLaunch: false,
+        emergencyLaunchReason: null,
+      }),
+    ).toEqual({
+      isEnabled: true,
+      isEmbeddedLaunch: false,
+      updateId: 'a1b2c3d4-0000-0000-0000-000000000000',
+      channel: 'production',
+      runtimeVersion: 'abcdef123456',
+      createdAtIso: '2026-06-20T07:53:51.000Z',
+      isEmergencyLaunch: false,
+      emergencyLaunchReason: null,
+    });
+  });
+
+  it('coerces absent fields (dev / Expo Go, where Updates is disabled) to null', () => {
+    expect(
+      buildOtaStatusProperties({
+        isEnabled: false,
+        isEmbeddedLaunch: true,
+        updateId: undefined,
+        channel: undefined,
+        runtimeVersion: undefined,
+        createdAt: undefined,
+        isEmergencyLaunch: false,
+        emergencyLaunchReason: undefined,
+      }),
+    ).toEqual({
+      isEnabled: false,
+      isEmbeddedLaunch: true,
+      updateId: null,
+      channel: null,
+      runtimeVersion: null,
+      createdAtIso: null,
+      isEmergencyLaunch: false,
+      emergencyLaunchReason: null,
+    });
+  });
+
+  it('keeps the mobile-only event names stable', () => {
+    expect(OTA_UPDATE_STATUS_EVENT).toBe('OTA Update Status');
+    expect(OTA_UPDATE_DOWNLOADED_EVENT).toBe('OTA Update Downloaded');
+  });
+});

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -51,6 +51,10 @@ export function registerSuperProperties(properties: Record<string, string | numb
   const registrable = client as unknown as { register?: (props: Record<string, unknown>) => void };
   if (typeof registrable.register === 'function') {
     registrable.register(properties);
+  } else if (__DEV__) {
+    // Loud in dev so an SDK API change (register() renamed/removed) surfaces
+    // instead of silently dropping super properties in production.
+    console.warn('[analytics] PostHog client exposes no register(); super properties not set', properties);
   }
 }
 

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -48,14 +48,10 @@ export function getAnalyticsClient(): PostHog | null {
 export function registerSuperProperties(properties: Record<string, string | number | boolean | null>): void {
   const client = getClient();
   if (!client) return;
-  const registrable = client as unknown as { register?: (props: Record<string, unknown>) => void };
-  if (typeof registrable.register === 'function') {
-    registrable.register(properties);
-  } else if (__DEV__) {
-    // Loud in dev so an SDK API change (register() renamed/removed) surfaces
-    // instead of silently dropping super properties in production.
-    console.warn('[analytics] PostHog client exposes no register(); super properties not set', properties);
-  }
+  // PostHog.register is part of the typed API, so this is compile-time safe — no
+  // duck-typing. Fire-and-forget (it returns a Promise) to match track()'s
+  // ergonomics; no-op when analytics is disabled (getClient() returned null).
+  void client.register(properties);
 }
 
 function coerceFeatureFlagBoolean(value: unknown): boolean | undefined {

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -39,6 +39,21 @@ export function getAnalyticsClient(): PostHog | null {
   return getClient();
 }
 
+// Register PostHog super properties — values stamped onto every subsequent event
+// from this client until unregistered / reset. OtaUpdateTracker uses this to tag
+// the OTA cohort (update id, embedded-vs-OTA, fingerprint) onto all events so any
+// existing funnel can be sliced by it. Guarded like the optional feature-flag
+// methods: no-op when analytics is disabled (dev / no key) or the SDK build
+// lacks register().
+export function registerSuperProperties(properties: Record<string, string | number | boolean | null>): void {
+  const client = getClient();
+  if (!client) return;
+  const registrable = client as unknown as { register?: (props: Record<string, unknown>) => void };
+  if (typeof registrable.register === 'function') {
+    registrable.register(properties);
+  }
+}
+
 function coerceFeatureFlagBoolean(value: unknown): boolean | undefined {
   if (typeof value === 'boolean') return value;
   if (value === 'true') return true;

--- a/packages/mobile/src/lib/ota-telemetry.ts
+++ b/packages/mobile/src/lib/ota-telemetry.ts
@@ -1,0 +1,56 @@
+// OTA-adoption telemetry. Mobile-only (web has no OTA), so the event names stay
+// free-string constants rather than entries in @boardsesh/analytics'
+// SHARED_EVENTS (which is for names fired by BOTH platforms). See
+// docs/mobile-ota-updates.md for what each event measures.
+
+// Fired once per launch with the running JS bundle's metadata. The adoption
+// signal: isEmbeddedLaunch === false means the install is running an OTA'd
+// bundle; group by updateId to size the rollout of a specific JS-only fix; and
+// runtimeVersion is the fingerprint cohort that can receive OTAs at all.
+export const OTA_UPDATE_STATUS_EVENT = 'OTA Update Status';
+
+// Fired when a newer bundle finishes downloading this session (it applies on the
+// next launch, which the following launch's OTA Update Status event records).
+// Together they form the published → downloaded → applied funnel.
+export const OTA_UPDATE_DOWNLOADED_EVENT = 'OTA Update Downloaded';
+
+// The raw expo-updates constants the status event is built from. Nullable string
+// and Date fields accept `undefined` too so the mapper can run against the
+// disabled-Updates state (dev / Expo Go), where they are absent.
+export type OtaUpdateFields = {
+  isEnabled: boolean;
+  isEmbeddedLaunch: boolean;
+  updateId: string | null | undefined;
+  channel: string | null | undefined;
+  runtimeVersion: string | null | undefined;
+  createdAt: Date | null | undefined;
+  isEmergencyLaunch: boolean;
+  emergencyLaunchReason: string | null | undefined;
+};
+
+export type OtaStatusProperties = {
+  isEnabled: boolean;
+  isEmbeddedLaunch: boolean;
+  updateId: string | null;
+  channel: string | null;
+  runtimeVersion: string | null;
+  createdAtIso: string | null;
+  isEmergencyLaunch: boolean;
+  emergencyLaunchReason: string | null;
+};
+
+// Maps the expo-updates constants to a flat PostHog property object. Coerces
+// absent fields to null (PostHog drops undefined) and the Date to an ISO string.
+// Pure so it unit-tests with plain objects, no native module.
+export function buildOtaStatusProperties(fields: OtaUpdateFields): OtaStatusProperties {
+  return {
+    isEnabled: fields.isEnabled,
+    isEmbeddedLaunch: fields.isEmbeddedLaunch,
+    updateId: fields.updateId ?? null,
+    channel: fields.channel ?? null,
+    runtimeVersion: fields.runtimeVersion ?? null,
+    createdAtIso: fields.createdAt ? fields.createdAt.toISOString() : null,
+    isEmergencyLaunch: fields.isEmergencyLaunch,
+    emergencyLaunchReason: fields.emergencyLaunchReason ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Closes the two remaining codeable follow-ups on #3098. Items #1 (on-device OTA-apply verification) and #2 (fingerprint/env parity) are already resolved per the issue's diagnosis comment — this PR addresses **#3 (observability)** and **#4 (force-native policy)**.

A JS-only fix merged to `main` ships OTA-only and skips the native build when its fingerprint already shipped. Today we can't measure whether that rollout reached users, and there's no deliberate lever to force a native rebuild for a binary whose fingerprint has drifted past the OTA (the orphaning that left the #3097 board-freeze fix stranded on older Android installs).

### OTA observability (#3)
- New `OtaUpdateTracker` (mounted once near the app root beside `AnalyticsScreenTracker`) fires:
  - **`OTA Update Status`** once per launch — running bundle's `updateId`, `isEmbeddedLaunch`, `runtimeVersion`, `channel`, `createdAtIso`, emergency flags. `isEmbeddedLaunch === false` ⇒ running an OTA'd bundle; group by `updateId` to size a rollout; `runtimeVersion` is the fingerprint cohort. The cohort is also registered as PostHog **super properties** so any existing funnel can be sliced by OTA-vs-embedded.
  - **`OTA Update Downloaded`** when a newer bundle finishes downloading in-session (applies next launch) — completing the published → downloaded → applied funnel.
- Pure, unit-tested `buildOtaStatusProperties` mapper + free-string event names (mobile-only, not `SHARED_EVENTS`) in `ota-telemetry.ts`; guarded `registerSuperProperties` helper added to `analytics.ts`.

### Force-native escape hatch (#4)
- `android-apk-rn.yml` gains a `force_native` `workflow_dispatch` input (default **on**). On → build regardless of the fingerprint (the documented way to push an urgent JS-only fix to OTA-orphaned binaries); off → fall through to the same fingerprint-tag check as a push. The fingerprint-affecting `env:` block is untouched, so `scripts/mobile-ci-env-parity.test.ts` stays green.

### Docs
- `docs/mobile-ota-updates.md`: new "OTA observability" section + the force-native runbook step.

Out of scope (noted on the issue): #1's physical-device check and the broader "minimise native churn between store builds" process work.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 2558 passed, incl. the 6 new tests (`ota-telemetry.test.ts`, `ota-update-tracker.test.tsx`).
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp check` — my files clean (remaining flags are pre-existing drift on `main`).
- `scripts/mobile-ci-env-parity.test.ts` — 16 passed (workflow env block unchanged).
- Workflow YAML parses; `version_code_offset` + `force_native` inputs present.
- Local: in `__DEV__` the analytics debug hook logs `[analytics] OTA Update Status …` to Metro once on startup (no events sent in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)