### PR TITLE
perf(mobile): cut board-art image memory (display-size overlays, recycle, bg flush)

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -257,6 +257,41 @@ surface the previous size's bundled background paths.
 
 ---
 
+## 7. Board-art image memory: render at display size, recycle, release on background
+
+**Rule:** Board-art surfaces are the app's largest memory consumer (decoded bitmaps live in the
+Android native heap + as GPU textures, not the JS heap). Three contracts keep them in check:
+
+- **Size the overlay to the display, keep the photo full-res.** The play-drawer board passes
+  `renderWidth` (display px × `PixelRatio.get()`) so the per-climb holds overlay rasterizes at the
+  shown size instead of the board's native ~1080px, plus `backgroundVariant="full"` so the *shared*
+  board photo (one decode per board-config, reused across every climb) stays crisp. `renderWidth`
+  alone would downgrade the photo to the 416px `thumb` — only the overlay should shrink.
+- **`recyclingKey` on always-mounted board surfaces that swap climbs.** The carousel boards key on the
+  climb's `frames` so swapping releases the previous overlay instead of holding both.
+- **Release board-art on background.** `LayeredClimbImage` blanks its `<Image>` layers when
+  `useIsAppBackgrounded()` is true, and `useImageCacheMemoryManagement` (mounted at the app root)
+  sweeps expo-image's memory cache on background / `memoryWarning`. Re-decodes from disk on
+  foreground (no network).
+
+**Why:** On-device profiling (Pixel 8 Pro, Android 16) showed ~248 MB native heap idle on the feed
+and the play-drawer carousel piling a native-res (~7 MB RGBA) overlay per swiped climb into the
+cache. Display-sizing + recycling cut carousel browse-growth ~19%; background-blanking cut the
+worst case (board left open on app-switch) ~96 MB. **Ceiling:** expo-image on Android is Glide,
+whose cache/pool are sized to device RAM and resist JS `clearMemoryCache()` (the native allocator
+retains freed pages), so the common feed-backgrounded footprint is unmoved by JS — the next lever is
+native (`onTrimMemory(UI_HIDDEN) → Glide.clearMemory()`). The high MB on a 12 GB device overstates
+real risk; Glide auto-sizes far smaller on 4–6 GB phones.
+
+**Examples in this repo:**
+
+- `packages/mobile/src/lib/app-visibility.ts` (`useIsAppBackgrounded`, one ref-counted AppState
+  listener) + `packages/mobile/src/hooks/use-image-cache-memory-management.ts` (root cache sweep).
+- `renderWidth` + `backgroundVariant` threaded through `BoardImageNative.tsx` →
+  `use-native-climb-render.ts`; applied in `play-drawer/SwipeBoardCarousel.tsx`.
+
+---
+
 ## Profiling workflow
 
 Required evidence for any list / provider / theme PR: a **before/after recording on the climbs list

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -57,6 +57,7 @@ import { spacing } from '../src/theme/tokens';
 import { glassStackScreenOptions } from '../src/theme/navigation';
 import { reportError } from '../src/lib/error-reporting';
 import { loadRequiredFonts } from '../src/lib/required-fonts';
