### PR TITLE
feat(backend): link Kilter accounts via username/password to migrate data

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -153,11 +153,29 @@ Next internal routes:
   per-board credentials. Non-Kilter boards use Aurora username/password login.
 - `GET /api/aurora-credentials/unsynced` returns pending local ticks/climbs
   that have not synced back to the upstream board account.
+- `POST /api/board-credentials/kilter/password` links a Kilter account from a
+  username + password via Keycloak's Resource-Owner-Password-Credentials (ROPC)
+  grant. This is the primary Kilter path: it rides the public `kilter` client and
+  needs no Kilter-registered redirect URI. The backend exchanges the credentials
+  for a refresh token, verifies the returned JWT (`sub` = Keycloak user id), and
+  hands it to the same `saveKilterCredential` the OAuth callback uses — the
+  password itself is never stored. Auth-gated, allowlist-gated, and per-user
+  rate-limited (5/min) so it can't be used as a credential-testing oracle.
 - `POST /api/board-credentials/kilter/handoff` creates a short-lived signed
   OAuth handoff, then `/board-credentials/kilter/start` and
   `/board-credentials/kilter/callback` return a completion token to the app.
+  This authorization-code flow is **dormant** — it needs Kilter to register a
+  redirect URI for us, which they have not. Kept for when they do.
 - `POST /api/board-credentials/kilter/finalize` verifies that completion token
   against the signed-in user and saves the Kilter account link.
+
+Both Kilter link paths are gated by `isKilterSyncAllowed` (the
+`KILTER_SYNC_ALLOWED_USER_IDS` env var: unset/empty disables everyone, `*` opens
+it to all signed-in users, or a comma-separated list restricts to those ids) and
+the `kilter-oauth-linking` PostHog flag on the client. The gate is enforced only
+at link time on the backend — the kilter-sync daemon syncs whatever lands in
+`aurora_credentials`, so the kill switch lives on the write path.
+
 - `POST /api/aurora-import` streams newline-delimited progress events while
   importing Aurora JSON export chunks through the shared importer.
 

--- a/docs/ui/18-settings.md
+++ b/docs/ui/18-settings.md
@@ -107,16 +107,24 @@ The mobile More tab contains appearance and UI-style controls that have no direc
 **Web component:** `AuroraCredentialsSection`
 **Mobile component:** `BoardAccountsSection` on Connected apps
 
-Card for each board type (iterates `AURORA_BOARDS`: kilter, tension).
+Card for each board type (iterates `AURORA_BOARDS`). Kilter renders **two** cards:
+"Kilter (Aurora)" for the legacy Aurora-built app (JSON import + data request) and
+"Kilter (new)" for the new Kilter Grips account, which links via username/password.
+The "Kilter (new)" card shows when the `kilter-oauth-linking` PostHog flag **and**
+the backend `kilterSyncAllowed` gate are on, or whenever a Kilter account is already
+linked.
 
 **Not Connected state:**
 
-- Board name + "Board" suffix as title.
-- Description text (Kilter has special "shutdown" text).
+- Board name + "Board" suffix as title (or "Kilter (Aurora)" / "Kilter (new)").
+- Description text.
 - Buttons:
-  - "Link Account" contained button (non-Kilter only): Opens link dialog.
+  - "Link Account" contained button (non-Kilter boards): Opens link dialog.
+  - "Sign in to Kilter" contained button (Kilter new card): Opens the Kilter
+    username/password dialog, which links via the ROPC password grant.
   - "Import JSON" outlined button: Opens file picker.
-  - "Request Data" outlined button (Kilter only): Opens pre-filled mailto link to Aurora Climbing.
+  - "Request Data" outlined button (Kilter Aurora card): Opens pre-filled mailto
+    link to Aurora Climbing.
 
 **Connected state:**
 
@@ -132,9 +140,15 @@ Card for each board type (iterates `AURORA_BOARDS`: kilter, tension).
 
 **Link Account Dialog:**
 
-- Title: "Link <Board> Account"
-- Username + password text fields.
+- Title: "Link <Board> Account" (or "Sign in to Kilter" for Kilter).
+- Username + password text fields. For Kilter the submit calls the ROPC password
+  endpoint; the password is exchanged for a refresh token server-side and never
+  stored.
 - "Link Account" contained button.
+
+**Reconnect:** a connected card whose `syncStatus` is `expired` shows a
+"Reconnect" button that reopens the same link dialog (re-submitting resets the
+credential to `pending` so the daemon picks it up again).
 
 **Import Flow** (unified dialog with phase transitions):
 
@@ -151,9 +165,13 @@ Card for each board type (iterates `AURORA_BOARDS`: kilter, tension).
 - Route: `packages/mobile/app/(tabs)/profile/integrations.tsx`.
 - Board account cards render above platform/device integration cards.
 - Uses backend REST endpoints instead of Next internal routes.
-- Kilter can connect through OAuth only when `KILTER_SYNC_ALLOWED_USER_IDS`
-  allows the current user; otherwise the card offers JSON import and data
-  request actions.
+- Kilter links via the username/password (ROPC) "Sign in to Kilter" card when
+  `KILTER_SYNC_ALLOWED_USER_IDS` allows the current user (set it to `*` to open
+  it to everyone) and the `kilter-oauth-linking` flag is on; otherwise only the
+  "Kilter (Aurora)" JSON-import / data-request card shows. The username/password
+  path also serves users for whom the dormant OAuth flow can't run (no
+  Kilter-registered redirect URI). Two-factor or social-login-only Kilter
+  accounts can't use ROPC and must fall back to JSON import.
 - Non-Kilter boards use the same username/password link dialog semantics as
   web.
 - JSON import reads a local file with `expo-document-picker`, previews the

--- a/packages/backend/src/__tests__/aurora-credentials-gate.test.ts
+++ b/packages/backend/src/__tests__/aurora-credentials-gate.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// `isKilterSyncAllowed` reads KILTER_SYNC_ALLOWED_USER_IDS once at module load,
+// so each case re-imports the module with `vi.resetModules()` after setting the
+// env. Mock the db client so importing the service never opens a connection.
+vi.mock('../db/client', () => ({ db: {}, dbRead: {} }));
+
+async function loadGate(allowList: string | undefined) {
+  vi.resetModules();
+  if (allowList === undefined) {
+    delete process.env.KILTER_SYNC_ALLOWED_USER_IDS;
+  } else {
+    process.env.KILTER_SYNC_ALLOWED_USER_IDS = allowList;
+  }
+  const module = await import('../services/aurora-credentials');
+  return module.isKilterSyncAllowed;
+}
+
+describe('isKilterSyncAllowed', () => {
+  const originalAllowList = process.env.KILTER_SYNC_ALLOWED_USER_IDS;
+
+  beforeEach(() => {
+    process.env.AURORA_CREDENTIALS_SECRET ??= 'test-aurora-secret';
+  });
+
+  afterEach(() => {
+    if (originalAllowList === undefined) {
+      delete process.env.KILTER_SYNC_ALLOWED_USER_IDS;
+    } else {
+      process.env.KILTER_SYNC_ALLOWED_USER_IDS = originalAllowList;
+    }
+  });
+
+  it('disables everyone when unset', async () => {
+    const isKilterSyncAllowed = await loadGate(undefined);
+    expect(isKilterSyncAllowed('any-user')).toBe(false);
+  });
+
+  it('disables everyone when empty', async () => {
+    const isKilterSyncAllowed = await loadGate('');
+    expect(isKilterSyncAllowed('any-user')).toBe(false);
+  });
+
+  it('allows every user with the * wildcard', async () => {
+    const isKilterSyncAllowed = await loadGate('*');
+    expect(isKilterSyncAllowed('user-a')).toBe(true);
+    expect(isKilterSyncAllowed('user-b')).toBe(true);
+  });
+
+  it('honours an explicit comma-separated allowlist', async () => {
+    const isKilterSyncAllowed = await loadGate('user-a, user-b');
+    expect(isKilterSyncAllowed('user-a')).toBe(true);
+    expect(isKilterSyncAllowed('user-b')).toBe(true);
+    expect(isKilterSyncAllowed('user-c')).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/kilter-credentials-oauth.test.ts
+++ b/packages/backend/src/__tests__/kilter-credentials-oauth.test.ts
@@ -7,11 +7,25 @@ const verifyKeycloakTokenMock = vi.fn();
 const validateTokenMock = vi.fn();
 const isKilterSyncAllowedMock = vi.fn();
 const saveKilterCredentialMock = vi.fn();
+const saveKilterCredentialViaPasswordMock = vi.fn();
+
+// Mirror the real KilterApiError so the handler's `instanceof` error mapping works.
+const KilterApiErrorMock = class KilterApiError extends Error {
+  code: string;
+  httpStatus?: number;
+  constructor(code: string, message: string, httpStatus?: number) {
+    super(message);
+    this.code = code;
+    this.httpStatus = httpStatus;
+    this.name = 'KilterApiError';
+  }
+};
 
 vi.mock('@boardsesh/kilter-sync/api', () => ({
   exchangeAuthorizationCode: exchangeAuthorizationCodeMock,
   KILTER_BOARD_TYPE: 'kilter',
   KILTER_OAUTH_AUTH_URL: 'https://kilter.example/auth',
+  KilterApiError: KilterApiErrorMock,
   verifyKeycloakToken: verifyKeycloakTokenMock,
 }));
 
@@ -22,6 +36,7 @@ vi.mock('../middleware/auth', () => ({
 vi.mock('../services/aurora-credentials', () => ({
   isKilterSyncAllowed: isKilterSyncAllowedMock,
   saveKilterCredential: saveKilterCredentialMock,
+  saveKilterCredentialViaPassword: saveKilterCredentialViaPasswordMock,
 }));
 
 vi.mock('../redis/client', () => ({
@@ -195,5 +210,109 @@ describe('Kilter credential OAuth handlers', () => {
       kilterUserId: 'kilter-user',
       username: 'kilter-name',
     });
+  });
+
+  it('password rejects unauthenticated requests', async () => {
+    const request = makeRequest({
+      method: 'POST',
+      body: JSON.stringify({ username: 'climber', password: 'secret' }),
+    });
+    const response = makeResponse();
+
+    await oauthHandlers.handleKilterCredentialsPassword(request as never, response as never);
+
+    expect(response.statusCode).toBe(401);
+    expect(saveKilterCredentialViaPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('password rejects accounts without Kilter sync access', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'pw-blocked-user' });
+    isKilterSyncAllowedMock.mockReturnValue(false);
+    const request = makeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ username: 'climber', password: 'secret' }),
+    });
+    const response = makeResponse();
+
+    await oauthHandlers.handleKilterCredentialsPassword(request as never, response as never);
+
+    expect(response.statusCode).toBe(403);
+    expect(saveKilterCredentialViaPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('password rejects an invalid body', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'pw-invalid-user' });
+    const request = makeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ username: 'climber' }),
+    });
+    const response = makeResponse();
+
+    await oauthHandlers.handleKilterCredentialsPassword(request as never, response as never);
+
+    expect(response.statusCode).toBe(400);
+    expect(saveKilterCredentialViaPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('password links the Kilter account on success', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'pw-ok-user' });
+    saveKilterCredentialViaPasswordMock.mockResolvedValue(undefined);
+    const request = makeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ username: 'climber', password: 'secret' }),
+    });
+    const response = makeResponse();
+
+    await oauthHandlers.handleKilterCredentialsPassword(request as never, response as never);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ success: true });
+    expect(saveKilterCredentialViaPasswordMock).toHaveBeenCalledWith({
+      userId: 'pw-ok-user',
+      username: 'climber',
+      password: 'secret',
+    });
+  });
+
+  it('password returns a generic 401 on bad Kilter credentials', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'pw-bad-creds-user' });
+    saveKilterCredentialViaPasswordMock.mockRejectedValue(
+      new KilterApiErrorMock('invalid_grant', 'Account does not exist or password is wrong'),
+    );
+    const request = makeRequest({
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ username: 'climber', password: 'wrong' }),
+    });
+    const response = makeResponse();
+
+    await oauthHandlers.handleKilterCredentialsPassword(request as never, response as never);
+
+    expect(response.statusCode).toBe(401);
+    // Generic message — never leaks whether the username exists, and matches the
+    // string the mobile client maps to `invalid_credentials`.
+    expect(JSON.parse(response.body)).toEqual({ error: 'Invalid Aurora credentials' });
+  });
+
+  it('password rate-limits repeated attempts', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'pw-rate-limit-user' });
+    saveKilterCredentialViaPasswordMock.mockResolvedValue(undefined);
+
+    let lastStatus = 0;
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const request = makeRequest({
+        method: 'POST',
+        headers: { authorization: 'Bearer token' },
+        body: JSON.stringify({ username: 'climber', password: 'secret' }),
+      });
+      const response = makeResponse();
+      await oauthHandlers.handleKilterCredentialsPassword(request as never, response as never);
+      lastStatus = response.statusCode;
+    }
+
+    expect(lastStatus).toBe(429);
   });
 });

