### PR TITLE
refactor: type MoonBoard climb method as a GraphQL enum

### DIFF
--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -398,6 +398,38 @@ describe('climb mutations', () => {
     expect(insertCalls[0].values).toMatchObject({ characteristics: ['method_footless'] });
   });
 
+  it('stores null characteristics when no MoonBoard method is supplied', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select
+      .mockReturnValueOnce(
+        createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+      )
+      .mockReturnValueOnce(createMockChain([{ difficulty: 17 }]));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'Feet Follow Hands Problem',
+          description: '',
+          holds: { start: ['A1'], hand: ['B2'], finish: ['C3'] },
+          angle: 40,
+          isDraft: false,
+          userGrade: '6A+',
+          // No `method` — the "feet follow hands" default carries no characteristic token.
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[0].values).toMatchObject({ characteristics: null });
+  });
+
   it('seeds a stats row for MoonBoard climbs saved without a grade', async () => {
     mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockDb.select.mockReturnValueOnce(

--- a/packages/shared-schema/src/__tests__/characteristics.test.ts
+++ b/packages/shared-schema/src/__tests__/characteristics.test.ts
@@ -94,4 +94,20 @@ describe('moonBoardMethodToCharacteristic', () => {
     // "no kickboard" without footless → the no-kickboard token.
     expect(moonBoardMethodToCharacteristic('Feet follow hands, no kickboard')).toBe('method_no_kickboard');
   });
+
+  // The canonical method labels the MoonBoard app surfaces, which appear verbatim
+  // as `.data[].method` in the community dump (the import call site:
+  // packages/db/scripts/import-moonboard-problems.ts). Locking them here documents
+  // the contract for each. NOTE: a full sweep of every *distinct* `.method` value
+  // across all six layout JSONs in the dump is deferred — the mapper is
+  // substring-based (see characteristics.ts:88-91) so minor label variants still
+  // resolve, but extending it should re-confirm against that authoritative set.
+  it.each([
+    ['Feet follow hands', null],
+    ['Footless', 'method_footless'],
+    ['Footless + kickboard', 'method_footless_kickboard'],
+    ['No kickboard', 'method_no_kickboard'],
+  ])('maps the canonical MoonBoard label %j to %j', (label, expected) => {
+    expect(moonBoardMethodToCharacteristic(label as string)).toBe(expected);
+  });
 });

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3574,6 +3574,20 @@ input SaveClimbInput {
   angle: Int!
 }
 
+"""
+MoonBoard problem method, stored as a mutually-exclusive climb-characteristic
+token. Omit for the "feet follow hands" default. Source of truth for the token
+set: CLIMB_CHARACTERISTICS in @boardsesh/shared-schema.
+"""
+enum MoonBoardMethod {
+  "No foot holds; the kickboard is not used."
+  method_footless
+  "No foot holds; the kickboard may be used."
+  method_footless_kickboard
+  "Feet follow hands, but the kickboard is off-limits."
+  method_no_kickboard
+}
+
 input SaveMoonBoardClimbInput {
   boardType: String!
   layoutId: Int!
@@ -3584,8 +3598,8 @@ input SaveMoonBoardClimbInput {
   isDraft: Boolean
   userGrade: String
   isBenchmark: Boolean
-  "MoonBoard method as a characteristic token: method_footless / method_footless_kickboard / method_no_kickboard. Omit for the 'feet follow hands' default."
-  method: String
+  "MoonBoard method as a characteristic token. Omit for the 'feet follow hands' default."
+  method: MoonBoardMethod
   setter: String
 }
 

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2132,6 +2132,19 @@ export type MoonBoardHoldsInput = {
   start: Array<Scalars['String']['input']>;
 };
 
+/**
+ * MoonBoard problem method, stored as a mutually-exclusive climb-characteristic
+ * token. Omit for the "feet follow hands" default. Source of truth for the token
+ * set: CLIMB_CHARACTERISTICS in @boardsesh/shared-schema.
+ */
+export type MoonBoardMethod =
+  /** No foot holds; the kickboard is not used. */
+  | 'method_footless'
+  /** No foot holds; the kickboard may be used. */
+  | 'method_footless_kickboard'
+  /** Feet follow hands, but the kickboard is off-limits. */
+  | 'method_no_kickboard';
+
 /** Root mutation type for all write operations. */
 export type Mutation = {
   __typename?: 'Mutation';
@@ -4602,8 +4615,8 @@ export type SaveMoonBoardClimbInput = {
   isBenchmark?: InputMaybe<Scalars['Boolean']['input']>;
   isDraft?: InputMaybe<Scalars['Boolean']['input']>;
   layoutId: Scalars['Int']['input'];
-  /** MoonBoard method as a characteristic token: method_footless / method_footless_kickboard / method_no_kickboard. Omit for the 'feet follow hands' default. */
-  method?: InputMaybe<Scalars['String']['input']>;
+  /** MoonBoard method as a characteristic token. Omit for the 'feet follow hands' default. */
+  method?: InputMaybe<MoonBoardMethod>;
   name: Scalars['String']['input'];
   setter?: InputMaybe<Scalars['String']['input']>;
   userGrade?: InputMaybe<Scalars['String']['input']>;
@@ -6303,6 +6316,7 @@ export type ResolversTypes = ResolversObject<{
   MoonBoardClimbDuplicateCandidateInput: MoonBoardClimbDuplicateCandidateInput;
   MoonBoardClimbDuplicateMatch: ResolverTypeWrapper<MoonBoardClimbDuplicateMatch>;
   MoonBoardHoldsInput: MoonBoardHoldsInput;
+  MoonBoardMethod: MoonBoardMethod;
   Mutation: ResolverTypeWrapper<{}>;
   MyBoardsInput: MyBoardsInput;
   MyGymsInput: MyGymsInput;

--- a/packages/shared-schema/src/schema/new-climb-feed.ts
+++ b/packages/shared-schema/src/schema/new-climb-feed.ts
@@ -83,6 +83,20 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     angle: Int!
   }
 
+  """
+  MoonBoard problem method, stored as a mutually-exclusive climb-characteristic
+  token. Omit for the "feet follow hands" default. Source of truth for the token
+  set: CLIMB_CHARACTERISTICS in @boardsesh/shared-schema.
+  """
+  enum MoonBoardMethod {
+    "No foot holds; the kickboard is not used."
+    method_footless
+    "No foot holds; the kickboard may be used."
+    method_footless_kickboard
+    "Feet follow hands, but the kickboard is off-limits."
+    method_no_kickboard
+  }
+
   input SaveMoonBoardClimbInput {
     boardType: String!
     layoutId: Int!
@@ -93,8 +107,8 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     isDraft: Boolean
     userGrade: String
     isBenchmark: Boolean
-    "MoonBoard method as a characteristic token: method_footless / method_footless_kickboard / method_no_kickboard. Omit for the 'feet follow hands' default."
-    method: String
+    "MoonBoard method as a characteristic token. Omit for the 'feet follow hands' default."
+    method: MoonBoardMethod
     setter: String
   }
 

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2129,6 +2129,19 @@ export type MoonBoardHoldsInput = {
   start: Array<Scalars['String']['input']>;
 };
 
+/**
+ * MoonBoard problem method, stored as a mutually-exclusive climb-characteristic
+ * token. Omit for the "feet follow hands" default. Source of truth for the token
+ * set: CLIMB_CHARACTERISTICS in @boardsesh/shared-schema.
+ */
+export type MoonBoardMethod =
+  /** No foot holds; the kickboard is not used. */
+  | 'method_footless'
+  /** No foot holds; the kickboard may be used. */
+  | 'method_footless_kickboard'
+  /** Feet follow hands, but the kickboard is off-limits. */
+  | 'method_no_kickboard';
+
 /** Root mutation type for all write operations. */
 export type Mutation = {
   __typename?: 'Mutation';
@@ -4599,8 +4612,8 @@ export type SaveMoonBoardClimbInput = {
   isBenchmark?: InputMaybe<Scalars['Boolean']['input']>;
   isDraft?: InputMaybe<Scalars['Boolean']['input']>;
   layoutId: Scalars['Int']['input'];
-  /** MoonBoard method as a characteristic token: method_footless / method_footless_kickboard / method_no_kickboard. Omit for the 'feet follow hands' default. */
-  method?: InputMaybe<Scalars['String']['input']>;
+  /** MoonBoard method as a characteristic token. Omit for the 'feet follow hands' default. */
+  method?: InputMaybe<MoonBoardMethod>;
   name: Scalars['String']['input'];
   setter?: InputMaybe<Scalars['String']['input']>;
   userGrade?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
## Summary

Post-merge review follow-up for the structured climb-characteristics work (#3171, merged).

- **GraphQL `method` is now an enum, not `String`.** `SaveMoonBoardClimbInput.method` was typed `String`, but the resolver's Zod validator already enforces a strict three-value set. Introspection and client tooling couldn't catch a bad value like `method_invalid` — it only failed at the resolver. This adds a `MoonBoardMethod` GraphQL enum (`method_footless` / `method_footless_kickboard` / `method_no_kickboard`) and points the field at it, so the schema matches the constraint. Wire values are unchanged: codegen emits a string-literal union, and the web create-climb form's existing token type assigns cleanly (verified by typecheck). Mobile doesn't call this mutation; the bulk-import and REST proxy paths don't send `method`.
- **Explicit "no method" test.** Added a backend test asserting a MoonBoard climb saved without a `method` stores `characteristics: null`, making the new data contract explicit rather than implicit.
- **Mapper test coverage.** Expanded `moonBoardMethodToCharacteristic` tests to lock the canonical MoonBoard labels (`Feet follow hands` → null, `Footless`, `Footless + kickboard`, `No kickboard`). A full distinct-value sweep against the community dump is noted as deferred in-code.

The fourth review point — the benchmark toggle showing for non-admins — was already resolved in commit `356ef5951` (the `canSetBenchmark` guard hides it and the backend rejects non-privileged saves), so no change here.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run codegen` — regenerated all three generated artifacts; diff is only the new enum + field type.
- `vp run typecheck` — green (web + backend + shared, no fallout from String → enum).
- `vp test run --project backend` — 1797 passed; new "method omitted → null" test passes, existing method test still green.
- `vp test run characteristics` — 15 passed (4 new canonical-label cases).
- `vp check` on changed files — 0 errors, formatting clean.