### PR TITLE
feat: add password reset flow to web and mobile

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -315,6 +315,15 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
           ],
           category: ['BROWSABLE', 'DEFAULT'],
         },
+        {
+          action: 'VIEW',
+          autoVerify: true,
+          data: [
+            { scheme: 'https', host: 'www.boardsesh.com', pathPrefix: '/auth/reset-password' },
+            { scheme: 'https', host: 'boardsesh.com', pathPrefix: '/auth/reset-password' },
+          ],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
       ],
       // Keep the legacy predictive back gesture OFF. Enabling it
       // (android.predictiveBackGestureEnabled: true) currently breaks

--- a/packages/mobile/app/auth/_layout.tsx
+++ b/packages/mobile/app/auth/_layout.tsx
@@ -6,8 +6,10 @@ export default function AuthLayout() {
   return (
     <Stack screenOptions={{ ...screenOptions, headerShown: false }}>
       <Stack.Screen name="login" />
-      {/* register.tsx sets its own header (title + back chevron) via Stack.Screen. */}
+      {/* register, forgot-password, and reset-password set their own header via Stack.Screen. */}
       <Stack.Screen name="register" />
+      <Stack.Screen name="forgot-password" />
+      <Stack.Screen name="reset-password" />
     </Stack>
   );
 }

--- a/packages/mobile/app/auth/forgot-password.tsx
+++ b/packages/mobile/app/auth/forgot-password.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { Stack } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { EMAIL_REGEX } from '../../src/lib/auth-validation';
 import { requestPasswordReset } from '../../src/lib/auth';
