### PR TITLE
fix(web): wall-confirm resolves from convergent state, not a 2s verdict (#3121)

### DIFF
--- a/packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts
+++ b/packages/shared/play-view/src/__tests__/wall-confirm-fallback.test.ts
@@ -309,4 +309,62 @@ describe('createWallConfirmFallbackController', () => {
       boardLayout: 'Original',
     });
   });
+
+  it('pulseOnly: classifies a connected backstop as a genuine board-ack timeout, not pulse_only', () => {
+    // Connected when the backstop fires means the connect handshake wasn't the
+    // problem — we were on the board but no confirm converged. That's the
+    // genuine board-ack signal, even though pulseOnly still suppresses connect.
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus, { isBluetoothConnected: () => true });
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, pulseOnly: true });
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+    expect(callbacks.onTrackTimeout).toHaveBeenCalledWith({
+      mode: 'solo',
+      fallback: 'already_connected',
+      boardLayout: 'Original',
+    });
+  });
+
+  it('respects a custom timeoutMs backstop', () => {
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, timeoutMs: 5000 });
+    // Past the default window — the backstop must NOT have fired yet.
+    vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS + 500);
+    expect(callbacks.onTimeout).not.toHaveBeenCalled();
+    expect(callbacks.onTrackTimeout).not.toHaveBeenCalled();
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+
+    // Reach the custom backstop — now it fires.
+    vi.advanceTimersByTime(5000 - (WALL_CONFIRM_TIMEOUT_MS + 500));
+    expect(callbacks.onTimeout).toHaveBeenCalledWith({ climbUuid: 'climb-1' });
+    expect(callbacks.onTrackTimeout).toHaveBeenCalledOnce();
+  });
+
+  it('records a confirm that lands after the default window but within a widened backstop (no clipping)', () => {
+    const wallConfirmBus = createLocalWallConfirmBus();
+    const callbacks = createCallbacks();
+    const deps = createDeps(wallConfirmBus);
+    const controller = createWallConfirmFallbackController(deps, callbacks);
+
+    controller.armWatcher({ ...baseClimb, timeoutMs: 5000 });
+    vi.advanceTimersByTime(2500); // past the old 2s clip ceiling
+    wallConfirmBus.emit('climb-1');
+
+    expect(callbacks.onConfirmed).toHaveBeenCalledWith({
+      climbUuid: 'climb-1',
+      latencyMs: 2500,
+      confirmedByRole: 'other',
+    });
+    expect(callbacks.onTimeout).not.toHaveBeenCalled();
+    expect(callbacks.onTrackTimeout).not.toHaveBeenCalled();
+  });
 });

--- a/packages/shared/play-view/src/wall-confirm-fallback.ts
+++ b/packages/shared/play-view/src/wall-confirm-fallback.ts
@@ -11,6 +11,19 @@
  */
 export const WALL_CONFIRM_TIMEOUT_MS = 2000;
 
+/**
+ * Backstop for the connect-included arm (the lightbulb tap, which must cover a
+ * cold BLE connect + first frame write + ack convergence). The timer is no
+ * longer a verdict — a confirm is sourced from convergent state (the local BLE
+ * write, the seq'd board-presence `BoardClimbSet`, or `WallConfirmedClimb`) and
+ * the pulse otherwise clears when the climb is superseded (queue moves on) or
+ * the board disconnects. This value only bounds a *stuck* pulse and classifies
+ * the "never converged" telemetry. Kept generous so a slow cold connect that
+ * converges at ~5–6s still lands as `Wall Confirmed` rather than being clipped;
+ * re-tune from the (now un-clipped) confirm-latency distribution after shipping.
+ */
+export const WALL_CONFIRM_BACKSTOP_MS = 8000;
+
 export type WallConfirmMode = 'party' | 'solo';
 export type WallConfirmFallback = 'already_connected' | 'unsupported' | 'auto_connect' | 'picker' | 'pulse_only';
 
@@ -19,16 +32,23 @@ export type WallConfirmArmArgs = {
   mode: WallConfirmMode;
   boardLayout: string;
   /**
-   * Drive the pulse/confirm UI but never connect on timeout. Set this when the
-   * caller has *itself* just initiated a connect (the always-live lightbulb tap
-   * does this): re-connecting 2s later is at best redundant (a successful
+   * Drive the pulse/confirm UI but never connect on the backstop. Set this when
+   * the caller has *itself* just initiated a connect (the always-live lightbulb
+   * tap does this): re-connecting later is at best redundant (a successful
    * connect already short-circuits via `already_connected`) and at worst a
    * second native scan started while the first picker is still open — which
    * trips "Already scanning. Stopping now." on the iOS shell. The watcher still
-   * waits for `WallConfirmedClimb` and fires `onConfirmed` / `onTimeout` to
-   * clear the pulse; only the connect fallback is suppressed.
+   * waits for a confirm and fires `onConfirmed` / `onTimeout` to clear the
+   * pulse; only the connect fallback is suppressed.
    */
   pulseOnly?: boolean;
+  /**
+   * Override the backstop window for this arm. Defaults to
+   * `WALL_CONFIRM_TIMEOUT_MS`. The connect-included lightbulb arm passes
+   * `WALL_CONFIRM_BACKSTOP_MS` (it must cover a cold connect + write + ack); a
+   * steady-state already-connected arm can keep the tight default.
+   */
+  timeoutMs?: number;
 };
 
 type WallConfirmTimeoutId = ReturnType<typeof setTimeout>;
