### PR TITLE
feat(mobile): add tester feature-flag override UI

### DIFF
--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -24,6 +24,8 @@ export default function ProfileLayout() {
       <Stack.Screen name="dev-servers" options={{ title: t('mobile.more.metroServersTitle') }} />
       {/* i18n-ignore-next-line — tester-only screen */}
       <Stack.Screen name="channel-switcher" options={{ title: 'OTA Channel Switcher' }} />
+      {/* i18n-ignore-next-line — tester-only screen */}
+      <Stack.Screen name="feature-flags" options={{ title: 'Feature Flags' }} />
       <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />
     </Stack>
   );

--- a/packages/mobile/app/(tabs)/profile/feature-flags.tsx
+++ b/packages/mobile/app/(tabs)/profile/feature-flags.tsx
@@ -1,0 +1,5 @@
+import { FeatureFlagsScreen } from '../../../src/components/FeatureFlagsScreen';
+
+export default function FeatureFlagsRoute() {
+  return <FeatureFlagsScreen />;
+}

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -63,9 +63,15 @@ export default function MoreScreen() {
   // it can actually work; testers on a release build get the OTA channel switcher.
   const showDevServerSwitcher = isDevLauncherAvailable();
 
-  // Don't render an empty "Development" section header when neither tool applies
+  // Feature-flag overrides work in every build (dev forces them in place of the
+  // disabled PostHog read; release builds layer them on top), so show the entry
+  // wherever the dev section is allowed — for testers and in dev.
+  const showFeatureFlags = __DEV__ || Boolean(profile?.isTester);
+
+  // Don't render an empty "Development" section header when no tool applies
   // (e.g. a tester on a release build with updates disabled).
-  const showDevSection = (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showChannelSwitcher);
+  const showDevSection =
+    (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showChannelSwitcher || showFeatureFlags);
 
   // Whether the bundled changelog has an entry the user hasn't opened yet — drives
   // the "New" pill on the What's New row. Re-read every time this screen regains
@@ -316,7 +322,7 @@ export default function MoreScreen() {
                 subtitle={t('mobile.more.metroServersSubtitle')}
                 leading={<Icon name="server" size={22} color={systemColors.secondaryLabel} />}
                 showChevron
-                showSeparator={showChannelSwitcher}
+                showSeparator={showChannelSwitcher || showFeatureFlags}
                 onPress={() => router.push('/(tabs)/profile/dev-servers')}
               />
             ) : null}
@@ -328,8 +334,20 @@ export default function MoreScreen() {
                 subtitle="Switch Expo update channel"
                 leading={<Icon name="transfer" size={22} color={systemColors.secondaryLabel} />}
                 showChevron
-                showSeparator={false}
+                showSeparator={showFeatureFlags}
                 onPress={() => router.push('/(tabs)/profile/channel-switcher')}
+              />
+            ) : null}
+            {showFeatureFlags ? (
+              <ListRow
+                // i18n-ignore-next-line — tester-only dev tooling
+                title="Feature Flags"
+                // i18n-ignore-next-line
+                subtitle="Force feature flags on or off"
+                leading={<Icon name="flag" size={22} color={systemColors.secondaryLabel} />}
+                showChevron
+                showSeparator={false}
+                onPress={() => router.push('/(tabs)/profile/feature-flags')}
               />
             ) : null}
           </View>

