### PR TITLE
feat(mobile): auto-bump patch version when App Store submission is accepted

### DIFF
--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -1,0 +1,100 @@
+name: Mobile Auto Version Bump
+
+# Polls App Store Connect hourly. When the current marketing version in
+# packages/mobile/app.config.ts has been accepted by Apple (PENDING_DEVELOPER_RELEASE,
+# PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, or READY_FOR_SALE), this workflow
+# bumps the patch version and pushes directly to main via the OTA push-back app token,
+# bypassing the PR requirement. The commit carries [skip ci] to prevent a spurious OTA
+# publish (the version change busts the fingerprint; no binary can pull such an OTA).
+#
+# Minor version bumps are intentionally excluded — those are a manual decision.
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly; App Review approval is not time-critical
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log what would change without writing or pushing'
+        type: boolean
+        default: true
+
+concurrency:
+  group: mobile-auto-version-bump
+  cancel-in-progress: false
+
+jobs:
+  check-and-bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: Production
+    permissions:
+      contents: write # needed for push-back; the app token is what actually bypasses branch protection
+    steps:
+      # Mint a token for the GitHub App that is in main's PR-bypass list.
+      # The checkout action persists this in git's credential store so the
+      # later push authenticates as the app, not github-actions[bot] (which
+      # would be rejected by the branch protection rule).
+      - name: Mint push token
+        id: push_token
+        if: vars.OTA_PUSH_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.OTA_PUSH_APP_ID }}
+          private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.push_token.outputs.token || github.token }}
+
+      - uses: oven-sh/setup-bun@v2
+
+      # No bun install needed — the script only uses built-in node:crypto / node:fs.
+      - name: Check ASC and bump version if accepted
+        id: bump
+        env:
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: bun scripts/mobile-auto-version-bump.ts
+
+      - name: Commit and push version bump to main
+        if: steps.bump.outputs.bumped == 'true' && vars.OTA_PUSH_APP_ID != ''
+        run: |
+          set -euo pipefail
+          git config user.name "boardsesh-repo-bot[bot]"
+          git config user.email "boardsesh-repo-bot[bot]@users.noreply.github.com"
+          git add packages/mobile/app.config.ts
+          git commit -m "chore(mobile): auto-bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
+
+          # Rebase-and-retry in case another commit landed on main since checkout.
+          # Hard-reset to main then re-apply our file, same pattern as the OTA
+          # changelog push-back — avoids merge conflicts on unrelated changes.
+          saved_version="${{ steps.bump.outputs.new_version }}"
+          for attempt in 1 2 3; do
+            git fetch origin main
+
+            # Idempotent: skip if main already has our version (shouldn't happen, but safe).
+            main_version="$(git show origin/main:packages/mobile/app.config.ts | grep -oP "version: '\\K[^']+")"
+            if [ "$main_version" = "$saved_version" ]; then
+              echo "main already has version $saved_version — nothing to push."
+              exit 0
+            fi
+
+            git reset --hard origin/main
+            sed -i "s/version: '[0-9]*\.[0-9]*\.[0-9]*'/version: '$saved_version'/" packages/mobile/app.config.ts
+            git add packages/mobile/app.config.ts
+            git commit -m "chore(mobile): auto-bump version to $saved_version [skip ci]"
+
+            if git push origin HEAD:main; then
+              echo "Pushed version bump to main."
+              exit 0
+            fi
+            echo "Push rejected (main advanced); retry ${attempt}/3…"
+          done
+          echo "::error::Could not push version bump to main after 3 attempts."
+          exit 1