+import { useImageCacheMemoryManagement } from '../src/hooks/use-image-cache-memory-management';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
@@ -269,6 +270,10 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
 function RootLayout() {
   const [authReady, setAuthReady] = useState(false);
   const [fontsReady, setFontsReady] = useState(false);
+
+  // Flush the decoded-image memory cache on background / memory warning so the
+  // board-art bitmaps don't keep the backgrounded app at ~575 MB (kill risk).
+  useImageCacheMemoryManagement();
 
   useEffect(() => {
     let cancelled = false;

--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, type ViewStyle } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useNativeClimbRender } from '../hooks/use-native-climb-render';
+import type { BackgroundVariant } from '../lib/background-image-cache';
 import { LayeredClimbImage } from './LayeredClimbImage';
 
 type BoardImageNativeProps = {
@@ -30,6 +31,20 @@ type BoardImageNativeProps = {
    * for the full-size play view (renders at native board width).
    */
   renderWidth?: number;
+  /**
+   * Force the bundled board-photo resolution independently of `renderWidth`.
+   * The play-drawer carousel passes `renderWidth` (display-sized overlay) +
+   * `backgroundVariant="full"` (crisp shared photo). See useNativeClimbRender.
+   */
+  backgroundVariant?: BackgroundVariant;
+  /**
+   * Forwarded to the holds-overlay <Image> so expo-image recycles the view and
+   * releases the previous climb's decoded overlay bitmap when this stays mounted
+   * but the climb changes (the play-drawer carousel swapping climbs). Without it,
+   * the old full-size overlay lingers in the in-memory cache alongside the new
+   * one. Key it on the per-climb `frames`.
+   */
+  recyclingKey?: string;
   style?: ViewStyle;
   /**
    * testID forwarded to the holds-overlay layer, which only mounts once the async
@@ -61,6 +76,8 @@ const BoardImageNative = React.memo(function BoardImageNative({
   mirrored,
   filledStyle = false,
   renderWidth,
+  backgroundVariant,
+  recyclingKey,
   style,
   overlayTestID,
 }: BoardImageNativeProps) {
@@ -72,6 +89,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
     setIds,
     filledStyle,
     renderWidth,
+    backgroundVariant,
   });
 
   const containerStyle: ViewStyle = {
@@ -87,6 +105,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}
+        recyclingKey={recyclingKey}
         overlayTestID={overlayTestID}
       />
     </View>

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
+import { useIsAppBackgrounded } from '../lib/app-visibility';
 
 type LayeredClimbImageProps = {
   overlayUri: string | null;
@@ -60,6 +61,17 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   // blank drawer. Gating on onLoad makes the anchor mean "the lit board is on
   // screen".
   const [overlayPainted, setOverlayPainted] = useState(false);
+
+  // While the app is backgrounded, drop the decoded board-art bitmaps: render
+  // an empty stack instead of the <Image> layers so expo-image releases their
+  // GPU textures + native-heap bitmaps (the views stay mounted across a
+  // background, so without this they pin ~100 MB+ that raises the OS
+  // background-kill risk). The empty stack preserves the parent's layout box;
+  // layers re-mount and re-decode from disk (no network) on foreground.
+  const isBackgrounded = useIsAppBackgrounded();
+  if (isBackgrounded) {
+    return <View style={[styles.stack, mirrored && styles.mirrored]} />;
+  }
 
   return (
     <View style={[styles.stack, mirrored && styles.mirrored]}>

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 import { useIsAppBackgrounded } from '../lib/app-visibility';
@@ -69,6 +69,12 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   // background-kill risk). The empty stack preserves the parent's layout box;
   // layers re-mount and re-decode from disk (no network) on foreground.
   const isBackgrounded = useIsAppBackgrounded();
+  // Reset the overlay-painted anchor when backgrounded so the screenshot/e2e
+  // anchor re-gates on the next real onLoad after foreground (the overlay
+  // re-decodes); otherwise the anchor would re-appear before the lit board does.
+  useEffect(() => {
+    if (isBackgrounded) setOverlayPainted(false);
+  }, [isBackgrounded]);
   if (isBackgrounded) {
     return <View style={[styles.stack, mirrored && styles.mirrored]} />;
   }

--- a/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-backgrounded.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source }: { source: { uri: string } }) => createElement('img', { src: source.uri }),
+}));
+
+// Force the backgrounded branch.
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => true }));
+
+import { LayeredClimbImage } from '../LayeredClimbImage';
+
+describe('LayeredClimbImage (backgrounded)', () => {
+  it('drops every image layer while the app is backgrounded', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bundled/kilter.webp'],
+      }),
+    );
+
+    // No decoded bitmaps mounted while backgrounded — the whole stack is blank.
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/layered-climb-image-recycling.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image-recycling.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source, recyclingKey }: { source: { uri: string }; recyclingKey?: string }) =>
+    createElement('img', { src: source.uri, 'data-recycling-key': recyclingKey ?? '' }),
+}));
+
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => false }));
+
+import { LayeredClimbImage } from '../LayeredClimbImage';
+
+describe('LayeredClimbImage recyclingKey', () => {
+  it('forwards recyclingKey to the overlay image so swaps release the old bitmap', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bg.webp'],
+        recyclingKey: 'frames-abc',
+      }),
+    );
+    const overlay = container.querySelector('img[src="file:///overlay.png"]');
+    expect(overlay?.getAttribute('data-recycling-key')).toBe('frames-abc');
+  });
+
+  it('does not apply recyclingKey to the shared background image', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bg.webp'],
+        recyclingKey: 'frames-abc',
+      }),
+    );
+    // The board photo is shared per board-config (keyed by path), so it must not
+    // recycle on every climb change.
+    const background = container.querySelector('img[src="file:///bg.webp"]');
+    expect(background?.getAttribute('data-recycling-key')).toBe('');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   StyleSheet,
   useWindowDimensions,
+  PixelRatio,
   type LayoutChangeEvent,
   type ViewStyle,
 } from 'react-native';
@@ -100,6 +101,18 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   );
   const boardStyle = useMemo<ViewStyle | undefined>(
     () => (boardBox ? { width: boardBox.width, height: boardBox.height } : undefined),
+    [boardBox],
+  );
+  // Render the per-climb holds overlay at the displayed pixel size, not the
+  // board's native ~1080px. The board photo is shared per board-config (one
+  // decode for every climb on the wall) and stays full-res via
+  // backgroundVariant="full"; only the overlay shrinks. Without this, swiping
+  // through climbs piles a native-res (~7 MB RGBA) overlay per climb into
+  // expo-image's memory cache. Clamped to native width inside
+  // useNativeClimbRender (never upscales), so high-DPR phones whose display
+  // width already exceeds native render unchanged.
+  const overlayRenderWidth = useMemo(
+    () => (boardBox ? Math.round(boardBox.width * PixelRatio.get()) : undefined),
     [boardBox],
   );
   // The carousel works in board-width units: a letterboxed (narrower) board
@@ -233,6 +246,11 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
                 boardWidth={boardWidth}
                 boardHeight={boardHeight}
                 mirrored={mirrored}
+                renderWidth={overlayRenderWidth}
+                backgroundVariant="full"
+                // Climb identity (not the per-frame override) so the overlay
+                // recycles on swipe-to-new-climb, not on every playback frame.
+                recyclingKey={currentFrames}
                 style={boardStyle}
               />
             </Animated.View>
@@ -250,6 +268,9 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               boardWidth={boardWidth}
               boardHeight={boardHeight}
               mirrored={mirrored}
+              renderWidth={overlayRenderWidth}
+              backgroundVariant="full"
+              recyclingKey={peekFrames}
               style={boardStyle}
             />
           )}

--- a/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-image-cache-memory-management.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const clearMemoryCache = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+
+// Capture each AppState handler by event name so tests can fire them and assert
+// the registered subscriptions are torn down on unmount.
+const appState = vi.hoisted(() => {
+  const handlers: Record<string, (state?: string) => void> = {};
+  const removers: Record<string, ReturnType<typeof vi.fn>> = {};
+  return {
+    handlers,
+    removers,
+    addEventListener: vi.fn((event: string, cb: (state?: string) => void) => {
+      handlers[event] = cb;
+      const remove = vi.fn();
+      removers[event] = remove;
+      return { remove };
+    }),
+    fire: (event: string, state?: string) => handlers[event]?.(state),
+  };
+});
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: { clearMemoryCache },
+}));
+
+// Control the background flag directly so the cache-flush effect can be asserted
+// without driving the real AppState store.
+const isBackgrounded = vi.hoisted(() => ({ value: false }));
+vi.mock('../../lib/app-visibility', () => ({
+  useIsAppBackgrounded: () => isBackgrounded.value,
+}));
+
+import { useImageCacheMemoryManagement } from '../use-image-cache-memory-management';
+
+describe('useImageCacheMemoryManagement', () => {
+  beforeEach(() => {
+    clearMemoryCache.mockClear();
+    appState.addEventListener.mockClear();
+    isBackgrounded.value = false;
+  });
+
+  it('does not flush while foregrounded', () => {
+    renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+  });
+
+  it('flushes the image memory cache once the app is backgrounded', () => {
+    isBackgrounded.value = true;
+    renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes when transitioning foreground -> background', () => {
+    const { rerender } = renderHook(() => useImageCacheMemoryManagement());
+    expect(clearMemoryCache).not.toHaveBeenCalled();
+    isBackgrounded.value = true;
+    rerender();
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers and tears down the memoryWarning listener', () => {
+    const { unmount } = renderHook(() => useImageCacheMemoryManagement());
+    expect(appState.addEventListener).toHaveBeenCalledWith('memoryWarning', expect.any(Function));
+    appState.fire('memoryWarning');
+    expect(clearMemoryCache).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(appState.removers.memoryWarning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { Image } from 'expo-image';
+import { useIsAppBackgrounded } from '../lib/app-visibility';
+
+/**
+ * Sweep expo-image's in-memory decoded-bitmap cache + pool when the app
+ * backgrounds, and on OS memory-pressure warnings.
+ *
+ * On-device profiling (Pixel 8 Pro, Android 16) showed the app holding board-art
+ * bitmaps + GPU textures while backgrounded (the views stay mounted, so the
+ * system can't reclaim them) — a background-kill risk on lower-RAM phones.
+ * LayeredClimbImage blanks its <Image> layers on background (see
+ * `useIsAppBackgrounded`), returning their bitmaps to expo-image's pool; this
+ * sweep then frees the pool. The clear runs as a post-commit effect keyed on the
+ * background flag so it fires AFTER the blank has committed — clearing first
+ * would leave the still-mounted bitmaps referenced. The disk cache is untouched,
+ * so foregrounding re-decodes from disk in tens of ms (no network).
+ */
+export function useImageCacheMemoryManagement(): void {
+  const isBackgrounded = useIsAppBackgrounded();
+
+  useEffect(() => {
+    if (isBackgrounded) void Image.clearMemoryCache();
+  }, [isBackgrounded]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('memoryWarning', () => {
+      void Image.clearMemoryCache();
+    });
+    return () => sub.remove();
+  }, []);
+}

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -71,9 +71,20 @@ type NativeClimbRenderParams = {
    * <Image> never has to downscale a large source on the main thread (the
    * cause of the iOS app hang). Omit for the full-size play view, which
    * renders at native board width. Clamped to the board width (never
-   * upscales). Also selects the bundled `thumb` background variant.
+   * upscales). Selects the bundled `thumb` background variant by default
+   * (override with `backgroundVariant`).
    */
   renderWidth?: number;
+  /**
+   * Force the bundled board-photo resolution independently of `renderWidth`.
+   * The board photo is shared per board-config (one decode across every climb
+   * on the wall), so the play-drawer carousel can render the per-climb *overlay*
+   * at display size (a small `renderWidth`) while keeping the photo crisp
+   * (`backgroundVariant="full"`) — without it, any `renderWidth` would downgrade
+   * the photo to the 416px `thumb`, blurring the full-screen board. Defaults to
+   * `thumb` when `renderWidth` is set, `full` otherwise.
+   */
+  backgroundVariant?: BackgroundVariant;
 };
 
 type NativeClimbRenderResult = {
@@ -480,7 +491,7 @@ function getNativeModule() {
  * and the component shows backgrounds alone.
  */
 export function useNativeClimbRender(params: NativeClimbRenderParams): NativeClimbRenderResult {
-  const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth } = params;
+  const { frames, boardName, layoutId, sizeId, setIds, filledStyle = false, renderWidth, backgroundVariant } = params;
   const {
     overrides: holdColorOverrides,
     shapes: holdShapeOverrides,
@@ -491,8 +502,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
 
   // Small surfaces that pass a renderWidth want the bundled thumb-sized
   // background too, so neither the overlay nor the photo is a large source
-  // the main thread has to downscale.
-  const variant: BackgroundVariant = renderWidth != null ? 'thumb' : 'full';
+  // the main thread has to downscale. The play-drawer carousel overrides this
+  // to 'full' so it can shrink the per-climb overlay (via renderWidth) while
+  // keeping the shared board photo crisp on the full-screen board.
+  const variant: BackgroundVariant = backgroundVariant ?? (renderWidth != null ? 'thumb' : 'full');
 
   // Run the disk-cache scan once per JS context. Safe to call on every
   // render — the function self-guards via `warmupRun`.

--- a/packages/mobile/src/lib/__tests__/app-visibility.test.ts
+++ b/packages/mobile/src/lib/__tests__/app-visibility.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// Capture the single 'change' handler the store installs at module load.
+// Capture the 'change' handler the store installs on first subscribe.
 const appState = vi.hoisted(() => {
   const ref: { handler: ((state: string) => void) | null } = { handler: null };
   return {
@@ -21,14 +21,17 @@ vi.mock('react-native', () => ({
 
 import { useIsAppBackgrounded } from '../app-visibility';
 
+// The store is a module-level singleton, so each stateful test normalizes to the
+// foreground at the start rather than relying on the previous test's end state.
 describe('app-visibility store', () => {
-  it('installs a single AppState change listener at module load', () => {
-    expect(appState.addEventListener).toHaveBeenCalledTimes(1);
+  it('subscribes to AppState change events', () => {
+    renderHook(() => useIsAppBackgrounded());
     expect(appState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
   });
 
-  it('flips to backgrounded on "background" and back on "active"', () => {
+  it('reports backgrounded on "background" and clears on "active"', () => {
     const { result } = renderHook(() => useIsAppBackgrounded());
+    act(() => appState.fire('active'));
     expect(result.current).toBe(false);
     act(() => appState.fire('background'));
     expect(result.current).toBe(true);
@@ -36,8 +39,9 @@ describe('app-visibility store', () => {
     expect(result.current).toBe(false);
   });
 
-  it('ignores the transient "inactive" state (no blank-on-app-switcher-peek)', () => {
+  it('ignores the transient "inactive" state', () => {
     const { result } = renderHook(() => useIsAppBackgrounded());
+    act(() => appState.fire('active'));
     act(() => appState.fire('inactive'));
     expect(result.current).toBe(false);
   });

--- a/packages/mobile/src/lib/__tests__/app-visibility.test.ts
+++ b/packages/mobile/src/lib/__tests__/app-visibility.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Capture the single 'change' handler the store installs at module load.
+const appState = vi.hoisted(() => {
+  const ref: { handler: ((state: string) => void) | null } = { handler: null };
+  return {
+    ref,
+    addEventListener: vi.fn((_event: string, cb: (state: string) => void) => {
+      ref.handler = cb;
+      return { remove: vi.fn() };
+    }),
+    fire: (state: string) => ref.handler?.(state),
+  };
+});
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+
+import { useIsAppBackgrounded } from '../app-visibility';
+
+describe('app-visibility store', () => {
+  it('installs a single AppState change listener at module load', () => {
+    expect(appState.addEventListener).toHaveBeenCalledTimes(1);
+    expect(appState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('flips to backgrounded on "background" and back on "active"', () => {
+    const { result } = renderHook(() => useIsAppBackgrounded());
+    expect(result.current).toBe(false);
+    act(() => appState.fire('background'));
+    expect(result.current).toBe(true);
+    act(() => appState.fire('active'));
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores the transient "inactive" state (no blank-on-app-switcher-peek)', () => {
+    const { result } = renderHook(() => useIsAppBackgrounded());
+    act(() => appState.fire('inactive'));
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/app-visibility.test.ts
+++ b/packages/mobile/src/lib/__tests__/app-visibility.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Capture the 'change' handler the store installs on first subscribe.
@@ -21,8 +21,13 @@ vi.mock('react-native', () => ({
 
 import { useIsAppBackgrounded } from '../app-visibility';
 
-// The store is a module-level singleton, so each stateful test normalizes to the
-// foreground at the start rather than relying on the previous test's end state.
+// The store is a module-level singleton — reset it to the foreground after every
+// test so they pass in any order. The captured handler stays callable even after
+// the component unmounts, so this resets the flag regardless of subscriptions.
+afterEach(() => {
+  act(() => appState.fire('active'));
+});
+
 describe('app-visibility store', () => {
   it('subscribes to AppState change events', () => {
     renderHook(() => useIsAppBackgrounded());
@@ -31,7 +36,6 @@ describe('app-visibility store', () => {
 
   it('reports backgrounded on "background" and clears on "active"', () => {
     const { result } = renderHook(() => useIsAppBackgrounded());
-    act(() => appState.fire('active'));
     expect(result.current).toBe(false);
     act(() => appState.fire('background'));
     expect(result.current).toBe(true);
@@ -41,7 +45,6 @@ describe('app-visibility store', () => {
 
   it('ignores the transient "inactive" state', () => {
     const { result } = renderHook(() => useIsAppBackgrounded());
-    act(() => appState.fire('active'));
     act(() => appState.fire('inactive'));
     expect(result.current).toBe(false);
   });

--- a/packages/mobile/src/lib/app-visibility.ts
+++ b/packages/mobile/src/lib/app-visibility.ts
@@ -33,6 +33,9 @@ function subscribe(onStoreChange: () => void): () => void {
       if (AppState?.currentState != null) backgrounded = AppState.currentState === 'background';
       subscription = AppState?.addEventListener?.('change', (state) => setBackgrounded(state === 'background')) ?? null;
     } catch {
+      // Keep the flag + subscription consistent if currentState read but
+      // addEventListener threw (partial mock).
+      backgrounded = false;
       subscription = null;
     }
   }

--- a/packages/mobile/src/lib/app-visibility.ts
+++ b/packages/mobile/src/lib/app-visibility.ts
@@ -1,27 +1,22 @@
 import { useSyncExternalStore } from 'react';
-import { AppState } from 'react-native';
+import { AppState, type NativeEventSubscription } from 'react-native';
 
 /**
- * Single source of truth for "is the app backgrounded", backed by ONE AppState
- * listener installed at module load. Components subscribe via
- * `useIsAppBackgrounded()` and re-render only when the flag flips — so many
- * climb-image instances can cheaply blank their decoded bitmaps on background
- * (freeing GPU textures + native heap) without each adding its own AppState
- * subscription.
+ * Single source of truth for "is the app backgrounded", consumed via
+ * `useIsAppBackgrounded()`. The AppState listener is installed lazily on the
+ * first subscribe and removed on the last unsubscribe (ref-counted) — not at
+ * module load — so Fast Refresh re-evaluating this module can't accumulate
+ * orphan listeners, and there's still only ONE AppState listener regardless of
+ * how many climb-image instances subscribe.
  *
- * On-device profiling (Pixel 8 Pro, Android 16) showed backgrounding with the
- * play drawer open pinned ~104 MB GPU + ~387 MB *live* native heap (board-art
- * bitmaps held by the still-mounted views — RN doesn't unmount on background).
- * Blanking those views on background lets the system reclaim the textures and
- * returns the bitmaps to expo-image's pool, which the cache sweep then frees.
- *
- * Only `background` flips the flag — not `inactive`, which fires on transient
- * iOS interruptions (notification shade, app-switcher peek) where the user is
- * about to return and a blank-then-reload would just be a flash.
+ * Only `background` flips the flag (not the transient iOS `inactive`), so a
+ * notification-shade pull or app-switcher peek doesn't blank-then-reload the UI.
+ * See `useImageCacheMemoryManagement` + LayeredClimbImage for the consumers.
  */
 
 let backgrounded = false;
 const listeners = new Set<() => void>();
+let subscription: NativeEventSubscription | null = null;
 
 function setBackgrounded(next: boolean): void {
   if (next === backgrounded) return;
@@ -29,21 +24,25 @@ function setBackgrounded(next: boolean): void {
   for (const listener of listeners) listener();
 }
 
-// Defensive: unit tests mock `react-native` with a partial surface that often
-// omits AppState. Optional-chaining + try/catch keep importing this module from
-// throwing there (the flag simply stays at its foreground default).
-try {
-  AppState?.addEventListener?.('change', (state) => {
-    setBackgrounded(state === 'background');
-  });
-} catch {
-  // No AppState in this environment — leave the flag false.
-}
-
 function subscribe(onStoreChange: () => void): () => void {
+  if (listeners.size === 0) {
+    // try/catch (not just optional-chaining): some unit-test RN mocks omit
+    // AppState, and vitest throws on accessing an undefined named export. In
+    // production AppState is always present, so this only guards partial mocks.
+    try {
+      if (AppState?.currentState != null) backgrounded = AppState.currentState === 'background';
+      subscription = AppState?.addEventListener?.('change', (state) => setBackgrounded(state === 'background')) ?? null;
+    } catch {
+      subscription = null;
+    }
+  }
   listeners.add(onStoreChange);
   return () => {
     listeners.delete(onStoreChange);
+    if (listeners.size === 0) {
+      subscription?.remove();
+      subscription = null;
+    }
   };
 }
 

--- a/packages/mobile/src/lib/app-visibility.ts
+++ b/packages/mobile/src/lib/app-visibility.ts
@@ -1,0 +1,56 @@
+import { useSyncExternalStore } from 'react';
+import { AppState } from 'react-native';
+
+/**
+ * Single source of truth for "is the app backgrounded", backed by ONE AppState
+ * listener installed at module load. Components subscribe via
+ * `useIsAppBackgrounded()` and re-render only when the flag flips — so many
+ * climb-image instances can cheaply blank their decoded bitmaps on background
+ * (freeing GPU textures + native heap) without each adding its own AppState
+ * subscription.
+ *
+ * On-device profiling (Pixel 8 Pro, Android 16) showed backgrounding with the
+ * play drawer open pinned ~104 MB GPU + ~387 MB *live* native heap (board-art
+ * bitmaps held by the still-mounted views — RN doesn't unmount on background).
+ * Blanking those views on background lets the system reclaim the textures and
+ * returns the bitmaps to expo-image's pool, which the cache sweep then frees.
+ *
+ * Only `background` flips the flag — not `inactive`, which fires on transient
+ * iOS interruptions (notification shade, app-switcher peek) where the user is
+ * about to return and a blank-then-reload would just be a flash.
+ */
+
+let backgrounded = false;
+const listeners = new Set<() => void>();
+
+function setBackgrounded(next: boolean): void {
+  if (next === backgrounded) return;
+  backgrounded = next;
+  for (const listener of listeners) listener();
+}
+
+// Defensive: unit tests mock `react-native` with a partial surface that often
+// omits AppState. Optional-chaining + try/catch keep importing this module from
+// throwing there (the flag simply stays at its foreground default).
+try {
+  AppState?.addEventListener?.('change', (state) => {
+    setBackgrounded(state === 'background');
+  });
+} catch {
+  // No AppState in this environment — leave the flag false.
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): boolean {
+  return backgrounded;
+}
+
+export function useIsAppBackgrounded(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Summary

On-device performance profile of the mobile app on a **Pixel 8 Pro (Android 16)** found board-art images dominating memory (CPU, jank, and startup were all healthy):

- **~248 MB native heap** sitting idle on the Home feed (decoded board-art bitmaps; Java/JS heap was only ~24 MB).
- **~105 MB GPU** (GL mtrack) on a full play board.
- The play-drawer carousel piled a **native-res (~7 MB RGBA) holds overlay per swiped climb** into expo-image's memory cache (it plateaus, so a high ceiling rather than a leak).

This is a JS-layer pass at the most actionable parts. Three changes:

1. **Overlay at display resolution.** The play-drawer holds overlay rendered at the board's native ~1080px even though it displays at ~930px. `BoardImageNative` now takes a `renderWidth` (display px × DPR) plus a new `backgroundVariant` override so the *overlay* shrinks while the **shared board photo stays full-res** (the photo is per-board-config, decoded once for the whole wall — so it's not what accumulates). Also removes a per-render downscale. Clamped to native width (never upscales), so high-DPR phones are unaffected.
2. **`recyclingKey` on the carousel boards.** Swapping climbs now releases the previous climb's decoded overlay instead of holding both alongside.
3. **Release board-art on background.** A shared `useIsAppBackgrounded` store gates `LayeredClimbImage` to blank its `<Image>` layers while the app is backgrounded, and a hook sweeps expo-image's memory cache on background / OS memory-warning. Re-decodes from disk on resume (no network; no observed flash).

## Measured impact (Pixel 8 Pro, before → after)

| Scenario | Before | After |
|---|--:|--:|
| Carousel browse growth (board-open → 30 swipes) | +90 MB | **+73 MB (~19% less)** |
| Backgrounded with play drawer open | 681 MB | **585 MB (−96 MB)** |
| Backgrounded from feed (common) | 566 MB | 564 MB (unchanged) |

**Honest scope:** the common feed-backgrounded case is bound by Glide's (expo-image's Android engine) RAM-adaptive image cache + native-allocator page retention, which resists JS-level clearing — that needs a native `onTrimMemory → Glide.clearMemory()` hook, deferred as a follow-up. The high absolute numbers also partly reflect Glide using a 12 GB device's headroom; it auto-sizes far smaller on 4–6 GB phones.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2585 passed (+8 new: app-visibility store, cache-flush hook, backgrounded blanking)
- `vp check` — lint/format clean on changed files
- `vp run check:mobile-bundle` — OK (12.3 MB)
- **On-device (Pixel 8 Pro, Android 16):** release build sideloaded; verified the play board renders crisp (full background preserved, overlay sharp at display size), no resume flash, and the memory deltas above via `dumpsys meminfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gaQWQSM1dfJ7oXK3hzku9