### PR TITLE
fix(mobile): recover from BLE write stalls instead of dropping the climb (#3181)

### DIFF
--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -24,6 +24,7 @@ enum BoardBleError: LocalizedError {
     case writeCancelled
     case superseded
     case writeTimedOut
+    case writeRecoveryFailed
 
     var errorDescription: String? {
         switch self {
@@ -46,7 +47,19 @@ enum BoardBleError: LocalizedError {
         case .superseded:
             return "Bluetooth connection attempt was superseded by a newer one"
         case .writeTimedOut:
+            // CONTRACT: the JS `isBleWriteTimeoutError` classifier
+            // (packages/shared/ble-protocol/src/connection-error.ts) matches this
+            // message via /write timed out/i to keep the self-healing severity
+            // downgrade + recovery metric. Keep the literal substring "write timed
+            // out" if you reword this.
             return "BLE write timed out waiting for the board to accept data"
+        case .writeRecoveryFailed:
+            // Hard failure surfaced when write-stall recovery is exhausted. Worded
+            // to AVOID both the disconnect classifier (so the JS write-failure path
+            // doesn't call native disconnect() and clear the stored board) and the
+            // /write timed out/ matcher (so it reports as a real error, not a
+            // self-healed warning). See connection-error.ts.
+            return "BLE write failed; board stopped accepting data and recovery attempts were exhausted"
         }
     }
 }
@@ -74,6 +87,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // peripheralIsReady before the queue is failed. Generous: a healthy link
     // drains its transmit buffer in milliseconds.
     private let writeResumeTimeout: TimeInterval = 5
+    // How many CONSECUTIVE write stalls (with no successful write between them)
+    // we recover from by cycling the connection before giving up and surfacing
+    // the disconnect to JS. A fresh GATT link clears CoreBluetooth's wedged
+    // transmit state; bounding it stops a permanently dead link from spinning in
+    // a reconnect loop. The counter resets whenever a write fully drains (#3181).
+    private let maxWriteStallRecoveries = 2
 
     private lazy var centralManager = CBCentralManager(
         delegate: self,
@@ -108,6 +127,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
     private var pendingWriteResumeWatchdog: DispatchWorkItem?
+    // Write-stall recovery (#3181). `writeStallRecoveries` counts consecutive
+    // stalls (reset on any drained write). `writeStallRecoveringPeripheralId` is
+    // the board whose congested link we deliberately cycled; it is set across the
+    // whole recovery window (cancel → deferred reconnect → characteristics
+    // discovered) so that: (1) only the matching didDisconnectPeripheral triggers
+    // the reconnect — never an unrelated peripheral's intentional disconnect —
+    // and (2) a write that lands during the brief disconnected window surfaces
+    // the self-healing `writeTimedOut` rather than `notConnected`, which the JS
+    // classifier would mistake for a hard drop and tear the link down. Cleared by
+    // any successful (re)connect, a deliberate disconnect, or Bluetooth-off.
+    private var writeStallRecoveries = 0
+    private var writeStallRecoveringPeripheralId: UUID?
+    // Fail-closed safety net for the recover window: if the cancel's
+    // `didDisconnectPeripheral` never arrives (a wedged link while Bluetooth
+    // stays on), this fires so the window can't strand forever (wall dark, JS
+    // still "connected"). Cancelled the moment the reconnect actually starts —
+    // from there the reconnect's own connect timeout owns the deadline (#3181).
+    private var writeStallRecoveryWatchdog: DispatchWorkItem?
     private var configuration: BoardBleConfiguration?
     private lazy var readyWaiters = WaiterPool(queue: bleQueue)
     private lazy var drainWaiters = WaiterPool(queue: bleQueue)
@@ -351,6 +388,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
+        // Starting a fresh connection. Unless this is the same board's write-stall
+        // recovery reconnect (which routes through here with the SAME id and must
+        // keep its in-progress budget so recovery stays bounded), a connect to a
+        // DIFFERENT board supersedes any in-flight recovery: clear the recovery
+        // window + watchdog so a stale didDisconnect for the old board can't hijack
+        // this connect, and reset the budget for the new link (#3181).
+        if writeStallRecoveringPeripheralId != peripheral.identifier {
+            writeStallRecoveringPeripheralId = nil
+            writeStallRecoveries = 0
+            writeStallRecoveryWatchdog?.cancel()
+            writeStallRecoveryWatchdog = nil
+        }
+
         stopScanOnBleQueue()
         failQueuedWrites(BoardBleError.writeCancelled)
         // Settle any still-pending connect before starting this one. Silently
@@ -470,6 +520,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private func disconnectOnBleQueue(completion: (() -> Void)? = nil) {
         connectionGeneration += 1
+        // A deliberate disconnect supersedes any in-flight write-stall recovery
+        // (#3181): drop the recovery window and reset the budget.
+        writeStallRecoveringPeripheralId = nil
+        writeStallRecoveries = 0
         // Settle any in-flight reconnect-by-last-known scan before tearing down.
         failReconnectScan(BoardBleError.notConnected)
         // A deliberate disconnect forgets the board so the widget lightbulb won't
@@ -495,7 +549,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private func writeOnBleQueue(data: Data, completion: ((Error?) -> Void)? = nil) {
         guard connectedPeripheral != nil, writeCharacteristic != nil else {
-            completion?(BoardBleError.notConnected)
+            // During a write-stall recovery the link is briefly down between the
+            // cancel and the reconnect. Surface the self-healing `writeTimedOut`
+            // (a warning JS rides out with `isConnected` kept) rather than
+            // `notConnected`, which the JS classifier treats as a hard drop and
+            // would tear the connection down mid-recovery (#3181).
+            completion?(writeStallRecoveringPeripheralId != nil ? BoardBleError.writeTimedOut : BoardBleError.notConnected)
             return
         }
 
@@ -618,6 +677,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     CBCentralManagerScanOptionAllowDuplicatesKey: true,
                 ])
             }
+        } else {
+            // Bluetooth went away mid-recovery: the deferred reconnect's
+            // didDisconnect may never arrive, so close the write-stall recovery
+            // window and reset the budget. Otherwise a later intentional
+            // disconnect could be mistaken for a stall recovery, writes would
+            // keep parking on the window, or a post-power-on session would start
+            // with a depleted budget (#3181).
+            writeStallRecoveringPeripheralId = nil
+            writeStallRecoveries = 0
         }
     }
 
