### PR TITLE
fix(mobile): logbook filter sheet close + grade rail + collapsed sections

### DIFF
--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -73,6 +73,12 @@ type GradeRangeRailProps = {
   grades: readonly Grade[];
   bound: GradeBound;
   sendDifficultyIds?: readonly number[];
+  /**
+   * Auto-center the rail on mount when there is no grade selection. True (the
+   * default) surfaces the climber's typical grades; the logbook filter passes
+   * false so an unset rail opens at the easiest grade instead of mid-scrolled.
+   */
+  centerOnEmpty?: boolean;
   onChange: (next: GradeBound) => void;
   /**
    * Asked to dismiss itself (swipe the handle down, completed range, or cleared
@@ -89,6 +95,7 @@ export function GradeRangeRail({
   grades: unsortedGrades,
   bound,
   sendDifficultyIds = [],
+  centerOnEmpty = true,
   onChange,
   onRequestClose,
   dismissible = true,
@@ -111,7 +118,12 @@ export function GradeRangeRail({
 
   const grades = useMemo(() => sortedGrades(unsortedGrades), [unsortedGrades]);
   const gradeIds = useMemo(() => grades.map((grade) => grade.difficultyId), [grades]);
-  const centerId = useMemo(() => gradeRailCenter(bound, grades, sendDifficultyIds), [bound, grades, sendDifficultyIds]);
+  const centerId = useMemo(() => {
+    // With centering-on-empty off (the logbook filter), only auto-center when a
+    // grade is actually selected; otherwise open at the start, not mid-scrolled.
+    if (!centerOnEmpty && bound.minGradeId == null && bound.maxGradeId == null) return undefined;
+    return gradeRailCenter(bound, grades, sendDifficultyIds);
+  }, [centerOnEmpty, bound, grades, sendDifficultyIds]);
 
   const clearDismissTimer = useCallback(() => {
     if (dismissTimerRef.current) {

--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -280,6 +280,7 @@ export function LogbookFilterSheet({
       index={0}
       snapPoints={snapPoints}
       enableDynamicSizing={false}
+      enablePanDownToClose
       onDismiss={onDismiss}
       handleIndicatorStyle={styles.indicator}
     >
@@ -315,12 +316,7 @@ export function LogbookFilterSheet({
 
         <View style={styles.sectionsContainer}>
           {/* REFINE — status / flash / grade / angle. */}
-          <CollapsibleSection
-            title={t('mobile.logbook.refine')}
-            defaultExpanded
-            summary={refineSummary}
-            resetKey={sectionResetKey}
-          >
+          <CollapsibleSection title={t('mobile.logbook.refine')} summary={refineSummary} resetKey={sectionResetKey}>
             <Text variant="footnote" style={styles.subsectionLabel}>
               {t('mobile.logbook.statusLabel')}
             </Text>
