### PR TITLE
fix(ci): ignore generated files via .prettierignore (fix red main format check)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Generated / tool-owned files — never formatted, or the generator's output drifts vs a
+# formatted copy (and the `changelog-owned` CI gate rejects changelog edits). See vite.config.ts.
+**/*.generated.json
+**/drizzle/meta/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,23 +18,14 @@ export default defineConfig({
     // formatting it produces noise diffs every time `vp check --fix`
     // runs without changing what ships, and the linter already ignores
     // the same path. Keep them in lock-step.
-    // Generated / tool-owned files — never hand-format, or the generator's output and a formatted
-    // copy drift (and CI flags it):
-    //   - CHANGELOG.md + *.generated.json (notably packages/mobile/src/data/changelog.generated.json):
-    //     owned by the mobile OTA pipeline, regenerated from PR Release Notes; the `changelog-owned`
-    //     CI gate rejects any PR that edits them. `**/generated/**` only matches a `generated/`
-    //     DIRECTORY, so the `.generated.json` NAME pattern is needed too (also covers e.g.
-    //     oss-licenses.generated.json).
-    //   - drizzle/meta/** (snapshots + _journal.json): emitted byte-for-byte by `drizzle-kit generate`;
-    //     reformatting them is noise drizzle re-churns on the next migration.
-    ignore: [
-      'design/**',
-      '**/generated/**',
-      '**/*.generated.json',
-      '**/drizzle/meta/**',
-      '**/board-controller/**',
-      'CHANGELOG.md',
-    ],
+    // CHANGELOG.md is generated (and owned/pushed) by the mobile OTA pipeline
+    // from PR Release Notes — never hand-format it, or the bot's output and a
+    // formatted copy would drift (and the push-to-main `vp check` would flag it).
+    // NOTE: files ignored by NAME (e.g. *.generated.json like
+    // packages/mobile/src/data/changelog.generated.json) or by nested dir
+    // (drizzle/meta/) live in .prettierignore — this `ignore` glob list does not
+    // reliably match those forms in `vp check`, but .prettierignore does.
+    ignore: ['design/**', '**/generated/**', '**/board-controller/**', 'CHANGELOG.md'],
   },
   lint: {
     ignorePatterns: ['**/board-controller/**'],


### PR DESCRIPTION
## Summary

The push-to-main format check (`vp check`, repo-wide) has been **failing on every main push** on 7 generated/tool-owned files whose generators re-emit unformatted output:
- `packages/mobile/src/data/changelog.generated.json` — owned by the mobile OTA pipeline; the `changelog-owned` gate forbids editing it in a PR, so it can only be *ignored*, not formatted.
- `packages/db/drizzle/meta/*.json` — `drizzle-kit` snapshots + `_journal.json`, re-churned byte-for-byte on each migration.

#3148 tried to ignore these via the `fmt.ignore` glob list in `vite.config.ts`, but that list doesn't reliably match files by **name** (`*.generated.json`) or by **nested dir** (`drizzle/meta/`) in `vp check` — they stayed flagged. vite-plus's formatter is Prettier-based and honours **`.prettierignore`**, which matches them correctly.

This adds a `.prettierignore` with those patterns and reverts the non-working `fmt.ignore` additions (leaving a pointer note). `vp check` now reports **all 3490 files correctly formatted**.

Note: `vp check` also surfaces pre-existing repo-wide *lint* warnings/errors in unrelated files (e.g. `scripts/generate-graphql-types.test.mjs`) — those are out of scope here; this PR only addresses the format check.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` → `pass: All 3490 files are correctly formatted` (was: 7 files flagged)
- The 7 generated files are excluded by the new `.prettierignore`; no source files are over-ignored (`**/*.generated.json` + `**/drizzle/meta/` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uy3mZSmRoNQGMsjthnuzv