@@ -735,6 +803,33 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             if peripheralGenerations[peripheral.identifier] == intentionalDisconnectGeneration {
                 peripheralGenerations.removeValue(forKey: peripheral.identifier)
             }
+            // Write-stall recovery (#3181): the congested link we deliberately
+            // dropped is now fully torn down, so reconnect to the same board.
+            // Gated on the peripheral id so an unrelated intentional disconnect
+            // (user disconnect, a different board's connect supersede) can't be
+            // mistaken for a stall recovery. Deferring to here (rather than
+            // reconnecting inside handleWriteStall) serialises
+            // teardown-then-reconnect for the same peripheral id and avoids a late
+            // didDisconnect tearing the new link back down. didDisconnect already
+            // consumed the intentional flag above, so this fires at most once per
+            // cancel. On success, didDiscoverCharacteristicsFor clears the window
+            // and re-lights the wall (the counter resets when that write drains);
+            // on failure we surface the disconnect to JS and reset the budget.
+            if writeStallRecoveringPeripheralId == peripheral.identifier {
+                // The reconnect is starting; its own connect timeout now owns the
+                // deadline, so retire the cancel→didDisconnect safety net.
+                writeStallRecoveryWatchdog?.cancel()
+                writeStallRecoveryWatchdog = nil
+                reconnectToLastKnownBoardOnBleQueue { [weak self] result in
+                    guard let self else { return }
+                    if case .failure(let error) = result {
+                        self.logger.error("BLE write-stall reconnect failed: \(error.localizedDescription, privacy: .public)")
+                        self.writeStallRecoveringPeripheralId = nil
+                        self.writeStallRecoveries = 0
+                        self.onDisconnect?(deviceId)
+                    }
+                }
+            }
             return
         }
 
@@ -810,6 +905,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         connectedPeripheral = peripheral
         writeCharacteristic = characteristic
+        // Any successful (re)connect closes a write-stall recovery window (#3181)
+        // — writes flow normally again from here.
+        writeStallRecoveringPeripheralId = nil
         // Remember the board so the Live Activity lightbulb can reconnect to it
         // by identifier later, no device pick required.
         persistLastConnectedPeripheral(peripheral)
@@ -967,6 +1065,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         guard chunkIndex < request.chunks.count else {
             _ = writeQueue.removeFirst()
+            // A write got through end-to-end: the link is healthy, so refresh the
+            // write-stall recovery budget (#3181).
+            writeStallRecoveries = 0
             request.completion(nil)
             isWriting = false
             processWriteQueue()
@@ -988,8 +1089,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // forever and the wall would freeze until a manual disconnect.
             let watchdog = DispatchWorkItem { [weak self] in
                 guard let self, self.pendingWriteResume != nil else { return }
-                self.logger.error("BLE write stalled: peripheral never became ready for write-without-response; failing queued writes")
-                self.failQueuedWrites(BoardBleError.writeTimedOut)
+                self.logger.error("BLE write stalled: peripheral never became ready for write-without-response; attempting recovery")
+                self.handleWriteStall()
             }
             pendingWriteResumeWatchdog?.cancel()
             pendingWriteResumeWatchdog = watchdog
@@ -1020,6 +1121,108 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             request.completion(error)
         }
         notifyDrainWaitersIfDrainedOnBleQueue()
