### PR TITLE
test(mobile): cover Sentry enabled-path scope mapping + dedup doc note

### DIFF
--- a/docs/mobile-error-telemetry.md
+++ b/docs/mobile-error-telemetry.md
@@ -59,7 +59,10 @@ so events group in Sentry: `react-query`, `native-auth`, `queue-mutation`,
 - **React Query** (`providers/query-provider.tsx`) — `QueryCache` / `MutationCache`
   `onError` report every query/mutation failure once `retry` is exhausted. This is
   the chokepoint for API / GraphQL-HTTP / REST failures; don't re-report at
-  individual `useQuery`/`useMutation` call sites.
+  individual `useQuery`/`useMutation` call sites. A query that keeps failing re-fires
+  `onError` on every refetch (focus / reconnect / remount), but Sentry groups those
+  into one issue by stack fingerprint — the event count climbs without spawning
+  duplicates, so no extra `queryHash` dedup is needed (unlike the old PostHog setup).
 - Direct **GraphQL-WS** ops (`@boardsesh/queue-react`, `@boardsesh/playlists-react`)
   bypass React Query, so their catch sites report explicitly.
 

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -15,7 +15,14 @@ vi.mock('@sentry/react-native', () => ({
 }));
 
 import * as Sentry from '@sentry/react-native';
