### PR TITLE
feat(mobile): bug report + Discord on login, hide climb bar on auth

### DIFF
--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -13,6 +13,7 @@ import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import { GoogleSigninButton } from '@react-native-google-signin/google-signin';
+import type { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { classifyNativeAuthFailureReason } from '../../src/lib/native-auth-analytics';
@@ -23,6 +24,7 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { useNativeOAuthSignIn } from '../../src/hooks/use-native-oauth-sign-in';
 import { AuthTextInput } from '../../src/components/AuthTextInput';
 import { Button } from '../../src/components/Button';
+import { FeedbackSheet } from '../../src/components/user-drawer/FeedbackSheet';
 import { track } from '../../src/lib/analytics';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
@@ -33,6 +35,10 @@ export default function LoginScreen() {
   const theme = useTheme();
   const router = useRouter();
   const passwordRef = useRef<RNTextInput>(null);
+  // Bug report sheet — the only in-app way for a user who can't get past login to
+  // reach us. Mounted here (inside the QueueProvider / BottomSheetModalProvider
+  // tree) so the shared FeedbackSheet works without auth; submission is public.
+  const feedbackSheetRef = useRef<BottomSheetModal>(null);
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -245,7 +251,27 @@ export default function LoginScreen() {
             <Text style={[styles.footerLink, { color: theme.systemColors.accent }]}>{t('login.submit.signUp')}</Text>
           </Pressable>
         </View>
+
+        {/* Last-resort help for someone stuck at the gate: sign-in failing, can't
+            create an account. Subtle so it stays out of the way of the happy path. */}
+        <View style={styles.troubleRow}>
+          <Text style={[styles.footerText, { color: theme.systemColors.secondaryLabel }]}>
+            {t('login.links.troubleSigningIn')}{' '}
+          </Text>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              feedbackSheetRef.current?.present();
+            }}
+            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+            style={styles.footerLinkHit}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.footerLink, { color: theme.systemColors.accent }]}>{t('login.links.reportBug')}</Text>
+          </Pressable>
+        </View>
       </ScrollView>
+      <FeedbackSheet sheetRef={feedbackSheetRef} mode="bug" showDiscordLink />
     </KeyboardAvoidingView>
   );
 }