@@ -15,6 +15,7 @@ import { track } from '../../src/lib/analytics';
 export default function ForgotPasswordScreen() {
   const { t } = useTranslation('auth');
   const theme = useTheme();
+  const router = useRouter();
 
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
@@ -74,6 +75,12 @@ export default function ForgotPasswordScreen() {
               <Text style={[styles.successText, { color: theme.systemColors.label }]}>
                 {t('forgotPassword.toasts.success')}
               </Text>
+              <Button
+                title={t('forgotPassword.back')}
+                onPress={() => router.replace('/auth/login')}
+                variant="text"
+                size="large"
+              />
             </View>
           ) : (
             <>

--- a/packages/mobile/app/auth/forgot-password.tsx
+++ b/packages/mobile/app/auth/forgot-password.tsx
@@ -88,7 +88,7 @@ export default function ForgotPasswordScreen() {
                     setEmail(text);
                     if (emailError) setEmailError(null);
                   }}
-                  placeholder="your@email.com"
+                  placeholder={t('login.placeholders.email')}
                   keyboardType="email-address"
                   autoCapitalize="none"
                   autoCorrect={false}

--- a/packages/mobile/app/auth/forgot-password.tsx
+++ b/packages/mobile/app/auth/forgot-password.tsx
@@ -30,7 +30,7 @@ export default function ForgotPasswordScreen() {
     if (!canSubmit) return;
 
     if (!EMAIL_REGEX.test(trimmedEmail)) {
-      setEmailError(t('login.validation.emailInvalid'));
+      setEmailError(t('forgotPassword.validation.emailInvalid'));
       return;
     }
 

--- a/packages/mobile/app/auth/forgot-password.tsx
+++ b/packages/mobile/app/auth/forgot-password.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { EMAIL_REGEX } from '../../src/lib/auth-validation';
+import { requestPasswordReset } from '../../src/lib/auth';
+import { useTheme } from '../../src/providers/theme-provider';
+import { AuthTextInput } from '../../src/components/AuthTextInput';
+import { Button } from '../../src/components/Button';
+import { hapticLight } from '../../src/lib/haptics';
+import { reportError } from '../../src/lib/error-reporting';
+import { track } from '../../src/lib/analytics';
+
+export default function ForgotPasswordScreen() {
+  const { t } = useTranslation('auth');
+  const theme = useTheme();
+
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const trimmedEmail = email.trim();
+  const canSubmit = !submitting && trimmedEmail.length > 0;
+
+  async function onSubmit() {
+    if (!canSubmit) return;
+
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      setEmailError(t('login.validation.emailInvalid'));
+      return;
+    }
+
+    setEmailError(null);
+    setFormError(null);
+    setSubmitting(true);
+    hapticLight();
+    track('Forgot Password Requested', { flow: 'native' });
+
+    try {
+      const result = await requestPasswordReset(trimmedEmail);
+      if (!result.success) {
+        if (result.error === 'network') {
+          setFormError(t('nativeStart.networkError'));
+        } else {
+          reportError(new Error(`Forgot password failed: ${result.error}`), {
+            tags: { source: 'native-auth', flow: 'forgot-password' },
+            extra: { status: result.status, server_error: result.error },
+          });
+          setFormError(t('forgotPassword.toasts.failed'));
+        }
+        return;
+      }
+      setSubmitted(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: true, title: t('forgotPassword.heading') }} />
+      <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+        >
+          {submitted ? (
+            <View style={styles.successContainer}>
+              <Text style={[styles.successText, { color: theme.systemColors.label }]}>
+                {t('forgotPassword.toasts.success')}
+              </Text>
+            </View>
+          ) : (
+            <>
+              <Text style={[styles.description, { color: theme.systemColors.secondaryLabel }]}>
+                {t('forgotPassword.description')}
+              </Text>
+
+              <View style={styles.form}>
+                <AuthTextInput
+                  label={t('forgotPassword.fields.email')}
+                  value={email}
+                  onChangeText={(text) => {
+                    setEmail(text);
+                    if (emailError) setEmailError(null);
+                  }}
+                  placeholder="your@email.com"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  textContentType="emailAddress"
+                  autoComplete="email"
+                  returnKeyType="done"
+                  onSubmitEditing={() => {
+                    void onSubmit();
+                  }}
+                  editable={!submitting}
+                  error={emailError ?? undefined}
+                />
+
+                {formError ? (
+                  <Text style={styles.errorText} accessibilityLiveRegion="polite">
+                    {formError}
+                  </Text>
+                ) : null}
+
+                <Button
+                  title={t('forgotPassword.submit')}
+                  onPress={() => {
+                    void onSubmit();
+                  }}
+                  variant="filled"
+                  size="large"
+                  loading={submitting}
+                  disabled={!canSubmit}
+                  style={styles.submitButton}
+                />
+              </View>
+            </>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1, padding: 24, paddingTop: 16 },
+  description: { fontSize: 15, lineHeight: 22, marginBottom: 24 },
+  form: { gap: 12 },
+  submitButton: { alignSelf: 'stretch', marginTop: 4 },
+  errorText: { color: '#FF3B30', fontSize: 15 },
+  successContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+  successText: { fontSize: 17, textAlign: 'center', lineHeight: 26 },
+});

--- a/packages/mobile/app/auth/forgot-password.tsx
+++ b/packages/mobile/app/auth/forgot-password.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { EMAIL_REGEX } from '../../src/lib/auth-validation';
 import { requestPasswordReset } from '../../src/lib/auth';
+import { iosSystemColors } from '../../src/theme/ios-colors';
 import { useTheme } from '../../src/providers/theme-provider';
 import { AuthTextInput } from '../../src/components/AuthTextInput';
 import { Button } from '../../src/components/Button';
@@ -133,7 +134,7 @@ const styles = StyleSheet.create({
   description: { fontSize: 15, lineHeight: 22, marginBottom: 24 },
   form: { gap: 12 },
   submitButton: { alignSelf: 'stretch', marginTop: 4 },
-  errorText: { color: '#FF3B30', fontSize: 15 },
+  errorText: { color: iosSystemColors.systemRed, fontSize: 15 },
   successContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
   successText: { fontSize: 17, textAlign: 'center', lineHeight: 26 },
 });

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -209,6 +209,19 @@ export default function LoginScreen() {
               {error}
             </Text>
           ) : null}
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              router.push('/auth/forgot-password');
+            }}
+            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+            style={styles.forgotPasswordHit}
+            accessibilityRole="link"
+          >
+            <Text style={[styles.forgotPasswordLink, { color: theme.systemColors.secondaryLabel }]}>
+              {t('login.links.forgotPassword')}
+            </Text>
+          </Pressable>
         </View>
 
         {showSocialSignIn && (
@@ -349,6 +362,15 @@ const styles = StyleSheet.create({
   // Apple's native button needs explicit height + width or it renders nothing.
   appleButton: { width: '100%', height: 50 },
   googleButton: { width: '100%', height: 50 },
+  forgotPasswordHit: {
+    alignSelf: 'center',
+    marginTop: 4,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  forgotPasswordLink: {
+    fontSize: 15,
+  },
   footer: {
     flexDirection: 'row',
     justifyContent: 'center',

--- a/packages/mobile/app/auth/reset-password.tsx
+++ b/packages/mobile/app/auth/reset-password.tsx
@@ -59,7 +59,7 @@ export default function ResetPasswordScreen() {
     track('Password Reset Submitted', { flow: 'native' });
 
     try {
-      const result = await resetPassword(email, token, password);
+      const result = await resetPassword(email, token, password, confirmPassword);
       if (!result.success) {
         if (result.error === 'network') {
           setFormError(t('nativeStart.networkError'));

--- a/packages/mobile/app/auth/reset-password.tsx
+++ b/packages/mobile/app/auth/reset-password.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { PASSWORD_MIN_LENGTH } from '../../src/lib/auth-validation';
+import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from '../../src/lib/auth-validation';
 import { resetPassword } from '../../src/lib/auth';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { useTheme } from '../../src/providers/theme-provider';
@@ -44,6 +44,9 @@ export default function ResetPasswordScreen() {
     let hasError = false;
     if (password.length < PASSWORD_MIN_LENGTH) {
       setPasswordError(t('resetPassword.validation.passwordTooShort'));
+      hasError = true;
+    } else if (password.length > PASSWORD_MAX_LENGTH) {
+      setPasswordError(t('resetPassword.validation.passwordTooLong'));
       hasError = true;
     }
     if (password !== confirmPassword) {
@@ -97,6 +100,12 @@ export default function ResetPasswordScreen() {
               <Text style={[styles.invalidLinkText, { color: theme.systemColors.label }]}>
                 {t('resetPassword.invalidLink')}
               </Text>
+              <Button
+                title={t('resetPassword.back')}
+                onPress={() => router.replace('/auth/login')}
+                variant="text"
+                size="large"
+              />
             </View>
           ) : (
             <>
@@ -164,6 +173,14 @@ export default function ResetPasswordScreen() {
                   loading={submitting}
                   disabled={!canSubmit}
                   style={styles.submitButton}
+                />
+
+                <Button
+                  title={t('resetPassword.back')}
+                  onPress={() => router.replace('/auth/login')}
+                  variant="text"
+                  size="large"
+                  disabled={submitting}
                 />
               </View>
             </>

--- a/packages/mobile/app/auth/reset-password.tsx
+++ b/packages/mobile/app/auth/reset-password.tsx
@@ -12,6 +12,7 @@ import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { PASSWORD_MIN_LENGTH } from '../../src/lib/auth-validation';
 import { resetPassword } from '../../src/lib/auth';
+import { iosSystemColors } from '../../src/theme/ios-colors';
 import { useTheme } from '../../src/providers/theme-provider';
 import { AuthTextInput } from '../../src/components/AuthTextInput';
 import { Button } from '../../src/components/Button';
@@ -178,7 +179,7 @@ const styles = StyleSheet.create({
   description: { fontSize: 15, lineHeight: 22, marginBottom: 24 },
   form: { gap: 12 },
   submitButton: { alignSelf: 'stretch', marginTop: 4 },
-  errorText: { color: '#FF3B30', fontSize: 15 },
+  errorText: { color: iosSystemColors.systemRed, fontSize: 15 },
   errorContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
   invalidLinkText: { fontSize: 17, textAlign: 'center', lineHeight: 26 },
 });

--- a/packages/mobile/app/auth/reset-password.tsx
+++ b/packages/mobile/app/auth/reset-password.tsx
@@ -1,0 +1,184 @@
+import { useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type TextInput as RNTextInput,
+} from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { PASSWORD_MIN_LENGTH } from '../../src/lib/auth-validation';
+import { resetPassword } from '../../src/lib/auth';
+import { useTheme } from '../../src/providers/theme-provider';
+import { AuthTextInput } from '../../src/components/AuthTextInput';
+import { Button } from '../../src/components/Button';
+import { hapticLight } from '../../src/lib/haptics';
+import { reportError } from '../../src/lib/error-reporting';
+import { track } from '../../src/lib/analytics';
+
+export default function ResetPasswordScreen() {
+  const { t } = useTranslation('auth');
+  const theme = useTheme();
+  const router = useRouter();
+  const confirmRef = useRef<RNTextInput>(null);
+
+  const { token, email } = useLocalSearchParams<{ token?: string; email?: string }>();
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isLinkInvalid = !token || !email;
+  const canSubmit = !submitting && password.length > 0 && confirmPassword.length > 0;
+
+  async function onSubmit() {
+    if (!canSubmit || isLinkInvalid) return;
+
+    let hasError = false;
+    if (password.length < PASSWORD_MIN_LENGTH) {
+      setPasswordError(t('resetPassword.validation.passwordTooShort'));
+      hasError = true;
+    }
+    if (password !== confirmPassword) {
+      setConfirmPasswordError(t('resetPassword.validation.passwordsMismatch'));
+      hasError = true;
+    }
+    if (hasError) return;
+
+    setPasswordError(null);
+    setConfirmPasswordError(null);
+    setFormError(null);
+    setSubmitting(true);
+    hapticLight();
+    track('Password Reset Submitted', { flow: 'native' });
+
+    try {
+      const result = await resetPassword(email, token, password);
+      if (!result.success) {
+        if (result.error === 'network') {
+          setFormError(t('nativeStart.networkError'));
+        } else if (result.status === 400) {
+          setFormError(t('resetPassword.toasts.failed'));
+        } else {
+          reportError(new Error(`Reset password failed: ${result.error}`), {
+            tags: { source: 'native-auth', flow: 'reset-password' },
+            extra: { status: result.status, server_error: result.error },
+          });
+          setFormError(t('resetPassword.toasts.failed'));
+        }
+        return;
+      }
+      track('Password Reset Succeeded', { flow: 'native' });
+      router.replace('/auth/login');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: true, title: t('resetPassword.heading') }} />
+      <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+        >
+          {isLinkInvalid ? (
+            <View style={styles.errorContainer}>
+              <Text style={[styles.invalidLinkText, { color: theme.systemColors.label }]}>
+                {t('resetPassword.invalidLink')}
+              </Text>
+            </View>
+          ) : (
+            <>
+              <Text style={[styles.description, { color: theme.systemColors.secondaryLabel }]}>
+                {t('resetPassword.description', { email })}
+              </Text>
+
+              <View style={styles.form}>
+                <AuthTextInput
+                  label={t('resetPassword.fields.newPassword')}
+                  value={password}
+                  onChangeText={(text) => {
+                    setPassword(text);
+                    if (passwordError) setPasswordError(null);
+                  }}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  textContentType="newPassword"
+                  autoComplete="new-password"
+                  returnKeyType="next"
+                  onSubmitEditing={() => confirmRef.current?.focus()}
+                  editable={!submitting}
+                  error={passwordError ?? undefined}
+                  showLabel={t('login.a11y.showPassword')}
+                  hideLabel={t('login.a11y.hidePassword')}
+                />
+
+                <AuthTextInput
+                  ref={confirmRef}
+                  label={t('resetPassword.fields.confirmPassword')}
+                  value={confirmPassword}
+                  onChangeText={(text) => {
+                    setConfirmPassword(text);
+                    if (confirmPasswordError) setConfirmPasswordError(null);
+                  }}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  textContentType="newPassword"
+                  autoComplete="new-password"
+                  returnKeyType="done"
+                  onSubmitEditing={() => {
+                    void onSubmit();
+                  }}
+                  editable={!submitting}
+                  error={confirmPasswordError ?? undefined}
+                  showLabel={t('login.a11y.showPassword')}
+                  hideLabel={t('login.a11y.hidePassword')}
+                />
+
+                {formError ? (
+                  <Text style={styles.errorText} accessibilityLiveRegion="polite">
+                    {formError}
+                  </Text>
+                ) : null}
+
+                <Button
+                  title={t('resetPassword.submit')}
+                  onPress={() => {
+                    void onSubmit();
+                  }}
+                  variant="filled"
+                  size="large"
+                  loading={submitting}
+                  disabled={!canSubmit}
+                  style={styles.submitButton}
+                />
+              </View>
+            </>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1, padding: 24, paddingTop: 16 },
+  description: { fontSize: 15, lineHeight: 22, marginBottom: 24 },
+  form: { gap: 12 },
+  submitButton: { alignSelf: 'stretch', marginTop: 4 },
+  errorText: { color: '#FF3B30', fontSize: 15 },
+  errorContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+  invalidLinkText: { fontSize: 17, textAlign: 'center', lineHeight: 26 },
+});

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -374,6 +374,75 @@ export async function registerWithCredentials(
   return { success: true };
 }
 
+export type PasswordResetResult = { success: true } | NativeAuthFailure;
+
+/**
+ * Request a password reset email. Calls the web API's forgot-password endpoint.
+ * Always returns success=true on 2xx even though the backend is intentionally
+ * non-committal about whether the email exists (user enumeration prevention).
+ */
+export async function requestPasswordReset(email: string): Promise<PasswordResetResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${WEB_BASE_URL}/api/auth/forgot-password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+      signal: createTimeoutSignal(15_000),
+    });
+  } catch {
+    return { success: false, status: null, error: 'network' };
+  }
+
+  if (!response.ok) {
+    let serverError = `HTTP ${response.status}`;
+    try {
+      const parsed = (await response.json()) as { error?: unknown };
+      if (typeof parsed.error === 'string' && parsed.error.length > 0) {
+        serverError = parsed.error;
+      }
+    } catch {
+      // Body wasn't JSON; fall back to the HTTP status string.
+    }
+    return { success: false, status: response.status, error: serverError };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Submit a new password using a reset token from the email link.
+ * Calls the web API's reset-password endpoint.
+ */
+export async function resetPassword(email: string, token: string, newPassword: string): Promise<PasswordResetResult> {
+  let response: Response;
+  try {
+    response = await fetch(`${WEB_BASE_URL}/api/auth/reset-password`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, token, password: newPassword, confirmPassword: newPassword }),
+      signal: createTimeoutSignal(15_000),
+    });
+  } catch {
+    return { success: false, status: null, error: 'network' };
+  }
+
+  if (!response.ok) {
+    let serverError = `HTTP ${response.status}`;
+    try {
+      const parsed = (await response.json()) as { error?: unknown };
+      if (typeof parsed.error === 'string' && parsed.error.length > 0) {
+        serverError = parsed.error;
+      }
+    } catch {
+      // Body wasn't JSON; fall back to the HTTP status string.
+    }
+    return { success: false, status: response.status, error: serverError };
+  }
+
+  return { success: true };
+}
+
 export async function signOut(): Promise<void> {
   const refreshToken = await getRefreshToken();
   if (refreshToken) {

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -414,13 +414,18 @@ export async function requestPasswordReset(email: string): Promise<PasswordReset
  * Submit a new password using a reset token from the email link.
  * Calls the web API's reset-password endpoint.
  */
-export async function resetPassword(email: string, token: string, newPassword: string): Promise<PasswordResetResult> {
+export async function resetPassword(
+  email: string,
+  token: string,
+  newPassword: string,
+  confirmPassword: string,
+): Promise<PasswordResetResult> {
   let response: Response;
   try {
     response = await fetch(`${WEB_BASE_URL}/api/auth/reset-password`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, token, password: newPassword, confirmPassword: newPassword }),
+      body: JSON.stringify({ email, token, password: newPassword, confirmPassword }),
       signal: createTimeoutSignal(15_000),
     });
   } catch {

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -60,7 +60,8 @@
       "haveAccount": "Already have an account?",
       "noAccount": "New here?",
       "troubleSigningIn": "Trouble signing in?",
-      "discord": "Join Discord"
+      "discord": "Join Discord",
+      "forgotPassword": "Forgot password?"
     },
     "splitScreenNotice": {
       "title": "Sign-in not responding?",
@@ -120,6 +121,43 @@
     "networkError": "Could not reach Boardsesh. Check your connection and try again.",
     "oauthError": "Sign in didn't complete. Give it another go."
   },
+  "forgotPassword": {
+    "heading": "Reset Password",
+    "description": "Enter your account email and we'll send you a link to reset your password.",
+    "fields": {
+      "email": "Email"
+    },
+    "validation": {
+      "emailRequired": "Please enter your email"
+    },
+    "submit": "Send Reset Link",
+    "toasts": {
+      "success": "If an account exists for that email, a reset link has been sent.",
+      "failed": "Failed to request password reset"
+    },
+    "back": "Back to Login"
+  },
+  "resetPassword": {
+    "heading": "Create New Password",
+    "description": "Enter a new password for {{email}}.",
+    "invalidLink": "This reset link is invalid. Please request a new password reset email.",
+    "fields": {
+      "newPassword": "New Password",
+      "confirmPassword": "Confirm New Password"
+    },
+    "validation": {
+      "passwordRequired": "Please enter a new password",
+      "passwordTooShort": "Password must be at least 8 characters",
+      "confirmPasswordRequired": "Please confirm your new password",
+      "passwordsMismatch": "Passwords do not match"
+    },
+    "submit": "Update Password",
+    "toasts": {
+      "success": "Password updated successfully. Please sign in.",
+      "failed": "Failed to reset password"
+    },
+    "back": "Back to Login"
+  },
   "metadata": {
     "login": {
       "title": "Login",
@@ -132,6 +170,14 @@
     "verifyRequest": {
       "title": "Verify Email",
       "description": "Verify your email address"
+    },
+    "forgotPassword": {
+      "title": "Forgot Password",
+      "description": "Request a password reset link for your Boardsesh account"
+    },
+    "resetPassword": {
+      "title": "Create New Password",
+      "description": "Set a new password for your Boardsesh account"
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -132,6 +132,7 @@
       "emailInvalid": "Please enter a valid email"
     },
     "submit": "Send Reset Link",
+    "success": "If an account exists for that email, a reset link is on its way.",
     "toasts": {
       "success": "If an account exists for that email, a reset link has been sent.",
       "failed": "Failed to request password reset"

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -150,6 +150,7 @@
     "validation": {
       "passwordRequired": "Please enter a new password",
       "passwordTooShort": "Password must be at least 8 characters",
+      "passwordTooLong": "Password must be less than 128 characters",
       "confirmPasswordRequired": "Please confirm your new password",
       "passwordsMismatch": "Passwords do not match"
     },

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -128,7 +128,8 @@
       "email": "Email"
     },
     "validation": {
-      "emailRequired": "Please enter your email"
+      "emailRequired": "Please enter your email",
+      "emailInvalid": "Please enter a valid email"
     },
     "submit": "Send Reset Link",
     "toasts": {

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -60,7 +60,8 @@
       "haveAccount": "¿Ya tienes una cuenta?",
       "noAccount": "¿Nuevo por aquí?",
       "troubleSigningIn": "¿Problemas para iniciar sesión?",
-      "discord": "Únete a Discord"
+      "discord": "Únete a Discord",
+      "forgotPassword": "¿Olvidaste tu contraseña?"
     },
     "splitScreenNotice": {
       "title": "¿El inicio de sesión no responde?",
@@ -120,6 +121,43 @@
     "networkError": "No se pudo conectar con Boardsesh. Comprueba tu conexión e inténtalo de nuevo.",
     "oauthError": "No se pudo completar el inicio de sesión. Inténtalo de nuevo."
   },
+  "forgotPassword": {
+    "heading": "Restablecer contraseña",
+    "description": "Escribe tu correo y te enviaremos un enlace para restablecer tu contraseña.",
+    "fields": {
+      "email": "Correo electrónico"
+    },
+    "validation": {
+      "emailRequired": "Escribe tu correo"
+    },
+    "submit": "Enviar enlace de restablecimiento",
+    "toasts": {
+      "success": "Si existe una cuenta con ese correo, el enlace está en camino.",
+      "failed": "No se pudo solicitar el restablecimiento de contraseña"
+    },
+    "back": "Volver a iniciar sesión"
+  },
+  "resetPassword": {
+    "heading": "Crear nueva contraseña",
+    "description": "Escribe una nueva contraseña para {{email}}.",
+    "invalidLink": "Este enlace no es válido. Pide un nuevo correo de restablecimiento.",
+    "fields": {
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar nueva contraseña"
+    },
+    "validation": {
+      "passwordRequired": "Escribe una nueva contraseña",
+      "passwordTooShort": "La contraseña debe tener al menos 8 caracteres",
+      "confirmPasswordRequired": "Confirma tu nueva contraseña",
+      "passwordsMismatch": "Las contraseñas no coinciden"
+    },
+    "submit": "Actualizar contraseña",
+    "toasts": {
+      "success": "Contraseña actualizada. Ya puedes iniciar sesión.",
+      "failed": "No se pudo restablecer la contraseña"
+    },
+    "back": "Volver a iniciar sesión"
+  },
   "metadata": {
     "login": {
       "title": "Iniciar sesión",
@@ -132,6 +170,14 @@
     "verifyRequest": {
       "title": "Verifica tu correo",
       "description": "Verifica tu correo electrónico"
+    },
+    "forgotPassword": {
+      "title": "Contraseña olvidada",
+      "description": "Solicita un enlace para restablecer tu contraseña de Boardsesh"
+    },
+    "resetPassword": {
+      "title": "Crear nueva contraseña",
+      "description": "Establece una nueva contraseña para tu cuenta de Boardsesh"
     }
   }
 }

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -132,6 +132,7 @@
       "emailInvalid": "Escribe un correo válido"
     },
     "submit": "Enviar enlace de restablecimiento",
+    "success": "Si existe una cuenta con ese correo, el enlace está en camino.",
     "toasts": {
       "success": "Si existe una cuenta con ese correo, el enlace está en camino.",
       "failed": "No se pudo solicitar el restablecimiento de contraseña"

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -150,6 +150,7 @@
     "validation": {
       "passwordRequired": "Escribe una nueva contraseña",
       "passwordTooShort": "La contraseña debe tener al menos 8 caracteres",
+      "passwordTooLong": "La contraseña debe tener menos de 128 caracteres",
       "confirmPasswordRequired": "Confirma tu nueva contraseña",
       "passwordsMismatch": "Las contraseñas no coinciden"
     },

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -128,7 +128,8 @@
       "email": "Correo electrónico"
     },
     "validation": {
-      "emailRequired": "Escribe tu correo"
+      "emailRequired": "Escribe tu correo",
+      "emailInvalid": "Escribe un correo válido"
     },
     "submit": "Enviar enlace de restablecimiento",
     "toasts": {

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -132,6 +132,7 @@
       "emailInvalid": "Saisissez un e-mail valide"
     },
     "submit": "Envoyer le lien de réinitialisation",
+    "success": "Si un compte existe pour cet e-mail, le lien est en route.",
     "toasts": {
       "success": "Si un compte existe pour cet e-mail, le lien est en route.",
       "failed": "Impossible de demander la réinitialisation du mot de passe"

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -60,7 +60,8 @@
       "haveAccount": "Vous avez déjà un compte ?",
       "noAccount": "Nouveau ici ?",
       "troubleSigningIn": "Problème de connexion ?",
-      "discord": "Rejoindre Discord"
+      "discord": "Rejoindre Discord",
+      "forgotPassword": "Mot de passe oublié ?"
     },
     "splitScreenNotice": {
       "title": "La connexion ne répond pas ?",
@@ -120,6 +121,43 @@
     "networkError": "Impossible de joindre Boardsesh. Vérifiez votre connexion et réessayez.",
     "oauthError": "La connexion n'a pas abouti. Réessayez."
   },
+  "forgotPassword": {
+    "heading": "Réinitialiser le mot de passe",
+    "description": "Saisissez votre e-mail et nous vous enverrons un lien pour réinitialiser votre mot de passe.",
+    "fields": {
+      "email": "E-mail"
+    },
+    "validation": {
+      "emailRequired": "Saisissez votre e-mail"
+    },
+    "submit": "Envoyer le lien de réinitialisation",
+    "toasts": {
+      "success": "Si un compte existe pour cet e-mail, le lien est en route.",
+      "failed": "Impossible de demander la réinitialisation du mot de passe"
+    },
+    "back": "Retour à la connexion"
+  },
+  "resetPassword": {
+    "heading": "Créer un nouveau mot de passe",
+    "description": "Choisissez un nouveau mot de passe pour {{email}}.",
+    "invalidLink": "Ce lien est invalide. Demandez un nouvel e-mail de réinitialisation.",
+    "fields": {
+      "newPassword": "Nouveau mot de passe",
+      "confirmPassword": "Confirmer le nouveau mot de passe"
+    },
+    "validation": {
+      "passwordRequired": "Saisissez un nouveau mot de passe",
+      "passwordTooShort": "Le mot de passe doit faire au moins 8 caractères",
+      "confirmPasswordRequired": "Confirmez votre nouveau mot de passe",
+      "passwordsMismatch": "Les mots de passe ne correspondent pas"
+    },
+    "submit": "Mettre à jour le mot de passe",
+    "toasts": {
+      "success": "Mot de passe mis à jour. Vous pouvez vous connecter.",
+      "failed": "Impossible de réinitialiser le mot de passe"
+    },
+    "back": "Retour à la connexion"
+  },
   "metadata": {
     "login": {
       "title": "Connexion",
@@ -132,6 +170,14 @@
     "verifyRequest": {
       "title": "Vérifiez votre e-mail",
       "description": "Vérifiez votre adresse e-mail"
+    },
+    "forgotPassword": {
+      "title": "Mot de passe oublié",
+      "description": "Demandez un lien pour réinitialiser votre mot de passe Boardsesh"
+    },
+    "resetPassword": {
+      "title": "Créer un nouveau mot de passe",
+      "description": "Définissez un nouveau mot de passe pour votre compte Boardsesh"
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -150,6 +150,7 @@
     "validation": {
       "passwordRequired": "Saisissez un nouveau mot de passe",
       "passwordTooShort": "Le mot de passe doit faire au moins 8 caractères",
+      "passwordTooLong": "Le mot de passe doit faire moins de 128 caractères",
       "confirmPasswordRequired": "Confirmez votre nouveau mot de passe",
       "passwordsMismatch": "Les mots de passe ne correspondent pas"
     },

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -128,7 +128,8 @@
       "email": "E-mail"
     },
     "validation": {
-      "emailRequired": "Saisissez votre e-mail"
+      "emailRequired": "Saisissez votre e-mail",
+      "emailInvalid": "Saisissez un e-mail valide"
     },
     "submit": "Envoyer le lien de réinitialisation",
     "toasts": {

--- a/packages/web/.env.local
+++ b/packages/web/.env.local
@@ -16,6 +16,14 @@ IRON_SESSION_PASSWORD={ "1": "dev-secret-change-me" }
 NEXTAUTH_SECRET=dev-secret-change-me
 NEXTAUTH_URL=http://localhost:3000
 
+# Fastmail SMTP for transactional email (password reset, verification)
+# Get credentials from 1Password: Boardsesh vault → "Boardsesh SMTP"
+SMTP_HOST=smtp.fastmail.com
+SMTP_PORT=465
+SMTP_USER=
+SMTP_PASSWORD=
+EMAIL_FROM=
+
 # Backend WebSocket URL
 # For production, set this via your deployment platform's environment variables (e.g., Vercel)
 NEXT_PUBLIC_WS_URL=ws://localhost:8080/graphql

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -10,6 +10,12 @@ vi.mock('@/app/lib/auth/rate-limiter', () => ({
   getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
 }));
 
+vi.mock('@/app/lib/auth/password-reset', () => ({
+  getPasswordResetIdentifier: (email: string) => `password-reset:${email}`,
+  hashResetToken: (token: string) => `sha256:${token}`,
+  consistentDelay: async () => {},
+}));
+
 const mockSendPasswordResetEmail = vi.fn();
 vi.mock('@/app/lib/email/email-service', () => ({
   sendPasswordResetEmail: (...args: unknown[]) => mockSendPasswordResetEmail(...args),

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -21,6 +21,11 @@ vi.mock('@/app/lib/email/email-service', () => ({
   sendPasswordResetEmail: (...args: unknown[]) => mockSendPasswordResetEmail(...args),
 }));
 
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 const mockUserLimit = vi.fn();
 const mockCredentialsLimit = vi.fn();
 const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
@@ -127,6 +132,18 @@ describe('POST /api/auth/forgot-password', () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.message).toContain('If an account exists');
+  });
+
+  it('reports the SMTP failure to Sentry while keeping the response generic', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+    const smtpError = new Error('smtp failed');
+    mockSendPasswordResetEmail.mockRejectedValue(smtpError);
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+
+    expect(response.status).toBe(200);
+    expect(mockCaptureException).toHaveBeenCalledWith(smtpError, expect.objectContaining({ tags: expect.anything() }));
   });
 
   it('returns 500 when database transaction fails', async () => {

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -109,6 +109,11 @@ describe('POST /api/auth/forgot-password', () => {
     expect(response.status).toBe(200);
     expect(mockTransaction).toHaveBeenCalled();
     expect(mockSendPasswordResetEmail).toHaveBeenCalled();
+    // The old token must be deleted before the new one is inserted, otherwise the
+    // unique identifier collides and rotation fails.
+    expect(mockTxDelete).toHaveBeenCalled();
+    expect(mockTxInsert).toHaveBeenCalled();
+    expect(mockTxDelete.mock.invocationCallOrder[0]).toBeLessThan(mockTxInsert.mock.invocationCallOrder[0]);
   });
 
   it('returns generic response and does not send email for OAuth-only account', async () => {

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('server-only', () => ({}));
+
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+}));
+
+const mockSendPasswordResetEmail = vi.fn();
+vi.mock('@/app/lib/email/email-service', () => ({
+  sendPasswordResetEmail: (...args: unknown[]) => mockSendPasswordResetEmail(...args),
+}));
+
+const mockUserLimit = vi.fn();
+const mockCredentialsLimit = vi.fn();
+const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockValues = vi.fn().mockResolvedValue(undefined);
+const mockTxDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+const mockTxInsert = vi.fn(() => ({ values: mockValues }));
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+  await fn({ delete: mockTxDelete, insert: mockTxInsert });
+});
+
+let selectCall = 0;
+const mockSelect = vi.fn(() => {
+  selectCall += 1;
+  return {
+    from: () => ({
+      where: () => ({
+        limit: selectCall === 1 ? mockUserLimit : mockCredentialsLimit,
+      }),
+    }),
+  };
+});
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: (...args: unknown[]) => mockSelect(...args),
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  users: { id: 'users.id', email: 'users.email' },
+  userCredentials: { userId: 'user_credentials.userId' },
+  verificationTokens: { identifier: 'verificationTokens.identifier' },
+}));
+
+import { POST } from '../route';
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/forgot-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/forgot-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCall = 0;
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+  });
+
+  it('returns 429 when rate limited', async () => {
+    mockCheckRateLimit.mockReturnValueOnce({ limited: true, retryAfterSeconds: 30 });
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+    expect(response.status).toBe(429);
+  });
+
+  it('returns 400 for invalid email', async () => {
+    const response = await POST(createRequest({ email: 'bad-email' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('returns generic response when user is not found', async () => {
+    mockUserLimit.mockResolvedValue([]);
+
+    const response = await POST(createRequest({ email: 'missing@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toContain('If an account exists');
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it('sends reset email for valid credential account', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+
+    expect(response.status).toBe(200);
+    expect(mockTransaction).toHaveBeenCalled();
+    expect(mockSendPasswordResetEmail).toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -118,13 +118,15 @@ describe('POST /api/auth/forgot-password', () => {
     expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
   });
 
-  it('returns 500 when email delivery fails', async () => {
+  it('returns 200 generic message when email delivery fails (no user enumeration)', async () => {
     mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
     mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
     mockSendPasswordResetEmail.mockRejectedValue(new Error('smtp failed'));
 
     const response = await POST(createRequest({ email: 'test@example.com' }));
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toContain('If an account exists');
   });
 
   it('returns 500 when database transaction fails', async () => {

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -101,4 +101,16 @@ describe('POST /api/auth/forgot-password', () => {
     expect(mockTransaction).toHaveBeenCalled();
     expect(mockSendPasswordResetEmail).toHaveBeenCalled();
   });
+
+  it('returns generic response and does not send email for OAuth-only account', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'oauth-user' }]);
+    mockCredentialsLimit.mockResolvedValue([]);
+
+    const response = await POST(createRequest({ email: 'oauth@example.com' }));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toContain('If an account exists');
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -38,8 +38,8 @@ const mockSelect = vi.fn((selection?: Record<string, unknown>) => {
 
 vi.mock('@/app/lib/db/db', () => ({
   getDb: () => ({
-    select: (...args: unknown[]) => mockSelect(...args),
-    transaction: (...args: unknown[]) => mockTransaction(...args),
+    select: (selection?: Record<string, unknown>) => mockSelect(selection),
+    transaction: (fn: (tx: unknown) => Promise<void>) => mockTransaction(fn),
   }),
 }));
 

--- a/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -25,13 +25,12 @@ const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
   await fn({ delete: mockTxDelete, insert: mockTxInsert });
 });
 
-let selectCall = 0;
-const mockSelect = vi.fn(() => {
-  selectCall += 1;
+const mockSelect = vi.fn((selection?: Record<string, unknown>) => {
+  const limitMock = selection?.id ? mockUserLimit : mockCredentialsLimit;
   return {
     from: () => ({
       where: () => ({
-        limit: selectCall === 1 ? mockUserLimit : mockCredentialsLimit,
+        limit: limitMock,
       }),
     }),
   };
@@ -63,7 +62,6 @@ function createRequest(body: Record<string, unknown>): NextRequest {
 describe('POST /api/auth/forgot-password', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    selectCall = 0;
     mockGetClientIp.mockReturnValue('127.0.0.1');
     mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
   });
@@ -112,5 +110,23 @@ describe('POST /api/auth/forgot-password', () => {
     expect(response.status).toBe(200);
     expect(data.message).toContain('If an account exists');
     expect(mockSendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when email delivery fails', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+    mockSendPasswordResetEmail.mockRejectedValue(new Error('smtp failed'));
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+    expect(response.status).toBe(500);
+  });
+
+  it('returns 500 when database transaction fails', async () => {
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+    mockTransaction.mockRejectedValueOnce(new Error('db transaction failed'));
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+    expect(response.status).toBe(500);
   });
 });

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -5,13 +5,13 @@ import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { sendPasswordResetEmail } from '@/app/lib/email/email-service';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+import { getPasswordResetIdentifier } from '@/app/lib/auth/password-reset';
 
 const forgotPasswordSchema = z.object({
   email: z.string().email('Invalid email address'),
 });
 
 const MIN_RESPONSE_TIME_MS = 1500;
-const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
 
 async function consistentDelay(startTime: number): Promise<void> {
   const elapsed = Date.now() - startTime;
@@ -19,10 +19,6 @@ async function consistentDelay(startTime: number): Promise<void> {
   if (remaining > 0) {
     await new Promise((resolve) => setTimeout(resolve, remaining));
   }
-}
-
-function getResetIdentifier(email: string): string {
-  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
 }
 
 export async function POST(request: NextRequest) {
@@ -81,7 +77,7 @@ export async function POST(request: NextRequest) {
 
     const token = crypto.randomUUID();
     const expires = new Date(Date.now() + 60 * 60 * 1000);
-    const identifier = getResetIdentifier(email);
+    const identifier = getPasswordResetIdentifier(email);
 
     await db.transaction(async (tx) => {
       await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -87,6 +87,9 @@ export async function POST(request: NextRequest) {
     });
 
     const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    // Email is sent outside the transaction intentionally (nodemailer is not transactional).
+    // If this throws, the token remains in the DB but unreachable to the user — the
+    // delete-before-insert at the start of the next attempt cleans it up automatically.
     await sendPasswordResetEmail(email, token, baseUrl);
 
     await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { sendPasswordResetEmail } from '@/app/lib/email/email-service';
+import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Invalid email address'),
+});
+
+const MIN_RESPONSE_TIME_MS = 1500;
+const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
+
+async function consistentDelay(startTime: number): Promise<void> {
+  const elapsed = Date.now() - startTime;
+  const remaining = MIN_RESPONSE_TIME_MS - elapsed;
+  if (remaining > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remaining));
+  }
+}
+
+function getResetIdentifier(email: string): string {
+  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+}
+
+export async function POST(request: NextRequest) {
+  const startTime = Date.now();
+  const genericMessage = 'If an account exists for this email, a reset link will be sent.';
+
+  try {
+    const clientIp = getClientIp(request);
+    const rateLimitResult = checkRateLimit(`forgot-password:${clientIp}`, 5, 60_000);
+
+    if (rateLimitResult.limited) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rateLimitResult.retryAfterSeconds),
+          },
+        }
+      );
+    }
+
+    const body = await request.json();
+    const validationResult = forgotPasswordSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      await consistentDelay(startTime);
+      return NextResponse.json(
+        { error: validationResult.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { email } = validationResult.data;
+    const db = getDb();
+
+    const user = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email))
+      .limit(1);
+
+    if (user.length === 0) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ message: genericMessage }, { status: 200 });
+    }
+
+    const hasCredentials = await db
+      .select({ userId: schema.userCredentials.userId })
+      .from(schema.userCredentials)
+      .where(eq(schema.userCredentials.userId, user[0].id))
+      .limit(1);
+
+    if (hasCredentials.length === 0) {
+      await consistentDelay(startTime);
+      return NextResponse.json({ message: genericMessage }, { status: 200 });
+    }
+
+    const token = crypto.randomUUID();
+    const expires = new Date(Date.now() + 60 * 60 * 1000);
+    const identifier = getResetIdentifier(email);
+
+    await db.transaction(async (tx) => {
+      await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+
+      await tx.insert(schema.verificationTokens).values({
+        identifier,
+        token,
+        expires,
+      });
+    });
+
+    const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    await sendPasswordResetEmail(email, token, baseUrl);
+
+    await consistentDelay(startTime);
+    return NextResponse.json({ message: genericMessage }, { status: 200 });
+  } catch (error) {
+    console.error('Forgot password error:', error);
+    await consistentDelay(startTime);
+    return NextResponse.json({ error: 'Failed to process password reset request' }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -5,7 +5,7 @@ import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { sendPasswordResetEmail } from '@/app/lib/email/email-service';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
-import { getPasswordResetIdentifier } from '@/app/lib/auth/password-reset';
+import { getPasswordResetIdentifier, hashResetToken, consistentDelay } from '@/app/lib/auth/password-reset';
 
 const forgotPasswordSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -13,24 +13,19 @@ const forgotPasswordSchema = z.object({
 
 const MIN_RESPONSE_TIME_MS = 1500;
 
-async function consistentDelay(startTime: number): Promise<void> {
-  const elapsed = Date.now() - startTime;
-  const remaining = MIN_RESPONSE_TIME_MS - elapsed;
-  if (remaining > 0) {
-    await new Promise((resolve) => setTimeout(resolve, remaining));
-  }
-}
-
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
   const genericMessage = 'If an account exists for this email, a reset link will be sent.';
 
   try {
     const clientIp = getClientIp(request);
+    // NOTE: checkRateLimit is in-memory and not shared across serverless instances.
+    // This provides best-effort protection only. Add Redis/Upstash rate limiting
+    // before relying on this as a production security control.
     const rateLimitResult = checkRateLimit(`forgot-password:${clientIp}`, 5, 60_000);
 
     if (rateLimitResult.limited) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },
         {
@@ -46,7 +41,7 @@ export async function POST(request: NextRequest) {
     const validationResult = forgotPasswordSchema.safeParse(body);
 
     if (!validationResult.success) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
@@ -60,7 +55,7 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (user.length === 0) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ message: genericMessage }, { status: 200 });
     }
 
@@ -71,20 +66,22 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (hasCredentials.length === 0) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ message: genericMessage }, { status: 200 });
     }
 
     const token = crypto.randomUUID();
+    const tokenHash = hashResetToken(token);
     const expires = new Date(Date.now() + 60 * 60 * 1000);
     const identifier = getPasswordResetIdentifier(email);
 
     await db.transaction(async (tx) => {
       await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
 
+      // Store the hash, not the raw token — raw token is only in the email link.
       await tx.insert(schema.verificationTokens).values({
         identifier,
-        token,
+        token: tokenHash,
         expires,
       });
     });
@@ -92,11 +89,11 @@ export async function POST(request: NextRequest) {
     const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
     await sendPasswordResetEmail(email, token, baseUrl);
 
-    await consistentDelay(startTime);
+    await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
     return NextResponse.json({ message: genericMessage }, { status: 200 });
   } catch (error) {
     console.error('Forgot password error:', error);
-    await consistentDelay(startTime);
+    await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
     return NextResponse.json({ error: 'Failed to process password reset request' }, { status: 500 });
   }
 }

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
           headers: {
             'Retry-After': String(rateLimitResult.retryAfterSeconds),
           },
-        }
+        },
       );
     }
 
@@ -51,10 +51,7 @@ export async function POST(request: NextRequest) {
 
     if (!validationResult.success) {
       await consistentDelay(startTime);
-      return NextResponse.json(
-        { error: validationResult.error.issues[0].message },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
     const { email } = validationResult.data;

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { getDb } from '@/app/lib/db/db';
@@ -95,7 +96,13 @@ export async function POST(request: NextRequest) {
     try {
       await sendPasswordResetEmail(email, token, baseUrl);
     } catch (emailError) {
+      // Swallow so the response stays generic (no user enumeration), but surface
+      // the failure to Sentry — a misconfigured SMTP credential would otherwise
+      // fail silently for every user with no signal in observability tooling.
       console.error('Failed to send password reset email:', emailError);
+      Sentry.captureException(emailError, {
+        tags: { area: 'auth', flow: 'forgot-password', phase: 'send-email' },
+      });
     }
 
     await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -90,7 +90,13 @@ export async function POST(request: NextRequest) {
     // Email is sent outside the transaction intentionally (nodemailer is not transactional).
     // If this throws, the token remains in the DB but unreachable to the user — the
     // delete-before-insert at the start of the next attempt cleans it up automatically.
-    await sendPasswordResetEmail(email, token, baseUrl);
+    // Return the generic message even on SMTP failure to avoid user enumeration
+    // ("account exists but email failed" vs "no account").
+    try {
+      await sendPasswordResetEmail(email, token, baseUrl);
+    } catch (emailError) {
+      console.error('Failed to send password reset email:', emailError);
+    }
 
     await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
     return NextResponse.json({ message: genericMessage }, { status: 200 });

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -10,6 +10,12 @@ vi.mock('@/app/lib/auth/rate-limiter', () => ({
   getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
 }));
 
+vi.mock('@/app/lib/auth/password-reset', () => ({
+  getPasswordResetIdentifier: (email: string) => `password-reset:${email}`,
+  hashResetToken: (token: string) => `sha256:${token}`,
+  consistentDelay: async () => {},
+}));
+
 const mockHash = vi.fn();
 vi.mock('bcryptjs', () => ({
   default: {

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -40,13 +40,12 @@ const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
   await fn(tx);
 });
 
-let selectCall = 0;
-const mockSelect = vi.fn(() => {
-  selectCall += 1;
+const mockSelect = vi.fn((selection?: Record<string, unknown>) => {
+  const limitMock = selection?.id ? mockUserLimit : mockTokenLimit;
   return {
     from: () => ({
       where: () => ({
-        limit: selectCall === 1 ? mockTokenLimit : mockUserLimit,
+        limit: limitMock,
       }),
     }),
   };
@@ -79,11 +78,26 @@ function createRequest(body: Record<string, unknown>): NextRequest {
 describe('POST /api/auth/reset-password', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    selectCall = 0;
     mockGetClientIp.mockReturnValue('127.0.0.1');
     mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
     mockHash.mockResolvedValue('hashed-password');
     mockTxCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
+  });
+
+  it('returns 429 when rate limited', async () => {
+    mockCheckRateLimit.mockReturnValueOnce({ limited: true, retryAfterSeconds: 25 });
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('25');
   });
 
   it('returns 400 for invalid request body', async () => {
@@ -158,5 +172,22 @@ describe('POST /api/auth/reset-password', () => {
 
     expect(response.status).toBe(200);
     expect(mockTxInsertValues).toHaveBeenCalled();
+  });
+
+  it('returns 500 when transaction fails unexpectedly', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+    mockTransaction.mockRejectedValueOnce(new Error('db transaction failed'));
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(500);
   });
 });

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -131,6 +131,27 @@ describe('POST /api/auth/reset-password', () => {
     expect(mockDelete).not.toHaveBeenCalled();
   });
 
+  it('returns 400 without mutating anything when the token belongs to a different email', async () => {
+    // The SELECT requires identifier (derived from email) AND tokenHash to match the
+    // same row, so a real token paired with the wrong email yields no rows. Nothing
+    // should be hashed, written, or deleted on this path.
+    mockTokenLimit.mockResolvedValue([]);
+
+    const response = await POST(
+      createRequest({
+        email: 'attacker@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockHash).not.toHaveBeenCalled();
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
   it('resets password successfully', async () => {
     mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
     mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -19,14 +19,23 @@ vi.mock('bcryptjs', () => ({
 
 const mockTokenLimit = vi.fn();
 const mockUserLimit = vi.fn();
+const mockTxCredentialsLimit = vi.fn();
+const mockTxUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxUserUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxTokenDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxInsertValues = vi.fn().mockResolvedValue(undefined);
 const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
 const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
 const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
   const tx = {
-    select: () => ({ from: () => ({ where: () => ({ limit: vi.fn().mockResolvedValue([{ userId: 'user-1' }]) }) }) }),
-    update: () => ({ set: () => ({ where: vi.fn().mockResolvedValue(undefined) }) }),
-    insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
-    delete: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+    select: () => ({ from: () => ({ where: () => ({ limit: mockTxCredentialsLimit }) }) }),
+    update: (table: unknown) => ({
+      set: () => ({
+        where: table === 'userCredentials' ? mockTxUpdateWhere : mockTxUserUpdateWhere,
+      }),
+    }),
+    insert: () => ({ values: mockTxInsertValues }),
+    delete: () => ({ where: mockTxTokenDeleteWhere }),
   };
   await fn(tx);
 });
@@ -54,7 +63,7 @@ vi.mock('@/app/lib/db/db', () => ({
 vi.mock('@/app/lib/db/schema', () => ({
   verificationTokens: { identifier: 'verificationTokens.identifier', token: 'verificationTokens.token', expires: 'verificationTokens.expires' },
   users: { id: 'users.id', email: 'users.email', emailVerified: 'users.emailVerified' },
-  userCredentials: { userId: 'userCredentials.userId' },
+  userCredentials: 'userCredentials',
 }));
 
 import { POST } from '../route';
@@ -74,6 +83,7 @@ describe('POST /api/auth/reset-password', () => {
     mockGetClientIp.mockReturnValue('127.0.0.1');
     mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
     mockHash.mockResolvedValue('hashed-password');
+    mockTxCredentialsLimit.mockResolvedValue([{ userId: 'user-1' }]);
   });
 
   it('returns 400 for invalid request body', async () => {
@@ -112,5 +122,41 @@ describe('POST /api/auth/reset-password', () => {
     expect(response.status).toBe(200);
     expect(mockHash).toHaveBeenCalledWith('validpassword', 12);
     expect(mockTransaction).toHaveBeenCalled();
+    expect(mockTxUpdateWhere).toHaveBeenCalled();
+  });
+
+  it('returns 400 when token is expired', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() - 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it('inserts credentials when user does not already have password credentials', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'oauth-user' }]);
+    mockTxCredentialsLimit.mockResolvedValue([]);
+
+    const response = await POST(
+      createRequest({
+        email: 'oauth@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockTxInsertValues).toHaveBeenCalled();
   });
 });

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -115,7 +115,7 @@ describe('POST /api/auth/reset-password', () => {
     expect(response.status).toBe(400);
   });
 
-  it('returns 400 when reset token does not exist', async () => {
+  it('returns 400 when reset token does not exist (no cleanup delete to avoid DoS)', async () => {
     mockTokenLimit.mockResolvedValue([]);
 
     const response = await POST(
@@ -128,7 +128,7 @@ describe('POST /api/auth/reset-password', () => {
     );
 
     expect(response.status).toBe(400);
-    expect(mockDelete).toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('resets password successfully', async () => {
@@ -152,6 +152,7 @@ describe('POST /api/auth/reset-password', () => {
 
   it('returns 400 when token is expired (simulated by empty SELECT result from db-side expiry filter)', async () => {
     // The WHERE clause includes gt(expires, now), so an expired token returns no rows.
+    // We do NOT delete here to avoid a DoS where an attacker invalidates a victim's token.
     mockTokenLimit.mockResolvedValue([]);
 
     const response = await POST(
@@ -164,7 +165,7 @@ describe('POST /api/auth/reset-password', () => {
     );
 
     expect(response.status).toBe(400);
-    expect(mockDelete).toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 
   it('inserts credentials when user does not already have password credentials', async () => {

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -25,7 +25,7 @@ const mockTxUserUpdateWhere = vi.fn().mockResolvedValue(undefined);
 const mockTxTokenDeleteWhere = vi.fn().mockResolvedValue(undefined);
 const mockTxInsertValues = vi.fn().mockResolvedValue(undefined);
 const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
-const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+const mockDelete = vi.fn((_table?: unknown) => ({ where: mockDeleteWhere }));
 const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
   const tx = {
     select: () => ({ from: () => ({ where: () => ({ limit: mockTxCredentialsLimit }) }) }),
@@ -53,14 +53,18 @@ const mockSelect = vi.fn((selection?: Record<string, unknown>) => {
 
 vi.mock('@/app/lib/db/db', () => ({
   getDb: () => ({
-    select: (...args: unknown[]) => mockSelect(...args),
-    delete: (...args: unknown[]) => mockDelete(...args),
-    transaction: (...args: unknown[]) => mockTransaction(...args),
+    select: (selection?: Record<string, unknown>) => mockSelect(selection),
+    delete: (table?: unknown) => mockDelete(table),
+    transaction: (fn: (tx: unknown) => Promise<void>) => mockTransaction(fn),
   }),
 }));
 
 vi.mock('@/app/lib/db/schema', () => ({
-  verificationTokens: { identifier: 'verificationTokens.identifier', token: 'verificationTokens.token', expires: 'verificationTokens.expires' },
+  verificationTokens: {
+    identifier: 'verificationTokens.identifier',
+    token: 'verificationTokens.token',
+    expires: 'verificationTokens.expires',
+  },
   users: { id: 'users.id', email: 'users.email', emailVerified: 'users.emailVerified' },
   userCredentials: 'userCredentials',
 }));
@@ -93,7 +97,7 @@ describe('POST /api/auth/reset-password', () => {
         token: crypto.randomUUID(),
         password: 'validpassword',
         confirmPassword: 'validpassword',
-      })
+      }),
     );
 
     expect(response.status).toBe(429);
@@ -114,7 +118,7 @@ describe('POST /api/auth/reset-password', () => {
         token: crypto.randomUUID(),
         password: 'validpassword',
         confirmPassword: 'validpassword',
-      })
+      }),
     );
 
     expect(response.status).toBe(400);
@@ -130,7 +134,7 @@ describe('POST /api/auth/reset-password', () => {
         token: crypto.randomUUID(),
         password: 'validpassword',
         confirmPassword: 'validpassword',
-      })
+      }),
     );
 
     expect(response.status).toBe(200);
@@ -149,7 +153,7 @@ describe('POST /api/auth/reset-password', () => {
         token: crypto.randomUUID(),
         password: 'validpassword',
         confirmPassword: 'validpassword',
-      })
+      }),
     );
 
     expect(response.status).toBe(400);
@@ -167,7 +171,7 @@ describe('POST /api/auth/reset-password', () => {
         token: crypto.randomUUID(),
         password: 'validpassword',
         confirmPassword: 'validpassword',
-      })
+      }),
     );
 
     expect(response.status).toBe(200);
@@ -185,7 +189,7 @@ describe('POST /api/auth/reset-password', () => {
         token: crypto.randomUUID(),
         password: 'validpassword',
         confirmPassword: 'validpassword',
-      })
+      }),
     );
 
     expect(response.status).toBe(500);

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('server-only', () => ({}));
+
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+}));
+
+const mockHash = vi.fn();
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash: (...args: unknown[]) => mockHash(...args),
+  },
+}));
+
+const mockTokenLimit = vi.fn();
+const mockUserLimit = vi.fn();
+const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+  const tx = {
+    select: () => ({ from: () => ({ where: () => ({ limit: vi.fn().mockResolvedValue([{ userId: 'user-1' }]) }) }) }),
+    update: () => ({ set: () => ({ where: vi.fn().mockResolvedValue(undefined) }) }),
+    insert: () => ({ values: vi.fn().mockResolvedValue(undefined) }),
+    delete: () => ({ where: vi.fn().mockResolvedValue(undefined) }),
+  };
+  await fn(tx);
+});
+
+let selectCall = 0;
+const mockSelect = vi.fn(() => {
+  selectCall += 1;
+  return {
+    from: () => ({
+      where: () => ({
+        limit: selectCall === 1 ? mockTokenLimit : mockUserLimit,
+      }),
+    }),
+  };
+});
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: (...args: unknown[]) => mockSelect(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  verificationTokens: { identifier: 'verificationTokens.identifier', token: 'verificationTokens.token', expires: 'verificationTokens.expires' },
+  users: { id: 'users.id', email: 'users.email', emailVerified: 'users.emailVerified' },
+  userCredentials: { userId: 'userCredentials.userId' },
+}));
+
+import { POST } from '../route';
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/auth/reset-password', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCall = 0;
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+    mockHash.mockResolvedValue('hashed-password');
+  });
+
+  it('returns 400 for invalid request body', async () => {
+    const response = await POST(createRequest({ email: 'bad', token: 'x', password: '123', confirmPassword: '123' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when reset token does not exist', async () => {
+    mockTokenLimit.mockResolvedValue([]);
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('resets password successfully', async () => {
+    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() + 60_000) }]);
+    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+
+    const response = await POST(
+      createRequest({
+        email: 'test@example.com',
+        token: crypto.randomUUID(),
+        password: 'validpassword',
+        confirmPassword: 'validpassword',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHash).toHaveBeenCalledWith('validpassword', 12);
+    expect(mockTransaction).toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -128,6 +128,7 @@ describe('POST /api/auth/reset-password', () => {
     );
 
     expect(response.status).toBe(400);
+    expect(mockDelete).toHaveBeenCalled();
   });
 
   it('resets password successfully', async () => {
@@ -149,9 +150,9 @@ describe('POST /api/auth/reset-password', () => {
     expect(mockTxUpdateWhere).toHaveBeenCalled();
   });
 
-  it('returns 400 when token is expired', async () => {
-    mockTokenLimit.mockResolvedValue([{ expires: new Date(Date.now() - 60_000) }]);
-    mockUserLimit.mockResolvedValue([{ id: 'user-1' }]);
+  it('returns 400 when token is expired (simulated by empty SELECT result from db-side expiry filter)', async () => {
+    // The WHERE clause includes gt(expires, now), so an expired token returns no rows.
+    mockTokenLimit.mockResolvedValue([]);
 
     const response = await POST(
       createRequest({

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, gt, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { getDb } from '@/app/lib/db/db';
@@ -59,18 +59,20 @@ export async function POST(request: NextRequest) {
     const identifier = getPasswordResetIdentifier(email);
     const tokenHash = hashResetToken(token);
 
+    const now = new Date();
     const resetToken = await db
       .select()
       .from(schema.verificationTokens)
-      .where(and(eq(schema.verificationTokens.identifier, identifier), eq(schema.verificationTokens.token, tokenHash)))
+      .where(
+        and(
+          eq(schema.verificationTokens.identifier, identifier),
+          eq(schema.verificationTokens.token, tokenHash),
+          gt(schema.verificationTokens.expires, now),
+        ),
+      )
       .limit(1);
 
     if (resetToken.length === 0) {
-      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
-      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
-    }
-
-    if (new Date() > resetToken[0].expires) {
       await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
       await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -10,7 +10,10 @@ const resetPasswordSchema = z
   .object({
     email: z.string().email('Invalid email address'),
     token: z.string().uuid('Invalid reset token'),
-    password: z.string().min(8, 'Password must be at least 8 characters').max(128, 'Password must be less than 128 characters'),
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters')
+      .max(128, 'Password must be less than 128 characters'),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -48,7 +51,7 @@ export async function POST(request: NextRequest) {
           headers: {
             'Retry-After': String(rateLimitResult.retryAfterSeconds),
           },
-        }
+        },
       );
     }
 
@@ -81,7 +84,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
-    const user = await db.select({ id: schema.users.id }).from(schema.users).where(eq(schema.users.email, email)).limit(1);
+    const user = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email))
+      .limit(1);
     if (user.length === 0) {
       await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
       await consistentDelay(startTime);

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
     // NOTE: checkRateLimit is in-memory and not shared across serverless instances.
     // This provides best-effort protection only. Add Redis/Upstash rate limiting
     // before relying on this as a production security control.
-    const rateLimitResult = checkRateLimit(`reset-password:${clientIp}`, 10, 60_000);
+    const rateLimitResult = checkRateLimit(`reset-password:${clientIp}`, 5, 60_000);
 
     if (rateLimitResult.limited) {
       await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
@@ -73,7 +73,9 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (resetToken.length === 0) {
-      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      // Do NOT delete here — a wrong token in this position could let an attacker
+      // invalidate a victim's freshly-issued token (DoS). Tokens expire naturally
+      // (1 hour TTL) and are cleaned up by the delete-before-insert in forgot-password.
       await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
@@ -84,7 +86,6 @@ export async function POST(request: NextRequest) {
       .where(eq(schema.users.email, email))
       .limit(1);
     if (user.length === 0) {
-      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
       await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
@@ -104,6 +105,9 @@ export async function POST(request: NextRequest) {
           .set({ passwordHash, updatedAt: new Date() })
           .where(eq(schema.userCredentials.userId, user[0].id));
       } else {
+        // Insert credentials for OAuth-only users who want to add a password.
+        // In practice forgot-password skips OAuth-only accounts, but this supports
+        // future flows where an admin or other path may issue a reset token directly.
         await tx.insert(schema.userCredentials).values({
           userId: user[0].id,
           passwordHash,

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: NextRequest) {
 
     const now = new Date();
     const resetToken = await db
-      .select()
+      .select({ expires: schema.verificationTokens.expires })
       .from(schema.verificationTokens)
       .where(
         and(

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -114,6 +114,9 @@ export async function POST(request: NextRequest) {
         });
       }
 
+      // Completing a reset proves the user controls the inbox the link was sent to,
+      // so mark previously-unverified emails as verified here. Scoped to NULL
+      // emailVerified rows so we never overwrite an existing verification timestamp.
       await tx
         .update(schema.users)
         .set({ emailVerified: new Date(), updatedAt: new Date() })

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -5,7 +5,7 @@ import bcrypt from 'bcryptjs';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
-import { getPasswordResetIdentifier } from '@/app/lib/auth/password-reset';
+import { getPasswordResetIdentifier, hashResetToken, consistentDelay } from '@/app/lib/auth/password-reset';
 
 const resetPasswordSchema = z
   .object({
@@ -24,22 +24,17 @@ const resetPasswordSchema = z
 
 const MIN_RESPONSE_TIME_MS = 1500;
 
-async function consistentDelay(startTime: number): Promise<void> {
-  const elapsed = Date.now() - startTime;
-  const remaining = MIN_RESPONSE_TIME_MS - elapsed;
-  if (remaining > 0) {
-    await new Promise((resolve) => setTimeout(resolve, remaining));
-  }
-}
-
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
   try {
     const clientIp = getClientIp(request);
+    // NOTE: checkRateLimit is in-memory and not shared across serverless instances.
+    // This provides best-effort protection only. Add Redis/Upstash rate limiting
+    // before relying on this as a production security control.
     const rateLimitResult = checkRateLimit(`reset-password:${clientIp}`, 10, 60_000);
 
     if (rateLimitResult.limited) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },
         {
@@ -55,28 +50,29 @@ export async function POST(request: NextRequest) {
     const validationResult = resetPasswordSchema.safeParse(body);
 
     if (!validationResult.success) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
     const { email, token, password } = validationResult.data;
     const db = getDb();
     const identifier = getPasswordResetIdentifier(email);
+    const tokenHash = hashResetToken(token);
 
     const resetToken = await db
       .select()
       .from(schema.verificationTokens)
-      .where(and(eq(schema.verificationTokens.identifier, identifier), eq(schema.verificationTokens.token, token)))
+      .where(and(eq(schema.verificationTokens.identifier, identifier), eq(schema.verificationTokens.token, tokenHash)))
       .limit(1);
 
     if (resetToken.length === 0) {
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
     if (new Date() > resetToken[0].expires) {
       await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
@@ -87,7 +83,7 @@ export async function POST(request: NextRequest) {
       .limit(1);
     if (user.length === 0) {
       await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
-      await consistentDelay(startTime);
+      await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
@@ -120,13 +116,13 @@ export async function POST(request: NextRequest) {
       await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
     });
 
-    await consistentDelay(startTime);
+    await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
     return NextResponse.json({
       message: 'Password reset successful. You can now sign in with your new password.',
     });
   } catch (error) {
     console.error('Reset password error:', error);
-    await consistentDelay(startTime);
+    await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);
     return NextResponse.json({ error: 'Failed to reset password' }, { status: 500 });
   }
 }

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -80,6 +80,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
+    // The token row only carries the email-derived identifier, not the user id —
+    // look the user up to get the id the transaction below needs. This also guards
+    // the rare case where the account was deleted within the token's 1-hour window.
     const user = await db
       .select({ id: schema.users.id })
       .from(schema.users)

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -19,17 +19,28 @@ const resetPasswordSchema = z
   });
 
 const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
+const MIN_RESPONSE_TIME_MS = 1500;
 
 function getResetIdentifier(email: string): string {
   return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
 }
 
+async function consistentDelay(startTime: number): Promise<void> {
+  const elapsed = Date.now() - startTime;
+  const remaining = MIN_RESPONSE_TIME_MS - elapsed;
+  if (remaining > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remaining));
+  }
+}
+
 export async function POST(request: NextRequest) {
+  const startTime = Date.now();
   try {
     const clientIp = getClientIp(request);
     const rateLimitResult = checkRateLimit(`reset-password:${clientIp}`, 10, 60_000);
 
     if (rateLimitResult.limited) {
+      await consistentDelay(startTime);
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },
         {
@@ -45,6 +56,7 @@ export async function POST(request: NextRequest) {
     const validationResult = resetPasswordSchema.safeParse(body);
 
     if (!validationResult.success) {
+      await consistentDelay(startTime);
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
@@ -59,17 +71,20 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (resetToken.length === 0) {
+      await consistentDelay(startTime);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
     if (new Date() > resetToken[0].expires) {
       await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      await consistentDelay(startTime);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
     const user = await db.select({ id: schema.users.id }).from(schema.users).where(eq(schema.users.email, email)).limit(1);
     if (user.length === 0) {
       await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      await consistentDelay(startTime);
       return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
     }
 
@@ -102,11 +117,13 @@ export async function POST(request: NextRequest) {
       await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
     });
 
+    await consistentDelay(startTime);
     return NextResponse.json({
       message: 'Password reset successful. You can now sign in with your new password.',
     });
   } catch (error) {
     console.error('Reset password error:', error);
+    await consistentDelay(startTime);
     return NextResponse.json({ error: 'Failed to reset password' }, { status: 500 });
   }
 }

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { and, eq, isNull } from 'drizzle-orm';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+import { getDb } from '@/app/lib/db/db';
+import * as schema from '@/app/lib/db/schema';
+import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+
+const resetPasswordSchema = z
+  .object({
+    email: z.string().email('Invalid email address'),
+    token: z.string().uuid('Invalid reset token'),
+    password: z.string().min(8, 'Password must be at least 8 characters').max(128, 'Password must be less than 128 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
+
+function getResetIdentifier(email: string): string {
+  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const clientIp = getClientIp(request);
+    const rateLimitResult = checkRateLimit(`reset-password:${clientIp}`, 10, 60_000);
+
+    if (rateLimitResult.limited) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(rateLimitResult.retryAfterSeconds),
+          },
+        }
+      );
+    }
+
+    const body = await request.json();
+    const validationResult = resetPasswordSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
+    }
+
+    const { email, token, password } = validationResult.data;
+    const db = getDb();
+    const identifier = getResetIdentifier(email);
+
+    const resetToken = await db
+      .select()
+      .from(schema.verificationTokens)
+      .where(and(eq(schema.verificationTokens.identifier, identifier), eq(schema.verificationTokens.token, token)))
+      .limit(1);
+
+    if (resetToken.length === 0) {
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
+
+    if (new Date() > resetToken[0].expires) {
+      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
+
+    const user = await db.select({ id: schema.users.id }).from(schema.users).where(eq(schema.users.email, email)).limit(1);
+    if (user.length === 0) {
+      await db.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      return NextResponse.json({ error: 'Invalid or expired reset link' }, { status: 400 });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 12);
+
+    await db.transaction(async (tx) => {
+      const existingCredentials = await tx
+        .select({ userId: schema.userCredentials.userId })
+        .from(schema.userCredentials)
+        .where(eq(schema.userCredentials.userId, user[0].id))
+        .limit(1);
+
+      if (existingCredentials.length > 0) {
+        await tx
+          .update(schema.userCredentials)
+          .set({ passwordHash, updatedAt: new Date() })
+          .where(eq(schema.userCredentials.userId, user[0].id));
+      } else {
+        await tx.insert(schema.userCredentials).values({
+          userId: user[0].id,
+          passwordHash,
+        });
+      }
+
+      await tx
+        .update(schema.users)
+        .set({ emailVerified: new Date(), updatedAt: new Date() })
+        .where(and(eq(schema.users.id, user[0].id), isNull(schema.users.emailVerified)));
+
+      await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+    });
+
+    return NextResponse.json({
+      message: 'Password reset successful. You can now sign in with your new password.',
+    });
+  } catch (error) {
+    console.error('Reset password error:', error);
+    return NextResponse.json({ error: 'Failed to reset password' }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcryptjs';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+import { getPasswordResetIdentifier } from '@/app/lib/auth/password-reset';
 
 const resetPasswordSchema = z
   .object({
@@ -21,12 +22,7 @@ const resetPasswordSchema = z
     path: ['confirmPassword'],
   });
 
-const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
 const MIN_RESPONSE_TIME_MS = 1500;
-
-function getResetIdentifier(email: string): string {
-  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
-}
 
 async function consistentDelay(startTime: number): Promise<void> {
   const elapsed = Date.now() - startTime;
@@ -65,7 +61,7 @@ export async function POST(request: NextRequest) {
 
     const { email, token, password } = validationResult.data;
     const db = getDb();
-    const identifier = getResetIdentifier(email);
+    const identifier = getPasswordResetIdentifier(email);
 
     const resetToken = await db
       .select()

--- a/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
+++ b/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+vi.mock('@/app/components/brand/logo', () => ({
+  default: () => <div data-testid="logo" />,
+}));
+
+vi.mock('@/app/components/back-button', () => ({
+  default: () => <button data-testid="back-button" />,
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: { shadows: { xs: '0 1px 2px rgba(0,0,0,0.05)' } },
+}));
+
+const mockShowMessage = vi.fn();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetch = vi.fn() as any;
+global.fetch = mockFetch;
+
+import ForgotPasswordContent from '../forgot-password-content';
+
+describe('ForgotPasswordContent', () => {
+  beforeEach(() => {
+    mockShowMessage.mockClear();
+    mockFetch.mockClear();
+  });
+
+  it('shows email required error when submitting empty form', async () => {
+    render(<ForgotPasswordContent />);
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    expect(await screen.findByText(/please enter your email/i)).toBeTruthy();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows email invalid error for malformed address', async () => {
+    render(<ForgotPasswordContent />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'notanemail' } });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    expect(await screen.findByText(/please enter a valid email/i)).toBeTruthy();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('submits valid email and shows success toast', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'If an account exists...' }),
+    });
+    render(<ForgotPasswordContent />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
+    expect(mockFetch).toHaveBeenCalledWith('/api/auth/forgot-password', expect.objectContaining({ method: 'POST' }));
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledOnce());
+  });
+
+  it('shows error toast when API returns failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Too many requests' }),
+    });
+    render(<ForgotPasswordContent />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Too many requests', 'error'));
+  });
+});

--- a/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
+++ b/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
@@ -37,6 +37,13 @@ global.fetch = mockFetch as unknown as typeof global.fetch;
 
 import ForgotPasswordContent from '../forgot-password-content';
 
+/** Submit the form via its native submit event (fireEvent.click on type=submit doesn't trigger onSubmit in jsdom). */
+function submitForm(container: HTMLElement) {
+  const form = container.querySelector('form');
+  if (!form) throw new Error('No form found');
+  fireEvent.submit(form);
+}
+
 describe('ForgotPasswordContent', () => {
   beforeEach(() => {
     mockShowMessage.mockClear();
@@ -44,16 +51,16 @@ describe('ForgotPasswordContent', () => {
   });
 
   it('shows email required error when submitting empty form', async () => {
-    render(<ForgotPasswordContent />);
-    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    const { container } = render(<ForgotPasswordContent />);
+    submitForm(container);
     expect(await screen.findByText(/please enter your email/i)).toBeTruthy();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('shows email invalid error for malformed address', async () => {
-    render(<ForgotPasswordContent />);
+    const { container } = render(<ForgotPasswordContent />);
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'notanemail' } });
-    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    submitForm(container);
     expect(await screen.findByText(/please enter a valid email/i)).toBeTruthy();
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -63,14 +70,15 @@ describe('ForgotPasswordContent', () => {
       ok: true,
       json: async () => ({ message: 'If an account exists...' }),
     });
-    render(<ForgotPasswordContent />);
+    const { container } = render(<ForgotPasswordContent />);
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    submitForm(container);
     await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
     expect(mockFetch).toHaveBeenCalledWith('/api/auth/forgot-password', expect.objectContaining({ method: 'POST' }));
     // Form hides and confirmation message appears
     expect(screen.queryByLabelText(/email/i)).toBeNull();
     expect(screen.queryByRole('button', { name: /send reset link/i })).toBeNull();
+    expect(screen.getByText(/if an account exists/i)).toBeTruthy();
   });
 
   it('shows error toast when API returns failure', async () => {
@@ -78,9 +86,9 @@ describe('ForgotPasswordContent', () => {
       ok: false,
       json: async () => ({ error: 'Too many requests' }),
     });
-    render(<ForgotPasswordContent />);
+    const { container } = render(<ForgotPasswordContent />);
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'test@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+    submitForm(container);
     await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Too many requests', 'error'));
   });
 });

--- a/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
+++ b/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
@@ -32,9 +32,8 @@ vi.mock('@/app/theme/theme-config', () => ({
 
 const mockShowMessage = vi.fn();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockFetch = vi.fn() as any;
-global.fetch = mockFetch;
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof global.fetch;
 
 import ForgotPasswordContent from '../forgot-password-content';
 

--- a/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
+++ b/packages/web/app/auth/forgot-password/__tests__/forgot-password-content.test.tsx
@@ -58,7 +58,7 @@ describe('ForgotPasswordContent', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('submits valid email and shows success toast', async () => {
+  it('submits valid email and shows inline confirmation (hides form)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ message: 'If an account exists...' }),
@@ -68,7 +68,9 @@ describe('ForgotPasswordContent', () => {
     fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
     await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
     expect(mockFetch).toHaveBeenCalledWith('/api/auth/forgot-password', expect.objectContaining({ method: 'POST' }));
-    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledOnce());
+    // Form hides and confirmation message appears
+    expect(screen.queryByLabelText(/email/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /send reset link/i })).toBeNull();
   });
 
   it('shows error toast when API returns failure', async () => {

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -86,7 +86,14 @@ export default function ForgotPasswordContent() {
       <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
         <Card sx={{ width: '100%', maxWidth: 400 }}>
           <CardContent>
-            <Stack spacing={2}>
+            <Stack
+              spacing={2}
+              component="form"
+              onSubmit={(e) => {
+                e.preventDefault();
+              }}
+              noValidate
+            >
               {submitted ? (
                 <>
                   <Typography variant="body1" component="p">
@@ -126,6 +133,7 @@ export default function ForgotPasswordContent() {
                   />
 
                   <Button
+                    type="submit"
                     variant="contained"
                     onClick={handleSubmit}
                     disabled={loading}

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -24,6 +24,7 @@ export default function ForgotPasswordContent() {
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const { showMessage } = useSnackbar();
 
   const handleSubmit = async () => {
@@ -52,7 +53,7 @@ export default function ForgotPasswordContent() {
         return;
       }
 
-      showMessage(data.message || t('forgotPassword.toasts.success'), 'success');
+      setSubmitted(true);
     } catch (error) {
       console.error('Forgot password error:', error);
       showMessage(t('forgotPassword.toasts.failed'), 'error');
@@ -86,45 +87,58 @@ export default function ForgotPasswordContent() {
         <Card sx={{ width: '100%', maxWidth: 400 }}>
           <CardContent>
             <Stack spacing={2}>
-              <Typography variant="body1" component="p" color="text.secondary">
-                {t('forgotPassword.description')}
-              </Typography>
+              {submitted ? (
+                <>
+                  <Typography variant="body1" component="p">
+                    {t('forgotPassword.success')}
+                  </Typography>
+                  <Button component={LocaleLink} variant="text" href="/auth/login">
+                    {t('forgotPassword.back')}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Typography variant="body1" component="p" color="text.secondary">
+                    {t('forgotPassword.description')}
+                  </Typography>
 
-              <TextField
-                label={t('forgotPassword.fields.email')}
-                type="email"
-                placeholder={t('login.placeholders.email')}
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                  if (emailError) setEmailError(null);
-                }}
-                error={!!emailError}
-                helperText={emailError}
-                required
-                slotProps={{
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <MailOutlined />
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
+                  <TextField
+                    label={t('forgotPassword.fields.email')}
+                    type="email"
+                    placeholder={t('login.placeholders.email')}
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (emailError) setEmailError(null);
+                    }}
+                    error={!!emailError}
+                    helperText={emailError}
+                    required
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <MailOutlined />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
 
-              <Button
-                variant="contained"
-                onClick={handleSubmit}
-                disabled={loading}
-                startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
-              >
-                {t('forgotPassword.submit')}
-              </Button>
+                  <Button
+                    variant="contained"
+                    onClick={handleSubmit}
+                    disabled={loading}
+                    startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
+                  >
+                    {t('forgotPassword.submit')}
+                  </Button>
 
-              <Button component={LocaleLink} variant="text" href="/auth/login">
-                {t('forgotPassword.back')}
-              </Button>
+                  <Button component={LocaleLink} variant="text" href="/auth/login">
+                    {t('forgotPassword.back')}
+                  </Button>
+                </>
+              )}
             </Stack>
           </CardContent>
         </Card>

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import MailOutlined from '@mui/icons-material/MailOutlined';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Logo from '@/app/components/brand/logo';
+import BackButton from '@/app/components/back-button';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { themeTokens } from '@/app/theme/theme-config';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function ForgotPasswordContent() {
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const { showMessage } = useSnackbar();
+
+  const handleSubmit = async () => {
+    if (!email) {
+      setEmailError('Please enter your email');
+      return;
+    }
+
+    if (!EMAIL_REGEX.test(email)) {
+      setEmailError('Please enter a valid email');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        showMessage(data.error || 'Failed to request password reset', 'error');
+        return;
+      }
+
+      showMessage(data.message || 'If an account exists, a reset link has been sent.', 'success');
+    } catch (error) {
+      console.error('Forgot password error:', error);
+      showMessage('Failed to request password reset', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ minHeight: '100vh', background: 'var(--semantic-background)' }}>
+      <Box
+        component="header"
+        sx={{
+          background: 'var(--semantic-surface)',
+          padding: '0 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          boxShadow: themeTokens.shadows.xs,
+          height: 64,
+        }}
+      >
+        <BackButton />
+        <Logo size="sm" showText={false} />
+        <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
+          Reset Password
+        </Typography>
+      </Box>
+
+      <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
+        <Card sx={{ width: '100%', maxWidth: 400 }}>
+          <CardContent>
+            <Stack spacing={2}>
+              <Typography variant="body1" component="p" color="text.secondary">
+                Enter your account email and we&apos;ll send you a link to reset your password.
+              </Typography>
+
+              <TextField
+                label="Email"
+                placeholder="your@email.com"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  if (emailError) setEmailError(null);
+                }}
+                error={!!emailError}
+                helperText={emailError}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <MailOutlined />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+
+              <Button
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={loading}
+                startIcon={loading ? <CircularProgress size={16} /> : undefined}
+              >
+                Send Reset Link
+              </Button>
+
+              <Button variant="text" href="/auth/login">
+                Back to Login
+              </Button>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -17,6 +18,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export default function ForgotPasswordContent() {
+  const { t } = useTranslation('auth');
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -24,7 +26,7 @@ export default function ForgotPasswordContent() {
 
   const handleSubmit = async () => {
     if (!email) {
-      setEmailError('Please enter your email');
+      setEmailError(t('forgotPassword.validation.emailRequired'));
       return;
     }
 
@@ -39,14 +41,14 @@ export default function ForgotPasswordContent() {
       const data = await response.json();
 
       if (!response.ok) {
-        showMessage(data.error || 'Failed to request password reset', 'error');
+        showMessage(data.error || t('forgotPassword.toasts.failed'), 'error');
         return;
       }
 
-      showMessage(data.message || 'If an account exists, a reset link has been sent.', 'success');
+      showMessage(data.message || t('forgotPassword.toasts.success'), 'success');
     } catch (error) {
       console.error('Forgot password error:', error);
-      showMessage('Failed to request password reset', 'error');
+      showMessage(t('forgotPassword.toasts.failed'), 'error');
     } finally {
       setLoading(false);
     }
@@ -69,7 +71,7 @@ export default function ForgotPasswordContent() {
         <BackButton />
         <Logo size="sm" showText={false} />
         <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
-          Reset Password
+          {t('forgotPassword.heading')}
         </Typography>
       </Box>
 
@@ -78,13 +80,13 @@ export default function ForgotPasswordContent() {
           <CardContent>
             <Stack spacing={2}>
               <Typography variant="body1" component="p" color="text.secondary">
-                Enter your account email and we&apos;ll send you a link to reset your password.
+                {t('forgotPassword.description')}
               </Typography>
 
               <TextField
-                label="Email"
+                label={t('forgotPassword.fields.email')}
                 type="email"
-                placeholder="your@email.com"
+                placeholder={t('login.placeholders.email')}
                 value={email}
                 onChange={(e) => {
                   setEmail(e.target.value);
@@ -110,11 +112,11 @@ export default function ForgotPasswordContent() {
                 disabled={loading}
                 startIcon={loading ? <CircularProgress size={16} /> : undefined}
               >
-                Send Reset Link
+                {loading ? <CircularProgress size={16} /> : t('forgotPassword.submit')}
               </Button>
 
               <Button variant="text" href="/auth/login">
-                Back to Login
+                {t('forgotPassword.back')}
               </Button>
             </Stack>
           </CardContent>

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -14,8 +14,11 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
+import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function ForgotPasswordContent() {
   const { t } = useTranslation('auth');
@@ -25,8 +28,13 @@ export default function ForgotPasswordContent() {
   const { showMessage } = useSnackbar();
 
   const handleSubmit = async () => {
-    if (!email) {
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
       setEmailError(t('forgotPassword.validation.emailRequired'));
+      return;
+    }
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      setEmailError(t('forgotPassword.validation.emailInvalid'));
       return;
     }
 
@@ -35,7 +43,7 @@ export default function ForgotPasswordContent() {
       const response = await fetch('/api/auth/forgot-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email: trimmedEmail }),
       });
 
       const data = await response.json();
@@ -110,12 +118,12 @@ export default function ForgotPasswordContent() {
                 variant="contained"
                 onClick={handleSubmit}
                 disabled={loading}
-                startIcon={loading ? <CircularProgress size={16} /> : undefined}
+                startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
               >
-                {loading ? <CircularProgress size={16} /> : t('forgotPassword.submit')}
+                {t('forgotPassword.submit')}
               </Button>
 
-              <Button variant="text" href="/auth/login">
+              <Button component={LocaleLink} variant="text" href="/auth/login">
                 {t('forgotPassword.back')}
               </Button>
             </Stack>

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -16,8 +16,6 @@ import BackButton from '@/app/components/back-button';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 export default function ForgotPasswordContent() {
   const [email, setEmail] = useState('');
   const [emailError, setEmailError] = useState<string | null>(null);
@@ -27,11 +25,6 @@ export default function ForgotPasswordContent() {
   const handleSubmit = async () => {
     if (!email) {
       setEmailError('Please enter your email');
-      return;
-    }
-
-    if (!EMAIL_REGEX.test(email)) {
-      setEmailError('Please enter a valid email');
       return;
     }
 
@@ -90,6 +83,7 @@ export default function ForgotPasswordContent() {
 
               <TextField
                 label="Email"
+                type="email"
                 placeholder="your@email.com"
                 value={email}
                 onChange={(e) => {
@@ -98,6 +92,7 @@ export default function ForgotPasswordContent() {
                 }}
                 error={!!emailError}
                 helperText={emailError}
+                required
                 slotProps={{
                   input: {
                     startAdornment: (

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -17,8 +17,7 @@ import BackButton from '@/app/components/back-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { EMAIL_REGEX } from '@/app/components/auth/validate-fields';
 
 export default function ForgotPasswordContent() {
   const { t } = useTranslation('auth');

--- a/packages/web/app/auth/forgot-password/forgot-password-content.tsx
+++ b/packages/web/app/auth/forgot-password/forgot-password-content.tsx
@@ -91,6 +91,7 @@ export default function ForgotPasswordContent() {
               component="form"
               onSubmit={(e) => {
                 e.preventDefault();
+                void handleSubmit();
               }}
               noValidate
             >
@@ -135,7 +136,6 @@ export default function ForgotPasswordContent() {
                   <Button
                     type="submit"
                     variant="contained"
-                    onClick={handleSubmit}
                     disabled={loading}
                     startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
                   >

--- a/packages/web/app/auth/forgot-password/page.tsx
+++ b/packages/web/app/auth/forgot-password/page.tsx
@@ -1,12 +1,24 @@
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import I18nProvider from '@/app/components/providers/i18n-provider';
 import ForgotPasswordContent from './forgot-password-content';
 
-export const metadata = createNoIndexMetadata({
-  title: 'Forgot Password',
-  description: 'Request a password reset link for your Boardsesh account',
-  path: '/auth/forgot-password',
-});
+export async function generateMetadata() {
+  const { t, locale } = await getServerTranslation('auth');
+  return createNoIndexMetadata({
+    title: t('metadata.forgotPassword.title'),
+    description: t('metadata.forgotPassword.description'),
+    path: '/auth/forgot-password',
+    locale,
+  });
+}
 
-export default function ForgotPasswordPage() {
-  return <ForgotPasswordContent />;
+export default async function ForgotPasswordPage() {
+  const locale = await getLocale();
+  return (
+    <I18nProvider locale={locale} namespaces={['auth']}>
+      <ForgotPasswordContent />
+    </I18nProvider>
+  );
 }

--- a/packages/web/app/auth/forgot-password/page.tsx
+++ b/packages/web/app/auth/forgot-password/page.tsx
@@ -1,0 +1,12 @@
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import ForgotPasswordContent from './forgot-password-content';
+
+export const metadata = createNoIndexMetadata({
+  title: 'Forgot Password',
+  description: 'Request a password reset link for your Boardsesh account',
+  path: '/auth/forgot-password',
+});
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordContent />;
+}

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -334,6 +334,10 @@ export default function AuthPageContent() {
                 >
                   {t('login.submit.signIn')}
                 </Button>
+
+                <Button variant="text" href="/auth/forgot-password">
+                  Forgot password?
+                </Button>
               </Box>
             </TabPanel>
 

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -336,7 +336,7 @@ export default function AuthPageContent() {
                 </Button>
 
                 <Button variant="text" href="/auth/forgot-password">
-                  Forgot password?
+                  {t('login.links.forgotPassword')}
                 </Button>
               </Box>
             </TabPanel>

--- a/packages/web/app/auth/login/auth-page-content.tsx
+++ b/packages/web/app/auth/login/auth-page-content.tsx
@@ -36,6 +36,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 import { track, setPersonProperties } from '@/app/lib/analytics';
 import { authMethodFromError, safeAuthError } from './auth-error-classification';
+import LocaleLink from '@/app/components/i18n/locale-link';
 
 export default function AuthPageContent() {
   const { t } = useTranslation('auth');
@@ -335,7 +336,7 @@ export default function AuthPageContent() {
                   {t('login.submit.signIn')}
                 </Button>
 
-                <Button variant="text" href="/auth/forgot-password">
+                <Button component={LocaleLink} variant="text" href="/auth/forgot-password">
                   {t('login.links.forgotPassword')}
                 </Button>
               </Box>

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -54,6 +54,14 @@ function renderWithParams(token?: string, email?: string) {
   return render(<ResetPasswordContent />);
 }
 
+// jsdom does not dispatch a form's submit event from a submit-button click, so
+// exercise submission directly on the form (covers both Enter and button press).
+function submitForm() {
+  const form = document.querySelector('form');
+  if (!form) throw new Error('No form found');
+  fireEvent.submit(form);
+}
+
 describe('ResetPasswordContent', () => {
   beforeEach(() => {
     mockShowMessage.mockClear();
@@ -81,7 +89,7 @@ describe('ResetPasswordContent', () => {
 
   it('shows error when password field is empty', async () => {
     renderWithParams('abc-token', 'user@example.com');
-    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    submitForm();
     expect(await screen.findByText(/please enter a new password/i)).toBeTruthy();
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -89,7 +97,7 @@ describe('ResetPasswordContent', () => {
   it('shows error when password is too short', async () => {
     renderWithParams('abc-token', 'user@example.com');
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'short' } });
-    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    submitForm();
     expect(await screen.findByText(/at least 8 characters/i)).toBeTruthy();
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -98,7 +106,7 @@ describe('ResetPasswordContent', () => {
     renderWithParams('abc-token', 'user@example.com');
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'DifferentPass!' } });
-    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    submitForm();
     expect(await screen.findByText(/passwords do not match/i)).toBeTruthy();
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -111,7 +119,7 @@ describe('ResetPasswordContent', () => {
     renderWithParams('abc-token', 'user@example.com');
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
-    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    submitForm();
     await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
     await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/auth/login'));
   });
@@ -124,7 +132,7 @@ describe('ResetPasswordContent', () => {
     renderWithParams('abc-token', 'user@example.com');
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
-    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    submitForm();
     await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Invalid or expired reset link', 'error'));
     expect(mockRouterReplace).not.toHaveBeenCalled();
   });

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -40,9 +40,8 @@ vi.mock('@/app/theme/theme-config', () => ({
 
 const mockShowMessage = vi.fn();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockFetch = vi.fn() as any;
-global.fetch = mockFetch;
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof global.fetch;
 
 import ResetPasswordContent from '../reset-password-content';
 
@@ -98,5 +97,18 @@ describe('ResetPasswordContent', () => {
     fireEvent.click(screen.getByRole('button', { name: /update password/i }));
     await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
     await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/auth/login'));
+  });
+
+  it('shows error toast when API returns failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Invalid or expired reset link' }),
+    });
+    renderWithParams('abc-token', 'user@example.com');
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Invalid or expired reset link', 'error'));
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
 const mockRouterPush = vi.fn();
+const mockRouterReplace = vi.fn();
 const mockSearchParams = new URLSearchParams();
 
 vi.mock('react-i18next', () => ({
@@ -14,7 +15,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockRouterPush }),
+  useRouter: () => ({ push: mockRouterPush, replace: mockRouterReplace }),
   useSearchParams: () => mockSearchParams,
 }));
 
@@ -58,6 +59,7 @@ describe('ResetPasswordContent', () => {
     mockShowMessage.mockClear();
     mockFetch.mockClear();
     mockRouterPush.mockClear();
+    mockRouterReplace.mockClear();
   });
 
   it('shows invalid link message when token or email is missing', () => {
@@ -111,7 +113,7 @@ describe('ResetPasswordContent', () => {
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
     fireEvent.click(screen.getByRole('button', { name: /update password/i }));
     await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
-    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/auth/login'));
+    await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/auth/login'));
   });
 
   it('shows error toast when API returns failure', async () => {
@@ -124,6 +126,6 @@ describe('ResetPasswordContent', () => {
     fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
     fireEvent.click(screen.getByRole('button', { name: /update password/i }));
     await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Invalid or expired reset link', 'error'));
-    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+const mockRouterPush = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+vi.mock('@/app/components/brand/logo', () => ({
+  default: () => <div data-testid="logo" />,
+}));
+
+vi.mock('@/app/components/back-button', () => ({
+  default: () => <button data-testid="back-button" />,
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: { shadows: { xs: '0 1px 2px rgba(0,0,0,0.05)' } },
+}));
+
+const mockShowMessage = vi.fn();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetch = vi.fn() as any;
+global.fetch = mockFetch;
+
+import ResetPasswordContent from '../reset-password-content';
+
+function renderWithParams(token?: string, email?: string) {
+  mockSearchParams.delete('token');
+  mockSearchParams.delete('email');
+  if (token) mockSearchParams.set('token', token);
+  if (email) mockSearchParams.set('email', email);
+  return render(<ResetPasswordContent />);
+}
+
+describe('ResetPasswordContent', () => {
+  beforeEach(() => {
+    mockShowMessage.mockClear();
+    mockFetch.mockClear();
+    mockRouterPush.mockClear();
+  });
+
+  it('shows invalid link message when token or email is missing', () => {
+    renderWithParams();
+    expect(screen.getByText(/invalid/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/new password/i)).toBeNull();
+  });
+
+  it('shows invalid link when only token is provided', () => {
+    renderWithParams('some-token', undefined);
+    expect(screen.getByText(/invalid/i)).toBeTruthy();
+  });
+
+  it('shows password fields when both token and email are present', () => {
+    renderWithParams('abc-token', 'user@example.com');
+    expect(screen.getByLabelText(/^new password$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/confirm new password/i)).toBeTruthy();
+  });
+
+  it('shows mismatch error when passwords do not match', async () => {
+    renderWithParams('abc-token', 'user@example.com');
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'DifferentPass!' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    expect(await screen.findByText(/passwords do not match/i)).toBeTruthy();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('submits and redirects on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Password reset successful.' }),
+    });
+    renderWithParams('abc-token', 'user@example.com');
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), { target: { value: 'SecurePass1!' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mockRouterPush).toHaveBeenCalledWith('/auth/login'));
+  });
+});

--- a/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
+++ b/packages/web/app/auth/reset-password/__tests__/reset-password-content.test.tsx
@@ -77,6 +77,21 @@ describe('ResetPasswordContent', () => {
     expect(screen.getByLabelText(/confirm new password/i)).toBeTruthy();
   });
 
+  it('shows error when password field is empty', async () => {
+    renderWithParams('abc-token', 'user@example.com');
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    expect(await screen.findByText(/please enter a new password/i)).toBeTruthy();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows error when password is too short', async () => {
+    renderWithParams('abc-token', 'user@example.com');
+    fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'short' } });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+    expect(await screen.findByText(/at least 8 characters/i)).toBeTruthy();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('shows mismatch error when passwords do not match', async () => {
     renderWithParams('abc-token', 'user@example.com');
     fireEvent.change(screen.getByLabelText(/^new password$/i), { target: { value: 'SecurePass1!' } });

--- a/packages/web/app/auth/reset-password/page.tsx
+++ b/packages/web/app/auth/reset-password/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import ResetPasswordContent from './reset-password-content';
+
+export const metadata = createNoIndexMetadata({
+  title: 'Create New Password',
+  description: 'Set a new password for your Boardsesh account',
+  path: '/auth/reset-password',
+});
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/packages/web/app/auth/reset-password/page.tsx
+++ b/packages/web/app/auth/reset-password/page.tsx
@@ -1,17 +1,27 @@
 import { Suspense } from 'react';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import I18nProvider from '@/app/components/providers/i18n-provider';
 import ResetPasswordContent from './reset-password-content';
 
-export const metadata = createNoIndexMetadata({
-  title: 'Create New Password',
-  description: 'Set a new password for your Boardsesh account',
-  path: '/auth/reset-password',
-});
+export async function generateMetadata() {
+  const { t, locale } = await getServerTranslation('auth');
+  return createNoIndexMetadata({
+    title: t('metadata.resetPassword.title'),
+    description: t('metadata.resetPassword.description'),
+    path: '/auth/reset-password',
+    locale,
+  });
+}
 
-export default function ResetPasswordPage() {
+export default async function ResetPasswordPage() {
+  const locale = await getLocale();
   return (
-    <Suspense fallback={null}>
-      <ResetPasswordContent />
-    </Suspense>
+    <I18nProvider locale={locale} namespaces={['auth']}>
+      <Suspense fallback={null}>
+        <ResetPasswordContent />
+      </Suspense>
+    </I18nProvider>
   );
 }

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import LockOutlined from '@mui/icons-material/LockOutlined';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Logo from '@/app/components/brand/logo';
+import BackButton from '@/app/components/back-button';
+import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { themeTokens } from '@/app/theme/theme-config';
+
+export default function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { showMessage } = useSnackbar();
+
+  const token = searchParams.get('token') || '';
+  const email = searchParams.get('email') || '';
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const isLinkInvalid = !token || !email;
+
+  const handleSubmit = async () => {
+    if (!password) {
+      setPasswordError('Please enter a new password');
+      return;
+    }
+    if (password.length < 8) {
+      setPasswordError('Password must be at least 8 characters');
+      return;
+    }
+    if (!confirmPassword) {
+      setConfirmPasswordError('Please confirm your new password');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setConfirmPasswordError('Passwords do not match');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, token, password, confirmPassword }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        showMessage(data.error || 'Failed to reset password', 'error');
+        return;
+      }
+
+      showMessage('Password updated successfully. Please sign in.', 'success');
+      router.push('/auth/login');
+    } catch (error) {
+      console.error('Reset password error:', error);
+      showMessage('Failed to reset password', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ minHeight: '100vh', background: 'var(--semantic-background)' }}>
+      <Box
+        component="header"
+        sx={{
+          background: 'var(--semantic-surface)',
+          padding: '0 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          boxShadow: themeTokens.shadows.xs,
+          height: 64,
+        }}
+      >
+        <BackButton />
+        <Logo size="sm" showText={false} />
+        <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
+          Create New Password
+        </Typography>
+      </Box>
+
+      <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
+        <Card sx={{ width: '100%', maxWidth: 400 }}>
+          <CardContent>
+            <Stack spacing={2}>
+              {isLinkInvalid ? (
+                <Typography variant="body1" color="error">
+                  This reset link is invalid. Please request a new password reset email.
+                </Typography>
+              ) : (
+                <>
+                  <Typography variant="body1" component="p" color="text.secondary">
+                    Enter a new password for <strong>{email}</strong>.
+                  </Typography>
+
+                  <TextField
+                    label="New Password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      if (passwordError) setPasswordError(null);
+                    }}
+                    error={!!passwordError}
+                    helperText={passwordError}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <LockOutlined />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
+
+                  <TextField
+                    label="Confirm New Password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => {
+                      setConfirmPassword(e.target.value);
+                      if (confirmPasswordError) setConfirmPasswordError(null);
+                    }}
+                    error={!!confirmPasswordError}
+                    helperText={confirmPasswordError}
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <LockOutlined />
+                          </InputAdornment>
+                        ),
+                      },
+                    }}
+                  />
+
+                  <Button
+                    variant="contained"
+                    onClick={handleSubmit}
+                    disabled={loading}
+                    startIcon={loading ? <CircularProgress size={16} /> : undefined}
+                  >
+                    Update Password
+                  </Button>
+                </>
+              )}
+
+              <Button variant="text" href="/auth/login">
+                Back to Login
+              </Button>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -107,7 +107,15 @@ export default function ResetPasswordContent() {
       <Box component="main" sx={{ padding: '24px', display: 'flex', justifyContent: 'center', paddingTop: '48px' }}>
         <Card sx={{ width: '100%', maxWidth: 400 }}>
           <CardContent>
-            <Stack spacing={2}>
+            <Stack
+              spacing={2}
+              component="form"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void handleSubmit();
+              }}
+              noValidate
+            >
               {isLinkInvalid ? (
                 <Typography variant="body1" color="error">
                   {t('resetPassword.invalidLink')}
@@ -161,10 +169,10 @@ export default function ResetPasswordContent() {
                   />
 
                   <Button
+                    type="submit"
                     variant="contained"
-                    onClick={handleSubmit}
                     disabled={loading}
-                    startIcon={loading ? <CircularProgress size={16} /> : undefined}
+                    startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
                   >
                     {t('resetPassword.submit')}
                   </Button>

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -17,6 +17,7 @@ import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
+import { PASSWORD_MIN_LENGTH } from '@/app/components/auth/validate-fields';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export default function ResetPasswordContent() {
@@ -41,7 +42,7 @@ export default function ResetPasswordContent() {
       setPasswordError(t('resetPassword.validation.passwordRequired'));
       return;
     }
-    if (password.length < 8) {
+    if (password.length < PASSWORD_MIN_LENGTH) {
       setPasswordError(t('resetPassword.validation.passwordTooShort'));
       return;
     }

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -17,7 +17,7 @@ import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
-import { PASSWORD_MIN_LENGTH } from '@/app/components/auth/validate-fields';
+import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from '@/app/components/auth/validate-fields';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export default function ResetPasswordContent() {
@@ -44,6 +44,10 @@ export default function ResetPasswordContent() {
     }
     if (password.length < PASSWORD_MIN_LENGTH) {
       setPasswordError(t('resetPassword.validation.passwordTooShort'));
+      return;
+    }
+    if (password.length > PASSWORD_MAX_LENGTH) {
+      setPasswordError(t('resetPassword.validation.passwordTooLong'));
       return;
     }
     if (!confirmPassword) {

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -15,6 +15,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Logo from '@/app/components/brand/logo';
 import BackButton from '@/app/components/back-button';
+import LocaleLink from '@/app/components/i18n/locale-link';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 
@@ -165,7 +166,7 @@ export default function ResetPasswordContent() {
                 </>
               )}
 
-              <Button variant="text" href="/auth/login">
+              <Button component={LocaleLink} variant="text" href="/auth/login">
                 {t('resetPassword.back')}
               </Button>
             </Stack>

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -18,6 +19,7 @@ import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import { themeTokens } from '@/app/theme/theme-config';
 
 export default function ResetPasswordContent() {
+  const { t } = useTranslation('auth');
   const searchParams = useSearchParams();
   const router = useRouter();
   const { showMessage } = useSnackbar();
@@ -35,19 +37,19 @@ export default function ResetPasswordContent() {
 
   const handleSubmit = async () => {
     if (!password) {
-      setPasswordError('Please enter a new password');
+      setPasswordError(t('resetPassword.validation.passwordRequired'));
       return;
     }
     if (password.length < 8) {
-      setPasswordError('Password must be at least 8 characters');
+      setPasswordError(t('resetPassword.validation.passwordTooShort'));
       return;
     }
     if (!confirmPassword) {
-      setConfirmPasswordError('Please confirm your new password');
+      setConfirmPasswordError(t('resetPassword.validation.confirmPasswordRequired'));
       return;
     }
     if (password !== confirmPassword) {
-      setConfirmPasswordError('Passwords do not match');
+      setConfirmPasswordError(t('resetPassword.validation.passwordsMismatch'));
       return;
     }
 
@@ -61,15 +63,15 @@ export default function ResetPasswordContent() {
 
       const data = await response.json();
       if (!response.ok) {
-        showMessage(data.error || 'Failed to reset password', 'error');
+        showMessage(data.error || t('resetPassword.toasts.failed'), 'error');
         return;
       }
 
-      showMessage('Password updated successfully. Please sign in.', 'success');
+      showMessage(t('resetPassword.toasts.success'), 'success');
       router.push('/auth/login');
     } catch (error) {
       console.error('Reset password error:', error);
-      showMessage('Failed to reset password', 'error');
+      showMessage(t('resetPassword.toasts.failed'), 'error');
     } finally {
       setLoading(false);
     }
@@ -92,7 +94,7 @@ export default function ResetPasswordContent() {
         <BackButton />
         <Logo size="sm" showText={false} />
         <Typography variant="h4" sx={{ margin: 0, flex: 1 }}>
-          Create New Password
+          {t('resetPassword.heading')}
         </Typography>
       </Box>
 
@@ -102,16 +104,16 @@ export default function ResetPasswordContent() {
             <Stack spacing={2}>
               {isLinkInvalid ? (
                 <Typography variant="body1" color="error">
-                  This reset link is invalid. Please request a new password reset email.
+                  {t('resetPassword.invalidLink')}
                 </Typography>
               ) : (
                 <>
                   <Typography variant="body1" component="p" color="text.secondary">
-                    Enter a new password for <strong>{email}</strong>.
+                    {t('resetPassword.description', { email })}
                   </Typography>
 
                   <TextField
-                    label="New Password"
+                    label={t('resetPassword.fields.newPassword')}
                     type="password"
                     value={password}
                     onChange={(e) => {
@@ -132,7 +134,7 @@ export default function ResetPasswordContent() {
                   />
 
                   <TextField
-                    label="Confirm New Password"
+                    label={t('resetPassword.fields.confirmPassword')}
                     type="password"
                     value={confirmPassword}
                     onChange={(e) => {
@@ -158,13 +160,13 @@ export default function ResetPasswordContent() {
                     disabled={loading}
                     startIcon={loading ? <CircularProgress size={16} /> : undefined}
                   >
-                    Update Password
+                    {t('resetPassword.submit')}
                   </Button>
                 </>
               )}
 
               <Button variant="text" href="/auth/login">
-                Back to Login
+                {t('resetPassword.back')}
               </Button>
             </Stack>
           </CardContent>

--- a/packages/web/app/auth/reset-password/reset-password-content.tsx
+++ b/packages/web/app/auth/reset-password/reset-password-content.tsx
@@ -70,7 +70,7 @@ export default function ResetPasswordContent() {
       }
 
       showMessage(t('resetPassword.toasts.success'), 'success');
-      router.push('/auth/login');
+      router.replace('/auth/login');
     } catch (error) {
       console.error('Reset password error:', error);
       showMessage(t('resetPassword.toasts.failed'), 'error');

--- a/packages/web/app/components/auth/validate-fields.ts
+++ b/packages/web/app/components/auth/validate-fields.ts
@@ -1,6 +1,8 @@
 import type { TFunction } from 'i18next';
 
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const PASSWORD_MIN_LENGTH = 8;
+export const PASSWORD_MAX_LENGTH = 128;
 
 export const initialLoginValues = { email: '', password: '' };
 export const initialRegisterValues = { name: '', email: '', password: '', confirmPassword: '' };

--- a/packages/web/app/lib/auth/__tests__/password-reset.test.ts
+++ b/packages/web/app/lib/auth/__tests__/password-reset.test.ts
@@ -53,7 +53,9 @@ describe('password-reset utilities', () => {
     it('waits the remaining time up to the minimum', async () => {
       const start = Date.now();
       await consistentDelay(start, 60);
-      expect(Date.now() - start).toBeGreaterThanOrEqual(55);
+      // setTimeout never fires early, so the delay is always >= the requested 60ms;
+      // assert a generous lower bound so a coarse-resolution clock can't flake it.
+      expect(Date.now() - start).toBeGreaterThanOrEqual(45);
     });
 
     it('returns immediately when the minimum has already elapsed', async () => {

--- a/packages/web/app/lib/auth/__tests__/password-reset.test.ts
+++ b/packages/web/app/lib/auth/__tests__/password-reset.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createHash } from 'node:crypto';
+import {
+  PASSWORD_RESET_IDENTIFIER_PREFIX,
+  getPasswordResetIdentifier,
+  hashResetToken,
+  consistentDelay,
+} from '../password-reset';
+
+describe('password-reset utilities', () => {
+  describe('getPasswordResetIdentifier', () => {
+    it('prefixes the email with the reset namespace', () => {
+      expect(getPasswordResetIdentifier('user@example.com')).toBe('password-reset:user@example.com');
+    });
+
+    it('uses the exported prefix constant', () => {
+      const email = 'climber@boardsesh.com';
+      expect(getPasswordResetIdentifier(email)).toBe(`${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`);
+    });
+
+    it('keeps password-reset identifiers distinct from raw emails (no token collision)', () => {
+      expect(getPasswordResetIdentifier('a@b.com')).not.toBe('a@b.com');
+    });
+  });
+
+  describe('hashResetToken', () => {
+    it('returns the sha256 hex digest of the token', () => {
+      const token = '11111111-2222-3333-4444-555555555555';
+      const expected = createHash('sha256').update(token).digest('hex');
+      expect(hashResetToken(token)).toBe(expected);
+    });
+
+    it('is deterministic for the same token', () => {
+      const token = 'abc-token';
+      expect(hashResetToken(token)).toBe(hashResetToken(token));
+    });
+
+    it('produces different hashes for different tokens', () => {
+      expect(hashResetToken('token-a')).not.toBe(hashResetToken('token-b'));
+    });
+
+    it('does not return the raw token (so a DB leak does not expose the link)', () => {
+      const token = 'raw-secret-token';
+      expect(hashResetToken(token)).not.toContain(token);
+    });
+
+    it('emits a 64-char hex string', () => {
+      expect(hashResetToken('anything')).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('consistentDelay', () => {
+    it('waits the remaining time up to the minimum', async () => {
+      const start = Date.now();
+      await consistentDelay(start, 60);
+      expect(Date.now() - start).toBeGreaterThanOrEqual(55);
+    });
+
+    it('returns immediately when the minimum has already elapsed', async () => {
+      const start = Date.now() - 1000;
+      const before = Date.now();
+      await consistentDelay(start, 50);
+      expect(Date.now() - before).toBeLessThan(40);
+    });
+  });
+});

--- a/packages/web/app/lib/auth/password-reset.ts
+++ b/packages/web/app/lib/auth/password-reset.ts
@@ -1,5 +1,20 @@
+import { createHash } from 'node:crypto';
+
 export const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
 
 export function getPasswordResetIdentifier(email: string): string {
   return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+}
+
+/** sha256(token) stored in DB; raw token travels only in the email link. */
+export function hashResetToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/** Pad response to a minimum duration to prevent timing-based enumeration. */
+export async function consistentDelay(startTime: number, minMs: number): Promise<void> {
+  const remaining = minMs - (Date.now() - startTime);
+  if (remaining > 0) {
+    await new Promise((resolve) => setTimeout(resolve, remaining));
+  }
 }

--- a/packages/web/app/lib/auth/password-reset.ts
+++ b/packages/web/app/lib/auth/password-reset.ts
@@ -1,0 +1,5 @@
+export const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
+
+export function getPasswordResetIdentifier(email: string): string {
+  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+}

--- a/packages/web/app/lib/email/__tests__/email-service.test.ts
+++ b/packages/web/app/lib/email/__tests__/email-service.test.ts
@@ -39,12 +39,14 @@ describe('sendPasswordResetEmail', () => {
   });
 
   it('escapes the URL in the HTML body but leaves the plain-text link raw', async () => {
-    await sendPasswordResetEmail('user@example.com', 'a&b"c', 'https://boardsesh.com');
+    // A single quote survives encodeURIComponent but must be HTML-escaped to &#39;
+    // in the markup — proves the URL is both URL-safe and HTML-safe.
+    await sendPasswordResetEmail('user@example.com', "a'b", 'https://boardsesh.com');
 
     const mail = lastMail();
-    expect(mail.html).toContain('token=a&amp;b&quot;c');
-    expect(mail.html).not.toContain('token=a&b"c');
-    expect(mail.text).toContain('token=a&b"c');
+    expect(mail.html).toContain('token=a&#39;b');
+    expect(mail.html).not.toContain("token=a'b");
+    expect(mail.text).toContain("token=a'b");
   });
 
   it('rejects an invalid email before sending', async () => {

--- a/packages/web/app/lib/email/__tests__/email-service.test.ts
+++ b/packages/web/app/lib/email/__tests__/email-service.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const sendMail = vi.fn();
+vi.mock('nodemailer', () => ({
+  default: { createTransport: vi.fn(() => ({ sendMail })) },
+}));
+
+import { sendPasswordResetEmail } from '../email-service';
+
+type SentMail = { to: string; from: string; subject: string; html: string; text: string };
+
+describe('sendPasswordResetEmail', () => {
+  beforeEach(() => {
+    sendMail.mockReset();
+    sendMail.mockResolvedValue(undefined);
+    process.env.SMTP_USER = 'smtp-user@example.com';
+    process.env.SMTP_PASSWORD = 'secret';
+    process.env.EMAIL_FROM = 'noreply@boardsesh.com';
+  });
+
+  function lastMail(): SentMail {
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    return sendMail.mock.calls[0][0] as SentMail;
+  }
+
+  it('builds the link against /auth/reset-password with the token and encoded email', async () => {
+    await sendPasswordResetEmail('user@example.com', 'tok-123', 'https://boardsesh.com');
+
+    const mail = lastMail();
+    expect(mail.text).toContain('https://boardsesh.com/auth/reset-password?token=tok-123&email=user%40example.com');
+    expect(mail.to).toBe('user@example.com');
+    expect(mail.subject).toContain('Reset your Boardsesh password');
+  });
+
+  it('url-encodes the email address in the link', async () => {
+    await sendPasswordResetEmail('user+tag@example.com', 'tok', 'https://boardsesh.com');
+
+    expect(lastMail().text).toContain('email=user%2Btag%40example.com');
+  });
+
+  it('escapes the URL in the HTML body but leaves the plain-text link raw', async () => {
+    await sendPasswordResetEmail('user@example.com', 'a&b"c', 'https://boardsesh.com');
+
+    const mail = lastMail();
+    expect(mail.html).toContain('token=a&amp;b&quot;c');
+    expect(mail.html).not.toContain('token=a&b"c');
+    expect(mail.text).toContain('token=a&b"c');
+  });
+
+  it('rejects an invalid email before sending', async () => {
+    await expect(sendPasswordResetEmail('not-an-email', 'tok', 'https://boardsesh.com')).rejects.toThrow();
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/lib/email/email-service.ts
+++ b/packages/web/app/lib/email/email-service.ts
@@ -92,3 +92,50 @@ export async function sendVerificationEmail(email: string, token: string, baseUr
     text: `Welcome to Boardsesh!\n\nPlease verify your email address by clicking this link:\n\n${verifyUrl}\n\nThis link expires in 24 hours.\n\nIf you didn't create a Boardsesh account, you can safely ignore this email.`,
   });
 }
+
+export async function sendPasswordResetEmail(
+  email: string,
+  token: string,
+  baseUrl: string
+): Promise<void> {
+  const validatedEmail = emailSchema.parse(email);
+
+  const resetUrl = `${baseUrl}/auth/reset-password?token=${token}&email=${encodeURIComponent(validatedEmail)}`;
+  const safeResetUrl = escapeHtml(resetUrl);
+
+  await getTransporter().sendMail({
+    from: process.env.EMAIL_FROM || process.env.SMTP_USER,
+    to: validatedEmail,
+    subject: 'Reset your Boardsesh password',
+    html: `
+      <div style="font-family: ${themeTokens.typography.fontFamily}; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h1 style="color: ${emailColors.primary}; margin-bottom: 24px;">Password reset request</h1>
+        <p style="color: ${emailColors.textPrimary}; font-size: 16px; line-height: 1.5;">
+          We received a request to reset your Boardsesh password.
+        </p>
+        <a href="${safeResetUrl}" style="
+          display: inline-block;
+          background-color: ${emailColors.primary};
+          color: white;
+          padding: 14px 28px;
+          text-decoration: none;
+          border-radius: ${themeTokens.borderRadius.md}px;
+          margin: 24px 0;
+          font-weight: ${themeTokens.typography.fontWeight.semibold};
+          font-size: 16px;
+        ">Reset Password</a>
+        <p style="color: ${emailColors.textSecondary}; font-size: 14px; margin-top: 24px;">
+          Or copy and paste this link into your browser:
+        </p>
+        <p style="color: ${emailColors.primary}; font-size: 14px; word-break: break-all;">
+          ${safeResetUrl}
+        </p>
+        <hr style="border: none; border-top: 1px solid ${emailColors.border}; margin: 32px 0;" />
+        <p style="color: ${emailColors.textMuted}; font-size: 12px;">
+          This link expires in 1 hour. If you did not request a password reset, you can safely ignore this email.
+        </p>
+      </div>
+    `,
+    text: `Reset your Boardsesh password\n\nUse this link to reset your password:\n\n${resetUrl}\n\nThis link expires in 1 hour.\n\nIf you did not request this, you can safely ignore this email.`,
+  });
+}

--- a/packages/web/app/lib/email/email-service.ts
+++ b/packages/web/app/lib/email/email-service.ts
@@ -93,11 +93,7 @@ export async function sendVerificationEmail(email: string, token: string, baseUr
   });
 }
 
-export async function sendPasswordResetEmail(
-  email: string,
-  token: string,
-  baseUrl: string
-): Promise<void> {
+export async function sendPasswordResetEmail(email: string, token: string, baseUrl: string): Promise<void> {
   const validatedEmail = emailSchema.parse(email);
 
   const resetUrl = `${baseUrl}/auth/reset-password?token=${token}&email=${encodeURIComponent(validatedEmail)}`;

--- a/packages/web/app/lib/email/email-service.ts
+++ b/packages/web/app/lib/email/email-service.ts
@@ -96,7 +96,7 @@ export async function sendVerificationEmail(email: string, token: string, baseUr
 export async function sendPasswordResetEmail(email: string, token: string, baseUrl: string): Promise<void> {
   const validatedEmail = emailSchema.parse(email);
 
-  const resetUrl = `${baseUrl}/auth/reset-password?token=${token}&email=${encodeURIComponent(validatedEmail)}`;
+  const resetUrl = `${baseUrl}/auth/reset-password?token=${encodeURIComponent(token)}&email=${encodeURIComponent(validatedEmail)}`;
   const safeResetUrl = escapeHtml(resetUrl);
 
   await getTransporter().sendMail({

--- a/plan.md
+++ b/plan.md
@@ -22,7 +22,7 @@ Only other `FullWindowOverlay`s stack above the player (that's why `ClimbReactio
 
 Make the player a real top-of-stack modal VC. Anything presented **from within its React tree** (sub-drawers, queue, share) presents off the player's VC and stacks above naturally; it still covers the tab bar.
 
-**By construction this fixes 5 of the 6 reported breakages** — the sub-drawers (LogAscent, AngleSelector, ClimbActions, AddBetaVideo) and the native share are already rendered _inside_ `PlayDrawer`, so as route content they stack above. **Only `QueueSheet` needs extra handling** (see Wrinkle).
+**By construction this fixes 5 of the 6 reported breakages** — the sub-drawers (LogAscent, AngleSelector, ClimbActions, AddBetaVideo) and the native share are already rendered *inside* `PlayDrawer`, so as route content they stack above. **Only `QueueSheet` needs extra handling** (see Wrinkle).
 
 ### Implementation steps
 
@@ -42,25 +42,21 @@ Make the player a real top-of-stack modal VC. Anything presented **from within i
 
 `openQueueSheet` is called from the player (`onOpenQueue`) AND from the "added to queue" snackbar (`QueueAddedSnackbar` → context `openQueueSheet`), i.e. with the player closed. It's currently one `QueueSheet` rendered in drawer-host (main window) — fine when the player is closed, but BELOW the player route when open.
 Options (pick during impl):
-
 - (a) Make `QueueSheet` ALSO a route (e.g. `app/queue.tsx`, `presentation: 'formSheet'`/`modal`) so it stacks on top of whatever's current (the player route, or the tabs). Cleanest "everything stacks naturally." Most work.
 - (b) Render a second `QueueSheet` instance INSIDE the player route (used when opened from the player); keep the drawer-host one for the snackbar/closed-player case. Simpler, slightly redundant.
-  Recommend trying (a) — it's the logical end-state (the play-drawer ecosystem becomes stacked modal routes) and removes the dual-instance hazard.
+Recommend trying (a) — it's the logical end-state (the play-drawer ecosystem becomes stacked modal routes) and removes the dual-instance hazard.
 
 ## Validation
-
 - `vp run typecheck:mobile`, `vp run test:mobile`, `vp check` (changed files only — `vp check --fix <paths>`; bare `vp check --fix` reformats the whole repo).
 - Update any test mock for PlayDrawer if added (no test renders the full PlayDrawer today).
 - **Device/sim QA matrix** (the whole point): open the player → open EACH of beta, queue, share, angle, climb-actions (long-press), tick → confirm each stacks ABOVE the player and dismisses cleanly (no freeze). Then change-between-climbs while open; Reduce-Transparency; Android Material.
 
 ## Environment notes (this arm64 Mac)
-
 - **iOS device deploy** (iPhone 17 Pro `3573AA37-0E25-5AFE-B58F-80CE29FE88E9`, paired): JS-only changes ride Metro — just restart `CI=1 REACT_NATIVE_PACKAGER_HOSTNAME=192.168.0.83 vp run dev:mobile` and reload. Native changes need a rebuild: `xcodebuild build -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -configuration Debug -destination 'platform=iOS,id=<udid>' -derivedDataPath packages/mobile/ios/build-device -allowProvisioningUpdates DEVELOPMENT_TEAM=9L3HKPZBH3`, then `xcrun devicectl device install app --device <udid> <app>` + `process launch`. (build-device/ was deleted to free disk — it rebuilds.)
 - **Android emulator** (this arm64 Mac): `vp run mobile:android-shots` is BROKEN here (downloads x86_64 image + linux JDK). Use the manual path that worked: arm64 AVD `boardsesh-android16` (or `Boardsesh_API_35`); build with `JAVA_HOME=/opt/homebrew/opt/openjdk@21 node_modules/.bin/expo prebuild -p android --no-install` then `cd android && ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a --no-daemon`; `adb install -r` (uninstall the higher-version `com.boardsesh.app` first); `adb reverse tcp:8081 tcp:8081`; Metro `CI=1 EXPO_PUBLIC_SCREENSHOT_MODE=1 EXPO_PUBLIC_SCREENSHOT_USER_EMAIL=test@boardsesh.com EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD=test vp run dev:mobile`; launch via `am start -a android.intent.action.VIEW -d "com.boardsesh.app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"` (uninstall `com.boardsesh.app.dev` first or you get a scheme chooser). Screenshot deep links: `com.boardsesh.app://climbs?screenshotOpenFirst=1` (player), `?screenshotOpenBoardSheet=1` (BoardSheet).
 - **Disk** ran out mid-Android-build once; iOS DerivedData trees are ~4GB each.
 
 ## Key files
-
 - `packages/mobile/src/components/play-drawer/PlayDrawer.tsx` — the player (props→context, overlay→route content, open/close→router).
 - `packages/mobile/src/components/play-drawer/PlayDrawerOverlay.tsx` — likely delete (keep GlassSurface recipe).
 - `packages/mobile/src/components/play-drawer/use-deferred-sheet-open.ts` / `sheet-open-serializer.ts` — race guard (presentation-agnostic; rewire dismiss signal to route unmount).

--- a/plan.md
+++ b/plan.md
@@ -22,7 +22,7 @@ Only other `FullWindowOverlay`s stack above the player (that's why `ClimbReactio
 
 Make the player a real top-of-stack modal VC. Anything presented **from within its React tree** (sub-drawers, queue, share) presents off the player's VC and stacks above naturally; it still covers the tab bar.
 
-**By construction this fixes 5 of the 6 reported breakages** — the sub-drawers (LogAscent, AngleSelector, ClimbActions, AddBetaVideo) and the native share are already rendered *inside* `PlayDrawer`, so as route content they stack above. **Only `QueueSheet` needs extra handling** (see Wrinkle).
+**By construction this fixes 5 of the 6 reported breakages** — the sub-drawers (LogAscent, AngleSelector, ClimbActions, AddBetaVideo) and the native share are already rendered _inside_ `PlayDrawer`, so as route content they stack above. **Only `QueueSheet` needs extra handling** (see Wrinkle).
 
 ### Implementation steps
 
@@ -42,21 +42,25 @@ Make the player a real top-of-stack modal VC. Anything presented **from within i
 
 `openQueueSheet` is called from the player (`onOpenQueue`) AND from the "added to queue" snackbar (`QueueAddedSnackbar` → context `openQueueSheet`), i.e. with the player closed. It's currently one `QueueSheet` rendered in drawer-host (main window) — fine when the player is closed, but BELOW the player route when open.
 Options (pick during impl):
+
 - (a) Make `QueueSheet` ALSO a route (e.g. `app/queue.tsx`, `presentation: 'formSheet'`/`modal`) so it stacks on top of whatever's current (the player route, or the tabs). Cleanest "everything stacks naturally." Most work.
 - (b) Render a second `QueueSheet` instance INSIDE the player route (used when opened from the player); keep the drawer-host one for the snackbar/closed-player case. Simpler, slightly redundant.
-Recommend trying (a) — it's the logical end-state (the play-drawer ecosystem becomes stacked modal routes) and removes the dual-instance hazard.
+  Recommend trying (a) — it's the logical end-state (the play-drawer ecosystem becomes stacked modal routes) and removes the dual-instance hazard.
 
 ## Validation
+
 - `vp run typecheck:mobile`, `vp run test:mobile`, `vp check` (changed files only — `vp check --fix <paths>`; bare `vp check --fix` reformats the whole repo).
 - Update any test mock for PlayDrawer if added (no test renders the full PlayDrawer today).
 - **Device/sim QA matrix** (the whole point): open the player → open EACH of beta, queue, share, angle, climb-actions (long-press), tick → confirm each stacks ABOVE the player and dismisses cleanly (no freeze). Then change-between-climbs while open; Reduce-Transparency; Android Material.
 
 ## Environment notes (this arm64 Mac)
+
 - **iOS device deploy** (iPhone 17 Pro `3573AA37-0E25-5AFE-B58F-80CE29FE88E9`, paired): JS-only changes ride Metro — just restart `CI=1 REACT_NATIVE_PACKAGER_HOSTNAME=192.168.0.83 vp run dev:mobile` and reload. Native changes need a rebuild: `xcodebuild build -workspace packages/mobile/ios/Boardsesh.xcworkspace -scheme Boardsesh -configuration Debug -destination 'platform=iOS,id=<udid>' -derivedDataPath packages/mobile/ios/build-device -allowProvisioningUpdates DEVELOPMENT_TEAM=9L3HKPZBH3`, then `xcrun devicectl device install app --device <udid> <app>` + `process launch`. (build-device/ was deleted to free disk — it rebuilds.)
 - **Android emulator** (this arm64 Mac): `vp run mobile:android-shots` is BROKEN here (downloads x86_64 image + linux JDK). Use the manual path that worked: arm64 AVD `boardsesh-android16` (or `Boardsesh_API_35`); build with `JAVA_HOME=/opt/homebrew/opt/openjdk@21 node_modules/.bin/expo prebuild -p android --no-install` then `cd android && ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a --no-daemon`; `adb install -r` (uninstall the higher-version `com.boardsesh.app` first); `adb reverse tcp:8081 tcp:8081`; Metro `CI=1 EXPO_PUBLIC_SCREENSHOT_MODE=1 EXPO_PUBLIC_SCREENSHOT_USER_EMAIL=test@boardsesh.com EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD=test vp run dev:mobile`; launch via `am start -a android.intent.action.VIEW -d "com.boardsesh.app://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"` (uninstall `com.boardsesh.app.dev` first or you get a scheme chooser). Screenshot deep links: `com.boardsesh.app://climbs?screenshotOpenFirst=1` (player), `?screenshotOpenBoardSheet=1` (BoardSheet).
 - **Disk** ran out mid-Android-build once; iOS DerivedData trees are ~4GB each.
 
 ## Key files
+
 - `packages/mobile/src/components/play-drawer/PlayDrawer.tsx` — the player (props→context, overlay→route content, open/close→router).
 - `packages/mobile/src/components/play-drawer/PlayDrawerOverlay.tsx` — likely delete (keep GlassSurface recipe).
 - `packages/mobile/src/components/play-drawer/use-deferred-sheet-open.ts` / `sheet-open-serializer.ts` — race guard (presentation-agnostic; rewire dismiss signal to route unmount).


### PR DESCRIPTION
## Summary

- **Web**: Forgot-password and reset-password pages with full i18n (en-US, es, fr), rate-limited API routes, bcrypt-secured credential update, enumeration-safe responses, and a 1h expiring single-use token via `verificationTokens`
- **Email**: Fastmail SMTP via nodemailer — `sendPasswordResetEmail()` wired to `forgot-password` API. Credentials live in 1Password (Boardsesh vault → "Boardsesh SMTP"); add to Vercel before enabling
- **Mobile**: Native forgot-password and reset-password screens under `app/auth/`, "Forgot password?" link on the login screen, `requestPasswordReset` / `resetPassword` in `src/lib/auth.ts`, Android App Link intent filter for `/auth/reset-password`

## Vercel env vars to set before merging

```
SMTP_HOST=smtp.fastmail.com
SMTP_PORT=465
SMTP_USER=           # from 1Password: Boardsesh vault → Boardsesh SMTP → username
SMTP_PASSWORD=       # from 1Password: Boardsesh vault → Boardsesh SMTP → app-password
EMAIL_FROM=          # same as SMTP_USER
```

## Mobile rollout note

The Android intent filter change in `app.config.ts` requires a native build — an OTA update alone won't capture reset-password deep links on Android. iOS users are already covered by `applinks:boardsesh.com`. Queue a new build after merge.

## Known limitations / follow-ups

These are systemic to the existing credentials-auth stack (not introduced by this feature), kept out of this PR to stay scoped. Worth a follow-up before/around production rollout:

- **Rate limiting is in-memory (best-effort only).** `checkRateLimit` is per-process, so on serverless each instance keeps its own counter and the 5/min limit isn't enforced globally. `getClientIp` also trusts the first `x-forwarded-for` entry, which is spoofable. Follow-up: shared store (Redis/Upstash) keyed on IP+email, with correct edge IP resolution (`x-vercel-forwarded-for` / last `x-forwarded-for` entry). Affects all auth routes.
- **No session invalidation on password change.** Sessions use the JWT strategy (required for the credentials provider), so there are no DB sessions to delete and existing JWTs stay valid until expiry. Revoking them needs a per-user token version checked in the NextAuth `jwt`/`session` callback, bumped on password change — a cross-cutting auth change.
- **Email lookups are case-sensitive system-wide.** Login, register, and forgot-password all use `eq(users.email, email)` with no normalization, so this flow is consistent with the rest of auth. Normalizing to lowercase should be done uniformly across register + login + reset (not just here, which would create mismatches).

## Test plan

- [ ] Web: visit `/auth/forgot-password`, submit email for a credentials-auth account, receive email from `marco@sent.com`, follow link to `/auth/reset-password?token=…&email=…`, set new password, sign in
- [ ] Web: confirm expired/used tokens return appropriate error
- [ ] Web: confirm non-existent email returns same generic message (enumeration-safe)
- [ ] Mobile: login screen shows "Forgot password?" link, tapping opens forgot-password screen
- [ ] Mobile: submit email → see confirmation message
- [ ] Mobile: deep link `https://boardsesh.com/auth/reset-password?token=…&email=…` opens reset screen on iOS and Android (after native build)
- [ ] i18n: `vp run check:i18n` passes
- [ ] Typecheck: `vp run typecheck` and `vp run typecheck:mobile` pass
- [ ] Tests: `vp test run --project web` passes (359 files, 4766 tests)

## Release Notes

Forgot your password? Now you can reset it — tap "Forgot password?" on the login screen and we'll email you a secure reset link. Works on web and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URm6sHsgCiRNM26JncMfKZ
