### PR TITLE
fix(mobile): pull the iOS accessory thumbnail closer to the lightbulb

### DIFF
--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -86,8 +86,13 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
     <View style={[styles.row, { width, height: rowHeight }]}>
       {/* Leading board control as a content-layer element (the platter is
           UIKit-owned, so the glow lives here, not on the glass). Static state
-          swap; no long-press recognizer — it would fight UIKit's own gestures. */}
-      <BoardControlIndicator size={glassSize.inline} iconSize={22} />
+          swap; no long-press recognizer — it would fight UIKit's own gestures.
+          The negative trailing margin pulls the climb thumbnail in toward the
+          lightbulb (the 44pt tap slot otherwise leaves a wide gap), without
+          shrinking the indicator's halo. */}
+      <View style={styles.controlGutter}>
+        <BoardControlIndicator size={glassSize.inline} iconSize={22} />
+      </View>
       <GestureDetector gesture={openGesture}>
         <View style={styles.tapClip} accessibilityRole="button" accessibilityLabel={climb.name}>
           <View style={styles.labelSlot}>
@@ -114,6 +119,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingLeft: ACCESSORY_LEADING_INSET,
     paddingRight: ACCESSORY_TRAILING_INSET,
+  },
+  // Pulls the climb thumbnail ~12pt closer to the lightbulb by eating into the
+  // 44pt tap slot's empty right padding (the icon is centred, so this never
+  // overlaps it) — the halo stays full-size.
+  controlGutter: {
+    marginRight: -spacing[3],
   },
   tapClip: {
     flex: 1,


### PR DESCRIPTION
## What & why

Follow-up to #3115. On the iOS 26 native bottom-accessory bar, the lightbulb icon sits centered in a 44pt tap slot, which left a wide gap before the climb thumbnail. This pulls the thumbnail (and the climb name) ~12pt closer to the lightbulb so the leading group reads tighter.

Done via a negative trailing margin on the control that eats into the slot's *empty* right padding (the icon is centered, so it never overlaps), which keeps the amber "you have control" halo full-size and the 44pt tap target intact. Scoped to the iOS native platter (`NativeAccessoryClimbRow`); Android's Material bar is untouched.

## Release Notes

<!-- Cosmetic spacing polish on an existing bar — nothing a user would notice as new. -->

- [x] No release note needed (internal / technical change)

## Test plan

- Captured on an iPhone 16 Pro Max simulator: the thumbnail now sits snug against the lightbulb halo (was ~19pt off), the halo is unchanged, name/grade/tick unaffected.
- `native-accessory-climb-row` unit test + typecheck + lint green.