### PR TITLE
feat(mobile): report errors and native crashes to Sentry

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -58,12 +58,11 @@ env:
   # binary via AndroidManifest by `expo prebuild`. See docs/mobile-ota-updates.md.
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
-  # NOTE: currently inert at runtime — the mobile app has no
-  # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
-  # DSN is not read by the running app; client-side errors go to PostHog only
-  # (reportError → captureError). Kept so adding Sentry later needs no workflow
-  # change. Same DSN/project as web + backend; not secret — already hardcoded
-  # in packages/web and packages/backend source.
+  # Read at runtime by src/lib/sentry.ts (Sentry.init) — Sentry is the mobile
+  # error + native-crash sink (PostHog is product analytics only). Same DSN/
+  # project as web + backend; not secret — already hardcoded in packages/web and
+  # packages/backend source. JS source-map upload stays disabled below (Gradle
+  # incompat); native crashes are still captured and reported.
   EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
   # PostHog product analytics. Intentionally the SAME project token as web
   # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -45,12 +45,11 @@ env:
   # binary via Expo.plist by `expo prebuild`. See docs/mobile-ota-updates.md.
   EXPO_UPDATES_CHANNEL: production
   EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
-  # NOTE: currently inert at runtime — the mobile app has no
-  # @sentry/react-native wiring (no Sentry.init, no src/lib/sentry.ts), so this
-  # DSN is not read by the running app; client-side errors go to PostHog only
-  # (reportError → captureError). Kept so adding Sentry later needs no workflow
-  # change. Same DSN/project as web + backend; not secret — already hardcoded
-  # in packages/web and packages/backend source.
+  # Read at runtime by src/lib/sentry.ts (Sentry.init) — Sentry is the mobile
+  # error + native-crash sink (PostHog is product analytics only). Same DSN/
+  # project as web + backend; not secret — already hardcoded in packages/web and
+  # packages/backend source. The source-map + dSYM upload (gated on
+  # SENTRY_AUTH_TOKEN below) symbolicates the stack traces.
   EXPO_PUBLIC_SENTRY_DSN: https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400
   # PostHog product analytics. Intentionally the SAME project token as web
   # (vars.NEXT_PUBLIC_POSTHOG_KEY) so a signed-in user's web + mobile activity

--- a/bun.lock
+++ b/bun.lock
@@ -229,6 +229,8 @@
         "@react-native-community/datetimepicker": "9.1.0",
         "@react-native-google-signin/google-signin": "^16.0.0",
         "@react-native-masked-view/masked-view": "0.3.2",
+        "@sentry/cli": "2.53.0",
+        "@sentry/react-native": "^6.14.0",
         "@shopify/flash-list": "^2.3.1",
         "@tanstack/react-query": "^5.0.0",
         "expo": "56.0.12",
@@ -1900,37 +1902,37 @@
 
     "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-Cz6NzYFmWJlHh1tvtltKsmLl+1jlseQaPXk18Z0P1g6lXAwhT3aJ99x7vDm4jwCzcJ12qAa8Oga8T3C23Ihijw=="],
 
-    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-14D+TPgi75zogGQ/EWwtIm34FVWP34gso4SfJZRAoHiQrRfd907q8/7MTXNItxi81x79cH9vweu/o55LBml6MA=="],
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@8.55.0", "", { "dependencies": { "@sentry/core": "8.55.0" } }, "sha512-cP3BD/Q6pquVQ+YL+rwCnorKuTXiS9KXW8HNKu4nmmBAyf7urjs+F6Hr1k9MXP5yQ8W3yK7jRWd09Yu6DHWOiw=="],
 
-    "@sentry-internal/replay": ["@sentry-internal/replay@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-B7eicNhAomJ7bGihJO7mCw7pZ8FFo/THQgGPo85VR3FaJVCCot20WxVgvhjc7IVBQVlaaxSrnlUFvA+yHjszqQ=="],
+    "@sentry-internal/replay": ["@sentry-internal/replay@8.55.0", "", { "dependencies": { "@sentry-internal/browser-utils": "8.55.0", "@sentry/core": "8.55.0" } }, "sha512-roCDEGkORwolxBn8xAKedybY+Jlefq3xYmgN2fr3BTnsXjSYOPC7D1/mYqINBat99nDtvgFvNfRcZPiwwZ1hSw=="],
 
-    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.54.0", "", { "dependencies": { "@sentry-internal/replay": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-CGsH019npxnU5cocVDoZKod7JaQtaM6JiR6e2fI8tDwssohJAxP616UQTmoTtBLe3yLG18P4e1BxMxYZFalZEQ=="],
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@8.55.0", "", { "dependencies": { "@sentry-internal/replay": "8.55.0", "@sentry/core": "8.55.0" } }, "sha512-nIkfgRWk1091zHdu4NbocQsxZF1rv1f7bbp3tTIlZYbrH62XVZosx5iHAuZG0Zc48AETLE7K4AX9VGjvQj8i9w=="],
 
-    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.3.0", "", {}, "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA=="],
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@4.2.0", "", {}, "sha512-GFpS3REqaHuyX4LCNqlneAQZIKyHb5ePiI1802n0fhtYjk68I1DTQ3PnbzYi50od/vAsTQVCknaS5F6tidNqTQ=="],
 
-    "@sentry/browser": ["@sentry/browser@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry-internal/feedback": "10.54.0", "@sentry-internal/replay": "10.54.0", "@sentry-internal/replay-canvas": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-XYuAA2E4Hf6NOJiP3PqczPgBhFUEsEAh+avgxcYTjTwYdr+Nh5XmDxXATr6RxXUvRASTiYN9zNWyK2o9kEDloA=="],
+    "@sentry/browser": ["@sentry/browser@8.55.0", "", { "dependencies": { "@sentry-internal/browser-utils": "8.55.0", "@sentry-internal/feedback": "8.55.0", "@sentry-internal/replay": "8.55.0", "@sentry-internal/replay-canvas": "8.55.0", "@sentry/core": "8.55.0" } }, "sha512-1A31mCEWCjaMxJt6qGUK+aDnLDcK6AwLAZnqpSchNysGni1pSn1RWSmk9TBF8qyTds5FH8B31H480uxMPUJ7Cw=="],
 
     "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.3.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.3.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q=="],
 
-    "@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+    "@sentry/cli": ["@sentry/cli@2.53.0", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.53.0", "@sentry/cli-linux-arm": "2.53.0", "@sentry/cli-linux-arm64": "2.53.0", "@sentry/cli-linux-i686": "2.53.0", "@sentry/cli-linux-x64": "2.53.0", "@sentry/cli-win32-arm64": "2.53.0", "@sentry/cli-win32-i686": "2.53.0", "@sentry/cli-win32-x64": "2.53.0" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-n2ZNb+5Z6AZKQSI0SusQ7ZzFL637mfw3Xh4C3PEyVSn9LiF683fX0TTq8OeGmNZQS4maYfS95IFD+XpydU0dEA=="],
 
-    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.53.0", "", { "os": "darwin" }, "sha512-NNPfpILMwKgpHiyJubHHuauMKltkrgLQ5tvMdxNpxY60jBNdo5VJtpESp4XmXlnidzV4j1z61V4ozU6ttDgt5Q=="],
 