@@ -286,6 +312,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginTop: 24,
+  },
+  troubleRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 8,
   },
   footerText: { fontSize: 15 },
   footerLink: { fontSize: 15, fontWeight: '600' },

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -9,6 +9,7 @@ const cfg = vi.hoisted(() => ({
   onClimbsTab: true,
   insideTabs: true,
   onGymDiscovery: false,
+  onAuthRoute: false,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
   wallClimb: null as null | { uuid: string; angle: number },
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
@@ -49,6 +50,7 @@ vi.mock('../../../lib/route-segments', () => ({
   isClimbsTabRoute: () => cfg.onClimbsTab,
   isTabsRoute: () => cfg.insideTabs,
   isGymDiscoveryRoute: () => cfg.onGymDiscovery,
+  isAuthRoute: () => cfg.onAuthRoute,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
@@ -134,6 +136,7 @@ describe('PersistentQueueBar', () => {
     cfg.onClimbsTab = true;
     cfg.insideTabs = true;
     cfg.onGymDiscovery = false;
+    cfg.onAuthRoute = false;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
     cfg.wallClimb = null;
     cfg.variant = 'liquidGlass';
@@ -158,6 +161,15 @@ describe('PersistentQueueBar', () => {
     // The /gyms screen is a full-bleed map with its own bottom sheet, so the
     // climb accessory is suppressed there even with a current climb.
     cfg.onGymDiscovery = true;
+    const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  it('renders nothing on the auth (login) route', () => {
+    // Pre-auth screens have no user to tick for — a leftover queued or "on the
+    // wall" climb must not float a tick bar over the login screen.
+    cfg.onAuthRoute = true;
     const { container } = render(<PersistentQueueBar />);
     expect(container.querySelector('[data-capsule]')).toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,7 +21,7 @@ import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, gl
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
-import { isGymDiscoveryRoute } from '../../lib/route-segments';
+import { isAuthRoute, isGymDiscoveryRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
@@ -42,6 +42,9 @@ export function PersistentQueueBar() {
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
 
   if (!currentClimb) return null;
+  // The sign-in / sign-up flow is pre-auth — a leftover queued or "on the wall"
+  // climb must not float a tick bar over the login screen.
+  if (isAuthRoute(segments)) return null;
   // The gym-discovery screen is a full-bleed map with its own bottom sheet — the
   // climb accessory would overlap it, so suppress it there.
   if (isGymDiscoveryRoute(segments)) return null;

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useSubmitMobileAppFeedback } from '../../lib/feedback/use-submit-app-feedback';
+import { openDiscordInvite } from '../../lib/discord';
 
 export type FeedbackSheetMode = 'rating' | 'bug';
 
@@ -22,9 +23,15 @@ const STAR_RATING_VALUES = [1, 2, 3, 4, 5] as const;
 type FeedbackSheetProps = {
   sheetRef: RefObject<BottomSheetModal | null>;
   mode: FeedbackSheetMode;
+  /**
+   * Show a "Join Discord" link below the submit button. Used on the login screen,
+   * where a stuck user has no other route to help; off everywhere else (the user
+   * drawer already has its own Discord row).
+   */
+  showDiscordLink?: boolean;
 };
 
-export function FeedbackSheet({ sheetRef, mode }: FeedbackSheetProps) {
+export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: FeedbackSheetProps) {
   const { t } = useTranslation('settings');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
@@ -154,6 +161,19 @@ export function FeedbackSheet({ sheetRef, mode }: FeedbackSheetProps) {
         loading={isPending}
         style={styles.submitButton}
       />
+
+      {showDiscordLink ? (
+        <Button
+          title={t('feedbackDialog.joinDiscord')}
+          onPress={() => {
+            void openDiscordInvite('login');
+          }}
+          variant="text"
+          size="large"
+          icon="open.external"
+          tintColor={brandColors.primary}
+        />
+      ) : null}
     </ModalSheet>
   );
 }

--- a/packages/mobile/src/lib/__tests__/route-segments.test.ts
+++ b/packages/mobile/src/lib/__tests__/route-segments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTabsRoute, isClimbsTabRoute } from '../route-segments';
+import { isTabsRoute, isClimbsTabRoute, isAuthRoute } from '../route-segments';
 
 describe('isTabsRoute', () => {
   it('is true anywhere inside the tab navigator', () => {
@@ -26,5 +26,19 @@ describe('isClimbsTabRoute', () => {
     expect(isClimbsTabRoute(['(tabs)'])).toBe(false);
     expect(isClimbsTabRoute(['auth'])).toBe(false);
     expect(isClimbsTabRoute([])).toBe(false);
+  });
+});
+
+describe('isAuthRoute', () => {
+  it('is true anywhere inside the auth flow', () => {
+    expect(isAuthRoute(['auth'])).toBe(true);
+    expect(isAuthRoute(['auth', 'login'])).toBe(true);
+    expect(isAuthRoute(['auth', 'register'])).toBe(true);
+  });
+
+  it('is false outside the auth flow', () => {
+    expect(isAuthRoute(['(tabs)', 'climbs'])).toBe(false);
+    expect(isAuthRoute(['gyms'])).toBe(false);
+    expect(isAuthRoute([])).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/discord.ts
+++ b/packages/mobile/src/lib/discord.ts
@@ -3,7 +3,7 @@ import { reportError } from './error-reporting';
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/YXA8GsXfQK';
 
-type DiscordInviteSource = 'about' | 'user-drawer' | 'acknowledgements';
+type DiscordInviteSource = 'about' | 'user-drawer' | 'acknowledgements' | 'login';
 
 export async function openDiscordInvite(source: DiscordInviteSource): Promise<void> {
   try {

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -12,10 +12,20 @@ type Segments = readonly string[];
 const TABS_GROUP = '(tabs)';
 const CLIMBS_TAB = 'climbs';
 const GYMS_ROUTE = 'gyms';
+const AUTH_GROUP = 'auth';
 
 /** True when the focused route lives inside the bottom-tab navigator. */
 export function isTabsRoute(segments: Segments): boolean {
   return segments[0] === TABS_GROUP;
+}
+
+/**
+ * True when the focused route is the sign-in / sign-up flow (`/auth/*`). The user
+ * isn't signed in there, so the persistent climb accessory has nothing to act on
+ * and shouldn't float over the login screen.
+ */
+export function isAuthRoute(segments: Segments): boolean {
+  return segments[0] === AUTH_GROUP;
 }
 
 /** True when the focused route is the Climbs tab (or one of its sub-routes). */

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -58,7 +58,9 @@
     },
     "links": {
       "haveAccount": "Already have an account?",
-      "noAccount": "New here?"
+      "noAccount": "New here?",
+      "troubleSigningIn": "Trouble signing in?",
+      "reportBug": "Report a bug"
     },
     "a11y": {
       "showPassword": "Show password",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -310,7 +310,8 @@
     "successRating": "Thanks — logged.",
     "successBug": "Bug logged — thanks.",
     "errorRating": "Couldn't send — we'll keep your feedback.",
-    "closeAria": "Close"
+    "closeAria": "Close",
+    "joinDiscord": "Join Discord"
   },
   "feedbackForm": {
     "missingHeading": "What's missing?",

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -58,7 +58,9 @@
     },
     "links": {
       "haveAccount": "¿Ya tienes una cuenta?",
-      "noAccount": "¿Nuevo por aquí?"
+      "noAccount": "¿Nuevo por aquí?",
+      "troubleSigningIn": "¿Problemas para iniciar sesión?",
+      "reportBug": "Reportar un fallo"
     },
     "a11y": {
       "showPassword": "Mostrar contraseña",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -310,7 +310,8 @@
     "successRating": "Gracias — registrado.",
     "successBug": "Fallo registrado — gracias.",
     "errorRating": "No se pudo enviar — guardamos tus comentarios.",
-    "closeAria": "Cerrar"
+    "closeAria": "Cerrar",
+    "joinDiscord": "Únete a Discord"
   },
   "feedbackForm": {
     "missingHeading": "¿Qué falta?",

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -58,7 +58,9 @@
     },
     "links": {
       "haveAccount": "Vous avez déjà un compte ?",
-      "noAccount": "Nouveau ici ?"
+      "noAccount": "Nouveau ici ?",
+      "troubleSigningIn": "Problème de connexion ?",
+      "reportBug": "Signaler un bug"
     },
     "a11y": {
       "showPassword": "Afficher le mot de passe",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -310,7 +310,8 @@
     "successRating": "Merci, c'est noté.",
     "successBug": "Bug enregistré, merci.",
     "errorRating": "Envoi impossible. On garde votre retour.",
-    "closeAria": "Fermer"
+    "closeAria": "Fermer",
+    "joinDiscord": "Rejoindre Discord"
   },
   "feedbackForm": {
     "missingHeading": "Qu'est-ce qui manque ?",


### PR DESCRIPTION
## Summary

A user who can't get past the login screen had no in-app way to reach us — "Report a bug" and "Join Discord" both live in the user drawer, which is unreachable before sign-in.

- **Bug report from login.** Added a subtle "Trouble signing in? Report a bug" link to the login footer. It opens the existing `FeedbackSheet` (bug mode), so a stuck user can describe what's wrong and optionally turn on session recording. Feedback submission is public on the backend, so it records (with a null user) without auth.
- **Join Discord in the modal.** Extended `FeedbackSheet` with an opt-in `showDiscordLink` prop that adds a "Join Discord" button below the submit button. Only the login modal sets it; the user-drawer modal is unchanged (it already has its own Discord row).
- **No climb bar on the login screen.** The JS `PersistentQueueBar` mounts at app root and only checked the current climb / gym route / native accessory, so a leftover queued or "on the wall" climb could float a tick bar over the login screen. Gated it behind a new `isAuthRoute()` helper. The native iOS 26 bottom accessory was already gated by `insideTabs`, so it needed no change.

i18n keys added to all locales (`en-US`, `es`, `fr`).

## Release Notes

- Stuck at sign-in? Report a bug or jump into Discord without logging in first.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2556 passed (added `isAuthRoute` coverage + a "hidden on auth route" `PersistentQueueBar` test)
- `vp test run catalog-completeness` — locale parity OK
- `vp check --fix` (changed files) — format + lint clean
- `vp run check:mobile-bundle` — bundle OK
- Captured the login screen on the iOS simulator and Android emulator (dev-client + Metro), logged out, and confirmed: the "Report a bug" link renders in the footer, tapping it opens the bug modal with the comment field, session-recording toggle, "Send bug report", and the new "Join Discord" button. Screenshots shared with the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