+    }
+
+    /// Recovery for a write that parked on `canSendWriteWithoutResponse` and
+    /// never received `peripheralIsReady` within `writeResumeTimeout` — a
+    /// marginal link that stays connected but stops accepting data. The old
+    /// behaviour dropped the write outright, so the wall stayed dark until a
+    /// manual re-tap or reconnect (#3181).
+    ///
+    /// A fresh GATT connection is the only reliable way to clear CoreBluetooth's
+    /// wedged transmit state, so we cycle the link: settle the stalled writes
+    /// (so the JS `write()` promise resolves and never leaks — there is no
+    /// JS-side write timeout), then intentionally disconnect the current
+    /// peripheral and reconnect to it by identifier. The reconnect's success
+    /// path re-lights the wall via the existing
+    /// `displaySharedCurrentItemOnBleQueue` in didDiscoverCharacteristicsFor.
+    ///
+    /// Unlike an *unexpected* drop (didDisconnectPeripheral), reconnecting here
+    /// doesn't risk stealing a last-connection-wins board from someone else: we
+    /// still hold the link and are recovering our own congested connection to
+    /// the board the user is actively driving. There is a brief window between
+    /// the cancel and the reconnect where another device could grab the board;
+    /// it's bounded (at most `maxWriteStallRecoveries` cycles) and the recovering
+    /// user is the one actively on the wall, so contention is unlikely.
+    ///
+    /// Bounded by `maxWriteStallRecoveries` CONSECUTIVE stalls (the counter
+    /// resets on any successful write drain) so a permanently dead link can't
+    /// spin in a reconnect loop — once the budget is spent we tear the link down
+    /// and surface the disconnect to JS so the lightbulb reflects reality and
+    /// the user can re-tap.
+    private func handleWriteStall() {
+        guard let peripheral = connectedPeripheral else {
+            // No link to recover (a disconnect already settled and emptied the
+            // queue). Settle defensively; harmless on an empty queue.
+            failQueuedWrites(BoardBleError.writeTimedOut)
+            return
+        }
+        let deviceId = peripheral.identifier.uuidString
+
+        guard writeStallRecoveries < maxWriteStallRecoveries else {
+            // Budget spent: a fresh connection didn't help, so this is a genuine
+            // send failure, not a self-healing stall. Settle the queued writes with
+            // `writeRecoveryFailed` — NOT `writeTimedOut` (which JS would downgrade
+            // to an "auto-recovered" warning, mislabeling a dark wall) and NOT a
+            // disconnect-classified error (which would make the JS write-failure
+            // path call native disconnect() and clear the stored board). JS tears
+            // down via the onDisconnect event below; the persisted board is kept so
+            // the user / Live Activity lightbulb can reconnect on demand (we do NOT
+            // clear bleLastPeripheralUuidKey).
+            logger.error("BLE write-stall recovery budget exhausted; surfacing disconnect for \(deviceId, privacy: .public)")
+            failQueuedWrites(BoardBleError.writeRecoveryFailed)
+            writeStallRecoveries = 0
+            writeStallRecoveringPeripheralId = nil
+            cancelConnectionIntentionallyOnBleQueue(peripheral)
+            onDisconnect?(deviceId)
+            return
+        }
+
+        // Recoverable stall: settle the queued writes with the self-healing
+        // `writeTimedOut` (no JS promise leak; JS keeps `isConnected` true while we
+        // reconnect — a write timeout is not a disconnect on the JS side), then
+        // intentionally drop the congested link and reconnect to the same board.
+        // The reconnect is DEFERRED to the cancel's didDisconnect callback:
+        // reconnecting synchronously to the SAME peripheral id would let
+        // connectOnBleQueue clear the intentional flag, and a late didDisconnect
+        // from the cancelled link would then wrongly tear down the new connection.
+        failQueuedWrites(BoardBleError.writeTimedOut)
+        writeStallRecoveries += 1
+        logger.error("BLE write-stall recovery \(self.writeStallRecoveries, privacy: .public)/\(self.maxWriteStallRecoveries, privacy: .public): cycling the connection for \(deviceId, privacy: .public)")
+        writeStallRecoveringPeripheralId = peripheral.identifier
+        cancelConnectionIntentionallyOnBleQueue(peripheral)
+        // NOTE: bleLastPeripheralUuidKey is intentionally NOT cleared so the
+        // deferred reconnectToLastKnownBoard can find this board.
+
+        // Guard only the cancel → didDisconnect gap. `didDisconnectPeripheral`'s
+        // recovery arm cancels this and hands the deadline to the reconnect's own
+        // connect timeout; if didDisconnect never lands, this fails closed.
+        let recoveringId = peripheral.identifier
+        let recoveryWatchdog = DispatchWorkItem { [weak self] in
+            guard let self, self.writeStallRecoveringPeripheralId == recoveringId else { return }
+            self.logger.error("BLE write-stall recovery stalled before reconnect (no didDisconnect); surfacing disconnect for \(recoveringId.uuidString, privacy: .public)")
+            self.writeStallRecoveringPeripheralId = nil
+            self.writeStallRecoveries = 0
+            self.writeCharacteristic = nil
+            self.connectedPeripheral = nil
+            self.onDisconnect?(recoveringId.uuidString)
+        }
+        writeStallRecoveryWatchdog?.cancel()
+        writeStallRecoveryWatchdog = recoveryWatchdog
+        bleQueue.asyncAfter(deadline: .now() + connectTimeout, execute: recoveryWatchdog)
+    }
+
+    /// Intentionally drop the current link: bump the generation, mark the
+    /// disconnect intentional (so didDisconnectPeripheral suppresses the
+    /// onDisconnect-to-JS and invalidates the old link's stale callbacks), cancel,
+    /// and null the connection. Shared by the write-stall recovery paths (#3181).
+    private func cancelConnectionIntentionallyOnBleQueue(_ peripheral: CBPeripheral) {
+        connectionGeneration += 1
+        intentionalDisconnectGenerations[peripheral.identifier] = connectionGeneration
+        peripheralGenerations[peripheral.identifier] = connectionGeneration
+        centralManager.cancelPeripheralConnection(peripheral)
+        writeCharacteristic = nil
+        connectedPeripheral = nil
     }
 
     private func readConfiguration() -> BoardBleConfiguration? {

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -5,7 +5,7 @@ import os.log
 /// Expo Module bridge to `BoardBleManager`. Direct port of the Capacitor
 /// `BoardBlePlugin` API surface (`isAvailable`, `startScan`, `stopScan`,
 /// `connect`, `disconnect`, `write`, `cancelWrites`, `configureBoard`) plus
-/// the two listener events (`scanResult`, `disconnected`).
+/// the listener events (`scanResult`, `disconnected`, `connected`).
 ///
 /// The underlying `BoardBleManager` singleton is unchanged from the Capacitor
 /// app, so the same Swift code that backs Dynamic Island intent writes via

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -111,6 +111,15 @@ describe('reportHandledError', () => {
     });
   });
 