-    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.53.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-NdRzQ15Ht83qG0/Lyu11ciy/Hu/oXbbtJUgwzACc7bWvHQA8xEwTsehWexqn1529Kfc5EjuZ0Wmj3MHmp+jOWw=="],
 
-    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.53.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-xY/CZ1dVazsSCvTXzKpAgXaRqfljVfdrFaYZRUaRPf1ZJRGa3dcrivoOhSIeG/p5NdYtMvslMPY9Gm2MT0M83A=="],
 
-    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.53.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-0REmBibGAB4jtqt9S6JEsFF4QybzcXHPcHtJjgMi5T0ueh952uG9wLzjSxQErCsxTKF+fL8oG0Oz5yKBuCwCCQ=="],
 
-    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.53.0", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-9UGJL+Vy5N/YL1EWPZ/dyXLkShlNaDNrzxx4G7mTS9ywjg+BIuemo6rnN7w43K1NOjObTVO6zY0FwumJ1pCyLg=="],
 
-    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.53.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-G1kjOjrjMBY20rQcJV2GA8KQE74ufmROCDb2GXYRfjvb1fKAsm4Oh8N5+Tqi7xEHdjQoLPkE4CNW0aH68JSUDQ=="],
 
-    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.53.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-qbGTZUzesuUaPtY9rPXdNfwLqOZKXrJRC1zUFn52hdo6B+Dmv0m/AHwRVFHZP53Tg1NCa8bDei2K/uzRN0dUZw=="],
 
-    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.53.0", "", { "os": "win32", "cpu": "x64" }, "sha512-1TXYxYHtwgUq5KAJt3erRzzUtPqg7BlH9T7MdSPHjJatkrr/kwZqnVe2H6Arr/5NH891vOlIeSPHBdgJUAD69g=="],
 
-    "@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+    "@sentry/core": ["@sentry/core@8.55.0", "", {}, "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="],
 
     "@sentry/nextjs": ["@sentry/nextjs@10.54.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@rollup/plugin-commonjs": "28.0.1", "@sentry-internal/browser-utils": "10.54.0", "@sentry/bundler-plugin-core": "^5.3.0", "@sentry/core": "10.54.0", "@sentry/node": "10.54.0", "@sentry/opentelemetry": "10.54.0", "@sentry/react": "10.54.0", "@sentry/vercel-edge": "10.54.0", "@sentry/webpack-plugin": "^5.3.0", "rollup": "^4.60.3", "stacktrace-parser": "^0.1.11" }, "peerDependencies": { "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0" } }, "sha512-/pEsL5OsfCccPn0g5uIBHP4zyCL4G+sLiXn5UweKFHRJdU+SVuP+YyNByn9ZTld0gAWWpTBgL7C/1GMLFH81Zg=="],
 
@@ -1940,7 +1942,13 @@
 
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-58Jk9yMos5DwhamDsNmnoQMSNx0yD9E+h1pZwkw34ve2qB9tv+cys3Oz6nfazT9ZdIsXIgpQntN8AfMXAvv4/g=="],
 
-    "@sentry/react": ["@sentry/react@10.54.0", "", { "dependencies": { "@sentry/browser": "10.54.0", "@sentry/core": "10.54.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-P9x2oJwm0LpJC3HUFfvFMcMZt3qW+PFznDk0hl+QI3BO/In07IvzpdQ/nWO81SHt0uwglwGs3bAjnN84YVzXIw=="],
+    "@sentry/react": ["@sentry/react@8.55.0", "", { "dependencies": { "@sentry/browser": "8.55.0", "@sentry/core": "8.55.0", "hoist-non-react-statics": "^3.3.2" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-/qNBvFLpvSa/Rmia0jpKfJdy16d4YZaAnH/TuKLAtm0BWlsPQzbXCU4h8C5Hsst0Do0zG613MEtEmWpWrVOqWA=="],
+
+    "@sentry/react-native": ["@sentry/react-native@6.22.0", "", { "dependencies": { "@sentry/babel-plugin-component-annotate": "4.2.0", "@sentry/browser": "8.55.0", "@sentry/cli": "2.53.0", "@sentry/core": "8.55.0", "@sentry/react": "8.55.0", "@sentry/types": "8.55.0", "@sentry/utils": "8.55.0" }, "peerDependencies": { "expo": ">=49.0.0", "react": ">=17.0.0", "react-native": ">=0.65.0" }, "optionalPeers": ["expo"], "bin": { "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js" } }, "sha512-Xt8ZuYa7YsMTG7hFU8awfNpVWijH6kWdyqykML6qVohBmP2OS57oSAd4fAdCmbtaIbHs8Drux+uPtb/SdOy2Vg=="],
+
+    "@sentry/types": ["@sentry/types@8.55.0", "", { "dependencies": { "@sentry/core": "8.55.0" } }, "sha512-6LRT0+r6NWQ+RtllrUW2yQfodST0cJnkOmdpHA75vONgBUhpKwiJ4H7AmgfoTET8w29pU6AnntaGOe0LJbOmog=="],
+
+    "@sentry/utils": ["@sentry/utils@8.55.0", "", { "dependencies": { "@sentry/core": "8.55.0" } }, "sha512-cYcl39+xcOivBpN9d8ZKbALl+DxZKo/8H0nueJZ0PO4JA+MJGhSm6oHakXxLPaiMoNLTX7yor8ndnQIuFg+vmQ=="],
 
     "@sentry/vercel-edge": ["@sentry/vercel-edge@10.54.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/resources": "^2.6.1", "@sentry/core": "10.54.0" } }, "sha512-T362+/rjBarMKCfE0Zl+YZ4echCIhSwHxzku3QkHGG/nGvr5mgIiGB31MfkyObUXmwjUJ+9flxHeKed05oRGoQ=="],
 
@@ -4642,9 +4650,31 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "@sentry-internal/browser-utils/@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry-internal/replay/@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@8.55.0", "", { "dependencies": { "@sentry/core": "8.55.0" } }, "sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw=="],
+
+    "@sentry/browser/@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@8.55.0", "", { "dependencies": { "@sentry/core": "8.55.0" } }, "sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw=="],
+
+    "@sentry/bundler-plugin-core/@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.3.0", "", {}, "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+
     "@sentry/bundler-plugin-core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "@sentry/nextjs/@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/nextjs/@sentry/react": ["@sentry/react@10.54.0", "", { "dependencies": { "@sentry/browser": "10.54.0", "@sentry/core": "10.54.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-P9x2oJwm0LpJC3HUFfvFMcMZt3qW+PFznDk0hl+QI3BO/In07IvzpdQ/nWO81SHt0uwglwGs3bAjnN84YVzXIw=="],
+
+    "@sentry/node/@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/node-core/@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/opentelemetry/@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
+
+    "@sentry/vercel-edge/@sentry/core": ["@sentry/core@10.54.0", "", {}, "sha512-yC/bc8N5ut6vk9X/ugTnIFAbzaSZ2uGoKiHRGzt7VseDIrjXk5ENDJP0m7Rbchuozr41kBv2QB3mPcHUhfB43w=="],
 
     "@sigstore/sign/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
@@ -5136,7 +5166,27 @@
 
     "@npmcli/promise-spawn/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "@sentry/nextjs/@sentry/react/@sentry/browser": ["@sentry/browser@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry-internal/feedback": "10.54.0", "@sentry-internal/replay": "10.54.0", "@sentry-internal/replay-canvas": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-XYuAA2E4Hf6NOJiP3PqczPgBhFUEsEAh+avgxcYTjTwYdr+Nh5XmDxXATr6RxXUvRASTiYN9zNWyK2o9kEDloA=="],
 
     "@so-ric/colorspace/color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
 
