### PR TITLE
ci: SHA-pin actions, gate signing secrets, add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners for security-sensitive infrastructure.
+#
+# Anything that can read a secret, run on a self-hosted runner, or change the
+# build/deploy pipeline must be reviewed by a maintainer. This only *enforces* a
+# blocking review once branch protection on `main` has "Require review from Code
+# Owners" enabled (Settings → Branches). Until then it still routes review
+# requests, just without the hard gate.
+#
+# Replace @marcodejongh with a @boardsesh/<team> once a maintainers team exists,
+# so ownership survives any single account.
+
+# CI/CD workflows, Dependabot, and this file itself
+/.github/                       @marcodejongh
+
+# Build/deploy/release tooling invoked by the workflows above
+/scripts/                       @marcodejongh
+/Dockerfile.backend             @marcodejongh
+/docker-compose*.yml            @marcodejongh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,16 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  # Keep the SHA-pinned GitHub Actions current. Dependabot bumps the pinned
+  # commit and its trailing `# vX` comment together, so we get the supply-chain
+  # safety of SHA pins without manually chasing new releases. Grouped into one PR
+  # per week to avoid 28 separate bump PRs.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/android-apk-dev-client.yml
+++ b/.github/workflows/android-apk-dev-client.yml
@@ -60,21 +60,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Accept licenses and install SDK components
         run: |
@@ -82,7 +82,7 @@ jobs:
           sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -166,7 +166,7 @@ jobs:
           cp -f "$apk" "${debug_dir}/boardsesh-dev-android.apk"
 
       - name: Upload APK as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: boardsesh-dev-android-${{ github.run_number }}