+  it('downgrades a BLE write-resume timeout to a warning and tags it (native auto-recovers it — #3181)', () => {
+    const writeTimeout = new Error('BLE write timed out waiting for the board to accept data');
+    reportHandledError(writeTimeout, { tags: { source: 'ble-auto-send' } });
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(writeTimeout, {
+      level: 'warning',
+      tags: { source: 'ble-auto-send', ble_write_timeout: true },
+    });
+  });
+
   it('reports a real server error (response with an HTTP status) at error level', () => {
     const serverError = Object.assign(new Error('Internal Server Error'), { response: { status: 500 } });
     reportHandledError(serverError, { tags: { source: 'react-query', kind: 'mutation' } });

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,3 +1,4 @@
+import { isBleWriteTimeoutError } from '@boardsesh/ble-protocol/connection-error';
 import { captureToSentry, type ErrorReportContext } from './sentry';
 import { isExpectedAuthError, isExpectedBetaValidationError } from './graphql/extract-error-message';
 
@@ -54,6 +55,9 @@ function isNetworkError(error: unknown): boolean {
  *   - expected auth-required GraphQL failures are dropped entirely,
  *   - expected beta-attach validation rejections are dropped entirely,
  *   - offline/network failures are downgraded to `warning` and tagged `network`,
+ *   - BLE write-resume timeouts are downgraded to `warning` and tagged
+ *     `ble_write_timeout` (the native layer auto-recovers them by cycling the
+ *     connection — #3181 — so they're transient, not hard failures),
  *   - everything else reports at the caller's level (default `error`).
  * Use this from React Query caches, GraphQL-WS, and catch blocks; use the raw
  * `reportError` only when the caller already owns the severity decision.
@@ -67,6 +71,14 @@ export function reportHandledError(error: unknown, context?: ErrorReportContext)
       ...context,
       level: 'warning',
       tags: { ...context?.tags, network: true },
+    });
+    return;
+  }
+  if (isBleWriteTimeoutError(error)) {
+    reportError(error, {
+      ...context,
+      level: 'warning',
+      tags: { ...context?.tags, ble_write_timeout: true },
     });
     return;
   }

--- a/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyBleFailure,
   classifyBleFailureReason,
+  isBleWriteTimeoutError,
   isDisconnectionError,
   type BleFailureCategory,
   type BleSendFailureReason,
@@ -143,6 +144,14 @@ describe('isDisconnectionError', () => {
     },
     // Picker-dismissed.
     { name: 'NotFoundError', error: new DOMException('No device chosen', 'NotFoundError') },
+    // The write-stall recovery give-up message (#3181) must NOT classify as a
+    // disconnect: that path settles the failed write so JS surfaces a real
+    // failure, but the JS write-failure handler must NOT call native disconnect()
+    // (which would clear the stored board the lightbulb reconnects to).
+    {
+      name: 'write-recovery give-up',
+      error: new Error('BLE write failed; board stopped accepting data and recovery attempts were exhausted'),
+    },
     // Validation-shaped messages from the write path.
     { name: 'LED data missing', error: new Error('LED placement map is empty') },
     { name: 'incompatible climb', error: new Error('climb incompatible with board') },
@@ -162,6 +171,37 @@ describe('isDisconnectionError', () => {
   for (const { name, error } of notDisconnects) {
     it(`treats as non-disconnect: ${name}`, () => {
       expect(isDisconnectionError(error)).toBe(false);
+    });
+  }
+});
+
+describe('isBleWriteTimeoutError', () => {
+  it('matches the native iOS write-resume timeout message', () => {
+    expect(isBleWriteTimeoutError(new Error('BLE write timed out waiting for the board to accept data'))).toBe(true);
+  });
+
+  it('is NOT a disconnection error (JS keeps isConnected=true while native recovers — #3181)', () => {
+    expect(isDisconnectionError(new Error('BLE write timed out waiting for the board to accept data'))).toBe(false);
+  });
+
+  const notWriteTimeouts: Array<{ name: string; error: unknown }> = [
+    // A connect timeout is a different failure — must not be downgraded as a
+    // self-healing write stall.
+    { name: 'connect timeout', error: new Error('Bluetooth connection timed out') },
+    { name: 'disconnect', error: new Error('Device disconnected during write') },
+    // The recovery give-up is a hard failure, not a self-healing timeout.
+    {
+      name: 'write-recovery give-up',
+      error: new Error('BLE write failed; board stopped accepting data and recovery attempts were exhausted'),
+    },
+    { name: 'validation', error: new Error('LED placement map is empty') },
+    { name: 'opaque', error: new Error('something opaque') },
+    { name: 'plain string', error: 'a plain string' },
+  ];
+
+  for (const { name, error } of notWriteTimeouts) {
+    it(`treats as non-write-timeout: ${name}`, () => {
+      expect(isBleWriteTimeoutError(error)).toBe(false);
     });
   }
 });
@@ -189,6 +229,20 @@ describe('classifyBleFailureReason', () => {
       expected: 'dom_OperationError',
     },
     { name: 'DOMException with empty name', error: new DOMException('boom', ''), expected: 'dom_exception' },
+    // Native write-resume timeout gets its own bucket so #3181 recovery is
+    // measurable instead of hiding in write_failed.
+    {
+      name: 'write-resume timeout',
+      error: new Error('BLE write timed out waiting for the board to accept data'),
+      expected: 'write_timeout',
+    },
+    // The recovery give-up (#3181) is a genuine failure — write_failed, not the
+    // self-healing write_timeout bucket.
+    {
+      name: 'write-recovery give-up',
+      error: new Error('BLE write failed; board stopped accepting data and recovery attempts were exhausted'),
+      expected: 'write_failed',
+    },
     // Anything else thrown on a live link.
     { name: 'opaque write error', error: new Error('something opaque'), expected: 'write_failed' },
     { name: 'plain string', error: 'a plain string', expected: 'write_failed' },

--- a/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyBleFailure,
   classifyBleFailureReason,
+  isBleWriteRecoveryFailedError,
   isBleWriteTimeoutError,
   isDisconnectionError,
   type BleFailureCategory,
   type BleSendFailureReason,
 } from '../connection-error';
+
+const WRITE_RECOVERY_FAILED_MESSAGE =
+  'BLE write failed; board stopped accepting data and recovery attempts were exhausted';
 
 // Mimics a react-native-ble-plx BleError: an Error subclass whose `name` is
 // 'BleError' (so the predicate classifies from the message, not the name).
@@ -148,10 +152,7 @@ describe('isDisconnectionError', () => {
     // disconnect: that path settles the failed write so JS surfaces a real
     // failure, but the JS write-failure handler must NOT call native disconnect()
     // (which would clear the stored board the lightbulb reconnects to).
-    {
-      name: 'write-recovery give-up',
-      error: new Error('BLE write failed; board stopped accepting data and recovery attempts were exhausted'),
-    },
+    { name: 'write-recovery give-up', error: new Error(WRITE_RECOVERY_FAILED_MESSAGE) },
     // Validation-shaped messages from the write path.
     { name: 'LED data missing', error: new Error('LED placement map is empty') },
     { name: 'incompatible climb', error: new Error('climb incompatible with board') },
@@ -190,10 +191,7 @@ describe('isBleWriteTimeoutError', () => {
     { name: 'connect timeout', error: new Error('Bluetooth connection timed out') },
     { name: 'disconnect', error: new Error('Device disconnected during write') },
     // The recovery give-up is a hard failure, not a self-healing timeout.
-    {
-      name: 'write-recovery give-up',
-      error: new Error('BLE write failed; board stopped accepting data and recovery attempts were exhausted'),
-    },
+    { name: 'write-recovery give-up', error: new Error(WRITE_RECOVERY_FAILED_MESSAGE) },
     { name: 'validation', error: new Error('LED placement map is empty') },
     { name: 'opaque', error: new Error('something opaque') },
     { name: 'plain string', error: 'a plain string' },
@@ -202,6 +200,31 @@ describe('isBleWriteTimeoutError', () => {
   for (const { name, error } of notWriteTimeouts) {
     it(`treats as non-write-timeout: ${name}`, () => {
       expect(isBleWriteTimeoutError(error)).toBe(false);
+    });
+  }
+});
+
+describe('isBleWriteRecoveryFailedError', () => {
+  it('matches the native recovery give-up message', () => {
+    expect(isBleWriteRecoveryFailedError(new Error(WRITE_RECOVERY_FAILED_MESSAGE))).toBe(true);
+  });
+
+  it('does not match a plain write-resume timeout (the recoverable case)', () => {
+    expect(isBleWriteTimeoutError(new Error(WRITE_RECOVERY_FAILED_MESSAGE))).toBe(false);
+    expect(isBleWriteRecoveryFailedError(new Error('BLE write timed out waiting for the board to accept data'))).toBe(
+      false,
+    );
+  });
+
+  const notRecoveryFailures: Array<{ name: string; error: unknown }> = [
+    { name: 'disconnect', error: new Error('Device disconnected during write') },
+    { name: 'generic write failure', error: new Error('something opaque') },
+    { name: 'plain string', error: 'a plain string' },
+  ];
+
+  for (const { name, error } of notRecoveryFailures) {
+    it(`treats as non-recovery-failure: ${name}`, () => {
+      expect(isBleWriteRecoveryFailedError(error)).toBe(false);
     });
   }
 });
@@ -236,12 +259,12 @@ describe('classifyBleFailureReason', () => {
       error: new Error('BLE write timed out waiting for the board to accept data'),
       expected: 'write_timeout',
     },
-    // The recovery give-up (#3181) is a genuine failure — write_failed, not the
-    // self-healing write_timeout bucket.
+    // The recovery give-up (#3181) gets its own terminal bucket so the give-up
+    // rate is measurable separately from generic write failures.
     {
       name: 'write-recovery give-up',
-      error: new Error('BLE write failed; board stopped accepting data and recovery attempts were exhausted'),
-      expected: 'write_failed',
+      error: new Error(WRITE_RECOVERY_FAILED_MESSAGE),
+      expected: 'write_recovery_failed',
     },
     // Anything else thrown on a live link.
     { name: 'opaque write error', error: new Error('something opaque'), expected: 'write_failed' },

--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -30,6 +30,7 @@ export type BleSendFailureReason =
   | 'missing_led_placements' // LED placement map empty for this board config
   | 'missing_mirror_data' // mirroring requested but holdsData absent (pre-write)
   | 'missing_mirror_mapping' // a hold had no mirrored id while building the mirror
+  | 'write_timeout' // native write-resume timeout; auto-recovered by a reconnect (#3181)
   | 'write_failed' // any other thrown write failure on a live link
   | 'unknown' // defensive fallback: a `false` send left no reason set (unreachable in practice)
   | `dom_${string}`; // a DOMException name we don't otherwise classify
@@ -145,6 +146,25 @@ export function isDisconnectionError(error: unknown): boolean {
 }
 
 /**
+ * True when a write error is the native iOS BLE manager's write-resume timeout
+ * ("BLE write timed out waiting for the board to accept data") — a marginal link
+ * that stayed connected but stopped accepting write-without-response data. As of
+ * #3181 the native layer auto-recovers this by cycling the connection, so it's a
+ * transient, self-healing condition rather than a hard failure: callers report it
+ * at `warning` (not `error`) so it doesn't drown real send failures.
+ *
+ * CONTRACT: matched against `BoardBleError.writeTimedOut.errorDescription` in
+ * `packages/mobile/modules/live-activity/ios/BoardBleManager.swift`. The two are
+ * coupled only by this substring (the bridge surfaces the native error as its
+ * message), so keep the literal "write timed out" on both sides. A *recovery
+ * give-up* uses a different message (`writeRecoveryFailed`) that deliberately
+ * does NOT match here, so an exhausted stall reports as a real failure.
+ */
+export function isBleWriteTimeoutError(error: unknown): boolean {
+  return /write timed out/i.test(errorMessage(error));
+}
+
+/**
  * Classify an error thrown from a *send* (BLE write) into a `failureReason` for
  * the `Climb Sent to Board Failure` event. The dominant real cause on these
  * last-connection-wins boards is a mid-session disconnect — surfacing it as
@@ -155,6 +175,9 @@ export function isDisconnectionError(error: unknown): boolean {
  */
 export function classifyBleFailureReason(error: unknown): BleSendFailureReason {
   if (isDisconnectionError(error)) return 'disconnected';
+  // A write-resume timeout the native layer auto-recovers (#3181) — its own
+  // bucket so recovery rate is visible instead of hiding in `write_failed`.
+  if (isBleWriteTimeoutError(error)) return 'write_timeout';
   // `convertToMirroredFramesString` throws this when a hold has no mirrored id.
   if (error instanceof Error && error.message.includes('Mirrored hold ID')) return 'missing_mirror_mapping';
   if (typeof DOMException !== 'undefined' && error instanceof DOMException) {

--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -30,7 +30,8 @@ export type BleSendFailureReason =
   | 'missing_led_placements' // LED placement map empty for this board config
   | 'missing_mirror_data' // mirroring requested but holdsData absent (pre-write)
   | 'missing_mirror_mapping' // a hold had no mirrored id while building the mirror
-  | 'write_timeout' // native write-resume timeout; auto-recovered by a reconnect (#3181)
+  | 'write_timeout' // native write-resume timeout; the native layer is auto-recovering it (#3181)
+  | 'write_recovery_failed' // a write_timeout the native reconnect recovery could not fix — gave up (#3181)
   | 'write_failed' // any other thrown write failure on a live link
   | 'unknown' // defensive fallback: a `false` send left no reason set (unreachable in practice)
   | `dom_${string}`; // a DOMException name we don't otherwise classify
@@ -165,6 +166,25 @@ export function isBleWriteTimeoutError(error: unknown): boolean {
 }
 
 /**
+ * True when a write error is the native iOS BLE manager's *recovery give-up*
+ * (`BoardBleError.writeRecoveryFailed`): a write that stalled, was retried via a
+ * reconnect cycle `maxWriteStallRecoveries` times, and still couldn't be
+ * delivered (#3181). Distinct from a plain `write_failed` so the recovery give-up
+ * rate is directly measurable in PostHog (`write_timeout` = stalls encountered,
+ * `write_recovery_failed` = stalls recovery couldn't fix). It is deliberately NOT
+ * a disconnection (see [[isDisconnectionError]]) so the JS write-failure path
+ * doesn't clear the stored board the lightbulb reconnects to.
+ *
+ * CONTRACT: matched against `BoardBleError.writeRecoveryFailed.errorDescription`
+ * in `packages/mobile/modules/live-activity/ios/BoardBleManager.swift`. If the
+ * native message changes without updating this, the give-up degrades gracefully
+ * to `write_failed` (the metric blurs; nothing breaks).
+ */
+export function isBleWriteRecoveryFailedError(error: unknown): boolean {
+  return /recovery attempts were exhausted/i.test(errorMessage(error));
+}
+
+/**
  * Classify an error thrown from a *send* (BLE write) into a `failureReason` for
  * the `Climb Sent to Board Failure` event. The dominant real cause on these
  * last-connection-wins boards is a mid-session disconnect — surfacing it as
@@ -175,7 +195,11 @@ export function isBleWriteTimeoutError(error: unknown): boolean {
  */
 export function classifyBleFailureReason(error: unknown): BleSendFailureReason {
   if (isDisconnectionError(error)) return 'disconnected';
-  // A write-resume timeout the native layer auto-recovers (#3181) — its own
+  // The recovery give-up is checked before the plain write-timeout: it is a
+  // distinct, terminal outcome (#3181), and its message intentionally does not
+  // match the /write timed out/ pattern, but keep the order explicit.
+  if (isBleWriteRecoveryFailedError(error)) return 'write_recovery_failed';
+  // A write-resume timeout the native layer is auto-recovering (#3181) — its own
   // bucket so recovery rate is visible instead of hiding in `write_failed`.
   if (isBleWriteTimeoutError(error)) return 'write_timeout';
   // `convertToMirroredFramesString` throws this when a hold has no mirrored id.


### PR DESCRIPTION
## Summary

Closes #3181.

On iOS, under a **marginal Bluetooth link** the board can stop accepting LED data mid-stream (`canSendWriteWithoutResponse` stays false) without ever disconnecting. After the 5s write-resume watchdog fired, the old code called `failQueuedWrites(.writeTimedOut)` — it **dropped the write and cleared the queue with no retry or reconnect**, so a tapped climb silently failed to draw on the wall until the user re-tapped or reconnected.

The watchdog was correct (it surfaces the stall instead of freezing the wall forever); the gap was **recovery**. A fresh GATT connection is the reliable way to clear CoreBluetooth's wedged transmit state, so the watchdog now cycles the link and re-lights the wall automatically.

### What changed
- **`BoardBleManager.swift`** — the watchdog runs a new `handleWriteStall()`:
  - Settles the queued writes (no JS promise leak — there is no JS-side write timeout), then **intentionally disconnects and reconnects to the same board**. The reconnect re-lights the wall via the existing `displaySharedCurrentItem` path in `didDiscoverCharacteristicsFor`. It also covers the Live Activity / widget-intent send path.
  - The reconnect is **deferred** to the cancel's `didDisconnect` (serialises teardown-then-reconnect for the same peripheral id, avoiding a stale callback tearing down the new link).
  - Bounded to **2 consecutive stalls** (counter resets on any drained write), tracked by a **peripheral-keyed** recovery window with a **fail-closed watchdog** so it can't strand.
  - A *recoverable* stall settles as the self-healing `writeTimedOut` (JS keeps `isConnected`). A *budget-exhausted give-up* settles as a hard `writeRecoveryFailed` (real error + clean disconnect, board kept reconnectable) so telemetry doesn't mislabel a dark wall as an auto-recovery.
- **`@boardsesh/ble-protocol` + mobile `error-reporting.ts`** — the now-auto-recovered timeout is classified as a self-healing `warning` (`ble_write_timeout`), and the recovery lifecycle gets distinct PostHog failure reasons (see Telemetry).

### Telemetry / instrumentation
The recovery errors land in **both** backends (separate pipes: `reportHandledError` → Sentry; `track()` → PostHog), surfaced through `performSend`:

| Outcome | Sentry | PostHog |
|---|---|---|
| Recoverable stall | `warning` (tag `ble_write_timeout`) | `Climb Sent to Board Failure` · `failureReason: write_timeout` |
| Recovery give-up | `error` | `Climb Sent to Board Failure` · `failureReason: write_recovery_failed` + `Bluetooth Disconnected` |

The give-up gets its **own** `write_recovery_failed` reason (not lumped into generic `write_failed`), so recovery rate is measurable in PostHog: `write_timeout` = stalls the native layer attempted, `write_recovery_failed` = the ones it gave up on. Both native error strings are coupled to their JS classifiers with cross-reference comments.

**Known blind spot:** writes the native layer issues itself with no in-flight JS write (the backgrounded Dynamic Island / state-restoration `displaySharedCurrentItem` path) only log to `os.log` on a recoverable stall; their give-up still surfaces via `Bluetooth Disconnected` but without the `write_recovery_failed` reason. Pre-existing (those writes never had JS telemetry); the foreground user-tap path is fully covered. Closing it would need a native→JS recovery event — happy to add as a follow-up if we want widget-path coverage.

### Review
Heavy multi-agent review (cornerstone path): adversarial reviewers across concurrency, state-machine, native↔JS contract, widget-intent, and telemetry lenses, plus the workflow-backed `/code-review`. Found and fixed real issues: a concurrent-write-during-recovery teardown, a wrong-peripheral recovery-flag consumption, a board-hijack on a different-board connect mid-recovery, and a budget-exhausted hard-failure being mislabeled as an auto-recovery (which also would have cleared the stored board via a JS round-trip). Accepted/documented tradeoffs: a brief cancel→reconnect window (bounded, same board the user is driving), writes issued during that window re-driven by the native re-display, and the native-only-write telemetry blind spot above.

## Release Notes

- Tap a climb on a flaky Bluetooth link and the wall now re-lights itself instead of staying dark — no more re-tapping a climb that didn't show up.

## Test plan

**Native iOS change** — needs a real iPhone + a real board under a marginal link (no BLE in the simulator; OTA can't carry a native change, so it needs a dev-client / TestFlight build). QA flows in `.boardsesh/qa-notes.md`.

Automated (this PR):
- `vp run test:mobile` — 2589 pass.
- `vp test run packages/shared/ble-protocol/src/__tests__/connection-error.test.ts` — 59 pass (incl. `isBleWriteTimeoutError` / `isBleWriteRecoveryFailedError` + the `write_timeout` / `write_recovery_failed` classification, locking the native↔JS message contract).
- `vp run typecheck:mobile` / `:shared`, `vp run check:mobile-bundle` — green.
- Swift compiles in CI via `ios-rn-ci.yml` `prebuild-and-build` + `xcodebuild build-for-testing` (green; can't compile Swift on Linux).

Device check (maintainer): connect to a board, induce a marginal link, tap climbs → wall re-lights after a stall instead of staying dark; a persistently dead link gives up after 2 cycles and shows disconnected (board still reconnectable via the lightbulb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VumHLu17TrDhBvbyi55hf
