### PR TITLE
fix(backend): scope session feed stats to the viewer in party sessions

### DIFF
--- a/packages/backend/src/__tests__/session-feed-participant-scope-integration.test.ts
+++ b/packages/backend/src/__tests__/session-feed-participant-scope-integration.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { SessionFeedItem } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { sessionFeedQueries } from '../graphql/resolvers/social/session-feed';
+
+/**
+ * Real-DB integration coverage for PER-VIEWER scoping of the session-grouped
+ * feed. The "You"/profile Sessions surfaces call sessionGroupedFeed({ userId }),
+ * and used to show WHOLE-SESSION aggregates — so a party session inflated the
+ * viewer's own sends/flashes/grades/hardest with their party-mates' climbs.
+ *
+ * This seeds one party session two climbers share:
+ *   - VIEWER logs 3 sends (2 send + 1 flash), hardest at difficulty 15,
+ *   - PARTNER logs 2 sends, BOTH harder (difficulty 20 and 25).
+ *
+ * and proves the product behaviour the fix wants:
+ *   - sessionGroupedFeed({ userId: VIEWER }) returns the VIEWER's own totals
+ *     (3 sends, 1 flash), grade distribution (sums to 3, not 5), and hardest
+ *     send (difficulty 15 — the VIEWER's, not the partner's harder 25),
+ *   - participants[] STAYS whole-session (both climbers, with each one's own
+ *     sends) so the leaderboard is intact,
+ *   - the same scoping holds independently for the PARTNER,
+ *   - a feed with NO userId (the social/home feed) is UNSCOPED and keeps
+ *     whole-session aggregates (5 sends, hardest 25).
+ *
+ * The mock-based session-feed-query.test.ts proves the SQL *shape* (the query
+ * now carries `AND t.user_id = <id>` when a userId is set); this proves the
+ * row-level numbers.
+ */
+
+const OWNER_USER_ID = 'sf-pscope-owner';
+const VIEWER_USER_ID = 'sf-pscope-viewer';
+const PARTNER_USER_ID = 'sf-pscope-partner';
+const CLIMB_UUID = 'sf-pscope-climb-1';
+const BOARD_UUID = 'sf-pscope-board';
+const SESSION_ID = 'sf-pscope-session';
+
+let boardId: number;
+
+type SessionFeedResult = { sessions: SessionFeedItem[] };
+
+const callFeed = (input: Record<string, unknown>) =>
+  sessionFeedQueries.sessionGroupedFeed(null, { input }) as Promise<SessionFeedResult>;
+
+const insertUser = async (id: string) => {
+  await db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'Test ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+};
+
+const insertBoard = async (uuid: string): Promise<number> => {
+  const result = await db.execute(sql`
+    INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name)
+    VALUES (${uuid}, ${uuid}, ${OWNER_USER_ID}, 'kilter', 1, 10, '1,20', 'Participant Scope Board')
+    ON CONFLICT (uuid) DO UPDATE SET slug = excluded.slug
+    RETURNING id
+  `);
+  const rows = Array.from(result as Iterable<{ id: number }>);
+  return Number(rows[0].id);
+};
+
+const insertClimb = async () => {
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+    VALUES (${CLIMB_UUID}, 'kilter', 1, 'test-setter', 'Participant Scope Climb', 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+};
+
+const insertSession = async () => {
+  await db.execute(sql`
+    INSERT INTO board_sessions (id, board_path, created_by_user_id, name, board_id, status)
+    VALUES (${SESSION_ID}, ${'kilter/1/10/1,20/40'}, ${OWNER_USER_ID}, ${'Participant Scope Session'}, ${boardId}, 'active')
+    ON CONFLICT (id) DO NOTHING
+  `);
+};
+
+const insertTick = async (params: {
+  uuid: string;
+  userId: string;
+  status: 'send' | 'flash' | 'attempt';
+  difficulty: number;
+  attemptCount: number;
+  climbedAt: string;
+}) => {
+  await db.execute(sql`
+    INSERT INTO boardsesh_ticks (uuid, user_id, board_type, board_id, climb_uuid, angle, status, attempt_count, difficulty, climbed_at, session_id)
+    VALUES (${params.uuid}, ${params.userId}, 'kilter', ${boardId}, ${CLIMB_UUID}, 40, ${params.status}, ${params.attemptCount}, ${params.difficulty}, ${params.climbedAt}, ${SESSION_ID})
+  `);
+};
+
+const cleanup = async () => {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE session_id = ${SESSION_ID}`);
+  await db.execute(sql`DELETE FROM board_sessions WHERE id = ${SESSION_ID}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+  await db.execute(sql`DELETE FROM user_boards WHERE uuid = ${BOARD_UUID}`);
+  await db.execute(sql`DELETE FROM "users" WHERE id IN (${OWNER_USER_ID}, ${VIEWER_USER_ID}, ${PARTNER_USER_ID})`);
+};
+
+const findSession = (result: SessionFeedResult) => {
+  const session = result.sessions.find((s) => s.sessionId === SESSION_ID);
+  if (!session) throw new Error(`Seeded session ${SESSION_ID} missing from feed result`);
+  return session;
+};
+
+const successCount = (session: SessionFeedItem) =>
+  session.gradeDistribution.reduce((sum, item) => sum + item.flash + item.send, 0);
+
+describe('sessionGroupedFeed — per-viewer scoping in party sessions (real DB)', () => {
+  beforeAll(async () => {
+    await cleanup();
+    await insertUser(OWNER_USER_ID);
+    await insertUser(VIEWER_USER_ID);
+    await insertUser(PARTNER_USER_ID);
+    await insertClimb();
+    boardId = await insertBoard(BOARD_UUID);
+    await insertSession();
+
+    // VIEWER: 3 sends (2 send + 1 flash), 2 implicit attempts (the difficulty-15
+    // send took 3 tries), hardest send at difficulty 15.
+    await insertTick({
+      uuid: 'sf-pscope-viewer-send-1',
+      userId: VIEWER_USER_ID,
+      status: 'send',
+      difficulty: 10,
+      attemptCount: 1,
+      climbedAt: '2026-03-01 10:00:00',
+    });
+    await insertTick({
+      uuid: 'sf-pscope-viewer-send-2',
+      userId: VIEWER_USER_ID,
+      status: 'send',
+      difficulty: 15,
+      attemptCount: 3,
+      climbedAt: '2026-03-01 10:10:00',
+    });
+    await insertTick({
+      uuid: 'sf-pscope-viewer-flash-1',
+      userId: VIEWER_USER_ID,
+      status: 'flash',
+      difficulty: 12,
+      attemptCount: 1,
+      climbedAt: '2026-03-01 10:20:00',
+    });
+
+    // PARTNER: 2 sends, BOTH harder than the viewer's hardest (15) — so a
+    // whole-session hardest would be the partner's 25, but the viewer-scoped
+    // hardest must stay the viewer's 15.
+    await insertTick({
+      uuid: 'sf-pscope-partner-send-1',
+      userId: PARTNER_USER_ID,
+      status: 'send',
+      difficulty: 20,
+      attemptCount: 1,
+      climbedAt: '2026-03-01 10:05:00',
+    });
+    await insertTick({
+      uuid: 'sf-pscope-partner-send-2',
+      userId: PARTNER_USER_ID,
+      status: 'send',
+      difficulty: 25,
+      attemptCount: 1,
+      climbedAt: '2026-03-01 10:15:00',
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('scopes the party-session aggregates to the viewer (their own 3 sends, not the whole party of 5)', async () => {
+    const session = findSession(await callFeed({ userId: VIEWER_USER_ID, limit: 50 }));
+
+    expect(session.totalSends).toBe(3);
+    expect(session.totalFlashes).toBe(1);
+    expect(session.totalAttempts).toBe(2);
+    expect(session.tickCount).toBe(3);
+    // Grade distribution is the viewer's own — sums to 3 successful ascents, not 5.
+    expect(successCount(session)).toBe(3);
+  });
+
+  it("scopes hardestSend to the viewer (their difficulty 15, not the partner's harder 25)", async () => {
+    const session = findSession(await callFeed({ userId: VIEWER_USER_ID, limit: 50 }));
+
+    expect(session.hardestSend?.userId).toBe(VIEWER_USER_ID);
+    expect(session.hardestSend?.difficulty).toBe(15);
+  });
+
+  it('keeps participants[] whole-session so the leaderboard stays intact', async () => {
+    const session = findSession(await callFeed({ userId: VIEWER_USER_ID, limit: 50 }));
+
+    expect(session.participants).toHaveLength(2);
+    const viewer = session.participants.find((p) => p.userId === VIEWER_USER_ID);
+    const partner = session.participants.find((p) => p.userId === PARTNER_USER_ID);
+    expect(viewer).toMatchObject({ sends: 3, flashes: 1 });
+    expect(partner).toMatchObject({ sends: 2, flashes: 0 });
+  });
+
+  it('scopes independently for the partner (their own 2 sends, hardest 25)', async () => {
+    const session = findSession(await callFeed({ userId: PARTNER_USER_ID, limit: 50 }));
+
+    expect(session.totalSends).toBe(2);
+    expect(session.totalFlashes).toBe(0);
+    expect(session.tickCount).toBe(2);
+    expect(successCount(session)).toBe(2);
+    expect(session.hardestSend?.userId).toBe(PARTNER_USER_ID);
+    expect(session.hardestSend?.difficulty).toBe(25);
+  });
+
+  it('keeps whole-session aggregates when no userId is set (the social/home feed)', async () => {
+    // boardUuid isolates the assertion to the seeded session without engaging
+    // the per-user scope (participantFilterEnabled stays false).
+    const session = findSession(await callFeed({ boardUuid: BOARD_UUID, limit: 50 }));
+
+    expect(session.totalSends).toBe(5);
+    expect(session.totalFlashes).toBe(1);
+    expect(session.tickCount).toBe(5);
+    expect(successCount(session)).toBe(5);
+    // Whole-session hardest is the partner's 25.
+    expect(session.hardestSend?.difficulty).toBe(25);
+    expect(session.participants).toHaveLength(2);
+  });
+});

--- a/packages/backend/src/__tests__/session-feed-participant-scope-integration.test.ts
+++ b/packages/backend/src/__tests__/session-feed-participant-scope-integration.test.ts
@@ -149,13 +149,16 @@ describe('sessionGroupedFeed — per-viewer scoping in party sessions (real DB)'
     // PARTNER: 2 sends, BOTH harder than the viewer's hardest (15) — so a
     // whole-session hardest would be the partner's 25, but the viewer-scoped
     // hardest must stay the viewer's 15.
+    // The partner's ticks also BRACKET the viewer's 10:00-10:20 span (one before,
+    // one after), so the viewer-scoped first/last tick (and durationMinutes) stay
+    // the viewer's own 20-minute window while the whole session spans 35 minutes.
     await insertTick({
       uuid: 'sf-pscope-partner-send-1',
       userId: PARTNER_USER_ID,
       status: 'send',
       difficulty: 20,
       attemptCount: 1,
-      climbedAt: '2026-03-01 10:05:00',
+      climbedAt: '2026-03-01 09:55:00', // before the viewer's first tick
     });
     await insertTick({
       uuid: 'sf-pscope-partner-send-2',
@@ -163,7 +166,7 @@ describe('sessionGroupedFeed — per-viewer scoping in party sessions (real DB)'
       status: 'send',
       difficulty: 25,
       attemptCount: 1,
-      climbedAt: '2026-03-01 10:15:00',
+      climbedAt: '2026-03-01 10:30:00', // after the viewer's last tick
     });
   });
 
@@ -180,6 +183,9 @@ describe('sessionGroupedFeed — per-viewer scoping in party sessions (real DB)'
     expect(session.tickCount).toBe(3);
     // Grade distribution is the viewer's own — sums to 3 successful ascents, not 5.
     expect(successCount(session)).toBe(3);
+    // first/last tick (hence durationMinutes) are the viewer's 20-min window,
+    // not the partner-widened 35-min whole-session span.
+    expect(session.durationMinutes).toBe(20);
   });
 
   it("scopes hardestSend to the viewer (their difficulty 15, not the partner's harder 25)", async () => {
@@ -222,5 +228,7 @@ describe('sessionGroupedFeed — per-viewer scoping in party sessions (real DB)'
     // Whole-session hardest is the partner's 25.
     expect(session.hardestSend?.difficulty).toBe(25);
     expect(session.participants).toHaveLength(2);
+    // Whole-session span covers both partner ticks (09:55 to 10:30).
+    expect(session.durationMinutes).toBe(35);
   });
 });

--- a/packages/backend/src/__tests__/session-feed-query.test.ts
+++ b/packages/backend/src/__tests__/session-feed-query.test.ts
@@ -57,16 +57,19 @@ describe('sessionGroupedFeed user filtering', () => {
     vi.clearAllMocks();
 
     sessionFeedTestState.executeMock
+      // session_base row: with a userId filter the resolver now scopes the
+      // aggregates to that climber's own ticks, so this is user-1's slice (3
+      // sends), NOT the whole party's 5. participants[] below stays whole-session.
       .mockResolvedValueOnce([
         {
           session_id: 'party-1',
           session_type: 'party',
           session_first_tick: '2024-01-15T10:00:00.000Z',
           session_last_tick: '2024-01-15T12:00:00.000Z',
-          tick_count: 8,
-          total_sends: 5,
-          total_flashes: 2,
-          total_attempts: 6,
+          tick_count: 3,
+          total_sends: 3,
+          total_flashes: 1,
+          total_attempts: 2,
           vote_score: 4,
           vote_up: 5,
           vote_down: 1,
@@ -99,13 +102,14 @@ describe('sessionGroupedFeed user filtering', () => {
           attempts: 4,
         },
       ])
+      // Grade distribution is likewise the viewer's own slice (sums to 3 sends).
       .mockResolvedValueOnce([
         {
           session_id: 'party-1',
           diff_num: 10,
-          flash: 2,
-          send: 3,
-          attempt: 6,
+          flash: 1,
+          send: 2,
+          attempt: 2,
         },
       ])
       .mockResolvedValueOnce([
@@ -127,7 +131,7 @@ describe('sessionGroupedFeed user filtering', () => {
     ]);
   });
 
-  it('filters party sessions by participant but returns whole-session aggregates', async () => {
+  it('scopes party-session aggregates to the participant, keeping participants[] whole-session', async () => {
     const result = await sessionGroupedFeed(null, {
       input: {
         userId: 'user-1',
@@ -136,17 +140,32 @@ describe('sessionGroupedFeed user filtering', () => {
     });
 
     const mainQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[0][0]);
+    const participantsQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[1][0]);
+    const gradeDistQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[2][0]);
+    const boardTypesQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[3][0]);
+    const hardestSendsQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[4][0]);
+    const featuredBetaQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[5][0]);
 
+    // Membership still decides WHICH sessions appear…
     expect(mainQueryText).toContain('eligible_sessions');
     expect(mainQueryText).toContain('INNER JOIN eligible_sessions es ON es.session_id = t.session_id');
+    // …and the aggregates + grade/board/hardest/beta enrichment are now scoped to
+    // the filtered climber's own ticks, so a party-mate can't inflate them.
+    expect(mainQueryText).toContain('AND t.user_id =');
+    expect(gradeDistQueryText).toContain('AND t.user_id =');
+    expect(boardTypesQueryText).toContain('AND t.user_id =');
+    expect(hardestSendsQueryText).toContain('AND t.user_id =');
+    expect(featuredBetaQueryText).toContain('AND t.user_id =');
+    // participants[] is the leaderboard — it must stay whole-session, never scoped.
+    expect(participantsQueryText).not.toContain('AND t.user_id =');
 
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]).toMatchObject({
       sessionId: 'party-1',
       sessionType: 'party',
-      totalSends: 5,
-      totalFlashes: 2,
-      totalAttempts: 6,
+      totalSends: 3,
+      totalFlashes: 1,
+      totalAttempts: 2,
       hardestGrade: '4a/V0',
       hardestSend: null,
       featuredBeta: null,
@@ -157,5 +176,24 @@ describe('sessionGroupedFeed user filtering', () => {
         expect.objectContaining({ userId: 'user-2', sends: 2 }),
       ],
     });
+  });
+
+  it('does NOT scope aggregates when no userId is set (the public/social feed)', async () => {
+    const result = await sessionGroupedFeed(null, {
+      input: {
+        limit: 20,
+      },
+    });
+
+    const mainQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[0][0]);
+    const gradeDistQueryText = sqlToText(sessionFeedTestState.executeMock.mock.calls[2][0]);
+
+    // No participant filter at all — every party session, whole-session aggregates.
+    expect(mainQueryText).not.toContain('eligible_sessions');
+    expect(mainQueryText).not.toContain('AND t.user_id =');
+    expect(gradeDistQueryText).not.toContain('AND t.user_id =');
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].sessionId).toBe('party-1');
   });
 });

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -22,6 +22,13 @@ import { buildGradeDistributionFromTicks, computeSessionAggregates } from './ses
 
 type SessionFeedFilterOptions = {
   boardIdFilter: number | null;
+  // When the feed is scoped to a single climber (the "your sessions" surfaces
+  // that pass a userId), party-session aggregates are scoped to that climber's
+  // own ticks so the viewer's totals/grades/hardest don't count their party-
+  // mates. null on the public/social and following feeds, where whole-session
+  // aggregates are correct. participants[] stays whole-session regardless — it
+  // is the session leaderboard, not the viewer's own stats.
+  userIdFilter: string | null;
 };
 
 type SessionFeedRow = {
@@ -124,6 +131,13 @@ export const sessionFeedQueries = {
     let sessionRows;
     try {
       const sessionBoardFilter = boardIdFilter !== null ? sql`AND t.board_id = ${boardIdFilter}` : sql``;
+      // Per-user scope: when a single userId filters the feed (the "your
+      // sessions" surfaces on web + mobile), count only that climber's ticks in
+      // each party session — their own sends/flashes/attempts/grades/hardest —
+      // not the whole party's. Empty on the social/home/following feeds (no
+      // userId), so those keep whole-session aggregates, which is correct for a
+      // social card showing the whole crew.
+      const sessionUserFilter = userId ? sql`AND t.user_id = ${userId}` : sql``;
       const shouldIncludeDailyHighlights = includeDailyHighlights && participantFilterEnabled;
       const eligibleUsersCte = userId
         ? sql`eligible_users AS (SELECT ${userId}::text AS user_id),`
@@ -323,6 +337,7 @@ export const sessionFeedQueries = {
           ${participantFilterEnabled ? sql`INNER JOIN eligible_sessions es ON es.session_id = t.session_id` : sql``}
           WHERE t.session_id IS NOT NULL
             ${sessionBoardFilter}
+            ${sessionUserFilter}
           GROUP BY t.session_id
         ),
         scored AS (
@@ -372,7 +387,7 @@ export const sessionFeedQueries = {
     const dailyHighlightTickUuids = resultRows
       .filter((row) => row.session_type === 'daily_highlight' && !!row.highlight_tick_uuid)
       .map((row) => row.highlight_tick_uuid as string);
-    const filterOptions: SessionFeedFilterOptions = { boardIdFilter };
+    const filterOptions: SessionFeedFilterOptions = { boardIdFilter, userIdFilter: userId };
 
     const [
       participantMap,
@@ -931,11 +946,12 @@ async function fetchParticipantsBatch(
  */
 async function fetchGradeDistributionBatch(
   sessionIds: string[],
-  { boardIdFilter }: SessionFeedFilterOptions,
+  { boardIdFilter, userIdFilter }: SessionFeedFilterOptions,
 ): Promise<Map<string, SessionGradeDistributionItem[]>> {
   if (sessionIds.length === 0) return new Map();
 
   const batchBoardFilter = boardIdFilter !== null ? sql`AND t.board_id = ${boardIdFilter}` : sql``;
+  const batchUserFilter = userIdFilter !== null ? sql`AND t.user_id = ${userIdFilter}` : sql``;
 
   const result = await dbRead.execute(sql`
     SELECT
@@ -957,6 +973,7 @@ async function fetchGradeDistributionBatch(
       sql`, `,
     )})`}
       ${batchBoardFilter}
+      ${batchUserFilter}
       AND COALESCE(t.difficulty, ROUND(bcs.display_difficulty)::int) IS NOT NULL
     GROUP BY t.session_id, diff_num
     ORDER BY diff_num DESC
@@ -1015,11 +1032,12 @@ async function fetchSessionMetaBatch(
  */
 async function fetchBoardTypesBatch(
   sessionIds: string[],
-  { boardIdFilter }: SessionFeedFilterOptions,
+  { boardIdFilter, userIdFilter }: SessionFeedFilterOptions,
 ): Promise<Map<string, string[]>> {
   if (sessionIds.length === 0) return new Map();
 
   const batchBoardFilter = boardIdFilter !== null ? sql`AND t.board_id = ${boardIdFilter}` : sql``;
+  const batchUserFilter = userIdFilter !== null ? sql`AND t.user_id = ${userIdFilter}` : sql``;
 
   const result = await dbRead.execute(sql`
     SELECT
@@ -1031,6 +1049,7 @@ async function fetchBoardTypesBatch(
       sql`, `,
     )})`}
       ${batchBoardFilter}
+      ${batchUserFilter}
     GROUP BY t.session_id
   `);
 
@@ -1173,11 +1192,12 @@ async function fetchTickHighlightsByUuid(tickUuids: string[]): Promise<Map<strin
 
 async function fetchHardestSendsBatch(
   sessionIds: string[],
-  { boardIdFilter }: SessionFeedFilterOptions,
+  { boardIdFilter, userIdFilter }: SessionFeedFilterOptions,
 ): Promise<Map<string, SessionFeedTickHighlight>> {
   if (sessionIds.length === 0) return new Map();
 
   const batchBoardFilter = boardIdFilter !== null ? sql`AND t.board_id = ${boardIdFilter}` : sql``;
+  const batchUserFilter = userIdFilter !== null ? sql`AND t.user_id = ${userIdFilter}` : sql``;
 
   const result = await dbRead.execute(sql`
     WITH ranked AS (
@@ -1199,6 +1219,7 @@ async function fetchHardestSendsBatch(
         sql`, `,
       )})`}
         ${batchBoardFilter}
+        ${batchUserFilter}
         AND t.status IN ('flash', 'send')
     )
     SELECT
@@ -1423,11 +1444,12 @@ function betaCandidateRankSql(partitionExpression: SQL) {
 
 async function fetchSessionFeaturedBetaRows(
   sessionIds: string[],
-  { boardIdFilter }: SessionFeedFilterOptions,
+  { boardIdFilter, userIdFilter }: SessionFeedFilterOptions,
 ): Promise<FeaturedBetaRow[]> {
   if (sessionIds.length === 0) return [];
 
   const batchBoardFilter = boardIdFilter !== null ? sql`AND t.board_id = ${boardIdFilter}` : sql``;
+  const batchUserFilter = userIdFilter !== null ? sql`AND t.user_id = ${userIdFilter}` : sql``;
 
   const result = await dbRead.execute(sql`
     WITH ranked AS (
@@ -1456,6 +1478,7 @@ async function fetchSessionFeaturedBetaRows(
         sql`, `,
       )})`}
         ${batchBoardFilter}
+        ${batchUserFilter}
         AND t.status IN ('flash', 'send')
     )
     SELECT *

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -22,12 +22,9 @@ import { buildGradeDistributionFromTicks, computeSessionAggregates } from './ses
 
 type SessionFeedFilterOptions = {
   boardIdFilter: number | null;
-  // When the feed is scoped to a single climber (the "your sessions" surfaces
-  // that pass a userId), party-session aggregates are scoped to that climber's
-  // own ticks so the viewer's totals/grades/hardest don't count their party-
-  // mates. null on the public/social and following feeds, where whole-session
-  // aggregates are correct. participants[] stays whole-session regardless — it
-  // is the session leaderboard, not the viewer's own stats.
+  // Single-climber scope ("your sessions" surfaces): aggregates count only this
+  // climber's ticks. null on social/following feeds (whole-session). participants[]
+  // stays whole-session regardless; it is the leaderboard, not the viewer's stats.
   userIdFilter: string | null;
 };
 
@@ -131,13 +128,10 @@ export const sessionFeedQueries = {
     let sessionRows;
     try {
       const sessionBoardFilter = boardIdFilter !== null ? sql`AND t.board_id = ${boardIdFilter}` : sql``;
-      // Per-user scope: when a single userId filters the feed (the "your
-      // sessions" surfaces on web + mobile), count only that climber's ticks in
-      // each party session — their own sends/flashes/attempts/grades/hardest —
-      // not the whole party's. Empty on the social/home/following feeds (no
-      // userId), so those keep whole-session aggregates, which is correct for a
-      // social card showing the whole crew.
-      const sessionUserFilter = userId ? sql`AND t.user_id = ${userId}` : sql``;
+      // Per-user scope: a single userId ("your sessions") counts only that
+      // climber's ticks per session. Empty on social/home/following feeds, which
+      // keep whole-session aggregates. Mirrors boardIdFilter's null guard.
+      const sessionUserFilter = userId !== null ? sql`AND t.user_id = ${userId}` : sql``;
       const shouldIncludeDailyHighlights = includeDailyHighlights && participantFilterEnabled;
       const eligibleUsersCte = userId
         ? sql`eligible_users AS (SELECT ${userId}::text AS user_id),`


### PR DESCRIPTION
## Summary

The mobile "You" page and the web/mobile profile **Sessions** tabs showed climbing stats that **included other climbers' climbs from group/party sessions**, inflating the viewer's own numbers.

**Root cause.** Those surfaces call `sessionGroupedFeed({ userId })`. The `userId` input filtered *which* sessions appeared (sessions the climber was in) but the per-session aggregates were **whole-session** — `totalSends`, `totalFlashes`, `totalAttempts`, `tickCount`, `gradeDistribution`, `boardTypes`, `hardestGrade`/`hardestSend`, `featuredBeta` all summed every participant. The per-user split lived only in `participants[]` (sends/flashes/attempts), which has **no** per-user grade distribution, hardest, or board types. So the weekly rollup card, the per-session card's sends line, grade strip, board chip, and hardest-send hero were all party-wide on a "your sessions" surface.

This is **not** a public-feed bug: the home/activity feed passes no `userId` (it uses `followingOnly`/`boardUuid`), and whole-session aggregates are **correct** there — a social card should show the whole crew. Only the single-`userId` "your sessions" surfaces were wrong.

**Fix (resolver-side scoping).** When a single `userId` scopes the feed, count only that climber's own ticks in each party session for the per-session aggregates (totals, grade distribution, board types, hardest send, featured beta). `participants[]` stays whole-session for the leaderboard. The public/home/following feeds (no `userId`) are untouched and keep whole-session aggregates.

Why resolver-side and not consumer-side: the per-user `gradeDistribution`/`hardestGrade`/`boardTypes` simply don't exist in `participants[]`, so a client-side swap could fix the sends count but **not** the grade strip or hardest badge — the half-fix the issue explicitly warned against. Because web and mobile share the GraphQL query document (`GET_SESSION_GROUPED_FEED`) and the `SessionFeedItem` type, scoping in the resolver fixes **both clients with zero consumer changes** and no schema change.

Scope of change: backend resolver only (`packages/backend/src/graphql/resolvers/social/session-feed.ts`) plus tests. No web, mobile, or shared-schema changes.

### Behaviour changes worth calling out

- On a per-user feed, a party session's `firstTickAt`/`lastTickAt` (and therefore `durationMinutes` and feed ordering) now reflect the **viewer's own** active span in that session rather than the whole party's. That's the correct framing for a "your sessions" view, and it's now asserted in the integration test.
- `featuredBeta` is scoped to the viewer too: on a per-user card the featured beta video surfaces only if the **viewer** uploaded one (otherwise the card falls back to the viewer's own hardest-send hero). This keeps the card internally consistent — the hero send and its beta clip are both the viewer's — rather than featuring a party-mate's clip on your own stats card. The public/social feed still features the whole crew's beta.

## Release Notes

- Your session stats now count only your own climbs. On the You and profile Sessions tabs, your weekly sends and flashes, grade spread, and hardest send no longer fold in your crew's climbs from group sessions.

## Test plan

- **`session-feed-query.test.ts` (mocked, passing):** asserts the generated SQL now carries the per-user scope (`AND t.user_id = …`) on the aggregate **and** the grade/board/hardest/featured-beta enrichment queries, that `participants[]` is **not** scoped (leaderboard intact), and that a no-`userId` feed stays unscoped (whole-session preserved).
- **`session-feed-participant-scope-integration.test.ts` (new, real DB):** seeds one party session two climbers share (viewer: 3 sends incl. 1 flash, hardest at difficulty 15, climbing inside a 20-min window; partner: 2 harder sends, hardest 25, climbing 09:55 and 10:30 to bracket the viewer) and asserts:
  - `sessionGroupedFeed({ userId: viewer })` → totals scoped to the viewer (3 sends, not 5), grade distribution sums to 3, hardest send is the viewer's (difficulty 15, not the partner's 25), and `durationMinutes` is the viewer's 20-min span (not the 35-min whole-session span);
  - `participants[]` still has both climbers with their own sends (leaderboard intact);
  - the partner scopes independently (2 sends, hardest 25);
  - **no `userId`** (social feed) keeps whole-session aggregates (5 sends, hardest 25, 35-min span).
- `vp run typecheck` (full monorepo) — clean.
- `vp check` — my files are format + lint clean (the unrelated format-flagged files are pre-existing drift not touched here).
- The mocked `session-feed-board-scope` test still passes (no regression on the no-`userId` board path).

> Note on the integration test locally: this machine's `vp test` worker hits an `ECONNRESET` against the Docker Desktop postgres proxy during the shared `setup.ts` worker-DB bootstrap — it identically breaks the **pre-existing** `session-feed-board-scope-integration.test.ts`, so it's environmental, not this change. I verified the full DB path (connection + 23 KB `schemaSQL` → 32 tables) works against a fresh postgres under node, and CI's `test-backend` job runs it for real (green).