--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -107,9 +107,9 @@ jobs:
       fingerprint: ${{ steps.fp.outputs.fingerprint }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
@@ -182,28 +182,28 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
 
       - name: Setup Ruby and fastlane
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: '3.4'
           bundler-cache: true
           working-directory: fastlane
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Accept licenses and install SDK components
         run: |
@@ -211,7 +211,7 @@ jobs:
           sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -366,7 +366,7 @@ jobs:
           cp -f "$apk" "$release_asset"
 
       - name: Upload APK as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: boardsesh-rn-android-${{ github.run_number }}
@@ -461,7 +461,7 @@ jobs:
           ./scripts/check-16kb-alignment.sh "${archives[@]}"
 
       - name: Upload AAB as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: boardsesh-rn-android-aab-${{ github.run_number }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -19,26 +19,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -55,21 +55,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Accept licenses and install SDK components
         run: |
@@ -77,7 +77,7 @@ jobs:
           sdkmanager "platforms;android-36" "build-tools;36.0.0"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -142,7 +142,7 @@ jobs:
         run: ./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a -PboardseshAbiFilters=arm64-v8a --stacktrace
 
       - name: Upload sideloadable APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: boardsesh-rn-android-pr-${{ github.event.pull_request.number || github.run_number }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -18,30 +18,35 @@ permissions:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    # Gate the Android signing secrets behind the Production environment
+    # (main-only branch policy) so they can be stored ONLY in that environment,
+    # never at the repo level. Push is already main-only; this also blocks a
+    # feature-branch workflow_dispatch from reading the keystore.
+    environment: Production
     timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -101,7 +106,7 @@ jobs:
         run: ./gradlew bundleRelease --stacktrace
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: boardsesh-android-debug-${{ github.run_number }}
           path: mobile/android/app/build/outputs/apk/debug/*.apk
@@ -109,7 +114,7 @@ jobs:
 
       - name: Upload release APK
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: boardsesh-android-release-${{ github.run_number }}
           path: mobile/android/app/build/outputs/apk/release/*.apk
@@ -117,7 +122,7 @@ jobs:
 
       - name: Upload release AAB
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: boardsesh-android-aab-${{ github.run_number }}
           path: mobile/android/app/build/outputs/bundle/release/*.aab

--- a/.github/workflows/board-controller-docker.yml
+++ b/.github/workflows/board-controller-docker.yml
@@ -22,21 +22,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./board-controller
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       backend_changed: ${{ steps.changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -71,28 +71,28 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Generate web Docker context
         run: vp run docker-context:web
 
       - name: Build and push web image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .docker-context/web
           file: .docker-context/web/Dockerfile
@@ -112,7 +112,7 @@ jobs:
 
       - name: Build and push backend image
         if: needs.detect-changes.outputs.backend_changed == 'true'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .docker-context/backend
           file: .docker-context/backend/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       # test-backend / mobile-bundle / codegen-drift can run.
       runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.rootCi == 'true' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             anyJs:
@@ -109,9 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -120,7 +120,7 @@ jobs:
       - name: Build shared packages
         run: vp run build:db
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: built-packages
           path: |
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 50
       - name: Fetch base ref
@@ -142,15 +142,15 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --depth=50 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       - name: Lint changed files (PR)
@@ -181,16 +181,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       # `vp run typecheck` walks the dependsOn graph defined in root
@@ -209,16 +209,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       - name: Regenerate GraphQL types
@@ -239,16 +239,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       - name: Check hardcoded user-facing strings
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 50
       - name: Fetch base ref
@@ -270,15 +270,15 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --depth=50 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       # Run every project EXCEPT the two with dedicated infra-bearing jobs
@@ -312,7 +312,7 @@ jobs:
               --reporter=junit --outputFile.junit=./test-results/junit-default.xml
           fi
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: test-results-default
@@ -360,7 +360,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 50
       # Warn (don't fail) when shared Drizzle schema changed without a matching
@@ -383,15 +383,15 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --depth=50 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       - name: Run backend tests (shard ${{ matrix.shard }}/${{ matrix.total }})
@@ -414,7 +414,7 @@ jobs:
               --reporter=junit --outputFile.junit=./packages/backend/test-results/junit-backend-${{ matrix.shard }}.xml
           fi
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: test-results-backend-${{ matrix.shard }}
@@ -430,7 +430,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 50
       - name: Fetch base ref
@@ -442,15 +442,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       - name: Run OCR tests
@@ -469,7 +469,7 @@ jobs:
               --reporter=junit --outputFile.junit=./packages/moonboard-ocr/test-results/junit-ocr.xml
           fi
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: test-results-ocr
@@ -482,9 +482,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -511,7 +511,7 @@ jobs:
       - name: Check mobile variant usage
         run: vp run check:mobile-variants
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: built-packages
       - name: Metro bundle check
@@ -532,7 +532,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 50
       - name: Fetch base ref
@@ -540,8 +540,8 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch --depth=50 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -588,9 +588,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -636,15 +636,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: test-results-*
           path: test-results
           merge-multiple: true
       - name: Publish test report
-        uses: turing85/publish-report@v2
+        uses: turing85/publish-report@ee901e1a36f554c87b963f151170296227dac3d6 # v2
         with:
           comment-header: ci-tests
           comment-enabled: 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.142
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.99
+        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/cleanup-screenshots.yml
+++ b/.github/workflows/cleanup-screenshots.yml
@@ -16,7 +16,7 @@ jobs:
       # the whole branch — no path surgery needed, and if the branch was
       # never created (PR had no screenshot run) the 404 is a no-op.
       - name: Delete pr-screenshots/{PR} if it exists
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request.number;

--- a/.github/workflows/dev-db-docker.yml
+++ b/.github/workflows/dev-db-docker.yml
@@ -29,21 +29,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./packages/db/docker
           file: ./packages/db/docker/Dockerfile.postgres
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -86,21 +86,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -111,7 +111,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ./packages/db
           file: ./packages/db/docker/Dockerfile.dev-db
@@ -127,7 +127,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -146,21 +146,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -171,7 +171,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./packages/db/docker/Dockerfile
@@ -184,7 +184,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,18 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             node_modules
@@ -73,7 +73,7 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install unzip (required by setup-bun)
         # apt-get from the default Ubuntu mirror is intermittently unreachable
@@ -123,16 +123,16 @@ jobs:
           unzip -h >/dev/null 2>&1 || { echo "python unzip wrapper failed"; exit 1; }
           echo "python-based unzip wrapper installed at /usr/local/bin/unzip"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             node_modules
@@ -149,7 +149,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Cache Next.js incremental build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/web/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('bun.lock') }}-${{ hashFiles('packages/web/**/*.ts', 'packages/web/**/*.tsx', 'packages/web/**/*.js', 'packages/web/**/*.jsx') }}
@@ -194,7 +194,7 @@ jobs:
           ls -lh built-packages.tar
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.BUILT_PACKAGES_ARTIFACT }}
           path: built-packages.tar
@@ -232,7 +232,7 @@ jobs:
           --shm-size 256mb
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install unzip (required by setup-bun)
         # apt-get from the default Ubuntu mirror is intermittently unreachable
@@ -282,16 +282,16 @@ jobs:
           unzip -h >/dev/null 2>&1 || { echo "python unzip wrapper failed"; exit 1; }
           echo "python-based unzip wrapper installed at /usr/local/bin/unzip"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             node_modules
@@ -307,7 +307,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.BUILT_PACKAGES_ARTIFACT }}
 
