### PR TITLE
fix(mobile-ota): show what's new in the deploy Discord message

### DIFF
--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -185,7 +185,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Snapshot the changelog as it stood BEFORE this run so the Discord notify
+          # step can diff prev→next and announce only what this OTA newly adds. Must
+          # be captured before `generate:changelog` overwrites the working copy. A
+          # first-run/missing file degrades to an empty entry list (full new list).
+          git show HEAD:packages/mobile/src/data/changelog.generated.json \
+            > "$RUNNER_TEMP/changelog.prev.json" 2>/dev/null \
+            || echo '{"entries":[]}' > "$RUNNER_TEMP/changelog.prev.json"
           vp run generate:changelog
+          # Render the "What's new" block (newly-added entries, grouped by category)
+          # for Discord. Written to a file the notify step reads; empty when nothing
+          # is new, so that step falls back to the triggering commit subject.
+          vp run changelog:discord-summary -- \
+            --prev "$RUNNER_TEMP/changelog.prev.json" \
+            --next packages/mobile/src/data/changelog.generated.json \
+            --out "$RUNNER_TEMP/discord-changelog.md" || true
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           # Both outputs of the generator: the mobile JSON feed and the root
@@ -309,11 +323,23 @@ jobs:
           platforms=""
           [ "$IOS_OUTCOME" = "success" ] && platforms="iOS"
           [ "$ANDROID_OUTCOME" = "success" ] && platforms="${platforms:+$platforms, }Android"