@@ -350,6 +346,7 @@ export function LogbookFilterSheet({
               onChange={handleGradeChange}
               dismissible={false}
               showTitle
+              centerOnEmpty={false}
               style={styles.inlineGradeRail}
             />
 

--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -142,7 +142,7 @@ export function LogbookFilterSheet({
 }: LogbookFilterSheetProps) {
   const { t } = useTranslation('you');
   const theme = useTheme();
-  const { systemColors, brandColors } = theme;
+  const { systemColors } = theme;
   const insets = useSafeAreaInsets();
   const sheetRef = useRef<BottomSheetModal>(null);
   const scrollRef = useRef<ComponentRef<typeof BottomSheetScrollView>>(null);
@@ -197,10 +197,18 @@ export function LogbookFilterSheet({
     [updateFilters],
   );
 
-  const handleApply = useCallback(() => {
-    onApply(draftFilters, draftSort);
-    sheetRef.current?.dismiss();
-  }, [draftFilters, draftSort, onApply]);
+  // Commit-on-close: there's no Apply button — the draft applies when the sheet
+  // is dismissed (swipe down or tap the scrim). The ref holds the latest draft so
+  // the stable dismiss handler commits the newest values, never a stale closure.
+  const draftRef = useRef({ filters: draftFilters, sort: draftSort });
+  useEffect(() => {
+    draftRef.current = { filters: draftFilters, sort: draftSort };
+  }, [draftFilters, draftSort]);
+
+  const handleDismiss = useCallback(() => {
+    onApply(draftRef.current.filters, draftRef.current.sort);
+    onDismiss();
+  }, [onApply, onDismiss]);
 
   const handleReset = useCallback(() => {
     hapticSelection();
@@ -281,7 +289,7 @@ export function LogbookFilterSheet({
       snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose
-      onDismiss={onDismiss}
+      onDismiss={handleDismiss}
       handleIndicatorStyle={styles.indicator}
     >
       <View style={styles.header}>
@@ -297,7 +305,7 @@ export function LogbookFilterSheet({
         ref={scrollRef}
         style={styles.scrollView}
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + spacing[4] }]}
       >
         {/* PRESET — the headline one-tap sort. Above Refine/Advanced. */}
         <View style={styles.primary}>
@@ -414,26 +422,6 @@ export function LogbookFilterSheet({
           </CollapsibleSection>
         </View>
       </BottomSheetScrollView>
-
-      <View
-        style={[styles.footer, { paddingBottom: insets.bottom + spacing[3], borderTopColor: systemColors.separator }]}
-      >
-        {/* Amber Apply — the logbook-mode accent (fill + dark text, ~8.95:1). */}
-        <Pressable
-          onPress={handleApply}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.logbook.apply')}
-          style={({ pressed }) => [
-            styles.applyButton,
-            { backgroundColor: brandColors.accent },
-            pressed && styles.applyButtonPressed,
-          ]}
-        >
-          <Text variant="headline" color={iosSystemColors.black}>
-            {t('mobile.logbook.apply')}
-          </Text>
-        </Pressable>
-      </View>
     </BottomSheetModal>
   );
 }
@@ -631,22 +619,5 @@ const styles = StyleSheet.create({
   },
   dateButtonPressed: {
     opacity: 0.6,
-  },
-  footer: {
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[3],
-    paddingBottom: spacing[3],
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: iosSystemColors.separator,
-  },
-  applyButton: {
-    width: '100%',
-    minHeight: 50,
-    borderRadius: borderRadius.lg,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  applyButtonPressed: {
-    opacity: 0.85,
   },
 });

--- a/packages/mobile/src/components/you/__tests__/logbook-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-filter-sheet.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { createElement, type ReactNode } from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_LOGBOOK_FILTERS,
@@ -41,10 +41,15 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
-// BottomSheetModal auto-presents via an effect and is dismissed on Apply; the
-// imperative ref just needs present/dismiss to exist. Children render inline.
+// The sheet commits the draft on close (there's no Apply button), so capture the
+// onDismiss handler it hands BottomSheetModal — a test fires it to simulate the
+// swipe/scrim close. Children render inline.
+const sheetMock = vi.hoisted(() => ({ onDismiss: undefined as (() => void) | undefined }));
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  BottomSheetModal: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  BottomSheetModal: ({ children, onDismiss }: { children?: ReactNode; onDismiss?: () => void }) => {
+    sheetMock.onDismiss = onDismiss;
+    return createElement('div', null, children);
+  },
   BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 
@@ -168,6 +173,11 @@ function lastApply(onApply: ReturnType<typeof vi.fn>): {
   return { filters, sort };
 }
 
+// Close the sheet (swipe/scrim) — this is what commits the draft via onApply.
+function closeSheet() {
+  act(() => sheetMock.onDismiss?.());
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   nativePlatform.OS = 'ios';
@@ -179,10 +189,10 @@ describe('LogbookFilterSheet', () => {
   // sort with mode 'preset' / preset 'hardest'.
   it('applies the hardest preset sort', () => {
     const onApply = vi.fn();
-    const { getByTestId, getByLabelText } = renderSheet({ onApply });
+    const { getByTestId } = renderSheet({ onApply });
 
     fireEvent.click(getByTestId('segment-mobile.logbook.sort-hardest'));
-    fireEvent.click(getByLabelText('mobile.logbook.apply'));
+    closeSheet();
 
     const { sort } = lastApply(onApply);
     expect(sort.mode).toBe('preset');
@@ -193,13 +203,13 @@ describe('LogbookFilterSheet', () => {
   // drops includeSends AND auto-clears the now-hidden flashOnly flag.
   it('auto-clears flashOnly when sends are deselected', () => {
     const onApply = vi.fn();
-    const { getByTestId, getByLabelText } = renderSheet({
+    const { getByTestId } = renderSheet({
       onApply,
       currentFilters: { ...DEFAULT_LOGBOOK_FILTERS, includeSends: true, includeAttempts: true, flashOnly: true },
     });
 
     fireEvent.click(getByTestId('segment-mobile.logbook.statusLabel-attempts'));
-    fireEvent.click(getByLabelText('mobile.logbook.apply'));
+    closeSheet();
 
     const { filters } = lastApply(onApply);
     expect(filters.includeSends).toBe(false);
@@ -213,7 +223,7 @@ describe('LogbookFilterSheet', () => {
   it('resets to defaults and clears the search', () => {
     const onApply = vi.fn();
     const onClearSearch = vi.fn();
-    const { getByText, getByLabelText, getByTestId } = renderSheet({
+    const { getByText, getByTestId } = renderSheet({
       onApply,
       onClearSearch,
       // Start dirty so a no-op Reset would be observable as a failure.
@@ -227,7 +237,7 @@ describe('LogbookFilterSheet', () => {
     fireEvent.click(getByText('mobile.logbook.reset'));
     expect(onClearSearch).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(getByLabelText('mobile.logbook.apply'));
+    closeSheet();
 
     const { filters, sort } = lastApply(onApply);
     expect(filters).toEqual(DEFAULT_LOGBOOK_FILTERS);
@@ -247,7 +257,7 @@ describe('LogbookFilterSheet', () => {
     // by the field label, not an inline date picker.
     expect(getByLabelText('mobile.logbook.dateFrom')).toBeTruthy();
 
-    fireEvent.click(getByLabelText('mobile.logbook.apply'));
+    closeSheet();
 
     const { filters } = lastApply(onApply);
     expect(filters.fromDate).toBe('');
@@ -257,7 +267,7 @@ describe('LogbookFilterSheet', () => {
   // commits nothing until a date is actually picked — Apply leaves fromDate ''.
   it('reveals the From picker without committing a date until one is picked', () => {
     const onApply = vi.fn();
-    const { getByLabelText, getAllByLabelText, getByTestId, queryByTestId } = renderSheet({
+    const { getByLabelText, getByTestId, queryByTestId } = renderSheet({
       onApply,
       currentFilters: { ...DEFAULT_LOGBOOK_FILTERS, fromDate: '' },
     });
@@ -273,10 +283,8 @@ describe('LogbookFilterSheet', () => {
     // After reveal the inline picker exists, but onChange has NOT fired.
     expect(getByTestId('date-picker')).toBeTruthy();
 
-    // Apply without picking a date: fromDate stays ''. Re-resolve the Apply
-    // button (the tree re-rendered after reveal).
-    const applyButtons = getAllByLabelText('mobile.logbook.apply');
-    fireEvent.click(applyButtons[applyButtons.length - 1]);
+    // Close without picking a date: fromDate stays ''.
+    closeSheet();
 
     const { filters } = lastApply(onApply);
     expect(filters.fromDate).toBe('');

--- a/packages/shared/i18n/locales/en-US/you.json
+++ b/packages/shared/i18n/locales/en-US/you.json
@@ -128,7 +128,6 @@
       "dateTo": "To",
       "dateAny": "Any",
       "benchmarksOnly": "Benchmarks only",
-      "apply": "Apply",
       "reset": "Reset",
       "editTitle": "Edit ascent",
       "statusLabel": "Status",

--- a/packages/shared/i18n/locales/es/you.json
+++ b/packages/shared/i18n/locales/es/you.json
@@ -128,7 +128,6 @@
       "dateTo": "Hasta",
       "dateAny": "Cualquiera",
       "benchmarksOnly": "Solo referencias",
-      "apply": "Aplicar",
       "reset": "Restablecer",
       "editTitle": "Editar ascenso",
       "statusLabel": "Estado",

--- a/packages/shared/i18n/locales/fr/you.json
+++ b/packages/shared/i18n/locales/fr/you.json
@@ -128,7 +128,6 @@
       "dateTo": "Au",
       "dateAny": "Toutes",
       "benchmarksOnly": "Références seulement",
-      "apply": "Appliquer",
       "reset": "Réinitialiser",
       "editTitle": "Modifier la croix",
       "statusLabel": "Statut",


### PR DESCRIPTION
Follow-up UX fixes for the mobile logbook filter sheet (shipped in #3179, flag-gated by #3200, migrated to the native sheet in #3197), found while testing on TestFlight.

## What changed
- **Sheet wouldn't close, and applies on close now.** The raw `BottomSheetModal` was missing `enablePanDownToClose` (the `Sheet`/`ModalSheet` wrappers default it on), and the Apply button's footer was being pushed off-screen by the migrated native sheet — so once open there was no way to close *or* apply. Removed the Apply button entirely: filters/sort apply when the sheet is dismissed (swipe down or tap the scrim). A ref commits the latest draft on dismiss, so nothing is lost to a stale closure.
- **Grade rail opened mid-scrolled / looking cropped.** The shared `GradeRangeRail` auto-centers on the climber's grades on mount, which in the logbook (no send-grade seed, no selection) landed mid-rail with a half-cut chip. Added a `centerOnEmpty` prop (default `true`, so climb search is unchanged); the logbook passes `false` and only auto-centers when a grade is actually selected.
- **Refine + Advanced started expanded.** Dropped `defaultExpanded` on Refine so both sections open collapsed (and stay collapsed on Reset).
- Removed the now-dead footer styles, the unused `brandColors`, and the orphaned `mobile.logbook.apply` key across all three locales.

## Testing
- `vp run typecheck:mobile`, lint, format clean
- `vp test run --project mobile logbook` — 42 pass; i18n catalog parity — 92 pass
- `vp run check:mobile-bundle` — iOS + Android bundle clean

## Release Notes
Smoothed out the logbook filter: swipe down or tap outside to close it and your filters and sort apply automatically (no more Apply button), the grade picker opens at the start instead of jumping to the middle, and the Refine and Advanced sections start tucked away so it opens tidy.