--- a/packages/backend/src/handlers/kilter-credentials-oauth.ts
+++ b/packages/backend/src/handlers/kilter-credentials-oauth.ts
@@ -617,8 +617,8 @@ const PASSWORD_RATE_LIMIT_MAX = 5;
 const PASSWORD_RATE_LIMIT_WINDOW_MS = 60_000;
 
 const kilterPasswordSchema = z.object({
-  username: z.string().min(1),
-  password: z.string().min(1),
+  username: z.string().min(1).max(255),
+  password: z.string().min(1).max(255),
 });
 
 function kilterPasswordErrorStatus(error: unknown): number {

--- a/packages/backend/src/handlers/kilter-credentials-oauth.ts
+++ b/packages/backend/src/handlers/kilter-credentials-oauth.ts
@@ -1,9 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { createHash, randomBytes } from 'crypto';
+import { z } from 'zod';
 import {
   exchangeAuthorizationCode,
   KILTER_BOARD_TYPE,
   KILTER_OAUTH_AUTH_URL,
+  KilterApiError,
   verifyKeycloakToken,
 } from '@boardsesh/kilter-sync/api';
 import { decrypt, encrypt } from '@boardsesh/crypto';
@@ -18,7 +20,13 @@ import {
   verifyBoardCredentialHandoff,
   verifyBoardCredentialState,
 } from '../services/board-credential-state';
-import { isKilterSyncAllowed, saveKilterCredential } from '../services/aurora-credentials';
+import {
+  isKilterSyncAllowed,
+  saveKilterCredential,
+  saveKilterCredentialViaPassword,
+} from '../services/aurora-credentials';
+import { checkRateLimitRedis } from '../utils/redis-rate-limiter';
+import { RateLimitError } from '../utils/rate-limiter';
 import { logger } from '../utils/logger';
 
 const KILTER_OAUTH_CLIENT_ID = process.env.KILTER_OAUTH_CLIENT_ID;
@@ -603,4 +611,99 @@ export async function handleKilterCredentialsFinalize(req: IncomingMessage, res:
   }
 
   sendJson(res, 200, { success: true });
+}
+
+const PASSWORD_RATE_LIMIT_MAX = 5;
+const PASSWORD_RATE_LIMIT_WINDOW_MS = 60_000;
+
+const kilterPasswordSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+function kilterPasswordErrorStatus(error: unknown): number {
+  if (error instanceof KilterApiError) {
+    if (error.code === 'invalid_grant' || error.code === 'unauthorized') return 401;
+    if (error.code === 'rate_limited') return 429;
+    if (error.code === 'invalid_client') return 500;
+  }
+  return 502;
+}
+
+function kilterPasswordErrorMessage(error: unknown): string {
+  if (error instanceof KilterApiError) {
+    // Reuse the Aurora bad-credentials string verbatim: the mobile client keys
+    // its `invalid_credentials` mapping off this exact value, and it never
+    // reaches the user untranslated (web/mobile both localise on status/code).
+    if (error.code === 'invalid_grant' || error.code === 'unauthorized') return 'Invalid Aurora credentials';
+    if (error.code === 'rate_limited') return 'Too many login attempts. Please try again later.';
+    if (error.code === 'invalid_client') return 'Kilter sync is not configured';
+  }
+  return 'Kilter is unavailable. Please try again later.';
+}
+
+/**
+ * Link a Kilter account from a username + password (Keycloak ROPC). Used because
+ * Kilter hasn't registered an OAuth client/redirect URI for us; the public
+ * `kilter` client allows the password grant, so this path needs no Kilter-side
+ * setup. Auth-gated, allowlist-gated, and per-user rate-limited so it can't be
+ * abused as a credential-testing oracle against Kilter's Keycloak.
+ */
+export async function handleKilterCredentialsPassword(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { error: 'Method not allowed' });
+    return;
+  }
+
+  const userId = await authenticate(req, res);
+  if (!userId) return;
+
+  if (!isKilterSyncAllowed(userId)) {
+    sendJson(res, 403, { error: 'Kilter sync is not enabled for this account' });
+    return;
+  }
+
+  try {
+    await checkRateLimitRedis(userId, 'kilter-password', PASSWORD_RATE_LIMIT_MAX, PASSWORD_RATE_LIMIT_WINDOW_MS);
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      sendJson(res, 429, { error: 'Too many login attempts. Please try again later.' });
+      return;
+    }
+    throw error;
+  }
+
+  let body: unknown;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    sendJson(res, error instanceof Error && error.message === 'Request body too large' ? 413 : 400, {
+      error: error instanceof Error ? error.message : 'Invalid request body',
+    });
+    return;
+  }
+
+  const validationResult = kilterPasswordSchema.safeParse(body);
+  if (!validationResult.success) {
+    sendJson(res, 400, { error: 'Invalid request body', details: validationResult.error.flatten() });
+    return;
+  }
+
+  try {
+    await saveKilterCredentialViaPassword({
+      userId,
+      username: validationResult.data.username,
+      password: validationResult.data.password,
+    });
+    sendJson(res, 200, { success: true });
+  } catch (error) {
+    // Log the failure shape but never the credentials or raw Keycloak body.
+    logger.warn(
+      '[BoardCredentials] Kilter password login failed:',
+      error instanceof KilterApiError ? `${error.code}: ${error.message}` : error,
+    );
+    sendJson(res, kilterPasswordErrorStatus(error), { error: kilterPasswordErrorMessage(error) });
+  }
 }

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -21,6 +21,7 @@ import {
   handleKilterCredentialsCallback,
   handleKilterCredentialsFinalize,
   handleKilterCredentialsHandoff,
+  handleKilterCredentialsPassword,
   handleKilterCredentialsStart,
 } from './handlers/kilter-credentials-oauth';
 import { handleWidgetNavigate } from './handlers/widget-navigate';
@@ -366,6 +367,14 @@ export async function startServer(): Promise<ServerResources> {
         return;
       }
 