@@ -5299,6 +5349,14 @@
     "terser-webpack-plugin/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "@bacons/apple-targets/glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+
+    "@sentry/bundler-plugin-core/@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "@sentry/nextjs/@sentry/react/@sentry/browser/@sentry-internal/feedback": ["@sentry-internal/feedback@10.54.0", "", { "dependencies": { "@sentry/core": "10.54.0" } }, "sha512-14D+TPgi75zogGQ/EWwtIm34FVWP34gso4SfJZRAoHiQrRfd907q8/7MTXNItxi81x79cH9vweu/o55LBml6MA=="],
+
+    "@sentry/nextjs/@sentry/react/@sentry/browser/@sentry-internal/replay": ["@sentry-internal/replay@10.54.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-B7eicNhAomJ7bGihJO7mCw7pZ8FFo/THQgGPo85VR3FaJVCCot20WxVgvhjc7IVBQVlaaxSrnlUFvA+yHjszqQ=="],
+
+    "@sentry/nextjs/@sentry/react/@sentry/browser/@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.54.0", "", { "dependencies": { "@sentry-internal/replay": "10.54.0", "@sentry/core": "10.54.0" } }, "sha512-CGsH019npxnU5cocVDoZKod7JaQtaM6JiR6e2fI8tDwssohJAxP616UQTmoTtBLe3yLG18P4e1BxMxYZFalZEQ=="],
 
     "@so-ric/colorspace/color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 

--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -1,15 +1,29 @@
-# Mobile error telemetry (PostHog)
+# Mobile error telemetry (Sentry)
 
-The RN app (`packages/mobile`) has no Sentry — PostHog is the only error sink. So
-every error a user actually hits must be reported, or it's invisible. Two layers:
+The RN app (`packages/mobile`) reports errors and crashes to **Sentry** — the same
+`boardsesh` project as web (`@sentry/nextjs`) and backend (`@sentry/node`). PostHog
+stays in the app for **product analytics + session replay only**; it no longer
+captures errors. Two reasons Sentry owns crashes:
+
+- **Native crashes.** PostHog's RN SDK sees JS only. Sentry's native crash handler
+  catches iOS/Android native faults — the board-renderer, live-activity, and BLE
+  native modules, plus any Expo native module — persists them across the crash, and
+  uploads on the next launch. That coverage gap is why Sentry is here.
+- **Symbolicated JS.** The CI build uploads source maps (+ dSYMs on iOS), so JS stack
+  traces resolve to real file/line instead of minified offsets.
+
+`src/lib/sentry.ts` calls `Sentry.init()` (gated `!!dsn && !__DEV__`, so local Metro
+dev never sends), owns the global `ErrorUtils` handler, and exposes `captureToSentry`
+and `wrapWithSentry`. `app/_layout.tsx` imports it first (init before any other
+module side-effect) and wraps the root with `wrapWithSentry`.
 
 ## What's automatic
 
-`src/lib/posthog-client.ts` configures PostHog `errorTracking.autocapture` for
-**uncaught exceptions** and **unhandled promise rejections**, plus a global
-`ErrorUtils` handler (`global-error-capture.ts`) and the Expo Router
-`ErrorBoundary` (`app/_layout.tsx`). Crashes and render errors land in PostHog as
-`$exception` events with no extra work.
+`Sentry.init` installs the JS error integrations (**uncaught exceptions** and
+**unhandled promise rejections**) and the **native** crash handler. The global
+`ErrorUtils` wrapper (`global-error-capture.ts`) and the Expo Router `ErrorBoundary`
+(`app/_layout.tsx`) both report through `reportError`. Crashes and render errors land
+in Sentry with no extra work.
 
 ## What you must do: report _handled_ errors
 
@@ -17,7 +31,7 @@ The blind spot is errors the app **catches** and turns into a toast, inline
 message, degraded state, or silent `console.warn`. Those never reach autocapture.
 Rule of thumb: **every catch that handles a user-affecting failure reports it.**
 
-Use the helpers in `src/lib/error-reporting.ts`:
+Use the helpers in `src/lib/error-reporting.ts` (they route to `captureToSentry`):
 
 - `reportHandledError(error, { tags: { source, ... }, extra })` — the default.
   Drops cancellations (`AbortError` / TanStack `CancelledError`) and downgrades
@@ -28,19 +42,17 @@ Use the helpers in `src/lib/error-reporting.ts`:
   the caller already owns the severity (e.g. auth: a 401 is an `error`, a network
   blip is a `warning`).
 
-Always pass a `tags.source` (and an `op` where it helps) so events group in
-PostHog: `react-query`, `native-auth`, `queue-mutation`, `queue-sync`,
-`auth-refresh`, `ble-send`, `ble-connect`, `playlist`, `wall-control`, etc.
+`level` maps to the Sentry severity, `tags` become Sentry tags (string-coerced), and
+`extra` becomes scope extras. Always pass a `tags.source` (and an `op` where it helps)
+so events group in Sentry: `react-query`, `native-auth`, `queue-mutation`,
+`queue-sync`, `auth-refresh`, `ble-send`, `ble-connect`, `playlist`, `wall-control`, etc.
 
 ### Where it's already wired
 
 - **React Query** (`providers/query-provider.tsx`) — `QueryCache` / `MutationCache`
   `onError` report every query/mutation failure once `retry` is exhausted. This is
   the chokepoint for API / GraphQL-HTTP / REST failures; don't re-report at
-  individual `useQuery`/`useMutation` call sites. Known gap: a query that keeps
-  failing for a non-network reason re-reports on each refetch (focus / remount /
-  reconnect) — same `queryHash`, so it groups, but watch event volume in PostHog
-  after rollout; add short-TTL dedup keyed on `queryHash` if it's noisy.
+  individual `useQuery`/`useMutation` call sites.
 - Direct **GraphQL-WS** ops (`@boardsesh/queue-react`, `@boardsesh/playlists-react`)
   bypass React Query, so their catch sites report explicitly.
 
@@ -58,8 +70,20 @@ PostHog: `react-query`, `native-auth`, `queue-mutation`, `queue-sync`,
 - `__DEV__`-only diagnostics (keep the `console.warn`; report only if the failure
   is user-affecting in production too).
 
+## Source maps / symbolication (CI)
+
+- **iOS** (`ios-testflight-rn.yml`): the `@sentry/react-native` Xcode build phases
+  upload JS source maps + dSYMs when `SENTRY_AUTH_TOKEN` is present
+  (`SENTRY_DISABLE_AUTO_UPLOAD` gates it; the build stays green without the token).
+- **Android** (`android-apk-rn.yml`): JS source-map upload is **disabled**
+  (`SENTRY_DISABLE_AUTO_UPLOAD=true`) — the Gradle upload task is incompatible with
+  the Gradle version Expo prebuild generates. Native crashes are still captured;
+  Android JS symbolication is a follow-up.
+
 ## Verifying
 
