### PR TITLE
chore: add iOS traffic capture proxy tooling

### DIFF
--- a/tools/proxy/README.md
+++ b/tools/proxy/README.md
@@ -1,0 +1,85 @@
+# tools/proxy — iOS traffic capture with mitmproxy
+
+Dev tooling for inspecting the HTTPS traffic of iOS apps (e.g. reverse-engineering
+the Moon Climbing / MoonBoard app's backend). Two modes, pick by what you're capturing.
+
+|                                          | `start.sh` (HTTP proxy)               | `wireguard.sh` (WireGuard)      |
+| ---------------------------------------- | ------------------------------------- | ------------------------------- |
+| Target                                   | iOS **simulator** + Mac browsers      | **Physical phone**              |
+| Intercepts                               | Apps that honor the system HTTP proxy | **Everything**, at the IP layer |
+| Captures Firebase gRPC / WebSocket sync? | ❌ no (SDK ignores the proxy)         | ✅ yes                          |
+| Phone setup                              | Wi-Fi proxy → Mac IP:9090             | Free WireGuard app + scan QR    |
+| Touches Mac system proxy?                | yes (revert with `stop.sh`)           | no                              |
+
+Both share one mitmproxy CA (`~/.mitmproxy/mitmproxy-ca-cert.pem`), generated on first run.
+
+## Prerequisites
+
+```bash
+brew install mitmproxy qrencode
+```
+
+## Mode 1 — HTTP proxy (simulator / browsers)
+
+```bash
+./tools/proxy/start.sh     # installs CA in booted sims, sets Mac Wi-Fi proxy, starts mitmweb
+./tools/proxy/stop.sh      # stops mitmweb AND fully restores the Mac proxy settings
+```
+
+- Web UI: http://localhost:9091 (proxy on :9090).
+- The CA is auto-installed into every **booted** simulator (`simctl keychain … add-root-cert`).
+- For Mac browsers showing TLS errors, trust the CA once:
+  `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem`
+- **Apple services are bypassed** (`*.apple.com`, `*.mzstatic.com`, …) so the App Store/iCloud
+  keep working — they pin certs and would otherwise break.
+- **Limitation:** native SDKs that don't read the system proxy are invisible here. Firebase's
+  **Firestore** (gRPC/HTTP2) and **Realtime Database** (WebSocket) sync layers fall in this bucket —
+  you'll see App Check (`firebaseappcheck.googleapis.com`) but **not** `firestore.googleapis.com`
+  or `*.firebaseio.com`. Use WireGuard mode for those.
+
+Always run `stop.sh` when done, or normal browsing / the App Store may break (an enabled proxy
+pointing at a dead mitmproxy drops all traffic).
+
+## Mode 2 — WireGuard (physical phone, captures everything)
+
+```bash
+./tools/proxy/wireguard.sh start   # builds client config + QR, opens the QR, starts mitmweb
+./tools/proxy/wireguard.sh qr       # re-open the QR for a running instance
+./tools/proxy/wireguard.sh stop     # stop (system proxy is never touched)
+```
+
+Intercepts at the IP layer via mitmproxy's built-in WireGuard server, so proxy-unaware apps
+(Firebase gRPC/WebSocket, etc.) are captured too. No pfctl, no IP forwarding, no extra hardware.
+
+On the iPhone:
+
+1. Install the free **WireGuard** app from the App Store.
+2. `+` → **Create from QR code** → scan the QR the script opened (or import `/tmp/wg-client.conf`).
+3. Toggle the tunnel **ON**.
+4. **Trust the CA** (required, or HTTPS shows cert errors):
+   - With the tunnel on, open `http://mitm.it` in Safari → install the **Apple** profile.
+   - Settings → General → VPN & Device Management → install the mitmproxy profile.
+   - Settings → General → About → **Certificate Trust Settings** → enable **full trust** for mitmproxy.
+5. Watch flows at http://localhost:9091.
+
+Notes:
+
+- The client config's `Endpoint` is auto-set to the Mac's `en0` LAN IP. If the Mac is on a
+  different interface (or the phone can't connect), edit the Endpoint in the WireGuard app to the
+  Mac's reachable IP, port `51820`.
+- `mitmweb` only shows the WireGuard config in its web UI, not the console — so the script briefly
+  runs `mitmdump` against the same keyfile to extract the client config and rewrite the Endpoint.
+- Server key material lives in `~/.mitmproxy/wireguard.conf` (stable across runs → the QR stays valid).
+
+## Decoding captured payloads
+
+- **Realtime Database** (`*.firebaseio.com`): WebSocket frames are JSON — readable directly in the UI.
+- **Firestore** (`firestore.googleapis.com`): gRPC payloads are protobuf. mitmproxy's gRPC/protobuf
+  content viewer shows field numbers + values without schemas; decode against Google's Firestore
+  `.proto` for full field names. Save flows from the web UI for offline decoding.
+
+## Files
+
+- `start.sh` — HTTP-proxy mode (simulator + browsers); sets the Mac Wi-Fi proxy.
+- `stop.sh` — stops HTTP-proxy mitmweb and fully reverts the Mac proxy (host + bypass list + state).
+- `wireguard.sh` — WireGuard mode (physical phone); builds the client config/QR and runs mitmweb.

--- a/tools/proxy/start.sh
+++ b/tools/proxy/start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Start mitmweb and route iOS simulator traffic through it.
+# Run: ./tools/proxy/start.sh
+# Stop: ./tools/proxy/stop.sh
+# Web UI: http://localhost:8081
+
+set -euo pipefail
+
+PROXY_HOST="0.0.0.0"
+PROXY_PORT=9090
+WEB_PORT=9091
+CERT="$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
+PIDFILE="/tmp/mitmweb.pid"
+
+# Ensure cert exists (generated on first run)
+if [[ ! -f "$CERT" ]]; then
+  echo "Generating mitmproxy CA cert..."
+  mitmdump -p "$PROXY_PORT" --listen-host "$PROXY_HOST" &
+  TMP_PID=$!
+  sleep 3
+  kill "$TMP_PID" 2>/dev/null
+  wait "$TMP_PID" 2>/dev/null || true
+fi
+
+# Install cert in all booted iOS simulators
+echo "Installing mitmproxy CA cert in booted simulators..."
+while IFS= read -r udid; do
+  xcrun simctl keychain "$udid" add-root-cert "$CERT" 2>/dev/null && echo "  ✓ $udid" || echo "  ✗ $udid (skipped)"
+done < <(xcrun simctl list devices booted | grep -oE '[A-F0-9-]{36}')
+
+# Route Mac Wi-Fi traffic through mitmproxy (simulator inherits Mac proxy)
+echo "Setting Mac Wi-Fi proxy → $PROXY_HOST:$PROXY_PORT"
+networksetup -setwebproxy Wi-Fi "$PROXY_HOST" "$PROXY_PORT"
+networksetup -setsecurewebproxy Wi-Fi "$PROXY_HOST" "$PROXY_PORT"
+networksetup -setwebproxystate Wi-Fi on
+networksetup -setsecurewebproxystate Wi-Fi on
+# Bypass Apple services (App Store, iCloud, etc.) and local addresses — these use cert pinning
+networksetup -setproxybypassdomains Wi-Fi \
+  "*.apple.com" "*.itunes.com" "*.mzstatic.com" "*.icloud.com" "*.aaplimg.com" \
+  "localhost" "127.0.0.1" "*.local"
+
+# Start mitmweb in background
+echo "Starting mitmweb on port $WEB_PORT..."
+nohup mitmweb \
+  --listen-host "$PROXY_HOST" \
+  --listen-port "$PROXY_PORT" \
+  --web-port "$WEB_PORT" \
+  --web-host 127.0.0.1 \
+  > /tmp/mitmweb.log 2>&1 &
+echo $! > "$PIDFILE"
+
+echo ""
+echo "Proxy running — open http://localhost:$WEB_PORT in your browser"
+echo "Stop with: ./tools/proxy/stop.sh"
+echo ""
+echo "NOTE: If you see HTTPS errors in your Mac browser, trust the CA cert once:"
+echo "  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain $CERT"

--- a/tools/proxy/stop.sh
+++ b/tools/proxy/stop.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Stop the HTTP-proxy mitmweb and fully restore Mac proxy settings.
+# Use this to undo tools/proxy/start.sh. (WireGuard mode has its own teardown
+# in tools/proxy/wireguard.sh and does NOT touch the system proxy.)
+
+set -euo pipefail
+
+PIDFILE="/tmp/mitmweb.pid"
+
+if [[ -f "$PIDFILE" ]]; then
+  PID=$(cat "$PIDFILE")
+  kill "$PID" 2>/dev/null && echo "Stopped mitmweb (pid $PID)" || echo "mitmweb wasn't running"
+  rm -f "$PIDFILE"
+else
+  pkill -f mitmweb 2>/dev/null && echo "Stopped mitmweb" || echo "mitmweb wasn't running"
+fi
+
+echo "Restoring Mac Wi-Fi proxy settings..."
+# Clear the server host/port + bypass list FIRST (these commands re-enable the
+# proxy as a side effect), THEN toggle state off last — order matters, or the
+# proxy is left "enabled" with an empty server, which still breaks browsing.
+networksetup -setwebproxy Wi-Fi "" 0 2>/dev/null || true
+networksetup -setsecurewebproxy Wi-Fi "" 0 2>/dev/null || true
+# Reset bypass domains to the macOS default ("Empty" == none)
+networksetup -setproxybypassdomains Wi-Fi "Empty" 2>/dev/null || true
+networksetup -setwebproxystate Wi-Fi off
+networksetup -setsecurewebproxystate Wi-Fi off
+
+echo "Done. Normal browsing + App Store should work again."

--- a/tools/proxy/wireguard.sh
+++ b/tools/proxy/wireguard.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Capture a PHYSICAL phone's traffic with mitmproxy in WireGuard mode.
+#
+# Why this and not start.sh (HTTP proxy)? Apps that don't honor the system HTTP
+# proxy — Firebase Firestore (gRPC/HTTP2), Realtime Database (WebSocket), and most
+# native SDKs — are invisible to an HTTP proxy. WireGuard mode intercepts at the IP
+# layer, so EVERYTHING the phone sends is captured. No pfctl, no IP forwarding, no
+# gateway hacks. The phone just needs the free WireGuard app.
+#
+# Usage:
+#   ./tools/proxy/wireguard.sh start   # launch + write/open the client config & QR
+#   ./tools/proxy/wireguard.sh qr      # re-open the QR for the running instance
+#   ./tools/proxy/wireguard.sh stop    # stop it
+#
+# Web UI: http://localhost:9091 (save flows from there: toolbar → download).
+#
+# Deps: mitmproxy + qrencode (brew install mitmproxy qrencode).
+
+set -euo pipefail
+
+WG_PORT=51820                                   # UDP port the phone's WireGuard tunnel hits
+WEB_PORT=9091                                   # mitmweb UI (localhost only)
+KEYFILE="$HOME/.mitmproxy/wireguard.conf"       # server key material (auto-created)
+CERT="$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
+LOG="/tmp/mitmweb-wg.log"
+PIDFILE="/tmp/mitmweb-wg.pid"
+CLIENT_CONF="/tmp/wg-client.conf"
+QR_PNG="/tmp/wg-qr.png"
+
+lan_ip() { ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "<your-mac-LAN-IP>"; }
+
+# mitmweb does NOT print the WireGuard client config to the console (it only shows
+# it in the web UI). mitmdump DOES. So we briefly run mitmdump against the same
+# keyfile to capture the config, then rewrite its 0.0.0.0 Endpoint to our LAN IP.
+build_client_conf() {
+  local raw="/tmp/wg-raw.txt"
+  mitmdump --mode "wireguard:$KEYFILE" --listen-host 0.0.0.0 --listen-port "$WG_PORT" >"$raw" 2>&1 &
+  local md=$!
+  sleep 4
+  kill "$md" 2>/dev/null; wait "$md" 2>/dev/null || true
+
+  # Extract the [Interface]...AllowedIPs/Endpoint block and fix the Endpoint host.
+  awk '/^\[Interface\]/{f=1} f{print} /^Endpoint/{f=0}' "$raw" \
+    | sed -E "s|^Endpoint = .*:|Endpoint = $(lan_ip):|" > "$CLIENT_CONF"
+
+  # PersistentKeepalive keeps the tunnel alive through NAT/idle timeouts. Without it
+  # iOS lets the tunnel lapse after a minute or two and won't re-handshake until you
+  # manually toggle it — so the app's fresh auth calls silently never reach the proxy.
+  if ! grep -q '^PersistentKeepalive' "$CLIENT_CONF"; then
+    printf 'PersistentKeepalive = 25\n' >> "$CLIENT_CONF"
+  fi
+
+  if ! grep -q '^\[Interface\]' "$CLIENT_CONF"; then
+    echo "ERROR: could not extract WireGuard client config from mitmdump output:" >&2
+    cat "$raw" >&2
+    exit 1
+  fi
+  qrencode -r "$CLIENT_CONF" -o "$QR_PNG" -s 8 -m 2
+}
+
+start() {
+  if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+    echo "Already running (pid $(cat "$PIDFILE")). Use 'qr' to re-show, or 'stop' first."
+    exit 0
+  fi
+  # Free a stale UDP bind from a crashed run
+  pkill -f "mode wireguard" 2>/dev/null || true
+  sleep 1
+
+  if [[ ! -f "$CERT" ]]; then
+    echo "Generating mitmproxy CA cert..."
+    mitmdump -p 9090 --listen-host 127.0.0.1 >/dev/null 2>&1 &
+    local tmp=$!; sleep 3; kill "$tmp" 2>/dev/null; wait "$tmp" 2>/dev/null || true
+  fi
+
+  echo "Building WireGuard client config + QR..."
+  build_client_conf
+
+  echo "Starting mitmweb in WireGuard mode (UDP $WG_PORT, web UI :$WEB_PORT)..."
+  # Launch through a PTY (script -q) so mitmweb flushes its startup banner — incl. the
+  # web UI token — to the log; under a plain nohup pipe it buffers and we never see it.
+  # Leave http3 at its default (enabled). Disabling it makes some apps (the MoonBoard
+  # Flutter app) fail outright instead of falling back to TCP — they QUIC-only certain
+  # endpoints and won't downgrade, so mitmproxy must intercept HTTP/3 to see them.
+  nohup script -q /dev/null mitmweb \
+    --mode "wireguard:$KEYFILE" \
+    --listen-host 0.0.0.0 \
+    --listen-port "$WG_PORT" \
+    --web-port "$WEB_PORT" \
+    --web-host 127.0.0.1 \
+    --no-web-open-browser \
+    >"$LOG" 2>&1 &
+  echo $! >"$PIDFILE"
+  sleep 3
+
+  qr
+  local token
+  token=$(grep -oaE 'token=[a-f0-9]+' "$LOG" | tail -1 | cut -d= -f2 || true)
+  [[ -n "$token" ]] && echo " Web UI (with token): http://localhost:$WEB_PORT/?token=$token"
+}
+
+qr() {
+  echo ""
+  echo "=================================================================="
+  echo " WireGuard client config (import into the WireGuard iPhone app):"
+  echo "=================================================================="
+  cat "$CLIENT_CONF"
+  echo ""
+  echo " Scan this QR (WireGuard app → + → Create from QR code):"
+  qrencode -r "$CLIENT_CONF" -t ANSIUTF8
+  open "$QR_PNG" 2>/dev/null || true
+  echo "------------------------------------------------------------------"
+  echo " 1. Toggle the tunnel ON in the WireGuard app."
+  echo " 2. Trust the CA: open http://mitm.it → install the Apple profile →"
+  echo "    Settings → General → About → Certificate Trust Settings →"
+  echo "    enable FULL trust for mitmproxy."
+  echo " 3. Watch flows at http://localhost:$WEB_PORT"
+  echo " Mac LAN IP (the config Endpoint): $(lan_ip):$WG_PORT"
+  echo "------------------------------------------------------------------"
+}
+
+stop() {
+  # PIDFILE holds the `script` wrapper PID; kill it, then pkill mitmweb directly in
+  # case the child outlived its PTY. Either way the UDP/web ports get freed.
+  [[ -f "$PIDFILE" ]] && kill "$(cat "$PIDFILE")" 2>/dev/null || true
+  rm -f "$PIDFILE"
+  if pkill -f "mode wireguard" 2>/dev/null; then
+    echo "Stopped WireGuard mitmweb"
+  else
+    echo "WireGuard mitmweb wasn't running"
+  fi
+  echo "(WireGuard mode never touched the system proxy — nothing else to restore.)"
+}
+
+case "${1:-start}" in
+  start) start ;;
+  qr)    qr ;;
+  stop)  stop ;;
+  *) echo "Usage: $0 {start|qr|stop}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