@@ -91,7 +111,13 @@ export function createWallConfirmFallbackController(
     }
   };
 
-  const armWatcher = ({ climbUuid, mode, boardLayout, pulseOnly = false }: WallConfirmArmArgs) => {
+  const armWatcher = ({
+    climbUuid,
+    mode,
+    boardLayout,
+    pulseOnly = false,
+    timeoutMs = WALL_CONFIRM_TIMEOUT_MS,
+  }: WallConfirmArmArgs) => {
     cancelWatcher();
 
     const armedAt = getNow();
@@ -103,17 +129,25 @@ export function createWallConfirmFallbackController(
       cancelWatcher();
       callbacks.onTimeout?.({ climbUuid });
 
-      // The caller already kicked off its own connect — never start another one
-      // (the second scan is what breaks iOS pairing). Just record the timeout.
+      // Classify by connection state *first*, even under pulseOnly. Connected
+      // when the backstop fired (whether or not pulseOnly) means the connect
+      // handshake wasn't the problem — we were on the board but no confirm
+      // converged. That's the genuine board-ack/send signal; never run a
+      // connect fallback for it.
+      if (deps.isBluetoothConnected()) {
+        callbacks.onTrackTimeout?.({ mode, fallback: 'already_connected', boardLayout });
+        return;
+      }
+
+      // Not connected, and the caller already kicked off its own connect — never
+      // start another (the second scan is what breaks iOS pairing). The pulse
+      // simply timed out while still bringing the link up: not a board-ack
+      // failure. Record it, run no connect.
       if (pulseOnly) {
         callbacks.onTrackTimeout?.({ mode, fallback: 'pulse_only', boardLayout });
         return;
       }
 
-      if (deps.isBluetoothConnected()) {
-        callbacks.onTrackTimeout?.({ mode, fallback: 'already_connected', boardLayout });
-        return;
-      }
       if (!deps.isBluetoothSupported()) {
         callbacks.onTrackTimeout?.({ mode, fallback: 'unsupported', boardLayout });
         return;
@@ -140,7 +174,7 @@ export function createWallConfirmFallbackController(
       callbacks.onTrackConfirmed?.({ climbUuid, latencyMs, confirmedByRole, mode, boardLayout });
     });
 
-    capturedTimeoutId = scheduleTimeout(runFallback, WALL_CONFIRM_TIMEOUT_MS);
+    capturedTimeoutId = scheduleTimeout(runFallback, timeoutMs);
     watcher = { timeoutId: capturedTimeoutId, unsubscribe };
   };
 

--- a/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
@@ -132,7 +132,7 @@ describe('useWallConfirmFallback', () => {
     // serial, BLE supported → picker fallback.
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
     expect(deps.bluetoothConnect).toHaveBeenCalledWith();
-    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', {
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Connecting', {
       mode: 'solo',
       fallback: 'picker',
       boardLayout: 'Original',
@@ -154,7 +154,7 @@ describe('useWallConfirmFallback', () => {
     // Picker path: connect called with NO targetSerial arg.
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
     expect(deps.bluetoothConnect).toHaveBeenCalledWith();
-    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', {
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Connecting', {
       mode: 'party',
       fallback: 'picker',
       boardLayout: 'Original',
@@ -180,7 +180,7 @@ describe('useWallConfirmFallback', () => {
 
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
     expect(deps.bluetoothConnect).toHaveBeenCalledWith(undefined, undefined, 'serial-42');
-    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', {
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Connecting', {
       mode: 'party',
       fallback: 'auto_connect',
       boardLayout: 'Original',
@@ -206,7 +206,7 @@ describe('useWallConfirmFallback', () => {
 
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
     expect(deps.bluetoothConnect).toHaveBeenCalledWith();
-    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', expect.objectContaining({ fallback: 'picker' }));
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Connecting', expect.objectContaining({ fallback: 'picker' }));
   });
 
   it('does nothing when already BLE-connected (already_connected path)', () => {
@@ -243,7 +243,7 @@ describe('useWallConfirmFallback', () => {
 
     expect(deps.bluetoothConnect).not.toHaveBeenCalled();
     expect(mockTrack).toHaveBeenCalledWith(
-      'Wall Confirm Timeout',
+      'Wall Confirm Connecting',
       expect.objectContaining({ fallback: 'unsupported' }),
     );
   });
@@ -359,7 +359,7 @@ describe('useWallConfirmFallback', () => {
     });
     expect(deps.bluetoothConnect).toHaveBeenCalledOnce();
     expect(mockTrack).toHaveBeenCalledOnce();
-    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Timeout', expect.objectContaining({ fallback: 'picker' }));
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Connecting', expect.objectContaining({ fallback: 'picker' }));
 
     // A late confirm for the same climb arrives — must not double-fire or
     // tear anything down (the watcher is already gone).
@@ -453,5 +453,50 @@ describe('useWallConfirmFallback', () => {
       'Wall Confirm Timeout',
       expect.objectContaining({ fallback: 'already_connected' }),
     );
+  });
+
+  it('records a still-connecting backstop as "Wall Confirm Connecting", not a board-ack timeout', () => {
+    // The production lightbulb arm: pulseOnly + still disconnected when the
+    // backstop fires. This is "we were still bringing the link up", not a board
+    // failure — it must NOT inflate the genuine `Wall Confirm Timeout` metric.
+    const deps = makeDeps({ isBluetoothConnected: false });
+    const { result } = renderHook(() => useWallConfirmFallback(deps));
+
+    act(() => {
+      result.current.armWatcher({ ...baseClimb, pulseOnly: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+    });
+
+    expect(deps.bluetoothConnect).not.toHaveBeenCalled();
+    expect(mockTrack).toHaveBeenCalledWith('Wall Confirm Connecting', {
+      mode: 'solo',
+      fallback: 'pulse_only',
+      boardLayout: 'Original',
+    });
+    expect(mockTrack).not.toHaveBeenCalledWith('Wall Confirm Timeout', expect.anything());
+  });
+
+  it('records a confirm past the old 2s ceiling as Wall Confirmed (no clipping) with a widened backstop', () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useWallConfirmFallback(deps));
+
+    act(() => {
+      result.current.armWatcher({ ...baseClimb, pulseOnly: true, timeoutMs: 8000 });
+    });
+    act(() => {
+      vi.advanceTimersByTime(2500); // would have been clipped under the old 2s verdict
+    });
+    act(() => {
+      emitWallConfirm('climb-1');
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      'Wall Confirmed',
+      expect.objectContaining({ climbUuid: 'climb-1', latencyMs: 2500 }),
+    );
+    expect(mockTrack).not.toHaveBeenCalledWith('Wall Confirm Connecting', expect.anything());
+    expect(mockTrack).not.toHaveBeenCalledWith('Wall Confirm Timeout', expect.anything());
   });
 });

--- a/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
@@ -5,6 +5,7 @@ import { renderHook, act } from '@testing-library/react';
 import {
   useWallConfirmConvergence,
   useWallConfirmFallback,
+  WALL_CONFIRM_BACKSTOP_MS,
   WALL_CONFIRM_TIMEOUT_MS,
 } from '../use-wall-confirm-fallback';
 import { emitWallConfirm } from '@boardsesh/play-view';
@@ -460,17 +461,18 @@ describe('useWallConfirmFallback', () => {
   });
 
   it('records a still-connecting backstop as "Wall Confirm Connecting", not a board-ack timeout', () => {
-    // The production lightbulb arm: pulseOnly + still disconnected when the
-    // backstop fires. This is "we were still bringing the link up", not a board
-    // failure — it must NOT inflate the genuine `Wall Confirm Timeout` metric.
+    // The production lightbulb arm: pulseOnly + the connect-included backstop +
+    // still disconnected when it fires. This is "we were still bringing the link
+    // up", not a board failure — it must NOT inflate the genuine `Wall Confirm
+    // Timeout` metric.
     const deps = makeDeps({ isBluetoothConnected: false });
     const { result } = renderHook(() => useWallConfirmFallback(deps));
 
     act(() => {
-      result.current.armWatcher({ ...baseClimb, pulseOnly: true });
+      result.current.armWatcher({ ...baseClimb, pulseOnly: true, timeoutMs: WALL_CONFIRM_BACKSTOP_MS });
     });
     act(() => {
-      vi.advanceTimersByTime(WALL_CONFIRM_TIMEOUT_MS);
+      vi.advanceTimersByTime(WALL_CONFIRM_BACKSTOP_MS);
     });
 
     expect(deps.bluetoothConnect).not.toHaveBeenCalled();

--- a/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
+++ b/packages/web/app/components/play-view/__tests__/use-wall-confirm-fallback.test.tsx
@@ -2,7 +2,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
-import { useWallConfirmFallback, WALL_CONFIRM_TIMEOUT_MS } from '../use-wall-confirm-fallback';
+import {
+  useWallConfirmConvergence,
+  useWallConfirmFallback,
+  WALL_CONFIRM_TIMEOUT_MS,
+} from '../use-wall-confirm-fallback';
 import { emitWallConfirm } from '@boardsesh/play-view';
 
 const mockTrack = vi.fn();
@@ -498,5 +502,100 @@ describe('useWallConfirmFallback', () => {
     );
     expect(mockTrack).not.toHaveBeenCalledWith('Wall Confirm Connecting', expect.anything());
     expect(mockTrack).not.toHaveBeenCalledWith('Wall Confirm Timeout', expect.anything());
+  });
+});
+
+describe('useWallConfirmConvergence', () => {
+  type ConvergenceProps = Parameters<typeof useWallConfirmConvergence>[0];
+
+  function renderConvergence(initial: Partial<ConvergenceProps> = {}) {
+    const onConfirm = vi.fn();
+    const onSupersede = vi.fn();
+    const baseProps: ConvergenceProps = {
+      pendingClimbUuid: null,
+      wallCurrentClimbUuid: null,
+      committedClimbUuid: null,
+      onConfirm,
+      onSupersede,
+      ...initial,
+    };
+    const utils = renderHook((props: ConvergenceProps) => useWallConfirmConvergence(props), {
+      initialProps: baseProps,
+    });
+    return { ...utils, onConfirm, onSupersede, baseProps };
+  }
+
+  it('confirms when the wall transitions to the pending climb', () => {
+    // Wall shows A; user taps to light B (committed); B not yet on the wall.
+    const { rerender, onConfirm, baseProps } = renderConvergence({
+      pendingClimbUuid: 'climb-b',
+      wallCurrentClimbUuid: 'climb-a',
+      committedClimbUuid: 'climb-b',
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    // The wall now reports B (fresh BoardClimbSet) — a transition to pending.
+    rerender({
+      ...baseProps,
+      pendingClimbUuid: 'climb-b',
+      wallCurrentClimbUuid: 'climb-b',
+      committedClimbUuid: 'climb-b',
+    });
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledWith('climb-b');
+  });
+
+  it('does NOT confirm when the wall already shows the pending climb at arm time (no transition)', () => {
+    // Board already lit B; first observed wall value is the baseline, not a
+    // transition — the local BLE write confirms this case, not convergence.
+    const { onConfirm } = renderConvergence({
+      pendingClimbUuid: 'climb-b',
+      wallCurrentClimbUuid: 'climb-b',
+      committedClimbUuid: 'climb-b',
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('supersedes when the committed climb moves off the pending one', () => {
+    const { rerender, onSupersede, baseProps } = renderConvergence({
+      pendingClimbUuid: 'climb-b',
+      wallCurrentClimbUuid: 'climb-a',
+      committedClimbUuid: 'climb-b',
+    });
+    expect(onSupersede).not.toHaveBeenCalled();
+
+    // Queue advances to a different committed climb.
+    rerender({
+      ...baseProps,
+      pendingClimbUuid: 'climb-b',
+      wallCurrentClimbUuid: 'climb-a',
+      committedClimbUuid: 'climb-c',
+    });
+
+    expect(onSupersede).toHaveBeenCalledOnce();
+  });
+
+  it('supersedes when the queue is emptied while a pulse is pending', () => {
+    // Regression: an empty queue (committed null) must still supersede, not wait
+    // out the full backstop.
+    const { onSupersede } = renderConvergence({
+      pendingClimbUuid: 'climb-b',
+      wallCurrentClimbUuid: 'climb-a',
+      committedClimbUuid: null,
+    });
+    expect(onSupersede).toHaveBeenCalledOnce();
+  });
+
+  it('is inert when no pulse is pending', () => {
+    const { rerender, onConfirm, onSupersede, baseProps } = renderConvergence({
+      pendingClimbUuid: null,
+      wallCurrentClimbUuid: 'climb-a',
+      committedClimbUuid: 'climb-a',
+    });
+    rerender({ ...baseProps, pendingClimbUuid: null, wallCurrentClimbUuid: 'climb-b', committedClimbUuid: 'climb-c' });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onSupersede).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -11,6 +11,7 @@ import React, {
   useDeferredValue,
 } from 'react';
 import { BoardPresenceCurrentContext } from '@boardsesh/board-presence-react';
+import { emitWallConfirm } from '@boardsesh/play-view';
 import { useTranslation } from 'react-i18next';
 import { track } from '@/app/lib/analytics';
 import IconButton from '@mui/material/IconButton';
@@ -31,7 +32,7 @@ import { PlaybackControls } from '../playback/playback-controls';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
-import { useWallConfirmFallback } from './use-wall-confirm-fallback';
+import { useWallConfirmFallback, WALL_CONFIRM_BACKSTOP_MS } from './use-wall-confirm-fallback';
 import { useDrawerPlayback } from './use-drawer-playback';
 import { themeTokens } from '@/app/theme/theme-config';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
@@ -109,10 +110,10 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
    * Lightbulb pending state (queue-control-bar pivot, Phase 3).
    *
    * Set when the user presses the lightbulb to connect + send the current climb
-   * to the board — between the press and the matching `WallConfirmedClimb`, the
+   * to the board — between the press and the climb converging onto the wall, the
    * lightbulb renders with a soft pulse so the user can see we're waiting.
-   * Cleared either way when `useWallConfirmFallback` resolves (confirm,
-   * timeout, or session-swap cancellation).
+   * Cleared when the climb confirms (convergent state), is superseded (queue
+   * moves on), the session swaps, or the backstop fires.
    */
   const [pendingClimbUuid, setPendingClimbUuid] = useState<string | null>(null);
   /**
@@ -380,20 +381,22 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
   const handlePrevNavClick = useCallback(() => {
     navigate('previous', 'playViewDrawer');
   }, [navigate]);
-  // Wall-confirm watcher: armed by handleLightbulbClick, dismissed by the
-  // local wall-confirm bus or fires a connect fallback after 2 s. Owns its
-  // own unmount cleanup so the drawer doesn't need to thread that wiring.
+  // Wall-confirm watcher: armed by handleLightbulbClick. The pulse resolves
+  // from convergent state — the local wall-confirm bus (fed by the BLE write,
+  // the seq'd board-presence `BoardClimbSet`, and `WallConfirmedClimb`) — or
+  // clears when the climb is superseded (queue moves on) / the session ends.
+  // The timer is only a long backstop for a stuck pulse, not a verdict, so a
+  // slow confirm still lands solid-lit instead of being clipped at 2 s.
   //
   // `onConfirmed` / `onTimeout` clear the lightbulb's pending pulse state so
-  // the UI accurately reflects the round-trip — pulse during the window,
-  // solid lit on confirm, picker (or no-op) on timeout.
+  // the UI reflects the round-trip — pulse while pending, solid lit on confirm.
   const handleWallConfirmed = useCallback((info: { climbUuid: string }) => {
     setPendingClimbUuid((current) => (current === info.climbUuid ? null : current));
   }, []);
   const handleWallConfirmTimeout = useCallback((info: { climbUuid: string }) => {
     setPendingClimbUuid((current) => (current === info.climbUuid ? null : current));
   }, []);
-  const { armWatcher: armWallConfirmWatcher } = useWallConfirmFallback(
+  const { armWatcher: armWallConfirmWatcher, cancelWatcher: cancelWallConfirmWatcher } = useWallConfirmFallback(
     {
       isBluetoothConnected,
       isBluetoothSupported,
@@ -403,6 +406,37 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     },
     { onConfirmed: handleWallConfirmed, onTimeout: handleWallConfirmTimeout },
   );
+
+  // Derive the confirm from the convergent wall state: when the board-presence
+  // feed *transitions* to show the pending climb on the wall (a fresh seq'd
+  // `BoardClimbSet`, which also survives a reconnect catch-up), feed it into the
+  // same wall-confirm bus the watcher listens on so it records `Wall Confirmed`
+  // with the true, un-clipped latency. The bus coalesces, so this is safe
+  // alongside the local BLE write that fires it immediately. Gate on the
+  // transition (was-not → now-is), not steady-state equality: a tap while the
+  // board already shows the climb is confirmed by the local write, not a fresh
+  // round-trip, and would otherwise log a ~0 ms latency that skews the metric.
+  const wallCurrentClimbUuid = boardPresenceCurrent?.currentClimb?.climbUuid ?? null;
+  const prevWallCurrentClimbUuidRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prevWallClimbUuid = prevWallCurrentClimbUuidRef.current;
+    prevWallCurrentClimbUuidRef.current = wallCurrentClimbUuid;
+    if (pendingClimbUuid && wallCurrentClimbUuid === pendingClimbUuid && prevWallClimbUuid !== pendingClimbUuid) {
+      emitWallConfirm(pendingClimbUuid);
+    }
+  }, [wallCurrentClimbUuid, pendingClimbUuid]);
+
+  // Supersede: if the user navigates the queue off the pending climb before it
+  // confirms, the pulse was for a climb they've moved on from. Cancel the
+  // watcher silently (no confirm, no timeout — it's neither) and clear the
+  // pulse, so the longer backstop never leaves a stale pulse on the bulb.
+  const committedCurrentClimbUuid = currentClimbQueueItem?.climb.uuid ?? null;
+  useEffect(() => {
+    if (pendingClimbUuid && committedCurrentClimbUuid && committedCurrentClimbUuid !== pendingClimbUuid) {
+      cancelWallConfirmWatcher();
+      setPendingClimbUuid(null);
+    }
+  }, [committedCurrentClimbUuid, pendingClimbUuid, cancelWallConfirmWatcher]);
 
   // Session-swap during pending: if the watcher hook cancels because the
   // session ended mid-window, also clear the local pending UI state. The
@@ -423,9 +457,8 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
    *    clears.
    *  - Not BLE-connected → connect (silent reconnect to the last board on
    *    native shells, otherwise the device picker). The fresh AutoSender pushes
-   *    the current climb on mount; arm the 2-second wall-confirm watcher so the
-   *    bulb pulses until WallConfirmedClimb lands (the watcher no-ops once
-   *    connected).
+   *    the *committed* current climb on mount; arm the wall-confirm watcher on
+   *    that same climb so the bulb pulses until it converges onto the wall.
    */
   const handleLightbulbClick = useCallback(() => {
     const boardLayout = boardDetails.layout_name ?? '';
@@ -437,11 +470,16 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
       return;
     }
 
+    // Pulse/arm on the *committed* current climb — that's what the AutoSender
+    // writes on connect and what board presence will report — not a drawer
+    // browse-preview (`currentClimb` can be a previewed climb that never gets
+    // sent, which would never confirm and would trip the supersede guard).
+    const sendClimbUuid = currentClimbQueueItem?.climb.uuid ?? null;
     track('Wall Control Taken', {
       source: 'lightbulb_drawer',
       mode: isPersistentSessionActive ? 'party' : 'solo',
       boardLayout,
-      climbUuid: currentClimb?.uuid ?? null,
+      climbUuid: sendClimbUuid,
     });
     // Silent reconnect to the board we were last on (native shells only — Web
     // Bluetooth ignores a target serial and always shows the chooser). Null
@@ -453,22 +491,26 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     } else {
       void bluetoothConnect();
     }
-    // Pulse the bulb until the climb is confirmed on the wall. We just initiated
+    // Pulse the bulb until the climb converges onto the wall. We just initiated
     // the connect above, so arm pulse-only: the watcher must NOT fire its own
-    // connect fallback on timeout. Re-connecting 2s later is redundant once the
+    // connect fallback on the backstop. Re-connecting later is redundant once the
     // first connect lands, and firing it while the device picker is still open
     // starts a second scan that trips "Already scanning. Stopping now." on iOS.
-    if (currentClimb) {
-      setPendingClimbUuid(currentClimb.uuid);
+    // The backstop is connect-included (cold connect + write + ack), not a 2s
+    // verdict — the confirm comes from convergent state and supersede clears the
+    // pulse early when the user moves on.
+    if (sendClimbUuid) {
+      setPendingClimbUuid(sendClimbUuid);
       armWallConfirmWatcher({
-        climbUuid: currentClimb.uuid,
+        climbUuid: sendClimbUuid,
         mode: isPersistentSessionActive ? 'party' : 'solo',
         boardLayout,
         pulseOnly: true,
+        timeoutMs: WALL_CONFIRM_BACKSTOP_MS,
       });
     }
   }, [
-    currentClimb,
+    currentClimbQueueItem,
     isPersistentSessionActive,
     isBluetoothConnected,
     bluetoothConnect,

--- a/packages/web/app/components/play-view/play-view-drawer.tsx
+++ b/packages/web/app/components/play-view/play-view-drawer.tsx
@@ -32,7 +32,11 @@ import { PlaybackControls } from '../playback/playback-controls';
 import { useWakeLock } from '../board-bluetooth-control/use-wake-lock';
 import { useBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
-import { useWallConfirmFallback, WALL_CONFIRM_BACKSTOP_MS } from './use-wall-confirm-fallback';
+import {
+  useWallConfirmConvergence,
+  useWallConfirmFallback,
+  WALL_CONFIRM_BACKSTOP_MS,
+} from './use-wall-confirm-fallback';
 import { useDrawerPlayback } from './use-drawer-playback';
 import { themeTokens } from '@/app/theme/theme-config';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
@@ -407,36 +411,25 @@ const PlayViewDrawer: React.FC<PlayViewDrawerProps> = ({
     { onConfirmed: handleWallConfirmed, onTimeout: handleWallConfirmTimeout },
   );
 
-  // Derive the confirm from the convergent wall state: when the board-presence
-  // feed *transitions* to show the pending climb on the wall (a fresh seq'd
-  // `BoardClimbSet`, which also survives a reconnect catch-up), feed it into the
-  // same wall-confirm bus the watcher listens on so it records `Wall Confirmed`
-  // with the true, un-clipped latency. The bus coalesces, so this is safe
-  // alongside the local BLE write that fires it immediately. Gate on the
-  // transition (was-not → now-is), not steady-state equality: a tap while the
-  // board already shows the climb is confirmed by the local write, not a fresh
-  // round-trip, and would otherwise log a ~0 ms latency that skews the metric.
+  // Bridge the convergent board-presence state to the pulse: confirm when the
+  // wall transitions to the pending climb (feeding the same wall-confirm bus the
+  // watcher listens on, so it records the true un-clipped latency), and supersede
+  // when the committed queue climb moves off the pending one — so the longer
+  // backstop never leaves a stale pulse on the bulb. See `useWallConfirmConvergence`
+  // for the transition + empty-queue semantics.
   const wallCurrentClimbUuid = boardPresenceCurrent?.currentClimb?.climbUuid ?? null;
-  const prevWallCurrentClimbUuidRef = useRef<string | null>(null);
-  useEffect(() => {
-    const prevWallClimbUuid = prevWallCurrentClimbUuidRef.current;
-    prevWallCurrentClimbUuidRef.current = wallCurrentClimbUuid;
-    if (pendingClimbUuid && wallCurrentClimbUuid === pendingClimbUuid && prevWallClimbUuid !== pendingClimbUuid) {
-      emitWallConfirm(pendingClimbUuid);
-    }
-  }, [wallCurrentClimbUuid, pendingClimbUuid]);
-
-  // Supersede: if the user navigates the queue off the pending climb before it
-  // confirms, the pulse was for a climb they've moved on from. Cancel the
-  // watcher silently (no confirm, no timeout — it's neither) and clear the
-  // pulse, so the longer backstop never leaves a stale pulse on the bulb.
   const committedCurrentClimbUuid = currentClimbQueueItem?.climb.uuid ?? null;
-  useEffect(() => {
-    if (pendingClimbUuid && committedCurrentClimbUuid && committedCurrentClimbUuid !== pendingClimbUuid) {
-      cancelWallConfirmWatcher();
-      setPendingClimbUuid(null);
-    }
-  }, [committedCurrentClimbUuid, pendingClimbUuid, cancelWallConfirmWatcher]);
+  const handleWallConfirmSupersede = useCallback(() => {
+    cancelWallConfirmWatcher();
+    setPendingClimbUuid(null);
+  }, [cancelWallConfirmWatcher]);
+  useWallConfirmConvergence({
+    pendingClimbUuid,
+    wallCurrentClimbUuid,
+    committedClimbUuid: committedCurrentClimbUuid,
+    onConfirm: emitWallConfirm,
+    onSupersede: handleWallConfirmSupersede,
+  });
 
   // Session-swap during pending: if the watcher hook cancels because the
   // session ended mid-window, also clear the local pending UI state. The

--- a/packages/web/app/components/play-view/use-wall-confirm-fallback.ts
+++ b/packages/web/app/components/play-view/use-wall-confirm-fallback.ts
@@ -4,13 +4,14 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import {
   createWallConfirmFallbackController,
   subscribeToWallConfirm,
+  WALL_CONFIRM_BACKSTOP_MS,
   WALL_CONFIRM_TIMEOUT_MS,
   type WallConfirmArmArgs,
 } from '@boardsesh/play-view';
 import { track } from '@/app/lib/analytics';
 import { isNativeApp } from '@/app/lib/ble/capacitor-utils';
 
-export { WALL_CONFIRM_TIMEOUT_MS };
+export { WALL_CONFIRM_BACKSTOP_MS, WALL_CONFIRM_TIMEOUT_MS };
 
 type Deps = {
   /** Current local BLE connection state. */
@@ -78,7 +79,16 @@ export function useWallConfirmFallback(deps: Deps, callbacks: Callbacks = {}) {
             track('Wall Confirmed', { climbUuid, latencyMs, confirmedByRole, mode, boardLayout });
           },
           onTrackTimeout: ({ mode, fallback, boardLayout }) => {
-            track('Wall Confirm Timeout', { mode, fallback, boardLayout });
+            // Only the connected-but-no-converge case is a genuine board-ack
+            // failure. Everything else (`pulse_only`/`picker`/`auto_connect`/
+            // `unsupported`) is the backstop firing while the link was still
+            // coming up — not a wall failure. Split it out so it stops inflating
+            // the board-ack-failure metric.
+            if (fallback === 'already_connected') {
+              track('Wall Confirm Timeout', { mode, fallback, boardLayout });
+            } else {
+              track('Wall Confirm Connecting', { mode, fallback, boardLayout });
+            }
           },
         },
       ),

--- a/packages/web/app/components/play-view/use-wall-confirm-fallback.ts
+++ b/packages/web/app/components/play-view/use-wall-confirm-fallback.ts
@@ -118,3 +118,63 @@ export function useWallConfirmFallback(deps: Deps, callbacks: Callbacks = {}) {
 
   return { armWatcher, cancelWatcher };
 }
+
+type WallConfirmConvergenceArgs = {
+  /** The climb whose pulse is currently armed, or null when idle. */
+  pendingClimbUuid: string | null;
+  /** The climb the board-presence feed currently shows on the wall, or null. */
+  wallCurrentClimbUuid: string | null;
+  /** The committed queue climb (what the AutoSender sends), null when the queue
+   *  is empty. */
+  committedClimbUuid: string | null;
+  /** Fired once when the wall *transitions* to the pending climb — feed the
+   *  wall-confirm bus so the watcher records the confirm with its true latency. */
+  onConfirm: (climbUuid: string) => void;
+  /** Fired when the pending climb is superseded — the committed climb moved off
+   *  it (queue advanced or emptied). */
+  onSupersede: () => void;
+};
+
+/**
+ * Bridges the convergent board-presence state to the wall-confirm pulse. Two
+ * rules:
+ *
+ *  - **Confirm on transition.** When the wall feed *becomes* the pending climb
+ *    (a fresh `BoardClimbSet`, or a reconnect catch-up), fire `onConfirm`. Gate
+ *    on the transition (was-not → now-is), never steady-state equality: a tap
+ *    while the board already shows the climb is confirmed by the local BLE
+ *    write, and a steady-state emit would log a ~0 ms latency that skews the
+ *    metric. The first observed wall value is the baseline, not a transition.
+ *  - **Supersede.** When the committed climb no longer matches the pending one
+ *    — including the queue being emptied (`committedClimbUuid === null`) — fire
+ *    `onSupersede` so the pulse clears immediately instead of waiting out the
+ *    backstop.
+ *
+ * Extracted from the drawer so both rules are unit-testable without the full
+ * play-view tree.
+ */
+export function useWallConfirmConvergence({
+  pendingClimbUuid,
+  wallCurrentClimbUuid,
+  committedClimbUuid,
+  onConfirm,
+  onSupersede,
+}: WallConfirmConvergenceArgs): void {
+  // `undefined` until the first observed wall value, so a mount that already
+  // shows the pending climb is treated as the baseline, not a transition.
+  const prevWallClimbUuidRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    const prevWallClimbUuid = prevWallClimbUuidRef.current;
+    prevWallClimbUuidRef.current = wallCurrentClimbUuid;
+    if (prevWallClimbUuid === undefined) return;
+    if (pendingClimbUuid && wallCurrentClimbUuid === pendingClimbUuid && prevWallClimbUuid !== pendingClimbUuid) {
+      onConfirm(pendingClimbUuid);
+    }
+  }, [wallCurrentClimbUuid, pendingClimbUuid, onConfirm]);
+
+  useEffect(() => {
+    if (pendingClimbUuid && committedClimbUuid !== pendingClimbUuid) {
+      onSupersede();
+    }
+  }, [committedClimbUuid, pendingClimbUuid, onSupersede]);
+}


### PR DESCRIPTION
Closes #3121.

## What & why

After a send, the play-drawer lightbulb pulses while we wait for the board to confirm the climb lit up. That wait was a one-shot **2s timer that rendered a terminal verdict**: confirm or "timeout". Two problems fell out of that (PostHog project 412845, 30d):

- **Clipped confirms.** Successful confirm latency is p95 1,544ms / p99 1,884ms / **max 1,986ms** — pinned within 14ms of the 2,000ms ceiling because the cap *truncates* the distribution. ~5% of legitimate confirmations land just after 2s and were recorded as timeouts; the pulse also stopped early.
- **A lying metric.** `Wall Confirm Timeout` fired ~3:1 vs `Wall Confirmed`, but most of that is the `pulse_only` **connect phase** (the watcher armed at lightbulb tap, 2s before a cold BLE scan/pair can even finish) — not a board-ack failure.

Stepping back: the board-presence "now on the wall" feed is *already* a convergent, seq'd, reconciling model (gap-detection, catch-up, durable `board_climb_events`). The wall-confirm pulse was the one piece that never joined it. This is **slice 1** of converging it.

## What changed (web + `@boardsesh/play-view` only)

- The pulse now **derives from convergent state** and clears on confirm / supersede / a long backstop — not an arbitrary 2s verdict. The seq'd board-presence `BoardClimbSet` is fed into the existing wall-confirm bus (gated on a *transition*, so an already-lit climb doesn't log a ~0ms confirm). A slow confirm at ~5s now lands solid-lit with its true latency instead of being clipped.
- **Supersede:** if the user navigates the queue off the pending climb, the pulse clears immediately (the longer backstop never leaves a stale pulse).
- We now arm/pulse on the **committed** climb the AutoSender actually sends, not a drawer browse-preview.
- **Telemetry split:** only the genuine connected-but-never-converged case stays `Wall Confirm Timeout`; the connect-phase reasons (`pulse_only`/`picker`/`auto_connect`/`unsupported`) move to a new **`Wall Confirm Connecting`** event so they stop inflating the board-ack metric.

The RN app doesn't use this controller — affected users run the web bundle inside the Capacitor shell, so the fix is web/shared.

## Follow-ups (out of scope here)
- The larger convergent build-out (producer durable outbox, holder durability + web `boardConnection` backfill parity, spectator/party-member convergence) is tracked separately and ties into #2860 / #2712 / #2713 / #3008 / #3087.
- **PostHog owner:** any saved insight counting `Wall Confirm Timeout` unfiltered now sees only `already_connected`; the connect-phase count moved to `Wall Confirm Connecting`. Re-tune `WALL_CONFIRM_BACKSTOP_MS` from the now-un-clipped `Wall Confirmed` latency once data lands.

## Testing
- `vp run typecheck` (web + shared), `vp check` — clean.
- `vp test run --project play-view` (145) and the web play-view suite (76) — green. New cases cover the `timeoutMs` backstop, the connected-vs-connecting classification under `pulseOnly`, the telemetry split, and a 2.5s confirm landing as `Wall Confirmed` (no clipping).
- Manual QA to exercise: tap the drawer lightbulb on a cold connect (solo + party); confirm a slow (>2s) ack lands solid-lit, not a re-pop; navigate off the pending climb mid-pulse and confirm it clears.

## Release Notes
When you send a climb, the board light keeps pulsing until the wall actually lights up — even when the board takes an extra beat to answer. No more pulse cutting out early or the device picker popping back up on a send that worked.