-import { captureToSentry, flushSentry, wrapWithSentry, isSentryEnabled, toSentryTag } from '../sentry';
+import {
+  applyErrorContextToScope,
+  captureToSentry,
+  flushSentry,
+  wrapWithSentry,
+  isSentryEnabled,
+  toSentryTag,
+} from '../sentry';
 
 describe('isSentryEnabled', () => {
   it('is false in dev / test (no DSN + __DEV__)', () => {
@@ -66,5 +73,43 @@ describe('toSentryTag', () => {
     // The point is it returns a string and does not throw — exact text is the
     // String() fallback, not a crash.
     expect(typeof toSentryTag(circular)).toBe('string');
+  });
+});
+
+// captureToSentry only runs the scope mapping when isSentryEnabled (false under
+// vitest, since __DEV__ is frozen true), so the mapping is extracted into this
+// pure function and exercised here with a fake scope — that's where a level /
+// tag / extra bug would otherwise hide behind the enablement gate.
+describe('applyErrorContextToScope', () => {
+  function makeScope() {
+    return { setLevel: vi.fn(), setTag: vi.fn(), setExtra: vi.fn() };
+  }
+
+  it('sets the level when one is provided', () => {
+    const scope = makeScope();
+    applyErrorContextToScope(scope, { level: 'warning' });
+    expect(scope.setLevel).toHaveBeenCalledWith('warning');
+  });
+
+  it('sets each tag with its coerced value (objects → JSON, not "[object Object]")', () => {
+    const scope = makeScope();
+    applyErrorContextToScope(scope, { tags: { source: 'react-query', response: { status: 500 } } });
+    expect(scope.setTag).toHaveBeenCalledWith('source', 'react-query');
+    expect(scope.setTag).toHaveBeenCalledWith('response', '{"status":500}');
+  });
+
+  it('sets each extra verbatim (no coercion)', () => {
+    const scope = makeScope();
+    const payload = { board: 'kilter', angle: 40 };
+    applyErrorContextToScope(scope, { extra: { payload } });
+    expect(scope.setExtra).toHaveBeenCalledWith('payload', payload);
+  });
+
+  it('touches nothing when there is no context', () => {
+    const scope = makeScope();
+    applyErrorContextToScope(scope);
+    expect(scope.setLevel).not.toHaveBeenCalled();
+    expect(scope.setTag).not.toHaveBeenCalled();
+    expect(scope.setExtra).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -69,6 +69,31 @@ export function toSentryTag(value: unknown): string | number | boolean {
   }
 }
 
+// The slice of Sentry's Scope this module writes to. Structural (not the SDK's
+// `Scope`) so the mapping below is testable with a plain fake — and so the real
+// `Scope` passed by `withScope` stays assignable to it.
+type SentryScopeLike = {
+  setLevel: (level: NonNullable<ErrorReportContext['level']>) => void;
+  setTag: (key: string, value: string | number | boolean) => void;
+  setExtra: (key: string, value: unknown) => void;
+};
+
+/**
+ * Map our ErrorReportContext onto a Sentry scope. Extracted as a pure function
+ * (no enablement gate, no SDK init) so the level/tag/extra mapping is directly
+ * unit-testable: `captureToSentry` only runs on real builds (`!__DEV__`), so
+ * without this the coercion/mapping would be invisible to CI behind the gate.
+ */
+export function applyErrorContextToScope(scope: SentryScopeLike, context?: ErrorReportContext): void {
+  if (context?.level) scope.setLevel(context.level);
+  for (const [key, value] of Object.entries(context?.tags ?? {})) {
+    scope.setTag(key, toSentryTag(value));
+  }
+  for (const [key, value] of Object.entries(context?.extra ?? {})) {
+    scope.setExtra(key, value);
+  }
+}
+
 /**
  * Report an error to Sentry if it is active. No-op otherwise. The optional
  * context (level/tags/extra) is mapped onto a Sentry scope so callers can attach
@@ -77,13 +102,7 @@ export function toSentryTag(value: unknown): string | number | boolean {
 export function captureToSentry(error: unknown, context?: ErrorReportContext): void {
   if (!isSentryEnabled) return;
   Sentry.withScope((scope) => {
-    if (context?.level) scope.setLevel(context.level);
-    for (const [key, value] of Object.entries(context?.tags ?? {})) {
-      scope.setTag(key, toSentryTag(value));
-    }
-    for (const [key, value] of Object.entries(context?.extra ?? {})) {
-      scope.setExtra(key, value);
-    }
+    applyErrorContextToScope(scope, context);
     Sentry.captureException(error);
   });
 }


### PR DESCRIPTION
Follow-up to #3145 addressing the review feedback that landed after merge.

## 1. Enabled-path test coverage (the main gap)

The review flagged that every test in `sentry.test.ts` ran with `isSentryEnabled === false` (no DSN + `__DEV__` true), so the actual scope-building logic in `captureToSentry` — `setLevel` / `setTag(toSentryTag(value))` / `setExtra` — was never exercised. `__DEV__` is a compile-time `true` in the mobile vitest config, so the enablement gate can't be flipped at runtime to reach that branch.

Fix: extract the mapping into a pure, exported `applyErrorContextToScope(scope, context)` that `captureToSentry` calls inside `withScope`. Now the level mapping, tag coercion (objects → JSON, not `[object Object]`), and extra passthrough are unit-tested directly with a fake scope — no gate to fight.

## 2. Docs: restore the dropped dedup caveat

`docs/mobile-error-telemetry.md` lost the old PostHog-era note about React Query's `onError` re-firing on refetch. Added a one-liner clarifying that Sentry groups those re-fires into one issue by stack fingerprint, so the `queryHash`-dedup concern no longer applies.

## Not changed: @sentry/cli version split

The review also noted `@sentry/cli@2.53.0` (mobile) vs `2.58.6` (web's bundler-plugin-core) in the lockfile. Intentional and left as-is: `@sentry/react-native@6.22.0` pins `@sentry/cli` to **exactly** `2.53.0`, so deduping mobile up to 2.58.6 would diverge from what its xcode/gradle build scripts expect. The reviewer's own note concluded "no action required if the build validates clean" — and the main Android/iOS builds validate clean.

## Validation

- `vp run typecheck:mobile` ✓
- `vp run test:mobile` — sentry suite 11 tests pass ✓
- `vp check` — formatted, 0 errors ✓

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3o94PsH3DMco3sa5RJq5h