### PR TITLE
feat(mobile): gate logbook search + filters behind a feature flag

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -85,6 +85,10 @@ function buildStaticFeatureFlags(): FeatureFlags | undefined {
     flags['strava-integration'] = true;
   }
 
+  if (process.env.EXPO_PUBLIC_LOGBOOK_FILTERS === 'true') {
+    flags['logbook-filters'] = true;
+  }
+
   return Object.keys(flags).length > 0 ? flags : undefined;
 }
 

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { BottomSheet } from '@expo/ui/community/bottom-sheet';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations';
-import { toAscentFeedInput } from '@boardsesh/logbook';
+import { toAscentFeedInput, DEFAULT_LOGBOOK_FILTERS, DEFAULT_LOGBOOK_SORT } from '@boardsesh/logbook';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../lib/analytics';
 import { Text } from '../Text';
@@ -98,11 +98,24 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
 
   // The query input is rebuilt only when the committed filters/sort/name change,
   // so the React Query key (and the FlashList data identity downstream) is stable
-  // between unrelated re-renders.
-  const feedInput = useMemo(() => toAscentFeedInput({ filters, sort, name }), [filters, sort, name]);
+  // between unrelated re-renders. When the flag is off the toolbar is hidden, so
+  // ignore any persisted filter/sort/name and feed defaults — otherwise prefs
+  // saved during a prior flag-on session would silently narrow the list.
+  const feedInput = useMemo(
+    () =>
+      toAscentFeedInput(
+        logbookFiltersEnabled
+          ? { filters, sort, name }
+          : { filters: DEFAULT_LOGBOOK_FILTERS, sort: DEFAULT_LOGBOOK_SORT, name: '' },
+      ),
+    [logbookFiltersEnabled, filters, sort, name],
+  );
 
   // Gate on `hydrated` so the feed fetches once with the restored prefs rather
-  // than once with defaults then again after persistence loads.
+  // than once with defaults then again after persistence loads. (With the flag
+  // off `feedInput` already ignores persisted prefs, so this just fetches the
+  // defaults once hydration settles. Keeping the gate while the flag is still
+  // resolving avoids an early default fetch for the flag-on cohort.)
   const feed = useUserAscentsFeed(userId, feedInput, { enabled: hydrated });
   // Stabilise the FlashList `data` identity so it doesn't re-diff every render.
   const items = useMemo(() => feed.data?.pages.flatMap((page) => page.userAscentsFeed.items) ?? [], [feed.data]);

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -51,7 +51,7 @@ type LogbookTabProps = {
 export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenTitle }: LogbookTabProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
-  // The search + filter UI is unfinished; keep it dark until the flag is on.
+  // Temporary kill switch while the search + filter UI is unfinished.
   const logbookFiltersEnabled = useFeatureFlag('logbook-filters') === true;
   const router = useRouter();
   const { openPlayDrawer, openClimbActions } = useDrawerHost();

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -23,6 +23,7 @@ import { tickToClimb } from '../../lib/tick-to-climb';
 import { getBoardConfigForPlaylist } from '../../lib/playlists/board-details-for-playlist';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { normalizeSearchName } from '../../lib/search-name';
 import { hapticSelection } from '../../lib/haptics';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -50,6 +51,8 @@ type LogbookTabProps = {
 export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenTitle }: LogbookTabProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
+  // The search + filter UI is unfinished; keep it dark until the flag is on.
+  const logbookFiltersEnabled = useFeatureFlag('logbook-filters') === true;
   const router = useRouter();
   const { openPlayDrawer, openClimbActions } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
@@ -186,34 +189,36 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
           floating chrome. Sibling of the list, so list virtualization is intact. */}
       <View style={[styles.toolbar, { paddingTop: topInset }]}>
         {screenTitle ? <ScreenTitle style={styles.screenTitle}>{screenTitle}</ScreenTitle> : null}