-`isAnalyticsEnabled = !!apiKey && !__DEV__`, so **local Metro dev sends nothing**.
-Verify on a preview / TestFlight / production build: trigger the failure, then look
-for the `$exception` in PostHog filtered by `source`.
+`isSentryEnabled = !!dsn && !__DEV__`, so **local Metro dev sends nothing**. Verify on
+a preview / TestFlight / production build — and note that adding the native SDK changed
+the **fingerprint**, so this needs a fresh native build, not an OTA. Trigger the
+failure (a JS error, or `Sentry.nativeCrash()` for the native path), relaunch, and look
+for the event in the `boardsesh` Sentry project filtered by `source`.

--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -25,6 +25,13 @@ module side-effect) and wraps the root with `wrapWithSentry`.
 (`app/_layout.tsx`) both report through `reportError`. Crashes and render errors land
 in Sentry with no extra work.
 
+**App hangs / ANRs.** `enableAppHangTracking` (iOS) reports a main-thread freeze
+longer than `appHangTimeoutInterval` (2s) as an App Hang; Android ANR detection (5s
+main-thread block) is on by default in the native `sentry-android` layer. Both attach
+a JS stack pinned to the blocked frame — that's how the in-the-wild device freezes
+(e.g. Galaxy S24 / Pixel 10) surface with the exact culprit, rather than via emulator
+repro.
+
 ## What you must do: report _handled_ errors
 
 The blind spot is errors the app **catches** and turns into a toast, inline

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -508,6 +508,11 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
       // libraries and pod install fails. The plugin patches the generated
       // Podfile to add :modular_headers => true for both pods.
       './plugins/with-podfile-app-check-fix',
+      // org/project make `expo prebuild` write a valid ios/sentry.properties so
+      // the build-phase source-map + dSYM upload can find the Sentry project.
+      // The auth token is supplied via the SENTRY_AUTH_TOKEN env var in CI
+      // (never committed); url defaults to https://sentry.io/ (US region).
+      ['@sentry/react-native/expo', { organization: 'boardsesh', project: 'boardsesh' }],
     ],
     extra: {
       ...config.extra,

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -1,3 +1,8 @@
+// Import first so Sentry.init() runs (and installs its global handler) before
+// any other module side-effect — notably posthog-client's analytics init and the
+// worklet-serialization global-error-capture install, which must wrap Sentry's
+// handler, not the other way round.
+import { wrapWithSentry } from '../src/lib/sentry';
 import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
 import { LogBox, Pressable, StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo
@@ -451,4 +456,7 @@ function RootLayout() {
   );
 }
 
-export default RootLayout;
+// Wrap with Sentry so the root and its children report render errors and feed
+// the navigation/performance instrumentation. No-op when Sentry is disabled
+// (dev / no DSN), so it's safe in every build.
+export default wrapWithSentry(RootLayout);

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -1,10 +1,14 @@
-const { getDefaultConfig } = require('expo/metro-config');
+// getSentryExpoConfig wraps Expo's getDefaultConfig to add the Sentry source-map
+// serializer (debug-id injection) so production stack traces symbolicate. It
+// returns the same Expo config object, so every customisation below applies
+// unchanged.
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const path = require('path');
 
 const projectRoot = __dirname;
 const monorepoRoot = path.resolve(projectRoot, '../..');
 
-const config = getDefaultConfig(projectRoot);
+const config = getSentryExpoConfig(projectRoot);
 
 config.watchFolders = [monorepoRoot];
 

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -40,6 +40,8 @@
     "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-google-signin/google-signin": "^16.0.0",
     "@react-native-masked-view/masked-view": "0.3.2",
+    "@sentry/cli": "2.53.0",
+    "@sentry/react-native": "^6.14.0",
     "@shopify/flash-list": "^2.3.1",
     "@tanstack/react-query": "^5.0.0",
     "expo": "56.0.12",

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { View, ScrollView, ActivityIndicator, Alert, Pressable, StyleSheet, TextInput } from 'react-native';
 import * as Updates from 'expo-updates';
-import { reportHandledError } from '../lib/error-reporting';
+import { reportError, reportHandledError } from '../lib/error-reporting';
+import { isSentryEnabled, nativeSentryCrash } from '../lib/sentry';
 import { Text } from './Text';
 import { SectionHeader } from './SectionHeader';
 import { ListRow } from './ListRow';
@@ -32,7 +33,7 @@ function applyChannelOverride(channel: string | null): void {
 }
 
 export function ChannelSwitcherScreen() {
-  const { systemColors, spacing, borderRadius } = useTheme();
+  const { systemColors, brandColors, spacing, borderRadius } = useTheme();
   const confirm = useConfirm();
   const [override, setOverride] = useState<string | null>(null);
   const [customChannel, setCustomChannel] = useState('');
@@ -168,6 +169,52 @@ export function ChannelSwitcherScreen() {
       inFlightRef.current = false;
     }
   }, [confirm, buildChannel, makeDeps]);
+
+  // --- Sentry verification (tester-only) ---
+  // Sentry never sends from a dev / Metro build (gated on !__DEV__), so the only
+  // way to confirm the deployed binary actually reports is to fire each capture
+  // path from a real build and watch the boardsesh Sentry project.
+  const sendSentryTestEvent = useCallback(() => {
+    hapticLight();
+    reportError(new Error('Sentry test event (handled) — channel switcher'), {
+      tags: { source: 'sentry-test', kind: 'handled' },
+    });
+    Alert.alert(
+      // i18n-ignore-next-line — tester-only screen
+      'Test event sent',
+      isSentryEnabled
+        ? // i18n-ignore-next-line — tester-only screen
+          'A handled event was sent to the boardsesh Sentry project. Filter by source:sentry-test.'
+        : // i18n-ignore-next-line — tester-only screen
+          'Sentry is disabled in this build, so nothing was sent.',
+    );
+  }, []);
+
+  const throwSentryUncaught = useCallback(() => {
+    hapticError();
+    // Throw on a fresh tick so it escapes this handler and React, surfacing as a
+    // genuine uncaught JS error that the global handler reports to Sentry.
+    setTimeout(() => {
+      throw new Error('Sentry test: uncaught JS exception — channel switcher');
+    }, 0);
+  }, []);
+
+  const triggerSentryNativeCrash = useCallback(async () => {
+    hapticLight();
+    const confirmed = await confirm({
+      // i18n-ignore-next-line — tester-only screen
+      title: 'Force a native crash?',
+      // i18n-ignore-next-line — tester-only screen
+      message: 'The app crashes immediately. The crash uploads to Sentry on the next launch.',
+      // i18n-ignore-next-line — tester-only screen
+      confirmLabel: 'Crash',
+      // i18n-ignore-next-line — tester-only screen
+      cancelLabel: 'Cancel',
+    });
+    if (!confirmed) return;
+    hapticError();
+    nativeSentryCrash();
+  }, [confirm]);
 
   const channels = buildChannelList(override);
 
@@ -308,6 +355,43 @@ export function ChannelSwitcherScreen() {
           </Pressable>
         </>
       )}
