### PR TITLE
fix(mobile): split-screen workaround notice on the login screen

### DIFF
--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -23,6 +23,7 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { useNativeOAuthSignIn } from '../../src/hooks/use-native-oauth-sign-in';
 import { AuthTextInput } from '../../src/components/AuthTextInput';
 import { Button } from '../../src/components/Button';
+import { Icon } from '../../src/components/Icon';
 import { track } from '../../src/lib/analytics';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
@@ -99,6 +100,13 @@ export default function LoginScreen() {
     }
   }
 
+  // Newer Android (15+/edge-to-edge) can leave the login form touch-dead in full
+  // screen while split-screen restores touch — under investigation. Surface the
+  // split-screen workaround so a stuck user can still sign in. iOS/older Android
+  // are unaffected, so the notice is gated to the device class that hits it.
+  const showAndroidFreezeNotice =
+    Platform.OS === 'android' && typeof Platform.Version === 'number' && Platform.Version >= 35;
+
   const isDark = theme.colorScheme === 'dark';
 
   // Sign in with Apple is iOS-only; Google only when the build shipped its
@@ -116,6 +124,25 @@ export default function LoginScreen() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="interactive"
       >
+        {showAndroidFreezeNotice ? (
+          <View
+            style={[
+              styles.freezeNotice,
+              { backgroundColor: theme.systemColors.secondaryBackground, borderColor: theme.systemColors.separator },
+            ]}
+            accessibilityRole="alert"
+          >
+            <Icon name="warning" size={22} color={theme.brandColors.warning} />
+            <View style={styles.freezeNoticeText}>
+              <Text style={[styles.freezeNoticeTitle, { color: theme.systemColors.label }]}>
+                {t('login.splitScreenNotice.title')}
+              </Text>
+              <Text style={[styles.freezeNoticeBody, { color: theme.systemColors.secondaryLabel }]}>
+                {t('login.splitScreenNotice.body')}
+              </Text>
+            </View>
+          </View>
+        ) : null}
         <View style={styles.header}>
           <Image
             source={require('../../assets/splash-icon.png')}
@@ -272,6 +299,27 @@ export default function LoginScreen() {
 
 const styles = StyleSheet.create({
   container: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  freezeNotice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 24,
+  },
+  freezeNoticeText: {
+    flex: 1,
+    gap: 4,
+  },
+  freezeNoticeTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  freezeNoticeBody: {
+    fontSize: 14,
+    lineHeight: 19,
+  },
   header: { alignItems: 'center', marginBottom: 32 },
   logo: { width: 96, height: 96, marginBottom: 16 },
   title: { fontSize: 34, fontWeight: '700', marginBottom: 8 },

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -62,6 +62,10 @@
       "troubleSigningIn": "Trouble signing in?",
       "discord": "Join Discord"
     },
+    "splitScreenNotice": {
+      "title": "Sign-in not responding?",
+      "body": "On some newer Android phones the login screen can freeze. Open split-screen view to sign in while we fix it."
+    },
     "a11y": {
       "showPassword": "Show password",
       "hidePassword": "Hide password"

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -62,6 +62,10 @@
       "troubleSigningIn": "¿Problemas para iniciar sesión?",
       "discord": "Únete a Discord"
     },
+    "splitScreenNotice": {
+      "title": "¿El inicio de sesión no responde?",
+      "body": "En algunos teléfonos Android recientes la pantalla de inicio de sesión puede congelarse. Abre la vista de pantalla dividida para iniciar sesión mientras lo solucionamos."
+    },
     "a11y": {
       "showPassword": "Mostrar contraseña",
       "hidePassword": "Ocultar contraseña"

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -62,6 +62,10 @@
       "troubleSigningIn": "Problème de connexion ?",
       "discord": "Rejoindre Discord"
     },
+    "splitScreenNotice": {
+      "title": "La connexion ne répond pas ?",
+      "body": "Sur certains téléphones Android récents, l'écran de connexion peut se figer. Ouvrez le mode écran partagé pour vous connecter le temps que nous corrigions le problème."
+    },
     "a11y": {
       "showPassword": "Afficher le mot de passe",
       "hidePassword": "Masquer le mot de passe"


### PR DESCRIPTION
## Summary

Follow-up to #3158. Removing the gorhom feedback sheet did **not** fix the login freeze — the test user reports the rest of the app now works full screen (after today's edge-to-edge fixes) but the **sign-in screen is still touch-dead in full screen; split-screen restores touch** on Galaxy S24/S25 and Pixel 9a/10.

Until the login-specific freeze is root-caused, this surfaces an on-screen advisory telling a stuck user to switch to split-screen to sign in.

- Warning banner at the top of the login screen with the split-screen instruction.
- **Gated to Android API ≥ 35** (Android 15+, edge-to-edge) so iOS and older Android — which are unaffected — never see it.
- i18n: new `login.splitScreenNotice.{title,body}` across `en-US` / `es` / `fr`.

JS-only (no native change), so the **fingerprint is unchanged** and it ships over OTA to existing installs.

## Shipping note (Play Store)
Because the fingerprint is unchanged, `android-apk-rn.yml`'s gate will **skip** the native build on merge (a binary with this fingerprint already shipped; OTA covers existing installs). To get a fresh **Play AAB with the banner baked in and the same fingerprint**, the Android APK workflow must be **manually dispatched** on `main` after merge (`workflow_dispatch` forces `should_build=true`; `EXPO_UPDATES_FINGERPRINT_OVERRIDE` keeps the fingerprint identical, so OTA lineage is preserved and versionCode auto-increments for Play).

## Release Notes

- Android: if the sign-in screen won't respond to taps on a newer phone, the login screen now shows how to sign in using split-screen while we fix the freeze.

## Test plan

- `vp check` — clean.
- `vp run typecheck:mobile` — pass.
- `vp run test:mobile` — 347 files / 2577 tests pass.
- `catalog-completeness` i18n parity — 28 tests pass.
- Banner renders only on Android 15+ (gated on `Platform.OS === 'android' && Platform.Version >= 35`); not on iOS / older Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)