-        <View style={styles.toolbarRow}>
-          <SearchHeader
-            ref={searchHeaderRef}
-            placeholder={t('mobile.logbook.searchPlaceholder')}
-            onChangeText={handleSearchChange}
-            initialValue={name}
-            height={40}
-          />
-          <Pressable
-            onPress={handleOpenFilters}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.logbook.filter')}
-            style={({ pressed }) => [
-              styles.filterButton,
-              { backgroundColor: brandColors.accent },
-              pressed && styles.filterButtonPressed,
-            ]}
-          >
-            <Icon name="filter" size={18} color={iosSystemColors.black} />
-            {activeFilterCount > 0 ? (
-              <View style={[styles.filterBadge, { backgroundColor: iosSystemColors.black }]}>
-                <Text variant="caption2" color={brandColors.accent} style={styles.filterBadgeText}>
-                  {activeFilterCount}
-                </Text>
-              </View>
-            ) : null}
-          </Pressable>
-        </View>
+        {logbookFiltersEnabled ? (
+          <View style={styles.toolbarRow}>
+            <SearchHeader
+              ref={searchHeaderRef}
+              placeholder={t('mobile.logbook.searchPlaceholder')}
+              onChangeText={handleSearchChange}
+              initialValue={name}
+              height={40}
+            />
+            <Pressable
+              onPress={handleOpenFilters}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.logbook.filter')}
+              style={({ pressed }) => [
+                styles.filterButton,
+                { backgroundColor: brandColors.accent },
+                pressed && styles.filterButtonPressed,
+              ]}
+            >
+              <Icon name="filter" size={18} color={iosSystemColors.black} />
+              {activeFilterCount > 0 ? (
+                <View style={[styles.filterBadge, { backgroundColor: iosSystemColors.black }]}>
+                  <Text variant="caption2" color={brandColors.accent} style={styles.filterBadgeText}>
+                    {activeFilterCount}
+                  </Text>
+                </View>
+              ) : null}
+            </Pressable>
+          </View>
+        ) : null}
       </View>
 
       {feed.isPending ? (
@@ -280,7 +285,7 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
         <LogbookEditSheet sheetRef={editSheetRef} ascent={editAscent} onClose={() => setEditAscent(null)} />
       ) : null}
 
-      {filterSheetOpen ? (
+      {logbookFiltersEnabled && filterSheetOpen ? (
         <LogbookFilterSheet
           onDismiss={handleCloseFilters}
           currentFilters={filters}

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
@@ -16,6 +16,10 @@ const captured = vi.hoisted(() => ({
   sheetMounted: false,
 }));
 
+// Drives the `logbook-filters` feature flag the toolbar is gated on. Defaults on
+// so the toolbar tests below exercise the real wiring; one test flips it off.
+const flagState = vi.hoisted(() => ({ logbookFilters: true }));
+
 const feed = vi.hoisted(() => ({
   data: { pages: [{ userAscentsFeed: { items: [] } }] },
   isPending: false,
@@ -111,6 +115,9 @@ vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
 vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: vi.fn(), openClimbActions: vi.fn() }),
 }));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useFeatureFlag: (key: string) => (key === 'logbook-filters' ? flagState.logbookFilters : undefined),
+}));
 
 // use-logbook-search and @boardsesh/logbook are intentionally NOT mocked, so the
 // reducer + toAscentFeedInput run for real and the test asserts the real wiring.
@@ -123,6 +130,7 @@ beforeEach(() => {
   captured.onSearchChange = null;
   captured.onApply = null;
   captured.sheetMounted = false;
+  flagState.logbookFilters = true;
 });
 
 afterEach(() => {
@@ -194,5 +202,16 @@ describe('LogbookTab toolbar', () => {
     act(() => captured.onApply?.(filters, { ...DEFAULT_LOGBOOK_SORT, mode: 'preset', preset: 'hardest' }));
 
     expect(captured.feedInput).toMatchObject({ statusMode: 'attempt', sortBy: 'hardest' });
+  });
+
+  it('hides the search + filter toolbar and never mounts the sheet when the flag is off', () => {
+    flagState.logbookFilters = false;
+    const { queryByTestId, queryByLabelText } = render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    expect(queryByTestId('search-header')).toBeNull();
+    expect(queryByLabelText('mobile.logbook.filter')).toBeNull();
+    expect(captured.sheetMounted).toBe(false);
+    // The feed still runs, falling back to the default Latest sort.
+    expect(captured.feedInput).toMatchObject({ sortBy: 'recent', sortOrder: 'desc' });
   });
 });

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
@@ -213,4 +213,24 @@ describe('LogbookTab toolbar', () => {
     // The feed still runs, falling back to the default Latest sort.
     expect(captured.feedInput).toMatchObject({ sortBy: 'recent', sortOrder: 'desc' });
   });