@@ -366,7 +366,7 @@ jobs:
           cat web.log || true
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report-shard-${{ matrix.shard }}
@@ -374,7 +374,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Playwright test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: playwright-results-shard-${{ matrix.shard }}
@@ -418,7 +418,7 @@ jobs:
           --shm-size 256mb
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install unzip (required by setup-bun)
         # apt-get from the default Ubuntu mirror is intermittently unreachable
@@ -468,16 +468,16 @@ jobs:
           unzip -h >/dev/null 2>&1 || { echo "python unzip wrapper failed"; exit 1; }
           echo "python-based unzip wrapper installed at /usr/local/bin/unzip"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             node_modules
@@ -493,7 +493,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ env.BUILT_PACKAGES_ARTIFACT }}
 
@@ -564,7 +564,7 @@ jobs:
 
       - name: Upload screenshots artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: screenshots-current
           path: screenshots-out/
@@ -583,13 +583,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Download screenshots artifact
         id: dl
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         continue-on-error: true
         with:
           name: screenshots-current
@@ -700,7 +700,7 @@ jobs:
           PUSHED: ${{ steps.push.outputs.pushed }}
 
       - name: Upsert sticky PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: e2e-screenshots
           path: summary.md

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -61,7 +61,7 @@ jobs:
              firmware-${{ matrix.name }}.bin
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: firmware-${{ matrix.name }}
           path: firmware-${{ matrix.name }}.bin
@@ -74,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Download all firmware artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: firmware-artifacts
           merge-multiple: true

--- a/.github/workflows/firmware-tests.yml
+++ b/.github/workflows/firmware-tests.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -35,7 +35,7 @@ jobs:
         run: pio test -e native -v
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: test-results

--- a/.github/workflows/flake-report.yml
+++ b/.github/workflows/flake-report.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upsert sticky PR comment
         if: steps.pr.outputs.pr != ''
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           number: ${{ steps.pr.outputs.pr }}
           header: e2e-flake-report

--- a/.github/workflows/ios-board-placement-data.yml
+++ b/.github/workflows/ios-board-placement-data.yml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: mobile/ios/App/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('mobile/ios/App/Podfile.lock') }}