--- a/packages/mobile/src/components/FeatureFlagsScreen.tsx
+++ b/packages/mobile/src/components/FeatureFlagsScreen.tsx
@@ -1,0 +1,158 @@
+import { ScrollView, View, StyleSheet, Pressable } from 'react-native';
+import { Text } from './Text';
+import { SectionHeader } from './SectionHeader';
+import { Icon } from './Icon';
+import { useTheme } from '../providers/theme-provider';
+import { SegmentedControl } from './SegmentedControl';
+import { hapticLight } from '../lib/haptics';
+import { FEATURE_FLAG_DEFINITIONS } from '../providers/feature-flags-provider';
+import { useFeatureFlagOverrides } from '../lib/feature-flag-overrides';
+import { readPosthogFeatureFlags } from '../lib/analytics';
+
+// Tester-only screen — all copy is hardcoded English with `i18n-ignore`, matching
+// ChannelSwitcherScreen. It lets a tester force any catalog flag On/Off (or back
+// to Default) on-device; the choice is the highest-precedence layer in the
+// FeatureFlagsProvider merge and persists across restarts.
+
+type OverrideChoice = 'default' | 'on' | 'off';
+
+const CHOICE_OPTIONS: { key: OverrideChoice; label: string }[] = [
+  // i18n-ignore-next-line — tester-only screen
+  { key: 'default', label: 'Default' },
+  // i18n-ignore-next-line — tester-only screen
+  { key: 'on', label: 'On' },
+  // i18n-ignore-next-line — tester-only screen
+  { key: 'off', label: 'Off' },
+];
+
+export function FeatureFlagsScreen() {
+  const { systemColors, spacing, borderRadius } = useTheme();
+  const { overrides, setOverride, clearOverride, clearAll } = useFeatureFlagOverrides();
+
+  // Resolved base values (PostHog) so the footnote can show what a flag falls
+  // back to when its override is cleared. No-op / empty in dev or unkeyed builds.
+  const baseFlags = readPosthogFeatureFlags(FEATURE_FLAG_DEFINITIONS.map((definition) => definition.key));
+  const hasOverrides = Object.keys(overrides).length > 0;
+
+  const handleSelect = (key: string, choice: OverrideChoice) => {
+    if (choice === 'default') {
+      clearOverride(key);
+    } else {
+      setOverride(key, choice === 'on');
+    }
+  };
+
+  return (
+    <ScrollView contentInsetAdjustmentBehavior="automatic">
+      {/* i18n-ignore-next-line — tester-only screen */}
+      <SectionHeader title="Feature Flags" />
+      <View style={[styles.notice, { marginHorizontal: spacing[4] }]}>
+        <Text variant="footnote" color={systemColors.secondaryLabel}>
+          {/* i18n-ignore-next-line — tester-only screen */}
+          Force a flag On or Off on this device. Overrides win over PostHog and build-time settings and persist across
+          restarts. Default falls back to the live (PostHog) value.
+        </Text>
+      </View>
+
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: systemColors.secondaryBackground,
+            borderRadius: borderRadius.lg,
+            marginHorizontal: spacing[4],
+          },
+        ]}
+      >
+        {FEATURE_FLAG_DEFINITIONS.map((definition, index) => {
+          const override = overrides[definition.key];
+          const choice: OverrideChoice = override === undefined ? 'default' : override ? 'on' : 'off';
+          const base = baseFlags[definition.key];
+          // i18n-ignore-next-line — tester-only screen
+          const baseLabel = base === undefined ? 'not set' : base ? 'on' : 'off';
+          const effective = override ?? base ?? false;
+
+          return (
+            <View
+              key={definition.key}
+              style={[
+                styles.flagRow,
+                { paddingVertical: spacing[3], paddingHorizontal: spacing[4] },
+                index < FEATURE_FLAG_DEFINITIONS.length - 1 && {
+                  borderBottomWidth: StyleSheet.hairlineWidth,
+                  borderBottomColor: systemColors.separator,
+                },
+              ]}
+            >
+              <Text variant="body">{definition.label}</Text>
+              <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.flagDescription}>
+                {definition.description}
+              </Text>
+              <View style={{ marginTop: spacing[2] }}>
+                <SegmentedControl
+                  options={CHOICE_OPTIONS}
+                  selectedKey={choice}
+                  onSelect={(next) => handleSelect(definition.key, next)}
+                  trackColor={systemColors.fill}
+                  textVariant="footnote"
+                  accessibilityLabel={definition.label}
+                />
+              </View>
+              <Text variant="caption1" color={systemColors.secondaryLabel} style={{ marginTop: spacing[2] }}>
+                {/* i18n-ignore-next-line — tester-only screen */}
+                {`Live default: ${baseLabel} · Effective: ${effective ? 'on' : 'off'}`}
+              </Text>
+            </View>
+          );
+        })}
+      </View>
+
+      <Pressable
+        onPress={() => {
+          hapticLight();
+          clearAll();
+        }}
+        disabled={!hasOverrides}
+        accessibilityRole="button"
+        // i18n-ignore-next-line — tester-only screen
+        accessibilityLabel="Reset all overrides"
+        accessibilityState={{ disabled: !hasOverrides }}
+        style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: hasOverrides ? 1 : 0.5 }]}
+      >
+        <Icon name="refresh" size={16} color={systemColors.label} />
+        <Text variant="footnote" color={systemColors.label}>
+          {/* i18n-ignore-next-line — tester-only screen */}
+          Reset all overrides
+        </Text>
+      </Pressable>
+
+      <View style={styles.bottomSpacer} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    overflow: 'hidden',
+  },
+  notice: {
+    paddingVertical: 16,
+  },
+  flagRow: {
+    width: '100%',
+  },
+  flagDescription: {
+    marginTop: 2,
+  },
+  resetButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 12,
+    marginTop: 16,
+  },
+  bottomSpacer: {
+    height: 40,
+  },
+});

