### PR TITLE
ci: stop full-repo lint job panicking on stdout EAGAIN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,14 @@ jobs:
           fi
       - name: Lint full repo (main)
         if: github.event_name != 'pull_request'
-        run: vp check
+        # vp/Vite+ panics with "failed printing to stdout: Resource temporarily
+        # unavailable (os error 11)" when it flushes the full-repo warning list to the
+        # runner's non-blocking stdout. Write to a regular file (never EAGAIN), then
+        # echo it back, preserving vp's real exit code so errors still fail the job.
+        run: |
+          vp check > vp-check.log 2>&1 && status=0 || status=$?
+          cat vp-check.log || true
+          exit $status
 
   large-files:
     # Guards against committed binary churn (screenshots, build outputs, vendored


### PR DESCRIPTION
## Summary

After the logbook/format fix (#3197) landed, main's `lint` job started failing — but **not on a lint error**. `vp check` finds **0 errors** (only ~181 pre-existing warnings), then crashes while flushing them to stdout:

```
warn: Lint or type warnings found
Vite+ panicked. This is a bug in Vite+, not your code.
thread '<unnamed>' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Resource temporarily unavailable (os error 11)
##[error]Process completed with exit code 1.
```

`os error 11` is `EAGAIN`: the GitHub runner's stdout is non-blocking, and the large warning burst overruns it. This was **masked until now** — the lint job used to short-circuit on formatting before it ever printed the warnings. It reproduces deterministically on the full-repo lint (re-running twice hit the same panic).

It only bites the **main** path: PRs lint changed files only (`xargs vp check < changed-lintable.txt`, which also excludes `embedded/`), so the output is tiny — that's why #3197's own lint passed.

## Fix

Redirect `vp check` to a regular file (a regular-file fd never returns `EAGAIN` on write), echo it back for the log, and preserve vp's real exit code so genuine lint/type errors still fail the job.

```yaml
run: |
  vp check > vp-check.log 2>&1 && status=0 || status=$?
  cat vp-check.log || true
  exit $status
```

The underlying ~181 warnings are pre-existing tech debt (unused vars in `embedded/scripts`, backend test helpers, etc.) and out of scope here; this just stops the stdout flush from crashing the job.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` locally: **0 errors, 181 warnings**, exit 0 (the warnings don't fail the check — only the CI stdout flush did).
- This PR's own CI exercises the *PR* lint path; the changed-file is `.github/workflows/ci.yml`, so the fixed *main* path runs on merge. Will confirm the post-merge main `lint` job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LqZzB3S3C88t9Qs43kzrD