### PR TITLE
fix(mobile): bias play-drawer swipe direction-lock toward horizontal

### DIFF
--- a/packages/mobile/src/components/play-drawer/__tests__/use-carousel-gesture.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-carousel-gesture.test.ts
@@ -146,4 +146,46 @@ describe('useCarouselGesture', () => {
     expect(onSwipePrevious).not.toHaveBeenCalled();
     expect(result.current.translateX.value).toBe(0);
   });
+
+  // Direction lock — biased toward horizontal (VERTICAL_LOCK_RATIO) so a
+  // horizontal-intended swipe that drifts down still drives the carousel
+  // instead of falling through to the drawer's pull-to-dismiss.
+  function makeState() {
+    return { activate: vi.fn(), fail: vi.fn() };
+  }
+  function lockFrom(handlers: RecordedHandlers, dx: number, dy: number, state: ReturnType<typeof makeState>) {
+    handlers.onTouchesDown({ allTouches: [{ absoluteX: 100, absoluteY: 100 }] });
+    handlers.onTouchesMove({ allTouches: [{ absoluteX: 100 + dx, absoluteY: 100 + dy }] }, state);
+  }
+
+  it('locks horizontal for a slightly-diagonal swipe that the symmetric rule would call vertical', () => {
+    renderHook((props: Options) => useCarouselGesture(props), { initialProps: makeOptions() });
+    const state = makeState();
+    lockFrom(latestHandlers(), 10, 12, state); // |dy|(12) < |dx|(10) × 1.5
+
+    expect(state.activate).toHaveBeenCalledTimes(1);
+    expect(state.fail).not.toHaveBeenCalled();
+  });
+
+  it('still locks vertical (and fails) for a clearly-vertical drag', () => {
+    renderHook((props: Options) => useCarouselGesture(props), { initialProps: makeOptions() });
+    const state = makeState();
+    lockFrom(latestHandlers(), 4, 30, state); // |dy|(30) ≥ |dx|(4) × 1.5
+
+    expect(state.fail).toHaveBeenCalledTimes(1);
+    expect(state.activate).not.toHaveBeenCalled();
+  });
+
+  it('stays committed to horizontal once locked, even if the finger then drifts vertically', () => {
+    renderHook((props: Options) => useCarouselGesture(props), { initialProps: makeOptions() });
+    const handlers = latestHandlers();
+    const state = makeState();
+    lockFrom(handlers, 30, 4, state); // lock horizontal
+    state.activate.mockClear();
+
+    handlers.onTouchesMove({ allTouches: [{ absoluteX: 130, absoluteY: 220 }] }, state); // big Y drift
+
+    expect(state.activate).toHaveBeenCalledTimes(1);
+    expect(state.fail).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
@@ -1,7 +1,13 @@
 import { useEffect, useMemo, useRef, type ComponentType, type RefObject } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import { useSharedValue, withTiming, withSpring, runOnJS, type SharedValue } from 'react-native-reanimated';
-import { SWIPE_THRESHOLD, DIRECTION_THRESHOLD, EXIT_DURATION, SWIPE_OFFSCREEN_PAD } from '@boardsesh/play-view';
+import {
+  SWIPE_THRESHOLD,
+  DIRECTION_THRESHOLD,
+  VERTICAL_LOCK_RATIO,
+  EXIT_DURATION,
+  SWIPE_OFFSCREEN_PAD,
+} from '@boardsesh/play-view';
 import { springs } from '../../theme/animations';
 import { hapticMedium } from '../../lib/haptics';
 
@@ -149,12 +155,14 @@ export function useCarouselGesture({
     }
   };
 
-  // Lock direction on first significant move — matches the web pattern in
-  // useCardSwipeNavigation. Once locked horizontal, the gesture stays
-  // committed even if the user drifts vertically. failOffsetY would
-  // otherwise kill a horizontal swipe the moment Y drift crossed 10px,
-  // making carousel swipes finicky. Vertical-locked gestures fail so the
-  // touch falls through to BottomSheetScrollView.
+  // Lock direction on first significant move. Once locked horizontal, the gesture
+  // stays committed even if the user drifts vertically. failOffsetY would
+  // otherwise kill a horizontal swipe the moment Y drift crossed 10px, making
+  // carousel swipes finicky. Vertical-locked gestures fail so the touch falls
+  // through to the scroll. The decision is biased toward horizontal
+  // (VERTICAL_LOCK_RATIO) so a horizontal-intended swipe that drifts slightly down
+  // still locks horizontal — otherwise it read as vertical and the drawer's
+  // pull-to-dismiss grabbed it. Web stays symmetric; only the play drawer biases.
   const directionLock = useSharedValue<0 | 1 | -1>(0); // 0=undecided, 1=horizontal, -1=vertical
   const startTouchX = useSharedValue(0);
   const startTouchY = useSharedValue(0);
@@ -192,12 +200,15 @@ export function useCarouselGesture({
         const absX = Math.abs(dx);
         const absY = Math.abs(dy);
         if (absX <= DIRECTION_THRESHOLD && absY <= DIRECTION_THRESHOLD) return;
-        if (absX > absY) {
-          directionLock.value = 1;
-          state.activate();
-        } else {
+        // Bias toward horizontal: lock vertical only when the motion is clearly
+        // vertical (absY ≥ absX × VERTICAL_LOCK_RATIO). Keeps near-vertical
+        // scroll/dismiss working while protecting slightly-diagonal climb swipes.
+        if (absY >= absX * VERTICAL_LOCK_RATIO) {
           directionLock.value = -1;
           state.fail();
+        } else {
+          directionLock.value = 1;
+          state.activate();
         }
       })
       .onStart(() => {

--- a/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-carousel-gesture.ts
@@ -203,6 +203,9 @@ export function useCarouselGesture({
         // Bias toward horizontal: lock vertical only when the motion is clearly
         // vertical (absY ≥ absX × VERTICAL_LOCK_RATIO). Keeps near-vertical
         // scroll/dismiss working while protecting slightly-diagonal climb swipes.
+        // This mirrors decideSwipeDirection(dx, dy, threshold, VERTICAL_LOCK_RATIO)
+        // in @boardsesh/play-view (the canonical spec + web's path) — inlined here
+        // because the worklet can't call it; keep the two in sync if either changes.
         if (absY >= absX * VERTICAL_LOCK_RATIO) {
           directionLock.value = -1;
           state.fail();

--- a/packages/shared/play-view/src/__tests__/swipe-carousel.test.ts
+++ b/packages/shared/play-view/src/__tests__/swipe-carousel.test.ts
@@ -9,6 +9,7 @@ import {
   SWIPE_OFFSCREEN_PAD,
   SWIPE_THRESHOLD,
   DIRECTION_THRESHOLD,
+  VERTICAL_LOCK_RATIO,
 } from '../swipe-carousel';
 
 describe('computePeekOffset', () => {
@@ -61,6 +62,24 @@ describe('decideSwipeDirection', () => {
   it('honours a custom threshold', () => {
     expect(decideSwipeDirection(25, 5, 30)).toBeNull();
     expect(decideSwipeDirection(40, 5, 30)).toBe('horizontal');
+  });
+
+  it('defaults to the symmetric rule (ties lock vertical) so web is unchanged', () => {
+    expect(decideSwipeDirection(12, 12)).toBe('vertical');
+    expect(decideSwipeDirection(12, 13)).toBe('vertical');
+  });
+
+  it('biases toward horizontal under a >1 ratio so a slightly-diagonal swipe locks horizontal', () => {
+    // dx=10, dy=12 reads vertical with the symmetric default…
+    expect(decideSwipeDirection(10, 12)).toBe('vertical');
+    // …but horizontal once the vertical-lock bias applies (12 < 10 × 1.5).
+    expect(decideSwipeDirection(10, 12, DIRECTION_THRESHOLD, VERTICAL_LOCK_RATIO)).toBe('horizontal');
+  });
+
+  it('still locks a clearly-vertical drag even under the horizontal bias', () => {
+    // Genuine scroll/dismiss: near-vertical, so it clears absX × ratio easily.
+    expect(decideSwipeDirection(5, 20, DIRECTION_THRESHOLD, VERTICAL_LOCK_RATIO)).toBe('vertical');
+    expect(decideSwipeDirection(-4, -30, DIRECTION_THRESHOLD, VERTICAL_LOCK_RATIO)).toBe('vertical');
   });
 });
 

--- a/packages/shared/play-view/src/swipe-carousel.ts
+++ b/packages/shared/play-view/src/swipe-carousel.ts
@@ -3,6 +3,13 @@
 
 export const SWIPE_THRESHOLD = 80;
 export const DIRECTION_THRESHOLD = 10;
+// Direction-lock horizontal bias (mobile play drawer). The lock picks vertical
+// only when the motion is clearly vertical — absY at least this multiple of absX.
+// >1 favours horizontal so a horizontal-intended climb swipe that drifts slightly
+// down still locks horizontal, and the drawer's pull-to-dismiss can't grab it.
+// Genuine scroll/dismiss gestures are near-vertical (absX ≈ 0), so they clear this
+// easily and still lock vertical. Web keeps the symmetric default (1).
+export const VERTICAL_LOCK_RATIO = 1.5;
 export const EXIT_DURATION = 300;
 export const SNAP_BACK_DURATION = 200;
 // New climb swaps in this many ms after the slide-off begins.
@@ -82,11 +89,15 @@ export function decideSwipeDirection(
   deltaX: number,
   deltaY: number,
   threshold: number = DIRECTION_THRESHOLD,
+  verticalBiasRatio = 1,
 ): 'horizontal' | 'vertical' | null {
   const absX = Math.abs(deltaX);
   const absY = Math.abs(deltaY);
   if (absX <= threshold && absY <= threshold) return null;
-  return absX > absY ? 'horizontal' : 'vertical';
+  // Lock vertical only when absY is at least `verticalBiasRatio`× the horizontal
+  // travel. Ratio 1 is the original symmetric rule (ties → vertical); a higher
+  // ratio biases toward horizontal (see VERTICAL_LOCK_RATIO).
+  return absY >= absX * verticalBiasRatio ? 'vertical' : 'horizontal';
 }
 
 export function evaluateSwipeOutcome({


### PR DESCRIPTION
## Summary

Follow-up to #3195 (merged) — the axis lock still let users drift into a vertical drawer-dismiss while swiping between climbs.

#3195 blocks the dismiss *once a swipe is locked horizontal*. The residual leak is the lock decision itself: the carousel picked an axis symmetrically (`|dx| > |dy|`), so a horizontal-intended swipe whose first ~10px happened to be slightly more vertical locked **vertical** — and the drawer's pull-to-dismiss then grabbed it.

This biases the lock toward horizontal: it locks vertical only when the motion is clearly vertical (`|dy| >= |dx| × VERTICAL_LOCK_RATIO`, **1.5**). Genuine scroll / pull-to-dismiss gestures are near-vertical (`|dx| ≈ 0`), so they clear the ratio easily and still lock vertical; a slightly-diagonal climb swipe now stays horizontal. The shared `decideSwipeDirection` gains an optional `verticalBiasRatio` (default `1`), so **web keeps the symmetric rule unchanged** — only the play drawer passes the bias.

`VERTICAL_LOCK_RATIO` is a one-line knob in `packages/shared/play-view/src/swipe-carousel.ts` if 1.5 isn't strong enough on-device (raising it favours horizontal harder; too high risks reading a deliberate down-pull as a climb swipe).

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- The user-facing "no accidental drawer-drop mid-swipe" headline already shipped in #3195; this PR only strengthens that same behaviour, so a second What's New line would be a duplicate. -->

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:web`, `vp run typecheck:shared` — green (web signature unchanged).
- `vp test run swipe-carousel use-carousel-gesture` — 32 pass, incl. new cases: shared `decideSwipeDirection` default stays symmetric / biases under a >1 ratio / still locks a clearly-vertical drag; mobile lock activates for a slightly-diagonal swipe, fails for a clearly-vertical one, and stays committed to horizontal after a later vertical drift.
- `vp check` — clean.
- Device QA (best on the `pr-3210` OTA channel once published): with downward drift while fast-swiping L/R, the drawer should now hold far more firmly; a deliberate straight-down swipe from the top still dismisses, and vertical scroll to the beta-videos section still works.