+
+  it('ignores persisted filters/sort when the flag is off so the feed is not silently narrowed', async () => {
+    // Simulate prefs saved during a prior flag-on session.
+    vi.mocked(loadLogbookPrefs).mockResolvedValueOnce({
+      filters: { ...DEFAULT_LOGBOOK_FILTERS, includeSends: false, includeAttempts: true },
+      sort: { ...DEFAULT_LOGBOOK_SORT, mode: 'preset', preset: 'hardest' },
+    });
+    flagState.logbookFilters = false;
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    // Let the attempts-only/Hardest prefs hydrate into state.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The feed input stays on the defaults rather than the persisted narrowing.
+    expect(captured.feedInput).toMatchObject({ sortBy: 'recent', sortOrder: 'desc' });
+    expect(captured.feedInput).not.toHaveProperty('statusMode', 'attempt');
+  });
 });

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
@@ -16,8 +16,7 @@ const captured = vi.hoisted(() => ({
   sheetMounted: false,
 }));
 
-// Drives the `logbook-filters` feature flag the toolbar is gated on. Defaults on
-// so the toolbar tests below exercise the real wiring; one test flips it off.
+// Drives the `logbook-filters` flag; defaults on so the toolbar tests run.
 const flagState = vi.hoisted(() => ({ logbookFilters: true }));
 
 const feed = vi.hoisted(() => ({

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -16,7 +16,6 @@ import { useFeatureFlagOverrides } from '../lib/feature-flag-overrides';
 export type FeatureFlags = Record<string, boolean | undefined>;
 
 const DEFAULT_FEATURE_FLAGS: FeatureFlags = {};
-
 // The catalog of flags the app knows about. It drives the live PostHog read and
 // the tester-only Feature Flags settings screen (which lists every entry here).
 // Add a flag once, here, and it shows up in both. Labels/descriptions are
@@ -32,6 +31,11 @@ export const FEATURE_FLAG_DEFINITIONS = [
     key: 'strava-integration',
     label: 'Strava integration',
     description: 'Share sends to Strava and the Strava connect option in Integrations.',
+  },
+  {
+    key: 'logbook-filters',
+    label: 'Logbook filters',
+    description: 'Search box and filter sheet on the logbook (unfinished UI).',
   },
 ] as const satisfies readonly FeatureFlagDefinition[];
 


### PR DESCRIPTION
## Summary

The mobile logbook recently gained a search box and an amber filter sheet (status / flash / grade / angle / date / benchmark filters and a Latest/Hardest sort). The UI isn't finished, so this hides the whole search + filter toolbar behind a `logbook-filters` feature flag and ships it dark — no code ripped out.

- Registers `logbook-filters` in `FEATURE_FLAG_KEYS` (`feature-flags-provider.tsx`), reusing the existing PostHog-backed flag system.
- Adds an `EXPO_PUBLIC_LOGBOOK_FILTERS=true` build-time override in `_layout.tsx`, mirroring the `strava-integration` precedent, so the flag can be flipped on in a dev/preview build without PostHog.
- Gates the search box + filter button (and the filter sheet mount) in `LogbookTab` on the flag.

When the flag is **off** (the default), the logbook renders as a plain unfiltered list with the default Latest sort; the search box and filter button are gone and the sheet can never open. The outer toolbar container and screen title stay put, so the existing `topInset` / floating-chrome spacing is unchanged. Persisted filter prefs from prior flag-on sessions remain on disk but are inert while off.

## Release Notes

- Logbook search and filters are tucked away while we put the finishing touches on them

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2628 passed (355 files), including a new test asserting the toolbar is hidden and the sheet never mounts when the flag is off, with the existing toolbar tests updated to drive the flag on
- `vp lint` / `vp fmt --check` on the changed files — clean
- `vp run check:mobile-bundle` — OK (12.2 MB Android bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXYqUZCEo2isJqv8gm6CB4)_