### PR TITLE
fix(db): tolerate -- separator in dedupe CLIs and fix usage docs

### DIFF
--- a/packages/db/scripts/dedupe-beta-links-args.test.ts
+++ b/packages/db/scripts/dedupe-beta-links-args.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from './dedupe-beta-links.js';
+
+// `vp run db:dedupe-beta-links -- --apply` forwards the `--` separator to the
+// script verbatim (it is not stripped by vp), so the parser must skip it rather
+// than reject it as an unknown argument. Both invocation styles must work.
+
+test('a leading `--` separator is skipped, not treated as an unknown argument', () => {
+  const parsed = parseArgs(['--', '--apply']);
+  assert.equal(parsed.apply, true);
+});
+
+test('flags resolve the same with or without the `--` separator', () => {
+  const withSeparator = parseArgs(['--', '--board', 'kilter', '--limit', '20']);
+  const withoutSeparator = parseArgs(['--board', 'kilter', '--limit', '20']);
+  assert.deepEqual(withSeparator, withoutSeparator);
+  assert.equal(withSeparator.board, 'kilter');
+  assert.equal(withSeparator.limit, 20);
+});
+
+test('no args is a dry-run (apply stays false)', () => {
+  const parsed = parseArgs([]);
+  assert.equal(parsed.apply, false);
+  assert.equal(parsed.board, null);
+  assert.equal(parsed.limit, null);
+});

--- a/packages/db/scripts/dedupe-beta-links.ts
+++ b/packages/db/scripts/dedupe-beta-links.ts
@@ -17,8 +17,11 @@
  *
  * Usage:
  *   vp run db:dedupe-beta-links