Adds developer scripts under `tools/proxy/` for inspecting an iOS app's HTTPS traffic with mitmproxy during local development. Two modes:

- **`start.sh` / `stop.sh` — HTTP-proxy mode** for the iOS **simulator** + Mac browsers. Installs the mitmproxy CA into booted simulators, sets the Mac Wi-Fi proxy, and bypasses Apple services so the App Store/iCloud keep working. `stop.sh` fully reverts the proxy (host + bypass list + state).
- **`wireguard.sh` — WireGuard mode** for a **physical phone**. Uses mitmproxy's built-in WireGuard server to intercept at the IP layer, so proxy-unaware apps (Firebase gRPC/WebSocket, QUIC) are captured too — a plain HTTP proxy misses them. Builds the client config + QR with `PersistentKeepalive`, reuses the shared mitmproxy CA.
- **`README.md`** — when to use which mode, the cert-trust steps, and notes on decoding captured payloads.

Pure local dev tooling — no app/runtime code touched.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `tools/proxy/start.sh` → CA installed into booted simulators, Mac Wi-Fi proxy set, mitmweb UI on `http://localhost:9091`; `stop.sh` restores normal browsing + App Store.
- `tools/proxy/wireguard.sh start` → mitmweb in WireGuard mode (UDP 51820), client config + QR generated; physical iPhone tunnel connects and traffic is captured (verified end-to-end capturing a Flutter app's REST/Firebase traffic).
- `vp check` clean on `tools/proxy/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)