+      if (
+        pathname === '/api/board-credentials/kilter/password' &&
+        (req.method === 'POST' || req.method === 'OPTIONS')
+      ) {
+        await handleKilterCredentialsPassword(req, res);
+        return;
+      }
+
       if (pathname === '/board-credentials/kilter/start' && req.method === 'GET') {
         await handleKilterCredentialsStart(req, res, url);
         return;
@@ -535,6 +544,7 @@ export async function startServer(): Promise<ServerResources> {
     logger.info(`  Aurora credentials: ${httpScheme}://0.0.0.0:${PORT}/api/aurora-credentials`);
     logger.info(`  Aurora import: ${httpScheme}://0.0.0.0:${PORT}/api/aurora-import`);
     logger.info(`  Kilter credential OAuth: ${httpScheme}://0.0.0.0:${PORT}/board-credentials/kilter/start`);
+    logger.info(`  Kilter credential password: ${httpScheme}://0.0.0.0:${PORT}/api/board-credentials/kilter/password`);
     logger.info(`  Widget navigate: ${httpScheme}://0.0.0.0:${PORT}/api/widget/navigate`);
     logger.info(`  Widget take-control: ${httpScheme}://0.0.0.0:${PORT}/api/widget/take-control`);
     logger.info(`  Native auth exchange: ${httpScheme}://0.0.0.0:${PORT}/auth/native/exchange`);

--- a/packages/backend/src/services/aurora-credentials.ts
+++ b/packages/backend/src/services/aurora-credentials.ts
@@ -3,7 +3,13 @@ import { AuroraClimbingClient } from '@boardsesh/aurora-sync/api';
 import { decrypt, encrypt } from '@boardsesh/crypto';
 import { auroraCredentials, boardClimbs, boardseshTicks, userBoardMappings } from '@boardsesh/db/schema';
 import { AURORA_BOARDS, type AuroraBoardName } from '@boardsesh/shared-schema';
-import { KILTER_BOARD_TYPE, revokeRefreshToken } from '@boardsesh/kilter-sync/api';
+import {
+  KILTER_BOARD_TYPE,
+  KilterApiError,
+  passwordGrant,
+  revokeRefreshToken,
+  verifyKeycloakToken,
+} from '@boardsesh/kilter-sync/api';
 import { db } from '../db/client';
 import { logger } from '../utils/logger';
 
@@ -39,6 +45,11 @@ export function isAuroraBoardType(value: string | null | undefined): value is Au
 
 export function isKilterSyncAllowed(userId: string): boolean {
   if (!KILTER_SYNC_ALLOWED_USER_IDS) return false;
+
+  // `*` opens Kilter linking to every signed-in user. The env var stays the
+  // kill switch: unset/empty disables everyone, an explicit comma-separated
+  // list restricts to those user IDs.
+  if (KILTER_SYNC_ALLOWED_USER_IDS.trim() === '*') return true;
 
   return KILTER_SYNC_ALLOWED_USER_IDS.split(',')
     .map((allowedUserId) => allowedUserId.trim())
@@ -376,6 +387,54 @@ export async function saveKilterCredential(input: {
         boardUsername: input.username ?? null,
       });
     }
+  });
+}
+
+/**
+ * Link a Kilter account from a username + password using Keycloak's
+ * Resource-Owner-Password-Credentials grant. This is the path we use because
+ * Kilter hasn't registered an OAuth client / redirect URI for us — ROPC rides
+ * on the same public `kilter` client the catalog sync already uses, so it needs
+ * no Kilter-side registration. We mint a refresh token and hand it to the same
+ * `saveKilterCredential` the OAuth callback uses; the password itself is never
+ * stored.
+ */
+export async function saveKilterCredentialViaPassword(input: {
+  userId: string;
+  username: string;
+  password: string;
+}): Promise<void> {
+  if (!KILTER_OAUTH_CLIENT_ID) {
+    throw new KilterApiError('invalid_client', 'Kilter OAuth client is not configured');
+  }
+
+  const client = {
+    clientId: KILTER_OAUTH_CLIENT_ID,
+    ...(KILTER_OAUTH_CLIENT_SECRET ? { clientSecret: KILTER_OAUTH_CLIENT_SECRET } : {}),
+  };
+
+  const tokens = await passwordGrant({ username: input.username, password: input.password, client });
+
+  if (!tokens.refresh_token) {
+    // `offline_access` is requested, so a missing refresh token means the realm
+    // didn't grant one — treat it as a credential/realm failure, not a success.
+    throw new KilterApiError('invalid_grant', 'Kilter did not return a refresh token');
+  }
+
+  // Resolve the Keycloak user UUID (`sub`). Unlike the browser flow there's no
+  // nonce/redirect binding to lean on, and some realm configs emit an id_token
+  // whose `aud` is an array or omits the client — so we verify signature + iss
+  // (host-allowlisted) + exp only, without `expectedAudience`. The access token
+  // is a signed JWT from the same realm and is the fallback if no id_token came
+  // back.
+  const tokenToVerify = tokens.id_token ?? tokens.access_token;
+  const { sub, preferredUsername } = await verifyKeycloakToken(tokenToVerify);
+
+  await saveKilterCredential({
+    userId: input.userId,
+    refreshToken: tokens.refresh_token,
+    kilterUserId: sub,
+    username: preferredUsername ?? input.username,
   });
 }
 

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -30,15 +30,16 @@ import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { useConfirm } from '../../providers/dialog-provider';
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { borderRadius, spacing } from '../../theme/tokens';
 import { iosSystemColors } from '../../theme/ios-colors';
 import {
   BoardAccountError,
-  connectKilterAccount,
   deleteAuroraCredential,
   getAuroraCredentials,
   getAuroraUnsyncedCounts,
   saveAuroraCredential,
+  saveKilterCredentialViaPassword,
   streamAuroraImport,
   type AuroraCredentialStatus,
   type UnsyncedCounts,
@@ -46,6 +47,11 @@ import {
 
 type ImportPhase = 'preview' | 'importing' | 'complete' | 'error';
 type ImportStep = 'climbs' | 'resolving' | 'dedup' | 'ascents' | 'attempts' | 'circuits';
+
+// Kilter renders two cards: `kilterAurora` for the legacy Aurora-built app (JSON
+// import + data request) and `kilterNew` for the new Kilter Grips account, which
+// links via username/password (ROPC). Every other board is a single `aurora` card.
+type BoardAccountCardVariant = 'aurora' | 'kilterAurora' | 'kilterNew';
 
 type ImportProgress = {
   step: ImportStep;
@@ -86,6 +92,16 @@ function totalImported(result: ImportResult): number {
   return result.climbs.imported + result.ascents.imported + result.attempts.imported + result.circuits.imported;
 }
 
+// Kilter links via the password grant (`/api/board-credentials/kilter/password`);
+// every other board posts username/password to the Aurora endpoint.
+async function saveBoardCredential(input: { boardType: AuroraBoardName; username: string; password: string }) {
+  if (input.boardType === 'kilter') {
+    await saveKilterCredentialViaPassword({ username: input.username, password: input.password });
+    return null;
+  }
+  return saveAuroraCredential(input);
+}
+
 function errorMessageFor(error: unknown, t: TFunction<'settings'>): string {
   if (error instanceof BoardAccountError) {
     switch (error.code) {
@@ -121,10 +137,11 @@ export function BoardAccountsSection() {
     enabled: credentialsQuery.isSuccess,
   });
 
+  const kilterOauthLinkingEnabled = useFeatureFlag('kilter-oauth-linking') === true;
+
   const [linkBoard, setLinkBoard] = useState<AuroraBoardName | null>(null);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [connectingKilter, setConnectingKilter] = useState(false);
   const [importBoard, setImportBoard] = useState<AuroraBoardName | null>(null);
   const [importPreview, setImportPreview] = useState<AuroraExportPreview | null>(null);
   const [importData, setImportData] = useState<StrippedAuroraExportData | null>(null);
@@ -133,7 +150,7 @@ export function BoardAccountsSection() {
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
 
   const saveCredentialMutation = useMutation({
-    mutationFn: saveAuroraCredential,
+    mutationFn: saveBoardCredential,
     onSuccess: async (_credential, variables) => {
       const boardName = boardDisplayName(variables.boardType);
       showToast(t('aurora.mobile.linkSuccess', { boardName }), 'success');
@@ -204,28 +221,6 @@ export function BoardAccountsSection() {
       password,
     });
   }, [linkBoard, password, saveCredentialMutation, username]);
-
-  const handleConnectKilter = useCallback(() => {
-    setConnectingKilter(true);
-    void (async () => {
-      try {
-        const result = await connectKilterAccount();
-        if (result === 'connected') {
-          showToast(t('aurora.mobile.kilterConnected'), 'success');
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: AURORA_CREDENTIALS_QUERY_KEY }),
-            queryClient.invalidateQueries({ queryKey: AURORA_UNSYNCED_QUERY_KEY }),
-          ]);
-        } else if (result === 'not_allowed') {
-          showToast(t('aurora.mobile.kilterNotAllowed'), 'error');
-        } else if (result === 'error') {
-          showToast(t('aurora.mobile.kilterConnectFailed'), 'error');
-        }
-      } finally {
-        setConnectingKilter(false);
-      }
-    })();
-  }, [queryClient, showToast, t]);
 
   const handleRequestData = useCallback(() => {
     void Linking.openURL(buildKilterDataRequestMailto(t)).catch(() => {
@@ -358,8 +353,25 @@ export function BoardAccountsSection() {
 
   const credentials = credentialsQuery.data?.credentials;
   const kilterSyncAllowed = credentialsQuery.data?.kilterSyncAllowed === true;
+  const hasKilterCredential = getCredential(credentials ?? [], 'kilter') !== null;
+  // Show the new Kilter card when the flag + backend gate are on, or whenever a
+  // Kilter account is already linked (so it stays manageable if the flag flips off).
+  const showKilterNew = (kilterOauthLinkingEnabled && kilterSyncAllowed) || hasKilterCredential;
   const isLoading = credentialsQuery.isPending && !credentials;
   const hasLoadError = credentialsQuery.isError && !credentials;
+
+  const cardConfigs = AURORA_BOARDS.flatMap<{
+    key: string;
+    boardType: AuroraBoardName;
+    variant: BoardAccountCardVariant;
+  }>((boardType) => {
+    if (boardType !== 'kilter') return [{ key: boardType, boardType, variant: 'aurora' }];
+    const kilterCards: { key: string; boardType: AuroraBoardName; variant: BoardAccountCardVariant }[] = [
+      { key: 'kilter-aurora', boardType: 'kilter', variant: 'kilterAurora' },
+    ];
+    if (showKilterNew) kilterCards.push({ key: 'kilter-new', boardType: 'kilter', variant: 'kilterNew' });
+    return kilterCards;
+  });
 
   return (
     <View style={styles.section}>
@@ -382,26 +394,29 @@ export function BoardAccountsSection() {
           }}
         />
       ) : (
-        AURORA_BOARDS.map((boardType, boardIndex) => {
-          const credential = getCredential(credentials ?? [], boardType);
-          const unsynced = getUnsyncedCount(unsyncedQuery.data, boardType);
+        cardConfigs.map((cardConfig, cardIndex) => {
+          // The legacy "Kilter (Aurora)" card never owns the linked-account state —
+          // that belongs to the new card.
+          const credential =
+            cardConfig.variant === 'kilterAurora' ? null : getCredential(credentials ?? [], cardConfig.boardType);
+          const unsynced = getUnsyncedCount(unsyncedQuery.data, cardConfig.boardType);
           return (
             <BoardAccountCard
-              key={boardType}
-              boardType={boardType}
+              key={cardConfig.key}
+              boardType={cardConfig.boardType}
+              variant={cardConfig.variant}
               credential={credential}
               unsyncedCounts={unsynced}
-              kilterSyncAllowed={kilterSyncAllowed}
-              isLast={boardIndex === AURORA_BOARDS.length - 1}
-              isConnectingKilter={connectingKilter}
-              isRemoving={deleteCredentialMutation.isPending && deleteCredentialMutation.variables === boardType}
+              isLast={cardIndex === cardConfigs.length - 1}
+              isRemoving={
+                deleteCredentialMutation.isPending && deleteCredentialMutation.variables === cardConfig.boardType
+              }
               systemColors={systemColors}
               brandColors={brandColors}
-              onConnectKilter={handleConnectKilter}
-              onImport={() => handleImportPress(boardType)}
-              onLink={() => handleOpenLink(boardType)}
+              onImport={() => handleImportPress(cardConfig.boardType)}
+              onLink={() => handleOpenLink(cardConfig.boardType)}
               onRequestData={handleRequestData}
-              onUnlink={() => handleUnlink(boardType)}
+              onUnlink={() => handleUnlink(cardConfig.boardType)}
             />
           );
         })
@@ -411,10 +426,14 @@ export function BoardAccountsSection() {
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.modalBackdrop}>
           <View style={[styles.modalCard, { backgroundColor: systemColors.secondaryBackground }]}>
             <Text variant="headline" style={styles.modalTitle}>
-              {t('aurora.linkDialog.title', { boardName: linkBoard ? boardDisplayName(linkBoard) : '' })}
+              {linkBoard === 'kilter'
+                ? t('aurora.kilterLinkDialog.title')
+                : t('aurora.linkDialog.title', { boardName: linkBoard ? boardDisplayName(linkBoard) : '' })}
             </Text>
             <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.modalCopy}>
-              {t('aurora.linkDialog.description', { boardName: linkBoard ? boardDisplayName(linkBoard) : '' })}
+              {linkBoard === 'kilter'
+                ? t('aurora.kilterLinkDialog.description')
+                : t('aurora.linkDialog.description', { boardName: linkBoard ? boardDisplayName(linkBoard) : '' })}
             </Text>
             <TextInput
               value={username}
@@ -436,7 +455,7 @@ export function BoardAccountsSection() {
               style={inputStyle}
             />
             <Text variant="footnote" color={systemColors.secondaryLabel}>
-              {t('aurora.mobile.passwordHelp')}
+              {linkBoard === 'kilter' ? t('aurora.kilterLinkDialog.passwordHelp') : t('aurora.mobile.passwordHelp')}
             </Text>
             <View style={styles.modalActions}>
               <Button title={tCommon('actions.cancel')} variant="text" onPress={() => setLinkBoard(null)} />
@@ -533,15 +552,13 @@ function BoardAccountsLoadError({ systemColors, brandColors, isRetrying, onRetry
 
 type BoardAccountCardProps = {
   boardType: AuroraBoardName;
+  variant: BoardAccountCardVariant;
   credential: AuroraCredentialStatus | null;
   unsyncedCounts: { ascents: number; climbs: number };
-  kilterSyncAllowed: boolean;
   isLast: boolean;
-  isConnectingKilter: boolean;
   isRemoving: boolean;
   systemColors: ReturnType<typeof useTheme>['systemColors'];
   brandColors: ReturnType<typeof useTheme>['brandColors'];
-  onConnectKilter: () => void;
   onImport: () => void;
   onLink: () => void;
   onRequestData: () => void;
@@ -550,15 +567,13 @@ type BoardAccountCardProps = {
 
 function BoardAccountCard({
   boardType,
+  variant,
   credential,
   unsyncedCounts,
-  kilterSyncAllowed,
   isLast,
-  isConnectingKilter,
   isRemoving,
   systemColors,
   brandColors,
-  onConnectKilter,
   onImport,
   onLink,
   onRequestData,
@@ -566,10 +581,20 @@ function BoardAccountCard({
 }: BoardAccountCardProps) {
   const { t } = useTranslation('settings');
   const boardName = boardDisplayName(boardType);
+  const cardTitle =
+    variant === 'kilterAurora'
+      ? t('aurora.card.kilterAuroraTitle')
+      : variant === 'kilterNew'
+        ? t('aurora.card.kilterNewTitle')
+        : boardName;
   const totalUnsynced = unsyncedCounts.ascents + unsyncedCounts.climbs;
+  const isExpired = credential?.syncStatus === 'expired';
   const connectedLabel = credential?.auroraUsername
     ? t('aurora.mobile.connectedAs', { name: credential.auroraUsername })
     : t('aurora.mobile.connected');
+  // The legacy Kilter (Aurora) card is a data-import surface, not an account you
+  // connect — so it drops the connection subtitle + status pill.
+  const showStatus = variant !== 'kilterAurora';
 
   return (
     <View
@@ -582,23 +607,31 @@ function BoardAccountCard({
     >
       <View style={styles.accountHeader}>
         <View>
-          <Text variant="headline">{boardName}</Text>
-          <Text variant="subheadline" color={systemColors.secondaryLabel}>
-            {credential ? connectedLabel : t('aurora.mobile.notConnected')}
-          </Text>
+          <Text variant="headline">{cardTitle}</Text>
+          {showStatus ? (
+            <Text variant="subheadline" color={systemColors.secondaryLabel}>
+              {credential ? connectedLabel : t('aurora.mobile.notConnected')}
+            </Text>
+          ) : null}
         </View>
-        <View
-          style={[styles.statusPill, { backgroundColor: credential ? brandColors.primaryFill : systemColors.fill }]}
-        >
-          <Text variant="caption1" color={credential ? brandColors.onPrimary : systemColors.secondaryLabel}>
-            {credential ? t('aurora.status.connected') : t('aurora.mobile.notConnected')}
-          </Text>
-        </View>
+        {showStatus ? (
+          <View
+            style={[styles.statusPill, { backgroundColor: credential ? brandColors.primaryFill : systemColors.fill }]}
+          >
+            <Text variant="caption1" color={credential ? brandColors.onPrimary : systemColors.secondaryLabel}>
+              {credential ? t('aurora.status.connected') : t('aurora.mobile.notConnected')}
+            </Text>
+          </View>
+        ) : null}
       </View>
 
       {credential ? (
         <>
-          {credential.syncError ? (
+          {isExpired ? (
+            <Text variant="footnote" color={brandColors.error} style={styles.accountCopy}>
+              {t('aurora.status.expired')}
+            </Text>
+          ) : credential.syncError ? (
             <Text variant="footnote" color={brandColors.error} style={styles.accountCopy}>
               {t('aurora.status.error')}
             </Text>
@@ -612,6 +645,7 @@ function BoardAccountCard({
             </View>
           ) : null}
           <View style={styles.actionRow}>
+            {isExpired ? <Button title={t('aurora.card.reconnect')} icon="link" size="small" onPress={onLink} /> : null}
             <Button title={t('aurora.card.import')} icon="upload" variant="outlined" size="small" onPress={onImport} />
             <Button
               title={t('aurora.card.unlink')}
@@ -625,27 +659,20 @@ function BoardAccountCard({
             />
           </View>
         </>
-      ) : boardType === 'kilter' && kilterSyncAllowed ? (
+      ) : variant === 'kilterNew' ? (
         <>
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.accountCopy}>
-            {t('aurora.card.kilterConnectCopy')}
+            {t('aurora.card.kilterNewCopy')}
           </Text>
           <View style={styles.actionRow}>
-            <Button
-              title={t('aurora.card.kilterConnectButton')}
-              icon="open.external"
-              size="small"
-              loading={isConnectingKilter}
-              disabled={isConnectingKilter}
-              onPress={onConnectKilter}
-            />
+            <Button title={t('aurora.card.kilterSignIn')} icon="link" size="small" onPress={onLink} />
             <Button title={t('aurora.card.import')} icon="upload" variant="outlined" size="small" onPress={onImport} />
           </View>
         </>
-      ) : boardType === 'kilter' ? (
+      ) : variant === 'kilterAurora' ? (
         <>
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.accountCopy}>
-            {t('aurora.card.kilterShutdown')}
+            {t('aurora.card.kilterAuroraCopy')}
           </Text>
           <View style={styles.actionRow}>
             <Button title={t('aurora.card.import')} icon="upload" variant="outlined" size="small" onPress={onImport} />

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -38,7 +38,7 @@ type MutationOptions = {
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: mocks.invalidate }),
   useQuery: (opts: { queryKey: readonly unknown[] }) => {
-    const isCredentials = opts.queryKey.length === 1;
+    const isCredentials = opts.queryKey[0] === 'auroraCredentials' && opts.queryKey[1] !== 'unsynced';
     return {
       data: isCredentials
         ? ({ credentials: mocks.credentials, kilterSyncAllowed: mocks.kilterSyncAllowed } as AuroraCredentialsResponse)

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { AuroraCredentialStatus, AuroraCredentialsResponse } from '../../../lib/aurora-credentials';
+
+// --- Hoisted mock state, mutated per-test before render ---
+const mocks = vi.hoisted(() => ({
+  saveAurora: vi.fn(),
+  saveKilterViaPassword: vi.fn(() => Promise.resolve()),
+  deleteAurora: vi.fn(),
+  streamImport: vi.fn(),
+  showToast: vi.fn(),
+  confirm: vi.fn(() => Promise.resolve(true)),
+  invalidate: vi.fn(() => Promise.resolve()),
+  refetch: vi.fn(() => Promise.resolve()),
+  flags: {} as Record<string, boolean | undefined>,
+  credentials: [] as AuroraCredentialStatus[],
+  kilterSyncAllowed: true,
+}));
+
+vi.mock('../../../lib/aurora-credentials', () => ({
+  BoardAccountError: class BoardAccountError extends Error {},
+  getAuroraCredentials: () => Promise.resolve({ credentials: [], kilterSyncAllowed: true }),
+  getAuroraUnsyncedCounts: () => Promise.resolve({}),
+  saveAuroraCredential: mocks.saveAurora,
+  saveKilterCredentialViaPassword: mocks.saveKilterViaPassword,
+  deleteAuroraCredential: mocks.deleteAurora,
+  streamAuroraImport: mocks.streamImport,
+}));
+
+type MutationOptions = {
+  mutationFn: (vars: unknown) => unknown;
+  onSuccess?: (result: unknown, vars: unknown) => unknown;
+  onError?: (error: unknown) => unknown;
+};
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidate }),
+  useQuery: (opts: { queryKey: readonly unknown[] }) => {
+    const isCredentials = opts.queryKey.length === 1;
+    return {
+      data: isCredentials
+        ? ({ credentials: mocks.credentials, kilterSyncAllowed: mocks.kilterSyncAllowed } as AuroraCredentialsResponse)
+        : {},
+      isPending: false,
+      isError: false,
+      isSuccess: true,
+      isFetching: false,
+      refetch: mocks.refetch,
+    };
+  },
+  useMutation: (opts: MutationOptions) => ({
+    mutate: (vars: unknown) => {
+      void Promise.resolve(opts.mutationFn(vars))
+        .then((result) => opts.onSuccess?.(result, vars))
+        .catch((error) => opts.onError?.(error));
+    },
+    isPending: false,
+    variables: undefined,
+  }),
+}));
+
+type RNProps = { children?: ReactNode; visible?: boolean };
+vi.mock('react-native', () => ({
+  View: ({ children }: RNProps) => createElement('div', {}, children),
+  ScrollView: ({ children }: RNProps) => createElement('div', {}, children),
+  KeyboardAvoidingView: ({ children }: RNProps) => createElement('div', {}, children),
+  Modal: ({ visible, children }: RNProps) => (visible ? createElement('div', {}, children) : null),
+  ActivityIndicator: () => createElement('div', { 'data-spinner': 'true' }),
+  TextInput: ({
+    value,
+    onChangeText,
+    placeholder,
+  }: {
+    value?: string;
+    onChangeText?: (next: string) => void;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      value: value ?? '',
+      'data-input': placeholder,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+    }),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'ios' },
+  Linking: { openURL: () => Promise.resolve() },
+}));
+
+vi.mock('expo-file-system', () => ({ File: class File {} }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { name?: string }) => (opts?.name != null ? `${key}:${opts.name}` : key),
+  }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      secondaryBackground: '#fff',
+      secondaryLabel: '#888',
+      tertiaryBackground: '#eee',
+      fill: '#ddd',
+    },
+    brandColors: { primary: '#6D28D9', primaryFill: '#eee', onPrimary: '#fff', error: '#C81E1E', warning: '#F59E0B' },
+    colorScheme: 'light',
+  }),
+}));
+
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: mocks.showToast }) }));
+vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => mocks.confirm }));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useFeatureFlag: (key: string) => mocks.flags[key],
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
+  borderRadius: { md: 8, lg: 12, full: 999 },
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { white: '#fff' } }));
+
+type TextProps = { children?: ReactNode };
+vi.mock('../../Text', () => ({
+  Text: ({ children }: TextProps) => createElement('span', {}, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../../SectionHeader', () => ({
+  SectionHeader: () => createElement('div', { 'data-section-header': 'true' }),
+}));
+
+type ButtonProps = { title: string; onPress?: () => void; disabled?: boolean };
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress, disabled }: ButtonProps) =>
+    createElement('button', { 'data-button': title, disabled: !!disabled, onClick: onPress }),
+}));
+
+import { BoardAccountsSection } from '../BoardAccountsSection';
+
+const button = (root: HTMLElement, title: string) =>
+  root.querySelector(`[data-button="${title}"]`) as HTMLButtonElement | null;
+
+const input = (root: HTMLElement, placeholder: string) =>
+  root.querySelector(`[data-input="${placeholder}"]`) as HTMLInputElement | null;
+
+describe('BoardAccountsSection — Kilter password card', () => {
+  beforeEach(() => {
+    mocks.saveAurora.mockReset();
+    mocks.saveKilterViaPassword.mockReset().mockResolvedValue(undefined);
+    mocks.showToast.mockReset();
+    mocks.invalidate.mockClear();
+    mocks.flags = {};
+    mocks.credentials = [];
+    mocks.kilterSyncAllowed = true;
+  });
+
+  it('shows the Kilter (new) sign-in card when the flag and gate are on', () => {
+    mocks.flags = { 'kilter-oauth-linking': true };
+    const { container } = render(<BoardAccountsSection />);
+    expect(button(container, 'aurora.card.kilterSignIn')).not.toBeNull();
+  });
+
+  it('hides the Kilter (new) card when the flag is off and nothing is linked', () => {
+    mocks.flags = { 'kilter-oauth-linking': false };
+    const { container } = render(<BoardAccountsSection />);
+    expect(button(container, 'aurora.card.kilterSignIn')).toBeNull();
+    // The legacy Kilter (Aurora) import path is still offered.
+    expect(button(container, 'aurora.card.requestData')).not.toBeNull();
+  });
+
+  it('links Kilter via the password grant when the sign-in form is submitted', async () => {
+    mocks.flags = { 'kilter-oauth-linking': true };
+    const { container } = render(<BoardAccountsSection />);
+
+    fireEvent.click(button(container, 'aurora.card.kilterSignIn')!);
+
+    fireEvent.change(input(container, 'aurora.linkDialog.usernamePlaceholder')!, {
+      target: { value: 'climber' },
+    });
+    fireEvent.change(input(container, 'aurora.linkDialog.passwordPlaceholder')!, {
+      target: { value: 'secret' },
+    });
+
+    fireEvent.click(button(container, 'aurora.linkDialog.submit')!);
+
+    await waitFor(() => {
+      expect(mocks.saveKilterViaPassword).toHaveBeenCalledWith({ username: 'climber', password: 'secret' });
+    });
+    expect(mocks.saveAurora).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/aurora-credentials.ts
+++ b/packages/mobile/src/lib/aurora-credentials.ts
@@ -130,6 +130,20 @@ export async function deleteAuroraCredential(boardType: AuroraBoardName): Promis
   });
 }
 
+/**
+ * Link a Kilter account from a username + password (Keycloak ROPC). Used instead
+ * of the OAuth handoff because Kilter hasn't registered a redirect URI for us.
+ * The password is exchanged for a refresh token server-side and never stored.
+ * A 401 with the `Invalid Aurora credentials` body maps to `invalid_credentials`
+ * via `errorCodeForResponse`.
+ */
+export async function saveKilterCredentialViaPassword(input: { username: string; password: string }): Promise<void> {
+  await requestJson<{ success: true }>('/api/board-credentials/kilter/password', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
 async function createKilterHandoffStartUrl(): Promise<string> {
   const response = await requestJson<{ startUrl: string }>('/api/board-credentials/kilter/handoff', {
     method: 'POST',

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -37,6 +37,11 @@ export const FEATURE_FLAG_DEFINITIONS = [
     label: 'Logbook filters',
     description: 'Search box and filter sheet on the logbook (unfinished UI).',
   },
+  {
+    key: 'kilter-oauth-linking',
+    label: 'Kilter account linking',
+    description: 'Show the Kilter username/password sign-in card in Integrations.',
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 // The literal key union (e.g. `'strava-integration'`), preserved via the

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -170,9 +170,12 @@
       "username": "Username:",
       "lastSynced": "Last synced:",
       "never": "Never",
-      "kilterShutdown": "Direct sync with Kilter is rolling out gradually. In the meantime, import a JSON export from the Kilter app, or email Aurora Climbing to request your data.",
-      "kilterConnectCopy": "Hook up your Kilter account to pull your sends, attempts, ratings and circuits into Boardsesh. Pushing changes back to Kilter is coming soon.",
-      "kilterConnectButton": "Connect Kilter account",
+      "kilterAuroraTitle": "Kilter (Aurora)",
+      "kilterAuroraCopy": "Used the old Kilter app built by Aurora? Import a JSON export, or email Aurora Climbing to request your data.",
+      "kilterNewTitle": "Kilter (new)",
+      "kilterNewCopy": "Sign in with your Kilter username and password to pull your sends, attempts, ratings and circuits into Boardsesh.",
+      "kilterSignIn": "Sign in to Kilter",
+      "reconnect": "Reconnect",
       "notConnected": "Not connected. Link your {{boardName}} account to import your Aurora data, or import from a JSON export file.",
       "link": "Link",
       "import": "Import",
@@ -209,6 +212,11 @@
       "submitting": "Linking...",
       "linkError": "Failed to link account",
       "linkSuccess": "{{boardName}} account linked. Your data will show up within 12 hours."
+    },
+    "kilterLinkDialog": {
+      "title": "Sign in to Kilter",
+      "description": "Enter your Kilter username and password. Your password is exchanged for a secure token and never stored. Your sends sync within a few hours.",
+      "passwordHelp": "Works with your existing Kilter login. Two-factor or social-login-only accounts can't sign in this way — use Import instead."
     },
     "unlinkSuccess": "Account unlinked successfully",
     "unlinkError": "Failed to unlink account",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -170,9 +170,12 @@
       "username": "Usuario:",
       "lastSynced": "Última sincronización:",
       "never": "Nunca",
-      "kilterShutdown": "La sincronización directa con Kilter se está habilitando poco a poco. Mientras tanto, importa una exportación JSON de la app de Kilter, o escribe a Aurora Climbing para pedir tus datos.",
-      "kilterConnectCopy": "Vincula tu cuenta de Kilter para traer tus encadenamientos, intentos, valoraciones y circuitos a Boardsesh. La sincronización en sentido inverso llega pronto.",
-      "kilterConnectButton": "Vincular cuenta de Kilter",
+      "kilterAuroraTitle": "Kilter (Aurora)",
+      "kilterAuroraCopy": "¿Usabas la antigua app de Kilter hecha por Aurora? Importa una exportación JSON, o escribe a Aurora Climbing para pedir tus datos.",
+      "kilterNewTitle": "Kilter (nuevo)",
+      "kilterNewCopy": "Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenamientos, intentos, valoraciones y circuitos a Boardsesh.",
+      "kilterSignIn": "Iniciar sesión en Kilter",
+      "reconnect": "Volver a conectar",
       "notConnected": "No vinculado. Vincula tu cuenta de {{boardName}} para importar tus datos de Aurora, o impórtalos desde un archivo JSON.",
       "link": "Vincular",
       "import": "Importar",
@@ -209,6 +212,11 @@
       "submitting": "Vinculando...",
       "linkError": "No se pudo vincular la cuenta",
       "linkSuccess": "Cuenta de {{boardName}} vinculada. Tus datos aparecerán en menos de 12 horas."
+    },
+    "kilterLinkDialog": {
+      "title": "Iniciar sesión en Kilter",
+      "description": "Introduce tu usuario y contraseña de Kilter. Tu contraseña se canjea por un token seguro y nunca se guarda. Tus encadenamientos se sincronizan en unas horas.",
+      "passwordHelp": "Funciona con tu acceso habitual de Kilter. Las cuentas con verificación en dos pasos o solo con inicio de sesión social no pueden entrar por aquí: usa Importar."
     },
     "unlinkSuccess": "Cuenta desvinculada",
     "unlinkError": "No se pudo desvincular la cuenta",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -170,9 +170,12 @@
       "username": "Identifiant :",
       "lastSynced": "Dernière synchro :",
       "never": "Jamais",
-      "kilterShutdown": "La synchro directe avec Kilter se déploie progressivement. En attendant, importez un export JSON depuis l'app Kilter, ou écrivez à Aurora Climbing pour demander vos données.",
-      "kilterConnectCopy": "Liez votre compte Kilter pour rapatrier vos enchaînements, essais, notes et circuits dans Boardsesh. La synchro dans l'autre sens arrive bientôt.",
-      "kilterConnectButton": "Lier le compte Kilter",
+      "kilterAuroraTitle": "Kilter (Aurora)",
+      "kilterAuroraCopy": "Vous utilisiez l'ancienne app Kilter conçue par Aurora ? Importez un export JSON, ou écrivez à Aurora Climbing pour demander vos données.",
+      "kilterNewTitle": "Kilter (nouveau)",
+      "kilterNewCopy": "Connectez-vous avec votre identifiant et mot de passe Kilter pour rapatrier vos enchaînements, essais, notes et circuits dans Boardsesh.",
+      "kilterSignIn": "Se connecter à Kilter",
+      "reconnect": "Reconnecter",
       "notConnected": "Non lié. Liez votre compte {{boardName}} pour importer vos données Aurora, ou importez depuis un fichier d'export JSON.",
       "link": "Lier",
       "import": "Importer",
@@ -209,6 +212,11 @@
       "submitting": "Liaison...",
       "linkError": "Liaison du compte impossible",
       "linkSuccess": "Compte {{boardName}} lié. Vos données arriveront sous 12 heures."
+    },
+    "kilterLinkDialog": {
+      "title": "Se connecter à Kilter",
+      "description": "Saisissez votre identifiant et mot de passe Kilter. Votre mot de passe est échangé contre un jeton sécurisé et n'est jamais stocké. Vos enchaînements se synchronisent sous quelques heures.",
+      "passwordHelp": "Fonctionne avec votre connexion Kilter habituelle. Les comptes avec double authentification ou connexion sociale uniquement ne peuvent pas se connecter ainsi — utilisez Importer."
     },
     "unlinkSuccess": "Compte délié",
     "unlinkError": "Déliaison du compte impossible",

--- a/packages/web/app/components/banners/capacitor-update-banner.tsx
+++ b/packages/web/app/components/banners/capacitor-update-banner.tsx
@@ -12,7 +12,6 @@ import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
 import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
-import { CAPACITOR_UPDATE_BANNER_FLAG } from '@/app/flags';
 import { isUpdateBannerSnoozed, snoozeUpdateBanner } from '@/app/lib/capacitor-update-banner-db';
 import styles from './capacitor-update-banner.module.css';
 
@@ -56,7 +55,7 @@ const CapacitorUpdateBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onUpd
  * (which doesn't render the web UI), so it can't affect non-Capacitor users.
  */
 export const CapacitorUpdateBanner: React.FC = () => {
-  const flagEnabled = useFeatureFlag(CAPACITOR_UPDATE_BANNER_FLAG) === true;
+  const flagEnabled = useFeatureFlag('capacitor-update-banner') === true;
   const [open, setOpen] = useState(false);
   const titleId = useId();
 

--- a/packages/web/app/components/banners/capacitor-update-banner.tsx
+++ b/packages/web/app/components/banners/capacitor-update-banner.tsx
@@ -12,6 +12,7 @@ import { getPlatform, isNativeApp } from '@/app/lib/ble/capacitor-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
 import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
+import { CAPACITOR_UPDATE_BANNER_FLAG } from '@/app/flags';
 import { isUpdateBannerSnoozed, snoozeUpdateBanner } from '@/app/lib/capacitor-update-banner-db';
 import styles from './capacitor-update-banner.module.css';
 
@@ -55,7 +56,7 @@ const CapacitorUpdateBannerBody: React.FC<BannerBodyProps> = ({ onDismiss, onUpd
  * (which doesn't render the web UI), so it can't affect non-Capacitor users.
  */
 export const CapacitorUpdateBanner: React.FC = () => {
-  const flagEnabled = useFeatureFlag('capacitor-update-banner') === true;
+  const flagEnabled = useFeatureFlag(CAPACITOR_UPDATE_BANNER_FLAG) === true;
   const [open, setOpen] = useState(false);
   const titleId = useId();
 

--- a/packages/web/app/components/settings/__tests__/aurora-credentials-section.test.tsx
+++ b/packages/web/app/components/settings/__tests__/aurora-credentials-section.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+// --- Hoisted mocks ---
+const mockSaveKilterViaPassword = vi.fn();
+const mockSaveAuroraCredential = vi.fn();
+const mockGetAuroraCredentials = vi.fn();
+const mockGetAuroraUnsyncedCounts = vi.fn();
+const mockShowMessage = vi.fn();
+let mockFeatureFlags: Record<string, boolean | undefined> = {};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isLoading: false, isAuthenticated: true, error: null }),
+}));
+
+vi.mock('@/app/lib/aurora-credentials/client', () => ({
+  getAuroraCredentials: (...args: unknown[]) => mockGetAuroraCredentials(...args),
+  getAuroraUnsyncedCounts: (...args: unknown[]) => mockGetAuroraUnsyncedCounts(...args),
+  saveAuroraCredential: (...args: unknown[]) => mockSaveAuroraCredential(...args),
+  saveKilterCredentialViaPassword: (...args: unknown[]) => mockSaveKilterViaPassword(...args),
+  deleteAuroraCredential: vi.fn(),
+  finalizeKilterCredential: vi.fn(),
+  resolveAuroraBackendTransport: (token: string | null) => token,
+  streamImport: vi.fn(),
+}));
+
+vi.mock('@/app/components/providers/feature-flags-provider', () => ({
+  useFeatureFlag: (key: string) => mockFeatureFlags[key],
+  useFeatureFlags: () => mockFeatureFlags,
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'test-user', name: 'Test User', email: 'test@test.com' } } }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/settings',
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/data-sync/aurora/json-import-stream', () => ({
+  streamImport: vi.fn(),
+}));
+
+vi.mock('@/app/lib/data-sync/aurora/parse-aurora-export', () => ({
+  parseAuroraExport: vi.fn(),
+}));
+
+import AuroraCredentialsSection from '../aurora-credentials-section';
+
+describe('AuroraCredentialsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFeatureFlags = {};
+    mockGetAuroraCredentials.mockResolvedValue({ credentials: [], kilterSyncAllowed: true });
+    mockGetAuroraUnsyncedCounts.mockResolvedValue({});
+    mockSaveKilterViaPassword.mockResolvedValue({ success: true });
+    mockSaveAuroraCredential.mockResolvedValue({ success: true });
+  });
+
+  describe('credential save dispatch', () => {
+    it('calls saveKilterCredentialViaPassword when submitting kilter sign-in', async () => {
+      mockFeatureFlags = { 'kilter-oauth-linking': true };
+
+      render(<AuroraCredentialsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sign in to Kilter')).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByText('Sign in to Kilter'));
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your username')).toBeTruthy();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Enter your username'), {
+        target: { value: 'kilteruser' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+        target: { value: 'kilterpass' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Link Account' }));
+
+      await waitFor(() => {
+        expect(mockSaveKilterViaPassword).toHaveBeenCalledWith('test-token', {
+          username: 'kilteruser',
+          password: 'kilterpass',
+        });
+        expect(mockSaveAuroraCredential).not.toHaveBeenCalled();
+      });
+    });
+
+    it('calls saveAuroraCredential (not saveKilterCredentialViaPassword) when linking a non-kilter board', async () => {
+      render(<AuroraCredentialsSection />);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: 'Link' }).length).toBeGreaterThan(0);
+      });
+
+      // Click the first "Link" button — belongs to the first non-kilter aurora board (tension)
+      fireEvent.click(screen.getAllByRole('button', { name: 'Link' })[0]);
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Enter your username')).toBeTruthy();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Enter your username'), {
+        target: { value: 'aurorauser' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+        target: { value: 'aurorapass' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Link Account' }));
+
+      await waitFor(() => {
+        expect(mockSaveAuroraCredential).toHaveBeenCalledWith(
+          'test-token',
+          expect.objectContaining({ username: 'aurorauser', password: 'aurorapass' }),
+        );
+        expect(mockSaveKilterViaPassword).not.toHaveBeenCalled();
+      });
+    });
+
+    it('shows Reconnect before Unlink when a credential is expired', async () => {
+      mockGetAuroraCredentials.mockResolvedValue({
+        credentials: [
+          {
+            boardType: 'tension',
+            auroraUsername: 'tensionuser',
+            syncStatus: 'expired',
+            lastSyncAt: null,
+            syncError: null,
+          },
+        ],
+        kilterSyncAllowed: false,
+      });
+
+      render(<AuroraCredentialsSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Reconnect')).toBeTruthy();
+        expect(screen.getByText('Unlink')).toBeTruthy();
+      });
+
+      const buttons = screen.getAllByRole('button');
+      const reconnectIdx = buttons.findIndex((b) => b.textContent?.includes('Reconnect'));
+      const unlinkIdx = buttons.findIndex((b) => b.textContent?.includes('Unlink'));
+      expect(reconnectIdx).toBeLessThan(unlinkIdx);
+    });
+  });
+});

