### PR TITLE
fix: forward User-Agent to PostHog so real users aren't all flagged as bots

### DIFF
--- a/packages/backend/src/__tests__/posthog.test.ts
+++ b/packages/backend/src/__tests__/posthog.test.ts
@@ -14,6 +14,7 @@ type FakeReqOptions = {
   contentEncoding?: string;
   forwardedFor?: string;
   remoteAddress?: string;
+  userAgent?: string;
 };
 
 function createFakeReq(options: FakeReqOptions): ProxyReq {
@@ -23,6 +24,7 @@ function createFakeReq(options: FakeReqOptions): ProxyReq {
   if (options.contentType) headers['content-type'] = options.contentType;
   if (options.contentEncoding) headers['content-encoding'] = options.contentEncoding;
   if (options.forwardedFor) headers['x-forwarded-for'] = options.forwardedFor;
+  if (options.userAgent) headers['user-agent'] = options.userAgent;
 
   const req = {
     method: options.method,
@@ -150,6 +152,7 @@ describe('PostHog Proxy Handler', () => {
       body: '{"event":"test"}',
       contentType: 'application/json',
       forwardedFor: '203.0.113.7, 10.0.0.1',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124.0 Safari/537.36',
     });
     const res = createFakeRes();
 
@@ -164,6 +167,10 @@ describe('PostHog Proxy Handler', () => {
     const headers = init.headers as Record<string, string>;
     expect(headers['Content-Type']).toBe('application/json');
     expect(headers['X-Forwarded-For']).toBe('203.0.113.7');
+    // UA must reach PostHog so it isn't recorded with an empty user agent (→ bot).
+    expect(headers['User-Agent']).toBe(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124.0 Safari/537.36',
+    );
     // Body must be forwarded as bytes (the SDK may have gzipped it).
     expect(init.body).toBeInstanceOf(Uint8Array);
     expect(new TextDecoder().decode(init.body as Uint8Array)).toBe('{"event":"test"}');
@@ -216,6 +223,18 @@ describe('PostHog Proxy Handler', () => {
 
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     expect((init.headers as Record<string, string>)['X-Forwarded-For']).toBe('198.51.100.4');
+  });
+
+  it('omits User-Agent when the incoming request has none (avoids sending an empty UA)', async () => {
+    fetchMock.mockResolvedValue(new Response('1', { status: 200 }));
+
+    const req = createFakeReq({ method: 'POST', origin: 'https://boardsesh.com', body: '{}' });
+    const res = createFakeRes();
+
+    await handlePosthogProxy(req, res.asProxyRes, buildUrl('/api/posthog/i/v0/e/'));
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)['User-Agent']).toBeUndefined();
   });
 
   it('returns 404 when the path is exactly the prefix (no upstream target)', async () => {

--- a/packages/backend/src/handlers/posthog.ts
+++ b/packages/backend/src/handlers/posthog.ts
@@ -41,6 +41,11 @@ function readBody(req: IncomingMessage, limitBytes: number): Promise<Buffer | { 
  * the query string, request body bytes, and Content-Encoding header (the JS SDK
  * gzips the /batch/ payload when CompressionStream is available, so the body is
  * binary, not text).
+ *
+ * Also forwards the browser's User-Agent. PostHog derives `$raw_user_agent` (and
+ * its bot/traffic classification + device parsing) from the request UA header;
+ * Node's fetch sends none by default, so without this every proxied event lands
+ * with an empty UA and PostHog flags it as a bot.
  */
 export async function handlePosthogProxy(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
   if (!applyCorsHeaders(req, res)) return;
@@ -75,6 +80,10 @@ export async function handlePosthogProxy(req: IncomingMessage, res: ServerRespon
   }
   const clientIp = getClientIp(req);
   if (clientIp) headers['X-Forwarded-For'] = clientIp;
+  const userAgent = req.headers['user-agent'];
+  if (typeof userAgent === 'string' && userAgent.length > 0) {
+    headers['User-Agent'] = userAgent;
+  }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);

--- a/packages/mobile/src/lib/__tests__/posthog-client.test.ts
+++ b/packages/mobile/src/lib/__tests__/posthog-client.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { MOBILE_USER_AGENT } from '../posthog-client';
+
+// The whole point of MOBILE_USER_AGENT is to give mobile events a User-Agent that
+// PostHog's classifier reads as "Regular" rather than the bot it assigns to an
+// empty UA. If a future edit makes it empty or sneaks in a denylisted substring,
+// every mobile user silently falls back into the bot bucket — guard against that.
+describe('MOBILE_USER_AGENT', () => {
+  it('is a non-empty string', () => {
+    expect(typeof MOBILE_USER_AGENT).toBe('string');
+    expect(MOBILE_USER_AGENT.length).toBeGreaterThan(0);
+  });
+
+  it('matches none of PostHog’s bot denylist substrings', () => {
+    // Sample of PostHog's DEFAULT_BLOCKED_UA_STRS (substring match, case-insensitive).
+    const botPatterns = /bot|crawler|spider|slurp|headless|cypress|prerender|archiver|lighthouse/i;
+    expect(botPatterns.test(MOBILE_USER_AGENT)).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/posthog-client.test.ts
+++ b/packages/mobile/src/lib/__tests__/posthog-client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { MOBILE_USER_AGENT } from '../posthog-client';
+import { describe, it, expect, vi } from 'vitest';
+import { MOBILE_USER_AGENT, registerMobileUserAgent } from '../posthog-client';
 
 // The whole point of MOBILE_USER_AGENT is to give mobile events a User-Agent that
 // PostHog's classifier reads as "Regular" rather than the bot it assigns to an
@@ -15,5 +15,23 @@ describe('MOBILE_USER_AGENT', () => {
     // Sample of PostHog's DEFAULT_BLOCKED_UA_STRS (substring match, case-insensitive).
     const botPatterns = /bot|crawler|spider|slurp|headless|cypress|prerender|archiver|lighthouse/i;
     expect(botPatterns.test(MOBILE_USER_AGENT)).toBe(false);
+  });
+});
+
+describe('registerMobileUserAgent', () => {
+  it('registers the non-bot UA as a $raw_user_agent super property', () => {
+    const register = vi.fn();
+    registerMobileUserAgent({ register });
+    expect(register).toHaveBeenCalledWith({ $raw_user_agent: MOBILE_USER_AGENT });
+  });
+
+  it('never throws and logs when register() fails (must not block analytics init)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const register = vi.fn(() => {
+      throw new Error('boom');
+    });
+    expect(() => registerMobileUserAgent({ register })).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -1,18 +1,11 @@
 import { PostHog } from 'posthog-react-native';
 import { installGlobalErrorCapture } from './global-error-capture';
 
-// PostHog classifies traffic by parsing the request User-Agent into
-// `$raw_user_agent` (its `$virt_is_bot` / traffic-type is `isLikelyBot($raw_user_agent)`).
-// The RN SDK sends no UA that PostHog stores, so without this every mobile event
-// lands with an empty UA — which PostHog treats as a bot, hiding all real mobile
-// users behind the "Regular traffic" filter. A non-empty UA with no denylisted
-// bot substring ("bot"/"crawler"/…) classifies as Regular. Kept a static
-// constant rather than derived from `react-native` Platform so this module stays
-// free of the RN Flow barrel (react-native/index.js), which the node-env test
-// runner that imports this file transitively can't parse. OS, device, and app
-// version already ride on $os / $device_model / $app_version, so the UA only
-// needs the non-bot signature; the SDK still sets $os / $device_type directly.
-const MOBILE_USER_AGENT = 'Boardsesh Mobile';
+// PostHog flags events with an empty User-Agent as bots, and the RN SDK sends no
+// UA it stores — so without this, real mobile traffic hides behind the bot filter.
+// Static, non-bot constant (not `react-native` Platform) to keep the RN Flow
+// barrel out of this module's graph, which would break the node-env test runner.
+export const MOBILE_USER_AGENT = 'Boardsesh Mobile';
 
 // PostHog project token. Intentionally the SAME project as web so a signed-in
 // user's web + mobile activity resolves to one person. `EXPO_PUBLIC_*` vars are
@@ -80,12 +73,10 @@ export function getPostHogClient(): PostHog | null {
       captureLog: true,
     },
   });
-  // Attach a device User-Agent to every event so PostHog's bot classifier sees
-  // real mobile traffic instead of an empty UA. Never let this block init.
   try {
     client.register({ $raw_user_agent: MOBILE_USER_AGENT });
   } catch {
-    // Super-property registration is best-effort; analytics must still start.
+    // Best-effort: registration must never block analytics init.
   }
   installMobileGlobalErrorCapture();
   return client;

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -1,6 +1,19 @@
 import { PostHog } from 'posthog-react-native';
 import { installGlobalErrorCapture } from './global-error-capture';
 
+// PostHog classifies traffic by parsing the request User-Agent into
+// `$raw_user_agent` (its `$virt_is_bot` / traffic-type is `isLikelyBot($raw_user_agent)`).
+// The RN SDK sends no UA that PostHog stores, so without this every mobile event
+// lands with an empty UA — which PostHog treats as a bot, hiding all real mobile
+// users behind the "Regular traffic" filter. A non-empty UA with no denylisted
+// bot substring ("bot"/"crawler"/…) classifies as Regular. Kept a static
+// constant rather than derived from `react-native` Platform so this module stays
+// free of the RN Flow barrel (react-native/index.js), which the node-env test
+// runner that imports this file transitively can't parse. OS, device, and app
+// version already ride on $os / $device_model / $app_version, so the UA only
+// needs the non-bot signature; the SDK still sets $os / $device_type directly.
+const MOBILE_USER_AGENT = 'Boardsesh Mobile';
+
 // PostHog project token. Intentionally the SAME project as web so a signed-in
 // user's web + mobile activity resolves to one person. `EXPO_PUBLIC_*` vars are
 // inlined into the JS bundle at build time, so this must be set when the bundle
@@ -67,6 +80,13 @@ export function getPostHogClient(): PostHog | null {
       captureLog: true,
     },
   });
+  // Attach a device User-Agent to every event so PostHog's bot classifier sees
+  // real mobile traffic instead of an empty UA. Never let this block init.
+  try {
+    client.register({ $raw_user_agent: MOBILE_USER_AGENT });
+  } catch {
+    // Super-property registration is best-effort; analytics must still start.
+  }
   installMobileGlobalErrorCapture();
   return client;
 }

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -7,6 +7,18 @@ import { installGlobalErrorCapture } from './global-error-capture';
 // barrel out of this module's graph, which would break the node-env test runner.
 export const MOBILE_USER_AGENT = 'Boardsesh Mobile';
 
+// Registers the non-bot User-Agent as a super property on every event. Exported
+// so the call site is unit-testable — the live invocation in getPostHogClient()
+// is __DEV__-gated and never runs under the test env. Best-effort: a failure must
+// never block analytics init.
+export function registerMobileUserAgent(client: Pick<PostHog, 'register'>): void {
+  try {
+    client.register({ $raw_user_agent: MOBILE_USER_AGENT });
+  } catch (error) {
+    if (__DEV__) console.warn('[analytics] failed to register $raw_user_agent super property', error);
+  }
+}
+
 // PostHog project token. Intentionally the SAME project as web so a signed-in
 // user's web + mobile activity resolves to one person. `EXPO_PUBLIC_*` vars are
 // inlined into the JS bundle at build time, so this must be set when the bundle
@@ -73,11 +85,7 @@ export function getPostHogClient(): PostHog | null {
       captureLog: true,
     },
   });
-  try {
-    client.register({ $raw_user_agent: MOBILE_USER_AGENT });
-  } catch {
-    // Best-effort: registration must never block analytics init.
-  }
+  registerMobileUserAgent(client);
   installMobileGlobalErrorCapture();
   return client;
 }

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -8,9 +8,10 @@ import { installGlobalErrorCapture } from './global-error-capture';
 export const MOBILE_USER_AGENT = 'Boardsesh Mobile';
 
 // Registers the non-bot User-Agent as a super property on every event. Exported
