### PR TITLE
fix(mobile): lock swipe axis + kill Android end-of-swipe flash

### DIFF
--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -32,6 +32,13 @@ type BoardImageNativeProps = {
   renderWidth?: number;
   style?: ViewStyle;
   /**
+   * Drop the holds overlay's cross-fade for this render — forwarded to
+   * LayeredClimbImage. The play-drawer carousel sets it on the current board while
+   * committing a swipe so the new climb's (already-cached) holds swap instantly
+   * instead of fading up, which removed the Android end-of-swipe flash.
+   */
+  suppressOverlayTransition?: boolean;
+  /**
    * testID forwarded to the holds-overlay layer, which only mounts once the async
    * overlay render is ready — lets screenshot/e2e flows wait for the lit board to
    * appear. The full-size play-drawer board sets this; thumbnails leave it unset.
@@ -62,6 +69,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
   filledStyle = false,
   renderWidth,
   style,
+  suppressOverlayTransition,
   overlayTestID,
 }: BoardImageNativeProps) {
   const { overlayUri, backgroundPaths, missingBackgroundCount } = useNativeClimbRender({
@@ -87,6 +95,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}
+        suppressOverlayTransition={suppressOverlayTransition}
         overlayTestID={overlayTestID}
       />
     </View>

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -21,6 +21,14 @@ type LayeredClimbImageProps = {
    * View-layer only — not baked into the cached PNG, so no cache-key impact.
    */
   dimBackground?: boolean;
+  /**
+   * Drop the holds overlay's 150ms cross-fade for this render. The play-drawer
+   * carousel sets this while committing a swipe: the incoming climb's overlay is
+   * already a memory-cache hit (the peek painted it during the drag), so an instant
+   * swap lands the new holds on the very next frame instead of fading them up —
+   * which on Android was the visible end-of-swipe flash at centre.
+   */
+  suppressOverlayTransition?: boolean;
   recyclingKey?: string;
   /**
    * testID for the holds-overlay layer. Only rendered once the async overlay PNG
@@ -48,6 +56,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   missingBackgroundCount = 0,
   mirrored,
   dimBackground,
+  suppressOverlayTransition,
   recyclingKey,
   overlayTestID,
 }: LayeredClimbImageProps) {
@@ -103,7 +112,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           contentFit="contain"
           recyclingKey={recyclingKey}
           cachePolicy="memory-disk"
-          transition={150}
+          transition={suppressOverlayTransition ? 0 : 150}
           // Overlay PNG is rasterized at the surface size (small for the
           // list/accessory, native for play) so no main-thread downscale
           // is needed — skip expo-image's resample.

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -11,8 +11,12 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('expo-image', () => ({
-  Image: ({ source, testID }: { source: { uri: string }; testID?: string }) =>
-    createElement('img', { src: source.uri, 'data-testid': testID ?? 'expo-image' }),
+  Image: ({ source, testID, transition }: { source: { uri: string }; testID?: string; transition?: number }) =>
+    createElement('img', {
+      src: source.uri,
+      'data-testid': testID ?? 'expo-image',
+      'data-transition': transition,
+    }),
 }));
 
 import { LayeredClimbImage } from '../LayeredClimbImage';
@@ -48,5 +52,28 @@ describe('LayeredClimbImage', () => {
     );
 
     expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+  });
+
+  it('cross-fades the holds overlay by default', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bundled/kilter.webp'],
+      }),
+    );
+
+    expect(container.querySelector('img[src="file:///overlay.png"]')?.getAttribute('data-transition')).toBe('150');
+  });
+
+  it('swaps the holds overlay instantly when suppressOverlayTransition is set (no end-of-swipe flash)', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bundled/kilter.webp'],
+        suppressOverlayTransition: true,
+      }),
+    );
+
+    expect(container.querySelector('img[src="file:///overlay.png"]')?.getAttribute('data-transition')).toBe('0');
   });
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -224,14 +224,6 @@ export function PlayDrawer({
   const handleDismiss = useCallback(() => {
     router.dismiss();
   }, []);
-  const { gesture: dismissGesture, translateY: dismissTranslateY } = useDrawerDismissGesture({
-    onDismiss: handleDismiss,
-    scrollYSV,
-    scrollRef: scrollGestureRef,
-  });
-  const dismissAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: dismissTranslateY.value }],
-  }));
 
   // The header (title + grade) rides this exact value as the board so they swipe
   // in lockstep; the carousel's gesture writes into it (externalTranslateX). The
@@ -242,6 +234,21 @@ export function PlayDrawer({
   // covering centre) and snaps it back to 0 only once the new climb has actually
   // rendered — so the swap is invisible instead of flashing the old climb.
   const swipeIsAnimating = useSharedValue(false);
+
+  // The dismiss reads these so it can stand down while a horizontal swipe owns the
+  // gesture (offset non-zero) or a fling is still settling (carousel inert) — that's
+  // when an accidental downward drift would otherwise yank the drawer down.
+  const { gesture: dismissGesture, translateY: dismissTranslateY } = useDrawerDismissGesture({
+    onDismiss: handleDismiss,
+    scrollYSV,
+    scrollRef: scrollGestureRef,
+    swipeTranslateX,
+    swipeIsAnimating,
+  });
+  const dismissAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: dismissTranslateY.value }],
+  }));
+
   const [swipeDirection, setSwipeDirection] = useState<'next' | 'prev'>('next');
   useAnimatedReaction(
     () => (swipeTranslateX.value < 0 ? 'next' : 'prev'),

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -285,6 +285,11 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
                 boardHeight={boardHeight}
                 mirrored={mirrored}
                 style={boardStyle}
+                // During a swipe commit the current board's frames swap to the
+                // climb the peek was showing; that overlay is already cached, so an
+                // instant (no-fade) swap lands it before the reset uncovers it —
+                // killing the Android end-of-swipe flash. See isCommitting above.
+                suppressOverlayTransition={isCommitting}
               />
             </Animated.View>
           </Animated.View>

--- a/packages/mobile/src/components/play-drawer/__tests__/use-drawer-dismiss-gesture.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-drawer-dismiss-gesture.test.ts
@@ -132,6 +132,21 @@ describe('useDrawerDismissGesture', () => {
     expect(result.current.translateY.value).toBe(0);
   });
 
+  it('does not dismiss on a fast flick while a fling is still settling, even past the velocity threshold', () => {
+    // The velocity-sneak path must also be blocked by the animating flag alone:
+    // the fresh re-touch during a settling fling never sets swipeTranslateX.
+    const { result } = renderHook((props: Options) => useDrawerDismissGesture(props), {
+      initialProps: makeOptions({ swipeIsAnimating: sv(true) }),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onBegin();
+    handlers.onEnd({ velocityY: 1200 });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(result.current.translateY.value).toBe(0);
+  });
+
   it('dismisses on a committed downward drag when no horizontal swipe is active', () => {
     renderHook((props: Options) => useDrawerDismissGesture(props), {
       initialProps: makeOptions(),

--- a/packages/mobile/src/components/play-drawer/__tests__/use-drawer-dismiss-gesture.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-drawer-dismiss-gesture.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { SharedValue } from 'react-native-reanimated';
+
+// The hook composes a reanimated worklet Pan — stub the native layers so it runs
+// in node. These tests pin the axis-lock behaviour: while the carousel owns the
+// gesture as a horizontal swipe (offset non-zero) or is settling a fling, the
+// vertical dismiss must stand down, and a fast horizontal flick's vertical
+// velocity must not sneak a dismiss through in onEnd.
+
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef<{ value: unknown } | null>(null);
+      if (ref.current === null) ref.current = { value: initial };
+      return ref.current;
+    },
+    withSpring: (toValue: unknown) => toValue,
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+// Chainable Gesture.Pan() builder that records the worklet handlers for driving.
+type RecordedHandlers = Record<string, (...args: unknown[]) => unknown>;
+const recordedBuilders: { handlers: RecordedHandlers }[] = [];
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = () => {
+    const handlers: RecordedHandlers = {};
+    recordedBuilders.push({ handlers });
+    const builder: Record<string, (...args: unknown[]) => unknown> = {};
+    const proxy: typeof builder = new Proxy(builder, {
+      get: (_target, prop: string) => {
+        return (maybeHandler: unknown) => {
+          if (typeof maybeHandler === 'function' && prop.startsWith('on')) {
+            handlers[prop] = maybeHandler as RecordedHandlers[string];
+          }
+          return proxy;
+        };
+      },
+    });
+    return proxy;
+  };
+  return {
+    Gesture: { Pan: () => makeBuilder() },
+  };
+});
+
+import { useDrawerDismissGesture } from '../use-drawer-dismiss-gesture';
+
+type Options = Parameters<typeof useDrawerDismissGesture>[0];
+
+const onDismiss = vi.fn();
+
+function sv<T>(value: T): SharedValue<T> {
+  return { value } as unknown as SharedValue<T>;
+}
+
+function makeOptions(overrides: Partial<Options> = {}): Options {
+  return {
+    onDismiss,
+    scrollYSV: sv(0),
+    swipeTranslateX: sv(0),
+    swipeIsAnimating: sv(false),
+    ...overrides,
+  };
+}
+
+function latestHandlers(): RecordedHandlers {
+  const latest = recordedBuilders[recordedBuilders.length - 1];
+  if (!latest) throw new Error('no Gesture.Pan() composed');
+  return latest.handlers;
+}
+
+describe('useDrawerDismissGesture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recordedBuilders.length = 0;
+  });
+
+  it('follows a downward drag from the top when no horizontal swipe is active', () => {
+    const { result } = renderHook((props: Options) => useDrawerDismissGesture(props), {
+      initialProps: makeOptions(),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 50 });
+
+    expect(result.current.translateY.value).toBe(50);
+  });
+
+  it('pins translateY to 0 while a horizontal swipe offset is non-zero', () => {
+    const { result } = renderHook((props: Options) => useDrawerDismissGesture(props), {
+      initialProps: makeOptions({ swipeTranslateX: sv(-40) }),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 50 });
+
+    expect(result.current.translateY.value).toBe(0);
+  });
+
+  it('pins translateY to 0 while a fling is still settling', () => {
+    const { result } = renderHook((props: Options) => useDrawerDismissGesture(props), {
+      initialProps: makeOptions({ swipeIsAnimating: sv(true) }),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 50 });
+
+    expect(result.current.translateY.value).toBe(0);
+  });
+
+  it('does not dismiss on a fast flick while a horizontal swipe is active, even past the velocity threshold', () => {
+    const { result } = renderHook((props: Options) => useDrawerDismissGesture(props), {
+      initialProps: makeOptions({ swipeTranslateX: sv(-40) }),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onBegin();
+    // velocityY well past DISMISS_VELOCITY_THRESHOLD (600) — must still be blocked.
+    handlers.onEnd({ velocityY: 1200 });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(result.current.translateY.value).toBe(0);
+  });
+
+  it('dismisses on a committed downward drag when no horizontal swipe is active', () => {
+    renderHook((props: Options) => useDrawerDismissGesture(props), {
+      initialProps: makeOptions(),
+    });
+    const handlers = latestHandlers();
+
+    handlers.onBegin();
+    // Past DISMISS_DISTANCE_THRESHOLD (110) with the dismiss free to engage.
+    handlers.onUpdate({ translationY: 150 });
+    handlers.onEnd({ velocityY: 0 });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/use-drawer-dismiss-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-drawer-dismiss-gesture.ts
@@ -17,7 +17,10 @@ import { springs } from '../../theme/animations';
 // "can't dismiss easily" bug). It activates on a downward drag (`activeOffsetY`)
 // and bails on a horizontal one (`failOffsetX`) so the carousel keeps L/R
 // swipes. To avoid a jump when a scroll-to-top rolls into a dismiss, it only
-// engages when the gesture BEGAN at the top of the scroll.
+// engages when the gesture BEGAN at the top of the scroll. `failOffsetX` alone
+// isn't enough during fast climb-swapping — the carousel goes inert while a fling
+// settles, so a fresh downward touch reaches this Pan; we also hard-block it
+// whenever the carousel's swipe offset is non-zero or a fling is in progress.
 
 /** Downward travel (px) before the dismiss activates. */
 const DISMISS_ACTIVATE_OFFSET = 14;
@@ -38,6 +41,14 @@ type UseDrawerDismissGestureOptions = {
    *  (without it the native scroll wins by default and the dismiss barely fires).
    *  Typed as RNGH's GestureRef shape so the method call needs no cast. */
   scrollRef?: RefObject<ComponentType | undefined | null>;
+  /** The carousel's horizontal swipe offset. Non-zero while a L/R swipe is dragging
+   *  or mid-fling — we block the vertical dismiss for that whole window so a downward
+   *  drift during fast climb-swapping can't accidentally pull the drawer down. */
+  swipeTranslateX?: SharedValue<number>;
+  /** The carousel's fling-in-progress flag. True while a thrown swipe is still
+   *  settling (the carousel is inert then, so a fresh downward touch would otherwise
+   *  reach this dismiss) — block the dismiss until it clears. */
+  swipeIsAnimating?: SharedValue<boolean>;
 };
 
 type UseDrawerDismissGestureReturn = {
@@ -50,6 +61,8 @@ export function useDrawerDismissGesture({
   onDismiss,
   scrollYSV,
   scrollRef,
+  swipeTranslateX,
+  swipeIsAnimating,
 }: UseDrawerDismissGestureOptions): UseDrawerDismissGestureReturn {
   const translateY = useSharedValue(0);
   const isDismissing = useSharedValue(false);
@@ -81,6 +94,15 @@ export function useDrawerDismissGesture({
       .onUpdate((event) => {
         'worklet';
         if (isDismissing.value) return;
+        // Once the carousel owns the gesture as a horizontal swipe (offset non-zero)
+        // or is still settling a fling, block the vertical dismiss entirely — a
+        // downward drift while quickly swapping climbs must not pull the drawer down.
+        // Guard via `?? 0` so an absent shared value reads as "no swipe", not as a
+        // permanent block (`undefined !== 0` is true).
+        if ((swipeTranslateX?.value ?? 0) !== 0 || swipeIsAnimating?.value === true) {
+          translateY.value = 0;
+          return;
+        }
         // Follow the finger only when the gesture began at the top and is heading
         // down; otherwise it's a scroll (the ScrollView, running simultaneously,
         // handles it) and the drawer stays put.
@@ -88,6 +110,14 @@ export function useDrawerDismissGesture({
       })
       .onEnd((event) => {
         'worklet';
+        // Same guard as onUpdate, and it must run BEFORE the velocity check: a fast
+        // horizontal flick carries vertical velocity, so without this an accidental
+        // down-component could satisfy velocityY > threshold and commit a dismiss
+        // even though translateY was pinned at 0.
+        if ((swipeTranslateX?.value ?? 0) !== 0 || swipeIsAnimating?.value === true) {
+          translateY.value = withSpring(0, springs.interactive);
+          return;
+        }
         const committed =
           startedAtTop.value &&
           (translateY.value > DISMISS_DISTANCE_THRESHOLD || event.velocityY > DISMISS_VELOCITY_THRESHOLD);
@@ -111,7 +141,7 @@ export function useDrawerDismissGesture({
         isDismissing.value = false;
       });
     return scrollRef ? pan.simultaneousWithExternalGesture(scrollRef) : pan;
-  }, [translateY, isDismissing, startedAtTop, scrollYSV, scrollRef]);
+  }, [translateY, isDismissing, startedAtTop, scrollYSV, scrollRef, swipeTranslateX, swipeIsAnimating]);
 
   return { gesture, translateY };
 }


### PR DESCRIPTION
## Summary

Two follow-ups on the revamped play-drawer swipe carousel, both surfaced during device QA.

**Lock the swipe axis (block accidental dismiss).** Once a horizontal swipe owns the gesture (offset non-zero) or a fling is still settling, the pull-down-to-dismiss Pan now stands down. During fast climb-swapping the carousel goes inert while a fling settles, so a fresh downward touch reached the dismiss Pan and a small downward drift yanked the whole drawer down. The dismiss now reads the carousel's `swipeTranslateX` + `swipeIsAnimating` shared values and pins `translateY` to 0 — and skips the commit *before* the velocity check, so a fast flick's vertical velocity can't sneak a dismiss through. A genuine downward swipe from rest is unchanged.

**Kill the Android end-of-swipe flash.** The holds overlay's `expo-image` `transition={150}` cross-faded the current board to the new climb at commit, but the host reset snaps the board to centre keyed on a React state change, not actual paint — so on Android the holds were still fading in when they reached centre (iOS lands the already-cached overlay in the same transaction, so it never showed). The carousel now passes `suppressOverlayTransition` to the current board while committing, so its already-cached holds swap instantly instead of fading. Threaded `BoardImageNative` → `LayeredClimbImage`; the peek board and normal climb changes keep their fade.

## Release Notes

- Flick through climbs in the player without the view accidentally sliding shut mid-swipe.
- On Android, the next climb now lands cleanly at the end of a swipe — no more flash.

## Test plan

- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — full suite green (2592), plus 5 new `use-drawer-dismiss-gesture` tests covering the axis-lock branches (blocks while a swipe offset is non-zero / a fling is settling / a fast flick carries vertical velocity; still dismisses from rest).
- `vp run check:mobile-bundle` — green.
- Device QA still to confirm on an Android build: (1) rapidly swipe L/R through climbs with downward drift — drawer must not drop; a deliberate downward swipe from rest still dismisses; (2) step the end-of-swipe frames (next/prev, a fast short-drag swipe, and a queue boundary) — the new climb's holds are fully present on the frame the card reaches centre, no fade-in/blank. iOS regression: end-of-swipe stays seamless and dismiss still works.