--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -55,11 +55,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -87,7 +87,7 @@ jobs:
         run: bunx expo prebuild --platform ios --clean --no-install
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/mobile/ios/Pods
           key: ${{ runner.os }}-pods-rn-ci-${{ hashFiles('packages/mobile/ios/Podfile.lock') }}

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -83,9 +83,9 @@ jobs:
       fingerprint: ${{ steps.fp.outputs.fingerprint }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
@@ -170,9 +170,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile
@@ -213,7 +213,7 @@ jobs:
         run: bunx expo prebuild --platform ios --clean --no-install
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/mobile/ios/Pods
           key: ${{ runner.os }}-pods-rn-${{ hashFiles('packages/mobile/ios/Podfile.lock') }}
@@ -225,7 +225,7 @@ jobs:
         run: pod install
 
       - name: Setup Ruby and fastlane
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: '3.4'
           bundler-cache: true
@@ -516,7 +516,7 @@ jobs:
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
 
       - name: Upload IPA as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: boardsesh-rn-ios-${{ steps.build_number.outputs.value }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -15,6 +15,11 @@ concurrency:
 jobs:
   build-and-upload:
     runs-on: macos-26
+    # Gate the iOS signing + App Store Connect secrets behind the Production
+    # environment (main-only branch policy) so they can be stored ONLY in that
+    # environment, never at the repo level. Push is already main-only; this also
+    # blocks a feature-branch workflow_dispatch from reading the cert/profiles.
+    environment: Production
     timeout-minutes: 45
 
     env:
@@ -27,17 +32,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: mobile/ios/App/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('mobile/ios/App/Podfile.lock') }}
@@ -134,7 +139,7 @@ jobs:
             -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
 
       - name: Upload IPA as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: boardsesh-ios-${{ github.run_number }}

--- a/.github/workflows/mobile-eas-update.yml
+++ b/.github/workflows/mobile-eas-update.yml
@@ -54,9 +54,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -106,7 +106,7 @@ jobs:
 
       - name: Post update link to PR
         if: github.event_name == 'push'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.name }}
           UPDATE_PLATFORM: ${{ env.INPUT_PLATFORM }}

--- a/.github/workflows/mobile-ota-check.yml
+++ b/.github/workflows/mobile-ota-check.yml
@@ -67,16 +67,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Need origin/main reachable for the baseline worktree, and the tags for
           # the secondary "already on a released build" lookup.
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies (PR tree)
         run: bun install --frozen-lockfile
@@ -104,7 +104,7 @@ jobs:
 
       - name: Comment OTA compatibility on the PR
         if: github.event_name == 'push' && steps.ota.outputs.comment_b64 != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_B64: ${{ steps.ota.outputs.comment_b64 }}
         with:
@@ -146,7 +146,7 @@ jobs:
 
       - name: Publish neutral check-run
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           # Falls back to "unknown" if an earlier step failed before the script
           # produced an output (e.g. install died), so the check always posts.

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -104,13 +104,13 @@ jobs:
       - name: Mint push token
         id: push_token
         if: vars.OTA_PUSH_APP_ID != ''
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ vars.OTA_PUSH_APP_ID }}
           private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Full history so the changelog push-back can rebase onto the latest main.
           fetch-depth: 0
@@ -124,9 +124,9 @@ jobs:
           # token (read-only checkout) when the app isn't set up.
           token: ${{ steps.push_token.outputs.token || github.token }}
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Node.js dependencies (workspace root)
         run: bun install --frozen-lockfile

--- a/.github/workflows/mobile-screenshots-android.yml
+++ b/.github/workflows/mobile-screenshots-android.yml
@@ -57,6 +57,11 @@ permissions:
 jobs:
   android:
     runs-on: ubuntu-latest
+    # Gate OTA_PUSH_APP_PRIVATE_KEY + DISCORD_DEPLOY_WEBHOOK behind the Production
+    # environment (main-only branch policy) so they live ONLY in that environment,
+    # never at the repo level. Capture/commit only runs from the scheduled main
+    # job or an admin dispatch — a feature-branch dispatch can't read the secrets.
+    environment: Production
     timeout-minutes: 75
 
     env:
@@ -98,13 +103,13 @@ jobs:
       - name: Mint push token
         id: push_token
         if: vars.OTA_PUSH_APP_ID != ''
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ vars.OTA_PUSH_APP_ID }}
           private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Full history so the screenshot push-back can reset onto the latest main.
           fetch-depth: 0