--- a/scripts/mobile-auto-version-bump.ts
+++ b/scripts/mobile-auto-version-bump.ts
@@ -1,0 +1,186 @@
+/// <reference types="node" />
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { createSign } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const APP_STORE_CONNECT_API_BASE = 'https://api.appstoreconnect.apple.com';
+const BUNDLE_ID = 'com.boardsesh.app';
+
+// App Store states that indicate Apple has accepted the submission.
+// Once the current version in app.config.ts appears in any of these states,
+// we bump the patch so the next build gets a fresh marketing version.
+const ACCEPTED_APP_STORE_STATES = [
+  'PENDING_DEVELOPER_RELEASE',
+  'PENDING_APPLE_RELEASE',
+  'PROCESSING_FOR_APP_STORE',
+  'READY_FOR_SALE',
+].join(',');
+
+type AppStoreJwtInput = {
+  keyId: string;
+  issuerId: string;
+  privateKey: string;
+  nowSeconds?: number;
+  expiresInSeconds?: number;
+};
+
+type AppResource = {
+  type: 'apps';
+  id: string;
+  attributes?: { bundleId?: string };
+};
+
+type AppStoreVersionResource = {
+  type: 'appStoreVersions';
+  id: string;
+  attributes?: {
+    versionString?: string;
+    appStoreState?: string;
+  };
+};
+
+type JsonApiCollectionResponse<T> = {
+  data: T[];
+};
+
+function base64UrlEncode(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+function createAppStoreConnectJwt(input: AppStoreJwtInput): string {
+  const nowSeconds = input.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const expiresInSeconds = input.expiresInSeconds ?? 20 * 60;
+  const header = { alg: 'ES256', kid: input.keyId, typ: 'JWT' };
+  const payload = {
+    aud: 'appstoreconnect-v1',
+    exp: nowSeconds + expiresInSeconds,
+    iat: nowSeconds,
+    iss: input.issuerId,
+  };
+  const signingInput = `${base64UrlEncode(JSON.stringify(header))}.${base64UrlEncode(JSON.stringify(payload))}`;
+  const signer = createSign('sha256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign({ key: input.privateKey, dsaEncoding: 'ieee-p1363' });
+  return `${signingInput}.${signature.toString('base64url')}`;
+}
+
+function decodePrivateKey(secret: string): string {
+  const trimmed = secret.trim();
+  return trimmed.includes('BEGIN PRIVATE KEY') ? trimmed : Buffer.from(trimmed, 'base64').toString('utf8');
+}
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+async function ascFetch<T>(path: string, token: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(path, APP_STORE_CONNECT_API_BASE);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`ASC ${path} → ${response.status}: ${body.slice(0, 500)}`);
+  }
+  return JSON.parse(body) as T;
+}
+
+async function resolveAppId(token: string): Promise<string> {
+  const data = await ascFetch<JsonApiCollectionResponse<AppResource>>('/v1/apps', token, {
+    'filter[bundleId]': BUNDLE_ID,
+    'fields[apps]': 'bundleId',
+    limit: '1',
+  });
+  const app = data.data[0];
+  if (!app) throw new Error(`No ASC app found for ${BUNDLE_ID}`);
+  return app.id;
+}
+
+async function getAcceptedVersionStrings(token: string, appId: string): Promise<string[]> {
+  const data = await ascFetch<JsonApiCollectionResponse<AppStoreVersionResource>>(
+    `/v1/apps/${appId}/appStoreVersions`,
+    token,
+    {
+      'filter[appStoreState]': ACCEPTED_APP_STORE_STATES,
+      'fields[appStoreVersions]': 'versionString,appStoreState',
+      limit: '10',
+    },
+  );
+  return data.data
+    .map((v) => v.attributes?.versionString)
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+function emitOutput(name: string, value: string): void {
+  const githubOutput = process.env['GITHUB_OUTPUT'];
+  if (githubOutput) {
+    appendFileSync(githubOutput, `${name}=${value}\n`);
+  }
+  console.log(`output: ${name}=${value}`);
+}
+
+async function main(): Promise<number> {
+  try {
+    const dryRun = process.env['DRY_RUN'] === 'true';
+
+    const token = createAppStoreConnectJwt({
+      keyId: getRequiredEnv('APP_STORE_CONNECT_API_KEY_ID'),
+      issuerId: getRequiredEnv('APP_STORE_CONNECT_ISSUER_ID'),
+      privateKey: decodePrivateKey(getRequiredEnv('APP_STORE_CONNECT_API_KEY_BASE64')),
+    });
+
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
+    const appConfigPath = join(scriptDir, '..', 'packages', 'mobile', 'app.config.ts');
+    const content = readFileSync(appConfigPath, 'utf-8');
+
+    const versionMatch = content.match(/version:\s*'(\d+)\.(\d+)\.(\d+)'/);
+    if (!versionMatch) {
+      throw new Error(`Could not find version field in ${appConfigPath}`);
+    }
+    const [, major, minor, patch] = versionMatch;
+    const currentVersion = `${major}.${minor}.${patch}`;
+    console.log(`Current marketing version: ${currentVersion}`);
+
+    const appId = await resolveAppId(token);
+    const accepted = await getAcceptedVersionStrings(token, appId);
+    console.log(`Accepted App Store versions: ${accepted.length > 0 ? accepted.join(', ') : 'none'}`);
+
+    if (!accepted.includes(currentVersion)) {
+      console.log(`${currentVersion} is not yet in an accepted state — nothing to bump.`);
+      emitOutput('bumped', 'false');
+      return 0;
+    }
+
+    const newVersion = `${major}.${minor}.${parseInt(patch, 10) + 1}`;
+    console.log(`${currentVersion} is accepted → ${dryRun ? 'would bump' : 'bumping'} to ${newVersion}`);
+
+    if (dryRun) {
+      emitOutput('bumped', 'false');
+      emitOutput('new_version', newVersion);
+      return 0;
+    }
+
+    const updated = content.replace(/version:\s*'(\d+\.\d+\.\d+)'/, `version: '${newVersion}'`);
+    writeFileSync(appConfigPath, updated, 'utf-8');
+    console.log(`Wrote ${newVersion} to ${appConfigPath}`);
+
+    emitOutput('bumped', 'true');
+    emitOutput('new_version', newVersion);
+    return 0;
+  } catch (err) {
+    console.error(`[mobile-auto-version-bump] ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().then((exitCode) => process.exit(exitCode));
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/mobile-auto-version-bump.yml` — runs hourly on a schedule (+ `workflow_dispatch` with `dry_run` option). Polls App Store Connect and bumps the patch version in `packages/mobile/app.config.ts` whenever the current version reaches an accepted state (PENDING_DEVELOPER_RELEASE / PENDING_APPLE_RELEASE / PROCESSING_FOR_APP_STORE / READY_FOR_SALE).
- Adds `scripts/mobile-auto-version-bump.ts` — the script that reads the current version, queries ASC, writes the bump, and emits CI outputs.

**No new secrets needed** — reuses `OTA_PUSH_APP_ID`/`OTA_PUSH_APP_PRIVATE_KEY` (GitHub App push-back) and `APP_STORE_CONNECT_API_KEY_*` (already in the `Production` environment), exactly like `mobile-ota-production.yml` and `testflight-feedback-to-issues.yml`.

**Self-limiting by design** — after bumping `2.0.1 → 2.0.2`, the version `2.0.2` isn't in ASC yet, so every subsequent poll finds nothing and exits. No state file needed.

**`[skip ci]` on the commit** — prevents a spurious OTA publish; a version change would bust the fingerprint so OTA would publish to a fingerprint no binary can use.

Minor version bumps remain manual.

## Test plan

- [ ] Trigger `workflow_dispatch` with `dry_run: true` while the current version is live on the App Store → workflow logs "would bump X.Y.Z → X.Y.(Z+1)", no commit pushed
- [ ] Trigger `workflow_dispatch` with `dry_run: false` (or wait for hourly schedule when a version is accepted) → commit `chore(mobile): auto-bump version to X.Y.(Z+1) [skip ci]` lands on main
- [ ] Re-run immediately after → `bumped=false` (idempotent — new version not in ASC yet)
- [ ] Confirm `[skip ci]` prevents `mobile-ota-production.yml` and `ios-testflight-rn.yml` from triggering on that commit

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6ZNLTU5iEbYWkRA8SijEm