--- a/packages/mobile/src/components/FeatureFlagsScreen.tsx
+++ b/packages/mobile/src/components/FeatureFlagsScreen.tsx
@@ -1,13 +1,17 @@
-import { ScrollView, View, StyleSheet, Pressable } from 'react-native';
+import { useMemo } from 'react';
+import { ScrollView, View, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
+import { Redirect } from 'expo-router';
 import { Text } from './Text';
 import { SectionHeader } from './SectionHeader';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 import { SegmentedControl } from './SegmentedControl';
 import { hapticLight } from '../lib/haptics';
-import { FEATURE_FLAG_DEFINITIONS } from '../providers/feature-flags-provider';
+import { spacing } from '../theme/tokens';
+import { FEATURE_FLAG_DEFINITIONS, FEATURE_FLAG_KEYS } from '../providers/feature-flags-provider';
 import { useFeatureFlagOverrides } from '../lib/feature-flag-overrides';
 import { readPosthogFeatureFlags } from '../lib/analytics';
+import { useProfile } from '../lib/graphql/hooks';
 
 // Tester-only screen — all copy is hardcoded English with `i18n-ignore`, matching
 // ChannelSwitcherScreen. It lets a tester force any catalog flag On/Off (or back
@@ -26,12 +30,15 @@ const CHOICE_OPTIONS: { key: OverrideChoice; label: string }[] = [
 ];
 
 export function FeatureFlagsScreen() {
-  const { systemColors, spacing, borderRadius } = useTheme();
+  const { systemColors, borderRadius } = useTheme();
   const { overrides, setOverride, clearOverride, clearAll } = useFeatureFlagOverrides();
+  const { data: profile, isLoading: profileLoading } = useProfile();
 
   // Resolved base values (PostHog) so the footnote can show what a flag falls
   // back to when its override is cleared. No-op / empty in dev or unkeyed builds.
-  const baseFlags = readPosthogFeatureFlags(FEATURE_FLAG_DEFINITIONS.map((definition) => definition.key));
+  // Read once on mount: PostHog values rarely move while this tester screen is
+  // open, and live override changes already re-render via the store hook.
+  const baseFlags = useMemo(() => readPosthogFeatureFlags(FEATURE_FLAG_KEYS), []);
   const hasOverrides = Object.keys(overrides).length > 0;
 
   const handleSelect = (key: string, choice: OverrideChoice) => {
@@ -41,6 +48,25 @@ export function FeatureFlagsScreen() {
       setOverride(key, choice === 'on');
     }
   };
+
+  // Route guard. Hiding the More-tab row for non-testers is not a guard — a deep
+  // link or manual navigation reaches this route directly, and the overrides it
+  // writes apply globally via FeatureFlagsProvider, so a non-tester could force
+  // rollout-only flags on. Gate the screen itself: __DEV__ always passes (the
+  // profile query may not resolve in dev); otherwise wait for the profile, then
+  // keep non-testers out.
+  if (!__DEV__) {
+    if (profileLoading) {
+      return (
+        <View style={styles.loading}>
+          <ActivityIndicator />
+        </View>
+      );
+    }
+    if (!profile?.isTester) {
+      return <Redirect href="/(tabs)/profile/more" />;
+    }
+  }
 
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
@@ -136,7 +162,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   notice: {
-    paddingVertical: 16,
+    paddingVertical: spacing[4],
   },
   flagRow: {
     width: '100%',
@@ -148,11 +174,17 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 6,
-    paddingVertical: 12,
-    marginTop: 16,
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    marginTop: spacing[4],
   },
   bottomSpacer: {
-    height: 40,
+    height: spacing[10],
+  },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[10],
   },
 });

--- a/packages/mobile/src/components/FeatureFlagsScreen.tsx
+++ b/packages/mobile/src/components/FeatureFlagsScreen.tsx
@@ -31,7 +31,7 @@ const CHOICE_OPTIONS: { key: OverrideChoice; label: string }[] = [
 
 export function FeatureFlagsScreen() {
   const { systemColors, borderRadius } = useTheme();
-  const { overrides, setOverride, clearOverride, clearAll } = useFeatureFlagOverrides();
+  const { overrides, loaded: overridesLoaded, setOverride, clearOverride, clearAll } = useFeatureFlagOverrides();
   const { data: profile, isLoading: profileLoading } = useProfile();
 
   // Resolved base values (PostHog) so the footnote can show what a flag falls
@@ -66,6 +66,17 @@ export function FeatureFlagsScreen() {
     if (!profile?.isTester) {
       return <Redirect href="/(tabs)/profile/more" />;
     }
+  }
+
+  // Persisted overrides load async from storage. Wait for them before rendering
+  // the controls so a cold open doesn't flash every flag at "Default" and then
+  // snap to the tester's saved choices.
+  if (!overridesLoaded) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator />
+      </View>
+    );
   }
 
   return (

--- a/packages/mobile/src/lib/__tests__/feature-flag-overrides.test.ts
+++ b/packages/mobile/src/lib/__tests__/feature-flag-overrides.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+    },
+  };
+});
+
+const STORAGE_KEY = 'featureFlagOverrides';
+
+describe('feature-flag-overrides', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __reset: () => void;
+    };
+    asyncStorage.__reset();
+  });
+
+  it('loads an empty bag when nothing is stored', async () => {
+    const { loadFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({});
+  });
+
+  it('loads persisted overrides', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw(STORAGE_KEY, JSON.stringify({ 'strava-integration': true }));
+
+    const { loadFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({ 'strava-integration': true });
+  });
+
+  it('ignores a malformed (non-boolean) persisted payload', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw(STORAGE_KEY, JSON.stringify({ 'strava-integration': 'yes' }));
+
+    const { loadFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({});
+  });
+
+  it('sets and persists an override', async () => {
+    const { setFeatureFlagOverride, loadFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    setFeatureFlagOverride('strava-integration', false);
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({ 'strava-integration': false });
+
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      getItem: (key: string) => Promise<string | null>;
+    };
+    await expect(asyncStorage.getItem(STORAGE_KEY)).resolves.toBe(JSON.stringify({ 'strava-integration': false }));
+  });
+
+  it('clears a single override, leaving others', async () => {
+    const { setFeatureFlagOverride, clearFeatureFlagOverride, loadFeatureFlagOverrides } =
+      await import('../feature-flag-overrides');
+    setFeatureFlagOverride('flag-a', true);
+    setFeatureFlagOverride('flag-b', false);
+    clearFeatureFlagOverride('flag-a');
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({ 'flag-b': false });
+  });
+
+  it('clears all overrides', async () => {
+    const { setFeatureFlagOverride, clearAllFeatureFlagOverrides, loadFeatureFlagOverrides } =
+      await import('../feature-flag-overrides');
+    setFeatureFlagOverride('flag-a', true);
+    setFeatureFlagOverride('flag-b', true);
+    clearAllFeatureFlagOverrides();
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({});
+  });
+});

