### PR TITLE
chore(mobile): bump version to 2.0.1

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.0.0',
+    version: '2.0.1',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,


### PR DESCRIPTION
Bumps the app `version` in `app.config.ts` from `2.0.0` to `2.0.1` so the next TestFlight submission is accepted by App Store Connect (which requires a higher marketing version than the last accepted build).

## Release Notes

none

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvWpYz5zDZneBX1pWvK7Ps)_