+
+      {/* i18n-ignore-next-line — tester-only screen */}
+      <SectionHeader title="Test crash reporting (Sentry)" />
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: systemColors.secondaryBackground,
+            borderRadius: borderRadius.lg,
+            marginHorizontal: spacing[4],
+          },
+        ]}
+      >
+        {/* i18n-ignore-next-line — tester-only screen */}
+        <InfoRow label="Sentry" value={isSentryEnabled ? 'Active' : 'Disabled in this build'} />
+        <ListRow
+          // i18n-ignore-next-line — tester-only screen
+          title="Send test event (handled)"
+          trailing={<Icon name="send" size={18} color={systemColors.secondaryLabel} />}
+          onPress={sendSentryTestEvent}
+          showSeparator
+        />
+        <ListRow
+          // i18n-ignore-next-line — tester-only screen
+          title="Throw JS exception (uncaught)"
+          trailing={<Icon name="warning" size={18} color={brandColors.warning} />}
+          onPress={throwSentryUncaught}
+          showSeparator
+        />
+        <ListRow
+          // i18n-ignore-next-line — tester-only screen
+          title="Native crash"
+          trailing={<Icon name="flame" size={18} color={brandColors.error} />}
+          onPress={() => void triggerSentryNativeCrash()}
+          showSeparator={false}
+        />
+      </View>
 
       <View style={styles.bottomSpacer} />
     </ScrollView>

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -1,25 +1,25 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { reportError, reportHandledError } from '../error-reporting';
-import { captureError } from '../posthog-client';
+import { captureToSentry } from '../sentry';
 