--- a/packages/mobile/src/lib/__tests__/feature-flag-overrides.test.ts
+++ b/packages/mobile/src/lib/__tests__/feature-flag-overrides.test.ts
@@ -85,4 +85,47 @@ describe('feature-flag-overrides', () => {
     clearAllFeatureFlagOverrides();
     await expect(loadFeatureFlagOverrides()).resolves.toEqual({});
   });
+
+  it('removes the storage key (not an empty bag) on clear-all', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      getItem: (key: string) => Promise<string | null>;
+    };
+    const { setFeatureFlagOverride, clearAllFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    setFeatureFlagOverride('flag-a', true);
+    clearAllFeatureFlagOverrides();
+    await expect(asyncStorage.getItem(STORAGE_KEY)).resolves.toBeNull();
+  });
+
+  it('merges a mutator that races the load on top of the persisted bag', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.__setRaw(STORAGE_KEY, JSON.stringify({ 'flag-a': true }));
+
+    const { setFeatureFlagOverride, loadFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    // Start the load, then set an override before the storage read resolves.
+    const pendingLoad = loadFeatureFlagOverrides();
+    setFeatureFlagOverride('flag-b', false);
+    await pendingLoad;
+
+    // The persisted flag-a survives alongside the racing flag-b (a plain replace
+    // would have dropped flag-a).
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({ 'flag-a': true, 'flag-b': false });
+  });
+
+  it('retries the read after a failed load (does not cache the failure)', async () => {
+    const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+      getItem: { mockRejectedValueOnce: (error: Error) => void };
+      __setRaw: (key: string, value: string) => void;
+    };
+    asyncStorage.getItem.mockRejectedValueOnce(new Error('storage unavailable'));
+
+    const { loadFeatureFlagOverrides } = await import('../feature-flag-overrides');
+    await expect(loadFeatureFlagOverrides()).rejects.toThrow('storage unavailable');
+
+    // The failed read left `hasLoaded` false, so the next attempt reads fresh
+    // instead of staying stuck at the default until restart.
+    asyncStorage.__setRaw(STORAGE_KEY, JSON.stringify({ 'flag-a': true }));
+    await expect(loadFeatureFlagOverrides()).resolves.toEqual({ 'flag-a': true });
+  });
 });

--- a/packages/mobile/src/lib/feature-flag-overrides.ts
+++ b/packages/mobile/src/lib/feature-flag-overrides.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
-import { getPreference, setPreference } from './preference-store';
+import { getPreference, setPreference, removePreference } from './preference-store';
 
 // Local, on-device feature-flag overrides — the highest-precedence layer in the
 // FeatureFlagsProvider merge (PostHog < static env < this). A tester flips a