- *   vp run db:dedupe-beta-links -- --board kilter --limit 20
- *   vp run db:dedupe-beta-links -- --apply
+ *   vp run db:dedupe-beta-links --board kilter --limit 20
+ *   vp run db:dedupe-beta-links --apply
+ *
+ * (A `--` separator before the flags also works — `vp` forwards it to the script
+ * verbatim and parseArgs skips it — but it isn't needed.)
  */
 import { and, eq, sql } from 'drizzle-orm';
 import { pathToFileURL } from 'node:url';
@@ -30,6 +33,7 @@ const APPLY_FLAG = '--apply';
 const BOARD_FLAG = '--board';
 const LIMIT_FLAG = '--limit';
 const HELP_FLAG = '--help';
+const ARG_SEPARATOR = '--';
 
 type ScriptArgs = {
   apply: boolean;
@@ -47,10 +51,16 @@ function readRequiredOptionValue(args: string[], optionIndex: number, flagName: 
   return optionValue;
 }
 
-function parseArgs(args: string[]): ScriptArgs {
+export function parseArgs(args: string[]): ScriptArgs {
   const parsed: ScriptArgs = { apply: false, board: null, limit: null, help: false };
   for (let index = 0; index < args.length; index++) {
     const current = args[index];
+    if (current === ARG_SEPARATOR) {
+      // `vp run db:dedupe-beta-links -- --apply` forwards the `--` separator to
+      // the script verbatim, so tolerate (skip) it rather than rejecting it as
+      // an unknown argument. Both `-- --apply` and `--apply` then work.
+      continue;
+    }
     if (current === APPLY_FLAG) {
       parsed.apply = true;
       continue;
@@ -83,8 +93,8 @@ function parseArgs(args: string[]): ScriptArgs {
 function printHelp(): void {
   console.info(`Usage:
   vp run db:dedupe-beta-links
-  vp run db:dedupe-beta-links -- --board kilter --limit 20
-  vp run db:dedupe-beta-links -- --apply
+  vp run db:dedupe-beta-links --board kilter --limit 20
+  vp run db:dedupe-beta-links --apply
 
 Options:
   --apply           Delete the redundant rows. Omit for a dry-run report.

--- a/packages/db/scripts/dedupe-gym-locations-args.test.ts
+++ b/packages/db/scripts/dedupe-gym-locations-args.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from './dedupe-gym-locations.js';
+
+// `vp run db:dedupe-gyms -- --apply` forwards the `--` separator to the script
+// verbatim (it is not stripped by vp), so the parser must skip it rather than
+// reject it as an unknown argument. Both invocation styles must work.
+
+test('a leading `--` separator is skipped, not treated as an unknown argument', () => {
+  const parsed = parseArgs(['--', '--apply']);
+  assert.equal(parsed.apply, true);
+});
+
+test('flags resolve the same with or without the `--` separator', () => {
+  const withSeparator = parseArgs(['--', '--only-name', 'Sandbox Bouldering', '--limit', '10']);
+  const withoutSeparator = parseArgs(['--only-name', 'Sandbox Bouldering', '--limit', '10']);
+  assert.deepEqual(withSeparator, withoutSeparator);
+  assert.equal(withSeparator.onlyName, 'Sandbox Bouldering');
+  assert.equal(withSeparator.limit, 10);
+});
+
+test('no args is a dry-run (apply stays false)', () => {
+  const parsed = parseArgs([]);
+  assert.equal(parsed.apply, false);
+  assert.equal(parsed.limit, null);
+  assert.equal(parsed.onlyName, null);
+});

--- a/packages/db/scripts/dedupe-gym-locations.ts
+++ b/packages/db/scripts/dedupe-gym-locations.ts
@@ -6,8 +6,11 @@
  *
  * Usage:
  *   vp run db:dedupe-gyms
- *   vp run db:dedupe-gyms -- --only-name "Sandbox Bouldering"
- *   vp run db:dedupe-gyms -- --apply --limit 10
+ *   vp run db:dedupe-gyms --only-name "Sandbox Bouldering"
+ *   vp run db:dedupe-gyms --apply --limit 10
+ *
+ * (A `--` separator before the flags also works — `vp` forwards it to the script
+ * verbatim and parseArgs skips it — but it isn't needed.)
  */
 
 import { sql, type SQLWrapper } from 'drizzle-orm';
@@ -29,6 +32,7 @@ const APPLY_FLAG = '--apply';
 const LIMIT_FLAG = '--limit';
 const ONLY_NAME_FLAG = '--only-name';
 const HELP_FLAG = '--help';
+const ARG_SEPARATOR = '--';
 
 type ExecuteDb = {
   execute(query: SQLWrapper | string): PromiseLike<unknown>;
@@ -101,6 +105,12 @@ function parseArgs(args: string[]): ScriptArgs {
 
   for (let index = 0; index < args.length; index++) {
     const currentArg = args[index];
+    if (currentArg === ARG_SEPARATOR) {
+      // `vp run db:dedupe-gyms -- --apply` forwards the `--` separator to the
+      // script verbatim, so tolerate (skip) it rather than rejecting it as an
+      // unknown argument. Both `-- --apply` and `--apply` then work.
+      continue;
+    }
     if (currentArg === APPLY_FLAG) {
       parsedArgs.apply = true;
       continue;
@@ -130,8 +140,8 @@ function parseArgs(args: string[]): ScriptArgs {
 function printHelp(): void {
   console.info(`Usage:
   vp run db:dedupe-gyms
-  vp run db:dedupe-gyms -- --only-name "Sandbox Bouldering"
-  vp run db:dedupe-gyms -- --apply --limit 10
+  vp run db:dedupe-gyms --only-name "Sandbox Bouldering"
+  vp run db:dedupe-gyms --apply --limit 10
 
 Options:
   --apply              Merge candidates. Omit for dry-run.

--- a/packages/db/scripts/dedupe-gym-locations.ts
+++ b/packages/db/scripts/dedupe-gym-locations.ts
@@ -95,7 +95,7 @@ function readRequiredOptionValue(args: string[], optionIndex: number, flagName: 
   return optionValue;
 }
 
-function parseArgs(args: string[]): ScriptArgs {
+export function parseArgs(args: string[]): ScriptArgs {
   const parsedArgs: ScriptArgs = {
     apply: false,
     limit: null,


### PR DESCRIPTION
## Summary

Follow-up to #3142. While running the new beta-link dedupe command against prod I hit a footgun: the documented invocation never worked.

`vp run db:dedupe-beta-links -- --apply` (the form printed in the docstring, `--help`, and the PR description) forwards the `--` separator to the script **verbatim** — `vp` does not strip it. `parseArgs` then hit `--` first and bailed with `Unknown argument: --` (exit 2) before ever seeing `--apply`, so the command was a **silent no-op**. The actual apply only ran once I dropped the separator (`vp run db:dedupe-beta-links --apply`).

`db:dedupe-gyms` is copy-pasted from the same template and had the identical bug and the same wrong docs.

## Fix

- Skip a standalone `--` token in both parsers, so `-- --apply` (npm/bun muscle memory) **and** `--apply` both work.
- Correct the usage comment + `--help` text in both scripts to the no-separator form, with a note that the separator is tolerated but unnecessary.
- Add `parseArgs` unit coverage for the beta-links CLI (separator skipped; flags resolve identically with/without it; no-args is a dry-run).

No behaviour change to the dedupe logic itself — only argument parsing and docs.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `bunx tsx --test packages/db/scripts/dedupe-beta-links-args.test.ts` — 3/3 pass.
- `bunx tsx --test packages/db/scripts/dedupe-beta-links-helpers.test.ts` — 7/7 pass (unchanged).
- `vp run typecheck:db` — clean.
- `vp check` on the changed files — 0 errors.
- Manually verified `vp run db:dedupe-beta-links -- --help` and `vp run db:dedupe-gyms -- --help` now print help instead of `Unknown argument: --`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)