@@ -113,9 +118,9 @@ jobs:
           # token (read-only checkout) when the app isn't set up.
           token: ${{ steps.push_token.outputs.token || github.token }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -124,13 +129,13 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Accept licenses and install SDK components
         run: |
@@ -145,7 +150,7 @@ jobs:
       # stale). The key busts on native-config inputs (app.config.ts, plugins,
       # patches) so a stale build cache can't mask a native change.
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -244,7 +249,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Capture Android screenshots
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
         # android-emulator-runner splits `script:` by newline and runs each line
         # as its own `sh -c`, so inline for-loops / multi-line commands break
         # ("Syntax error: ... expecting \"done\""). The capture logic lives in a
@@ -377,7 +382,7 @@ jobs:
 
       - name: Upload screenshots artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mobile-screenshots-android
           path: app-stores/google/screenshots/**
@@ -391,7 +396,7 @@ jobs:
       # error vs slow load) be debugged without a rerun.
       - name: Upload Android capture debug
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: android-capture-debug
           path: android-capture-debug/**

--- a/.github/workflows/mobile-screenshots-ios.yml
+++ b/.github/workflows/mobile-screenshots-ios.yml
@@ -122,11 +122,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -142,7 +142,7 @@ jobs:
       # job never uses — keeping the common-path critical path to ~1-2 min.
       - name: Check for cached simulator app
         id: app-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/mobile/.app-cache
           key: ${{ steps.appkey.outputs.key }}
@@ -163,7 +163,7 @@ jobs:
       # hit the entry already exists.
       - name: Save simulator app to cache
         if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/mobile/.app-cache
           key: ${{ steps.appkey.outputs.key }}
@@ -204,11 +204,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -221,7 +221,7 @@ jobs:
       # populates the cache before these shards start (needs: + cache saves at job
       # end), so this restore is a guaranteed hit.
       - name: Restore prebuilt simulator app
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: packages/mobile/.app-cache
           key: ${{ needs.ios-build.outputs.cache-key }}
@@ -281,7 +281,7 @@ jobs:
 
       - name: Upload capture debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           # Per-shard name: upload-artifact@v4 rejects two uploads with the same
           # name in one run.
@@ -297,7 +297,7 @@ jobs:
       # intermediate; the combined tree is re-uploaded by ios-finalize.
       - name: Upload shard screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-screenshots-${{ matrix.locale }}-${{ matrix.device.slug }}
           path: app-stores/apple/screenshots/**
@@ -310,6 +310,11 @@ jobs:
     # gap (a missing locale fails it loudly rather than uploading a partial set).
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    # Gate the App Store Connect secrets behind the Production environment
+    # (main-only branch policy) so they can be stored ONLY in that environment,
+    # never at the repo level. A workflow_dispatch from a feature branch can't
+    # read them — only the scheduled/main run can.
+    environment: Production
     timeout-minutes: 30
 
     env:
@@ -319,11 +324,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
@@ -336,7 +341,7 @@ jobs:
       # preserving each one's <locale>/<device>/NN-name.png layout — so the gate
       # and fastlane see the full four-locale tree.
       - name: Download locale screenshots
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: ios-screenshots-*
           path: app-stores/apple/screenshots
@@ -362,7 +367,7 @@ jobs:
       # it runs fine on ubuntu.
       - name: Set up Ruby + fastlane
         if: success() && env.UPLOAD_RUN == 'true'
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: '3.4'
           bundler-cache: true
@@ -406,7 +411,7 @@ jobs:
 
       - name: Upload screenshots artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mobile-screenshots-ios
           path: app-stores/apple/screenshots/**

--- a/.github/workflows/mobile-store-metadata.yml
+++ b/.github/workflows/mobile-store-metadata.yml
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Ruby and fastlane
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           ruby-version: '3.4'
           bundler-cache: true

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       web_changed: ${{ steps.changes.outputs.web }}
       backend_changed: ${{ steps.changes.outputs.backend }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -165,9 +165,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
@@ -221,7 +221,7 @@ jobs:
         run: tar -czf vercel-output.tar.gz .vercel/output .vercel/project.json packages/web/.next packages/web/public/openapi.json
 
       - name: Upload prebuilt output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: vercel-output
           path: vercel-output.tar.gz
@@ -240,26 +240,26 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
       image: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           # Same digest gets all of these tags. Homelab consumes :staging,
@@ -276,7 +276,7 @@ jobs:
 
       - name: Build and push backend image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .docker-context/backend
           file: .docker-context/backend/Dockerfile
@@ -287,7 +287,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=backend-main
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -306,9 +306,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -327,9 +327,9 @@ jobs:
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         # vercel deploy --prebuilt validates the prebuilt output's file traces
@@ -342,7 +342,7 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Download prebuilt output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: vercel-output
           path: .
@@ -388,7 +388,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Show image being deployed
         run: |
@@ -621,7 +621,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Need enough history to walk github.event.before..github.sha for the
           # PR list. A single push to main is normally 1–5 commits (merge +

--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish Web Unit Tests report
-        uses: turing85/publish-report@v2
+        uses: turing85/publish-report@ee901e1a36f554c87b963f151170296227dac3d6 # v2
         with:
           checkout: 'true'
           download-artifact-name: web-test-results
@@ -36,10 +36,10 @@ jobs:
     if: github.event.workflow.name == 'Backend Integration Tests'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Download all shard results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: backend-test-results-*
           path: test-results
@@ -48,7 +48,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Backend Integration Tests report
-        uses: turing85/publish-report@v2
+        uses: turing85/publish-report@ee901e1a36f554c87b963f151170296227dac3d6 # v2
         with:
           comment-header: backend-test-report
           comment-enabled: 'true'

--- a/.github/workflows/refresh-acknowledgements.yml
+++ b/.github/workflows/refresh-acknowledgements.yml
@@ -23,11 +23,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true

--- a/.github/workflows/refresh-recommendations.yml
+++ b/.github/workflows/refresh-recommendations.yml
@@ -21,11 +21,11 @@ jobs:
     environment: Production
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true

--- a/.github/workflows/service-deploy-inputs.yml
+++ b/.github/workflows/service-deploy-inputs.yml
@@ -49,11 +49,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true

--- a/.github/workflows/sync-deploy.yml
+++ b/.github/workflows/sync-deploy.yml
@@ -38,26 +38,26 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
       image: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           # Same digest gets all of these tags. The homelab compose pins :production;
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and push sync image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .docker-context/sync
           file: .docker-context/sync/Dockerfile
@@ -85,7 +85,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=sync-main
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/testflight-feedback-issues.yml
+++ b/.github/workflows/testflight-feedback-issues.yml
@@ -29,11 +29,11 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
           node-version: 'lts'
           cache: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/ai-design-guidelines.md` — Velvet Send design system (mobile-canonical: palette, typography, tokens, Liquid Glass / Material variants; web still on the legacy rose/sage palette, pending migration)
 - `docs/live-activity-push-testing.md` — APNs Live Activity push testing
 - `docs/logging.md` — backend structured logger (winston)
+- `docs/ci-security.md` — CI/CD secret scoping, write-access threat model, rules for new workflows/secrets
 
 ## Architecture Overview
 

--- a/docs/ci-security.md
+++ b/docs/ci-security.md
@@ -1,0 +1,111 @@
+# CI/CD & secrets security
+
+How GitHub Actions secrets are scoped in this repo, the threat model for giving
+contributors write access, and the rules to keep new workflows safe. For
+vulnerability disclosure see the root `SECURITY.md`.
+
+## The one rule that matters
+
+**Write access = the ability to read every _repo-level_ secret.**
+
+When someone has write (push) access, they can push a branch — or `workflow_dispatch`
+a workflow against their branch — and GitHub runs _their_ version of the workflow
+file with repo secrets injected. A two-line step (`echo "${{ secrets.X }}" | curl …`)
+exfiltrates the secret. There is no review gate on this; the workflow runs on push.
+
+The fork boundary you might be thinking of (forks get no secrets, read-only token)
+**does not apply to collaborators** — they push branches, not forks.
+
+The only thing that protects a secret from a write-access contributor is **storing
+it in an Environment whose deployment-branch policy excludes their branches**
+(here: the `Production` environment, restricted to `main`). A job reads an
+environment secret only when it declares `environment: <name>` _and_ the run's ref
+is allowed by that environment's branch policy.
+
+### Repo-level secret + same-named environment secret = the repo one wins for ungated jobs
+
+If a secret named `FOO` exists both at the repo level and in the `Production`
+environment, a job _without_ `environment: Production` still gets the **repo-level**
+`FOO`. So duplicating a gated secret at the repo level silently cancels the gating.
+Don't do it. A secret belongs in exactly one place.
+
+## Secret placement policy
+
+| Sensitivity                          | Where it goes                                        | Examples                                                                                                                                                                         |
+| ------------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Production infra & app signing       | `Production` environment **only** (never repo-level) | `VERCEL_TOKEN`, `RAILWAY_TOKEN`, prod `DATABASE_URL`, `SENTRY_AUTH_TOKEN`, Android keystore, iOS p12/profiles, App Store Connect key, Google Play SA, `OTA_PUSH_APP_PRIVATE_KEY` |
+| Needed on feature branches by design | Repo-level, but **must be low-blast-radius**         | `EXPO_TOKEN` (preview OTA), `CLAUDE_CODE_OAUTH_TOKEN`, test-account creds                                                                                                        |
+
+If a workflow legitimately needs a high-value secret, gate its job with
+`environment: Production` instead of copying the secret to the repo level.
+
+`OTA_PUSH_APP_PRIVATE_KEY` deserves special care: it mints a `boardsesh-repo-bot`
+token with `contents: write` that is on `main`'s pull-request-bypass allowlist.
+Leaking it = push to `main` without review = read every `Production` secret. Keep it
+environment-scoped.
+
+## Adding a new workflow or secret — checklist
+
+- Set an explicit least-privilege `permissions:` block. The repo default token is
+  read-only; keep it that way and grant only what the job needs.
+- Never interpolate untrusted input (`github.event.pull_request.title/body`,
+  `head_ref`, issue/comment bodies, dispatch inputs) directly into a `run:` block.
+  Pass it through `env:` and reference `"$VAR"`. See `ci.yml` for the pattern.
+- New high-value secret? Put it in the `Production` environment and gate the job
+  with `environment: Production`. Do **not** add it at the repo level "to make it
+  work" on a branch.
+- Pin every external action to a full commit SHA with a `# vX` comment. Dependabot
+  (`github-actions` ecosystem) keeps the pins current.
+- No `pull_request_target`. If you think you need it, you almost certainly don't —
+  ask first.
+- Self-hosted runners (`[self-hosted, homelab, …]`) run untrusted-from-a-branch
+  code on our hardware. Any job on one must be gated by an `environment:` with
+  required reviewers, and the runner kept in a restricted runner group. The
+  `branch-deploy*` workflows are the only ones that target self-hosted and their
+  push/PR triggers are currently disabled — keep it that way until the guardrails
+  above are in place.
+
+## Settings that back this up (verify these, they aren't in the YAML)
+
+- **Default workflow token:** read-only, can't approve PRs. ✅
+- **`main` branch protection:** require PR review (≥1), `require_last_push_approval`,
+  required status checks (so red CI can't merge), and "Require review from Code
+  Owners" (enforces `.github/CODEOWNERS`).
+- **`Production` environment:** deployment branches = `main` only; add ≥1 required
+  reviewer so a human approves before prod/store secrets are used.
+- **No secret may live at both the repo level and the `Production` environment.**
+
+## Audit — 2026-06-21
+
+Triggered by a plan to grant more contributors write access. Full review of all 36
+workflows plus live repo/environment settings.
+
+**Already solid:** read-only default token; no `pull_request_target`; no script
+injection (untrusted PR fields go through `env:`); fork PRs require approval and get
+no secrets; production infra secrets (`VERCEL_TOKEN`, `RAILWAY_TOKEN`, prod
+`DATABASE_URL`, `SENTRY_AUTH_TOKEN`, `DISCORD_DEPLOY_WEBHOOK`) are environment-only
+and `main`-gated; force-push disabled; `require_last_push_approval` on.
+
+**Fixed in the hardening PR:** all external actions SHA-pinned; `github-actions`
+added to Dependabot; `.github/CODEOWNERS` added; the four workflows that consumed
+signing/ASC/OTA secrets without gating (`android-release.yml`, `ios-testflight.yml`,
+`mobile-screenshots-ios.yml`, `mobile-screenshots-android.yml`) now run their
+secret-using job under `environment: Production`.
+
+**Requires admin action (settings/secrets — tracked in the follow-up issue):**
+
+1. Delete the **repo-level duplicates** of every secret also in `Production`
+   (Android keystore + passwords, iOS p12 + password + provisioning profiles, App
+   Store Connect key/id/issuer, Google Play SA JSON). They make the `Production`
+   gating moot today. Do this only **after** the hardening PR merges.
+2. Move `OTA_PUSH_APP_PRIVATE_KEY` into the `Production` environment; remove the
+   repo-level copy.
+3. Split `EXPO_TOKEN` into a least-privilege preview token (repo) and a separate
+   production-channel token (`Production`), or accept that every write contributor
+   can read the current one.
+4. Replace the `ACKNOWLEDGEMENTS_GH_TOKEN` PAT with the existing `github.token`
+   fallback (or a fine-grained, environment-scoped token); move `BRANCH_DEPLOY_*`
+   secrets into an environment.
+5. Branch protection: add required status checks + "Require review from Code
+   Owners". `Production` environment: add a required reviewer.
+6. Delete the stray empty `boardsesh / production` environment.


### PR DESCRIPTION
## Summary

Security hardening of GitHub Actions ahead of granting more contributors **write** access.

The core issue: write access = the ability to read every **repo-level** secret. A collaborator can push a branch (or `workflow_dispatch` against their branch) and GitHub runs *their* workflow with repo secrets injected — no review gate. The fork boundary (forks get no secrets) doesn't protect against collaborators, who push branches. Today the mobile **signing secrets** sit at the repo level (duplicated alongside the `Production` environment copies), so any future write-access contributor could exfiltrate the Android keystore, iOS distribution cert, App Store Connect key, and Google Play service account from a throwaway branch.

This PR removes the *code-side* blockers so those repo-level duplicates can be safely deleted, and tightens the supply chain.

### What changed
- **SHA-pin every external action** (263 refs across 35 workflows) to a full commit SHA with a `# vX` comment — a moved tag can't swap in malicious code. The two already-pinned actions are untouched.
- **Add `github-actions` to Dependabot** (grouped, weekly) so the new pins stay current.
- **Gate the four ungated signing-secret consumers** behind `environment: Production` (main-only branch policy): `android-release.yml`, `ios-testflight.yml`, `mobile-screenshots-ios.yml` (`ios-finalize`), `mobile-screenshots-android.yml` (`android`). These were the *reason* the secrets had to exist at the repo level; with the jobs gated, the secrets can live only in the `Production` environment.
- **Add `.github/CODEOWNERS`** routing CI/CD + deploy tooling to a maintainer (becomes a hard gate once branch protection enables code-owner review).
- **Document** the secret-scoping model, write-access threat model, and rules for new workflows in `docs/ci-security.md`.

### Behaviour change to note
The four gated jobs now only run their secret-using work from `main` (scheduled runs / push to main / admin dispatch). A `workflow_dispatch` of these from a **feature branch** will be blocked at the environment gate instead of getting secrets — which is the intended security boundary, and matches how the App Store / Play release flows already behave.

### Follow-up (admin-only, NOT in this PR)
Deleting the repo-level secret duplicates, relocating `OTA_PUSH_APP_PRIVATE_KEY`, splitting `EXPO_TOKEN`, and the branch-protection / environment-reviewer settings are tracked in a separate issue. **Do the repo-level secret deletions only after this PR merges**, or the gated jobs lose their fallback before the environment copies are the sole source.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan
- `vp check` — formatting/lint clean on changed files.
- All 35 workflow YAMLs parse; every external `uses:` resolves to a 40-char SHA; no tag residue.
- `environment: Production` confirmed on the four gated jobs.
- CI on this PR exercises the re-pinned actions end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)