### PR TITLE
perf(mobile): split BoardProvider context so logbook merges don't re-render all consumers

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -38,11 +38,17 @@ an automated gate.
 
 **Examples in this repo:**
 
-- `packages/shared/board-react/src/board-provider.tsx` — the `value` is `useMemo`'d over
-  `[boardName, isAuthenticated, …, logbook, logbookByClimbAngle, getLogbook, saveTick, …]`. The
-  mutation callbacks (`saveTick`/`saveClimb`/`updateClimb`) are kept stable via the
-  ref-updated-in-`useEffect` + empty-dep-`useCallback` pattern (lines 90–116), so a React Query
-  `mutateAsync` reference change does not churn the context.
+- `packages/shared/board-react/src/board-provider.tsx` — splits into **three** contexts (#3152):
+  `BoardActionsContext` (the **stable** half — identity, auth/init flags, `getLogbook`/`saveTick`/
+  `saveClimb`/`updateClimb`; its `useMemo` deps deliberately exclude the logbook, so a merge never
+  changes its identity), `BoardLogbookContext` (the **volatile** `logbook` + `logbookByClimbAngle`
+  index, read only by the per-row `useAscentStatus` and the tick forms), and the full back-compat
+  `BoardContext` (`{ ...actionsValue, ...logbookValue }`) that web still consumes via
+  `useBoardProvider()`. A callback-only consumer (`climbs/index.tsx` reading just `getLogbook`,
+  the create-climb screen reading the mutations) subscribes via `useBoardActions()` and skips the
+  per-merge re-render entirely. The mutation callbacks stay stable via the
+  ref-updated-in-`useEffect` + empty-dep-`useCallback` pattern, so a React Query `mutateAsync`
+  reference change does not churn the context either.
 - `packages/mobile/src/providers/queue-provider.tsx` — splits into **two** contexts:
   `QueueContext` (full state + actions) and `QueueSessionControlContext` (just the wall-control
   state + callbacks). A component that only drives take/release control subscribes to the smaller

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -108,7 +108,7 @@ vi.mock('@boardsesh/climb-filters', () => ({
 }));
 
 vi.mock('@boardsesh/board-react', () => ({
-  useBoardProvider: () => ({ getLogbook: mocks.getLogbook }),
+  useBoardActions: () => ({ getLogbook: mocks.getLogbook }),
 }));
 
 vi.mock('../../../../src/components/ClimbListRow', () => ({

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -30,7 +30,7 @@ import { useTheme } from '../../../src/providers/theme-provider';
 import { selectByVariant } from '../../../src/theme/variants';
 import { useActiveClimbUuid, useQueueActions } from '../../../src/providers/queue-provider';
 import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
-import { useBoardProvider } from '@boardsesh/board-react';
+import { useBoardActions } from '@boardsesh/board-react';
 import { randomUUID } from 'expo-crypto';
 import { type SearchHeaderHandle } from '../../../src/components/SearchHeader';
 import { RecentFilterPills } from '../../../src/components/RecentFilterPills';
@@ -162,7 +162,7 @@ function ClimbListInner() {
     patchFilters,
     patchBoardFilters,
   } = useClimbSearch();
-  const { getLogbook } = useBoardProvider();
+  const { getLogbook } = useBoardActions();
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
   const nativeSearchRef = useRef<NativeSearchBarRef>(null);
   const visibleSearchTextRef = useRef('');
@@ -559,9 +559,19 @@ function ClimbListInner() {
   // can render flash/send/attempt without baking per-user counts into the
   // (CDN-cacheable) search query. `getLogbook` is a noop when the user is
   // anonymous or the active board hasn't resolved yet.
+  //
+  // Deferred past the active fling via `runAfterInteractions`: the resulting
+  // logbook merge re-renders every visible ascent-status glyph, so letting it
+  // land after the scroll settles (instead of mid-fling) keeps those per-row
+  // re-renders off the gesture's frames. `getLogbook`'s fetched-uuid dedupe
+  // makes the call idempotent, and cancelling on cleanup stops a fast re-fling
+  // from stacking stale fetches.
   useEffect(() => {
     if (visibleClimbs.length === 0) return;
-    void getLogbook(visibleClimbs.map((climb) => climb.uuid));
+    const handle = InteractionManager.runAfterInteractions(() => {
+      void getLogbook(visibleClimbs.map((climb) => climb.uuid));
+    });
+    return () => handle.cancel();
   }, [visibleClimbs, getLogbook]);
 
   const handleRefresh = useCallback(() => {

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -563,9 +563,10 @@ function ClimbListInner() {
   // Deferred past the active fling via `runAfterInteractions`: the resulting
   // logbook merge re-renders every visible ascent-status glyph, so letting it
   // land after the scroll settles (instead of mid-fling) keeps those per-row
-  // re-renders off the gesture's frames. `getLogbook`'s fetched-uuid dedupe
-  // makes the call idempotent, and cancelling on cleanup stops a fast re-fling
-  // from stacking stale fetches.
+  // re-renders off the gesture's frames. The cleanup cancels a still-pending
+  // callback when `visibleClimbs` changes again or the screen unmounts, so a
+  // superseded snapshot never fires its `getLogbook`. (Network-level dedupe is
+  // separate: `useLogbook`'s fetched-uuid set skips uuids already pulled.)
   useEffect(() => {
     if (visibleClimbs.length === 0) return;
     const handle = InteractionManager.runAfterInteractions(() => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -69,7 +69,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
 }));
 
 vi.mock('@boardsesh/board-react', () => ({
-  useBoardProvider: () => ({
+  useBoardActions: () => ({
     isAuthenticated: board.isAuthenticated,
     saveClimb: board.saveClimb,
     updateClimb: board.updateClimb,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -63,7 +63,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
   buildInitialHoldsMap: () => ({}),
 }));
 vi.mock('@boardsesh/board-react', () => ({
-  useBoardProvider: () => ({
+  useBoardActions: () => ({
     isAuthenticated: true,
     saveClimb: vi.fn(),
     updateClimb: vi.fn(),

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -64,7 +64,7 @@ vi.mock('@boardsesh/create-climb-react', () => ({
 }));
 
 vi.mock('@boardsesh/board-react', () => ({
-  useBoardProvider: () => ({
+  useBoardActions: () => ({
     isAuthenticated: board.isAuthenticated,
     saveClimb: board.saveClimb,
     updateClimb: board.updateClimb,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -13,7 +13,7 @@ import {
   buildInitialHoldsMap,
   type SavedClimbSnapshot,
 } from '@boardsesh/create-climb-react';
-import { useBoardProvider, isDuplicateClimbError } from '@boardsesh/board-react';
+import { useBoardActions, isDuplicateClimbError } from '@boardsesh/board-react';
 import { GraphQLOperationError } from '@boardsesh/graphql-client';
 import { getLayoutName } from '@boardsesh/board-constants/product-sizes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -95,7 +95,7 @@ export function useCreateClimbScreen({
 }: UseCreateClimbScreenArgs) {
   const router = useRouter();
   const { t } = useTranslation('climbs');
-  const { isAuthenticated, saveClimb, updateClimb } = useBoardProvider();
+  const { isAuthenticated, saveClimb, updateClimb } = useBoardActions();
   const auth = useAuth();
   const { data: profile } = useProfile();
   const { setCurrentClimb } = useQueueActions();

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -21,7 +21,12 @@ import { InlineTriesPicker } from './InlineTriesPicker';
 import { GradeSingleSelectRail } from '../grade';
 import { useTheme } from '../../providers/theme-provider';
 import { useGrades } from '../../lib/graphql/hooks';
-import { useOptionalBoardProvider, useSaveTick, logbookClimbAngleKey } from '@boardsesh/board-react';
+import {
+  useOptionalBoardActions,
+  useOptionalBoardLogbook,
+  useSaveTick,
+  logbookClimbAngleKey,
+} from '@boardsesh/board-react';
 import { toBoardName } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useToast } from '../../providers/toast-provider';
@@ -93,15 +98,17 @@ export const QuickTickBar = React.memo(function QuickTickBar({
   // the raw `logbook` array — otherwise every logbook merge while this
   // sheet is open (own tick saves, list paging, peer ticks in a session)
   // re-runs an O(logbook) scan. Same index `useAscentStatus` reads.
-  const board = useOptionalBoardProvider();
+  const boardActions = useOptionalBoardActions();
+  const boardLogbook = useOptionalBoardLogbook();
   useEffect(() => {
-    if (!board) return;
-    void board.getLogbook([climbUuid]);
-  }, [board, climbUuid]);
+    if (!boardActions) return;
+    void boardActions.getLogbook([climbUuid]);
+  }, [boardActions, climbUuid]);
   const hasPriorHistory = useMemo(() => {
-    if (!board) return true;
-    return (board.logbookByClimbAngle.get(logbookClimbAngleKey(climbUuid, angle))?.length ?? 0) > 0;
-  }, [board, climbUuid, angle]);
+    // No provider → assume history so the label stays `Send` (failure mode 1).
+    if (!boardLogbook) return true;
+    return (boardLogbook.logbookByClimbAngle.get(logbookClimbAngleKey(climbUuid, angle))?.length ?? 0) > 0;
+  }, [boardLogbook, climbUuid, angle]);
 
   const [tickState, setTickState] = useState(createInitialTickState);
   const [comment, setComment] = useState('');

--- a/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/quick-tick-bar.test.tsx
@@ -56,9 +56,13 @@ vi.mock('../../../theme/tokens', () => ({ spacing: new Proxy({}, { get: () => 0 
 // plus a populated `logbookByClimbAngle` Map (the correct O(1) index).
 vi.mock('@boardsesh/board-react', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@boardsesh/board-react')>();
+  // QuickTickBar reads `getLogbook` from the stable actions context and the
+  // `logbookByClimbAngle` index from the volatile logbook context. The fixture
+  // object carries both fields, so both hooks resolve to it.
   return {
     ...actual,
-    useOptionalBoardProvider: () => boardState.current,
+    useOptionalBoardActions: () => boardState.current,
+    useOptionalBoardLogbook: () => boardState.current,
     useSaveTick: () => ({ mutate: vi.fn(), isPending: false }),
   };
 });

--- a/packages/mobile/src/components/queue-control/__tests__/log-ascent-fab.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/log-ascent-fab.test.tsx
@@ -27,7 +27,13 @@ vi.mock('react-native-reanimated', () => ({
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-vi.mock('@boardsesh/board-react', () => ({ useOptionalBoardProvider: () => boardProvider.value }));
+// useLogAscentAction reads `logbook` from the volatile logbook context and
+// `getLogbook` from the stable actions context. The fixture carries both, so
+// both hooks resolve to it (and both are null together when there's no provider).
+vi.mock('@boardsesh/board-react', () => ({
+  useOptionalBoardLogbook: () => boardProvider.value,
+  useOptionalBoardActions: () => boardProvider.value,
+}));
 
 // GlassIconButton → button exposing the wiring + the colour signals under test.
 type GlassIconButtonMockProps = {

--- a/packages/mobile/src/components/queue-control/use-log-ascent-action.ts
+++ b/packages/mobile/src/components/queue-control/use-log-ascent-action.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAnimatedStyle, useSharedValue, withSequence, withSpring } from 'react-native-reanimated';
 import type { Climb } from '@boardsesh/queue';
-import { useOptionalBoardProvider } from '@boardsesh/board-react';
+import { useOptionalBoardActions, useOptionalBoardLogbook } from '@boardsesh/board-react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../providers/theme-provider';
 import { useQueueSessionId } from '../../providers/queue-provider';
@@ -16,7 +16,8 @@ export function useLogAscentAction(climb: Climb) {
   const { systemColors, brandColors } = useTheme();
   const { boardConfig, openLogAscent } = useDrawerHost();
   const { sessionId } = useQueueSessionId();
-  const board = useOptionalBoardProvider();
+  const boardLogbook = useOptionalBoardLogbook();
+  const boardActions = useOptionalBoardActions();
   const reduceMotion = useReduceMotion();
 
   const angle = climb.angle;
@@ -26,8 +27,8 @@ export function useLogAscentAction(climb: Climb) {
   // selector the climb-row status glyph uses, so the toolbar and the list
   // marker agree.
   const sentCount = useMemo(
-    () => (board ? countSentAscents(board.logbook, climb.uuid, angle) : 0),
-    [board, climb.uuid, angle],
+    () => (boardLogbook ? countSentAscents(boardLogbook.logbook, climb.uuid, angle) : 0),
+    [boardLogbook, climb.uuid, angle],
   );
   const isLogged = sentCount > 0;
 
@@ -35,8 +36,8 @@ export function useLogAscentAction(climb: Climb) {
   // the visible list rows the screen already fetched, so the ticked-state is
   // accurate on every tab.
   useEffect(() => {
-    if (board && climb.uuid) void board.getLogbook([climb.uuid]);
-  }, [board, climb.uuid]);
+    if (boardActions && climb.uuid) void boardActions.getLogbook([climb.uuid]);
+  }, [boardActions, climb.uuid]);
 
   // Success burst: pop once when a fresh send/flash lands for the climb the user
   // just ticked. `pendingRef` (armed on press) gates out the false positive of

--- a/packages/mobile/src/hooks/__tests__/use-ascent-status.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-ascent-status.test.tsx
@@ -14,7 +14,7 @@ type Entry = {
 const ctrl = vi.hoisted(() => ({ board: null as { logbookByClimbAngle: Map<string, Entry[]> } | null }));
 
 vi.mock('@boardsesh/board-react', () => ({
-  useOptionalBoardProvider: () => ctrl.board,
+  useOptionalBoardLogbook: () => ctrl.board,
   logbookClimbAngleKey: (climbUuid: string, angle: number) => `${climbUuid}:${angle}`,
 }));
 // Stub the pure utils so the test exercises the hook's filtering/delegation, not

--- a/packages/mobile/src/hooks/use-ascent-status.ts
+++ b/packages/mobile/src/hooks/use-ascent-status.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { logbookClimbAngleKey, useOptionalBoardProvider } from '@boardsesh/board-react';
+import { logbookClimbAngleKey, useOptionalBoardLogbook } from '@boardsesh/board-react';
 import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from '../lib/ascent-status-utils';
 
 /**
@@ -14,8 +14,8 @@ import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue 
  * `logbook.filter(...)` made the climbs list O(rows × logbook) on every merge.
  */
 export function useAscentStatus(climbUuid: string, angle: number, isMirror?: boolean): AscentStatusValue | null {
-  const board = useOptionalBoardProvider();
-  const entries = board?.logbookByClimbAngle.get(logbookClimbAngleKey(climbUuid, angle));
+  const logbook = useOptionalBoardLogbook();
+  const entries = logbook?.logbookByClimbAngle.get(logbookClimbAngleKey(climbUuid, angle));
   return useMemo<AscentStatusValue | null>(() => {
     if (!entries || entries.length === 0) return null;
     const matching = isMirror === undefined ? entries : entries.filter((entry) => entry.is_mirror === isMirror);

--- a/packages/shared/board-react/src/__tests__/board-provider.test.tsx
+++ b/packages/shared/board-react/src/__tests__/board-provider.test.tsx
@@ -3,7 +3,16 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { BoardAdapterProvider, type BoardAdapter, type ExecuteHttp } from '../adapter';
-import { BoardProvider, useBoardProvider, useOptionalBoardProvider } from '../board-provider';
+import {
+  BoardProvider,
+  useBoardProvider,
+  useOptionalBoardProvider,
+  useBoardActions,
+  useOptionalBoardActions,
+  useBoardLogbook,
+  useOptionalBoardLogbook,
+} from '../board-provider';
+import { logbookClimbAngleKey } from '../logbook-keys';
 import { createTestQueryClient } from './test-helpers';
 
 function buildWrapper(adapter: Partial<BoardAdapter>, boardName: 'kilter' | 'tension' | null = 'kilter') {
@@ -144,5 +153,85 @@ describe('useOptionalBoardProvider (shared)', () => {
   it('returns null when called outside a BoardProvider', () => {
     const { result } = renderHook(() => useOptionalBoardProvider());
     expect(result.current).toBeNull();
+  });
+});
+
+describe('BoardProvider context split (actions vs logbook)', () => {
+  function tickResponse() {
+    return {
+      ticks: [
+        {
+          uuid: 'tick-1',
+          climbUuid: 'c-1',
+          angle: 40,
+          isMirror: false,
+          status: 'send' as const,
+          attemptCount: 1,
+          quality: null,
+          difficulty: null,
+          comment: '',
+          climbedAt: '2026-05-30T00:00:00.000Z',
+          upvotes: 0,
+          downvotes: 0,
+          commentCount: 0,
+        },
+      ],
+    };
+  }
+
+  it('exposes identity + callbacks on the actions context and the logbook on the logbook context', async () => {
+    const { wrapper } = buildWrapper({ isAuthenticated: true }, 'tension');
+    const { result } = renderHook(() => ({ actions: useBoardActions(), logbook: useBoardLogbook() }), { wrapper });
+    await waitFor(() => expect(result.current.actions.isInitialized).toBe(true));
+
+    expect(result.current.actions.boardName).toBe('tension');
+    expect(typeof result.current.actions.getLogbook).toBe('function');
+    expect(typeof result.current.actions.saveTick).toBe('function');
+    // The actions slice carries identity + callbacks but NOT the logbook fields.
+    expect(Object.prototype.hasOwnProperty.call(result.current.actions, 'logbook')).toBe(false);
+    expect(result.current.logbook.logbook).toEqual([]);
+    expect(result.current.logbook.logbookByClimbAngle.size).toBe(0);
+  });
+
+  it('keeps the actions context identity stable across a logbook merge while the logbook context identity changes', async () => {
+    const executeHttp = vi.fn().mockResolvedValue(tickResponse());
+    const { wrapper } = buildWrapper({
+      isAuthenticated: true,
+      executeHttp: executeHttp as unknown as ExecuteHttp,
+    });
+    const { result } = renderHook(() => ({ actions: useBoardActions(), logbook: useBoardLogbook() }), { wrapper });
+    await waitFor(() => expect(result.current.actions.isInitialized).toBe(true));
+
+    const actionsBefore = result.current.actions;
+    const logbookBefore = result.current.logbook;
+    expect(logbookBefore.logbook).toEqual([]);
+
+    await act(async () => {
+      await result.current.actions.getLogbook(['c-1']);
+    });
+    await waitFor(() => expect(result.current.logbook.logbook.length).toBe(1));
+
+    // The volatile slice gets a fresh identity; the stable slice does NOT —
+    // that identity stability is exactly what stops callback-only consumers
+    // re-rendering on every logbook merge.
+    expect(result.current.logbook).not.toBe(logbookBefore);
+    expect(result.current.actions).toBe(actionsBefore);
+    expect(result.current.logbook.logbookByClimbAngle.get(logbookClimbAngleKey('c-1', 40))?.length).toBe(1);
+  });
+});
+
+describe('useBoardActions / useBoardLogbook (shared)', () => {
+  it('throw when called outside a BoardProvider', () => {
+    expect(() => renderHook(() => useBoardActions())).toThrowError(
+      /useBoardActions must be used within a BoardProvider/,
+    );
+    expect(() => renderHook(() => useBoardLogbook())).toThrowError(
+      /useBoardLogbook must be used within a BoardProvider/,
+    );
+  });
+
+  it('optional variants return null outside a BoardProvider', () => {
+    expect(renderHook(() => useOptionalBoardActions()).result.current).toBeNull();
+    expect(renderHook(() => useOptionalBoardLogbook()).result.current).toBeNull();
   });
 });

--- a/packages/shared/board-react/src/board-provider.tsx
+++ b/packages/shared/board-react/src/board-provider.tsx
@@ -249,4 +249,7 @@ export function useOptionalBoardLogbook(): BoardLogbookContextType | null {
   return useContext(BoardLogbookContext) ?? null;
 }
 
-export { BoardContext, BoardActionsContext, BoardLogbookContext };
+// Only the full `BoardContext` is exported (web reads it directly). The split
+// contexts stay module-private so consumers go through the guarded hooks above
+// rather than a raw `useContext` that skips the within-provider invariant.
+export { BoardContext };

--- a/packages/shared/board-react/src/board-provider.tsx
+++ b/packages/shared/board-react/src/board-provider.tsx
@@ -46,7 +46,29 @@ export type BoardContextType = {
   updateClimb: (input: UpdateClimbInput) => Promise<UpdateClimbResponse>;
 };
 
+/**
+ * The stable half of the board context: identity, auth/init flags, and the
+ * callbacks. Excludes `logbook`/`logbookByClimbAngle`, so its value identity
+ * does NOT change when the logbook merges — a consumer that only needs
+ * `getLogbook`/`saveTick`/`saveClimb`/`updateClimb` (or `boardName`/auth) reads
+ * this via `useBoardActions()` and skips the per-merge re-render cascade.
+ */
+export type BoardActionsContextType = Omit<BoardContextType, 'logbook' | 'logbookByClimbAngle'>;
+
+/**
+ * The volatile half: the logbook and its prebuilt `${climb_uuid}:${angle}`
+ * index. Identity changes on every logbook merge, so only the per-row
+ * ascent-status reader (`useAscentStatus`) and the tick forms subscribe to it
+ * via `useBoardLogbook()` — they SHOULD re-render when ticks change.
+ */
+export type BoardLogbookContextType = Pick<BoardContextType, 'logbook' | 'logbookByClimbAngle'>;
+
+// Full context kept for back-compat: web and any consumer wanting everything
+// still use `useBoardProvider()`. Its value still changes on a logbook merge
+// (it contains the logbook), which is fine for those consumers.
 const BoardContext = createContext<BoardContextType | undefined>(undefined);
+const BoardActionsContext = createContext<BoardActionsContextType | undefined>(undefined);
+const BoardLogbookContext = createContext<BoardLogbookContextType | undefined>(undefined);
 
 export function BoardProvider({
   boardName,
@@ -144,7 +166,10 @@ export function BoardProvider({
     return updateClimbMutateRef.current(input);
   }, []);
 
-  const value = useMemo<BoardContextType>(
+  // Stable slice: NO logbook deps, so its identity holds steady across logbook
+  // merges. Consumers reading only callbacks/identity (via `useBoardActions`)
+  // don't re-render when the user scrolls and ticks merge in mid-fling.
+  const actionsValue = useMemo<BoardActionsContextType>(
     () => ({
       boardName,
       boardUuid: boardUuid ?? null,
@@ -152,29 +177,32 @@ export function BoardProvider({
       isLoading: isAuthLoading,
       error: null,
       isInitialized,
-      logbook,
-      logbookByClimbAngle,
       getLogbook,
       saveTick,
       saveClimb,
       updateClimb,
     }),
-    [
-      boardName,
-      boardUuid,
-      isAuthenticated,
-      isAuthLoading,
-      isInitialized,
-      logbook,
-      logbookByClimbAngle,
-      getLogbook,
-      saveTick,
-      saveClimb,
-      updateClimb,
-    ],
+    [boardName, boardUuid, isAuthenticated, isAuthLoading, isInitialized, getLogbook, saveTick, saveClimb, updateClimb],
   );
 
-  return <BoardContext.Provider value={value}>{children}</BoardContext.Provider>;
+  // Volatile slice: changes on every merge. Only the ascent-status reader and
+  // tick forms subscribe to it.
+  const logbookValue = useMemo<BoardLogbookContextType>(
+    () => ({ logbook, logbookByClimbAngle }),
+    [logbook, logbookByClimbAngle],
+  );
+
+  // Full value derived from the two slices so back-compat `useBoardProvider()`
+  // consumers keep seeing every field (and the latest logbook).
+  const value = useMemo<BoardContextType>(() => ({ ...actionsValue, ...logbookValue }), [actionsValue, logbookValue]);
+
+  return (
+    <BoardContext.Provider value={value}>
+      <BoardActionsContext.Provider value={actionsValue}>
+        <BoardLogbookContext.Provider value={logbookValue}>{children}</BoardLogbookContext.Provider>
+      </BoardActionsContext.Provider>
+    </BoardContext.Provider>
+  );
 }
 
 export function useBoardProvider(): BoardContextType {
@@ -189,4 +217,36 @@ export function useOptionalBoardProvider(): BoardContextType | null {
   return useContext(BoardContext) ?? null;
 }
 
-export { BoardContext };
+/**
+ * Stable board context: identity, auth/init flags, and callbacks — never the
+ * logbook. Prefer this over `useBoardProvider()` whenever a component reads only
+ * callbacks/identity, so a logbook merge doesn't re-render it.
+ */
+export function useBoardActions(): BoardActionsContextType {
+  const context = useContext(BoardActionsContext);
+  if (context === undefined) {
+    throw new Error('useBoardActions must be used within a BoardProvider');
+  }
+  return context;
+}
+
+export function useOptionalBoardActions(): BoardActionsContextType | null {
+  return useContext(BoardActionsContext) ?? null;
+}
+
+/** Volatile logbook context — `logbook` + the `logbookByClimbAngle` index.
+ *  Subscribing here re-renders on every logbook merge; only read it where that
+ *  is the intent (per-row ascent status, tick forms). */
+export function useBoardLogbook(): BoardLogbookContextType {
+  const context = useContext(BoardLogbookContext);
+  if (context === undefined) {
+    throw new Error('useBoardLogbook must be used within a BoardProvider');
+  }
+  return context;
+}
+
+export function useOptionalBoardLogbook(): BoardLogbookContextType | null {
+  return useContext(BoardLogbookContext) ?? null;
+}
+
+export { BoardContext, BoardActionsContext, BoardLogbookContext };

--- a/packages/shared/board-react/src/index.ts
+++ b/packages/shared/board-react/src/index.ts
@@ -30,5 +30,16 @@ export { useSaveTick } from './use-save-tick';
 export { useUpdateTick, useDeleteTick } from './use-mutate-tick';
 export { useSaveClimb, useUpdateClimb } from './use-save-climb';
 
-export { BoardProvider, useBoardProvider, useOptionalBoardProvider, BoardContext } from './board-provider';
-export type { BoardContextType } from './board-provider';
+export {
+  BoardProvider,
+  useBoardProvider,
+  useOptionalBoardProvider,
+  useBoardActions,
+  useOptionalBoardActions,
+  useBoardLogbook,
+  useOptionalBoardLogbook,
+  BoardContext,
+  BoardActionsContext,
+  BoardLogbookContext,
+} from './board-provider';
+export type { BoardContextType, BoardActionsContextType, BoardLogbookContextType } from './board-provider';

--- a/packages/shared/board-react/src/index.ts
+++ b/packages/shared/board-react/src/index.ts
@@ -39,7 +39,5 @@ export {
   useBoardLogbook,
   useOptionalBoardLogbook,
   BoardContext,
-  BoardActionsContext,
-  BoardLogbookContext,
 } from './board-provider';
 export type { BoardContextType, BoardActionsContextType, BoardLogbookContextType } from './board-provider';


### PR DESCRIPTION
> **Stacked on #3168** (`mobile/remove-gorhom-bottom-sheet`). This PR's base is that branch, so the diff above is only the context-split changes. Merge #3168 first; GitHub will retarget this PR to `main` automatically when #3168 lands.

## Summary

`BoardProvider` published one fat memoized context value that bundled the **volatile** `logbook` / `logbookByClimbAngle` together with the **stable** identity and callbacks. Because the logbook sits in that value's dep array, every logbook merge changed the value identity and re-rendered **every** `useBoardProvider()` consumer — even ones that read only `getLogbook`. On a Pixel 8 this was the biggest re-render cascade in the climbs-list scroll: the screen calls `getLogbook(visibleClimbs)` mid-fling → the merge replaces the logbook → the screen (which reads only `getLogbook`) re-renders itself.

Closes #3152.

### What changed

Split into two new contexts — the pattern `queue-provider.tsx` (8 contexts) and `board-presence-provider.tsx` (5 contexts) already follow:

- **`BoardActionsContext`** (stable): `boardName`, `boardUuid`, `isAuthenticated`, `isLoading`, `error`, `isInitialized`, `getLogbook`, `saveTick`, `saveClimb`, `updateClimb`. Its `useMemo` deps deliberately **exclude** the logbook, so its identity holds steady across a merge.
- **`BoardLogbookContext`** (volatile): `logbook` + the `logbookByClimbAngle` index.
- The full **`BoardContext`** is kept (derived as `{ ...actionsValue, ...logbookValue }`) so web and any back-compat consumer keep using `useBoardProvider()` unchanged. Web is left as-is — it isn't the profiled problem.

Mobile consumers move to the narrowest context:

| Consumer | Reads | Now uses |
|---|---|---|
| `climbs/index.tsx` | `getLogbook` | `useBoardActions()` — stops the mid-fling self re-render |
| `use-create-climb-screen.ts` | `isAuthenticated`, `saveClimb`, `updateClimb` | `useBoardActions()` |
| `use-ascent-status.ts` (per row) | `logbookByClimbAngle` | `useOptionalBoardLogbook()` — still updates when ticks change |
| `QuickTickBar.tsx` | `getLogbook` + `logbookByClimbAngle` | `useOptionalBoardActions()` + `useOptionalBoardLogbook()` |
| `use-log-ascent-action.ts` | `logbook` + `getLogbook` | `useOptionalBoardLogbook()` + `useOptionalBoardActions()` |

Also defers the mid-fling `getLogbook` in the climbs list via `InteractionManager.runAfterInteractions` (cancelled on cleanup) so the merge — and the per-row ascent-glyph re-renders it triggers — lands after the fling settles instead of during it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:shared`, `vp run typecheck:mobile`, `vp run typecheck:web` — clean.
- `vp run test:mobile` — 2577 passed. Shared board-react suite — 56 passed, including a new identity-stability test asserting the actions-context reference is `toBe` identical across a logbook merge while the logbook-context reference changes.
- `vp check` (changed files) — lint + format clean.
- `vp run check:mobile-bundle` — OK (12.3 MB).

### Acceptance (#3152)
- Stable-only consumers (`climbs/index.tsx`, create-climb) no longer re-render on logbook merges.
- `useAscentStatus` rows still flip to flash/send/attempt when their ticks change.
- Glyphs for newly-scrolled rows appear just after the fling settles (defer), not mid-fling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
