### PR TITLE
feat: filter the gym finder by board type

### DIFF
--- a/packages/backend/src/__tests__/search-board-type-filter.test.ts
+++ b/packages/backend/src/__tests__/search-board-type-filter.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { SearchGymsInputSchema } from '../validation/schemas/gyms';
+import { SearchBoardsInputSchema } from '../validation/schemas/boards';
+
+// The board-type filter (gym + board search) is enforced in SQL — a gym→board
+// EXISTS join for gyms, an inArray for boards. These tests cover the input
+// contract those queries depend on: the `boardTypes` array must accept valid
+// board names, reject junk, and stay optional so unfiltered search is unchanged.
+
+describe('SearchGymsInput board-type filter', () => {
+  it('accepts a multi-select array of valid board types', () => {
+    const parsed = SearchGymsInputSchema.parse({ boardTypes: ['kilter', 'tension'] });
+    expect(parsed.boardTypes).toEqual(['kilter', 'tension']);
+  });
+
+  it('stays optional — an unfiltered search leaves boardTypes undefined', () => {
+    expect(SearchGymsInputSchema.parse({}).boardTypes).toBeUndefined();
+  });
+
+  it('rejects an unknown board type', () => {
+    expect(SearchGymsInputSchema.safeParse({ boardTypes: ['not-a-board'] }).success).toBe(false);
+  });
+});
+
+describe('SearchBoardsInput board-type filter', () => {
+  it('accepts a multi-select array of valid board types', () => {
+    const parsed = SearchBoardsInputSchema.parse({ boardTypes: ['kilter'] });
+    expect(parsed.boardTypes).toEqual(['kilter']);
+  });
+
+  it('still accepts the legacy singular boardType alongside the array', () => {
+    const parsed = SearchBoardsInputSchema.parse({ boardType: 'tension', boardTypes: ['kilter'] });
+    expect(parsed.boardType).toBe('tension');
+    expect(parsed.boardTypes).toEqual(['kilter']);
+  });
+
+  it('rejects an unknown board type', () => {
+    expect(SearchBoardsInputSchema.safeParse({ boardTypes: ['nope'] }).success).toBe(false);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -842,7 +842,7 @@ export const socialBoardQueries = {
   searchBoards: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     await applyRateLimit(ctx, 20, 'searchBoards');
     const validatedInput = validateInput(SearchBoardsInputSchema, input, 'input');
-    const { query, boardType, latitude, longitude, radiusKm } = validatedInput;
+    const { query, boardType, boardTypes, latitude, longitude, radiusKm } = validatedInput;
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
     const useProximity = latitude !== undefined && longitude !== undefined;
@@ -879,6 +879,9 @@ export const socialBoardQueries = {
 
       if (boardType) {
         conditions.push(eq(dbSchema.userBoards.boardType, boardType));
+      }
+      if (boardTypes && boardTypes.length > 0) {
+        conditions.push(inArray(dbSchema.userBoards.boardType, boardTypes));
       }
       if (query) {
         const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
@@ -928,6 +931,10 @@ export const socialBoardQueries = {
 
     if (boardType) {
       conditions.push(eq(dbSchema.userBoards.boardType, boardType));
+    }
+
+    if (boardTypes && boardTypes.length > 0) {
+      conditions.push(inArray(dbSchema.userBoards.boardType, boardTypes));
     }
 
     if (query) {

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -97,6 +97,7 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
   const [
     ownerResult,
     boardCountResult,
+    boardTypesResult,
     memberCountResult,
     followerCountResult,
     commentCountResult,
@@ -119,6 +120,12 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
     // Count linked boards
     db
       .select({ count: count() })
+      .from(dbSchema.userBoards)
+      .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt))),
+
+    // Distinct board types at this gym (for filtering + badges)
+    db
+      .selectDistinct({ boardType: dbSchema.userBoards.boardType })
       .from(dbSchema.userBoards)
       .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt))),
 
@@ -160,6 +167,7 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
 
   const ownerInfo = ownerResult[0];
   const boardCount = Number(boardCountResult[0]?.count || 0);
+  const boardTypes = boardTypesResult.map((row) => row.boardType);
   const memberCount = Number(memberCountResult[0]?.count || 0);
   const followerCount = Number(followerCountResult[0]?.count || 0);
   const commentCount = Number(commentCountResult[0]?.count || 0);
@@ -188,6 +196,7 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
     imageUrl: gym.imageUrl,
     createdAt: gym.createdAt.toISOString(),
     boardCount,
+    boardTypes,
     memberCount,
     followerCount,
     commentCount,
@@ -315,10 +324,21 @@ export const socialGymQueries = {
 
   searchGyms: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     const validatedInput = validateInput(SearchGymsInputSchema, input, 'input');
-    const { query, latitude, longitude, radiusKm } = validatedInput;
+    const { query, boardTypes, latitude, longitude, radiusKm } = validatedInput;
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
     const useProximity = latitude !== undefined && longitude !== undefined;
+
+    // Filter to gyms that HAVE a board of one of the selected types (OR). A raw
+    // fragment so it composes into both the PostGIS proximity SQL and the
+    // text-only Drizzle path; empty when no board-type filter is active.
+    const boardTypeClause =
+      boardTypes && boardTypes.length > 0
+        ? sql` AND EXISTS (SELECT 1 FROM user_boards ub WHERE ub.gym_id = gyms.id AND ub.deleted_at IS NULL AND ub.board_type IN (${sql.join(
+            boardTypes.map((boardType) => sql`${boardType}`),
+            sql`, `,
+          )}))`
+        : sql.empty();
 
     if (useProximity) {
       const radiusMeters = (radiusKm ?? 50) * 1000;
@@ -330,15 +350,15 @@ export const socialGymQueries = {
 
       const countRows = await db.execute(
         likePattern
-          ? sql`SELECT count(*)::int as count FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) AND (name ILIKE ${likePattern} OR address ILIKE ${likePattern})`
-          : sql`SELECT count(*)::int as count FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters})`,
+          ? sql`SELECT count(*)::int as count FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) AND (name ILIKE ${likePattern} OR address ILIKE ${likePattern})${boardTypeClause}`
+          : sql`SELECT count(*)::int as count FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters})${boardTypeClause}`,
       );
       const totalCount = Number(rowsFromResult<Record<string, unknown>>(countRows)[0]?.count || 0);
 
       const gymRows = await db.execute(
         likePattern
-          ? sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) AND (name ILIKE ${likePattern} OR address ILIKE ${likePattern}) ORDER BY distance_meters ASC LIMIT ${limit} OFFSET ${offset}`
-          : sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) ORDER BY distance_meters ASC LIMIT ${limit} OFFSET ${offset}`,
+          ? sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) AND (name ILIKE ${likePattern} OR address ILIKE ${likePattern})${boardTypeClause} ORDER BY distance_meters ASC LIMIT ${limit} OFFSET ${offset}`
+          : sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters})${boardTypeClause} ORDER BY distance_meters ASC LIMIT ${limit} OFFSET ${offset}`,
       );
       const rows = rowsFromResult<Record<string, unknown>>(gymRows);
 
@@ -362,6 +382,15 @@ export const socialGymQueries = {
       const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
       conditions.push(
         or(ilike(dbSchema.gyms.name, `%${escapedQuery}%`), ilike(dbSchema.gyms.address, `%${escapedQuery}%`))!,
+      );
+    }
+
+    if (boardTypes && boardTypes.length > 0) {
+      conditions.push(
+        sql`EXISTS (SELECT 1 FROM user_boards ub WHERE ub.gym_id = ${dbSchema.gyms.id} AND ub.deleted_at IS NULL AND ub.board_type IN (${sql.join(
+          boardTypes.map((boardType) => sql`${boardType}`),
+          sql`, `,
+        )}))`,
       );
     }
 

--- a/packages/backend/src/validation/schemas/boards.ts
+++ b/packages/backend/src/validation/schemas/boards.ts
@@ -99,6 +99,7 @@ export const FollowBoardInputSchema = z.object({
 export const SearchBoardsInputSchema = z.object({
   query: z.string().max(200).optional(),
   boardType: BoardNameSchema.optional(),
+  boardTypes: z.array(BoardNameSchema).max(10).optional(),
   latitude: z.number().min(-90).max(90).optional(),
   longitude: z.number().min(-180).max(180).optional(),
   radiusKm: z.number().min(0.1).max(500).optional().default(50),

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { UUIDSchema, LatitudeSchema, LongitudeSchema, SlugSchema } from './primitives';
+import { UUIDSchema, LatitudeSchema, LongitudeSchema, SlugSchema, BoardNameSchema } from './primitives';
 
 /**
  * Gym member role validation schema
@@ -77,6 +77,7 @@ export const MyGymsInputSchema = z.object({
  */
 export const SearchGymsInputSchema = z.object({
   query: z.string().max(200).optional(),
+  boardTypes: z.array(BoardNameSchema).max(10).optional(),
   latitude: z.number().min(-90).max(90).optional(),
   longitude: z.number().min(-180).max(180).optional(),
   radiusKm: z.number().min(0.1).max(500).optional().default(50),

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -3,7 +3,7 @@ import { Linking, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+import type { BoardName, Gym, UserBoard } from '@boardsesh/shared-schema';
 import { useNearbyBoards, useNearbyGyms } from '../../src/lib/graphql/hooks';
 import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
 import { useDeviceLocation, type Coords } from '../../src/lib/use-device-location';
@@ -18,6 +18,7 @@ import { Button } from '../../src/components/Button';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { GymMap, type GymMapHandle, type GymMapMarker } from '../../src/components/gym-directory/GymMap';
 import { GymListPanel, type GymListPanelHandle } from '../../src/components/gym-directory/GymListPanel';
+import { BoardTypeChips } from '../../src/components/gym-directory/BoardTypeChips';
 import { buildGymListRows } from '../../src/components/gym-directory/gym-list-rows';
 import { DEFAULT_WALL_FINDER_FILTER, type WallFinderFilter } from '../../src/lib/wall-finder-filter';
 import { spacing, borderRadius, shadows } from '../../src/theme/tokens';
@@ -71,7 +72,7 @@ export default function GymDiscovery() {
   const panelRef = useRef<GymListPanelHandle>(null);
 
   // `inputText` is the raw field; `appliedFilter` is the applied filter sent to the
-  // backend (name only for now; board-type chips will populate `boardTypes` later).
+  // backend (name + the board-type chips' selected `boardTypes`).
   // `viewCenter` is the authoritative map/query center (a searched place or a panned
   // location); `searchLabel` drives the "Showing X" caption. Filters apply on submit
   // so typing doesn't fire a request per keystroke.
@@ -110,8 +111,13 @@ export default function GymDiscovery() {
     [],
   );
 
-  const { data: gymConnection, isLoading: gymsLoading } = useNearbyGyms(center, 50, appliedFilter.name);
-  const { data: boardConnection } = useNearbyBoards(center, 50, appliedFilter.name, 50);
+  const { data: gymConnection, isLoading: gymsLoading } = useNearbyGyms(
+    center,
+    50,
+    appliedFilter.name,
+    appliedFilter.boardTypes,
+  );
+  const { data: boardConnection } = useNearbyBoards(center, 50, appliedFilter.name, 50, appliedFilter.boardTypes);
 
   const gyms = useMemo(
     () => (gymConnection?.gyms ?? []).filter((gym) => gym.latitude != null && gym.longitude != null),
@@ -289,10 +295,35 @@ export default function GymDiscovery() {
     if (deviceCoords) moveCameraTo(deviceCoords);
   }, [moveCameraTo]);
 
+  // Toggle a board type in the filter (multi-select OR). It ANDs with the name
+  // filter + viewport and re-queries via the hooks' query keys; orthogonal to a
+  // place search (a place relocates, it isn't a filter term).
+  const onToggleBoardType = useCallback((boardType: BoardName) => {
+    setAppliedFilter((prev) => {
+      const current = prev.boardTypes ?? [];
+      const next = current.includes(boardType) ? current.filter((type) => type !== boardType) : [...current, boardType];
+      return { ...prev, boardTypes: next.length > 0 ? next : undefined };
+    });
+  }, []);
+
+  const onClearBoardTypes = useCallback(() => {
+    setAppliedFilter((prev) => ({ ...prev, boardTypes: undefined }));
+  }, []);
+
   const closeScreen = useCallback(() => {
     if (router.canGoBack()) router.back();
     else router.dismissTo(boardReturnTo);
   }, [router, boardReturnTo]);
+
+  // Board-type chips live in the panel header. Only meaningful once we have a
+  // place to query, so hide them in the pre-location prompt state.
+  const filterSlot = center ? (
+    <BoardTypeChips
+      selected={appliedFilter.boardTypes ?? []}
+      onToggle={onToggleBoardType}
+      onClear={onClearBoardTypes}
+    />
+  ) : undefined;
 
   // The root stack hides headers globally; this screen draws its own floating
   // close button over the map. The title is kept for the back/breadcrumb affordance.
@@ -406,6 +437,7 @@ export default function GymDiscovery() {
         noBoardsLabel={t('mobile.gyms.noBoards')}
         searchSlot={searchField}
         placeCaption={placeCaption}
+        filterSlot={filterSlot}
         locationPrompt={locationPrompt}
       />
 

--- a/packages/mobile/src/components/gym-directory/BoardTypeChips.tsx
+++ b/packages/mobile/src/components/gym-directory/BoardTypeChips.tsx
@@ -1,0 +1,120 @@
+import { useCallback } from 'react';
+import { Pressable, ScrollView, StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import { SUPPORTED_BOARDS, formatBoardDisplayName } from '@boardsesh/board-config';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { spacing } from '../../theme/tokens';
+import { springs } from '../../theme/animations';
+import { hapticSelection } from '../../lib/haptics';
+import { useTheme } from '../../providers/theme-provider';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+function Chip({
+  boardType,
+  active,
+  onToggle,
+}: {
+  boardType: BoardName;
+  active: boolean;
+  onToggle: (boardType: BoardName) => void;
+}) {
+  const { brandColors, systemColors } = useTheme();
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+  // Brand product names — never translated.
+  const label = formatBoardDisplayName(boardType);
+
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    onToggle(boardType);
+  }, [onToggle, boardType]);
+
+  return (
+    <AnimatedPressable
+      onPress={handlePress}
+      onPressIn={() => {
+        scale.value = withSpring(0.95, springs.snappy);
+      }}
+      onPressOut={() => {
+        scale.value = withSpring(1, springs.snappy);
+      }}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+      style={[
+        animatedStyle,
+        styles.chip,
+        active
+          ? { borderColor: brandColors.primary, backgroundColor: `${brandColors.primary}14` }
+          : { borderColor: systemColors.separator },
+      ]}
+    >
+      <Text variant="caption1" color={active ? brandColors.primary : undefined} style={styles.chipLabel}>
+        {label}
+      </Text>
+    </AnimatedPressable>
+  );
+}
+
+export type BoardTypeChipsProps = {
+  /** Currently-selected board types (multi-select OR). */
+  selected: BoardName[];
+  onToggle: (boardType: BoardName) => void;
+  onClear: () => void;
+};
+
+/**
+ * Multi-select board-type filter for the gym panel header: one chip per supported
+ * board (Kilter / Tension / MoonBoard). OR semantics — tapping Kilter + Tension
+ * shows gyms/boards with either. A quiet "Clear" appears once anything is active.
+ * Filtering is a data-layer concern (the screen owns the selection), so it works
+ * identically whether or not the map renders.
+ */
+export function BoardTypeChips({ selected, onToggle, onClear }: BoardTypeChipsProps) {
+  const { t } = useTranslation('common');
+  const { brandColors } = useTheme();
+  const hasActive = selected.length > 0;
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.list}
+      keyboardShouldPersistTaps="handled"
+    >
+      {SUPPORTED_BOARDS.map((boardType) => (
+        <Chip key={boardType} boardType={boardType} active={selected.includes(boardType)} onToggle={onToggle} />
+      ))}
+      {hasActive ? (
+        <Pressable onPress={onClear} hitSlop={8} accessibilityRole="button" style={styles.clear}>
+          <Text variant="caption1" color={brandColors.primary} style={styles.chipLabel}>
+            {t('clear')}
+          </Text>
+        </Pressable>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    gap: spacing[2],
+    alignItems: 'center',
+  },
+  chip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: 20,
+    borderWidth: 1,
+  },
+  chipLabel: {
+    fontWeight: '500',
+  },
+  clear: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: spacing[2],
+  },
+});

--- a/packages/mobile/src/components/gym-directory/GymListPanel.tsx
+++ b/packages/mobile/src/components/gym-directory/GymListPanel.tsx
@@ -4,6 +4,7 @@ import Animated from 'react-native-reanimated';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { formatBoardDisplayName } from '@boardsesh/board-config';
 import type { Gym, UserBoard } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -248,6 +249,11 @@ const GymRow = memo(function GymRow({
           <Text variant="subheadline" color={systemColors.secondaryLabel}>
             {subtitle}
           </Text>
+          {gym.boardTypes.length > 0 ? (
+            <Text variant="caption1" color={systemColors.tertiaryLabel}>
+              {gym.boardTypes.map(formatBoardDisplayName).join(' · ')}
+            </Text>
+          ) : null}
         </View>
         <Icon name={expanded ? 'minus' : 'add'} size={20} color={systemColors.tertiaryLabel} />
       </PressableSurface>

--- a/packages/mobile/src/components/gym-directory/__tests__/board-type-chips.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/board-type-chips.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type Children = { children?: ReactNode };
+type PressProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+
+const hapticSelection = vi.fn();
+
+vi.mock('@boardsesh/board-config', () => ({
+  SUPPORTED_BOARDS: ['kilter', 'tension', 'moonboard'],
+  formatBoardDisplayName: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
+}));
+
+vi.mock('react-native', () => ({
+  Pressable: ({ children, onPress, accessibilityLabel }: PressProps) =>
+    createElement('button', { onClick: onPress, type: 'button', 'aria-label': accessibilityLabel }, children),
+  ScrollView: ({ children }: Children) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { createAnimatedComponent: (component: unknown) => component },
+  useAnimatedStyle: () => ({}),
+  useSharedValue: (value: number) => ({ value }),
+  withSpring: (value: number) => value,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../Text', () => ({ Text: ({ children }: Children) => createElement('span', null, children) }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12 } }));
+vi.mock('../../../theme/animations', () => ({ springs: { snappy: {} } }));
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: () => hapticSelection() }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { primary: '#6D28D9' }, systemColors: { separator: '#ccc' } }),
+}));
+
+import { BoardTypeChips } from '../BoardTypeChips';
+
+beforeEach(() => hapticSelection.mockClear());
+
+describe('BoardTypeChips', () => {
+  it('renders a chip per supported board', () => {
+    const { getByText } = render(<BoardTypeChips selected={[]} onToggle={vi.fn()} onClear={vi.fn()} />);
+    expect(getByText('Kilter')).toBeTruthy();
+    expect(getByText('Tension')).toBeTruthy();
+    expect(getByText('Moonboard')).toBeTruthy();
+  });
+
+  it('toggles a board type (with a haptic) when its chip is tapped', () => {
+    const onToggle = vi.fn();
+    const { getByLabelText } = render(<BoardTypeChips selected={[]} onToggle={onToggle} onClear={vi.fn()} />);
+    fireEvent.click(getByLabelText('Tension'));
+    expect(onToggle).toHaveBeenCalledWith('tension');
+    expect(hapticSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides Clear when nothing is selected and shows it once a type is active', () => {
+    const { queryByText, rerender, getByText } = render(
+      <BoardTypeChips selected={[]} onToggle={vi.fn()} onClear={vi.fn()} />,
+    );
+    expect(queryByText('clear')).toBeNull();
+    rerender(<BoardTypeChips selected={['kilter']} onToggle={vi.fn()} onClear={vi.fn()} />);
+    expect(getByText('clear')).toBeTruthy();
+  });
+
+  it('calls onClear when Clear is tapped', () => {
+    const onClear = vi.fn();
+    const { getByText } = render(<BoardTypeChips selected={['kilter']} onToggle={vi.fn()} onClear={onClear} />);
+    fireEvent.click(getByText('clear'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-list-panel.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-list-panel.test.tsx
@@ -102,9 +102,19 @@ vi.mock('../../../providers/theme-provider', () => ({
   }),
 }));
 
+vi.mock('@boardsesh/board-config', () => ({
+  formatBoardDisplayName: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
+}));
+
 import { GymListPanel } from '../GymListPanel';
 
-const gym = { uuid: 'g1', name: 'Movement', address: '1 Crag St', boardCount: 1 } as unknown as Gym;
+const gym = {
+  uuid: 'g1',
+  name: 'Movement',
+  address: '1 Crag St',
+  boardCount: 1,
+  boardTypes: ['kilter', 'tension'],
+} as unknown as Gym;
 
 function makeData(): GymListRow[] {
   return [
@@ -134,6 +144,8 @@ describe('GymListPanel', () => {
     expect(getByTestId('search')).toBeTruthy();
     expect(getByText('Movement')).toBeTruthy();
     expect(getByText('1 Crag St')).toBeTruthy();
+    // Board-type badges render from Gym.boardTypes.
+    expect(getByText('Kilter · Tension')).toBeTruthy();
   });
 
   it('invokes onPressGym with the gym when its row is tapped', () => {

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import type {
+  BoardName,
   UserBoard,
   UserBoardConnection,
   Climb,
@@ -224,15 +225,25 @@ export function useNearbyBoards(
   // would falsely show "no boards" for a gym whose boards fell outside the top
   // 20). The "Near you" carousel keeps the small default.
   limit = 20,
+  // Filter to these board types (OR). Empty/undefined means no board-type filter.
+  boardTypes?: BoardName[],
 ) {
   // Empty string means "no name filter" to the resolver; normalise to undefined
   // so the cache key and the request payload stay clean.
   const nameFilter = query && query.trim().length > 0 ? query.trim() : undefined;
+  const typeFilter = boardTypes && boardTypes.length > 0 ? boardTypes : undefined;
   return useQuery({
-    queryKey: ['nearbyBoards', coords, radiusKm, nameFilter, limit],
+    queryKey: ['nearbyBoards', coords, radiusKm, nameFilter, limit, typeFilter ?? null],
     queryFn: () =>
       getHttpClient().request<SearchBoardsQueryResponse>(SEARCH_BOARDS, {
-        input: { latitude: coords?.latitude, longitude: coords?.longitude, radiusKm, limit, query: nameFilter },
+        input: {
+          latitude: coords?.latitude,
+          longitude: coords?.longitude,
+          radiusKm,
+          limit,
+          query: nameFilter,
+          boardTypes: typeFilter,
+        },
       }),
     select: (data) => data.searchBoards,
     enabled: coords !== null,
@@ -244,13 +255,27 @@ export function useNearbyBoards(
   });
 }
 
-export function useNearbyGyms(coords: { latitude: number; longitude: number } | null, radiusKm = 50, query?: string) {
+export function useNearbyGyms(
+  coords: { latitude: number; longitude: number } | null,
+  radiusKm = 50,
+  query?: string,
+  // Filter to gyms that have a board of one of these types (OR).
+  boardTypes?: BoardName[],
+) {
   const nameFilter = query && query.trim().length > 0 ? query.trim() : undefined;
+  const typeFilter = boardTypes && boardTypes.length > 0 ? boardTypes : undefined;
   return useQuery({
-    queryKey: ['nearbyGyms', coords, radiusKm, nameFilter],
+    queryKey: ['nearbyGyms', coords, radiusKm, nameFilter, typeFilter ?? null],
     queryFn: () =>
       getHttpClient().request<SearchGymsQueryResponse>(SEARCH_GYMS, {
-        input: { latitude: coords?.latitude, longitude: coords?.longitude, radiusKm, limit: 50, query: nameFilter },
+        input: {
+          latitude: coords?.latitude,
+          longitude: coords?.longitude,
+          radiusKm,
+          limit: 50,
+          query: nameFilter,
+          boardTypes: typeFilter,
+        },
       }),
     select: (data) => data.searchGyms,
     enabled: coords !== null,

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2313,6 +2313,8 @@ input SearchBoardsInput {
   query: String
   "Filter by board type"
   boardType: String
+  "Filter by board type (OR) — multi-select; composes with boardType if both are set"
+  boardTypes: [String!]
   "Latitude for proximity search"
   latitude: Float
   "Longitude for proximity search"
@@ -2450,6 +2452,8 @@ type Gym {
   createdAt: String!
   "Number of linked boards"
   boardCount: Int!
+  "Distinct board types at this gym (kilter, tension, ...) — for filtering and badges"
+  boardTypes: [String!]!
   "Number of members"
   memberCount: Int!
   "Number of followers"
@@ -2606,6 +2610,8 @@ Input for searching gyms.
 input SearchGymsInput {
   "Search query"
   query: String
+  "Filter to gyms that have a board of one of these types (OR)"
+  boardTypes: [String!]
   "Latitude for proximity search"
   latitude: Float
   "Longitude for proximity search"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1841,6 +1841,8 @@ export type Gym = {
   address?: Maybe<Scalars['String']['output']>;
   /** Number of linked boards */
   boardCount: Scalars['Int']['output'];
+  /** Distinct board types at this gym (kilter, tension, ...) — for filtering and badges */
+  boardTypes: Array<Scalars['String']['output']>;
   /** Number of comments */
   commentCount: Scalars['Int']['output'];
   /** Contact email */
@@ -4570,6 +4572,8 @@ export type SaveTickInput = {
 export type SearchBoardsInput = {
   /** Filter by board type */
   boardType?: InputMaybe<Scalars['String']['input']>;
+  /** Filter by board type (OR) — multi-select; composes with boardType if both are set */
+  boardTypes?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Latitude for proximity search */
   latitude?: InputMaybe<Scalars['Float']['input']>;
   /** Max results to return */
@@ -4586,6 +4590,8 @@ export type SearchBoardsInput = {
 
 /** Input for searching gyms. */
 export type SearchGymsInput = {
+  /** Filter to gyms that have a board of one of these types (OR) */
+  boardTypes?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Latitude for proximity search */
   latitude?: InputMaybe<Scalars['Float']['input']>;
   /** Max results to return */
@@ -7515,6 +7521,7 @@ export type GymResolvers<
 > = ResolversObject<{
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   boardCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardTypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   commentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   contactEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   contactPhone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -277,6 +277,8 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     query: String
     "Filter by board type"
     boardType: String
+    "Filter by board type (OR) — multi-select; composes with boardType if both are set"
+    boardTypes: [String!]
     "Latitude for proximity search"
     latitude: Float
     "Longitude for proximity search"

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -44,6 +44,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     createdAt: String!
     "Number of linked boards"
     boardCount: Int!
+    "Distinct board types at this gym (kilter, tension, ...) — for filtering and badges"
+    boardTypes: [String!]!
     "Number of members"
     memberCount: Int!
     "Number of followers"
@@ -200,6 +202,8 @@ export const gymsTypeDefs = /* GraphQL */ `
   input SearchGymsInput {
     "Search query"
     query: String
+    "Filter to gyms that have a board of one of these types (OR)"
+    boardTypes: [String!]
     "Latitude for proximity search"
     latitude: Float
     "Longitude for proximity search"

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -127,6 +127,7 @@ export type FollowBoardInput = {
 export type SearchBoardsInput = {
   query?: string;
   boardType?: string;
+  boardTypes?: string[];
   latitude?: number;
   longitude?: number;
   radiusKm?: number;

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -19,6 +19,7 @@ export type Gym = {
   imageUrl?: string | null;
   createdAt: string;
   boardCount: number;
+  boardTypes: string[];
   memberCount: number;
   followerCount: number;
   commentCount: number;
@@ -97,6 +98,7 @@ export type MyGymsInput = {
 
 export type SearchGymsInput = {
   query?: string;
+  boardTypes?: string[];
   latitude?: number;
   longitude?: number;
   radiusKm?: number;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1838,6 +1838,8 @@ export type Gym = {
   address?: Maybe<Scalars['String']['output']>;
   /** Number of linked boards */
   boardCount: Scalars['Int']['output'];
+  /** Distinct board types at this gym (kilter, tension, ...) — for filtering and badges */
+  boardTypes: Array<Scalars['String']['output']>;
   /** Number of comments */
   commentCount: Scalars['Int']['output'];
   /** Contact email */
@@ -4567,6 +4569,8 @@ export type SaveTickInput = {
 export type SearchBoardsInput = {
   /** Filter by board type */
   boardType?: InputMaybe<Scalars['String']['input']>;
+  /** Filter by board type (OR) — multi-select; composes with boardType if both are set */
+  boardTypes?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Latitude for proximity search */
   latitude?: InputMaybe<Scalars['Float']['input']>;
   /** Max results to return */
@@ -4583,6 +4587,8 @@ export type SearchBoardsInput = {
 
 /** Input for searching gyms. */
 export type SearchGymsInput = {
+  /** Filter to gyms that have a board of one of these types (OR) */
+  boardTypes?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Latitude for proximity search */
   latitude?: InputMaybe<Scalars['Float']['input']>;
   /** Max results to return */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -35,6 +35,7 @@ const GYM_FIELDS = `
   imageUrl
   createdAt
   boardCount
+  boardTypes
   memberCount
   followerCount
   commentCount


### PR DESCRIPTION
## Summary

Adds board-type filtering to the Find Gym map, end to end. The panel header gains a
multi-select chips row (Kilter / Tension / MoonBoard, OR semantics); picking types
narrows the gym list, the standalone-boards section, and their map pins together.
Each gym row also badges the board types it has.

**Stacked on #3168** (the non-modal gym panel — the chips drop into `GymListPanel`'s
`filterSlot`). Base is `mobile/remove-gorhom-bottom-sheet`; rebase onto `main` once
#3168 merges.

Backend:
- `SearchGymsInput.boardTypes` + `Gym.boardTypes` (`[String!]!`); `SearchBoardsInput`
  gains a multi-select `boardTypes` alongside the existing singular `boardType`.
- `searchGyms` filters via an `EXISTS` gym→`user_boards` join composed into both the
  PostGIS proximity SQL and the text-only Drizzle path; `searchBoards` uses `inArray`.
- `enrichGym` aggregates a gym's distinct board types (`deleted_at IS NULL`, matching
  `boardCount`'s semantics) for the filter + badges.

Frontend:
- `BoardTypeChips` (mirrors `RecentFilterPills`: brand-violet active state, press
  haptic, a quiet "Clear" once active). Board names are brand products, never
  translated; "Clear" reuses `common:clear`.
- `useNearbyGyms` / `useNearbyBoards` take an optional `boardTypes` param. The screen
  threads it through the `WallFinderFilter` object; the filter ANDs with the name
  filter + viewport and is orthogonal to a place search. The list stays the source of
  truth, so filtering works the same whether or not the native map renders.

## Release Notes

Find a gym by board type

- Filter the map to gyms that have a Kilter, Tension, or MoonBoard.

- [ ] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` (all packages incl. web) — clean.
- `vp run codegen` — no drift.
- `vp check` — clean on changed files.
- `vp run test:mobile` — 348 files / 2579 tests (incl. new `BoardTypeChips` + gym-row badge tests).
- Backend `search-board-type-filter.test.ts` — 6/6 (zod input contract; `SKIP_TEST_INFRA=1`).
- `vp run check:mobile-bundle` — Android bundle OK (12.1 MB).
- The gym→board SQL join is type-checked and mirrors existing patterns (`search.ts` `EXISTS`, `searchBoards` `inArray`). A DB integration test for the join is a recommended follow-up — local docker was unavailable this session, and prod read-only access is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