--- a/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
+++ b/packages/web/app/components/settings/__tests__/board-import-prompt.test.tsx
@@ -115,8 +115,9 @@ describe('BoardImportPrompt', () => {
 
       render(<BoardImportPrompt boardType="kilter" />);
 
+      // The board-import prompt surfaces the legacy "Kilter (Aurora)" import card.
       await waitFor(() => {
-        expect(screen.getByText('Kilter Board')).toBeTruthy();
+        expect(screen.getByText('Kilter (Aurora)')).toBeTruthy();
       });
 
       expect(screen.getByText('Import')).toBeTruthy();

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -39,16 +39,17 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import {
-  createKilterHandoffStartUrl,
   deleteAuroraCredential,
   finalizeKilterCredential,
   getAuroraCredentials,
   getAuroraUnsyncedCounts,
   resolveAuroraBackendTransport,
   saveAuroraCredential,
+  saveKilterCredentialViaPassword,
   type AuroraCredentialStatus,
   type UnsyncedCounts,
 } from '@/app/lib/aurora-credentials/client';
+import { useFeatureFlag } from '@/app/components/providers/feature-flags-provider';
 import type { ImportResult } from '@/app/lib/data-sync/aurora/json-import';
 import { streamImport } from '@/app/lib/data-sync/aurora/json-import-stream';
 import {
@@ -110,46 +111,48 @@ function buildKilterDataRequestMailto(
   return `mailto:peter@auroraclimbing.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 }
 
+// Kilter renders two cards: `kilterAurora` for the legacy Aurora-built app (JSON
+// import + data request) and `kilterNew` for the new Kilter Grips account, which
+// links via username/password (ROPC). Every other board is a single `aurora` card.
+export type BoardCredentialCardVariant = 'aurora' | 'kilterAurora' | 'kilterNew';
+
 export type BoardCredentialCardProps = {
   boardType: AuroraBoardName;
+  variant: BoardCredentialCardVariant;
   credential: AuroraCredentialStatus | null;
   unsyncedCounts: BoardUnsyncedCounts;
   onAdd: () => void;
   onRemove: () => void;
   onImportJson: () => void;
-  onConnectKilter?: () => void;
   isRemoving: boolean;
   isImporting: boolean;
-  isConnectingKilter?: boolean;
   userName?: string | null;
   userEmail?: string | null;
-  /**
-   * When true and the user has no Kilter credential yet, render the
-   * "Connect Kilter account" OAuth button instead of the shut-down notice.
-   * Allowlist-gated by the backend's credential status response.
-   */
-  kilterSyncEnabled?: boolean;
 };
 
 export function BoardCredentialCard({
   boardType,
+  variant,
   credential,
   unsyncedCounts,
   onAdd,
   onRemove,
   onImportJson,
-  onConnectKilter,
   isRemoving,
   isImporting,
-  isConnectingKilter = false,
   userName,
   userEmail,
-  kilterSyncEnabled = false,
 }: BoardCredentialCardProps) {
   const { t } = useTranslation('settings');
   const boardName = boardType.charAt(0).toUpperCase() + boardType.slice(1);
   const totalUnsynced = unsyncedCounts.ascents + unsyncedCounts.climbs;
-  const isKilter = boardType === 'kilter';
+  const isExpired = credential?.syncStatus === 'expired';
+  const cardTitle =
+    variant === 'kilterAurora'
+      ? t('aurora.card.kilterAuroraTitle')
+      : variant === 'kilterNew'
+        ? t('aurora.card.kilterNewTitle')
+        : `${boardName} ${t('aurora.card.boardSuffix')}`;
 
   const getSyncStatusTag = () => {
     if (!credential) return null;
@@ -180,52 +183,71 @@ export function BoardCredentialCard({
         <CardContent>
           <div className={styles.cardHeader}>
             <Typography variant="h5" sx={{ margin: 0 }}>
-              {boardName} {t('aurora.card.boardSuffix')}
+              {cardTitle}
             </Typography>
           </div>
-          {isKilter ? (
-            <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
-              {kilterSyncEnabled ? t('aurora.card.kilterConnectCopy') : t('aurora.card.kilterShutdown')}
-            </Typography>
+          {variant === 'kilterNew' ? (
+            <>
+              <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
+                {t('aurora.card.kilterNewCopy')}
+              </Typography>
+              <div className={styles.buttonRowStacked}>
+                <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
+                  {t('aurora.card.kilterSignIn')}
+                </Button>
+                <Button
+                  variant="outlined"
+                  startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
+                  onClick={onImportJson}
+                  disabled={isImporting}
+                >
+                  {t('aurora.card.import')}
+                </Button>
+              </div>
+            </>
+          ) : variant === 'kilterAurora' ? (
+            <>
+              <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
+                {t('aurora.card.kilterAuroraCopy')}
+              </Typography>
+              <div className={styles.buttonRowStacked}>
+                <Button
+                  variant="contained"
+                  startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
+                  onClick={onImportJson}
+                  disabled={isImporting}
+                >
+                  {t('aurora.card.import')}
+                </Button>
+                <Button
+                  variant="outlined"
+                  startIcon={<EmailOutlined />}
+                  href={buildKilterDataRequestMailto(t, userName, userEmail)}
+                >
+                  {t('aurora.card.requestData')}
+                </Button>
+              </div>
+            </>
           ) : (
-            <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
-              {t('aurora.card.notConnected', { boardName })}
-            </Typography>
+            <>
+              <Typography variant="body2" component="span" color="text.secondary" className={styles.notConnectedText}>
+                {t('aurora.card.notConnected', { boardName })}
+              </Typography>
+              <div className={styles.buttonRow}>
+                <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
+                  {t('aurora.card.link')}
+                </Button>
+                <Button
+                  variant="outlined"
+                  startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
+                  onClick={onImportJson}
+                  disabled={isImporting}
+                >
+                  {t('aurora.card.import')}
+                </Button>
+              </div>
+            </>
           )}
-          <div className={isKilter ? styles.buttonRowStacked : styles.buttonRow}>
-            {!isKilter && (
-              <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
-                {t('aurora.card.link')}
-              </Button>
-            )}
-            {isKilter && kilterSyncEnabled && (
-              <Button
-                variant="contained"
-                startIcon={isConnectingKilter ? <CircularProgress size={16} /> : <LinkOutlined />}
-                onClick={onConnectKilter}
-                disabled={isConnectingKilter || !onConnectKilter}
-              >
-                {t('aurora.card.kilterConnectButton')}
-              </Button>
-            )}
-            <Button
-              variant={isKilter && !kilterSyncEnabled ? 'contained' : 'outlined'}
-              startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
-              onClick={onImportJson}
-              disabled={isImporting}
-            >
-              {t('aurora.card.import')}
-            </Button>
-            {isKilter && !kilterSyncEnabled && (
-              <Button
-                variant="outlined"
-                startIcon={<EmailOutlined />}
-                href={buildKilterDataRequestMailto(t, userName, userEmail)}
-              >
-                {t('aurora.card.requestData')}
-              </Button>
-            )}
-          </div>
         </CardContent>
       </Card>
     );
@@ -236,7 +258,7 @@ export function BoardCredentialCard({
       <CardContent>
         <div className={styles.cardHeader}>
           <Typography variant="h5" sx={{ margin: 0 }}>
-            {boardName} {t('aurora.card.boardSuffix')}
+            {cardTitle}
           </Typography>
           {getSyncStatusTag()}
         </div>
@@ -292,6 +314,11 @@ export function BoardCredentialCard({
               {t('aurora.card.unlink')}
             </Button>
           </ConfirmPopover>
+          {isExpired && (
+            <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
+              {t('aurora.card.reconnect')}
+            </Button>
+          )}
           <Button
             variant="outlined"
             startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}
@@ -359,7 +386,7 @@ export default function AuroraCredentialsSection() {
   const [loading, setLoading] = useState(true);
   const [credentialsLoadError, setCredentialsLoadError] = useState(false);
   const [kilterSyncAllowed, setKilterSyncAllowed] = useState(false);
-  const [connectingKilter, setConnectingKilter] = useState(false);
+  const kilterOauthLinkingEnabled = useFeatureFlag('kilter-oauth-linking') === true;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedBoard, setSelectedBoard] = useState<AuroraBoardName>('kilter');
   const [isSaving, setIsSaving] = useState(false);
@@ -487,11 +514,18 @@ export default function AuroraCredentialsSection() {
       const transport = resolveAuroraBackendTransport(authToken);
       if (!transport) throw new Error(t('aurora.linkDialog.linkError'));
 
-      await saveAuroraCredential(transport, {
-        boardType: selectedBoard,
-        username: values.username,
-        password: values.password,
-      });
+      if (selectedBoard === 'kilter') {
+        await saveKilterCredentialViaPassword(transport, {
+          username: values.username,
+          password: values.password,
+        });
+      } else {
+        await saveAuroraCredential(transport, {
+          boardType: selectedBoard,
+          username: values.username,
+          password: values.password,
+        });
+      }
 
       showMessage(t('aurora.linkDialog.linkSuccess', { boardName: selectedBoardName }), 'success');
       setIsModalOpen(false);
@@ -522,22 +556,6 @@ export default function AuroraCredentialsSection() {
       showMessage(error instanceof Error ? error.message : t('aurora.unlinkError'), 'error');
     } finally {
       setRemovingBoard(null);
-    }
-  };
-
-  const handleConnectKilter = async () => {
-    setConnectingKilter(true);
-    try {
-      const transport = resolveAuroraBackendTransport(authToken);
-      if (!transport) throw new Error(t('aurora.mobile.kilterConnectFailed'));
-
-      const returnUrl =
-        typeof window === 'undefined' ? '/settings' : `${window.location.origin}${window.location.pathname}`;
-      const startUrl = await createKilterHandoffStartUrl(transport, returnUrl);
-      window.location.assign(startUrl);
-    } catch (error) {
-      showMessage(error instanceof Error ? error.message : t('aurora.mobile.kilterConnectFailed'), 'error');
-      setConnectingKilter(false);
     }
   };
 
@@ -680,6 +698,22 @@ export default function AuroraCredentialsSection() {
     return credentials.find((credential) => credential.boardType === boardType) || null;
   };
 
+  // Show the new Kilter card when the flag + backend gate are on, or whenever a
+  // Kilter account is already linked (so it stays manageable if the flag flips off).
+  const showKilterNew = (kilterOauthLinkingEnabled && kilterSyncAllowed) || getCredentialForBoard('kilter') !== null;
+  const cardConfigs = AURORA_BOARDS.flatMap<{
+    key: string;
+    boardType: AuroraBoardName;
+    variant: BoardCredentialCardVariant;
+  }>((boardType) => {
+    if (boardType !== 'kilter') return [{ key: boardType, boardType, variant: 'aurora' }];
+    const kilterCards: { key: string; boardType: AuroraBoardName; variant: BoardCredentialCardVariant }[] = [
+      { key: 'kilter-aurora', boardType: 'kilter', variant: 'kilterAurora' },
+    ];
+    if (showKilterNew) kilterCards.push({ key: 'kilter-new', boardType: 'kilter', variant: 'kilterNew' });
+    return kilterCards;
+  });
+
   const isImporting = importPhase === 'importing';
   const isImportDialogOpen =
     importPhase === 'preview' || importPhase === 'importing' || importPhase === 'complete' || importPhase === 'error';
@@ -750,30 +784,24 @@ export default function AuroraCredentialsSection() {
           </Typography>
 
           <Stack spacing={2} className={styles.cardsContainer}>
-            {AURORA_BOARDS.map((boardType) => {
-              const kilterProps =
-                boardType === 'kilter'
-                  ? {
-                      onConnectKilter: handleConnectKilter,
-                      isConnectingKilter: connectingKilter,
-                      userName: session?.user?.name ?? null,
-                      userEmail: session?.user?.email ?? null,
-                      kilterSyncEnabled: kilterSyncAllowed,
-                    }
-                  : {};
-
+            {cardConfigs.map(({ key, boardType, variant }) => {
+              // The legacy "Kilter (Aurora)" card never owns the linked-account state —
+              // that belongs to the new card.
+              const credential = variant === 'kilterAurora' ? null : getCredentialForBoard(boardType);
               return (
                 <BoardCredentialCard
-                  key={boardType}
+                  key={key}
                   boardType={boardType}
-                  credential={getCredentialForBoard(boardType)}
+                  variant={variant}
+                  credential={credential}
                   unsyncedCounts={unsyncedCounts?.[boardType] ?? { ascents: 0, climbs: 0 }}
                   onAdd={() => handleAddClick(boardType)}
                   onRemove={() => handleRemove(boardType)}
                   onImportJson={() => handleImportClick(boardType)}
                   isRemoving={removingBoard === boardType}
                   isImporting={isImporting && importingBoard === boardType}
-                  {...kilterProps}
+                  userName={boardType === 'kilter' ? (session?.user?.name ?? null) : null}
+                  userEmail={boardType === 'kilter' ? (session?.user?.email ?? null) : null}
                 />
               );
             })}
@@ -793,10 +821,16 @@ export default function AuroraCredentialsSection() {
 
       {/* Link Account Dialog */}
       <Dialog open={isModalOpen} onClose={handleModalCancel} maxWidth="sm" fullWidth>
-        <DialogTitle>{t('aurora.linkDialog.title', { boardName: selectedBoardName })}</DialogTitle>
+        <DialogTitle>
+          {selectedBoard === 'kilter'
+            ? t('aurora.kilterLinkDialog.title')
+            : t('aurora.linkDialog.title', { boardName: selectedBoardName })}
+        </DialogTitle>
         <DialogContent>
           <Typography variant="body2" component="span" color="text.secondary" className={styles.modalDescription}>
-            {t('aurora.linkDialog.description', { boardName: selectedBoardName })}
+            {selectedBoard === 'kilter'
+              ? t('aurora.kilterLinkDialog.description')
+              : t('aurora.linkDialog.description', { boardName: selectedBoardName })}
           </Typography>
           <Box
             component="form"

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -298,6 +298,11 @@ export function BoardCredentialCard({
           )}
         </div>
         <div className={styles.buttonRow}>
+          {isExpired && (
+            <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
+              {t('aurora.card.reconnect')}
+            </Button>
+          )}
           <ConfirmPopover
             title={t('aurora.card.unlinkConfirm.title')}
             description={t('aurora.card.unlinkConfirm.description', { boardName })}
@@ -314,11 +319,6 @@ export function BoardCredentialCard({
               {t('aurora.card.unlink')}
             </Button>
           </ConfirmPopover>
-          {isExpired && (
-            <Button variant="contained" startIcon={<LinkOutlined />} onClick={onAdd}>
-              {t('aurora.card.reconnect')}
-            </Button>
-          )}
           <Button
             variant="outlined"
             startIcon={isImporting ? <CircularProgress size={16} /> : <FileUploadOutlined />}

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -327,6 +327,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
     <>
       <BoardCredentialCard
         boardType={boardType}
+        variant={boardType === 'kilter' ? 'kilterAurora' : 'aurora'}
         credential={credential}
         unsyncedCounts={{ ascents: 0, climbs: 0 }}
         onAdd={handleAddClick}

--- a/packages/web/app/components/settings/board-import-prompt.tsx
+++ b/packages/web/app/components/settings/board-import-prompt.tsx
@@ -328,7 +328,7 @@ export default function BoardImportPrompt({ boardType, onImportComplete }: Board
       <BoardCredentialCard
         boardType={boardType}
         variant={boardType === 'kilter' ? 'kilterAurora' : 'aurora'}
-        credential={credential}
+        credential={boardType === 'kilter' ? null : credential}
         unsyncedCounts={{ ascents: 0, climbs: 0 }}
         onAdd={handleAddClick}
         onRemove={handleRemove}

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -15,7 +15,7 @@ export const CAPACITOR_UPDATE_BANNER_FLAG = 'capacitor-update-banner';
 
 // Keys read from PostHog by FeatureFlagsProvider. Each must have a matching
 // PostHog feature flag; values stay `undefined` (OFF) until that flag resolves.
-export const FEATURE_FLAG_KEYS = [CAPACITOR_UPDATE_BANNER_FLAG] as const;
+export const FEATURE_FLAG_KEYS = [CAPACITOR_UPDATE_BANNER_FLAG, 'kilter-oauth-linking'] as const;
 
 // Vercel's flags discovery endpoint expects an allFlags export.
 export const allFlags: Array<{ key: string }> = FEATURE_FLAG_KEYS.map((key) => ({ key }));

--- a/packages/web/app/lib/aurora-credentials/client.ts
+++ b/packages/web/app/lib/aurora-credentials/client.ts
@@ -142,3 +142,18 @@ export async function finalizeKilterCredential(
     body: JSON.stringify({ completion }),
   });
 }
+
+/**
+ * Link a Kilter account from a username + password (Keycloak ROPC). Used instead
+ * of the OAuth handoff because Kilter hasn't registered a redirect URI for us. The
+ * password is exchanged for a refresh token server-side and never stored.
+ */
+export async function saveKilterCredentialViaPassword(
+  transport: AuroraBackendTransport,
+  input: { username: string; password: string },
+): Promise<{ success: true }> {
+  return requestBackendJson<{ success: true }>(transport, '/api/board-credentials/kilter/password', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}


### PR DESCRIPTION
## Summary

Kilter moved to a new Keycloak + PowerSync backend and never gave us an OAuth client/redirect URI, so the existing authorization-code link flow can't run. The public `kilter` Keycloak client **does** allow the Resource-Owner-Password-Credentials (ROPC) grant — the same one we already use for catalog sync — so this adds a username/password sign-in that mints a Kilter refresh token directly and feeds it into the existing credential-storage + sync daemon. That unblocks users migrating their Kilter data into Boardsesh.

**Backend**
- `saveKilterCredentialViaPassword()` — `passwordGrant` → verify the returned JWT (`sub` = Keycloak user id; verified without `expectedAudience` since ROPC has no nonce/redirect binding, falling back to the access token) → reuse the existing `saveKilterCredential`. The password is never stored, only the refresh token.
- `POST /api/board-credentials/kilter/password` — auth-gated, allowlist-gated, per-user rate-limited (5/min). Bad credentials return a generic `Invalid Aurora credentials` 401 that never leaks whether a username exists (and which the mobile client already maps).
- `isKilterSyncAllowed` now honours a `*` wildcard, so `KILTER_SYNC_ALLOWED_USER_IDS=*` opens linking to every signed-in user while the env var stays the kill switch.

**Mobile + web** (ported from the card scaffolding in #2943, which this supersedes)
- Kilter now renders two cards: **Kilter (Aurora)** (legacy JSON import + data request) and **Kilter (new)** (username/password sign-in), gated by the `kilter-oauth-linking` PostHog flag + the backend allowlist. A **Reconnect** action appears on expired credentials. JSON import stays as the fallback for 2FA / social-login-only accounts ROPC can't serve.

The dormant authorization-code OAuth flow (handlers + lib) is kept for when Kilter registers us.

### Rollout (ops)
- Set `KILTER_SYNC_ALLOWED_USER_IDS=*` on **both** the backend and the kilter-sync daemon, and turn the `kilter-oauth-linking` PostHog flag to 100%.
- Confirm `KILTER_OAUTH_CLIENT_ID` (the public `kilter` client) is set on the backend, and that the backend + daemon share the same `@boardsesh/crypto` key.

## Release Notes

- Connect your Kilter account with your username and password to pull your sends, attempts, ratings, and circuits into Boardsesh.
- Used the old Kilter app built by Aurora? Import a JSON export or request your data from the new "Kilter (Aurora)" card.

## Test plan

- `vp run typecheck` (backend, mobile, web) — green.
- `vp check` on all changed files — 0 warnings/errors.
- Backend: `kilter-credentials-oauth.test.ts` (+6 password handler cases: auth, gate, validation, happy path, generic-401 on bad creds, rate limit) and new `aurora-credentials-gate.test.ts` (wildcard/allowlist/off) — 13 pass.
- Mobile: full suite (2587) green, incl. new `BoardAccountsSection.test.tsx` (kilterNew card shows/hides on the flag; sign-in routes to the password grant). Metro bundle check OK.
- Web: settings suite green (updated `board-import-prompt` title assertion for the new "Kilter (Aurora)" card).
- i18n: catalog completeness + `check:i18n` + `check:i18n:orphans` all green (es/fr added with the `plafón` glossary; removed the now-orphaned `kilterShutdown`/`kilterConnect*` keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)