### PR TITLE
Add Android diagnostic APK logging

### DIFF
--- a/.github/workflows/android-diagnostic-apk.yml
+++ b/.github/workflows/android-diagnostic-apk.yml
@@ -1,0 +1,105 @@
+name: Android Diagnostic APK (React Native)
+
+# Manual-only build for contributor diagnostics on physical Android devices.
+# Produces a side-by-side "Boardsesh Dev" APK with remote diagnostic logging
+# enabled, so the tester only needs to sideload, reproduce, reopen, and send the
+# visible diagnostic code.
+
+on:
+  workflow_dispatch:
+    inputs:
+      note:
+        description: 'Optional note shown in the run summary'
+        required: false
+        default: ''
+      posthog_key:
+        description: 'Optional PostHog project key; falls back to the NEXT_PUBLIC_POSTHOG_KEY repo variable'
+        required: false
+        default: ''
+
+concurrency:
+  group: android-diagnostic-apk-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      BOARDSESH_DIAGNOSTIC_APK_DIR: /tmp/boardsesh-diagnostic-apks
+      EXPO_PUBLIC_POSTHOG_KEY: ${{ inputs.posthog_key || vars.NEXT_PUBLIC_POSTHOG_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install Node.js dependencies (workspace root)
+        run: bun install --frozen-lockfile
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Accept licenses and install SDK components
+        run: |
+          yes | sdkmanager --licenses > /dev/null 2>&1 || true
+          sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Assert diagnostic telemetry key is configured
+        run: |
+          if [ -z "$EXPO_PUBLIC_POSTHOG_KEY" ]; then
+            echo "::error::Set the posthog_key workflow input or the NEXT_PUBLIC_POSTHOG_KEY repo variable; diagnostic logs would not upload."
+            exit 1
+          fi
+
+      - name: Build diagnostic APK
+        run: ./node_modules/.bin/vp run mobile:android-diagnostic-apk
+
+      - name: Verify diagnostic APK
+        run: |
+          set -euo pipefail
+          apk="$(find "$BOARDSESH_DIAGNOSTIC_APK_DIR" -maxdepth 1 -type f -name '*.apk' | sort | head -n 1)"
+          if [ -z "$apk" ]; then
+            echo "::error::No diagnostic APK found in $BOARDSESH_DIAGNOSTIC_APK_DIR"
+            exit 1
+          fi
+          echo "APK=$apk" >> "$GITHUB_ENV"
+          unzip -l "$apk" | grep 'lib/arm64-v8a/libboard_renderer_ffi.so'
+          unzip -l "$apk" | grep 'lib/arm64-v8a/libboard_renderer_jni.so'
+          bash scripts/check-16kb-alignment.sh "$apk"
+
+      - name: Upload diagnostic APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: boardsesh-dev-diagnostics-${{ github.run_number }}
+          path: ${{ env.BOARDSESH_DIAGNOSTIC_APK_DIR }}/*.apk
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Summary
+        env:
+          RUN_NOTE: ${{ inputs.note }}
+        run: |
+          {
+            echo "## Android diagnostic APK"
+            echo ""
+            echo "- Artifact: \`boardsesh-dev-diagnostics-${{ github.run_number }}\`"
+            echo "- Package: \`com.boardsesh.app.dev\`"
+            echo "- ABI: \`arm64-v8a\`"
+            echo "- Logging: PostHog diagnostic upload enabled"
+            echo "- Default mode: \`bare_climbs\`"
+            if [ -n "$RUN_NOTE" ]; then
+              echo "- Note: $RUN_NOTE"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -36,6 +36,7 @@ import { type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
 import { useNativeAccessoryActive } from '../../../src/hooks/use-bottom-accessory';
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
+import { useDiagnosticMode } from '../../../src/hooks/use-diagnostic-mode';
 import { useGrades } from '../../../src/lib/graphql/hooks';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
@@ -61,6 +62,7 @@ import { getFilterSummary, buildClimbFilterSummary } from '../../../src/lib/filt
 import { getActiveFilterTokens } from '../../../src/lib/filter-tokens';
 import { normalizeSearchName, visibleSearchTextNeedsSync } from '../../../src/lib/search-name';
 import { track } from '../../../src/lib/analytics';
+import { boardDiagnosticProperties, flushDiagnosticLogs, logDiagnostic } from '../../../src/lib/diagnostic-logger';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { spacing } from '../../../src/theme/tokens';
 import { glassSize } from '../../../src/theme/layout';
@@ -168,6 +170,8 @@ function ClimbListInner() {
   const visibleSearchTextRef = useRef('');
   const insets = useSafeAreaInsets();
   const bottomChrome = useBottomChromeMetrics();
+  const diagnosticMode = useDiagnosticMode();
+  const useBareClimbsDiagnosticMode = diagnosticMode === 'bare_climbs';
 
   // iOS 26 uses the native tab-bar bottom accessory for current climb + tick, and
   // presents this screen's headerSearchBarOptions controller in the bottom tab
@@ -189,6 +193,13 @@ function ClimbListInner() {
     filterFabMinimumBottom,
     bottomChrome.floatingControlBottom + spacing[2] - filterFabNativeAccessoryDrop,
   );
+
+  useEffect(() => {
+    logDiagnostic('climbs_screen_mount');
+    return () => {
+      logDiagnostic('climbs_screen_unmount');
+    };
+  }, []);
 
   // On the Material variant the filter lives in the top-right toolbar (next to
   // the light/bluetooth button) inside ClimbTopChrome, so the bottom filter FAB
@@ -297,6 +308,11 @@ function ClimbListInner() {
 
   const { data: activeBoard, isLoading: isBoardLoading } = useActiveBoard();
 
+  useEffect(() => {
+    if (!activeBoard) return;
+    logDiagnostic('climbs_screen_active_board_ready', boardDiagnosticProperties(activeBoard));
+  }, [activeBoard]);
+
   // One-time board-history reveal banner: armed when the user binds a board from
   // the onboarding hand-off (app/boards/index.tsx) and consumed on focus so it
   // shows on the Climbs landing, pointing at the board's "now on the wall" sheet.
@@ -368,6 +384,14 @@ function ClimbListInner() {
     let cancelled = false;
     restoredKeyRef.current = null;
     setRestoredKey(null);
+    logDiagnostic('climbs_last_search_restore_start', {
+      boardName: boardConfig.boardName,
+      layoutId: boardConfig.layoutId,
+      sizeId: boardConfig.sizeId,
+      setIds: boardConfig.setIds,
+      angle: boardConfig.angle,
+      boardKey,
+    });
     getLastSearch(boardConfig, { isAuthenticated })
       .then((saved) => {
         if (cancelled) return;
@@ -384,14 +408,36 @@ function ClimbListInner() {
         }
         restoredKeyRef.current = boardKey;
         setRestoredKey(boardKey);
+        logDiagnostic('climbs_last_search_restore_success', {
+          boardName: boardConfig.boardName,
+          layoutId: boardConfig.layoutId,
+          sizeId: boardConfig.sizeId,
+          setIds: boardConfig.setIds,
+          angle: boardConfig.angle,
+          boardKey,
+          hadSavedSearch: !!saved,
+        });
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (cancelled) return;
         replaceSearch(DEFAULT_CLIMB_FILTER_STATE, '', DEFAULT_CLIMB_BOARD_FILTER_STATE);
         visibleSearchTextRef.current = '';
         applyVisibleSearchText('');
         restoredKeyRef.current = boardKey;
         setRestoredKey(boardKey);
+        logDiagnostic(
+          'climbs_last_search_restore_failed',
+          {
+            boardName: boardConfig.boardName,
+            layoutId: boardConfig.layoutId,
+            sizeId: boardConfig.sizeId,
+            setIds: boardConfig.setIds,
+            angle: boardConfig.angle,
+            boardKey,
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+          'error',
+        );
       });
     return () => {
       cancelled = true;
@@ -406,14 +452,42 @@ function ClimbListInner() {
 
   useEffect(() => {
     if (!boardConfig || !searchReady) return;
+    if (useBareClimbsDiagnosticMode) {
+      logDiagnostic('climbs_board_holds_prewarm_skipped_by_diagnostic_mode', {
+        boardName: boardConfig.boardName,
+        layoutId: boardConfig.layoutId,
+        sizeId: boardConfig.sizeId,
+        setIds: boardConfig.setIds,
+        diagnosticMode,
+      });
+      return;
+    }
     let task: ReturnType<typeof InteractionManager.runAfterInteractions> | null = null;
+    logDiagnostic('climbs_board_holds_prewarm_scheduled', {
+      boardName: boardConfig.boardName,
+      layoutId: boardConfig.layoutId,
+      sizeId: boardConfig.sizeId,
+      setIds: boardConfig.setIds,
+    });
     const timeout = setTimeout(() => {
       task = InteractionManager.runAfterInteractions(() => {
+        logDiagnostic('climbs_board_holds_prewarm_start', {
+          boardName: boardConfig.boardName,
+          layoutId: boardConfig.layoutId,
+          sizeId: boardConfig.sizeId,
+          setIds: boardConfig.setIds,
+        });
         prewarmCreateBoardHolds({
           boardName: boardConfig.boardName as BoardName,
           layoutId: boardConfig.layoutId,
           sizeId: boardConfig.sizeId,
           setIds: parseSetIdsParam(boardConfig.setIds),
+        });
+        logDiagnostic('climbs_board_holds_prewarm_done', {
+          boardName: boardConfig.boardName,
+          layoutId: boardConfig.layoutId,
+          sizeId: boardConfig.sizeId,
+          setIds: boardConfig.setIds,
         });
       });
     }, PREWARM_BOARD_HOLDS_DELAY_MS);
@@ -421,7 +495,7 @@ function ClimbListInner() {
       clearTimeout(timeout);
       task?.cancel();
     };
-  }, [boardConfig, searchReady]);
+  }, [boardConfig, searchReady, useBareClimbsDiagnosticMode, diagnosticMode]);
 
   useEffect(() => {
     // Compare NORMALIZED so an in-progress trim-only difference (e.g. the user
@@ -463,19 +537,42 @@ function ClimbListInner() {
   // over HTTP (the production CDN/WAF 403s the app's request).
   useEffect(() => {
     if (!activeBoard) return;
+    if (diagnosticMode === 'no_thumbnails' || useBareClimbsDiagnosticMode) {
+      logDiagnostic('climbs_background_cache_skipped_by_diagnostic_mode', {
+        ...boardDiagnosticProperties(activeBoard),
+        diagnosticMode,
+      });
+      return;
+    }
     const task = InteractionManager.runAfterInteractions(() => {
       const parsedSetIds = activeBoard.setIds.split(',').map(Number);
-      void ensureBackgroundsCached({
-        boardName: activeBoard.boardType as BoardName,
-        layoutId: activeBoard.layoutId,
-        sizeId: activeBoard.sizeId,
-        setIds: parsedSetIds,
-      });
+      logDiagnostic('climbs_background_cache_start', boardDiagnosticProperties(activeBoard));
+      void Promise.resolve(
+        ensureBackgroundsCached({
+          boardName: activeBoard.boardType as BoardName,
+          layoutId: activeBoard.layoutId,
+          sizeId: activeBoard.sizeId,
+          setIds: parsedSetIds,
+        }),
+      )
+        .then(() => {
+          logDiagnostic('climbs_background_cache_done', boardDiagnosticProperties(activeBoard));
+        })
+        .catch((error: unknown) => {
+          logDiagnostic(
+            'climbs_background_cache_failed',
+            {
+              ...boardDiagnosticProperties(activeBoard),
+              errorMessage: error instanceof Error ? error.message : String(error),
+            },
+            'error',
+          );
+        });
     });
     return () => {
       task.cancel();
     };
-  }, [activeBoard]);
+  }, [activeBoard, diagnosticMode, useBareClimbsDiagnosticMode]);
 
   const searchInput = useMemo(
     () =>
@@ -491,15 +588,19 @@ function ClimbListInner() {
     [boardName, layoutId, sizeId, setIds, angle, name, filters, boardFilters],
   );
 
+  const searchQueryEnabled = searchReady && !useBareClimbsDiagnosticMode;
+
   const {
     data: searchPages,
     isLoading: isClimbsLoading,
+    isError: isClimbsError,
+    error: climbsError,
     isFetchingNextPage,
     isRefetching,
     fetchNextPage,
     hasNextPage,
     refetch,
-  } = useInfiniteSearchClimbs(searchInput, searchReady);
+  } = useInfiniteSearchClimbs(searchInput, searchQueryEnabled);
   const isLoadingMoreRef = useRef(false);
 
   const visibleClimbs = useMemo(() => {
@@ -516,6 +617,109 @@ function ClimbListInner() {
   }, [searchPages?.pages]);
 
   const firstSearchPage = searchPages?.pages[0];
+  const heartbeatSnapshotRef = useRef({
+    searchReady: false,
+    visibleCount: 0,
+    firstClimbUuid: null as string | null,
+    isClimbsLoading: false,
+    isFetchingNextPage: false,
+    isClimbsError: false,
+  });
+  heartbeatSnapshotRef.current = {
+    searchReady,
+    visibleCount: visibleClimbs.length,
+    firstClimbUuid: visibleClimbs[0]?.uuid ?? null,
+    isClimbsLoading,
+    isFetchingNextPage,
+    isClimbsError,
+  };
+
+  useEffect(() => {
+    if (!searchReady) return;
+    logDiagnostic('climbs_search_ready', {
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      angle,
+      nameLength: name.length,
+      activeFilterCount: countActiveFilters(filters, boardFilters),
+    });
+  }, [searchReady, boardName, layoutId, sizeId, setIds, angle, name.length, filters, boardFilters]);
+
+  useEffect(() => {
+    if (!activeBoard) return;
+    const boardProperties = boardDiagnosticProperties(activeBoard);
+    let heartbeatIndex = 0;
+    logDiagnostic('climbs_heartbeat_start', boardProperties);
+    const interval = setInterval(() => {
+      heartbeatIndex += 1;
+      const snapshot = heartbeatSnapshotRef.current;
+      logDiagnostic('climbs_heartbeat', {
+        ...boardProperties,
+        heartbeatIndex,
+        secondsSinceStart: heartbeatIndex * 5,
+        searchReady: snapshot.searchReady,
+        visibleCount: snapshot.visibleCount,
+        firstClimbUuid: snapshot.firstClimbUuid,
+        isClimbsLoading: snapshot.isClimbsLoading,
+        isFetchingNextPage: snapshot.isFetchingNextPage,
+        isClimbsError: snapshot.isClimbsError,
+      });
+      if (heartbeatIndex % 2 === 0) void flushDiagnosticLogs();
+      if (heartbeatIndex >= 12) clearInterval(interval);
+    }, 5000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [activeBoard]);
+
+  useEffect(() => {
+    if (!activeBoard || !useBareClimbsDiagnosticMode) return;
+    logDiagnostic('climbs_bare_mode_ready', boardDiagnosticProperties(activeBoard));
+  }, [activeBoard, useBareClimbsDiagnosticMode]);
+
+  useEffect(() => {
+    if (!firstSearchPage) return;
+    logDiagnostic('climbs_search_first_page_loaded', {
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      angle,
+      resultCount: firstSearchPage.climbs.length,
+      hasMore: firstSearchPage.hasMore,
+    });
+  }, [firstSearchPage, boardName, layoutId, sizeId, setIds, angle]);
+
+  useEffect(() => {
+    if (!isClimbsError) return;
+    logDiagnostic(
+      'climbs_search_failed',
+      {
+        boardName,
+        layoutId,
+        sizeId,
+        setIds,
+        angle,
+        errorMessage: climbsError instanceof Error ? climbsError.message : String(climbsError),
+      },
+      'error',
+    );
+  }, [isClimbsError, climbsError, boardName, layoutId, sizeId, setIds, angle]);
+
+  useEffect(() => {
+    if (visibleClimbs.length === 0) return;
+    logDiagnostic('climbs_visible_rows_ready', {
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      angle,
+      visibleCount: visibleClimbs.length,
+      firstClimbUuid: visibleClimbs[0]?.uuid ?? null,
+    });
+  }, [visibleClimbs, boardName, layoutId, sizeId, setIds, angle]);
 
   useEffect(() => {
     if (!isFetchingNextPage) {
@@ -942,6 +1146,29 @@ function ClimbListInner() {
     );
   }
 
+  if (useBareClimbsDiagnosticMode && activeBoard) {
+    return (
+      <View
+        testID="climbs-screen-bare-diagnostic"
+        style={[styles.container, { backgroundColor: systemColors.background }]}
+      >
+        <Stack.Screen options={stackOptions} />
+        <View style={styles.bareDiagnosticContainer}>
+          <Icon name="boards" size={48} color={iosSystemColors.systemGray4} />
+          <Text variant="headline" style={styles.bareDiagnosticTitle}>
+            Bare diagnostic mode
+          </Text>
+          <Text variant="subheadline" style={styles.bareDiagnosticDetail}>
+            Active board loaded. Search, rows, thumbnails, renderer, and prewarm are off.
+          </Text>
+          <Text variant="caption1" style={styles.bareDiagnosticDetail}>
+            {activeBoard.boardType} · layout {activeBoard.layoutId} · size {activeBoard.sizeId}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   const isEmpty = visibleClimbs.length === 0 && !isClimbsLoading;
 
   return (
@@ -1090,5 +1317,20 @@ const styles = StyleSheet.create({
     marginHorizontal: spacing[4],
     marginTop: spacing[2],
     marginBottom: spacing[2],
+  },
+  bareDiagnosticContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    gap: 8,
+  },
+  bareDiagnosticTitle: {
+    marginTop: 12,
+    opacity: 0.7,
+  },
+  bareDiagnosticDetail: {
+    opacity: 0.5,
+    textAlign: 'center',
   },
 });

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -56,6 +56,7 @@ import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
+import { DiagnosticBanner } from '../src/components/DiagnosticBanner';
 
 void SplashScreen.preventAutoHideAsync();
 
@@ -420,6 +421,7 @@ function RootLayout() {
                                                             JS bottom-bar variants. */}
                                                           <AccessoryOnboardingTip />
                                                           <OnboardingGate ready={authReady && fontsReady} />
+                                                          <DiagnosticBanner />
                                                         </UserDrawerProvider>
                                                       </TabBarHeightProvider>
                                                       <AnalyticsScreenTracker />

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -23,6 +23,7 @@ import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metric
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
 import { track } from '../../src/lib/analytics';
+import { boardDiagnosticProperties, logDiagnostic } from '../../src/lib/diagnostic-logger';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
@@ -75,11 +76,13 @@ export default function BoardSelection() {
   const activateBoard = useCallback(
     async (board: UserBoard) => {
       hapticSelection();
+      logDiagnostic('board_selection_tap', boardDiagnosticProperties(board));
       try {
         // Persists to AsyncStorage + the ['activeBoard'] cache, then navigates
         // only once the write succeeds (a failed write must not strand the user
         // on a board that won't survive the next cold start).
         await setActiveBoard(board);
+        logDiagnostic('board_selection_active_board_set', boardDiagnosticProperties(board));
         if (fromOnboarding) {
           // The real activation metric — board history turns on the moment a
           // named board is bound — and the one-time Climbs reveal banner is armed
@@ -91,8 +94,21 @@ export default function BoardSelection() {
         // by default (including the onboarding hand-off), Discover when the pill
         // there opened it (replaces with that tab if it isn't already underneath,
         // e.g. opened from a deep link).
+        logDiagnostic('board_selection_dismiss_to_climbs', {
+          ...boardDiagnosticProperties(board),
+          returnTo: boardReturnTo,
+          fromOnboarding,
+        });
         router.dismissTo(boardReturnTo);
-      } catch {
+      } catch (error) {
+        logDiagnostic(
+          'board_selection_failed',
+          {
+            ...boardDiagnosticProperties(board),
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+          'error',
+        );
         showToast(t('mobile.boardSwitchError'), 'error');
       }
     },

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererBridge.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererBridge.kt
@@ -1,5 +1,9 @@
 package com.boardsesh.boardrenderer
 
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+
 data class RenderResult(
     val data: ByteArray,
     val width: Int,
@@ -21,15 +25,33 @@ data class RenderResult(
 
 object BoardRendererBridge {
     init {
-        System.loadLibrary("board_renderer_ffi")
-        System.loadLibrary("board_renderer_jni")
+        val startNanos = SystemClock.elapsedRealtimeNanos()
+        try {
+            Log.i(TAG, "Loading board renderer native libs; supportedAbis=${Build.SUPPORTED_ABIS.joinToString(",")}")
+            System.loadLibrary("board_renderer_ffi")
+            Log.i(TAG, "Loaded board_renderer_ffi in ${elapsedMs(startNanos)}ms")
+            System.loadLibrary("board_renderer_jni")
+            Log.i(TAG, "Loaded board_renderer_jni in ${elapsedMs(startNanos)}ms")
+        } catch (throwable: Throwable) {
+            Log.e(TAG, "Failed loading board renderer native libs after ${elapsedMs(startNanos)}ms", throwable)
+            throw throwable
+        }
     }
 
     external fun nativeRender(configJson: String): ByteArray?
 
     fun render(configJson: String): RenderResult? {
-        val raw = nativeRender(configJson) ?: return null
-        if (raw.size < 8) return null
+        val startNanos = SystemClock.elapsedRealtimeNanos()
+        Log.i(TAG, "nativeRender start configLength=${configJson.length} configHash=${configJson.hashCode()}")
+        val raw = nativeRender(configJson)
+        if (raw == null) {
+            Log.e(TAG, "nativeRender returned null durationMs=${elapsedMs(startNanos)}")
+            return null
+        }
+        if (raw.size < 8) {
+            Log.e(TAG, "nativeRender returned short payload bytes=${raw.size} durationMs=${elapsedMs(startNanos)}")
+            return null
+        }
 
         // First 8 bytes: width (u32 LE) + height (u32 LE)
         val width = (raw[0].toInt() and 0xFF) or
@@ -42,6 +64,12 @@ object BoardRendererBridge {
                 ((raw[7].toInt() and 0xFF) shl 24)
 
         val pixelData = raw.copyOfRange(8, raw.size)
+        Log.i(TAG, "nativeRender done ${width}x${height} bytes=${raw.size} durationMs=${elapsedMs(startNanos)}")
         return RenderResult(pixelData, width, height)
     }
+
+    private fun elapsedMs(startNanos: Long): Long =
+        (SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000
+
+    private const val TAG = "BoardRenderer"
 }

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -1,6 +1,8 @@
 package com.boardsesh.boardrenderer
 
 import android.graphics.Bitmap
+import android.os.SystemClock
+import android.util.Log
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.File
@@ -40,6 +42,7 @@ class BoardRendererModule : Module() {
     }
 
     private fun renderOverlay(configJson: String, cacheKey: String): String {
+        val totalStartNanos = SystemClock.elapsedRealtimeNanos()
         if (!pruned) {
             synchronized(this@BoardRendererModule) {
                 if (!pruned) {
@@ -53,11 +56,15 @@ class BoardRendererModule : Module() {
         if (outputFile.exists()) {
             // Touch mtime so LRU treats hot files as recently used.
             outputFile.setLastModified(System.currentTimeMillis())
+            Log.i(TAG, "renderOverlay cache hit cacheKey=$cacheKey sizeBytes=${outputFile.length()}")
             return "file://${outputFile.absolutePath}"
         }
 
+        Log.i(TAG, "renderOverlay start cacheKey=$cacheKey configLength=${configJson.length} configHash=${configJson.hashCode()}")
+        val nativeStartNanos = SystemClock.elapsedRealtimeNanos()
         val renderResult = BoardRendererBridge.render(configJson)
             ?: throw Exception("Rust render failed")
+        Log.i(TAG, "renderOverlay rust done cacheKey=$cacheKey durationMs=${elapsedMs(nativeStartNanos)}")
 
         val width = renderResult.width
         val height = renderResult.height
@@ -70,11 +77,16 @@ class BoardRendererModule : Module() {
         // we set it explicitly so future changes can't accidentally
         // flip it. Recycled in finally so a throw between create and
         // compress can't leak native pixel memory.
+        val bitmapStartNanos = SystemClock.elapsedRealtimeNanos()
         val overlayBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        Log.i(TAG, "renderOverlay bitmap allocated cacheKey=$cacheKey ${width}x${height} durationMs=${elapsedMs(bitmapStartNanos)}")
         try {
             overlayBitmap.setPremultiplied(true)
+            val copyStartNanos = SystemClock.elapsedRealtimeNanos()
             overlayBitmap.copyPixelsFromBuffer(ByteBuffer.wrap(rgbaData))
+            Log.i(TAG, "renderOverlay pixels copied cacheKey=$cacheKey bytes=${rgbaData.size} durationMs=${elapsedMs(copyStartNanos)}")
 
+            val writeStartNanos = SystemClock.elapsedRealtimeNanos()
             FileOutputStream(outputFile).use { outputStream ->
                 val written = overlayBitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
                 if (!written) {
@@ -82,10 +94,12 @@ class BoardRendererModule : Module() {
                     throw Exception("PNG compression failed")
                 }
             }
+            Log.i(TAG, "renderOverlay png written cacheKey=$cacheKey sizeBytes=${outputFile.length()} durationMs=${elapsedMs(writeStartNanos)}")
         } finally {
             overlayBitmap.recycle()
         }
 
+        Log.i(TAG, "renderOverlay done cacheKey=$cacheKey totalMs=${elapsedMs(totalStartNanos)}")
         return "file://${outputFile.absolutePath}"
     }
 
@@ -113,5 +127,9 @@ class BoardRendererModule : Module() {
         // Android may also reclaim on its own under storage pressure — this
         // is just our explicit upper bound.
         const val CACHE_CAP_BYTES: Long = 200L * 1024 * 1024
+        const val TAG = "BoardRenderer"
+
+        fun elapsedMs(startNanos: Long): Long =
+            (SystemClock.elapsedRealtimeNanos() - startNanos) / 1_000_000
     }
 }

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -8,6 +8,7 @@ import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbLi
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
 import { useGradeFormat } from '../hooks/use-grade-format';
 import { useAscentStatus } from '../hooks/use-ascent-status';
+import { useDiagnosticMode } from '../hooks/use-diagnostic-mode';
 import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
@@ -126,7 +127,10 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   primarySubtitleOverride,
 }: ClimbListItemContentProps) {
   const { t } = useTranslation('climbs');
+  const theme = useTheme();
+  const diagnosticMode = useDiagnosticMode();
   const { formatGrade } = useGradeFormat();
+  const hideThumbnail = diagnosticMode === 'no_thumbnails' || diagnosticMode === 'bare_climbs';
 
   const gradeColor = getGradeColor(climb.difficulty) ?? DEFAULT_GRADE_COLOR;
   const formattedGrade = formatGrade(climb.difficulty);
@@ -169,14 +173,35 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
     <>
       {/* Left: portrait thumbnail with ascent badge */}
       <View style={styles.thumbnailContainer}>
-        <ClimbListThumbnail
-          frames={climb.frames}
-          boardName={boardName}
-          layoutId={layoutId}
-          sizeId={sizeId}
-          setIds={setIds}
-          mirrored={climb.mirrored ?? false}
-        />
+        {hideThumbnail ? (
+          <View
+            style={[
+              styles.thumbnailPlaceholder,
+              {
+                backgroundColor: theme.systemColors.tertiaryBackground,
+                borderColor: theme.systemColors.separator,
+              },
+            ]}
+          >
+            <Text
+              variant="caption2"
+              color={theme.systemColors.secondaryLabel}
+              numberOfLines={2}
+              style={styles.thumbnailPlaceholderText}
+            >
+              No image
+            </Text>
+          </View>
+        ) : (
+          <ClimbListThumbnail
+            frames={climb.frames}
+            boardName={boardName}
+            layoutId={layoutId}
+            sizeId={sizeId}
+            setIds={setIds}
+            mirrored={climb.mirrored ?? false}
+          />
+        )}
       </View>
 
       {/* Center: name (+ intrinsic-attribute glyphs) + subtitle */}
@@ -218,6 +243,19 @@ const styles = StyleSheet.create({
     height: THUMBNAIL_HEIGHT,
     flexShrink: 0,
     position: 'relative',
+  },
+  thumbnailPlaceholder: {
+    width: THUMBNAIL_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 4,
+  },
+  thumbnailPlaceholderText: {
+    fontWeight: '600',
+    textAlign: 'center',
   },
   centerColumn: {
     flex: 1,

--- a/packages/mobile/src/components/DiagnosticBanner.tsx
+++ b/packages/mobile/src/components/DiagnosticBanner.tsx
@@ -1,0 +1,115 @@
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Text } from './Text';
+import {
+  flushDiagnosticLogs,
+  isDiagnosticLoggingEnabled,
+  setDiagnosticMode,
+  type DiagnosticMode,
+  type DiagnosticState,
+} from '../lib/diagnostic-logger';
+import { useDiagnosticState } from '../hooks/use-diagnostic-mode';
+import { brandColors } from '../theme/colors';
+import { spacing } from '../theme/tokens';
+
+const MODE_OPTIONS: { mode: DiagnosticMode; label: string }[] = [
+  { mode: 'bare_climbs', label: 'Bare' },
+  { mode: 'no_thumbnails', label: 'No images' },
+  { mode: 'no_overlays', label: 'No overlays' },
+  { mode: 'normal', label: 'Normal' },
+];
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: spacing[3],
+    right: spacing[3],
+    bottom: spacing[3],
+    zIndex: 1000,
+    borderRadius: 10,
+    backgroundColor: brandColors.warning,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 8,
+  },
+  title: {
+    fontWeight: '700',
+  },
+  detail: {
+    marginTop: 2,
+  },
+  modeRow: {
+    flexDirection: 'row',
+    gap: spacing[1],
+    marginTop: spacing[2],
+  },
+  modeButton: {
+    flex: 1,
+    alignItems: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.58)',
+    paddingHorizontal: spacing[1],
+    paddingVertical: 5,
+  },
+  modeButtonActive: {
+    backgroundColor: '#FFFFFF',
+    borderColor: '#FFFFFF',
+  },
+  modeButtonLabel: {
+    fontWeight: '700',
+  },
+});
+
+function statusText(state: DiagnosticState): string {
+  if (state.status === 'uploading') return `sending ${state.pendingCount}`;
+  if (state.status === 'error') return `upload waiting`;
+  if (state.status === 'sent') return 'sent';
+  return state.pendingCount > 0 ? `queued ${state.pendingCount}` : 'ready';
+}
+
+export function DiagnosticBanner() {
+  const state = useDiagnosticState();
+
+  if (!isDiagnosticLoggingEnabled) return null;
+
+  const sessionId = state.sessionId ?? 'starting';
+  return (
+    <View style={styles.container}>
+      <Pressable accessibilityRole="button" onPress={() => void flushDiagnosticLogs()}>
+        <Text variant="caption1" color="#FFFFFF" style={styles.title}>
+          Diagnostics {statusText(state)} · {state.mode}
+        </Text>
+        <Text variant="caption2" color="#FFFFFF" numberOfLines={1} style={styles.detail}>
+          Code: {sessionId}. Tap to send now.
+        </Text>
+      </Pressable>
+      <View style={styles.modeRow}>
+        {MODE_OPTIONS.map((option) => {
+          const selected = option.mode === state.mode;
+          return (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              key={option.mode}
+              onPress={() => setDiagnosticMode(option.mode)}
+              style={[styles.modeButton, selected ? styles.modeButtonActive : null]}
+            >
+              <Text
+                variant="caption2"
+                color={selected ? brandColors.warning : '#FFFFFF'}
+                numberOfLines={1}
+                style={styles.modeButtonLabel}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/packages/mobile/src/hooks/use-diagnostic-mode.ts
+++ b/packages/mobile/src/hooks/use-diagnostic-mode.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import {
+  getDiagnosticMode,
+  getDiagnosticState,
+  initializeDiagnostics,
+  isDiagnosticLoggingEnabled,
+  subscribeDiagnosticState,
+  type DiagnosticMode,
+} from '../lib/diagnostic-logger';
+
+export function useDiagnosticMode(): DiagnosticMode {
+  const [mode, setMode] = useState<DiagnosticMode>(() => getDiagnosticMode());
+
+  useEffect(() => {
+    if (!isDiagnosticLoggingEnabled) return undefined;
+    initializeDiagnostics();
+    return subscribeDiagnosticState((state) => {
+      setMode(state.mode);
+    });
+  }, []);
+
+  return isDiagnosticLoggingEnabled ? mode : 'normal';
+}
+
+export function useDiagnosticState() {
+  const [state, setState] = useState(() => getDiagnosticState());
+
+  useEffect(() => {
+    if (!isDiagnosticLoggingEnabled) return undefined;
+    initializeDiagnostics();
+    return subscribeDiagnosticState(setState);
+  }, []);
+
+  return state;
+}

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -9,6 +9,8 @@ import {
   type BackgroundVariant,
 } from '../lib/background-image-cache';
 import { reportError } from '../lib/error-reporting';
+import { logDiagnostic } from '../lib/diagnostic-logger';
+import { useDiagnosticMode } from './use-diagnostic-mode';
 import {
   DEFAULT_HOLD_COLOR_SIGNATURE,
   DEFAULT_HOLD_BRUSH_THICKNESS,
@@ -111,6 +113,9 @@ type NativeClimbRenderResult = {
 const inflightRenders = new Map<string, Promise<string>>();
 const INFLIGHT_RENDERS_MAX = 50;
 const unsupportedRenderSignatures = new Set<string>();
+const loggedNativeUnavailableCacheKeys = new Set<string>();
+const loggedMissingConfigCacheKeys = new Set<string>();
+const loggedDiagnosticModeSkipCacheKeys = new Set<string>();
 
 const BOARD_CONFIG_CACHE_MAX = 20;
 
@@ -481,6 +486,9 @@ function getNativeModule() {
  */
 export function useNativeClimbRender(params: NativeClimbRenderParams): NativeClimbRenderResult {
   const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth } = params;
+  const diagnosticMode = useDiagnosticMode();
+  const skipNativeOverlay =
+    diagnosticMode === 'no_overlays' || diagnosticMode === 'no_thumbnails' || diagnosticMode === 'bare_climbs';
   const {
     overrides: holdColorOverrides,
     shapes: holdShapeOverrides,
@@ -632,6 +640,24 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // have one for this cache key in the sync map.
   useEffect(() => {
     if (!frames || unsupportedRenderSignatures.has(holdRenderSignature)) return;
+    if (skipNativeOverlay) {
+      const skipKey = `${diagnosticMode}:${currentCacheKey}`;
+      if (!loggedDiagnosticModeSkipCacheKeys.has(skipKey)) {
+        loggedDiagnosticModeSkipCacheKeys.add(skipKey);
+        logDiagnostic('native_render_skipped_by_diagnostic_mode', {
+          boardName,
+          layoutId,
+          sizeId,
+          setIds,
+          filledStyle,
+          renderWidth: renderWidth ?? null,
+          framesLength: frames.length,
+          cacheKey: currentCacheKey,
+          diagnosticMode,
+        });
+      }
+      return;
+    }
 
     if (renderedOverlays.has(currentCacheKey)) {
       // Sync map already has it — make sure local state reflects that
@@ -639,13 +665,38 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       // overlay).
       const uri = renderedOverlays.get(currentCacheKey);
       if (uri && nativeRender?.key !== currentCacheKey) {
+        logDiagnostic('native_render_overlay_cache_hit', {
+          boardName,
+          layoutId,
+          sizeId,
+          setIds,
+          filledStyle,
+          renderWidth: renderWidth ?? null,
+          framesLength: frames.length,
+          cacheKey: currentCacheKey,
+        });
         setNativeRender({ key: currentCacheKey, uri });
       }
       return;
     }
 
     const nativeModule = getNativeModule();
-    if (!nativeModule) return;
+    if (!nativeModule) {
+      if (!loggedNativeUnavailableCacheKeys.has(currentCacheKey)) {
+        loggedNativeUnavailableCacheKeys.add(currentCacheKey);
+        logDiagnostic('native_render_module_unavailable', {
+          boardName,
+          layoutId,
+          sizeId,
+          setIds,
+          filledStyle,
+          renderWidth: renderWidth ?? null,
+          framesLength: frames.length,
+          cacheKey: currentCacheKey,
+        });
+      }
+      return;
+    }
 
     const boardConfig = getBoardConfig(
       boardName,
@@ -660,12 +711,39 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       shapeSize,
       holdRenderSignature,
     );
-    if (!boardConfig) return;
+    if (!boardConfig) {
+      if (!loggedMissingConfigCacheKeys.has(currentCacheKey)) {
+        loggedMissingConfigCacheKeys.add(currentCacheKey);
+        logDiagnostic('native_render_board_config_missing', {
+          boardName,
+          layoutId,
+          sizeId,
+          setIds,
+          filledStyle,
+          renderWidth: renderWidth ?? null,
+          framesLength: frames.length,
+          cacheKey: currentCacheKey,
+        });
+      }
+      return;
+    }
 
+    const renderStartedAt = Date.now();
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
       const configJson = JSON.stringify({
         ...boardConfig.configBase,
         frames,
+      });
+      logDiagnostic('native_render_start', {
+        boardName,
+        layoutId,
+        sizeId,
+        setIds,
+        filledStyle,
+        renderWidth: renderWidth ?? null,
+        framesLength: frames.length,
+        cacheKey: currentCacheKey,
+        configLength: configJson.length,
       });
       return nativeModule.renderHoldsOverlay(configJson, currentCacheKey);
     });
@@ -673,6 +751,17 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     renderPromise
       .then((fileUri) => {
         renderedOverlays.set(currentCacheKey, fileUri);
+        logDiagnostic('native_render_success', {
+          boardName,
+          layoutId,
+          sizeId,
+          setIds,
+          filledStyle,
+          renderWidth: renderWidth ?? null,
+          framesLength: frames.length,
+          cacheKey: currentCacheKey,
+          durationMs: Date.now() - renderStartedAt,
+        });
         if (mountedRef.current) setNativeRender({ key: currentCacheKey, uri: fileUri });
       })
       .catch((error: unknown) => {
@@ -689,6 +778,22 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // overlay layer.
         // eslint-disable-next-line no-console
         console.warn(`[useNativeClimbRender] render failed for ${currentCacheKey}:`, message);
+        logDiagnostic(
+          'native_render_failed',
+          {
+            boardName,
+            layoutId,
+            sizeId,
+            setIds,
+            filledStyle,
+            renderWidth: renderWidth ?? null,
+            framesLength: frames.length,
+            cacheKey: currentCacheKey,
+            durationMs: Date.now() - renderStartedAt,
+            errorMessage: message,
+          },
+          'error',
+        );
         reportError(error, {
           tags: {
             feature: 'mobile_board_renderer',
@@ -722,11 +827,13 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     brushThickness,
     shapeSize,
     holdRenderSignature,
+    skipNativeOverlay,
+    diagnosticMode,
   ]);
 
   // Only surface the native URI if it matches the *current* cache key —
   // a stale render (from before a prop change) would otherwise show.
-  const overlayUri = frames && nativeRender?.key === currentCacheKey ? nativeRender.uri : null;
+  const overlayUri = frames && !skipNativeOverlay && nativeRender?.key === currentCacheKey ? nativeRender.uri : null;
   // Same guard for backgrounds: a stored entry from a prior boardKey
   // (FlashList row recycle case) must not bleed through to the new climb.
   const backgroundPaths = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.paths : [];

--- a/packages/mobile/src/lib/diagnostic-logger.ts
+++ b/packages/mobile/src/lib/diagnostic-logger.ts
@@ -1,0 +1,292 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getPostHogClient } from './posthog-client';
+
+export const isDiagnosticLoggingEnabled = process.env.EXPO_PUBLIC_BOARDSESH_DIAGNOSTIC_LOGGING === '1';
+
+type DiagnosticLevel = 'debug' | 'info' | 'warn' | 'error';
+type DiagnosticStatus = 'idle' | 'uploading' | 'sent' | 'error';
+type DiagnosticPropertyValue = string | number | boolean | null;
+type DiagnosticProperties = Record<string, unknown>;
+export type DiagnosticMode = 'normal' | 'no_overlays' | 'no_thumbnails' | 'bare_climbs';
+export const DEFAULT_DIAGNOSTIC_MODE: DiagnosticMode = 'bare_climbs';
+
+type DiagnosticRecord = {
+  id: string;
+  sessionId: string;
+  timestamp: string;
+  level: DiagnosticLevel;
+  message: string;
+  properties: Record<string, DiagnosticPropertyValue>;
+};
+
+export type DiagnosticState = {
+  enabled: boolean;
+  sessionId: string | null;
+  pendingCount: number;
+  status: DiagnosticStatus;
+  lastError: string | null;
+  mode: DiagnosticMode;
+};
+
+type DiagnosticPostHogClient = {
+  capture?: (event: string, properties?: Record<string, DiagnosticPropertyValue>) => unknown;
+  captureLog?: (
+    level: DiagnosticLevel,
+    message: string,
+    properties?: Record<string, DiagnosticPropertyValue>,
+  ) => unknown;
+  flush?: () => Promise<unknown>;
+  flushLogs?: () => Promise<unknown>;
+};
+
+const SESSION_STORAGE_KEY = 'boardsesh:diagnostic-session-id:v1';
+const MODE_STORAGE_KEY = 'boardsesh:diagnostic-mode:v1';
+const PENDING_STORAGE_KEY = 'boardsesh:diagnostic-pending-records:v1';
+const MAX_PENDING_RECORDS = 400;
+const MAX_PROPERTY_STRING_LENGTH = 240;
+
+let sessionId: string | null = null;
+let state: DiagnosticState = {
+  enabled: isDiagnosticLoggingEnabled,
+  sessionId: null,
+  pendingCount: 0,
+  status: 'idle',
+  lastError: null,
+  mode: DEFAULT_DIAGNOSTIC_MODE,
+};
+let storageQueue: Promise<void> = Promise.resolve();
+let uploadQueued = false;
+let modeLoaded = false;
+const listeners = new Set<(nextState: DiagnosticState) => void>();
+
+function emitState(partial: Partial<DiagnosticState>): void {
+  state = { ...state, ...partial };
+  for (const listener of listeners) listener(state);
+}
+
+export function getDiagnosticState(): DiagnosticState {
+  return state;
+}
+
+export function subscribeDiagnosticState(listener: (nextState: DiagnosticState) => void): () => void {
+  listeners.add(listener);
+  listener(state);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function makeSessionId(): string {
+  return `diag-${makeDiagnosticId().slice(0, 8)}`;
+}
+
+function makeDiagnosticId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function ensureSessionId(): Promise<string> {
+  if (sessionId) return sessionId;
+  const stored = await AsyncStorage.getItem(SESSION_STORAGE_KEY);
+  sessionId = stored ?? makeSessionId();
+  if (!stored) await AsyncStorage.setItem(SESSION_STORAGE_KEY, sessionId);
+  emitState({ sessionId });
+  return sessionId;
+}
+
+function isDiagnosticMode(value: string | null): value is DiagnosticMode {
+  return value === 'normal' || value === 'no_overlays' || value === 'no_thumbnails' || value === 'bare_climbs';
+}
+
+async function ensureDiagnosticMode(): Promise<DiagnosticMode> {
+  if (modeLoaded) return state.mode;
+  const stored = await AsyncStorage.getItem(MODE_STORAGE_KEY);
+  const mode = isDiagnosticMode(stored) ? stored : DEFAULT_DIAGNOSTIC_MODE;
+  modeLoaded = true;
+  emitState({ mode });
+  return mode;
+}
+
+export function getDiagnosticMode(): DiagnosticMode {
+  return state.mode;
+}
+
+export function setDiagnosticMode(mode: DiagnosticMode): void {
+  if (!isDiagnosticLoggingEnabled) return;
+  void queueStorageMutation(async () => {
+    modeLoaded = true;
+    await AsyncStorage.setItem(MODE_STORAGE_KEY, mode);
+    emitState({ mode });
+  }).then(() => {
+    logDiagnostic('diagnostic_mode_changed', { mode });
+  });
+}
+
+function sanitizeValue(value: unknown): DiagnosticPropertyValue | undefined {
+  if (value === null) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
+  if (typeof value === 'string') {
+    return value.length > MAX_PROPERTY_STRING_LENGTH ? `${value.slice(0, MAX_PROPERTY_STRING_LENGTH)}...` : value;
+  }
+  if (value instanceof Date) return value.toISOString();
+  return undefined;
+}
+
+function sanitizeProperties(properties: DiagnosticProperties | undefined): Record<string, DiagnosticPropertyValue> {
+  const safeProperties: Record<string, DiagnosticPropertyValue> = {
+    diagnostic_platform: 'mobile',
+  };
+  for (const [key, value] of Object.entries(properties ?? {})) {
+    const sanitizedValue = sanitizeValue(value);
+    if (sanitizedValue !== undefined) safeProperties[key] = sanitizedValue;
+  }
+  return safeProperties;
+}
+
+async function readPendingRecords(): Promise<DiagnosticRecord[]> {
+  const raw = await AsyncStorage.getItem(PENDING_STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((record): record is DiagnosticRecord => {
+      if (typeof record !== 'object' || record === null) return false;
+      const candidate = record as Partial<DiagnosticRecord>;
+      return (
+        typeof candidate.id === 'string' &&
+        typeof candidate.sessionId === 'string' &&
+        typeof candidate.timestamp === 'string' &&
+        typeof candidate.level === 'string' &&
+        typeof candidate.message === 'string' &&
+        typeof candidate.properties === 'object' &&
+        candidate.properties !== null
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+async function writePendingRecords(records: DiagnosticRecord[]): Promise<void> {
+  const cappedRecords = records.slice(-MAX_PENDING_RECORDS);
+  await AsyncStorage.setItem(PENDING_STORAGE_KEY, JSON.stringify(cappedRecords));
+  emitState({ pendingCount: cappedRecords.length });
+}
+
+function asDiagnosticPostHogClient(): DiagnosticPostHogClient | null {
+  return getPostHogClient() as unknown as DiagnosticPostHogClient | null;
+}
+
+async function sendRecord(record: DiagnosticRecord): Promise<void> {
+  const posthog = asDiagnosticPostHogClient();
+  if (!posthog) throw new Error('PostHog client unavailable');
+  const properties: Record<string, DiagnosticPropertyValue> = {
+    ...record.properties,
+    diagnostic_session_id: record.sessionId,
+    diagnostic_record_id: record.id,
+    diagnostic_timestamp: record.timestamp,
+    diagnostic_level: record.level,
+    diagnostic_message: record.message,
+  };
+
+  try {
+    posthog.captureLog?.(record.level, record.message, properties);
+  } catch {
+    // Some PostHog SDK versions expose logs with a different runtime signature.
+    // The event below is the compatibility path we always send.
+  }
+  posthog.capture?.('Mobile Diagnostic Log', properties);
+  await posthog.flushLogs?.();
+  await posthog.flush?.();
+}
+
+function queueStorageMutation(work: () => Promise<void>): Promise<void> {
+  storageQueue = storageQueue.then(work, work).catch((error: unknown) => {
+    emitState({ status: 'error', lastError: error instanceof Error ? error.message : String(error) });
+  });
+  return storageQueue;
+}
+
+function queueUpload(): void {
+  if (uploadQueued) return;
+  uploadQueued = true;
+  void queueStorageMutation(async () => {
+    uploadQueued = false;
+    const records = await readPendingRecords();
+    if (records.length === 0) {
+      emitState({ status: 'sent', lastError: null, pendingCount: 0 });
+      return;
+    }
+
+    emitState({ status: 'uploading', lastError: null, pendingCount: records.length });
+    const unsentRecords: DiagnosticRecord[] = [];
+    for (const record of records) {
+      try {
+        await sendRecord(record);
+      } catch (error) {
+        unsentRecords.push(record);
+        emitState({ status: 'error', lastError: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    await writePendingRecords(unsentRecords);
+    if (unsentRecords.length === 0) emitState({ status: 'sent', lastError: null });
+  });
+}
+
+export function initializeDiagnostics(): void {
+  if (!isDiagnosticLoggingEnabled) return;
+  void queueStorageMutation(async () => {
+    await ensureSessionId();
+    await ensureDiagnosticMode();
+    const records = await readPendingRecords();
+    emitState({ pendingCount: records.length });
+  }).then(queueUpload);
+}
+
+export function flushDiagnosticLogs(): Promise<void> {
+  if (!isDiagnosticLoggingEnabled) return Promise.resolve();
+  queueUpload();
+  return storageQueue;
+}
+
+export function logDiagnostic(
+  message: string,
+  properties?: DiagnosticProperties,
+  level: DiagnosticLevel = 'info',
+): void {
+  if (!isDiagnosticLoggingEnabled) return;
+  const recordPromise = async () => {
+    const currentSessionId = await ensureSessionId();
+    const currentMode = await ensureDiagnosticMode();
+    const record: DiagnosticRecord = {
+      id: makeDiagnosticId(),
+      sessionId: currentSessionId,
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      properties: { ...sanitizeProperties(properties), diagnostic_mode: currentMode },
+    };
+    const records = await readPendingRecords();
+    await writePendingRecords([...records, record]);
+    console.info(`[boardsesh-diagnostics] ${message}`, record.properties);
+  };
+  void queueStorageMutation(recordPromise).then(queueUpload);
+}
+
+export function boardDiagnosticProperties(board: {
+  uuid?: string | null;
+  boardType?: string | null;
+  layoutId?: number | null;
+  sizeId?: number | null;
+  setIds?: string | null;
+  angle?: number | null;
+}): Record<string, DiagnosticPropertyValue> {
+  return {
+    boardUuid: board.uuid ?? null,
+    boardName: board.boardType ?? null,
+    layoutId: board.layoutId ?? null,
+    sizeId: board.sizeId ?? null,
+    setIds: board.setIds ?? null,
+    angle: board.angle ?? null,
+  };
+}

--- a/packages/mobile/src/lib/graphql/use-active-board.ts
+++ b/packages/mobile/src/lib/graphql/use-active-board.ts
@@ -14,6 +14,7 @@ import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { getStoredActiveBoard, setStoredActiveBoard, clearStoredActiveBoard } from '../active-board-store';
+import { boardDiagnosticProperties, logDiagnostic } from '../diagnostic-logger';
 
 export const ACTIVE_BOARD_QUERY_KEY = ['activeBoard'] as const;
 
@@ -41,8 +42,11 @@ export function useSetActiveBoard() {
   const queryClient = useQueryClient();
   return useCallback(
     async (board: UserBoard) => {
+      logDiagnostic('active_board_set_start', boardDiagnosticProperties(board));
       await setStoredActiveBoard(board);
+      logDiagnostic('active_board_storage_written', boardDiagnosticProperties(board));
       queryClient.setQueryData<UserBoard | null>(ACTIVE_BOARD_QUERY_KEY, board);
+      logDiagnostic('active_board_cache_written', boardDiagnosticProperties(board));
     },
     [queryClient],
   );

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -9,6 +9,7 @@ const apiKey = process.env.EXPO_PUBLIC_POSTHOG_KEY;
 // Native apps have no ad-blocker / first-party-cookie concern, so we talk to
 // PostHog cloud directly rather than the backend reverse proxy the web app uses.
 const host = process.env.EXPO_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+const isDiagnosticLoggingBuild = process.env.EXPO_PUBLIC_BOARDSESH_DIAGNOSTIC_LOGGING === '1';
 
 // Live only in non-dev builds with a key configured. Preview (TestFlight /
 // internal) and production builds are both `!__DEV__`, so telemetry flows from
@@ -51,6 +52,7 @@ export function getPostHogClient(): PostHog | null {
   // don't be surprised to see a few lifecycle events on a transient anon id.
   client = new PostHog(apiKey, {
     host,
+    ...(isDiagnosticLoggingBuild ? { flushAt: 1, flushInterval: 1000 } : {}),
     errorTracking: {
       autocapture: {
         uncaughtExceptions: true,

--- a/scripts/lib/android-sdk.ts
+++ b/scripts/lib/android-sdk.ts
@@ -46,6 +46,8 @@ const SDK_PACKAGES_BUILD = [`build-tools;${BUILD_TOOLS_VERSION}`];
 export interface EnsureSdkOptions {
   /** Also install build-tools — only needed for the local Gradle fallback build. */
   includeBuildTools?: boolean;
+  /** Also install emulator + system image packages. Needed for screenshot flows, not APK-only builds. */
+  includeEmulator?: boolean;
 }
 
 export interface AndroidToolchain {
@@ -87,6 +89,11 @@ export function emulatorPath(home: string): string {
 function findJava21(): string | null {
   const override = process.env.JAVA21_HOME ?? process.env.JAVA_21_HOME;
   if (override && existsSync(join(override, 'bin', 'java'))) return override;
+  const javaHome = process.env.JAVA_HOME;
+  if (javaHome && existsSync(join(javaHome, 'bin', 'java'))) {
+    const version = runCapture(join(javaHome, 'bin', 'java'), ['-version']);
+    if (/(version "21|openjdk 21|\b21\.\d)/.test(`${version.stderr}${version.stdout}`)) return javaHome;
+  }
   if (existsSync(join(JDK21_HOME, 'bin', 'java'))) return JDK21_HOME;
 
   const searchDirs = ['/usr/lib/jvm', '/usr/java', join(homedir(), '.sdkman', 'candidates', 'java')];
@@ -199,7 +206,11 @@ export function ensureAndroidSdk(options: EnsureSdkOptions = {}): AndroidToolcha
   const home = resolveAndroidHome();
   mkdirSync(home, { recursive: true });
 
-  const wanted = [...SDK_PACKAGES_CORE, ...(options.includeBuildTools ? SDK_PACKAGES_BUILD : [])];
+  const corePackages =
+    options.includeEmulator === false
+      ? ['platform-tools', `platforms;android-${ANDROID_API_LEVEL}`]
+      : SDK_PACKAGES_CORE;
+  const wanted = [...corePackages, ...(options.includeBuildTools ? SDK_PACKAGES_BUILD : [])];
   const needCmdlineTools = !existsSync(sdkmanagerPath(home));
   const missing = wanted.filter((pkg) => !existsSync(packageInstallPath(home, pkg)));
 

--- a/scripts/mobile-android-diagnostic-apk.ts
+++ b/scripts/mobile-android-diagnostic-apk.ts
@@ -1,0 +1,126 @@
+/// <reference types="node" />
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { commandExists, runCapture, runInherit } from './lib/exec';
+import { ensureAndroidSdk } from './lib/android-sdk';
+
+const LOG = '[mobile:android-diagnostic-apk]';
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_DIR = join(ROOT_DIR, 'packages', 'mobile');
+const ANDROID_DIR = join(MOBILE_DIR, 'android');
+const OUTPUT_DIR = process.env.BOARDSESH_DIAGNOSTIC_APK_DIR ?? '/private/tmp/boardsesh-diagnostic-apks';
+const REQUIRED_ABI = 'arm64-v8a';
+const EXPO_ENV_PATH = join(MOBILE_DIR, '.env');
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} must be set to build a remote-logging diagnostic APK`);
+  return value;
+}
+
+function writeExpoEnv(): string | null {
+  const posthogKey = requireEnv('EXPO_PUBLIC_POSTHOG_KEY');
+  const previousEnv = existsSync(EXPO_ENV_PATH) ? readFileSync(EXPO_ENV_PATH, 'utf8') : null;
+  const lines = [
+    'EXPO_PUBLIC_BACKEND_URL=https://ws.boardsesh.com',
+    'EXPO_PUBLIC_WS_URL=wss://ws.boardsesh.com/graphql',
+    'EXPO_PUBLIC_WEB_URL=https://www.boardsesh.com',
+    'EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=401523882502-0f6d7te1vekvkpmg18t8di6l0ig560q7.apps.googleusercontent.com',
+    'EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=401523882502-h92kdkck1qhmdbgq7ltek87g4rg8rg3h.apps.googleusercontent.com',
+    'EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=401523882502-hvfhh79p4q1qq0md7lk646c6sgmsi9q0.apps.googleusercontent.com',
+    `EXPO_PUBLIC_POSTHOG_KEY=${posthogKey}`,
+    'EXPO_PUBLIC_BOARDSESH_DIAGNOSTIC_LOGGING=1',
+    '',
+  ];
+  writeFileSync(EXPO_ENV_PATH, lines.join('\n'));
+  return previousEnv;
+}
+
+function restoreExpoEnv(previousEnv: string | null): void {
+  if (previousEnv === null) {
+    rmSync(EXPO_ENV_PATH, { force: true });
+    return;
+  }
+  writeFileSync(EXPO_ENV_PATH, previousEnv);
+}
+
+function shortSha(): string {
+  const gitHead = process.env.GITHUB_SHA;
+  if (gitHead) return gitHead.slice(0, 12);
+  const result = runCapture('git', ['rev-parse', '--short=12', 'HEAD'], { cwd: ROOT_DIR });
+  if (result.status !== 0) return 'local';
+  return result.stdout.trim() || 'local';
+}
+
+function findBuiltApk(): string {
+  const releaseDir = join(ANDROID_DIR, 'app', 'build', 'outputs', 'apk', 'release');
+  const apks = readdirSync(releaseDir)
+    .filter((name) => name.endsWith('.apk'))
+    .map((name) => join(releaseDir, name));
+  if (apks.length !== 1) throw new Error(`Expected exactly one release APK in ${releaseDir}, found ${apks.length}`);
+  return apks[0];
+}
+
+function main(): number {
+  let previousEnv: string | null | undefined;
+  try {
+    if (!commandExists('bunx')) throw new Error('bunx is not on PATH; run `vp install` first.');
+    previousEnv = writeExpoEnv();
+
+    const toolchain = ensureAndroidSdk({ includeBuildTools: true, includeEmulator: false });
+    if (!toolchain.java21) {
+      throw new Error('Diagnostic APK build needs JDK 21; run `vp run mobile:android-doctor -- --build` first.');
+    }
+
+    const buildEnv: NodeJS.ProcessEnv = {
+      ...toolchain.env,
+      BOARDSESH_APP_VARIANT: 'dev',
+      EXPO_PUBLIC_BOARDSESH_DIAGNOSTIC_LOGGING: '1',
+      EXPO_PUBLIC_POSTHOG_KEY: requireEnv('EXPO_PUBLIC_POSTHOG_KEY'),
+      JAVA_HOME: toolchain.java21,
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true',
+    };
+
+    console.log(`${LOG} expo prebuild (android, Boardsesh Dev diagnostic variant)...`);
+    rmSync(ANDROID_DIR, { recursive: true, force: true });
+    if (
+      runInherit('bunx', ['expo', 'prebuild', '--platform', 'android', '--clean', '--no-install'], {
+        env: buildEnv,
+        cwd: MOBILE_DIR,
+      }) !== 0
+    ) {
+      throw new Error('expo prebuild --platform android failed');
+    }
+
+    console.log(`${LOG} gradlew assembleRelease (${REQUIRED_ABI}, debug-signed release)...`);
+    const gradleStatus = runInherit(
+      join(ANDROID_DIR, 'gradlew'),
+      [
+        'assembleRelease',
+        `-PreactNativeArchitectures=${REQUIRED_ABI}`,
+        `-PboardseshAbiFilters=${REQUIRED_ABI}`,
+        '--no-daemon',
+        '--console=plain',
+        '--stacktrace',
+      ],
+      { env: buildEnv, cwd: ANDROID_DIR },
+    );
+    if (gradleStatus !== 0) throw new Error('gradlew assembleRelease failed');
+
+    const builtApk = findBuiltApk();
+    mkdirSync(OUTPUT_DIR, { recursive: true });
+    const targetApk = join(OUTPUT_DIR, `boardsesh-dev-diagnostics-${shortSha()}-${REQUIRED_ABI}.apk`);
+    copyFileSync(builtApk, targetApk);
+    console.log(`${LOG} APK ready: ${targetApk}`);
+    return 0;
+  } catch (error) {
+    console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  } finally {
+    if (previousEnv !== undefined) restoreExpoEnv(previousEnv);
+  }
+}
+
+process.exit(main());

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -566,6 +566,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-android-apk.ts',
         cache: false,
       },
+      'mobile:android-diagnostic-apk': {
+        command: 'tsx scripts/mobile-android-diagnostic-apk.ts',
+        cache: false,
+      },
       'check:screenshot-dimensions': {
         command: 'tsx scripts/assert-screenshot-dimensions.ts',
         cache: false,


### PR DESCRIPTION
## Summary
- Add a remote diagnostic logger for Android diagnostic builds, uploaded to PostHog with a persistent session code and diagnostic mode on every event.
- Add a diagnostic banner with modes: safe default `bare_climbs`, `no_thumbnails`, `no_overlays`, and `normal`.
- In `bare_climbs`, the Climbs screen loads the active board and heartbeat only: no search query, rows, thumbnails, native renderer, background cache, or hold prewarm.
- Add board-selection, active-board, climbs-screen heartbeat, image-cache, search, and native renderer diagnostics.
- Add a CI workflow and `vp run mobile:android-diagnostic-apk` task for an arm64 `Boardsesh Dev` sideload APK artifact.

## Why this changed after PR #3114
- The S24 tester reported that PR #3114 did not recover the app with any single toggle or with all toggles enabled.
- That rules out the #3114 touch/UI suspects: queue bar, FlashList vs FlatList, row swipe, always-mounted sheets, and top chrome.
- #3114 still rendered climb rows/thumbnails and still left renderer/cache/search work active, so this APK starts in `bare_climbs` to isolate the remaining pipeline.

## Validation
- `vp run typecheck:mobile`
- `vp test run --project mobile`
- `git diff --check`
- workflow YAML parse via Ruby
- local diagnostic APK entrypoint reaches the expected missing `EXPO_PUBLIC_POSTHOG_KEY` guard

## CI status
- Diagnostic APK run attempted: https://github.com/boardsesh/boardsesh/actions/runs/27900398125
- It failed before build because the repository currently has no `NEXT_PUBLIC_POSTHOG_KEY` variable or PostHog secret. The workflow now accepts a `posthog_key` dispatch input and still falls back to `vars.NEXT_PUBLIC_POSTHOG_KEY` if that repo variable is added.

## Notes
- `vp check` still reports pre-existing unrelated formatting drift in repo files outside this change set.