### PR TITLE
chore: weekly cleanup for stale merged-PR branches

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,55 @@
+name: Branch Cleanup
+
+# Weekly: delete stale `origin` branches whose PR has already merged. GitHub's
+# "Automatically delete head branches" setting handles new merges going forward;
+# this drains anything that setting misses (branches merged before it was enabled,
+# or merged via the API) so the branch list doesn't creep back up. The script is
+# conservative — merged-only, never an open-PR/protected/diverged branch — and
+# aborts without deleting if it can't gather a complete PR/branch picture.
+on:
+  schedule:
+    - cron: '0 5 * * 1' # 05:00 UTC every Monday (off the acknowledgements job at 07:00)
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually delete branches (unchecked = dry-run preview)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: branch-cleanup
+  cancel-in-progress: false
+
+permissions:
+  contents: write # delete branch refs via `git push origin --delete`
+  pull-requests: read # `gh pr list`
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Scheduled runs always apply. A manual dispatch only applies when the `apply`
+      # input is checked, so a human can preview the list first.
+      - name: Clean up merged branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.apply }}" == "true" ]]; then
+            vp run cleanup:branches -- --apply
+          else
+            vp run cleanup:branches
+          fi

--- a/scripts/__tests__/branch-cleanup.test.ts
+++ b/scripts/__tests__/branch-cleanup.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { selectBranchesToDelete, isProtected, type MergedPr } from '../lib/branch-cleanup';
+
+const PROTECTED_NAMES = ['main', 'master', 'gh-pages', 'production', 'staging'];
+const PROTECTED_PREFIXES = ['pr-screenshots/', 'dependabot/', 'renovate/', 'release/'];
+
+function merged(number: number, headRefName: string, mergedAt: string, headRefOid: string): MergedPr {
+  return { number, headRefName, mergedAt, headRefOid };
+}
+
+describe('isProtected', () => {
+  it('matches exact protected names', () => {
+    expect(isProtected('main', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
+    expect(isProtected('gh-pages', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
+  });
+
+  it('matches protected prefixes', () => {
+    expect(isProtected('dependabot/npm/lodash', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
+    expect(isProtected('pr-screenshots/42', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
+  });
+
+  it('leaves ordinary branches unprotected', () => {
+    expect(isProtected('feat/add-thing', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(false);
+    // A name that merely contains a protected word but does not match exactly.
+    expect(isProtected('my-production-fix', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(false);
+  });
+});
+
+describe('selectBranchesToDelete', () => {
+  const base = {
+    protectedNames: PROTECTED_NAMES,
+    protectedPrefixes: PROTECTED_PREFIXES,
+  };
+
+  it('marks a merged-PR branch whose tip is unchanged as eligible', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      remoteBranches: { 'feat/done': 'abc123' },
+      mergedPrs: [merged(10, 'feat/done', '2026-06-01T00:00:00Z', 'abc123')],
+      openHeads: [],
+    });
+    expect(result.eligible).toEqual([{ branch: 'feat/done', prNumber: 10, mergedAt: '2026-06-01T00:00:00Z' }]);
+    expect(result.keptOpen).toEqual([]);
+    expect(result.keptNoMergedPr).toEqual([]);
+    expect(result.keptDiverged).toEqual([]);
+  });
+
+  it('keeps a branch reused for new work after its PR merged (tip moved past merged head)', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      remoteBranches: { 'feat/reused': 'newsha999' },
+      mergedPrs: [merged(10, 'feat/reused', '2026-06-01T00:00:00Z', 'oldsha111')],
+      openHeads: [],
+    });
+    expect(result.eligible).toEqual([]);
+    expect(result.keptDiverged).toEqual(['feat/reused']);
+  });
+
+  it('keeps a branch that still has an open PR even if a merged PR shares the name', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      remoteBranches: { 'feat/reused': 'abc123' },
+      mergedPrs: [merged(10, 'feat/reused', '2026-06-01T00:00:00Z', 'abc123')],
+      openHeads: ['feat/reused'],
+    });
+    expect(result.eligible).toEqual([]);
+    expect(result.keptOpen).toEqual(['feat/reused']);
+  });
+
+  it('keeps a branch with no merged PR (experiments, renamed branches)', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      remoteBranches: { add_esphome_stuff: 'abc123' },
+      mergedPrs: [],
+      openHeads: [],
+    });
+    expect(result.eligible).toEqual([]);
+    expect(result.keptNoMergedPr).toEqual(['add_esphome_stuff']);
+  });
+
+  it('never deletes protected branches, even with a merged PR of the same name', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      remoteBranches: { main: 'abc123', 'dependabot/npm/lodash': 'def456' },
+      mergedPrs: [
+        merged(1, 'main', '2026-06-01T00:00:00Z', 'abc123'),
+        merged(2, 'dependabot/npm/lodash', '2026-06-02T00:00:00Z', 'def456'),
+      ],
+      openHeads: [],
+    });
+    expect(result.eligible).toEqual([]);
+    expect(result.keptProtected.sort()).toEqual(['dependabot/npm/lodash', 'main']);
+  });
+
+  it('ignores merged PRs whose head is not an actual remote branch (deleted/cross-repo forks)', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      // Only `feat/live` exists on origin. The fork PR's `patch-1` head and the
+      // already-deleted `already-gone` head have no remote branch, so they can
+      // never select anything.
+      remoteBranches: { 'feat/live': 'live000' },
+      mergedPrs: [
+        merged(10, 'feat/live', '2026-06-01T00:00:00Z', 'live000'),
+        merged(11, 'patch-1', '2026-06-02T00:00:00Z', 'fork111'),
+        merged(12, 'already-gone', '2026-06-03T00:00:00Z', 'gone222'),
+      ],
+      openHeads: [],
+    });
+    expect(result.eligible).toEqual([{ branch: 'feat/live', prNumber: 10, mergedAt: '2026-06-01T00:00:00Z' }]);
+  });
+
+  it('keeps the newest merged PR per reused branch name and sorts oldest-merge first', () => {
+    const result = selectBranchesToDelete({
+      ...base,
+      remoteBranches: { 'feat/a': 'sha-a2', 'feat/b': 'sha-b1' },
+      mergedPrs: [
+        merged(1, 'feat/a', '2026-06-05T00:00:00Z', 'sha-a1'),
+        merged(2, 'feat/a', '2026-06-10T00:00:00Z', 'sha-a2'), // newer reuse of the same name wins
+        merged(3, 'feat/b', '2026-06-01T00:00:00Z', 'sha-b1'),
+      ],
+      openHeads: [],
+    });
+    expect(result.eligible).toEqual([
+      { branch: 'feat/b', prNumber: 3, mergedAt: '2026-06-01T00:00:00Z' },
+      { branch: 'feat/a', prNumber: 2, mergedAt: '2026-06-10T00:00:00Z' },
+    ]);
+  });
+});