-          # INPUT_MESSAGE is the dispatch input (job env); fall back to the commit
-          # subject, which is the default update message mobile-publish.ts uses.
-          MESSAGE="${INPUT_MESSAGE:-$(git log -1 --pretty=%s)}"
-          CONTENT=$(printf '🚀 **Production OTA published** on `%s`\n• platforms: %s\n• channel: production\n• message: %s\n<%s>' \
-            "${COMMIT_SHA:0:7}" "$platforms" "$MESSAGE" "$RUN_URL")
+          # Prefer the "What's new" block the generate step rendered from the
+          # changelog diff (the entries this OTA newly added). It's empty when
+          # nothing new shipped (changelog unchanged) — then fall back to the
+          # triggering commit's subject. Read the subject from $COMMIT_SHA, NOT
+          # `git log -1`: by now HEAD is this workflow's own changelog commit, so a
+          # bare `git log -1` would always echo "chore(changelog): refresh…".
+          SUMMARY_FILE="$RUNNER_TEMP/discord-changelog.md"
+          if [ -s "$SUMMARY_FILE" ]; then
+            # Build the header and the block in ONE printf so the newline between
+            # them survives — `$(printf '…\n')$(cat …)` would strip the trailing
+            # newline and glue the header onto the first category label.
+            BODY="$(printf '**What'\''s new**\n%s' "$(cat "$SUMMARY_FILE")")"
+          else
+            BODY="message: ${INPUT_MESSAGE:-$(git log -1 --pretty=%s "$COMMIT_SHA")}"
+          fi
+          CONTENT=$(printf '🚀 **Production OTA published** on `%s`\n• platforms: %s\n• channel: production\n\n%s\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$platforms" "$BODY" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -60,7 +60,11 @@ skips with a green no-op. The matching native builds (`ios-testflight-rn` / `and
 on the same push but are **fingerprint-gated** — they only build when the fingerprint is new (see
 [Native-build gating](#native-build-gating-ota-only-when-the-fingerprint-is-unchanged) below). A
 successful publish (and any failure) posts to the Discord deploy channel via the
-`DISCORD_DEPLOY_WEBHOOK` secret, the same channel the native build workflows use.
+`DISCORD_DEPLOY_WEBHOOK` secret, the same channel the native build workflows use. The success
+message lists what the OTA newly added: the workflow snapshots `changelog.generated.json` before
+regenerating it, then `changelog-discord-summary.ts` diffs the two snapshots and renders the new
+entries grouped as New / Improved / Fixed. When nothing new shipped (changelog unchanged) it falls
+back to the triggering commit's subject.
 
 **Manual** (one branch, ad hoc) — once the server is deployed and you're logged in (`bunx eas
 login`, or `EXPO_TOKEN` set):

--- a/scripts/__tests__/changelog-discord-summary.test.ts
+++ b/scripts/__tests__/changelog-discord-summary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { newlyAddedEntries, renderDiscordSummary, buildDiscordSummary } from '../lib/changelog-discord-summary';
+import type { ChangelogEntry } from '../lib/changelog-transform';
+
+function entry(prNumber: number, category: ChangelogEntry['category'], title: string): ChangelogEntry {
+  return { prNumber, category, title, mergedAt: '2026-06-24T00:00:00.000Z', prUrl: `https://x/${prNumber}` };
+}
+
+describe('newlyAddedEntries', () => {
+  it('returns entries whose PR number is not in the previous set', () => {
+    const prev = [entry(1, 'new', 'A'), entry(2, 'fixed', 'B')];
+    const next = [entry(3, 'new', 'C'), entry(2, 'fixed', 'B'), entry(1, 'new', 'A')];
+    expect(newlyAddedEntries(prev, next).map((item) => item.prNumber)).toEqual([3]);
+  });
+
+  it('treats an empty previous list as everything-new', () => {
+    const next = [entry(3, 'new', 'C'), entry(1, 'new', 'A')];
+    expect(newlyAddedEntries([], next).map((item) => item.prNumber)).toEqual([3, 1]);
+  });
+
+  it('returns nothing when next is a subset of prev', () => {
+    const prev = [entry(1, 'new', 'A'), entry(2, 'fixed', 'B')];
+    expect(newlyAddedEntries(prev, [entry(1, 'new', 'A')])).toEqual([]);
+  });
+});
+
+describe('renderDiscordSummary', () => {
+  it('returns an empty string when there is nothing new', () => {
+    expect(renderDiscordSummary([])).toBe('');
+  });
+
+  it('groups entries by category in fixed order with emoji labels', () => {
+    const summary = renderDiscordSummary([
+      entry(1, 'fixed', 'Crash on resume'),
+      entry(2, 'new', 'Playlists'),
+      entry(3, 'improved', 'Faster sync'),
+      entry(4, 'new', 'Dark mode'),
+    ]);
+    expect(summary).toBe(
+      ['✨ New', '• Playlists', '• Dark mode', '🔧 Improved', '• Faster sync', '🐛 Fixed', '• Crash on resume'].join(
+        '\n',
+      ),
+    );
+  });
+
+  it('omits categories with no entries', () => {
+    const summary = renderDiscordSummary([entry(1, 'new', 'Playlists')]);
+    expect(summary).toBe('✨ New\n• Playlists');
+    expect(summary).not.toContain('Improved');
+    expect(summary).not.toContain('Fixed');
+  });
+
+  it('drops entries whose category is not rendered and keeps the overflow count honest', () => {
+    // A category outside CATEGORY_DISPLAY (cast past the closed union) must be
+    // filtered out before the cap, so it neither renders nor inflates "…and N more".
+    const bogus = { prNumber: 99, category: 'internal' as ChangelogEntry['category'], title: 'Hidden' };
+    const summary = renderDiscordSummary([entry(1, 'new', 'Playlists'), bogus]);
+    expect(summary).toBe('✨ New\n• Playlists');
+    expect(summary).not.toContain('Hidden');
+    expect(summary).not.toContain('more');
+  });
+
+  it('caps the list and summarises the overflow', () => {
+    const many = Array.from({ length: 20 }, (_, index) => entry(index + 1, 'new', `Feature ${index + 1}`));
+    const summary = renderDiscordSummary(many);
+    expect(summary).toContain('• Feature 15');
+    expect(summary).not.toContain('• Feature 16');
+    expect(summary).toContain('…and 5 more');
+  });
+});
+
+describe('buildDiscordSummary', () => {
+  it('diffs prev→next and renders only the new entries', () => {
+    const prev = [entry(1, 'new', 'Old feature')];
+    const next = [entry(2, 'fixed', 'New fix'), entry(1, 'new', 'Old feature')];
+    expect(buildDiscordSummary(prev, next)).toBe('🐛 Fixed\n• New fix');
+  });
+
+  it('returns empty when nothing changed', () => {
+    const same = [entry(1, 'new', 'A')];
+    expect(buildDiscordSummary(same, same)).toBe('');
+  });
+});

--- a/scripts/changelog-discord-summary.ts
+++ b/scripts/changelog-discord-summary.ts
@@ -1,0 +1,52 @@
+/// <reference types="node" />
+
+/**
+ * Prints the "What's new" block for the OTA deploy Discord message: the changelog
+ * entries newly added by this OTA run, grouped by category. Compares the changelog
+ * committed BEFORE the run (`--prev`) with the one committed AFTER (`--next`) and
+ * renders only the difference. Prints nothing when there's nothing new, so the
+ * workflow can fall back to the triggering commit subject.
+ *
+ * Usage (from the OTA workflow):
+ *   vp run changelog:discord-summary -- --prev <prev.json> --next <next.json> --out <out.md>
+ *
+ * Writes to `--out` (not stdout) so a `vp run` banner can't contaminate the file;
+ * with no `--out` it prints to stdout. Degrades gracefully: an unreadable/malformed
+ * file is treated as "no entries" (so a missing prior file yields the full new list,
+ * and a missing next file yields an empty summary) and the script still exits 0 — it
+ * must never break the deploy notification.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { buildDiscordSummary } from './lib/changelog-discord-summary';
+import type { ChangelogEntry } from './lib/changelog-transform';
+
+function argValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  return index !== -1 ? process.argv[index + 1] : undefined;
+}
+
+function readEntries(path: string | undefined): Pick<ChangelogEntry, 'prNumber' | 'category' | 'title'>[] {
+  if (!path) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { entries?: unknown };
+    // Guard the shape too: a well-formed JSON whose `entries` isn't an array
+    // (null, a primitive, an object) would otherwise reach the transform and throw
+    // on `.filter`. Treat anything but an array as "no entries".
+    return Array.isArray(parsed.entries) ? (parsed.entries as ChangelogEntry[]) : [];
+  } catch {
+    // Missing or malformed file → treat as no entries; the diff degrades safely.
+    return [];
+  }
+}
+
+const prevEntries = readEntries(argValue('--prev'));
+const nextEntries = readEntries(argValue('--next'));
+const summary = buildDiscordSummary(prevEntries, nextEntries);
+
+const outPath = argValue('--out');
+if (outPath) {
+  writeFileSync(outPath, summary);
+} else {
+  process.stdout.write(summary);
+}

--- a/scripts/lib/changelog-discord-summary.ts
+++ b/scripts/lib/changelog-discord-summary.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure transform for the OTA deploy Discord message. Given the changelog entries
+ * that were committed BEFORE this OTA run and the ones committed AFTER it, it
+ * computes the entries that are newly added (by PR number) and renders them as a
+ * compact, category-grouped "What's new" block for the deploy webhook.
+ *
+ * This replaces the old behaviour where the Discord message echoed the latest
+ * commit subject — which, by the time the notify step runs, is always the
+ * workflow's own `chore(changelog): refresh from merged PRs` commit, never the
+ * actual changes the OTA shipped.
+ *
+ * Kept I/O-free so it's unit-testable without GitHub or git (see
+ * scripts/__tests__/changelog-discord-summary.test.ts). The shell that reads the
+ * two JSON files lives in scripts/changelog-discord-summary.ts.
+ */
+
+import type { ChangelogCategory, ChangelogEntry } from './changelog-transform';
+
+// Emoji + label + fixed render order for each category, matching the mobile
+// "What's New" screen's grouping. Empty groups are skipped.
+const CATEGORY_DISPLAY: ReadonlyArray<readonly [ChangelogCategory, string]> = [
+  ['new', '✨ New'],
+  ['improved', '🔧 Improved'],
+  ['fixed', '🐛 Fixed'],
+];
+
+// Discord caps a message at 2000 characters; the header/footer the workflow adds
+// take a slice of that, so bound the list well under the limit and summarise the
+// overflow rather than risk a truncated (or rejected) post.
+const MAX_BULLETS = 15;
+
+type MinimalEntry = Pick<ChangelogEntry, 'prNumber' | 'category' | 'title'>;
+
+/**
+ * Returns the entries present in `nextEntries` whose PR number is not in
+ * `prevEntries` — i.e. the changelog items this OTA newly adds. Order follows
+ * `nextEntries` (the generator emits newest-first).
+ */
+export function newlyAddedEntries<Entry extends Pick<ChangelogEntry, 'prNumber'>>(
+  prevEntries: Entry[],
+  nextEntries: Entry[],
+): Entry[] {
+  const seen = new Set(prevEntries.map((entry) => entry.prNumber));
+  return nextEntries.filter((entry) => !seen.has(entry.prNumber));
+}
+
+/**
+ * Renders the newly-added entries as a category-grouped "What's new" block for the
+ * Discord deploy message. Returns an empty string when there's nothing new (the
+ * caller then falls back to the triggering commit subject), so the workflow can
+ * test it with a simple `[ -s file ]`.
+ */
+export function renderDiscordSummary(entries: MinimalEntry[]): string {
+  if (entries.length === 0) return '';
+
+  // Drop any entry whose category isn't rendered before capping, so `overflow`
+  // counts only entries that would have appeared. The union is exhaustive today,
+  // but this keeps the "…and N more" count honest if a category is ever added
+  // without a matching CATEGORY_DISPLAY row.
+  const knownCategories = new Set(CATEGORY_DISPLAY.map(([category]) => category));
+  const renderable = entries.filter((entry) => knownCategories.has(entry.category));
+  const shown = renderable.slice(0, MAX_BULLETS);
+  const overflow = renderable.length - shown.length;
+
+  const blocks: string[] = [];
+  for (const [category, label] of CATEGORY_DISPLAY) {
+    const inCategory = shown.filter((entry) => entry.category === category);
+    if (inCategory.length === 0) continue;
+    const bullets = inCategory.map((entry) => `• ${entry.title}`).join('\n');
+    blocks.push(`${label}\n${bullets}`);
+  }
+
+  let summary = blocks.join('\n');
+  if (overflow > 0) summary += `\n…and ${overflow} more`;
+  return summary;
+}
+
+/**
+ * Convenience composition used by the I/O shell: diff prev→next, then render.
+ */
+export function buildDiscordSummary(prevEntries: MinimalEntry[], nextEntries: MinimalEntry[]): string {
+  return renderDiscordSummary(newlyAddedEntries(prevEntries, nextEntries));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -302,6 +302,10 @@ export default defineConfig({
         command: 'node --import tsx scripts/generate-changelog.ts --check',
         cache: false,
       },
+      'changelog:discord-summary': {
+        command: 'node --import tsx scripts/changelog-discord-summary.ts',
+        cache: false,
+      },
       'cleanup:branches': {
         command: 'node --import tsx scripts/cleanup-merged-branches.ts',
         cache: false,


### PR DESCRIPTION
## Summary

The OTA production workflow (`mobile-ota-production.yml`) creates a local `chore(changelog): refresh from merged PRs` commit before the Discord notify step runs. That step read the update message with `git log -1 --pretty=%s`, so by then HEAD was always the changelog commit — the deploy message echoed "chore(changelog): refresh from merged PRs" every time instead of the changes the OTA actually shipped.

This reads the changelog instead and announces what's new:

- The generate step snapshots `changelog.generated.json` **before** regenerating it, then diffs prev → next to find the entries this OTA newly adds.
- A new testable transform (`scripts/lib/changelog-discord-summary.ts`) groups those entries as **✨ New / 🔧 Improved / 🐛 Fixed** and renders a compact "What's new" block (capped at 15 bullets with an "…and N more" overflow line to stay under Discord's 2000-char limit).
- The thin I/O shell (`scripts/changelog-discord-summary.ts`, wired as `vp run changelog:discord-summary`) writes the block to a file the notify step reads.
- When nothing new shipped (changelog unchanged), the message falls back to the triggering commit's subject — now read from `$COMMIT_SHA`, not `git log -1`, so the workflow's own changelog commit can never leak in again.

Degrades safely: a missing/malformed snapshot is treated as "no entries", and the summary step is best-effort (`|| true`), so it can never break a deploy notification.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Added `scripts/__tests__/changelog-discord-summary.test.ts` covering the diff, category grouping/ordering, empty-result fallback, and overflow cap.
- Verified the rendering output shape against sample entries.
- `vp run typecheck` + `vp test` pending local dependency install (running); will confirm green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9ii2ZgAhB97nLJTd9G32T)_