### PR TITLE
fix(mobile): hide dev-server switcher on builds without the native dev launcher

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -23,6 +23,7 @@ import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { HoldColorAccessibilitySection } from '../../../src/components/settings/HoldColorAccessibilitySection';
 import { SessionRecordingSwitchRow } from '../../../src/components/settings/SessionRecordingSwitchRow';
 import { isPreviewBuild } from '../../../src/lib/eas-api';
+import { isDevLauncherAvailable } from '../../../src/lib/dev-launcher';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useGlassCapability } from '../../../src/hooks/use-glass-capability';
 import { useToast } from '../../../src/providers/toast-provider';
@@ -55,6 +56,16 @@ export default function MoreScreen() {
   // work on real (non-dev) builds where updates are enabled. Gated on the tester
   // flag so only admin-marked testers see it.
   const showChannelSwitcher = Boolean(profile?.isTester) && !__DEV__ && Updates.isEnabled;
+
+  // Live Metro dev-server switching needs expo-dev-client's native launcher, which
+  // is only linked into dev-client / Debug builds — never the App Store / TestFlight
+  // binary (where it would throw "Dev launcher unavailable"). Show the row only where
+  // it can actually work; testers on a release build get the OTA channel switcher.
+  const showDevServerSwitcher = isDevLauncherAvailable();
+
+  // Don't render an empty "Development" section header when neither tool applies
+  // (e.g. a tester on a release build with updates disabled).
+  const showDevSection = (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showChannelSwitcher);
 
   // Whether the bundled changelog has an entry the user hasn't opened yet — drives
   // the "New" pill on the What's New row. Re-read every time this screen regains
@@ -295,18 +306,20 @@ export default function MoreScreen() {
         </View>
       </View>
 
-      {__DEV__ || profile?.isTester ? (
+      {showDevSection ? (
         <View style={styles.section}>
           <SectionHeader title={t('mobile.more.development')} />
           <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-            <ListRow
-              title={t('mobile.more.metroServersTitle')}
-              subtitle={t('mobile.more.metroServersSubtitle')}
-              leading={<Icon name="server" size={22} color={systemColors.secondaryLabel} />}
-              showChevron
-              showSeparator={showChannelSwitcher}
-              onPress={() => router.push('/(tabs)/profile/dev-servers')}
-            />
+            {showDevServerSwitcher ? (
+              <ListRow
+                title={t('mobile.more.metroServersTitle')}
+                subtitle={t('mobile.more.metroServersSubtitle')}
+                leading={<Icon name="server" size={22} color={systemColors.secondaryLabel} />}
+                showChevron
+                showSeparator={showChannelSwitcher}
+                onPress={() => router.push('/(tabs)/profile/dev-servers')}
+              />
+            ) : null}
             {showChannelSwitcher ? (
               <ListRow
                 // i18n-ignore-next-line — tester-only dev tooling

--- a/packages/mobile/src/components/DevServerSwitcherScreen.tsx
+++ b/packages/mobile/src/components/DevServerSwitcherScreen.tsx
@@ -14,7 +14,6 @@ import {
 } from 'react-native';
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import Constants from 'expo-constants';
-import { requireOptionalNativeModule } from 'expo-modules-core';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Text } from './Text';
 import { SectionHeader } from './SectionHeader';
@@ -28,12 +27,7 @@ import { useConfirm } from '../providers/dialog-provider';
 import { hapticLight, hapticError } from '../lib/haptics';
 import { discoverBundlers, type DiscoveredBundler } from '../lib/metro-discovery';
 import { addSavedMetroTarget, getSavedMetroTargets, removeSavedMetroTarget } from '../lib/metro-target-store';
-
-type ExpoDevLauncherModule = {
-  loadApp(url: string): Promise<boolean>;
-};
-
-const ExpoDevLauncher = requireOptionalNativeModule<ExpoDevLauncherModule>('ExpoDevLauncher');
+import { expoDevLauncher, isDevLauncherAvailable } from '../lib/dev-launcher';
 
 function getTailscaleHosts(): string[] {
   const hosts = Constants.expoConfig?.extra?.tailscaleHosts;
@@ -89,11 +83,11 @@ export function DevServerSwitcherScreen() {
 
   const switchMutation = useMutation({
     mutationFn: async (bundler: DiscoveredBundler) => {
-      if (!ExpoDevLauncher) {
+      if (!expoDevLauncher) {
         throw new Error('Dev launcher unavailable — install expo-dev-client and rebuild');
       }
       setSwitchingUrl(bundler.url);
-      await ExpoDevLauncher.loadApp(bundler.url);
+      await expoDevLauncher.loadApp(bundler.url);
     },
     onError: (mutationError: unknown) => {
       hapticError();
@@ -247,7 +241,7 @@ export function DevServerSwitcherScreen() {
           {/* i18n-ignore-next-line */}
           <InfoRow label="Saved targets" value={String(savedTargets.length)} />
           {/* i18n-ignore-next-line */}
-          <InfoRow label="Dev launcher" value={ExpoDevLauncher ? 'available' : 'missing'} />
+          <InfoRow label="Dev launcher" value={isDevLauncherAvailable() ? 'available' : 'missing'} />
           <InfoRow
             // i18n-ignore-next-line
             label="Bundlers live"

--- a/packages/mobile/src/lib/__tests__/dev-launcher.test.ts
+++ b/packages/mobile/src/lib/__tests__/dev-launcher.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// dev-launcher.ts calls requireOptionalNativeModule('ExpoDevLauncher') at module
+// scope. We control what it returns per test by reassigning the variable the mock
+// factory closes over, then re-importing the module against the fresh value.
+type LauncherMock = { loadApp(url: string): Promise<boolean> } | null;
+
+let launcherMock: LauncherMock = null;
+
+vi.mock('expo-modules-core', () => ({
+  requireOptionalNativeModule: () => launcherMock,
+}));
+
+// resetModules forces dev-launcher.ts to re-run its top-level probe against the
+// freshly assigned launcherMock instead of freezing the first import's value.
+async function loadDevLauncher() {
+  vi.resetModules();
+  return await import('../dev-launcher');
+}
+
+beforeEach(() => {
+  launcherMock = null;
+});
+
+describe('isDevLauncherAvailable', () => {
+  it('reports unavailable when ExpoDevLauncher is not linked (App Store / TestFlight binary)', async () => {
+    launcherMock = null;
+    const { isDevLauncherAvailable, expoDevLauncher } = await loadDevLauncher();
+
+    expect(isDevLauncherAvailable()).toBe(false);
+    expect(expoDevLauncher).toBeNull();
+  });
+
+  it('reports available when ExpoDevLauncher is linked (dev-client build)', async () => {
+    const loadApp = vi.fn().mockResolvedValue(true);
+    launcherMock = { loadApp };
+    const { isDevLauncherAvailable, expoDevLauncher } = await loadDevLauncher();
+
+    expect(isDevLauncherAvailable()).toBe(true);
+    expect(expoDevLauncher).toBe(launcherMock);
+  });
+});

--- a/packages/mobile/src/lib/dev-launcher.ts
+++ b/packages/mobile/src/lib/dev-launcher.ts
@@ -1,0 +1,15 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+type ExpoDevLauncherModule = {
+  loadApp(url: string): Promise<boolean>;
+};
+
+// expo-dev-client's launcher native module is only linked into Debug / dev-client
+// builds. requireOptionalNativeModule returns null in Expo Go and in any Release
+// (App Store / TestFlight / Play) binary — so this doubles as our signal for
+// "live Metro dev-server switching is possible on this build."
+export const expoDevLauncher = requireOptionalNativeModule<ExpoDevLauncherModule>('ExpoDevLauncher');
+
+export function isDevLauncherAvailable(): boolean {
+  return expoDevLauncher !== null;
+}


### PR DESCRIPTION
## What & why

Admin/tester users see a **Development** section in the mobile More tab with two rows: an **OTA Channel Switcher** and a **Metro servers** (dev-server) switcher. The dev-server switcher calls `ExpoDevLauncher.loadApp(url)` to point the app at a Metro dev server, but `ExpoDevLauncher` is the native module from `expo-dev-client`, which Expo links into **dev-client / Debug builds only** — never a Release (App Store / TestFlight / Play) binary. There, `requireOptionalNativeModule('ExpoDevLauncher')` returns `null`, so testers saw the row and got `"Dev launcher unavailable"` when tapping a server.

We're not making it work on the App Store binary: loading arbitrary remote JS from any Metro URL is exactly what Apple **2.5.2 / 3.3.2** prohibit (and why Expo strips the launcher from Release). Testers already have the compliant equivalent — the **OTA Channel Switcher**, which pulls code-signed, fingerprint-matched bundles from our own server under 3.3.2's interpreted-code carve-out.

This hides the dead row where it can't work.

## Changes

- New `packages/mobile/src/lib/dev-launcher.ts` — extracts the `ExpoDevLauncher` probe into a shared `isDevLauncherAvailable()` helper (mirrors `isPreviewBuild()` in `eas-api.ts`).
- `DevServerSwitcherScreen.tsx` — uses the shared helper instead of its own inline probe (no behaviour change; the in-screen guard still fails safe on a deep link).
- `more.tsx` — gates the Metro-servers row on `isDevLauncherAvailable()`, and skips an empty Development section header when neither dev tool applies.
- New unit test `dev-launcher.test.ts` — covers the null probe (App Store case → hidden) and the linked probe (dev-client case → shown).

Resulting matrix:
- **App Store / TestFlight (tester):** launcher absent → Metro row hidden; OTA Channel Switcher shown.
- **Dev-client build (dev/tester):** launcher present → Metro row shown (Channel Switcher hidden by its existing `Updates.isEnabled && !__DEV__` gate).
- **Non-tester production user:** section hidden entirely (unchanged).

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2555 pass (incl. new `dev-launcher.test.ts`)
- `vp run check:mobile-bundle` — OK
- `vp check` on touched files — clean
- App Store / Release behaviour is covered by the `null`-probe unit test (can't link `ExpoDevLauncher` into a Release build by design). On a dev-client build the Metro-servers row and switching are unchanged.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162pe9NLjJ8oCDyFDCYFUsD