--- a/scripts/__tests__/branch-cleanup.test.ts
+++ b/scripts/__tests__/branch-cleanup.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { selectBranchesToDelete, isProtected, type MergedPr } from '../lib/branch-cleanup';
 
-const PROTECTED_NAMES = ['main', 'master', 'gh-pages', 'production', 'staging'];
+// Mirror how the CLI composes the protected list: a static set, plus the resolved
+// default branch appended at runtime. `main` is NOT in the static set — it is only
+// protected because the default branch gets added. The tests below assert both
+// halves of that contract so a refactor dropping the dynamic add fails here.
+const DEFAULT_BRANCH = 'main';
+const STATIC_PROTECTED_NAMES = ['master', 'gh-pages', 'production', 'staging'];
+const PROTECTED_NAMES = [...STATIC_PROTECTED_NAMES, DEFAULT_BRANCH];
 const PROTECTED_PREFIXES = ['pr-screenshots/', 'dependabot/', 'renovate/', 'release/'];
 
 function merged(number: number, headRefName: string, mergedAt: string, headRefOid: string): MergedPr {
@@ -10,8 +16,13 @@ function merged(number: number, headRefName: string, mergedAt: string, headRefOi
 
 describe('isProtected', () => {
   it('matches exact protected names', () => {
-    expect(isProtected('main', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
+    expect(isProtected('master', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
     expect(isProtected('gh-pages', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
+  });
+
+  it('protects the default branch only once it is appended (not statically)', () => {
+    expect(isProtected('main', STATIC_PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(false);
+    expect(isProtected('main', PROTECTED_NAMES, PROTECTED_PREFIXES)).toBe(true);
   });
 
   it('matches protected prefixes', () => {

--- a/scripts/cleanup-merged-branches.ts
+++ b/scripts/cleanup-merged-branches.ts
@@ -31,7 +31,10 @@ const REPO_SLUG = `${REPO_OWNER}/${REPO_NAME}`;
 // count; if a run ever hits this cap it warns, and the only effect is that some of
 // the oldest branches are kept (never wrongly deleted). Bump if the repo outgrows it.
 const MERGED_PR_FETCH_LIMIT = 6000;
-const OPEN_PR_FETCH_LIMIT = 500;
+// Upper bound on OPEN PRs fetched. Unlike the merged cap, hitting this one is
+// UNSAFE — a dropped open PR's branch would wrongly become eligible — so the run
+// aborts (see fetchOpenHeads) rather than warning. Sized well above the current count.
+const OPEN_PR_FETCH_LIMIT = 2000;
 
 // Never delete these, regardless of merge state. The default branch is added at
 // runtime. These are defense-in-depth: a branch with no merged PR is already kept,
@@ -95,7 +98,9 @@ function resolveDefaultBranch(): string {
   try {
     return gh(['api', `repos/${REPO_SLUG}`, '--jq', '.default_branch']).trim() || 'main';
   } catch {
-    // Fall back to `main` — it's protected either way, so a wrong guess is harmless.
+    // Fall back to `main`. A wrong guess is harmless in practice: the default
+    // branch is never the head of a merged PR (PRs merge *into* it), so it can't
+    // be selected, and `master` is already in PROTECTED_NAMES regardless.
     return 'main';
   }
 }
@@ -115,6 +120,13 @@ function fetchOpenHeads(): string[] {
     'headRefName,isCrossRepository',
   ]);
   const prs = JSON.parse(raw) as RawOpenPr[];
+  // Hitting the cap means we may not have every open PR — and a missing open PR
+  // would let its still-active branch be deleted. Refuse to run on a partial list.
+  if (prs.length >= OPEN_PR_FETCH_LIMIT) {
+    throw new Error(
+      `open-PR fetch hit the cap of ${OPEN_PR_FETCH_LIMIT}; the open-PR list may be incomplete. Bump OPEN_PR_FETCH_LIMIT.`,
+    );
+  }
   return prs.filter((pr) => !pr.isCrossRepository).map((pr) => pr.headRefName);
 }
 

--- a/scripts/cleanup-merged-branches.ts
+++ b/scripts/cleanup-merged-branches.ts
@@ -1,0 +1,295 @@
+/// <reference types="node" />
+
+/**
+ * Delete stale `origin` branches whose PR has already merged.
+ *
+ * GitHub's "Automatically delete head branches" setting handles new merges going
+ * forward; this script drains the pre-existing backlog and acts as a weekly safety
+ * net for anything that setting misses (branches merged before it was enabled, or
+ * merged via the API). It is intentionally conservative — see scripts/lib/branch-cleanup.ts
+ * for the eligibility rules. Closed-but-unmerged branches and branches with no PR
+ * are always left alone.
+ *
+ * Usage:
+ *   vp run cleanup:branches             # dry-run: list what would be deleted
+ *   vp run cleanup:branches -- --apply  # actually delete the eligible branches
+ *
+ * Degrades safely: if the PR/branch data can't be gathered, it deletes nothing and
+ * exits non-zero rather than acting on a partial picture.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { selectBranchesToDelete, type MergedPr, type SelectResult } from './lib/branch-cleanup';
+
+const REPO_OWNER = 'boardsesh';
+const REPO_NAME = 'boardsesh';
+const REPO_SLUG = `${REPO_OWNER}/${REPO_NAME}`;
+
+// Upper bound on merged PRs fetched in one run. Comfortably above the current
+// count; if a run ever hits this cap it warns, and the only effect is that some of
+// the oldest branches are kept (never wrongly deleted). Bump if the repo outgrows it.
+const MERGED_PR_FETCH_LIMIT = 6000;
+const OPEN_PR_FETCH_LIMIT = 500;
+
+// Never delete these, regardless of merge state. The default branch is added at
+// runtime. These are defense-in-depth: a branch with no merged PR is already kept,
+// but bot-/release-managed namespaces should never be touched even if one ever has.
+const PROTECTED_NAMES = ['master', 'gh-pages', 'production', 'staging'];
+const PROTECTED_PREFIXES = ['pr-screenshots/', 'dependabot/', 'renovate/', 'release/'];
+
+// How many branches to hand to a single `git push --delete`. Keeps the command
+// line bounded; a failed chunk is retried one branch at a time to isolate failures.
+const DELETE_CHUNK_SIZE = 50;
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const apply = process.argv.includes('--apply');
+const showHelp = process.argv.includes('-h') || process.argv.includes('--help');
+
+const tty = process.stdout.isTTY === true;
+const color = {
+  green: (text: string) => (tty ? `\x1b[32m${text}\x1b[0m` : text),
+  yellow: (text: string) => (tty ? `\x1b[33m${text}\x1b[0m` : text),
+  red: (text: string) => (tty ? `\x1b[31m${text}\x1b[0m` : text),
+  blue: (text: string) => (tty ? `\x1b[34m${text}\x1b[0m` : text),
+  dim: (text: string) => (tty ? `\x1b[2m${text}\x1b[0m` : text),
+};
+
+function gh(args: string[]): string {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function git(args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: here,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function describeError(error: unknown): string {
+  if (error && typeof error === 'object' && 'stderr' in error) {
+    const stderr = (error as { stderr?: unknown }).stderr;
+    if (typeof stderr === 'string' && stderr.trim()) return stderr.trim();
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+type RawOpenPr = { headRefName: string; isCrossRepository: boolean };
+type RawMergedPr = {
+  number: number;
+  headRefName: string;
+  mergedAt: string;
+  headRefOid: string;
+  isCrossRepository: boolean;
+};
+
+function resolveDefaultBranch(): string {
+  try {
+    return gh(['api', `repos/${REPO_SLUG}`, '--jq', '.default_branch']).trim() || 'main';
+  } catch {
+    // Fall back to `main` — it's protected either way, so a wrong guess is harmless.
+    return 'main';
+  }
+}
+
+/** Head names of open same-repo PRs. Fork PRs (cross-repo) can't pin our branches. */
+function fetchOpenHeads(): string[] {
+  const raw = gh([
+    'pr',
+    'list',
+    '--repo',
+    REPO_SLUG,
+    '--state',
+    'open',
+    '--limit',
+    String(OPEN_PR_FETCH_LIMIT),
+    '--json',
+    'headRefName,isCrossRepository',
+  ]);
+  const prs = JSON.parse(raw) as RawOpenPr[];
+  return prs.filter((pr) => !pr.isCrossRepository).map((pr) => pr.headRefName);
+}
+
+/** Merged same-repo PRs, with the head commit they merged. */
+function fetchMergedPrs(): MergedPr[] {
+  const raw = gh([
+    'pr',
+    'list',
+    '--repo',
+    REPO_SLUG,
+    '--state',
+    'merged',
+    '--limit',
+    String(MERGED_PR_FETCH_LIMIT),
+    '--json',
+    'number,headRefName,mergedAt,headRefOid,isCrossRepository',
+  ]);
+  const prs = JSON.parse(raw) as RawMergedPr[];
+  if (prs.length >= MERGED_PR_FETCH_LIMIT) {
+    console.warn(
+      color.yellow(
+        `[cleanup] hit the ${MERGED_PR_FETCH_LIMIT} merged-PR fetch cap; the oldest branches may be skipped this run. Bump MERGED_PR_FETCH_LIMIT.`,
+      ),
+    );
+  }
+  return prs
+    .filter((pr) => !pr.isCrossRepository)
+    .map((pr) => ({
+      number: pr.number,
+      headRefName: pr.headRefName,
+      mergedAt: pr.mergedAt,
+      headRefOid: pr.headRefOid,
+    }));
+}
+
+/** Branches on origin: name (no `refs/heads/` prefix) -> current tip commit oid. */
+function fetchRemoteBranches(): Record<string, string> {
+  const raw = git(['ls-remote', '--heads', 'origin']);
+  const branches: Record<string, string> = {};
+  const prefix = 'refs/heads/';
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [sha, ref] = trimmed.split(/\s+/);
+    if (!sha || !ref || !ref.startsWith(prefix)) continue;
+    branches[ref.slice(prefix.length)] = sha;
+  }
+  return branches;
+}
+
+function printSummary(totalBranches: number, result: SelectResult): void {
+  const line = '─'.repeat(60);
+  console.log(line);
+  console.log(`Remote branches:        ${totalBranches}`);
+  console.log(`Eligible for deletion:  ${color.green(String(result.eligible.length))}`);
+  console.log(`Kept — open PR:         ${result.keptOpen.length}`);
+  console.log(`Kept — no merged PR:    ${result.keptNoMergedPr.length}`);
+  console.log(`Kept — tip diverged:    ${color.yellow(String(result.keptDiverged.length))}`);
+  console.log(`Kept — protected:       ${result.keptProtected.length}`);
+  console.log(line);
+}
+
+/** Delete branches in chunks; retry a failed chunk one-by-one to isolate failures. */
+function deleteBranches(branches: string[]): { removed: string[]; failed: string[] } {
+  const removed: string[] = [];
+  const failed: string[] = [];
+  for (let offset = 0; offset < branches.length; offset += DELETE_CHUNK_SIZE) {
+    const chunk = branches.slice(offset, offset + DELETE_CHUNK_SIZE);
+    try {
+      git(['push', 'origin', '--delete', ...chunk]);
+      removed.push(...chunk);
+      console.log(color.green(`  ✓ deleted ${chunk.length} (${removed.length}/${branches.length})`));
+    } catch {
+      for (const branch of chunk) {
+        try {
+          git(['push', 'origin', '--delete', branch]);
+          removed.push(branch);
+        } catch (error) {
+          failed.push(branch);
+          console.warn(color.red(`  ! failed to delete ${branch}: ${describeError(error)}`));
+        }
+      }
+    }
+  }
+  return { removed, failed };
+}
+
+function printHelp(): void {
+  console.log(
+    [
+      'Delete stale origin branches whose PR has already merged.',
+      '',
+      'Usage:',
+      '  vp run cleanup:branches             dry-run: list what would be deleted',
+      '  vp run cleanup:branches -- --apply  actually delete the eligible branches',
+      '',
+      'A branch is deleted only when it is the head of a merged same-repo PR, has no',
+      'open PR, is not protected, and its tip still matches the merged commit.',
+    ].join('\n'),
+  );
+}
+
+function main(): number {
+  if (showHelp) {
+    printHelp();
+    return 0;
+  }
+
+  let openHeads: string[];
+  let mergedPrs: MergedPr[];
+  let remoteBranches: Record<string, string>;
+  try {
+    openHeads = fetchOpenHeads();
+    mergedPrs = fetchMergedPrs();
+    remoteBranches = fetchRemoteBranches();
+  } catch (error) {
+    console.error(color.red(`[cleanup] failed to gather PR/branch data: ${describeError(error)}`));
+    console.error(color.red('[cleanup] aborting without deleting anything.'));
+    return 1;
+  }
+
+  // Abort guards: never act on an incomplete picture.
+  if (mergedPrs.length === 0) {
+    console.error(
+      color.red('[cleanup] no merged PRs returned — likely an auth/API problem. Aborting without deleting anything.'),
+    );
+    return 1;
+  }
+  const totalBranches = Object.keys(remoteBranches).length;
+  if (totalBranches === 0) {
+    console.log('[cleanup] no remote branches found. Nothing to do.');
+    return 0;
+  }
+
+  const defaultBranch = resolveDefaultBranch();
+  const protectedNames = PROTECTED_NAMES.includes(defaultBranch)
+    ? PROTECTED_NAMES
+    : [...PROTECTED_NAMES, defaultBranch];
+
+  const result = selectBranchesToDelete({
+    remoteBranches,
+    mergedPrs,
+    openHeads,
+    protectedNames,
+    protectedPrefixes: PROTECTED_PREFIXES,
+  });
+
+  if (result.eligible.length > 0) {
+    console.log(apply ? 'Deleting branches from merged PRs:' : 'Branches from merged PRs eligible for deletion:');
+    for (const entry of result.eligible) {
+      console.log(`  ${entry.branch} ${color.dim(`← PR #${entry.prNumber} (merged ${entry.mergedAt.slice(0, 10)})`)}`);
+    }
+    console.log('');
+  }
+
+  printSummary(totalBranches, result);
+
+  if (result.eligible.length === 0) {
+    console.log('Nothing to delete.');
+    return 0;
+  }
+
+  if (!apply) {
+    console.log('');
+    console.log(
+      `${color.blue('Dry run.')} Re-run with ${color.blue('-- --apply')} to delete the ${result.eligible.length} branch(es) above.`,
+    );
+    return 0;
+  }
+
+  console.log('');
+  const { removed, failed } = deleteBranches(result.eligible.map((entry) => entry.branch));
+  console.log('');
+  console.log(`Done. Removed: ${color.green(String(removed.length))}   Failed: ${color.red(String(failed.length))}`);
+  return failed.length > 0 ? 1 : 0;
+}
+
+process.exit(main());

--- a/scripts/lib/branch-cleanup.ts
+++ b/scripts/lib/branch-cleanup.ts
@@ -1,0 +1,125 @@
+/// <reference types="node" />
+
+/**
+ * Pure selection logic for the stale-branch cleanup. Given the branches on `origin`
+ * (with their current tip commit) plus the merged and open PRs, decides which
+ * branches are safe to delete.
+ *
+ * A branch is eligible only when ALL hold:
+ *   - it is the head of a merged same-repo PR,
+ *   - no open PR still uses that name,
+ *   - its name (or prefix) is not protected,
+ *   - its current tip still equals the commit that PR merged — so a branch that was
+ *     reused for new work after its PR merged is kept, not silently dropped.
+ *
+ * Kept free of I/O so it's unit-testable without hitting GitHub (see
+ * scripts/__tests__/branch-cleanup.test.ts). The shell that runs `gh`/`git` and
+ * performs the actual deletion lives in scripts/cleanup-merged-branches.ts.
+ */
+
+/** A merged, same-repo PR — only the fields the selection needs. */
+export type MergedPr = {
+  number: number;
+  /** The branch the PR was opened from (no `refs/heads/` prefix). */
+  headRefName: string;
+  /** PR merge time, ISO 8601. */
+  mergedAt: string;
+  /** Head commit oid at merge; the live ref still points here unless the branch was reused. */
+  headRefOid: string;
+};
+
+export type SelectInput = {
+  /** Branches on `origin`: name (no `refs/heads/` prefix) -> current tip commit oid. */
+  remoteBranches: Record<string, string>;
+  /** Merged same-repo PRs; the newest-merged one wins when a head name repeats. */
+  mergedPrs: MergedPr[];
+  /** Head names of currently-open same-repo PRs — never delete these. */
+  openHeads: string[];
+  /** Exact branch names that must never be deleted (e.g. the default branch). */
+  protectedNames: string[];
+  /** Branch-name prefixes that must never be deleted (e.g. `dependabot/`). */
+  protectedPrefixes: string[];
+};
+
+export type EligibleBranch = {
+  branch: string;
+  prNumber: number;
+  /** ISO 8601 merge time of the PR that retired this branch. */
+  mergedAt: string;
+};
+
+export type SelectResult = {
+  /** Safe to delete: a merged PR's head, no open PR, not protected, tip unchanged. */
+  eligible: EligibleBranch[];
+  /** Kept because an open PR still uses the branch. */
+  keptOpen: string[];
+  /** Kept because no merged same-repo PR matches the branch name. */
+  keptNoMergedPr: string[];
+  /** Kept because the name (or its prefix) is protected. */
+  keptProtected: string[];
+  /** Kept because the tip moved past the merged PR's head — likely reused for new work. */
+  keptDiverged: string[];
+};
+
+/** True when `branch` matches a protected exact name or one of the protected prefixes. */
+export function isProtected(branch: string, protectedNames: string[], protectedPrefixes: string[]): boolean {
+  if (protectedNames.includes(branch)) return true;
+  return protectedPrefixes.some((prefix) => branch.startsWith(prefix));
+}
+
+/**
+ * Partition the remote branches into delete-eligible vs. the reasons each survivor
+ * was kept. Protection is checked first (it always wins), then open PRs, then the
+ * merged-PR lookup, then the tip-still-matches check. A branch with no merged
+ * same-repo PR of the same name is left untouched — the conservative default for
+ * experiments and renamed branches.
+ */
+export function selectBranchesToDelete(input: SelectInput): SelectResult {
+  const { remoteBranches, mergedPrs, openHeads, protectedNames, protectedPrefixes } = input;
+
+  // Newest-merged PR per head name. Branch names can be reused across PRs over
+  // time; the latest merge is the one that retired the current branch.
+  const mergedByHead = new Map<string, MergedPr>();
+  for (const pr of mergedPrs) {
+    const existing = mergedByHead.get(pr.headRefName);
+    if (!existing || pr.mergedAt > existing.mergedAt) {
+      mergedByHead.set(pr.headRefName, pr);
+    }
+  }
+
+  const openSet = new Set(openHeads);
+
+  const eligible: EligibleBranch[] = [];
+  const keptOpen: string[] = [];
+  const keptNoMergedPr: string[] = [];
+  const keptProtected: string[] = [];
+  const keptDiverged: string[] = [];
+
+  for (const branch of Object.keys(remoteBranches)) {
+    if (isProtected(branch, protectedNames, protectedPrefixes)) {
+      keptProtected.push(branch);
+      continue;
+    }
+    if (openSet.has(branch)) {
+      keptOpen.push(branch);
+      continue;
+    }
+    const merged = mergedByHead.get(branch);
+    if (!merged) {
+      keptNoMergedPr.push(branch);
+      continue;
+    }
+    // The branch carries commits the merged PR never saw (reused after merge) —
+    // keep it so we never drop un-PR'd work.
+    if (remoteBranches[branch] !== merged.headRefOid) {
+      keptDiverged.push(branch);
+      continue;
+    }
+    eligible.push({ branch, prNumber: merged.number, mergedAt: merged.mergedAt });
+  }
+
+  // Oldest merges first so the dry-run reads as a stale-to-fresh cleanup list.
+  eligible.sort((a, b) => a.mergedAt.localeCompare(b.mergedAt) || a.branch.localeCompare(b.branch));
+
+  return { eligible, keptOpen, keptNoMergedPr, keptProtected, keptDiverged };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -302,6 +302,10 @@ export default defineConfig({
         command: 'node --import tsx scripts/generate-changelog.ts --check',
         cache: false,
       },
+      'cleanup:branches': {
+        command: 'node --import tsx scripts/cleanup-merged-branches.ts',
+        cache: false,
+      },
       'check:commit-message': {
         command: 'tsx scripts/check-commit-message.ts',
         cache: false,


### PR DESCRIPTION
## Summary

The repo had ~1,700 live branches on `origin` with no auto-deletion ever configured. This adds a two-pronged cleanup:

1. **Enabled the repo's native "Automatically delete head branches"** (`delete_branch_on_merge=true`) so every future merged PR self-deletes its branch. No code involved — already flipped on.
2. **`scripts/cleanup-merged-branches.ts`** (`vp run cleanup:branches`) + a weekly **Branch Cleanup** workflow that drains the existing backlog and covers anything the native setting misses (branches merged before it was enabled, or merged via the API).

### How it decides

A branch is deleted **only** when all hold (logic in `scripts/lib/branch-cleanup.ts`, unit-tested):

- it is the head of a **merged**, same-repo PR,
- **no open PR** still uses that name,
- it is **not protected** (default branch, `master`, `gh-pages`, `production`, `staging`, and the `pr-screenshots/`, `dependabot/`, `renovate/`, `release/` prefixes),
- its **current tip still equals the merged commit** — so a branch reused for new work after its PR merged is kept, never silently dropped.

Closed-but-unmerged branches and branches with no PR are always left alone. It's **dry-run by default**; `--apply` deletes. If it can't gather a complete PR/branch picture it aborts without deleting anything.

The weekly workflow (`.github/workflows/branch-cleanup.yml`) runs Mondays 05:00 UTC with `--apply`; a manual `workflow_dispatch` defaults to a dry-run preview. Local/worktree branch cleanup is unchanged — that's still `scripts/cleanup-merged-worktrees.sh`.

### Dry-run on current `main`

```
Remote branches:        1692
Eligible for deletion:  1235
Kept — open PR:         48
Kept — no merged PR:    326
Kept — tip diverged:    77
Kept — protected:       6
```

The 77 "tip diverged" branches are reused-after-merge cases the SHA guard correctly preserves. I'll run the initial `--apply` backlog cleanup once this dry-run is reviewed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/__tests__/branch-cleanup.test.ts` — 10 passing (merged-eligible, open-PR-kept, no-PR-kept, protected name/prefix, cross-repo-ignored, tip-diverged-kept, newest-reuse-wins).
- `vp run lint` on the new files — 0 warnings, 0 errors.
- `tsc --noEmit` on the new sources — clean.
- `vp run cleanup:branches` dry-run against live `origin` — output above; open-PR / protected / diverged branches correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)