-// so the call site is unit-testable — the live invocation in getPostHogClient()
-// is __DEV__-gated and never runs under the test env. Best-effort: a failure must
-// never block analytics init.
+// so the call site is unit-testable: getPostHogClient() returns null before
+// reaching its own call to this whenever analytics is disabled (no token, or
+// __DEV__ — both hold in the test env), so the live path can't run in tests.
+// Best-effort: a failure must never block analytics init.
 export function registerMobileUserAgent(client: Pick<PostHog, 'register'>): void {
   try {
     client.register({ $raw_user_agent: MOBILE_USER_AGENT });

--- a/packages/mobile/test/posthog-react-native-stub.ts
+++ b/packages/mobile/test/posthog-react-native-stub.ts
@@ -19,6 +19,7 @@ export class PostHog {
   identify(): void {}
   alias(): void {}
   reset(): void {}
+  register(): void {}
   screen(): void {}
   setPersonProperties(): void {}
   flush(): Promise<void> {


### PR DESCRIPTION
## Summary

PostHog's bot classifier — `$virt_is_bot` = `isLikelyBot(properties.$raw_user_agent)` — reads the User-Agent. A geo/traffic analysis found `$raw_user_agent` is **empty on 100% of events** (web `js`, `posthog-react-native`, and `posthog-node`), and PostHog treats an empty UA as a bot. The result: every real user is classified as a bot and the "Regular traffic" tab shows **0 users**, so the built-in bot/traffic filters are useless.

Two causes, both fixed here:

- **Web** — the `/api/posthog` reverse proxy (`packages/backend/src/handlers/posthog.ts`) forwarded `Content-Type`, `Content-Encoding`, and `X-Forwarded-For` but **not** `User-Agent`. Node's `fetch` sends no UA by default, so PostHog recorded an empty one. Now it forwards the incoming browser `User-Agent` so `$raw_user_agent` (and bot/device parsing) populates. Falls back to omitting the header (not an empty string) when absent.
- **Mobile** — the RN SDK sends no UA that PostHog stores. Registers a static, non-bot `$raw_user_agent` super property (`Boardsesh Mobile`) so mobile events classify as "Regular". Kept **react-native-free** (a static constant, not `Platform`-derived) because importing `react-native` drags in its Flow-typed barrel, which the node-env test runner can't parse — and `posthog-client` is imported transitively by many node-env logic tests. OS/device/version already ride on `$os`/`$device_model`/`$app_version`, so the UA only needs the non-bot signature.

Bot detection is a query-time virtual column; it does not overwrite SDK-set `$os`/`$device_type`, so device fields are untouched.

Backend (`posthog-node`) events are intentionally left as-is — they're genuine server-side events, isolated by `$lib = posthog-node`.

> Note: a separate, stale data-cleanup (a one-time `signup_source: backfill` import that geo-pinned ~1,000 phantom users to a Sydney datacenter IP) is handled out-of-band via PostHog, not in this PR.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — my files formatting-clean (pre-existing format issues elsewhere are unrelated)
- `vp run typecheck:backend`, `vp run typecheck:mobile` — pass
- `vp test run --project backend posthog` — 17 pass, incl. new User-Agent forwarding + no-UA cases
- `vp run test:mobile` — 345 files / 2562 tests pass (confirmed the react-native-barrel regression is gone by diffing against a clean `origin/main` baseline)
- `vp run check:mobile-bundle` — OK (11.1 MB)
- Post-deploy verification (PostHog): for `$lib='js'` events after deploy, `$raw_user_agent` populated and `$virt_is_bot=0` for the majority; same check for `posthog-react-native` after the OTA, with `$os`/`$device_type` distributions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDs64ZbzEHTgJJgWLnia9r