@@ -46,12 +46,19 @@ function isOverridesRecord(value: unknown): value is FeatureFlagOverrides {
 export async function loadFeatureFlagOverrides(): Promise<FeatureFlagOverrides> {
   if (hasLoaded) return current;
   const stored = await getPreference<unknown>(STORAGE_KEY);
-  // A mutator may have raced in while we awaited storage; honour the live state
-  // over the (now stale) persisted value.
-  if (hasLoaded) return current;
-  current = isOverridesRecord(stored) ? stored : EMPTY_OVERRIDES;
+  // A mutator may have set an override while we awaited storage. Merge rather
+  // than replace: the persisted bag is the base, any keys a racing mutator wrote
+  // win on top. Replacing here would drop the persisted overrides if a mutator
+  // fired during boot (before this read resolved). `current` is EMPTY in the
+  // common no-race path, so the merge is just the stored bag.
+  const raced = Object.keys(current).length > 0;
+  current = { ...(isOverridesRecord(stored) ? stored : EMPTY_OVERRIDES), ...current };
   hasLoaded = true;
   notify();
+  // The racing mutator's persist() only wrote its own keys; re-persist the
+  // merged bag so the persisted flags it didn't know about survive the next
+  // cold boot.
+  if (raced) void persist();
   return current;
 }
 
@@ -77,13 +84,14 @@ export function clearFeatureFlagOverride(key: string): void {
 }
 
 export function clearAllFeatureFlagOverrides(): void {
-  // Nothing in memory to clear — return without churning storage with an empty
-  // write. The one-time load (if still pending) settles `loaded` on its own.
+  // Nothing in memory to clear — return without touching storage. The one-time
+  // load (if still pending) settles `loaded` on its own.
   if (Object.keys(current).length === 0) return;
   current = EMPTY_OVERRIDES;
   hasLoaded = true;
   notify();
-  void persist();
+  // Remove the key rather than writing `{}` — cleaner than leaving an empty bag.
+  void removePreference(STORAGE_KEY);
 }
 
 let loadPromise: Promise<FeatureFlagOverrides> | null = null;
@@ -149,6 +157,10 @@ export function useFeatureFlagOverrides(): {
 // FeatureFlagsProvider — resetting modules there would bind the provider and
 // these mutators to different module instances, so it needs an explicit reset.
 export function resetFeatureFlagOverridesForTests(): void {
+  // Guard on the test env so the body is dead code in release builds (Metro
+  // inlines NODE_ENV, so the reset logic gets stripped from the bundle). Vitest
+  // sets NODE_ENV=test, where this runs normally.
+  if (process.env.NODE_ENV !== 'test') return;
   current = EMPTY_OVERRIDES;
   hasLoaded = false;
   loadPromise = null;

--- a/packages/mobile/src/lib/feature-flag-overrides.ts
+++ b/packages/mobile/src/lib/feature-flag-overrides.ts
@@ -34,6 +34,10 @@ function notify(): void {
   for (const listener of listeners) listener();
 }
 
+// Whole-object validation: if ANY value is non-boolean the entire persisted bag
+// is rejected and load falls back to no overrides. A corrupt write is treated as
+// all-or-nothing rather than salvaging the valid keys — simpler and safer than
+// partially trusting a malformed blob (the tester can just re-set their flags).
 function isOverridesRecord(value: unknown): value is FeatureFlagOverrides {
   if (typeof value !== 'object' || value === null) return false;
   return Object.values(value).every((entry) => typeof entry === 'boolean');

--- a/packages/mobile/src/lib/feature-flag-overrides.ts
+++ b/packages/mobile/src/lib/feature-flag-overrides.ts
@@ -73,11 +73,9 @@ export function clearFeatureFlagOverride(key: string): void {
 }
 
 export function clearAllFeatureFlagOverrides(): void {
-  if (Object.keys(current).length === 0) {
-    // Still mark loaded so a consumer mounted before the first load sees a
-    // settled empty state instead of waiting on storage.
-    if (hasLoaded) return;
-  }
+  // Nothing in memory to clear — return without churning storage with an empty
+  // write. The one-time load (if still pending) settles `loaded` on its own.
+  if (Object.keys(current).length === 0) return;
   current = EMPTY_OVERRIDES;
   hasLoaded = true;
   notify();
@@ -139,4 +137,16 @@ export function useFeatureFlagOverrides(): {
   }, []);
 
   return { overrides, loaded, setOverride, clearOverride, clearAll };
+}
+
+// Test-only: reset the module singleton (state + the one-time load promise) so
+// each test starts clean. The standalone override test gets this isolation from
+// `vi.resetModules()`, but the provider test statically imports
+// FeatureFlagsProvider — resetting modules there would bind the provider and
+// these mutators to different module instances, so it needs an explicit reset.
+export function resetFeatureFlagOverridesForTests(): void {
+  current = EMPTY_OVERRIDES;
+  hasLoaded = false;
+  loadPromise = null;
+  notify();
 }

--- a/packages/mobile/src/lib/feature-flag-overrides.ts
+++ b/packages/mobile/src/lib/feature-flag-overrides.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+// Local, on-device feature-flag overrides — the highest-precedence layer in the
+// FeatureFlagsProvider merge (PostHog < static env < this). A tester flips a
+// flag here from the Feature Flags settings screen and the choice sticks across
+// restarts, so a gated feature can be exercised without a new build or a PostHog
+// rollout change.
+//
+// Structure mirrors `session-recording-preference.ts`: a module-level store read
+// via `useSyncExternalStore` with a referentially-stable cached snapshot
+// (rebuilt only inside `notify()` so the provider's `useMemo` doesn't thrash),
+// plus a promise-singleton one-time load so any number of mounted consumers
+// trigger the AsyncStorage read exactly once. Difference: the value is a
+// `Record<string, boolean>` (flag key -> forced value) rather than a single
+// boolean. A key being absent means "no override" — fall back to the next layer.
+const STORAGE_KEY = 'featureFlagOverrides';
+
+export type FeatureFlagOverrides = Record<string, boolean>;
+
+type OverridesSnapshot = { overrides: FeatureFlagOverrides; loaded: boolean };
+
+const EMPTY_OVERRIDES: FeatureFlagOverrides = {};
+
+let current: FeatureFlagOverrides = EMPTY_OVERRIDES;
+let hasLoaded = false;
+let snapshot: OverridesSnapshot = { overrides: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: OverridesSnapshot = { overrides: EMPTY_OVERRIDES, loaded: false };
+
+function notify(): void {
+  snapshot = { overrides: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+function isOverridesRecord(value: unknown): value is FeatureFlagOverrides {
+  if (typeof value !== 'object' || value === null) return false;
+  return Object.values(value).every((entry) => typeof entry === 'boolean');
+}
+
+export async function loadFeatureFlagOverrides(): Promise<FeatureFlagOverrides> {
+  if (hasLoaded) return current;
+  const stored = await getPreference<unknown>(STORAGE_KEY);
+  // A mutator may have raced in while we awaited storage; honour the live state
+  // over the (now stale) persisted value.
+  if (hasLoaded) return current;
+  current = isOverridesRecord(stored) ? stored : EMPTY_OVERRIDES;
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+async function persist(): Promise<void> {
+  await setPreference(STORAGE_KEY, current);
+}
+
+export function setFeatureFlagOverride(key: string, value: boolean): void {
+  current = { ...current, [key]: value };
+  hasLoaded = true;
+  notify();
+  void persist();
+}
+
+export function clearFeatureFlagOverride(key: string): void {
+  if (!(key in current)) return;
+  const next = { ...current };
+  delete next[key];
+  current = next;
+  hasLoaded = true;
+  notify();
+  void persist();
+}
+
+export function clearAllFeatureFlagOverrides(): void {
+  if (Object.keys(current).length === 0) {
+    // Still mark loaded so a consumer mounted before the first load sees a
+    // settled empty state instead of waiting on storage.
+    if (hasLoaded) return;
+  }
+  current = EMPTY_OVERRIDES;
+  hasLoaded = true;
+  notify();
+  void persist();
+}
+
+let loadPromise: Promise<FeatureFlagOverrides> | null = null;
+function ensureLoaded(): Promise<FeatureFlagOverrides> {
+  if (!loadPromise) {
+    loadPromise = loadFeatureFlagOverrides().catch((error: unknown) => {
+      // A failed read must not leave a rejected promise cached — clear the
+      // singleton so the next mount retries instead of staying stuck at the
+      // default until the app restarts.
+      loadPromise = null;
+      throw error;
+    });
+  }
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): OverridesSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): OverridesSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useFeatureFlagOverrides(): {
+  overrides: FeatureFlagOverrides;
+  loaded: boolean;
+  setOverride: (key: string, value: boolean) => void;
+  clearOverride: (key: string) => void;
+  clearAll: () => void;
+} {
+  const { overrides, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    // Swallow read failures here — the load already clears its cached promise so
+    // a later mount retries; nothing to do at this call site.
+    ensureLoaded().catch(() => {});
+  }, []);
+
+  const setOverride = useCallback((key: string, value: boolean) => {
+    setFeatureFlagOverride(key, value);
+  }, []);
+  const clearOverride = useCallback((key: string) => {
+    clearFeatureFlagOverride(key);
+  }, []);
+  const clearAll = useCallback(() => {
+    clearAllFeatureFlagOverrides();
+  }, []);
+
+  return { overrides, loaded, setOverride, clearOverride, clearAll };
+}

--- a/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
@@ -2,15 +2,16 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { FeatureFlagsProvider, useFeatureFlag, useFeatureFlags } from '../feature-flags-provider';
 import {
   setFeatureFlagOverride,
-  clearAllFeatureFlagOverrides,
+  resetFeatureFlagOverridesForTests,
   useFeatureFlagOverrides,
 } from '../../lib/feature-flag-overrides';
 
 vi.mock('@react-native-async-storage/async-storage', () => {
-  const storage: Record<string, string> = {};
+  let storage: Record<string, string> = {};
   return {
     default: {
       getItem: vi.fn(async (key: string) => storage[key] ?? null),
@@ -20,14 +21,20 @@ vi.mock('@react-native-async-storage/async-storage', () => {
       removeItem: vi.fn(async (key: string) => {
         delete storage[key];
       }),
+      __reset: () => {
+        storage = {};
+      },
     },
   };
 });
 
 describe('FeatureFlagsProvider', () => {
   afterEach(() => {
-    // The override store is a module-level singleton; reset it between tests.
-    clearAllFeatureFlagOverrides();
+    // The override store is a module-level singleton; fully reset it (state +
+    // cached load promise) AND the persisted mock storage so a value written by
+    // one test can't async-load into the next.
+    resetFeatureFlagOverridesForTests();
+    (AsyncStorage as unknown as { __reset: () => void }).__reset();
   });
 
   it('returns the empty default bag when no `flags` prop is supplied', () => {

--- a/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
@@ -1,10 +1,31 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { FeatureFlagsProvider, useFeatureFlag, useFeatureFlags } from '../feature-flags-provider';
+import { setFeatureFlagOverride, clearAllFeatureFlagOverrides } from '../../lib/feature-flag-overrides';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  const storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+    },
+  };
+});
 
 describe('FeatureFlagsProvider', () => {
+  afterEach(() => {
+    // The override store is a module-level singleton; reset it between tests.
+    clearAllFeatureFlagOverrides();
+  });
+
   it('returns the empty default bag when no `flags` prop is supplied', () => {
     const wrapper = ({ children }: { children: ReactNode }) => <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
     const { result } = renderHook(() => useFeatureFlags(), { wrapper });
@@ -37,5 +58,23 @@ describe('FeatureFlagsProvider', () => {
     // No wrapper — useContext sees the createContext default value.
     const { result } = renderHook(() => useFeatureFlags());
     expect(result.current).toEqual({});
+  });
+
+  it('a local override wins over the static `flags` prop', () => {
+    // Set before render so the first snapshot already carries the override (no
+    // act() warning from a post-mount store mutation).
+    setFeatureFlagOverride('heroImage', false);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FeatureFlagsProvider flags={{ heroImage: true }}>{children}</FeatureFlagsProvider>
+    );
+    const { result } = renderHook(() => useFeatureFlag('heroImage'), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  it('a local override surfaces a flag absent from PostHog and the `flags` prop', () => {
+    setFeatureFlagOverride('strava-integration', true);
+    const wrapper = ({ children }: { children: ReactNode }) => <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
+    const { result } = renderHook(() => useFeatureFlag('strava-integration'), { wrapper });
+    expect(result.current).toBe(true);
   });
 });

--- a/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { FeatureFlagsProvider, useFeatureFlag, useFeatureFlags } from '../feature-flags-provider';
-import { setFeatureFlagOverride, clearAllFeatureFlagOverrides } from '../../lib/feature-flag-overrides';
+import {
+  setFeatureFlagOverride,
+  clearAllFeatureFlagOverrides,
+  useFeatureFlagOverrides,
+} from '../../lib/feature-flag-overrides';
 
 vi.mock('@react-native-async-storage/async-storage', () => {
   const storage: Record<string, string> = {};
@@ -76,5 +80,22 @@ describe('FeatureFlagsProvider', () => {
     const wrapper = ({ children }: { children: ReactNode }) => <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
     const { result } = renderHook(() => useFeatureFlag('strava-integration'), { wrapper });
     expect(result.current).toBe(true);
+  });
+
+  it('useFeatureFlagOverrides re-renders consumers when an override changes post-mount', () => {
+    const { result } = renderHook(() => useFeatureFlagOverrides());
+    expect(result.current.overrides).toEqual({});
+
+    // Mutating the module store outside React must push through the
+    // useSyncExternalStore subscription and re-render the hook.
+    act(() => {
+      result.current.setOverride('strava-integration', false);
+    });
+    expect(result.current.overrides).toEqual({ 'strava-integration': false });
+
+    act(() => {
+      result.current.clearOverride('strava-integration');
+    });
+    expect(result.current.overrides).toEqual({});
   });
 });

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -11,11 +11,31 @@
 
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { readPosthogFeatureFlags, subscribePosthogFeatureFlags } from '../lib/analytics';
+import { useFeatureFlagOverrides } from '../lib/feature-flag-overrides';
 
 export type FeatureFlags = Record<string, boolean | undefined>;
 
 const DEFAULT_FEATURE_FLAGS: FeatureFlags = {};
-const FEATURE_FLAG_KEYS = ['strava-integration'] as const;
+
+// The catalog of flags the app knows about. It drives the live PostHog read and
+// the tester-only Feature Flags settings screen (which lists every entry here).
+// Add a flag once, here, and it shows up in both. Labels/descriptions are
+// tester-facing English only — this never reaches a non-tester surface.
+export type FeatureFlagDefinition = {
+  key: string;
+  label: string;
+  description: string;
+};
+
+export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
+  {
+    key: 'strava-integration',
+    label: 'Strava integration',
+    description: 'Share sends to Strava and the Strava connect option in Integrations.',
+  },
+] as const;
+
+export const FEATURE_FLAG_KEYS = FEATURE_FLAG_DEFINITIONS.map((definition) => definition.key);
 
 const FeatureFlagsContext = createContext<FeatureFlags>(DEFAULT_FEATURE_FLAGS);
 
@@ -27,6 +47,7 @@ export function FeatureFlagsProvider({
   children: ReactNode;
 }) {
   const [posthogFlags, setPosthogFlags] = useState<FeatureFlags>(DEFAULT_FEATURE_FLAGS);
+  const { overrides } = useFeatureFlagOverrides();
 
   useEffect(() => {
     let mounted = true;
@@ -45,11 +66,14 @@ export function FeatureFlagsProvider({
   }, []);
 
   const value = useMemo<FeatureFlags>(() => {
-    if (posthogFlags === DEFAULT_FEATURE_FLAGS && flags === DEFAULT_FEATURE_FLAGS) {
+    const hasOverrides = Object.keys(overrides).length > 0;
+    if (posthogFlags === DEFAULT_FEATURE_FLAGS && flags === DEFAULT_FEATURE_FLAGS && !hasOverrides) {
       return DEFAULT_FEATURE_FLAGS;
     }
-    return { ...posthogFlags, ...flags };
-  }, [posthogFlags, flags]);
+    // Local tester overrides win over the static env override, which wins over
+    // the live PostHog value.
+    return { ...posthogFlags, ...flags, ...overrides };
+  }, [posthogFlags, flags, overrides]);
 
   return <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;
 }

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -27,15 +27,22 @@ export type FeatureFlagDefinition = {
   description: string;
 };
 
-export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
+export const FEATURE_FLAG_DEFINITIONS = [
   {
     key: 'strava-integration',
     label: 'Strava integration',
     description: 'Share sends to Strava and the Strava connect option in Integrations.',
   },
-] as const;
+] as const satisfies readonly FeatureFlagDefinition[];
 
-export const FEATURE_FLAG_KEYS = FEATURE_FLAG_DEFINITIONS.map((definition) => definition.key);
+// The literal key union (e.g. `'strava-integration'`), preserved via the
+// `as const` above so a typo in a catalog key is a compile error instead of
+// silently widening to `string`.
+export type FeatureFlagKey = (typeof FEATURE_FLAG_DEFINITIONS)[number]['key'];
+
+export const FEATURE_FLAG_KEYS: readonly FeatureFlagKey[] = FEATURE_FLAG_DEFINITIONS.map(
+  (definition) => definition.key,
+);
 
 const FeatureFlagsContext = createContext<FeatureFlags>(DEFAULT_FEATURE_FLAGS);
 


### PR DESCRIPTION
## Summary

Adds a tester-only **Feature Flags** screen to mobile Settings (More → Development → Feature Flags) that lets an admin/tester force any known flag **On**, **Off**, or back to its remote **Default** directly on a device.

Until now the mobile app resolved flags only from PostHog (live) and build-time `EXPO_PUBLIC_*` env vars — so testing a gated feature like `strava-integration` meant cutting a new build or changing a PostHog rollout. This adds a local override layer at the top of the merge:

`PostHog < static env < local tester override`

Overrides persist on-device (AsyncStorage) and survive restarts.

### What's in here
- **Override store** (`feature-flag-overrides.ts`) — AsyncStorage-backed, reactive via `useSyncExternalStore`, mirroring the proven `session-recording-preference.ts` pattern (referentially-stable snapshot, promise-singleton one-time load, write-through mutators).
- **Provider wiring** — `FeatureFlagsProvider` folds overrides into its merge with top precedence, and now exports a `FEATURE_FLAG_DEFINITIONS` catalog (key/label/description) that drives both the PostHog read and the new screen. Add a flag once, there.
- **Screen** (`FeatureFlagsScreen.tsx`) — per-flag Default/On/Off `SegmentedControl` with a live-default + effective-value footnote, plus a "Reset all overrides" action. Styled after `ChannelSwitcherScreen`; tester-only copy is hardcoded English with `i18n-ignore`.
- **Entry point** — a gated `ListRow` in the Development section, shown for `__DEV__ || profile.isTester` (reusing the same `isTester` gate as the OTA Channel Switcher). The mobile profile has no separate admin flag, so `isTester` covers admins and testers.

## Release Notes

- Testers can now flip feature flags on or off right in the app, no new build needed

## Test plan

- `vp run typecheck:mobile` — passes
- `vp run test:mobile` (feature-flag specs) — 13 passing, covering override precedence and store set/clear/clearAll + persistence round-trip
- `vp run check:mobile-bundle` — Android bundle OK
- `vp check` — clean
- Manual (next): in a dev build, More → Development → Feature Flags → force `strava-integration` On and confirm the Strava integration surfaces; reset to Default and confirm it reverts; relaunch and confirm the override persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HGobXfk42HbHjru8yJNBk

---
_Generated by [Claude Code](https://claude.ai/code/session_019HGobXfk42HbHjru8yJNBk)_