-// captureError is the only side-effecting dependency; mocking it keeps this a
-// pure test of the noise policy (and avoids posthog-client's import-time global
-// error-capture install).
-vi.mock('../posthog-client', () => ({
-  captureError: vi.fn(),
+// captureToSentry is the only side-effecting dependency; mocking it keeps this a
+// pure test of the noise policy (and avoids sentry.ts's import-time Sentry.init +
+// global error-capture install).
+vi.mock('../sentry', () => ({
+  captureToSentry: vi.fn(),
 }));
 
-const mockedCaptureError = vi.mocked(captureError);
+const mockedCaptureToSentry = vi.mocked(captureToSentry);
 
 afterEach(() => {
-  mockedCaptureError.mockClear();
+  mockedCaptureToSentry.mockClear();
 });
 
 describe('reportHandledError', () => {
   it('drops cancellations (user dismiss / unmount) without reporting', () => {
     reportHandledError(Object.assign(new Error('aborted'), { name: 'AbortError' }));
     reportHandledError(Object.assign(new Error('cancelled'), { name: 'CancelledError' }));
-    expect(mockedCaptureError).not.toHaveBeenCalled();
+    expect(mockedCaptureToSentry).not.toHaveBeenCalled();
   });
 
   it('drops expected auth-required GraphQL errors (a session-only query ran logged-out)', () => {
@@ -32,7 +32,7 @@ describe('reportHandledError', () => {
       },
     });
     reportHandledError(authError, { tags: { source: 'react-query' } });
-    expect(mockedCaptureError).not.toHaveBeenCalled();
+    expect(mockedCaptureToSentry).not.toHaveBeenCalled();
   });
 
   it('drops the auth error before the network check, even when it looks transport-shaped', () => {
@@ -46,7 +46,7 @@ describe('reportHandledError', () => {
       },
     });
     reportHandledError(authError, { tags: { source: 'react-query' } });
-    expect(mockedCaptureError).not.toHaveBeenCalled();
+    expect(mockedCaptureToSentry).not.toHaveBeenCalled();
   });
 
   it('drops expected beta-attach validation rejections (user resolves them on the share sheet)', () => {
@@ -62,7 +62,7 @@ describe('reportHandledError', () => {
       },
     });
     reportHandledError(alreadyLinked, { tags: { source: 'react-query', kind: 'mutation' } });
-    expect(mockedCaptureError).not.toHaveBeenCalled();
+    expect(mockedCaptureToSentry).not.toHaveBeenCalled();
   });
 
   it('still reports a genuine beta-attach write fault (BETA_LINK_INSERT_FAILED)', () => {
@@ -78,7 +78,7 @@ describe('reportHandledError', () => {
       },
     });
     reportHandledError(insertFailed, { tags: { source: 'react-query', kind: 'mutation' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(insertFailed, {
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(insertFailed, {
       level: 'error',
       tags: { source: 'react-query', kind: 'mutation' },
     });
@@ -87,7 +87,7 @@ describe('reportHandledError', () => {
   it('downgrades offline fetch failures to a warning and tags them network', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { tags: { source: 'react-query' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(offline, {
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(offline, {
       level: 'warning',
       tags: { source: 'react-query', network: true },
     });
@@ -96,7 +96,7 @@ describe('reportHandledError', () => {
   it('treats a transport ClientError (response without a numeric status) as network', () => {
     const transport = Object.assign(new Error('boom'), { response: { errors: [] } });
     reportHandledError(transport, { tags: { source: 'queue-mutation' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(transport, {
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(transport, {
       level: 'warning',
       tags: { source: 'queue-mutation', network: true },
     });
@@ -105,7 +105,7 @@ describe('reportHandledError', () => {
   it('forces warning for a network error even if the caller asked for a higher level', () => {
     const offline = new TypeError('Network request failed');
     reportHandledError(offline, { level: 'fatal', tags: { source: 'x' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(offline, {
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(offline, {
       level: 'warning',
       tags: { source: 'x', network: true },
     });
@@ -114,7 +114,7 @@ describe('reportHandledError', () => {
   it('reports a real server error (response with an HTTP status) at error level', () => {
     const serverError = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
     reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(serverError, {
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(serverError, {
       level: 'error',
       tags: { source: 'react-query', kind: 'mutation' },
     });
@@ -123,7 +123,7 @@ describe('reportHandledError', () => {
   it('defaults a plain error to error level', () => {
     const error = new Error('boom');
     reportHandledError(error, { tags: { source: 'ble-connect' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(error, {
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, {
       level: 'error',
       tags: { source: 'ble-connect' },
     });
@@ -132,14 +132,14 @@ describe('reportHandledError', () => {
   it('lets the caller keep a non-error severity for a non-network failure', () => {
     const error = new Error('boom');
     reportHandledError(error, { level: 'info', tags: { source: 'x' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(error, { level: 'info', tags: { source: 'x' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, { level: 'info', tags: { source: 'x' } });
   });
 });
 
 describe('reportError', () => {
-  it('forwards verbatim to captureError', () => {
+  it('forwards verbatim to captureToSentry', () => {
     const error = new Error('x');
     reportError(error, { level: 'error', tags: { source: 's' } });
-    expect(mockedCaptureError).toHaveBeenCalledWith(error, { level: 'error', tags: { source: 's' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, { level: 'error', tags: { source: 's' } });
   });
 });

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ComponentType } from 'react';
+
+// Spy on the SDK so we can assert the disabled-build contract. Under vitest
+// `__DEV__` is true (vite.config define) and no DSN is set, so `isSentryEnabled`
+// is false for the whole suite — exactly the dev / no-DSN / test build path,
+// which must stay a silent no-op (never construct, send, or wrap). vi.mock takes
+// precedence over the vite alias stub so we can assert the spies are untouched.
+vi.mock('@sentry/react-native', () => ({
+  init: vi.fn(),
+  withScope: vi.fn(),
+  captureException: vi.fn(),
+  flush: vi.fn(() => Promise.resolve(true)),
+  wrap: vi.fn((component: unknown) => component),
+}));
+
+import * as Sentry from '@sentry/react-native';
+import { captureToSentry, flushSentry, wrapWithSentry, isSentryEnabled, toSentryTag } from '../sentry';
+
+describe('isSentryEnabled', () => {
+  it('is false in dev / test (no DSN + __DEV__)', () => {
+    expect(isSentryEnabled).toBe(false);
+  });
+});
+
+describe('captureToSentry (disabled build)', () => {
+  it('is a no-op — never reaches the Sentry SDK', () => {
+    captureToSentry(new Error('boom'), { level: 'error', tags: { source: 'react-query' } });
+    expect(Sentry.withScope).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('wrapWithSentry (disabled build)', () => {
+  it('returns the component unchanged without calling Sentry.wrap', () => {
+    const Component: ComponentType = () => null;
+    expect(wrapWithSentry(Component)).toBe(Component);
+    expect(Sentry.wrap).not.toHaveBeenCalled();
+  });
+});
+
+describe('flushSentry (disabled build)', () => {
+  it('resolves true without flushing the SDK', async () => {
+    await expect(flushSentry()).resolves.toBe(true);
+    expect(Sentry.flush).not.toHaveBeenCalled();
+  });
+});
+
+// toSentryTag runs purely (no SDK), so it's testable regardless of enablement —
+// it guards the tag coercion that keeps triage data readable in Sentry.
+describe('toSentryTag', () => {
+  it('passes primitives through unchanged', () => {
+    expect(toSentryTag('react-query')).toBe('react-query');
+    expect(toSentryTag(404)).toBe(404);
+    expect(toSentryTag(true)).toBe(true);
+  });
+
+  it('JSON-serializes objects and arrays instead of "[object Object]"', () => {
+    expect(toSentryTag({ status: 500 })).toBe('{"status":500}');
+    expect(toSentryTag([1, 2, 3])).toBe('[1,2,3]');
+  });
+
+  it('falls back to String() for values JSON cannot serialize (circular)', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    // The point is it returns a string and does not throw — exact text is the
+    // String() fallback, not a crash.
+    expect(typeof toSentryTag(circular)).toBe('string');
+  });
+});

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,19 +1,18 @@
-import { captureError } from './posthog-client';
+import { captureToSentry, type ErrorReportContext } from './sentry';
 import { isExpectedAuthError, isExpectedBetaValidationError } from './graphql/extract-error-message';
 
-export type ErrorReportContext = {
-  level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
-  tags?: Record<string, unknown>;
-  extra?: Record<string, unknown>;
-};
+// Re-exported so the public reporting surface (`{ ErrorReportContext }` from
+// './error-reporting') is unchanged; the type itself lives in './sentry' to keep
+// the dependency one-directional.
+export type { ErrorReportContext };
 
 /**
- * Report an error to PostHog if it is active. No-op otherwise. The optional
+ * Report an error to Sentry if it is active. No-op otherwise. The optional
  * context lets callers attach triage data such as source, board path, or HTTP
  * status.
  */
 export function reportError(error: unknown, context?: ErrorReportContext): void {
-  captureError(error, context);
+  captureToSentry(error, context);
 }
 
 /**

--- a/packages/mobile/src/lib/posthog-client.ts
+++ b/packages/mobile/src/lib/posthog-client.ts
@@ -1,5 +1,4 @@
 import { PostHog } from 'posthog-react-native';
-import { installGlobalErrorCapture } from './global-error-capture';
 
 // PostHog flags events with an empty User-Agent as bots, and the RN SDK sends no
 // UA it stores — so without this, real mobile traffic hides behind the bot filter.
@@ -34,24 +33,12 @@ const host = process.env.EXPO_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
 // them; local Metro dev never sends.
 export const isAnalyticsEnabled = !!apiKey && !__DEV__;
 
-type ErrorReportContext = {
-  level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
-  tags?: Record<string, unknown>;
-  extra?: Record<string, unknown>;
-};
-type PostHogPropertyValue =
-  | string
-  | number
-  | boolean
-  | null
-  | PostHogPropertyValue[]
-  | { [key: string]: PostHogPropertyValue };
-
 let client: PostHog | null = null;
 let initAttempted = false;
 
 // Construct or return the single PostHog client. Returns null in dev / when
-// unkeyed, which makes every wrapper method a no-op.
+// unkeyed, which makes every wrapper method a no-op. PostHog is product
+// analytics only — error/crash reporting goes to Sentry (src/lib/sentry.ts).
 export function getPostHogClient(): PostHog | null {
   if (!isAnalyticsEnabled || !apiKey) return null;
   if (client) return client;
@@ -70,13 +57,6 @@ export function getPostHogClient(): PostHog | null {
   // don't be surprised to see a few lifecycle events on a transient anon id.
   client = new PostHog(apiKey, {
     host,
-    errorTracking: {
-      autocapture: {
-        uncaughtExceptions: true,
-        unhandledRejections: true,
-        console: [],
-      },
-    },
     // `enableSessionReplay` defaults false, so the SDK never auto-records.
     // Capture only begins when setSessionRecordingEnabled() calls
     // startSessionRecording(), which lazily initialises the native replay SDK.
@@ -87,86 +67,9 @@ export function getPostHogClient(): PostHog | null {
     },
   });
   registerMobileUserAgent(client);
-  installMobileGlobalErrorCapture();
   return client;
-}
-
-function toPostHogPropertyValue(
-  value: unknown,
-  seenObjects: WeakSet<object> = new WeakSet(),
-  depth = 0,
-): PostHogPropertyValue | undefined {
-  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
-  if (typeof value === 'number') return Number.isFinite(value) ? value : String(value);
-  if (value instanceof Date) return value.toISOString();
-  if (depth > 8) return '[Truncated]';
-  if (Array.isArray(value)) {
-    if (seenObjects.has(value)) return '[Circular]';
-    seenObjects.add(value);
-    const items: PostHogPropertyValue[] = [];
-    for (const item of value) {
-      const mappedItem = toPostHogPropertyValue(item, seenObjects, depth + 1);
-      if (mappedItem !== undefined) items.push(mappedItem);
-    }
-    seenObjects.delete(value);
-    return items;
-  }
-  if (typeof value === 'object') {
-    if (seenObjects.has(value)) return '[Circular]';
-    seenObjects.add(value);
-    const properties: { [key: string]: PostHogPropertyValue } = {};
-    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-      const mappedItem = toPostHogPropertyValue(item, seenObjects, depth + 1);
-      if (mappedItem !== undefined) properties[key] = mappedItem;
-    }
-    seenObjects.delete(value);
-    return properties;
-  }
-  return undefined;
-}
-
-function buildErrorProperties(context?: ErrorReportContext): Record<string, PostHogPropertyValue> {
-  const properties: Record<string, PostHogPropertyValue> = {};
-  if (!context) return properties;
-  if (context.level) properties.$exception_level = context.level;
-
-  for (const [key, value] of Object.entries(context.tags ?? {})) {
-    const mappedValue = toPostHogPropertyValue(value);
-    if (mappedValue !== undefined) properties[key] = mappedValue;
-  }
-  for (const [key, value] of Object.entries(context.extra ?? {})) {
-    const mappedValue = toPostHogPropertyValue(value);
-    if (mappedValue !== undefined) properties[key] = mappedValue;
-  }
-
-  return properties;
-}
-
-function installMobileGlobalErrorCapture(): void {
-  installGlobalErrorCapture({
-    report: (error, context) => captureError(error, context),
-    flush: () => flushPostHog(),
-    isDev: __DEV__,
-  });
-}
-
-export function captureError(error: unknown, context?: ErrorReportContext): void {
-  const posthog = getPostHogClient();
-  if (!posthog) return;
-  try {
-    posthog.captureException(error, buildErrorProperties(context));
-  } catch {
-    // Error reporting must never become the crash.
-  }
-}
-
-export function flushPostHog(): Promise<unknown> {
-  const posthog = getPostHogClient();
-  return posthog ? posthog.flush() : Promise.resolve(true);
 }
 
 if (isAnalyticsEnabled) {
   getPostHogClient();
-} else {
-  installMobileGlobalErrorCapture();
 }

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -1,0 +1,97 @@
+import type { ComponentType } from 'react';
+import * as Sentry from '@sentry/react-native';
+import { installGlobalErrorCapture } from './global-error-capture';
+
+/**
+ * Triage context attached to a reported error. Defined here (not in
+ * error-reporting) because error-reporting depends on this module — keeping the
+ * type here is what makes that dependency one-directional.
+ */
+export type ErrorReportContext = {
+  level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+  tags?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+};
+
+const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+
+/**
+ * Whether Sentry is active for the current session. False in dev builds and
+ * whenever no DSN is configured, so local Metro dev never sends. Preview
+ * (TestFlight / internal) and production builds are both `!__DEV__`.
+ */
+export const isSentryEnabled = !!sentryDsn && !__DEV__;
+
+if (isSentryEnabled) {
+  Sentry.init({
+    dsn: sentryDsn,
+    tracesSampleRate: 0.1,
+    // Explicit so a future option change can't silently turn either off. Native
+    // crash handling persists SIGABRT / native exceptions across the crash and
+    // uploads them on the next launch — the coverage gap PostHog (JS-only)
+    // can't fill, and the reason Sentry is back. attachStacktrace gives
+    // captureMessage calls a stack too.
+    enableNativeCrashHandling: true,
+    attachStacktrace: true,
+    // release/dist are intentionally left unset so @sentry/react-native
+    // auto-detects them from the native build (CFBundleShortVersionString +
+    // CFBundleVersion). Those are the exact values `sentry-cli react-native
+    // xcode` tags the uploaded source maps with, so stack traces symbolicate.
+    // Hardcoding release here (e.g. "2.0.0" without dist) would mismatch the
+    // uploaded artifacts and break symbolication.
+  });
+}
+
+// Sentry tags must be primitives; coerce non-scalar values to a readable string
+// rather than dropping them so triage data survives.
+function toSentryTag(value: unknown): string | number | boolean {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  return String(value);
+}
+
+/**
+ * Report an error to Sentry if it is active. No-op otherwise. The optional
+ * context (level/tags/extra) is mapped onto a Sentry scope so callers can attach
+ * triage data — e.g. a `source` tag and HTTP status on a failed session start.
+ */
+export function captureToSentry(error: unknown, context?: ErrorReportContext): void {
+  if (!isSentryEnabled) return;
+  Sentry.withScope((scope) => {
+    if (context?.level) scope.setLevel(context.level);
+    for (const [key, value] of Object.entries(context?.tags ?? {})) {
+      scope.setTag(key, toSentryTag(value));
+    }
+    for (const [key, value] of Object.entries(context?.extra ?? {})) {
+      scope.setExtra(key, value);
+    }
+    Sentry.captureException(error);
+  });
+}
+
+/** Best-effort flush so a report survives a later hard crash. */
+export function flushSentry(): Promise<unknown> {
+  return isSentryEnabled ? Sentry.flush() : Promise.resolve(true);
+}
+
+// Wrap the RN global error handler regardless of whether Sentry is enabled: the
+// console logging and worklet-serialization recovery are valuable even with no
+// DSN (dev / DSN-less builds). Installed after Sentry.init so it wraps Sentry's
+// handler rather than being clobbered by it. The `installed` latch inside makes
+// this the single install site (posthog-client no longer installs it).
+installGlobalErrorCapture({
+  report: (error, context) => captureToSentry(error, context),
+  flush: () => flushSentry(),
+  isDev: __DEV__,
+});
+
+/**
+ * Wrap a root component with the Sentry error tracking HOC. Returns the
+ * component unchanged when Sentry is not active.
+ */
+// The constraint mirrors Sentry.wrap's signature exactly. Note: `unknown` is the
+// top type, so `Record<string, unknown>` accepts any object props (including
+// ReactNode children, callbacks, refs) — the constraint isn't restrictive.
+export function wrapWithSentry<P extends Record<string, unknown>>(component: ComponentType<P>): ComponentType<P> {
+  if (!isSentryEnabled) return component;
+  return Sentry.wrap(component);
+}

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -33,6 +33,19 @@ if (isSentryEnabled) {
     // captureMessage calls a stack too.
     enableNativeCrashHandling: true,
     attachStacktrace: true,
+    // App-hang / ANR tracking. This is what catches the freezes users actually
+    // report in the wild (e.g. Galaxy S24 / Pixel 10) with a JS stack pinned to
+    // the blocked frame — far more reliable than chasing a repro in an emulator.
+    //   - iOS: enableAppHangTracking watches the main thread; any unresponsive
+    //     stretch ≥ appHangTimeoutInterval seconds is reported as an App Hang.
+    //     Both default on / 2s; set explicitly so a future SDK default can't
+    //     flip them, matching the enableNativeCrashHandling rationale above.
+    //   - Android: ANR detection is already on by default in the native
+    //     sentry-android layer (5s main-thread block) — there's no JS init
+    //     option to set; the @sentry/react-native/expo plugin wires the native
+    //     SDK that captures it and attaches the JS stack.
+    enableAppHangTracking: true,
+    appHangTimeoutInterval: 2,
     // release/dist are intentionally left unset so @sentry/react-native
     // auto-detects them from the native build (CFBundleShortVersionString +
     // CFBundleVersion). Those are the exact values `sentry-cli react-native

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -56,10 +56,17 @@ if (isSentryEnabled) {
 }
 
 // Sentry tags must be primitives; coerce non-scalar values to a readable string
-// rather than dropping them so triage data survives.
-function toSentryTag(value: unknown): string | number | boolean {
+// rather than dropping them so triage data survives. Objects/arrays would
+// stringify to a useless "[object Object]", so JSON-serialize them to keep the
+// real data; fall back to String() for anything JSON can't handle (circular
+// refs, BigInt).
+export function toSentryTag(value: unknown): string | number | boolean {
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
-  return String(value);
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
 }
 
 /**
@@ -82,8 +89,19 @@ export function captureToSentry(error: unknown, context?: ErrorReportContext): v
 }
 
 /** Best-effort flush so a report survives a later hard crash. */
-export function flushSentry(): Promise<unknown> {
+export function flushSentry(): Promise<boolean> {
   return isSentryEnabled ? Sentry.flush() : Promise.resolve(true);
+}
+
+/**
+ * Force a native crash to verify the native crash handler on a real binary — the
+ * event is persisted across the crash and uploaded on the next launch. No-op
+ * when Sentry is disabled so it can never hard-crash a dev / no-DSN build. Wired
+ * behind the tester-only channel switcher; not for production code paths.
+ */
+export function nativeSentryCrash(): void {
+  if (!isSentryEnabled) return;
+  Sentry.nativeCrash();
 }
 
 // Wrap the RN global error handler regardless of whether Sentry is enabled: the

--- a/packages/mobile/test/sentry-react-native-stub.ts
+++ b/packages/mobile/test/sentry-react-native-stub.ts
@@ -1,0 +1,45 @@
+// Vitest stub for `@sentry/react-native`.
+//
+// The real package's entry pulls in React Native internals (react-native's
+// `Libraries/Promise.js`, which imports `promise/setimmediate/es6-extensions`
+// without a file extension) that fail to resolve under vitest's node ESM
+// environment, breaking every suite that transitively imports `src/lib/sentry`
+// (via the queue provider, the root layout, PreSessionView, etc.).
+//
+// Sentry is disabled in tests anyway — `isSentryEnabled` is false without a DSN
+// — so this lightweight stub just needs to satisfy the static imports.
+//
+// Wired via the `@sentry/react-native` alias in packages/mobile/vite.config.ts.
+
+type StubScope = {
+  setLevel: () => void;
+  setTag: () => void;
+  setExtra: () => void;
+  setContext: () => void;
+};
+
+export function init(): void {}
+
+export function captureException(): void {}
+
+export function captureMessage(): void {}
+
+export function addBreadcrumb(): void {}
+
+export function setUser(): void {}
+
+export function setContext(): void {}
+
+export function setTag(): void {}
+
+export function withScope(callback: (scope: StubScope) => void): void {
+  callback({ setLevel: () => {}, setTag: () => {}, setExtra: () => {}, setContext: () => {} });
+}
+
+export function flush(): Promise<boolean> {
+  return Promise.resolve(true);
+}
+
+export function wrap<T>(component: T): T {
+  return component;
+}

--- a/packages/mobile/test/sentry-react-native-stub.ts
+++ b/packages/mobile/test/sentry-react-native-stub.ts
@@ -20,6 +20,8 @@ type StubScope = {
 
 export function init(): void {}
 
+export function nativeCrash(): void {}
+
 export function captureException(): void {}
 
 export function captureMessage(): void {}

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -55,6 +55,15 @@ export default defineConfig({
         find: '@react-native-community/blur',
         replacement: fileURLToPath(new URL('./test/community-blur-stub.tsx', import.meta.url)),
       },
+      // @sentry/react-native's real entry pulls in react-native's Promise.js,
+      // which imports `promise/setimmediate/es6-extensions` (no extension) and
+      // fails to resolve under vitest's node ESM env — breaking every suite that
+      // transitively imports `src/lib/sentry`. Sentry is disabled in tests, so a
+      // lightweight stub satisfies the static imports.
+      {
+        find: '@sentry/react-native',
+        replacement: fileURLToPath(new URL('./test/sentry-react-native-stub.ts', import.meta.url)),
+      },
       // expo-file-system and expo-image point their `main`/`exports` at TypeScript
       // source (src/index.ts). That source imports expo-modules-core native bindings
       // whose untransformed TS declarations throw `SyntaxError: Unexpected token


### PR DESCRIPTION
## What & why

PostHog's React Native SDK only captures **JS** errors, so iOS/Android **native** crashes — in the BLE, live-activity, and board-renderer native modules, plus any Expo native module — and **app hangs / ANRs** were completely invisible. This re-adds `@sentry/react-native` as the mobile **error + native-crash + app-hang sink**. PostHog reverts to **product analytics + session replay only** (it no longer captures errors).

Sentry was in mobile from May 24 → June 12 (removed in `8d49b0b32`, "switch mobile error reporting to PostHog"). This is effectively that revert, kept *additive* to the better post-migration architecture: the `error-reporting.ts` public API + noise policy stay; only the sink underneath swaps.

Reports into the same `boardsesh` Sentry project as web (`@sentry/nextjs`) and backend (`@sentry/node`).

## App hangs / ANRs (the priority)

The freezes users report in the wild (e.g. Galaxy S24 / Pixel 10) are main-thread hangs, not crashes. Sentry reports these with a JS stack pinned to the blocked frame — far more reliable than chasing a repro in an emulator:

- **iOS** — `enableAppHangTracking` + `appHangTimeoutInterval: 2` set explicitly (both default on/2s; explicit so a future SDK default can't flip them).
- **Android** — ANR detection is on by default in the native `sentry-android` layer (5s main-thread block); no JS init option — the `@sentry/react-native/expo` plugin wires the native SDK that captures it and attaches the JS stack.

## Changes

- **`src/lib/sentry.ts`** (new) — `Sentry.init` (gated `!!dsn && !__DEV__`, `enableNativeCrashHandling`, `enableAppHangTracking`, `attachStacktrace`), `captureToSentry` mapping our `ErrorReportContext` (level/tags/extra) onto a Sentry scope, `flushSentry`, `wrapWithSentry`, and the single `installGlobalErrorCapture` install (moved off `posthog-client`).
- **`error-reporting.ts`** — public API (`reportError`/`reportHandledError`, ~35 call sites) and noise policy unchanged; only the internal sink swaps (`captureError` → `captureToSentry`).
- **`posthog-client.ts`** — drops `errorTracking.autocapture` + all error-capture helpers; analytics/replay client only.
- **`app/_layout.tsx`** — imports `sentry` first (init ordering, so its global handler wraps cleanly) and `export default wrapWithSentry(RootLayout)`.
- Re-add the `@sentry/react-native/expo` config plugin (`app.config.ts`), the `getSentryExpoConfig` metro wrapper (`metro.config.js`), `@sentry/cli`, and the vitest stub + alias.
- Refresh the stale "Sentry inert" CI comments (`ios-testflight-rn.yml`, `android-apk-rn.yml`) and rewrite `docs/mobile-error-telemetry.md`. The CI source-map/dSYM upload steps were already wired and gated on `SENTRY_AUTH_TOKEN` — no functional workflow change.

## Heads-up

- **Needs a native build to ship.** The new native module + config plugin change the fingerprint runtimeVersion, so this won't reach devices via OTA — it lands with the next TestFlight/Play build.
- **Android JS symbolication is a follow-up.** JS source-map upload stays disabled on Android (`SENTRY_DISABLE_AUTO_UPLOAD=true`) for the existing Expo-prebuild Gradle incompatibility. Native crashes and ANRs are still captured; iOS gets full symbolication.

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — 2566 tests pass (error-reporting re-pointed to the Sentry sink; global-error-capture unchanged) ✓
- `vp run check:mobile-bundle` — Android bundle exports cleanly with the Sentry metro wrapper + plugin ✓
- `vp check` — formatted, 0 errors ✓

End-to-end native + app-hang capture can only be confirmed on a preview/TestFlight/internal build (Sentry is `!__DEV__`-gated).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- [ ] Build a preview/TestFlight (iOS) or internal APK (Android), trigger a JS error, a native crash, and a main-thread hang (≥2s iOS / ≥5s Android), relaunch, confirm all land in the `boardsesh` Sentry project with a JS stack.
- [ ] Confirm PostHog still shows lifecycle/screen events and no longer logs `\$exception` autocapture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3o94PsH3DMco3sa5RJq5h