### PR TITLE
fix(mobile): serialize native sheet present/dismiss to stop the iOS freeze

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -286,11 +286,11 @@
         "react-native-pager-view": "^8.0.2",
         "react-native-paper": "^5.15.3",
         "react-native-qrcode-svg": "^6.3.15",
-        "react-native-reanimated": "4.3.1",
+        "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-svg": "15.15.4",
-        "react-native-worklets": "0.8.3",
+        "react-native-worklets": "0.10.0",
       },
       "devDependencies": {
         "@bacons/apple-targets": "^4.0.7",
@@ -3802,7 +3802,7 @@
 
     "react-native-qrcode-svg": ["react-native-qrcode-svg@6.3.21", "", { "dependencies": { "prop-types": "^15.8.0", "qrcode": "^1.5.4", "text-encoding": "^0.7.0" }, "peerDependencies": { "react": "*", "react-native": ">=0.63.4", "react-native-svg": ">=14.0.0" } }, "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA=="],
 
-    "react-native-reanimated": ["react-native-reanimated@4.3.1", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.81 - 0.85", "react-native-worklets": "0.8.x" } }, "sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q=="],
+    "react-native-reanimated": ["react-native-reanimated@4.5.0", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.83 - 0.86", "react-native-worklets": "0.10.x" } }, "sha512-+iPfvK34PKKYP/p/4TaBliFkbfvjGDIvXuiiaxvISP5ip7sWegvlacwU/uAV6zNDSSmX0tDyER7PurPMKGDipA=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 
@@ -3810,7 +3810,7 @@
 
     "react-native-svg": ["react-native-svg@15.15.4", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A=="],
 
-    "react-native-worklets": ["react-native-worklets@0.8.3", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.27.1", "@babel/plugin-transform-classes": "^7.28.4", "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1", "@babel/plugin-transform-optional-chaining": "^7.27.1", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.3" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.81 - 0.85" } }, "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg=="],
+    "react-native-worklets": ["react-native-worklets@0.10.0", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.28.6", "@babel/plugin-transform-classes": "^7.28.6", "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6", "@babel/plugin-transform-optional-chaining": "^7.28.6", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.28.5", "@babel/types": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.4" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.83 - 0.86" } }, "sha512-JhE6IxDf6iabC0qu3+TAKA4v9RlluXmoIngPQX7/QUByf75lfrsHZ6/dQhyjEWnp1EEQiwzz8Cpew140ZcewDw=="],
 
     "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
 
@@ -4811,6 +4811,8 @@
     "expo/@expo/metro-config": ["@expo/metro-config@56.0.14", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "@babel/core": "^7.20.0", "@babel/generator": "^7.20.5", "@expo/config": "~56.0.9", "@expo/env": "~2.3.0", "@expo/json-file": "~10.2.0", "@expo/metro": "~56.0.0", "@expo/require-utils": "^56.1.3", "@expo/spawn-async": "^1.8.0", "@jridgewell/gen-mapping": "^0.3.13", "@jridgewell/remapping": "^2.3.5", "@jridgewell/sourcemap-codec": "^1.5.5", "browserslist": "^4.25.0", "chalk": "^4.1.0", "debug": "^4.3.2", "getenv": "^2.0.0", "glob": "^13.0.0", "hermes-parser": "^0.33.3", "jsc-safe-url": "^0.2.4", "lightningcss": "^1.30.1", "picomatch": "^4.0.4", "postcss": "^8.5.14", "resolve-from": "^5.0.0" }, "peerDependencies": { "expo": "*" }, "optionalPeers": ["expo"] }, "sha512-O3CIHruaTJhswPAf/nf3i8QQ3f2jl+mEwSea1eb3khuplabdy/wTQz+JvHN8VGUFyg7JKwUGU1QfO6T3JiSQqA=="],
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "expo-modules-core/react-native-worklets": ["react-native-worklets@0.8.3", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.27.1", "@babel/plugin-transform-classes": "^7.28.4", "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1", "@babel/plugin-transform-optional-chaining": "^7.27.1", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.3" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.81 - 0.85" } }, "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg=="],
 
     "expo-router/@expo/log-box": ["@expo/log-box@56.0.13", "", { "dependencies": { "@expo/dom-webview": "^56.0.5", "anser": "^1.4.9", "stacktrace-parser": "^0.1.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-QWRZSpWPyjkDLVQio4R7oAzg/Av2MOt/DciFkfjr8qQ3qxGVn1Rt1oHP/80hvcWDcHFV7N6PqpyxRXw6nbxzKQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -286,11 +286,11 @@
         "react-native-pager-view": "^8.0.2",
         "react-native-paper": "^5.15.3",
         "react-native-qrcode-svg": "^6.3.15",
-        "react-native-reanimated": "4.5.0",
+        "react-native-reanimated": "4.3.1",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-svg": "15.15.4",
-        "react-native-worklets": "0.10.0",
+        "react-native-worklets": "0.8.3",
       },
       "devDependencies": {
         "@bacons/apple-targets": "^4.0.7",
@@ -3802,7 +3802,7 @@
 
     "react-native-qrcode-svg": ["react-native-qrcode-svg@6.3.21", "", { "dependencies": { "prop-types": "^15.8.0", "qrcode": "^1.5.4", "text-encoding": "^0.7.0" }, "peerDependencies": { "react": "*", "react-native": ">=0.63.4", "react-native-svg": ">=14.0.0" } }, "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA=="],
 
-    "react-native-reanimated": ["react-native-reanimated@4.5.0", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.83 - 0.86", "react-native-worklets": "0.10.x" } }, "sha512-+iPfvK34PKKYP/p/4TaBliFkbfvjGDIvXuiiaxvISP5ip7sWegvlacwU/uAV6zNDSSmX0tDyER7PurPMKGDipA=="],
+    "react-native-reanimated": ["react-native-reanimated@4.3.1", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.81 - 0.85", "react-native-worklets": "0.8.x" } }, "sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 
@@ -3810,7 +3810,7 @@
 
     "react-native-svg": ["react-native-svg@15.15.4", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A=="],
 
-    "react-native-worklets": ["react-native-worklets@0.10.0", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.28.6", "@babel/plugin-transform-classes": "^7.28.6", "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6", "@babel/plugin-transform-optional-chaining": "^7.28.6", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.28.5", "@babel/types": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.4" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.83 - 0.86" } }, "sha512-JhE6IxDf6iabC0qu3+TAKA4v9RlluXmoIngPQX7/QUByf75lfrsHZ6/dQhyjEWnp1EEQiwzz8Cpew140ZcewDw=="],
+    "react-native-worklets": ["react-native-worklets@0.8.3", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.27.1", "@babel/plugin-transform-classes": "^7.28.4", "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1", "@babel/plugin-transform-optional-chaining": "^7.27.1", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.3" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.81 - 0.85" } }, "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg=="],
 
     "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
 
@@ -4811,8 +4811,6 @@
     "expo/@expo/metro-config": ["@expo/metro-config@56.0.14", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "@babel/core": "^7.20.0", "@babel/generator": "^7.20.5", "@expo/config": "~56.0.9", "@expo/env": "~2.3.0", "@expo/json-file": "~10.2.0", "@expo/metro": "~56.0.0", "@expo/require-utils": "^56.1.3", "@expo/spawn-async": "^1.8.0", "@jridgewell/gen-mapping": "^0.3.13", "@jridgewell/remapping": "^2.3.5", "@jridgewell/sourcemap-codec": "^1.5.5", "browserslist": "^4.25.0", "chalk": "^4.1.0", "debug": "^4.3.2", "getenv": "^2.0.0", "glob": "^13.0.0", "hermes-parser": "^0.33.3", "jsc-safe-url": "^0.2.4", "lightningcss": "^1.30.1", "picomatch": "^4.0.4", "postcss": "^8.5.14", "resolve-from": "^5.0.0" }, "peerDependencies": { "expo": "*" }, "optionalPeers": ["expo"] }, "sha512-O3CIHruaTJhswPAf/nf3i8QQ3f2jl+mEwSea1eb3khuplabdy/wTQz+JvHN8VGUFyg7JKwUGU1QfO6T3JiSQqA=="],
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
-
-    "expo-modules-core/react-native-worklets": ["react-native-worklets@0.8.3", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.27.1", "@babel/plugin-transform-classes": "^7.28.4", "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1", "@babel/plugin-transform-optional-chaining": "^7.27.1", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.3" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.81 - 0.85" } }, "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg=="],
 
     "expo-router/@expo/log-box": ["@expo/log-box@56.0.13", "", { "dependencies": { "@expo/dom-webview": "^56.0.5", "anser": "^1.4.9", "stacktrace-parser": "^0.1.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-QWRZSpWPyjkDLVQio4R7oAzg/Av2MOt/DciFkfjr8qQ3qxGVn1Rt1oHP/80hvcWDcHFV7N6PqpyxRXw6nbxzKQ=="],
 

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -33,6 +33,21 @@ Examples: `QueueSheet`, `BoardSheet`, `LogAscentSheet`, `AngleSelectorSheet`,
 `HoldRoleSheet` floats above the create drawer and how `ClimbReactionMenu` (the long-press
 context menu) floats above whatever's underneath.
 
+**Every native sheet must go through the presentation coordinator.** `@expo/ui`
+sheets all present off the **same** root-window view controller, and the library
+does no serialization — overlapping a present with another sheet's dismiss
+deadlocks UIKit and freezes the whole app (renders, but ignores every tap). The
+`ModalSheet`/`Sheet` wrappers route through `SheetPresentationProvider`
+(`src/providers/sheet-presentation-provider.tsx`) automatically. A surface with
+custom chrome that renders the raw `BottomSheetModal`/`BottomSheet` directly must
+drive present/dismiss with `useManagedSheet` (see `QueueSheet`, `BoardSheet`,
+`LogAscentSheet`). The coordinator serializes transitions per **presenter group**
+(default `'root'`) and auto-sequences a sheet-over-sheet open as
+dismiss(A) → settle → present(B). Two exceptions, both documented in-file:
+`CreateDrawer` (a route-primary drawer that opens once and whose only sub-sheet is
+a `fullWindowOverlay`, so it never overlaps a coordinated transition) and the
+`fullWindowOverlay` menus, which live in a higher window.
+
 ### Routes (`expo-router` `Stack.Screen`)
 
 | `presentation`         | Looks like                                           | Use when                                                                                                                                 | Examples                                                                                                       |

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -36,6 +36,7 @@ import { ShareTargetProvider } from '../src/providers/share-target-provider';
 import { TabBarHeightProvider } from '../src/providers/tab-bar-height-provider';
 import { FeatureFlagsProvider, type FeatureFlags } from '../src/providers/feature-flags-provider';
 import { MobileBoardPresenceProvider } from '../src/providers/board-presence-provider';
+import { SheetPresentationProvider } from '../src/providers/sheet-presentation-provider';
 import { PartyProfileProvider } from '../src/providers/party-profile-provider';
 import { ConnectionSettingsProvider } from '../src/providers/connection-settings-provider';
 import { FavoritesProvider } from '../src/providers/favorites-provider';
@@ -344,85 +345,102 @@ function RootLayout() {
                                     DrawerHostProvider so the BLE flow + Board sheet
                                     can use it. */}
                                         <MobileBoardPresenceProvider>
-                                          <BottomSheetModalProvider>
-                                            <BluetoothProviderWrapper>
-                                              {/* One BLE controls sheet (Re-light / Turn off /
+                                          {/* Serializes every native bottom-sheet present/dismiss so two
+                                              never overlap on the same presenter — the iOS UIKit deadlock
+                                              that froze the whole UI. Ancestor of every sheet (BLE, drawer
+                                              host, user drawer). See sheet-presentation-provider.tsx. */}
+                                          <SheetPresentationProvider>
+                                            <BottomSheetModalProvider>
+                                              <BluetoothProviderWrapper>
+                                                {/* One BLE controls sheet (Re-light / Turn off /
                                                   Disconnect) shared by the play-drawer lightbulb and
                                                   the persistent bar's board control. Wraps
                                                   DrawerHostProvider (which renders PlayDrawer as a
                                                   sibling of its children) so both the drawer and the
                                                   bar descend from it. */}
-                                              <BleControlSheetProvider>
-                                                <DrawerHostProvider>
-                                                  <DeepLinkProvider>
-                                                    <ShareTargetProvider>
-                                                      <TabBarHeightProvider>
-                                                        <UserDrawerProvider>
-                                                          <ThemedNavigation>
-                                                            <Stack
-                                                              // Root scenes keep the opaque, theme-aware nav background so a dark
-                                                              // backstop sits behind the tab screens (the tab stacks paint their own
-                                                              // transparent content over it). glassStackScreenOptions' transparent
-                                                              // contentStyle would expose the light window background at the top of the
-                                                              // screen in dark mode, where the floating chrome leaves it uncovered.
-                                                              // The header props still apply to root-level pushed screens (session, about).
-                                                              screenOptions={{
-                                                                ...glassStackScreenOptions,
-                                                                headerShown: false,
-                                                                contentStyle: undefined,
-                                                              }}
-                                                              initialRouteName="index"
-                                                            >
-                                                              <Stack.Screen name="index" />
-                                                              <Stack.Screen name="(tabs)" />
-                                                              <Stack.Screen
-                                                                name="auth"
-                                                                options={{ headerShown: false, gestureEnabled: false }}
-                                                              />
-                                                              {/* Public climber profiles + climber search, pushed from any
+                                                <BleControlSheetProvider>
+                                                  <DrawerHostProvider>
+                                                    <DeepLinkProvider>
+                                                      <ShareTargetProvider>
+                                                        <TabBarHeightProvider>
+                                                          <UserDrawerProvider>
+                                                            <ThemedNavigation>
+                                                              <Stack
+                                                                // Root scenes keep the opaque, theme-aware nav background so a dark
+                                                                // backstop sits behind the tab screens (the tab stacks paint their own
+                                                                // transparent content over it). glassStackScreenOptions' transparent
+                                                                // contentStyle would expose the light window background at the top of the
+                                                                // screen in dark mode, where the floating chrome leaves it uncovered.
+                                                                // The header props still apply to root-level pushed screens (session, about).
+                                                                screenOptions={{
+                                                                  ...glassStackScreenOptions,
+                                                                  headerShown: false,
+                                                                  contentStyle: undefined,
+                                                                }}
+                                                                initialRouteName="index"
+                                                              >
+                                                                <Stack.Screen name="index" />
+                                                                <Stack.Screen name="(tabs)" />
+                                                                <Stack.Screen
+                                                                  name="auth"
+                                                                  options={{
+                                                                    headerShown: false,
+                                                                    gestureEnabled: false,
+                                                                  }}
+                                                                />
+                                                                {/* Public climber profiles + climber search, pushed from any
                                                           tab (tappable avatars, the Home search action). */}
-                                                              <Stack.Screen name="users/[userId]/index" />
-                                                              {/* A climber's full beta-video grid — the "See all" target of
+                                                                <Stack.Screen name="users/[userId]/index" />
+                                                                {/* A climber's full beta-video grid — the "See all" target of
                                                           the profile beta shelf. Sets its own solid header. */}
-                                                              <Stack.Screen name="users/[userId]/beta" />
-                                                              {/* Headerless push — hides the tab bar like the other pushed
+                                                                <Stack.Screen name="users/[userId]/beta" />
+                                                                {/* Headerless push — hides the tab bar like the other pushed
                                                           screens, with its own in-body search bar. NOT a modal: a native
                                                           modal presentation traps the root play drawer beneath it when a
                                                           climb is opened from a profile pushed off search. */}
-                                                              <Stack.Screen
-                                                                name="users/search"
-                                                                options={{ headerShown: false }}
-                                                              />
-                                                              <Stack.Screen name="users/connections" />
-                                                              <Stack.Screen
-                                                                name="join/[sessionId]"
-                                                                options={{ presentation: 'modal', headerShown: false }}
-                                                              />
-                                                              <Stack.Screen
-                                                                name="share-beta"
-                                                                options={{ presentation: 'modal', headerShown: false }}
-                                                              />
-                                                              {/* Board selection is a modal off the Climbs capsule /
+                                                                <Stack.Screen
+                                                                  name="users/search"
+                                                                  options={{ headerShown: false }}
+                                                                />
+                                                                <Stack.Screen name="users/connections" />
+                                                                <Stack.Screen
+                                                                  name="join/[sessionId]"
+                                                                  options={{
+                                                                    presentation: 'modal',
+                                                                    headerShown: false,
+                                                                  }}
+                                                                />
+                                                                <Stack.Screen
+                                                                  name="share-beta"
+                                                                  options={{
+                                                                    presentation: 'modal',
+                                                                    headerShown: false,
+                                                                  }}
+                                                                />
+                                                                {/* Board selection is a modal off the Climbs capsule /
                                                       no-board CTA — board switching is rare, so it doesn't
                                                       earn a tab. Its own _layout owns the headers. */}
-                                                              <Stack.Screen
-                                                                name="boards"
-                                                                options={{ presentation: 'modal', headerShown: false }}
-                                                              />
-                                                              {/* First-run welcome walkthrough. Full-screen cover
+                                                                <Stack.Screen
+                                                                  name="boards"
+                                                                  options={{
+                                                                    presentation: 'modal',
+                                                                    headerShown: false,
+                                                                  }}
+                                                                />
+                                                                {/* First-run welcome walkthrough. Full-screen cover
                                                       over the Climbs tab; gesture disabled so the user
                                                       leaves only via Skip / finish / the final CTA, never
                                                       an accidental swipe-dismiss. */}
-                                                              <Stack.Screen
-                                                                name="onboarding"
-                                                                options={{
-                                                                  presentation: 'fullScreenModal',
-                                                                  headerShown: false,
-                                                                  gestureEnabled: false,
-                                                                  animation: 'fade',
-                                                                }}
-                                                              />
-                                                              {/* Full-screen "now playing" player. A modal VC so the
+                                                                <Stack.Screen
+                                                                  name="onboarding"
+                                                                  options={{
+                                                                    presentation: 'fullScreenModal',
+                                                                    headerShown: false,
+                                                                    gestureEnabled: false,
+                                                                    animation: 'fade',
+                                                                  }}
+                                                                />
+                                                                {/* Full-screen "now playing" player. A modal VC so the
                                                       sub-drawers / queue / share sheet opened from inside it stack
                                                       ABOVE it (the FullWindowOverlay it replaced sat in a higher
                                                       window, so native sheets rendered behind). transparentModal —
@@ -434,44 +452,63 @@ function RootLayout() {
                                                       opaque backing (see app/play.tsx) so the live tabs screen
                                                       doesn't show through the glass. Custom pull-down dismiss; covers
                                                       the tab bar. */}
-                                                              <Stack.Screen
-                                                                name="play"
-                                                                options={{
-                                                                  presentation: 'transparentModal',
-                                                                  headerShown: false,
-                                                                  // Native interactive dismiss OFF — it lives outside
-                                                                  // RNGH so it couldn't negotiate with the board
-                                                                  // swipe/pinch (only fired on the grabber). A custom
-                                                                  // RNGH pull-down (use-drawer-dismiss-gesture) drives
-                                                                  // dismissal from the whole surface instead.
-                                                                  gestureEnabled: false,
-                                                                  animation: 'slide_from_bottom',
-                                                                }}
-                                                              />
-                                                            </Stack>
-                                                          </ThemedNavigation>
-                                                          <PersistentQueueBar />
-                                                          {/* One-time tip floating above the tab bar / accessory bar,
+                                                                {/* User drawer as a route, not an RN-core <Modal>. A
+                                                      single native presentation system, so it no longer
+                                                      collides with the @expo/ui FeedbackSheet (the
+                                                      dual-presentation freeze, issue #3211). transparentModal
+                                                      — NOT fullScreenModal (hard rule 2) — so the screen
+                                                      behind stays live; animation 'none' because the panel
+                                                      runs its OWN reanimated slide (app/user-drawer.tsx).
+                                                      gestureEnabled off so the only dismiss is the panel's
+                                                      own animated close (backdrop tap / a row). */}
+                                                                <Stack.Screen
+                                                                  name="user-drawer"
+                                                                  options={{
+                                                                    presentation: 'transparentModal',
+                                                                    headerShown: false,
+                                                                    gestureEnabled: false,
+                                                                    animation: 'none',
+                                                                  }}
+                                                                />
+                                                                <Stack.Screen
+                                                                  name="play"
+                                                                  options={{
+                                                                    presentation: 'transparentModal',
+                                                                    headerShown: false,
+                                                                    // Native interactive dismiss OFF — it lives outside
+                                                                    // RNGH so it couldn't negotiate with the board
+                                                                    // swipe/pinch (only fired on the grabber). A custom
+                                                                    // RNGH pull-down (use-drawer-dismiss-gesture) drives
+                                                                    // dismissal from the whole surface instead.
+                                                                    gestureEnabled: false,
+                                                                    animation: 'slide_from_bottom',
+                                                                  }}
+                                                                />
+                                                              </Stack>
+                                                            </ThemedNavigation>
+                                                            <PersistentQueueBar />
+                                                            {/* One-time tip floating above the tab bar / accessory bar,
                                                             mounted next to PersistentQueueBar so it watches climb
                                                             presence globally and overlays both the native (iOS 26) and
                                                             JS bottom-bar variants. */}
-                                                          <AccessoryOnboardingTip />
-                                                          <OnboardingGate ready={authReady && fontsReady} />
-                                                          {/* Tester-only diagnostic for the Android-16 edge-to-edge
+                                                            <AccessoryOnboardingTip />
+                                                            <OnboardingGate ready={authReady && fontsReady} />
+                                                            {/* Tester-only diagnostic for the Android-16 edge-to-edge
                                                             touch-dead bug; a root sibling (stays tappable while the
                                                             <Stack> hit-region is frozen). No-op unless built with
                                                             EXPO_PUBLIC_FREEZE_DEBUG=1. */}
-                                                          <FreezeDebugOverlay />
-                                                        </UserDrawerProvider>
-                                                      </TabBarHeightProvider>
-                                                      <AnalyticsScreenTracker />
-                                                      <OtaUpdateTracker />
-                                                    </ShareTargetProvider>
-                                                  </DeepLinkProvider>
-                                                </DrawerHostProvider>
-                                              </BleControlSheetProvider>
-                                            </BluetoothProviderWrapper>
-                                          </BottomSheetModalProvider>
+                                                            <FreezeDebugOverlay />
+                                                          </UserDrawerProvider>
+                                                        </TabBarHeightProvider>
+                                                        <AnalyticsScreenTracker />
+                                                        <OtaUpdateTracker />
+                                                      </ShareTargetProvider>
+                                                    </DeepLinkProvider>
+                                                  </DrawerHostProvider>
+                                                </BleControlSheetProvider>
+                                              </BluetoothProviderWrapper>
+                                            </BottomSheetModalProvider>
+                                          </SheetPresentationProvider>
                                         </MobileBoardPresenceProvider>
                                       </BoardProviderWrapper>
                                     </PlaylistsAdapterWrapper>

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -1,0 +1,347 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
+import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { useProfile } from '../src/lib/graphql/hooks';
+import { useAuth } from '../src/providers/auth-provider';
+import { useTheme } from '../src/providers/theme-provider';
+import { spacing, borderRadius, shadows, overlays } from '../src/theme/tokens';
+import type { IconName } from '../src/components/icon-map';
+import { Avatar } from '../src/components/Avatar';
+import { Text } from '../src/components/Text';
+import { Icon } from '../src/components/Icon';
+import { ListRow } from '../src/components/ListRow';
+import { useUserDrawer } from '../src/components/user-drawer/UserDrawerProvider';
+
+const DRAWER_MAX_WIDTH = 320;
+const DRAWER_SCREEN_FRACTION = 0.86;
+const DRAWER_ANIMATION_MS = 220;
+
+/**
+ * User drawer route (`presentation: 'transparentModal'`, registered in
+ * app/_layout.tsx). Replaces the old RN-core `<Modal>` that UserDrawerProvider
+ * used to render: a real route is a single native presentation system, so it no
+ * longer collides with the @expo/ui FeedbackSheet (the dual-presentation freeze,
+ * issue #3211).
+ *
+ * The panel runs its OWN reanimated slide (the route is registered with
+ * `animation: 'none'`). `close(after)` slides the panel out, pops the route on
+ * settle, and runs the optional `after` in THIS screen's unmount cleanup — i.e.
+ * once the route's view controller is gone. That ordering is what lets a row
+ * navigate or present the (root-mounted) FeedbackSheet without ever stacking a
+ * second presentation over the still-up drawer.
+ */
+export default function UserDrawerScreen() {
+  const { t } = useTranslation('common');
+  const { t: tSettings } = useTranslation('settings');
+  const { systemColors, brandColors } = useTheme();
+  const { isAuthenticated } = useAuth();
+  const profileQuery = useProfile({ enabled: isAuthenticated });
+  const profile = profileQuery.data;
+  const insets = useSafeAreaInsets();
+  const windowDimensions = useWindowDimensions();
+  const drawerWidth = Math.min(DRAWER_MAX_WIDTH, windowDimensions.width * DRAWER_SCREEN_FRACTION);
+
+  const {
+    navigateToBoards,
+    navigateToManageBoards,
+    navigateToSettings,
+    navigateToEditProfile,
+    navigateToPlaylists,
+    navigateToAbout,
+    openDiscord,
+    signOutAction,
+    setFeedbackMode,
+    presentFeedback,
+  } = useUserDrawer();
+
+  const profileDisplayName = profile?.displayName ?? profile?.email ?? t('header.you');
+  const profileEmail = profile?.email ?? null;
+
+  const drawerProgress = useSharedValue(0);
+  // Queued action to run once THIS route has unmounted (see close). The native
+  // FeedbackSheet lives at the provider root and a destination route may itself
+  // present a second VC — running them only after the drawer's VC is gone is what
+  // keeps two presentations from overlapping and deadlocking UIKit.
+  const pendingAfterCloseRef = useRef<(() => void) | null>(null);
+  const closingRef = useRef(false);
+  // Guards popRoute against firing after this screen has unmounted (an interrupted
+  // slide-out's completion callback could otherwise router.back() the wrong route).
+  const mountedRef = useRef(true);
+
+  // Slide in on mount.
+  useEffect(() => {
+    drawerProgress.value = withTiming(1, {
+      duration: DRAWER_ANIMATION_MS,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [drawerProgress]);
+
+  // Fire the queued action once the route's view controller is gone. Deferring it
+  // ONE FRAME past unmount is load-bearing: router.back() (the pop) and a deferred
+  // native sheet present (FeedbackSheet, off the root window VC) would otherwise
+  // land in the SAME native transaction in undefined order — presenting a sheet
+  // while the route's VC is still tearing down is exactly the concurrent-
+  // presentation deadlock (#3211) this route exists to avoid. The frame yield lets
+  // the dismissal flush first. Mirrors the old RN-Modal's requestAnimationFrame.
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      const after = pendingAfterCloseRef.current;
+      pendingAfterCloseRef.current = null;
+      if (after) requestAnimationFrame(after);
+    },
+    [],
+  );
+
+  const popRoute = useCallback(() => {
+    if (!mountedRef.current) return;
+    router.back();
+  }, []);
+
+  const close = useCallback(
+    (after?: () => void) => {
+      if (closingRef.current) return;
+      closingRef.current = true;
+      if (after) pendingAfterCloseRef.current = after;
+      drawerProgress.value = withTiming(
+        0,
+        {
+          duration: DRAWER_ANIMATION_MS,
+          easing: Easing.out(Easing.cubic),
+        },
+        // Pop whenever the slide-out settles — not only on finished===true. A
+        // completion reported as unfinished would otherwise strand the route
+        // mounted with its full-screen (opacity-0 but still hit-testing) backdrop
+        // eating every tap; popRoute's mountedRef guard keeps an after-unmount
+        // callback from popping the wrong route.
+        () => {
+          runOnJS(popRoute)();
+        },
+      );
+    },
+    [drawerProgress, popRoute],
+  );
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: drawerProgress.value,
+  }));
+
+  const drawerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: -drawerWidth + drawerWidth * drawerProgress.value }],
+  }));
+
+  const handleRate = () => {
+    // Set the mode now (not in the deferred callback) so the root FeedbackSheet
+    // has re-rendered with it well before the deferred present() fires.
+    setFeedbackMode('rating');
+    close(() => presentFeedback());
+  };
+
+  const handleReportBug = () => {
+    setFeedbackMode('bug');
+    close(() => presentFeedback());
+  };
+
+  return (
+    <View style={styles.root}>
+      <Animated.View style={[styles.backdrop, { backgroundColor: overlays.scrim }, backdropStyle]}>
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={() => close()}
+          accessibilityRole="button"
+          accessibilityLabel={t('ariaLabels.close')}
+        />
+      </Animated.View>
+      <Animated.View
+        style={[
+          styles.drawer,
+          {
+            width: drawerWidth,
+            paddingTop: insets.top + spacing[4],
+            paddingBottom: insets.bottom + spacing[4],
+            backgroundColor: systemColors.secondaryBackground,
+            borderRightColor: systemColors.separator,
+          },
+          shadows.lg,
+          drawerStyle,
+        ]}
+      >
+        <ScrollView
+          contentContainerStyle={styles.drawerContent}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Tappable to edit only when signed in; otherwise a plain header. Both
+              branches render the same body, differing only in the wrapper +
+              chevron. */}
+          {profile?.id ? (
+            <Pressable
+              style={styles.profileHeader}
+              onPress={() => close(() => navigateToEditProfile())}
+              accessibilityRole="button"
+              accessibilityLabel={tSettings('profile.editAction')}
+            >
+              <ProfileHeaderBody avatarUrl={profile.avatarUrl} displayName={profileDisplayName} email={profileEmail} />
+              <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+            </Pressable>
+          ) : (
+            <View style={styles.profileHeader}>
+              <ProfileHeaderBody avatarUrl={profile?.avatarUrl} displayName={profileDisplayName} email={profileEmail} />
+            </View>
+          )}
+
+          <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+            <DrawerRow
+              icon="boards"
+              title={t('userDrawer.changeBoard')}
+              onPress={() => close(() => navigateToBoards())}
+            />
+            <DrawerRow
+              icon="boards.fill"
+              title={t('myBoards.title')}
+              onPress={() => close(() => navigateToManageBoards())}
+            />
+          </View>
+
+          <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+            <DrawerRow
+              icon="settings"
+              title={t('ariaLabels.settings')}
+              onPress={() => close(() => navigateToSettings())}
+            />
+            <DrawerRow
+              icon="playlist"
+              title={t('userDrawer.myPlaylists')}
+              onPress={() => close(() => navigateToPlaylists())}
+            />
+            <DrawerRow
+              icon="info"
+              title={t('userDrawer.about')}
+              onPress={() => close(() => navigateToAbout())}
+              showSeparator={false}
+            />
+          </View>
+
+          <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+            <DrawerRow icon="star" title={t('userDrawer.rateBoardsesh')} onPress={handleRate} />
+            <DrawerRow icon="flag" title={t('userDrawer.reportBug')} onPress={handleReportBug} />
+            <DrawerRow
+              icon="open.external"
+              title={t('userDrawer.joinDiscord')}
+              tintColor={brandColors.primary}
+              onPress={() => close(() => openDiscord())}
+              showSeparator={false}
+            />
+          </View>
+
+          <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
+            <DrawerRow
+              icon="logout"
+              title={t('userDrawer.logout')}
+              tintColor={brandColors.error}
+              onPress={() => close(() => signOutAction())}
+              showSeparator={false}
+            />
+          </View>
+        </ScrollView>
+      </Animated.View>
+    </View>
+  );
+}
+
+type ProfileHeaderBodyProps = {
+  avatarUrl: string | null | undefined;
+  displayName: string;
+  email: string | null;
+};
+
+// The avatar + name + email block shared by the tappable (signed-in) and plain
+// (signed-out) header variants, so the markup lives in one place.
+function ProfileHeaderBody({ avatarUrl, displayName, email }: ProfileHeaderBodyProps) {
+  const { systemColors } = useTheme();
+  return (
+    <>
+      <Avatar uri={avatarUrl} name={displayName} size={60} />
+      <View style={styles.profileText}>
+        <Text variant="headline" numberOfLines={1} style={styles.profileName}>
+          {displayName}
+        </Text>
+        {email ? (
+          <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
+            {email}
+          </Text>
+        ) : null}
+      </View>
+    </>
+  );
+}
+
+type DrawerRowProps = {
+  icon: IconName;
+  title: string;
+  onPress: () => void;
+  showSeparator?: boolean;
+  tintColor?: string;
+};
+
+function DrawerRow({ icon, title, onPress, showSeparator = true, tintColor }: DrawerRowProps) {
+  const { systemColors } = useTheme();
+  const iconColor = tintColor ?? systemColors.label;
+  return (
+    <ListRow
+      title={title}
+      leading={<Icon name={icon} size={22} color={iconColor} />}
+      showChevron
+      showSeparator={showSeparator}
+      separatorInset={16}
+      onPress={onPress}
+      accessibilityLabel={title}
+      style={styles.drawerRow}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  backdrop: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  drawer: {
+    height: '100%',
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  drawerContent: {
+    paddingHorizontal: spacing[3],
+    gap: spacing[3],
+  },
+  profileHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[2],
+    paddingBottom: spacing[3],
+  },
+  profileText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  profileName: {
+    fontWeight: '700',
+  },
+  menuGroup: {
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  drawerRow: {
+    minHeight: 48,
+  },
+});

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -96,11 +96,11 @@
     "react-native-pager-view": "^8.0.2",
     "react-native-paper": "^5.15.3",
     "react-native-qrcode-svg": "^6.3.15",
-    "react-native-reanimated": "4.5.0",
+    "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-svg": "15.15.4",
-    "react-native-worklets": "0.10.0"
+    "react-native-worklets": "0.8.3"
   },
   "devDependencies": {
     "@bacons/apple-targets": "^4.0.7",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -96,11 +96,11 @@
     "react-native-pager-view": "^8.0.2",
     "react-native-paper": "^5.15.3",
     "react-native-qrcode-svg": "^6.3.15",
-    "react-native-reanimated": "4.3.1",
+    "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-svg": "15.15.4",
-    "react-native-worklets": "0.8.3"
+    "react-native-worklets": "0.10.0"
   },
   "devDependencies": {
     "@bacons/apple-targets": "^4.0.7",

--- a/packages/mobile/src/components/AddBetaVideoSheet.tsx
+++ b/packages/mobile/src/components/AddBetaVideoSheet.tsx
@@ -7,9 +7,9 @@
 //
 // Driven by a `visible` prop (mirrors ClimbActionsSheet / LogAscentSheet) so it
 // can present above the play drawer's own modal via stackBehavior="push".
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { View, StyleSheet, Pressable } from 'react-native';
-import { BottomSheetTextInput, type BottomSheetModal } from '@expo/ui/community/bottom-sheet';
+import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
@@ -36,31 +36,28 @@ type AddBetaVideoSheetProps = {
   boardName: BoardName;
   layoutId: number;
   angle: number;
+  /** Request an animated close (pan-down, after submit). */
   onClose: () => void;
+  /** Fired once the dismiss animation has settled — safe to unmount/clear.
+   * Optional: always-mounted hosts (PlayDrawer) don't unmount, so they omit it. */
+  onFullyDismissed?: () => void;
 };
 
-export function AddBetaVideoSheet({ visible, climb, boardName, layoutId, angle, onClose }: AddBetaVideoSheetProps) {
+export function AddBetaVideoSheet({
+  visible,
+  climb,
+  boardName,
+  layoutId,
+  angle,
+  onClose,
+  onFullyDismissed,
+}: AddBetaVideoSheetProps) {
   const { t } = useTranslation('session');
   const { showToast } = useToast();
   const { systemColors, brandColors } = useTheme();
-  const sheetRef = useRef<BottomSheetModal>(null);
-  // Tracks presented state independently of `visible` so a pan-down dismiss can't
-  // race a programmatic dismiss() into the "present() is a no-op" state — same
-  // guard as ClimbActionsSheet / LogAscentSheet.
-  const isPresentedRef = useRef(false);
   const [url, setUrl] = useState('');
 
   const attach = useAttachBetaLink();
-
-  useEffect(() => {
-    if (visible && climb && !isPresentedRef.current) {
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if ((!visible || !climb) && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
-  }, [visible, climb]);
 
   const caption = useMemo(() => {
     if (!climb) return '';
@@ -74,11 +71,10 @@ export function AddBetaVideoSheet({ visible, climb, boardName, layoutId, angle, 
     });
   }, [climb, angle, boardName, layoutId]);
 
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
+  const handleFullyDismissed = useCallback(() => {
     setUrl('');
-    onClose();
-  }, [onClose]);
+    onFullyDismissed?.();
+  }, [onFullyDismissed]);
 
   const handleCopyCaption = useCallback(async () => {
     if (!caption || !climb) return;
@@ -120,7 +116,7 @@ export function AddBetaVideoSheet({ visible, climb, boardName, layoutId, angle, 
           void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
           showToast(t('mobile.betaVideos.attachSuccess'), 'success');
           setUrl('');
-          sheetRef.current?.dismiss();
+          onClose();
         },
         onError: (error: unknown) => {
           void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
@@ -128,13 +124,19 @@ export function AddBetaVideoSheet({ visible, climb, boardName, layoutId, angle, 
         },
       },
     );
-  }, [climb, isValid, attach, boardName, trimmed, angle, showToast, t]);
+  }, [climb, isValid, attach, boardName, trimmed, angle, showToast, t, onClose]);
 
   const snapPoints = useMemo(() => ['85%'], []);
   const submitDisabled = !isValid || attach.isPending;
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} scrollable>
+    <ModalSheet
+      visible={visible && !!climb}
+      snapPoints={snapPoints}
+      onClose={onClose}
+      onFullyDismissed={handleFullyDismissed}
+      scrollable
+    >
       <View style={styles.container}>
         <Text variant="title3" style={styles.title}>
           {t('mobile.betaVideos.shareTitle')}

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, View, StyleSheet } from 'react-native';
-import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { ModalSheet } from './ModalSheet';
@@ -24,7 +23,11 @@ type AddToPlaylistSheetProps = {
   sizeId: number;
   setIds: string;
   angle: number;
+  /** Request an animated close (pan-down, after add/create). */
   onClose: () => void;
+  /** Fired once the dismiss animation has settled — safe to unmount/clear.
+   * Optional: always-mounted hosts don't unmount, so they may omit it. */
+  onFullyDismissed?: () => void;
 };
 
 // Mirrors web's isValidHexColor gate before rendering a playlist's accent: a
@@ -43,6 +46,7 @@ function AddToPlaylistSheet({
   setIds,
   angle,
   onClose,
+  onFullyDismissed,
 }: AddToPlaylistSheetProps) {
   const { t } = useTranslation('climbs');
   const { brandColors, systemColors } = useTheme();
@@ -50,22 +54,12 @@ function AddToPlaylistSheet({
   const { playlists, addToPlaylist, createPlaylist, isLoading, isAuthenticated } = usePlaylistsContext();
   const [createVisible, setCreateVisible] = useState(false);
   const [creating, setCreating] = useState(false);
-  const sheetRef = useRef<BottomSheetModal>(null);
-  // Track presented state so we never dismiss() a not-presented modal (which
-  // then no-ops the next present()). Mirrors LogAscentSheet.
-  const isPresentedRef = useRef(false);
+  // Mirror the latest open intent so an in-flight create can tell whether the
+  // sheet is still open (replaces the old isPresentedRef gate).
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
   const createRequestIdRef = useRef(0);
   const sortedPlaylists = useMemo(() => sortPlaylistsByName(playlists), [playlists]);
-
-  useEffect(() => {
-    if (visible && climb && !isPresentedRef.current) {
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if ((!visible || !climb) && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
-  }, [visible, climb]);
 
   const handleAddToPlaylist = useCallback(
     async (playlist: Playlist) => {
@@ -102,7 +96,7 @@ function AddToPlaylistSheet({
       if (!climb) return;
       const createRequestId = createRequestIdRef.current + 1;
       createRequestIdRef.current = createRequestId;
-      const isCurrentCreateRequest = () => createRequestIdRef.current === createRequestId && isPresentedRef.current;
+      const isCurrentCreateRequest = () => createRequestIdRef.current === createRequestId && visibleRef.current;
       setCreating(true);
       try {
         const created = await createPlaylist(values.name, values.description, values.color, values.icon, {
@@ -146,13 +140,14 @@ function AddToPlaylistSheet({
     [climb, createPlaylist, boardName, layoutId, addToPlaylist, angle, showToast, t, onClose],
   );
 
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
+  // The dismiss animation has settled: cancel any in-flight create, reset the
+  // nested form, then let the parent clear the climb / unmount.
+  const handleFullyDismissed = useCallback(() => {
     createRequestIdRef.current += 1;
     setCreateVisible(false);
     setCreating(false);
-    onClose();
-  }, [onClose]);
+    onFullyDismissed?.();
+  }, [onFullyDismissed]);
 
   const handleShowCreate = useCallback(() => {
     setCreateVisible(true);
@@ -168,7 +163,14 @@ function AddToPlaylistSheet({
 
   return (
     <>
-      <ModalSheet ref={sheetRef} snapPoints={snapPoints} onDismiss={handleDismiss} enablePanDownToClose scrollable>
+      <ModalSheet
+        visible={visible && !!climb}
+        snapPoints={snapPoints}
+        onClose={onClose}
+        onFullyDismissed={handleFullyDismissed}
+        enablePanDownToClose
+        scrollable
+      >
         {climb && (
           <ClimbPreviewCard
             climb={climb}

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -38,6 +38,7 @@ import { RadioGroup, type RadioOption } from './RadioGroup';
 import { SwitchRow } from './SwitchRow';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
+import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useGrades, useSearchClimbsCount } from '../lib/graphql/hooks';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
@@ -85,6 +86,12 @@ const STATUS_OPTIONS_UI = ['any', 'drafts', 'projects'] as const;
 // status into one control. undefined = Any; 2 = Established (≥2 ascents).
 const POPULARITY_BUCKETS: ReadonlyArray<number | undefined> = [undefined, 2, 10, 100, 1000];
 const PREWARM_BOARD_HOLDS_AFTER_REFINE_EXPAND_MS = 150;
+
+// This sheet's child editors (setters / holds / zone) stack ON TOP of it and
+// present off the default `root` group. Keep this sheet in its own presenter
+// group so the coordinator doesn't treat a stacked child as an exclusive
+// hand-off and dismiss the filter sheet out from under it.
+const CLIMB_FILTER_PRESENTER_GROUP = 'climb-filter';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -167,10 +174,6 @@ export function ClimbFilterSheet({
     setLocalFilters(normalizeRetiredStatus(currentFilters));
     setLocalBoardFilters(currentBoardFilters);
   }, [currentFilters, currentBoardFilters]);
-
-  useEffect(() => {
-    sheetRef.current?.present();
-  }, []);
 
   useEffect(() => {
     return () => {
@@ -364,6 +367,18 @@ export function ClimbFilterSheet({
     onDismiss();
   }, [onDismiss]);
 
+  // The parent mounts this sheet only while it should be open, so present/dismiss
+  // route through the coordinator (serialized, no overlapping native
+  // transitions). `onClose` (handleSheetDismiss) clears the parent's open state
+  // on a user pan-down / backdrop. See CLIMB_FILTER_PRESENTER_GROUP for why this
+  // sheet keeps its own group instead of the default `root`.
+  const managed = useManagedSheet({
+    open: true,
+    sheetRef,
+    onClose: handleSheetDismiss,
+    group: CLIMB_FILTER_PRESENTER_GROUP,
+  });
+
   const handleReset = useCallback(() => {
     hapticSelection();
     updateLocalFilters(DEFAULT_FILTERS);
@@ -534,7 +549,7 @@ export function ClimbFilterSheet({
         enablePanDownToClose={!childSheetOpen}
         enableContentPanningGesture={!childSheetOpen}
         enableHandlePanningGesture={!childSheetOpen}
-        onDismiss={handleSheetDismiss}
+        onChange={managed.onChange}
         handleIndicatorStyle={styles.indicator}
       >
         <View style={styles.header}>

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -359,6 +359,10 @@ export function ClimbFilterSheet({
   const handleApply = useCallback(() => {
     hasLocalDraftEditsRef.current = false;
     onApply(localFilters, localBoardFilters);
+    // Dismiss the raw native ref directly (not via the coordinator handle). This
+    // is intentional and safe: the resulting native onChange(-1) routes back
+    // through managed.onChange → coordinator.notifyClosed, which opens the settle
+    // window. Keep it that way — don't assume the coordinator drove this close.
     sheetRef.current?.dismiss();
   }, [localFilters, localBoardFilters, onApply]);
 

--- a/packages/mobile/src/components/EndSessionSheet.tsx
+++ b/packages/mobile/src/components/EndSessionSheet.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
-import BottomSheet, { BottomSheetView } from '@expo/ui/community/bottom-sheet';
+import BottomSheet, { BottomSheetView, type BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { Text } from './Text';
 import { Button } from './Button';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
+import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { spacing, sheetStyles } from '../theme/tokens';
 
 type EndSessionSheetProps = {
@@ -21,37 +22,24 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
   const { t } = useTranslation('session');
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
-  const sheetRef = useRef<BottomSheet>(null);
-  const [mounted, setMounted] = useState(false);
+  const sheetRef = useRef<BottomSheetMethods>(null);
 
-  useEffect(() => {
-    if (visible) {
-      setMounted(true);
-    }
-  }, [visible]);
-
-  useEffect(() => {
-    if (mounted) {
-      sheetRef.current?.expand();
-    }
-  }, [mounted]);
-
-  const handleClose = useCallback(() => {
-    setMounted(false);
-    onDismiss();
-  }, [onDismiss]);
-
-  if (!mounted) return null;
+  // Present/dismiss route through the coordinator (serialized, no overlapping
+  // native transitions). Always mounted by InSessionView and toggled via
+  // `visible`, so no onFullyDismissed; `onDismiss` clears the parent's open state
+  // on a user pan-down / backdrop.
+  const managed = useManagedSheet({ open: visible, sheetRef, onClose: onDismiss });
 
   return (
     <BottomSheet
       ref={sheetRef}
+      index={-1}
       // Size to content rather than a fixed snap point — with safe-area bottom
       // padding added (up to ~34pt on gesture-nav phones), a fixed '35%' could
       // crowd or clip the buttons on shorter devices.
       enableDynamicSizing
       enablePanDownToClose
-      onClose={handleClose}
+      onChange={managed.onChange}
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >
@@ -74,7 +62,7 @@ export function EndSessionSheet({ visible, onDismiss, onConfirm, isEnding, climb
         </View>
 
         <View style={styles.buttonRow}>
-          <Button title={t('summary.done')} variant="outlined" onPress={handleClose} style={styles.button} />
+          <Button title={t('summary.done')} variant="outlined" onPress={onDismiss} style={styles.button} />
           <Button title={t('mobile.queue.endSession')} onPress={onConfirm} loading={isEnding} style={styles.button} />
         </View>
       </BottomSheetView>

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -5,10 +5,11 @@
 //
 // Uses `BottomSheetModal` (not the regular `BottomSheet`) so it presents as
 // a native modal above the play drawer's own modal.
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
+import { useManagedSheet } from '../providers/sheet-presentation-provider';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
@@ -17,7 +18,14 @@ import { QuickTickBar } from './play-drawer/QuickTickBar';
 
 type LogAscentSheetProps = {
   visible: boolean;
-  onDismiss: () => void;
+  /** Request an animated close (close button, pan-down, tick complete). The
+   * parent flips `visible` false; the sheet stays mounted until the animation
+   * settles (onFullyDismissed). */
+  onClose: () => void;
+  /** Fired once the dismiss animation has settled — safe for the parent to clear
+   * the climb data / unmount without tearing the native Host down mid-animation.
+   * Optional: always-mounted hosts (PlayDrawer) don't unmount, so they omit it. */
+  onFullyDismissed?: () => void;
   climbUuid: string;
   boardName: string;
   angle: number;
@@ -32,7 +40,8 @@ type LogAscentSheetProps = {
 
 export function LogAscentSheet({
   visible,
-  onDismiss,
+  onClose,
+  onFullyDismissed,
   climbUuid,
   boardName,
   angle,
@@ -45,28 +54,13 @@ export function LogAscentSheet({
   consensusGradeName,
 }: LogAscentSheetProps) {
   const sheetRef = useRef<BottomSheetModal>(null);
-  // Tracks whether the modal is currently *presented*, independent of the
-  // external `visible` prop, so we never call `dismiss()` on an already-closed
-  // sheet (or `present()` on an already-open one) when a pan-down dismiss and
-  // our `visible` effect race.
-  const isPresentedRef = useRef(false);
   const { systemColors } = useTheme();
   const { t } = useTranslation('session');
 
-  useEffect(() => {
-    if (visible && !isPresentedRef.current) {
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!visible && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
-  }, [visible]);
-
-  const handleSheetDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onDismiss();
-  }, [onDismiss]);
+  // Present/dismiss go through the coordinator (serialized, no overlapping
+  // transitions); `onClose` fires on a user pan-down, `onFullyDismissed` after
+  // the animation settles.
+  const managed = useManagedSheet({ open: visible, sheetRef, onClose, onFullyDismissed });
 
   // Default to 60% so the climb image stays visible above the sheet (the
   // UX review flagged full-cover + carousel-disabled as the wrong
@@ -80,7 +74,7 @@ export function LogAscentSheet({
       index={0}
       snapPoints={snapPoints}
       enablePanDownToClose
-      onDismiss={handleSheetDismiss}
+      onChange={managed.onChange}
       handleIndicatorStyle={styles.indicator}
       keyboardBehavior="extend"
       keyboardBlurBehavior="restore"
@@ -88,7 +82,7 @@ export function LogAscentSheet({
       <View style={styles.content}>
         <View style={styles.closeButtonRow}>
           <Pressable
-            onPress={onDismiss}
+            onPress={onClose}
             accessibilityRole="button"
             accessibilityLabel={t('playView.tickBar.closeAria')}
             hitSlop={8}
@@ -112,7 +106,7 @@ export function LogAscentSheet({
           setIds={setIds}
           sessionId={sessionId}
           consensusGradeName={consensusGradeName}
-          onDismiss={onDismiss}
+          onDismiss={onClose}
         />
       </View>
     </BottomSheetModal>

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -1,10 +1,16 @@
-// Modal bottom sheet, presented imperatively via ref (`present()` / `dismiss()`).
+// Modal bottom sheet, presented imperatively via ref (`present()` / `dismiss()`)
+// OR declaratively via the `visible` prop.
+//
 // Migrated off @gorhom/bottom-sheet to Expo's native bottom sheet (#3167): the
 // native modal already presents above root chrome (the queue bar), so the old
 // FullWindowOverlay container is gone, and the native sheet supplies the scrim,
 // handle and (iOS 26) glass background — retiring SheetBackdrop / GlassSheetBackground.
+//
+// All present/dismiss go through the SheetPresentationProvider coordinator, which
+// serializes native sheet transitions so two never overlap on the same presenter
+// (the iOS UIKit deadlock / app freeze — see sheet-presentation-provider.tsx).
 
-import { forwardRef, useCallback, useMemo, type ReactNode } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, type ReactNode } from 'react';
 import { KeyboardAvoidingView, Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import { BottomSheetModal, BottomSheetScrollView, type BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -12,14 +18,27 @@ import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
 type ModalSheetProps = {
   children: ReactNode;
+  /** Controlled open state. Leave undefined for purely imperative consumers that
+   * drive the sheet through the forwarded ref. */
+  visible?: boolean;
   snapPoints?: (string | number)[];
   enableDynamicSizing?: boolean;
   onChange?: (index: number) => void;
-  /** Fired when the sheet is dismissed (gesture or programmatic). */
+  /** Fired when the user closes the sheet themselves (pan-down / backdrop), so a
+   * controlled parent can clear the state driving `visible`. */
+  onClose?: () => void;
+  /** Fired AFTER the dismiss animation has really settled (the accurate hook). */
+  onFullyDismissed?: () => void;
+  /** @deprecated source-compat: fires on every close (user or programmatic),
+   * synchronously, like the old native onDismiss. Prefer onClose/onFullyDismissed. */
   onDismiss?: () => void;
+  /** Serialization domain. Sheets presented off the same view controller share a
+   * group; defaults to the root window VC. */
+  presenterGroup?: PresenterGroup;
   enablePanDownToClose?: boolean;
   scrollable?: boolean;
   contentContainerStyle?: StyleProp<ViewStyle>;
@@ -33,10 +52,14 @@ type ModalSheetProps = {
 export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(function ModalSheet(
   {
     children,
+    visible,
     snapPoints: customSnapPoints,
     enableDynamicSizing = false,
     onChange,
+    onClose,
+    onFullyDismissed,
     onDismiss,
+    presenterGroup,
     enablePanDownToClose = true,
     scrollable = false,
     contentContainerStyle,
@@ -52,12 +75,29 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
   // them a partial state instead (see androidSafeSnapPoints).
   const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
+  const sheetRef = useRef<BottomSheetMethods>(null);
+  const managed = useManagedSheet({
+    open: visible,
+    group: presenterGroup,
+    sheetRef,
+    onClose,
+    onFullyDismissed,
+  });
+  useImperativeHandle(ref, () => managed.handle as BottomSheetMethods, [managed.handle]);
+
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
   const handleChange = useCallback(
     (index: number) => {
       if (index >= 0) hapticMedium();
-      onChange?.(index);
+      managed.onChange(index);
+      if (index === -1) onDismissRef.current?.();
+      onChangeRef.current?.(index);
     },
-    [onChange],
+    [managed],
   );
 
   const body = scrollable ? (
@@ -91,14 +131,13 @@ export const ModalSheet = forwardRef<BottomSheetMethods, ModalSheetProps>(functi
 
   return (
     <BottomSheetModal
-      ref={ref}
+      ref={sheetRef}
       index={0}
       snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}
       handleIndicatorStyle={sheet.handleStyle}
       onChange={handleChange}
-      onDismiss={onDismiss}
       style={styles.sheet}
     >
       {footer ? (

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -1,22 +1,37 @@
-import { forwardRef, useCallback, useMemo, type ReactNode } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, type ReactNode } from 'react';
 import { KeyboardAvoidingView, Platform, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 // Migrated off @gorhom/bottom-sheet to Expo's native bottom sheet (#3167).
 // The native sheet draws its own scrim, drag handle and (on iOS 26) glass
 // background, so the old SheetBackdrop / GlassSheetBackground / FullWindowOverlay
 // wiring is gone. Scroll/keyboard coordination is handled natively.
+//
+// Present/dismiss route through the SheetPresentationProvider coordinator so two
+// native sheet transitions never overlap (the iOS UIKit deadlock / app freeze —
+// see sheet-presentation-provider.tsx).
 import BottomSheet, { BottomSheetScrollView, type BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
 import { androidSafeSnapPoints } from './sheet-snap-points';
+import { useManagedSheet, type PresenterGroup } from '../providers/sheet-presentation-provider';
 
 type SheetProps = {
   children: ReactNode;
+  /** Controlled open state. Leave undefined for purely imperative consumers that
+   * drive the sheet through the forwarded ref. */
+  visible?: boolean;
   snapPoints?: (string | number)[];
   enableDynamicSizing?: boolean;
   onChange?: (index: number) => void;
+  /** Fired when the user closes the sheet themselves (pan-down / backdrop), so a
+   * controlled parent can clear the state driving `visible`. */
   onClose?: () => void;
+  /** Fired AFTER the dismiss animation has really settled (the accurate hook). */
+  onFullyDismissed?: () => void;
+  /** Serialization domain. Sheets presented off the same view controller share a
+   * group; defaults to the root window VC. */
+  presenterGroup?: PresenterGroup;
   enablePanDownToClose?: boolean;
   // Render the content inside a scrollable container instead of a plain View.
   // Use this for content taller than the sheet.
@@ -40,10 +55,13 @@ type SheetProps = {
 export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   {
     children,
+    visible,
     snapPoints: customSnapPoints,
     enableDynamicSizing = false,
     onChange,
     onClose,
+    onFullyDismissed,
+    presenterGroup,
     enablePanDownToClose = true,
     scrollable = false,
     contentContainerStyle,
@@ -55,12 +73,26 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const insets = useSafeAreaInsets();
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
 
+  const sheetRef = useRef<BottomSheetMethods>(null);
+  const managed = useManagedSheet({
+    open: visible,
+    group: presenterGroup,
+    sheetRef,
+    onClose,
+    onFullyDismissed,
+  });
+  useImperativeHandle(ref, () => managed.handle as BottomSheetMethods, [managed.handle]);
+
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
   const handleChange = useCallback(
     (index: number) => {
       if (index >= 0) hapticMedium();
-      onChange?.(index);
+      managed.onChange(index);
+      onChangeRef.current?.(index);
     },
-    [onChange],
+    [managed],
   );
 
   const body = scrollable ? (
@@ -94,13 +126,12 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
 
   return (
     <BottomSheet
-      ref={ref}
+      ref={sheetRef}
       index={-1}
       snapPoints={enableDynamicSizing ? undefined : androidSafeSnapPoints(snapPoints)}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}
       onChange={handleChange}
-      onClose={onClose}
       handleIndicatorStyle={sheetChrome.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
-import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
+import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 
@@ -69,18 +69,35 @@ vi.mock('../../theme/tokens', () => ({
 }));
 
 vi.mock('../ModalSheet', () => ({
-  ModalSheet: forwardRef(function ModalSheet(
-    { children, onDismiss }: { children?: ReactNode; onDismiss?: () => void },
-    ref,
-  ) {
-    useImperativeHandle(ref, () => ({ present: vi.fn(), dismiss: vi.fn() }));
+  ModalSheet: function ModalSheet({
+    children,
+    onClose,
+    onFullyDismissed,
+  }: {
+    children?: ReactNode;
+    visible?: boolean;
+    onClose?: () => void;
+    onFullyDismissed?: () => void;
+  }) {
     return createElement(
       'div',
       { 'data-modal-sheet': 'true' },
       children,
-      createElement('button', { 'aria-label': 'dismiss-add-to-playlist-sheet', onClick: onDismiss }, 'dismiss'),
+      // The user-initiated close (pan-down/backdrop) → onClose; the parent then
+      // clears state on the settled onFullyDismissed.
+      createElement(
+        'button',
+        {
+          'aria-label': 'dismiss-add-to-playlist-sheet',
+          onClick: () => {
+            onClose?.();
+            onFullyDismissed?.();
+          },
+        },
+        'dismiss',
+      ),
     );
-  }),
+  },
 }));
 
 vi.mock('../ClimbPreviewCard', () => ({

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -25,7 +25,7 @@ const bottomSheetModalProps = vi.hoisted(() => ({
     enablePanDownToClose?: boolean;
     enableContentPanningGesture?: boolean;
     enableHandlePanningGesture?: boolean;
-    onDismiss?: () => void;
+    onChange?: (index: number) => void;
   },
 }));
 
@@ -95,6 +95,29 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
   ) {
     useImperativeHandle(ref, () => ({}), []);
     return createElement('div', null, children);
+  }),
+}));
+
+// Isolate the sheet from the presentation coordinator (its serialization is
+// covered by sheet-presentation-provider.test.tsx). The mock mirrors only the
+// user-close path: onChange(-1) → onClose, which the dismiss-without-Apply tests
+// exercise via the captured native onChange prop.
+vi.mock('../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: ({ onClose }: { onClose?: () => void }) => ({
+    onChange: (index: number) => {
+      if (index === -1) onClose?.();
+    },
+    onFullyDismissed: () => {},
+    handle: {
+      present: () => {},
+      dismiss: () => {},
+      close: () => {},
+      forceClose: () => {},
+      snapToIndex: () => {},
+      snapToPosition: () => {},
+      expand: () => {},
+      collapse: () => {},
+    },
   }),
 }));
 
@@ -391,7 +414,7 @@ describe('ClimbFilterSheet child filters', () => {
     fireEvent.click(rendered.getByLabelText('mobile.filter.setters'));
     fireEvent.click(rendered.getByText('setters-change'));
 
-    bottomSheetModalProps.latest?.onDismiss?.();
+    bottomSheetModalProps.latest?.onChange?.(-1);
     rendered.rerender(
       <ClimbFilterSheet
         {...rendered.props}
@@ -415,7 +438,7 @@ describe('ClimbFilterSheet child filters', () => {
     fireEvent.click(rendered.getByText('setters-change'));
     fireEvent.click(rendered.getByText('mobile.filter.reset'));
 
-    bottomSheetModalProps.latest?.onDismiss?.();
+    bottomSheetModalProps.latest?.onChange?.(-1);
     rendered.rerender(
       <ClimbFilterSheet
         {...rendered.props}

--- a/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/end-session-sheet.test.tsx
@@ -29,10 +29,11 @@ type SheetMockProps = {
   children?: ReactNode;
   enableDynamicSizing?: boolean;
   snapPoints?: (string | number)[];
+  index?: number;
 };
 type SheetViewMockProps = { children?: ReactNode; style?: unknown };
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  default: forwardRef(({ children, enableDynamicSizing, snapPoints }: SheetMockProps, ref: Ref<unknown>) => {
+  default: forwardRef(({ children, enableDynamicSizing, snapPoints, index }: SheetMockProps, ref: Ref<unknown>) => {
     useImperativeHandle(ref, () => ({ expand: sheet.expand }));
     return createElement(
       'div',
@@ -40,12 +41,36 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
         'data-sheet': 'true',
         'data-dynamic': enableDynamicSizing ? 'true' : 'false',
         'data-snappoints': snapPoints ? JSON.stringify(snapPoints) : '',
+        'data-index': index === undefined ? '' : String(index),
       },
       children,
     );
   }),
   BottomSheetView: ({ children, style }: SheetViewMockProps) =>
     createElement('div', { 'data-sheet-view': 'true', 'data-pb': String(readPaddingBottom(style) ?? '') }, children),
+}));
+
+// Isolate the sheet from the presentation coordinator (its serialization is
+// covered by sheet-presentation-provider.test.tsx). The sheet is always mounted
+// and opened/closed by the coordinator; these tests drive close via the Done
+// button's onDismiss prop, so a no-op managed handle is enough.
+vi.mock('../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: ({ onClose }: { onClose?: () => void }) => ({
+    onChange: (index: number) => {
+      if (index === -1) onClose?.();
+    },
+    onFullyDismissed: () => {},
+    handle: {
+      present: () => {},
+      dismiss: () => {},
+      close: () => {},
+      forceClose: () => {},
+      snapToIndex: () => {},
+      snapToPosition: () => {},
+      expand: () => {},
+      collapse: () => {},
+    },
+  }),
 }));
 
 // Gesture-nav phone: a non-zero bottom inset is the case the dynamic-sizing fix
@@ -110,9 +135,13 @@ describe('EndSessionSheet', () => {
     sheet.expand.mockClear();
   });
 
-  it('renders nothing until it has been made visible', () => {
+  it('stays mounted but closed (index -1) until the coordinator opens it', () => {
+    // The sheet is always mounted now — present/dismiss route through the
+    // coordinator — so it renders at the closed index rather than returning null.
     const { container } = render(<EndSessionSheet {...makeProps({ visible: false })} />);
-    expect(container.querySelector('[data-sheet]')).toBeNull();
+    const sheetEl = container.querySelector('[data-sheet]') as HTMLElement;
+    expect(sheetEl).not.toBeNull();
+    expect(sheetEl.getAttribute('data-index')).toBe('-1');
   });
 
   it('shows the confirmation copy, climb count, and both actions when visible', () => {

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -45,6 +45,13 @@ vi.mock('react-native-safe-area-context', () => ({
 const hapticMedium = vi.fn();
 vi.mock('../../lib/haptics', () => ({ hapticMedium: () => hapticMedium() }));
 
+// Isolate the wrapper from the coordinator: useManagedSheet's serialization is
+// covered by sheet-presentation-provider.test.tsx. Here we only assert the
+// wrapper's own chrome (footer/scroll/snap points/haptics + consumer onChange).
+vi.mock('../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: () => ({ onChange: () => {}, onFullyDismissed: () => {}, handle: {} }),
+}));
+
 vi.mock('../../theme/tokens', () => ({
   spacing: { 2: 8, 3: 12, 4: 16, 6: 24 },
 }));

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -49,7 +49,22 @@ vi.mock('../../lib/haptics', () => ({ hapticMedium: () => hapticMedium() }));
 // covered by sheet-presentation-provider.test.tsx. Here we only assert the
 // wrapper's own chrome (footer/scroll/snap points/haptics + consumer onChange).
 vi.mock('../../providers/sheet-presentation-provider', () => ({
-  useManagedSheet: () => ({ onChange: () => {}, onFullyDismissed: () => {}, handle: {} }),
+  useManagedSheet: () => ({
+    onChange: () => {},
+    onFullyDismissed: () => {},
+    // Stub the full handle (not {}) so a future test calling ref.current.present()
+    // gets a spy, not a silent undefined-is-not-a-function throw.
+    handle: {
+      present: vi.fn(),
+      dismiss: vi.fn(),
+      close: vi.fn(),
+      forceClose: vi.fn(),
+      snapToIndex: vi.fn(),
+      snapToPosition: vi.fn(),
+      expand: vi.fn(),
+      collapse: vi.fn(),
+    },
+  }),
 }));
 
 vi.mock('../../theme/tokens', () => ({

--- a/packages/mobile/src/components/ble/BleLightbulbButton.tsx
+++ b/packages/mobile/src/components/ble/BleLightbulbButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Pressable, StyleSheet } from 'react-native';
+import { Pressable, StyleSheet, type PressableStateCallbackType } from 'react-native';
 import Animated, {
   cancelAnimation,
   useAnimatedStyle,
@@ -112,7 +112,7 @@ export function BleLightbulbButton({
       )}
       accessibilityState={{ selected: accessibilitySelected ?? isConnected }}
       hitSlop={8}
-      style={({ pressed }) => [
+      style={({ pressed }: PressableStateCallbackType) => [
         styles.container,
         { width: containerSize, height: containerSize, borderRadius: containerSize / 2 },
         animatedStyle,

--- a/packages/mobile/src/components/ble/DevicePickerSheet.tsx
+++ b/packages/mobile/src/components/ble/DevicePickerSheet.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { BottomSheetModal, BottomSheetView, BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { parseSerialNumber } from '@boardsesh/ble-protocol';
 import type { DiscoveredDevice } from '../../lib/ble/types';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
 import { androidSafeSnapPoints } from '../sheet-snap-points';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { BleBoardConfig } from '../../lib/ble/board-config-match';
@@ -39,9 +40,11 @@ export function DevicePickerSheet({
 
   const snapPoints = useMemo(() => androidSafeSnapPoints(['72%']), []);
 
-  useEffect(() => {
-    sheetRef.current?.present();
-  }, []);
+  // The host mounts this sheet only while a picker session is active, so it is
+  // always meant to be open. Present/dismiss route through the coordinator
+  // (serialized, no overlapping native transitions); `onDismiss` clears the
+  // host's picker state on a user pan-down / backdrop.
+  const managed = useManagedSheet({ open: true, sheetRef, onClose: onDismiss });
 
   const sortedDevices = useMemo(() => [...devices].sort((deviceA, deviceB) => deviceB.rssi - deviceA.rssi), [devices]);
 
@@ -86,7 +89,7 @@ export function DevicePickerSheet({
       index={0}
       snapPoints={snapPoints}
       enablePanDownToClose
-      onDismiss={onDismiss}
+      onChange={managed.onChange}
       handleIndicatorStyle={styles.indicator}
     >
       <BottomSheetView style={styles.header}>

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -16,6 +16,7 @@ import { Platform, Pressable, RefreshControl, StyleSheet, View, type ColorValue 
 // SPIKE(spike/expo-bottom-sheet): swap gorhom -> Expo's native drop-in. The native
 // sheet draws its own scrim, so SheetBackdrop + stackBehavior are dropped.
 import { BottomSheetModal, BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
@@ -442,31 +443,42 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     onClose();
   }, [invalidatePendingActions, onClose]);
 
-  const handleDismissed = useCallback(() => {
+  // Fired once the dismiss animation has actually SETTLED (coordinator), not on
+  // the synchronous early callback — so we never tear anything down mid-animation.
+  const handleFullyDismissed = useCallback(() => {
     invalidatePendingActions();
     onDismissed?.();
   }, [invalidatePendingActions, onDismissed]);
+
+  // Present/dismiss route through the coordinator so the board sheet never
+  // overlaps another sheet's transition (the iOS UIKit deadlock). The sheet stays
+  // mounted (like QueueSheet) and is re-presented on the next open.
+  const managed = useManagedSheet({ sheetRef, onFullyDismissed: handleFullyDismissed });
 
   const handleSwitchBoard = useCallback(() => {
     invalidatePendingActions();
     onSwitchBoard();
   }, [invalidatePendingActions, onSwitchBoard]);
 
-  useImperativeHandle(ref, () => ({
-    present: () => {
-      if (historyCountRef.current > 0) {
-        track(SHARED_EVENTS.BoardHistoryViewed, {
-          boardId: boardPresenceBoardIdRef.current ?? undefined,
-          itemCount: historyCountRef.current,
-        });
-      }
-      sheetRef.current?.present();
-    },
-    dismiss: () => {
-      invalidatePendingActions();
-      sheetRef.current?.dismiss();
-    },
-  }));
+  useImperativeHandle(
+    ref,
+    () => ({
+      present: () => {
+        if (historyCountRef.current > 0) {
+          track(SHARED_EVENTS.BoardHistoryViewed, {
+            boardId: boardPresenceBoardIdRef.current ?? undefined,
+            itemCount: historyCountRef.current,
+          });
+        }
+        managed.handle.present();
+      },
+      dismiss: () => {
+        invalidatePendingActions();
+        managed.handle.dismiss();
+      },
+    }),
+    [managed.handle, invalidatePendingActions],
+  );
 
   const renderHistoryItem = useCallback(
     ({ item }: { item: BoardPresenceClimb }) => {
@@ -652,7 +664,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       // bounded content height to measure).
       enableDynamicSizing={false}
       enablePanDownToClose
-      onDismiss={handleDismissed}
+      onChange={managed.onChange}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -100,6 +100,26 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     ),
 }));
 
+// Isolate from the real coordinator (covered by sheet-presentation-provider.test):
+// route the handle straight to the mocked native ref and simulate an immediate
+// settle on dismiss so onFullyDismissed-driven behaviour still fires.
+vi.mock('../../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: (opts: {
+    sheetRef: { current: { present?: () => void; dismiss?: () => void } | null };
+    onFullyDismissed?: () => void;
+  }) => ({
+    onChange: () => {},
+    onFullyDismissed: () => opts.onFullyDismissed?.(),
+    handle: {
+      present: () => opts.sheetRef.current?.present?.(),
+      dismiss: () => {
+        opts.sheetRef.current?.dismiss?.();
+        opts.onFullyDismissed?.();
+      },
+    },
+  }),
+}));
+
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));

--- a/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSelectorSheet.tsx
@@ -16,6 +16,7 @@ import { iosSystemColors } from '../../theme/ios-colors';
 import { brandColors } from '../../theme/colors';
 import { spacing, sheetStyles } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
 
 type AngleSelectorSheetProps = {
   visible: boolean;
@@ -42,7 +43,6 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
   const insets = useSafeAreaInsets();
   const { gradeFormat } = useGradeFormat();
   const sheetRef = useRef<BottomSheetModal>(null);
-  const isPresentedRef = useRef(false);
 
   // Single large snap point so the sheet always opens at full "big" size with
   // room for the diagram, stats, slider and Done button above the home indicator.
@@ -71,24 +71,16 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
   const currentAngleRef = useRef(currentAngle);
   currentAngleRef.current = currentAngle;
 
+  // Reset the preview to the board's actual angle each time the sheet opens.
   useEffect(() => {
-    if (visible && !isPresentedRef.current) {
-      // Reset the preview to the board's actual angle each time the sheet opens.
-      setSelectedAngle(currentAngleRef.current);
-      sheetRef.current?.present();
-      isPresentedRef.current = true;
-    } else if (!visible && isPresentedRef.current) {
-      sheetRef.current?.dismiss();
-      isPresentedRef.current = false;
-    }
+    if (visible) setSelectedAngle(currentAngleRef.current);
   }, [visible]);
 
-  // Dismissed by gesture / backdrop / programmatically — does NOT apply the
-  // previewed angle (that only happens via "Done").
-  const handleDismiss = useCallback(() => {
-    isPresentedRef.current = false;
-    onClose();
-  }, [onClose]);
+  // Present/dismiss route through the coordinator (serialized, no overlapping
+  // native transitions). The sheet stays mounted as a PlayDrawer sibling, so no
+  // onFullyDismissed is needed; `onClose` fires on a user pan-down / backdrop —
+  // which does NOT apply the previewed angle (that only happens via "Done").
+  const managed = useManagedSheet({ open: visible, sheetRef, onClose });
 
   const handleDone = useCallback(() => {
     onAngleChange(selectedAngle);
@@ -101,7 +93,7 @@ export const AngleSelectorSheet = memo(function AngleSelectorSheet({
       index={0}
       snapPoints={snapPoints}
       enablePanDownToClose
-      onDismiss={handleDismiss}
+      onChange={managed.onChange}
       handleIndicatorStyle={sheetStyles.indicator}
     >
       <BottomSheetView style={[styles.container, { paddingBottom: insets.bottom + spacing[4] }]}>

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -923,7 +923,7 @@ export function PlayDrawer({
       {displayedClimb && (
         <LogAscentSheet
           visible={isTickBarActive}
-          onDismiss={handleTickBarDismiss}
+          onClose={handleTickBarDismiss}
           climbUuid={displayedClimb.uuid}
           boardName={boardName}
           angle={angle}

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -77,7 +77,6 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
   // request, backdrop, or pan-down). Reset local UI state; the sheet stays
   // mounted (imperative model) and is re-presented on the next open.
   const handleFullyDismissed = useCallback(() => {
-    setIsPresented(false);
     resetState();
     onDismissed?.();
   }, [resetState, onDismissed]);
@@ -86,11 +85,23 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
   // sheet's transition (the iOS UIKit deadlock).
   const managed = useManagedSheet({ sheetRef, onFullyDismissed: handleFullyDismissed });
 
+  // Track presented state off the native onChange (index >= 0 = a real snap) so
+  // it stays correct even when the COORDINATOR re-presents this sheet after a
+  // handoff — that path drives the native ref directly, not the imperative
+  // present() below, so deriving isPresented from present() alone would desync
+  // (no auto-scroll to the current climb on a re-present).
+  const handleSheetChange = useCallback(
+    (index: number) => {
+      managed.onChange(index);
+      setIsPresented(index >= 0);
+    },
+    [managed],
+  );
+
   useImperativeHandle(
     ref,
     () => ({
       present: () => {
-        setIsPresented(true);
         managed.handle.present();
       },
       dismiss: () => {
@@ -164,7 +175,7 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
       // never fights the reorder gesture.
       enableContentPanningGesture={!isDragging}
       enableHandlePanningGesture={!isDragging}
-      onChange={managed.onChange}
+      onChange={handleSheetChange}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/play-drawer/QueueSheet.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueSheet.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { View, Pressable, Platform, StyleSheet } from 'react-native';
 import { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
@@ -66,34 +67,38 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
 
   const currentItemUuid = currentClimbQueueItem?.uuid ?? null;
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      present: () => {
-        setIsPresented(true);
-        sheetRef.current?.present();
-      },
-      dismiss: () => {
-        sheetRef.current?.dismiss();
-      },
-    }),
-    [],
-  );
-
   const resetState = useCallback(() => {
     setIsEditMode(false);
     setSelectedItems(new Set());
     setShowFullHistory(false);
   }, []);
 
-  // The modal's dismiss animation has finished (header request, backdrop, or
-  // pan-down). Reset local UI state; the sheet stays mounted (imperative model)
-  // and is re-presented on the next open.
-  const handleDismissed = useCallback(() => {
+  // The modal's dismiss animation has actually SETTLED (coordinator: header
+  // request, backdrop, or pan-down). Reset local UI state; the sheet stays
+  // mounted (imperative model) and is re-presented on the next open.
+  const handleFullyDismissed = useCallback(() => {
     setIsPresented(false);
     resetState();
     onDismissed?.();
   }, [resetState, onDismissed]);
+
+  // Present/dismiss route through the coordinator so they never overlap another
+  // sheet's transition (the iOS UIKit deadlock).
+  const managed = useManagedSheet({ sheetRef, onFullyDismissed: handleFullyDismissed });
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      present: () => {
+        setIsPresented(true);
+        managed.handle.present();
+      },
+      dismiss: () => {
+        managed.handle.dismiss();
+      },
+    }),
+    [managed.handle],
+  );
 
   const handleToggleEditMode = useCallback(() => {
     setIsEditMode((prev) => {
@@ -159,7 +164,7 @@ export const QueueSheet = forwardRef<QueueSheetHandle, QueueSheetProps>(function
       // never fights the reorder gesture.
       enableContentPanningGesture={!isDragging}
       enableHandlePanningGesture={!isDragging}
-      onDismiss={handleDismissed}
+      onChange={managed.onChange}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >

--- a/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/angle-selector-sheet-stats-gate.test.tsx
@@ -36,6 +36,28 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
   BottomSheetView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 
+// Isolate the sheet from the presentation coordinator (its serialization is
+// covered by sheet-presentation-provider.test.tsx). This test only pins the
+// stats-history fetch gating, so a no-op managed handle is enough.
+vi.mock('../../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: ({ onClose }: { onClose?: () => void }) => ({
+    onChange: (index: number) => {
+      if (index === -1) onClose?.();
+    },
+    onFullyDismissed: () => {},
+    handle: {
+      present: () => {},
+      dismiss: () => {},
+      close: () => {},
+      forceClose: () => {},
+      snapToIndex: () => {},
+      snapToPosition: () => {},
+      expand: () => {},
+      collapse: () => {},
+    },
+  }),
+}));
+
 vi.mock('react-native-screens', () => ({
   FullWindowOverlay: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ComponentType, type RefObject } from 'react';
+import type { ViewStyle } from 'react-native';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
 import {
   useSharedValue,
@@ -48,7 +49,7 @@ type UseZoomPanGestureReturn = {
   containerWidthSV: SharedValue<number>;
   containerHeightSV: SharedValue<number>;
   resetZoom: () => void;
-  animatedZoomStyle: AnimatedStyle;
+  animatedZoomStyle: AnimatedStyle<ViewStyle>;
 };
 
 // Worklet-callable copy of clampTranslation from @boardsesh/play-view. The

--- a/packages/mobile/src/components/session-screen/InviteSheet.tsx
+++ b/packages/mobile/src/components/session-screen/InviteSheet.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { Share, StyleSheet, View } from 'react-native';
 // SPIKE(spike/expo-bottom-sheet): swap gorhom -> Expo's native drop-in. The native
 // sheet renders its own scrim, so the custom SheetBackdrop wiring is dropped.
-import BottomSheet, { BottomSheetView } from '@expo/ui/community/bottom-sheet';
+import BottomSheet, { BottomSheetView, type BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
@@ -11,6 +11,7 @@ import { Text } from '../Text';
 import { Button } from '../Button';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
 import { hapticSelection } from '../../lib/haptics';
 import { spacing, borderRadius, sheetStyles } from '../../theme/tokens';
 import { buildSessionShareUrl } from '../../lib/session-share';
@@ -32,29 +33,17 @@ export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps)
   const { systemColors } = useTheme();
   const { showToast } = useToast();
   const insets = useSafeAreaInsets();
-  const sheetRef = useRef<BottomSheet>(null);
-  const [mounted, setMounted] = useState(false);
+  const sheetRef = useRef<BottomSheetMethods>(null);
 
   const shareUrl = useMemo(() => buildSessionShareUrl(sessionId), [sessionId]);
 
-  useEffect(() => {
-    if (visible) {
-      setMounted(true);
-    }
-  }, [visible]);
-
-  useEffect(() => {
-    if (mounted) {
-      sheetRef.current?.expand();
-    }
-  }, [mounted]);
+  // Present/dismiss route through the coordinator (serialized, no overlapping
+  // native transitions). Always mounted by SessionScreen and toggled via
+  // `visible`, so no onFullyDismissed; `onDismiss` clears the parent's open state
+  // on a user pan-down / backdrop.
+  const managed = useManagedSheet({ open: visible, sheetRef, onClose: onDismiss });
 
   const snapPoints = useMemo(() => ['60%'], []);
-
-  const handleClose = useCallback(() => {
-    setMounted(false);
-    onDismiss();
-  }, [onDismiss]);
 
   const handleCopyLink = useCallback(() => {
     hapticSelection();
@@ -68,14 +57,13 @@ export function InviteSheet({ visible, onDismiss, sessionId }: InviteSheetProps)
     void Share.share({ message: shareUrl, url: shareUrl });
   }, [shareUrl]);
 
-  if (!mounted) return null;
-
   return (
     <BottomSheet
       ref={sheetRef}
+      index={-1}
       snapPoints={snapPoints}
       enablePanDownToClose
-      onClose={handleClose}
+      onChange={managed.onChange}
       backgroundStyle={{ backgroundColor: systemColors.secondaryBackground }}
       handleIndicatorStyle={sheetStyles.indicator}
     >

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -151,6 +151,8 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
 
   const openFeedback = useCallback(
     (mode: FeedbackSheetMode) => {
+      // Set the mode now (not inside the deferred callback) so the sheet has
+      // re-rendered with it well before the deferred present() fires.
       setFeedbackMode(mode);
       runAfterDrawerClosed(() => feedbackSheetRef.current?.present());
     },

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -1,32 +1,37 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
-import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react';
 import { router, useSegments } from 'expo-router';
 import type { BottomSheetModal } from '@expo/ui/community/bottom-sheet';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useTranslation } from 'react-i18next';
 import { openDiscordInvite } from '../../lib/discord';
 import { reportError } from '../../lib/error-reporting';
-import { useProfile } from '../../lib/graphql/hooks';
 import { useAuth } from '../../providers/auth-provider';
-import { useTheme } from '../../providers/theme-provider';
-import { spacing, borderRadius, shadows, overlays } from '../../theme/tokens';
-import type { IconName } from '../icon-map';
-import { Avatar } from '../Avatar';
-import { Text } from '../Text';
-import { Icon } from '../Icon';
-import { ListRow } from '../ListRow';
 import { FeedbackSheet, type FeedbackSheetMode } from './FeedbackSheet';
 
+type BoardReturnTo = '/(tabs)/discover' | '/(tabs)/climbs';
+
+// The drawer panel itself now lives in the `user-drawer` transparentModal route
+// (app/user-drawer.tsx). The provider is data + actions only: it opens the route
+// and exposes the RAW navigation/feedback actions. The route is responsible for
+// sequencing them (its animated `close(after)` runs `after` only once the route's
+// view controller has unmounted), so none of these defer on their own.
 type UserDrawerContextValue = {
   openUserDrawer: () => void;
+  // Kept for type/back-compat. The route owns the animated close; this is a
+  // plain pop for any non-route caller (none today — UserAvatarToolbarAction
+  // only uses openUserDrawer).
   closeUserDrawer: () => void;
+  navigateToBoards: () => void;
+  navigateToManageBoards: () => void;
+  navigateToSettings: () => void;
+  navigateToEditProfile: () => void;
+  navigateToPlaylists: () => void;
+  navigateToAbout: () => void;
+  openDiscord: () => void;
+  signOutAction: () => void;
+  setFeedbackMode: (mode: FeedbackSheetMode) => void;
+  presentFeedback: () => void;
 };
 
 const UserDrawerContext = createContext<UserDrawerContextValue | null>(null);
-const DRAWER_MAX_WIDTH = 320;
-const DRAWER_SCREEN_FRACTION = 0.86;
-const DRAWER_ANIMATION_MS = 220;
 
 export function useUserDrawer(): UserDrawerContextValue {
   const context = useContext(UserDrawerContext);
@@ -34,331 +39,119 @@ export function useUserDrawer(): UserDrawerContextValue {
   return context;
 }
 
-function currentBoardReturnTo(segments: readonly string[]): '/(tabs)/discover' | '/(tabs)/climbs' {
+function currentBoardReturnTo(segments: readonly string[]): BoardReturnTo {
   return segments.includes('discover') ? '/(tabs)/discover' : '/(tabs)/climbs';
 }
 
 export function UserDrawerProvider({ children }: { children: ReactNode }) {
-  const { t } = useTranslation('common');
-  const { t: tSettings } = useTranslation('settings');
-  const { systemColors, brandColors } = useTheme();
-  const { isAuthenticated, signOut } = useAuth();
-  const profileQuery = useProfile({ enabled: isAuthenticated });
-  const profile = profileQuery.data;
+  const { signOut } = useAuth();
   const segments = useSegments();
-  const insets = useSafeAreaInsets();
-  const windowDimensions = useWindowDimensions();
-  const drawerWidth = Math.min(DRAWER_MAX_WIDTH, windowDimensions.width * DRAWER_SCREEN_FRACTION);
-  const drawerProgress = useSharedValue(0);
-  const [drawerMounted, setDrawerMounted] = useState(false);
-  // An action (route push, sheet present, or browser open) to run only AFTER the
-  // drawer's RN Modal has fully unmounted. Doing it while the Modal is still on
-  // screen makes iOS present two view controllers at once — and once a native
-  // @expo/ui sheet has been opened/closed, that concurrent presentation deadlocks
-  // UIKit, the close animation never completes, and the whole UI freezes. Closing
-  // the drawer first (see runAfterDrawerClosed) avoids it.
-  const pendingActionRef = useRef<(() => void) | null>(null);
   const feedbackSheetRef = useRef<BottomSheetModal>(null);
   const [feedbackMode, setFeedbackMode] = useState<FeedbackSheetMode>('rating');
 
-  const profileDisplayName = profile?.displayName ?? profile?.email ?? t('header.you');
-  const profileEmail = profile?.email ?? null;
+  // Mirror the latest focused-route segments into a ref so the callbacks below
+  // stay referentially stable (no `segments` in their deps). Assigning during
+  // render is the standard "latest value" ref pattern.
+  const segmentsRef = useRef(segments);
+  segmentsRef.current = segments;
+
+  // The board picker's "return to" is captured when the drawer OPENS — at that
+  // moment the underlying tab (discover/climbs) is still focused. Capturing it
+  // later, after the drawer route has been popped, would read the wrong segments.
+  const returnToRef = useRef<BoardReturnTo>('/(tabs)/climbs');
 
   const openUserDrawer = useCallback(() => {
-    setDrawerMounted(true);
+    returnToRef.current = currentBoardReturnTo(segmentsRef.current);
+    router.push('/user-drawer');
   }, []);
 
   const closeUserDrawer = useCallback(() => {
-    drawerProgress.value = withTiming(
-      0,
-      {
-        duration: DRAWER_ANIMATION_MS,
-        easing: Easing.out(Easing.cubic),
-      },
-      (finished) => {
-        if (finished) runOnJS(setDrawerMounted)(false);
-      },
-    );
-  }, [drawerProgress]);
+    router.back();
+  }, []);
 
-  useEffect(() => {
-    if (!drawerMounted) return;
-    drawerProgress.value = withTiming(1, {
-      duration: DRAWER_ANIMATION_MS,
-      easing: Easing.out(Easing.cubic),
-    });
-  }, [drawerMounted, drawerProgress]);
+  // /boards is a `presentation: 'modal'` route. The route's `close(after)` runs
+  // this only after the drawer route has unmounted, so the boards modal never
+  // presents over the still-up drawer.
+  const navigateToBoards = useCallback(() => {
+    router.push({ pathname: '/boards', params: { returnTo: returnToRef.current } });
+  }, []);
 
-  // Run the queued action once the drawer Modal has unmounted (one frame after
-  // drawerMounted flips false), so nothing ever presents over the still-up drawer
-  // Modal.
-  useEffect(() => {
-    if (drawerMounted) return;
-    const action = pendingActionRef.current;
-    if (!action) return;
-    pendingActionRef.current = null;
-    const raf = requestAnimationFrame(action);
-    return () => cancelAnimationFrame(raf);
-  }, [drawerMounted]);
+  // "My Boards" is a management screen (edit / delete owned, unfollow followed),
+  // distinct from the board picker that "Change Board" opens.
+  const navigateToManageBoards = useCallback(() => {
+    router.push('/boards/manage');
+  }, []);
 
-  // Queue an action to run after the drawer's RN Modal has fully unmounted, then
-  // start closing the drawer. Every row that navigates or presents goes through
-  // here so the Modal is always gone before a second view controller appears.
-  const runAfterDrawerClosed = useCallback(
-    (action: () => void) => {
-      pendingActionRef.current = action;
-      closeUserDrawer();
-    },
-    [closeUserDrawer],
-  );
+  const navigateToSettings = useCallback(() => {
+    router.push('/(tabs)/profile/more');
+  }, []);
 
-  const backdropStyle = useAnimatedStyle(() => ({
-    opacity: drawerProgress.value,
-  }));
+  const navigateToEditProfile = useCallback(() => {
+    router.push('/(tabs)/profile/edit');
+  }, []);
 
-  const drawerStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: -drawerWidth + drawerWidth * drawerProgress.value }],
-  }));
+  const navigateToPlaylists = useCallback(() => {
+    router.push('/(tabs)/discover/all');
+  }, []);
 
-  // /boards is a `presentation: 'modal'` route — deferring keeps it from
-  // presenting over the still-up drawer Modal.
-  const openBoards = useCallback(() => {
-    const returnTo = currentBoardReturnTo(segments);
-    runAfterDrawerClosed(() => router.push({ pathname: '/boards', params: { returnTo } }));
-  }, [runAfterDrawerClosed, segments]);
-
-  // "My Boards" is now a management screen (edit / delete owned, unfollow
-  // followed), distinct from the board picker that "Change Board" opens.
-  const openManageBoards = useCallback(() => {
-    runAfterDrawerClosed(() => router.push('/boards/manage'));
-  }, [runAfterDrawerClosed]);
-
-  const openProfileSettings = useCallback(() => {
-    runAfterDrawerClosed(() => router.push('/(tabs)/profile/more'));
-  }, [runAfterDrawerClosed]);
-
-  const openEditProfile = useCallback(() => {
-    runAfterDrawerClosed(() => router.push('/(tabs)/profile/edit'));
-  }, [runAfterDrawerClosed]);
-
-  const openPlaylists = useCallback(() => {
-    runAfterDrawerClosed(() => router.push('/(tabs)/discover/all'));
-  }, [runAfterDrawerClosed]);
-
-  const openAbout = useCallback(() => {
-    runAfterDrawerClosed(() => router.push('/about'));
-  }, [runAfterDrawerClosed]);
-
-  const openFeedback = useCallback(
-    (mode: FeedbackSheetMode) => {
-      // Set the mode now (not inside the deferred callback) so the sheet has
-      // re-rendered with it well before the deferred present() fires.
-      setFeedbackMode(mode);
-      runAfterDrawerClosed(() => feedbackSheetRef.current?.present());
-    },
-    [runAfterDrawerClosed],
-  );
+  const navigateToAbout = useCallback(() => {
+    router.push('/about');
+  }, []);
 
   const openDiscord = useCallback(() => {
-    runAfterDrawerClosed(() => void openDiscordInvite('user-drawer'));
-  }, [runAfterDrawerClosed]);
+    void openDiscordInvite('user-drawer');
+  }, []);
 
-  const handleSignOut = useCallback(() => {
-    runAfterDrawerClosed(() => void signOut('manual').catch(reportError));
-  }, [runAfterDrawerClosed, signOut]);
+  const signOutAction = useCallback(() => {
+    void signOut('manual').catch(reportError);
+  }, [signOut]);
 
-  const contextValue = useMemo(() => ({ openUserDrawer, closeUserDrawer }), [openUserDrawer, closeUserDrawer]);
+  const presentFeedback = useCallback(() => {
+    feedbackSheetRef.current?.present();
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      openUserDrawer,
+      closeUserDrawer,
+      navigateToBoards,
+      navigateToManageBoards,
+      navigateToSettings,
+      navigateToEditProfile,
+      navigateToPlaylists,
+      navigateToAbout,
+      openDiscord,
+      signOutAction,
+      setFeedbackMode,
+      presentFeedback,
+    }),
+    [
+      openUserDrawer,
+      closeUserDrawer,
+      navigateToBoards,
+      navigateToManageBoards,
+      navigateToSettings,
+      navigateToEditProfile,
+      navigateToPlaylists,
+      navigateToAbout,
+      openDiscord,
+      signOutAction,
+      setFeedbackMode,
+      presentFeedback,
+    ],
+  );
 
   return (
     <UserDrawerContext.Provider value={contextValue}>
       {children}
-      <Modal visible={drawerMounted} transparent animationType="none" onRequestClose={closeUserDrawer}>
-        <View style={styles.modalRoot}>
-          <Animated.View style={[styles.backdrop, { backgroundColor: overlays.scrim }, backdropStyle]}>
-            <Pressable
-              style={StyleSheet.absoluteFill}
-              onPress={closeUserDrawer}
-              accessibilityRole="button"
-              accessibilityLabel={t('ariaLabels.close')}
-            />
-          </Animated.View>
-          <Animated.View
-            style={[
-              styles.drawer,
-              {
-                width: drawerWidth,
-                paddingTop: insets.top + spacing[4],
-                paddingBottom: insets.bottom + spacing[4],
-                backgroundColor: systemColors.secondaryBackground,
-                borderRightColor: systemColors.separator,
-              },
-              shadows.lg,
-              drawerStyle,
-            ]}
-          >
-            <ScrollView
-              contentContainerStyle={styles.drawerContent}
-              showsVerticalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled"
-            >
-              {/* Tappable to edit only when signed in; otherwise a plain header.
-                  Both branches render the same body, differing only in the
-                  wrapper + chevron. */}
-              {profile?.id ? (
-                <Pressable
-                  style={styles.profileHeader}
-                  onPress={openEditProfile}
-                  accessibilityRole="button"
-                  accessibilityLabel={tSettings('profile.editAction')}
-                >
-                  <ProfileHeaderBody
-                    avatarUrl={profile.avatarUrl}
-                    displayName={profileDisplayName}
-                    email={profileEmail}
-                  />
-                  <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
-                </Pressable>
-              ) : (
-                <View style={styles.profileHeader}>
-                  <ProfileHeaderBody
-                    avatarUrl={profile?.avatarUrl}
-                    displayName={profileDisplayName}
-                    email={profileEmail}
-                  />
-                </View>
-              )}
-
-              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
-                <DrawerRow icon="boards" title={t('userDrawer.changeBoard')} onPress={openBoards} />
-                <DrawerRow icon="boards.fill" title={t('myBoards.title')} onPress={openManageBoards} />
-              </View>
-
-              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
-                <DrawerRow icon="settings" title={t('ariaLabels.settings')} onPress={openProfileSettings} />
-                <DrawerRow icon="playlist" title={t('userDrawer.myPlaylists')} onPress={openPlaylists} />
-                <DrawerRow icon="info" title={t('userDrawer.about')} onPress={openAbout} showSeparator={false} />
-              </View>
-
-              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
-                <DrawerRow icon="star" title={t('userDrawer.rateBoardsesh')} onPress={() => openFeedback('rating')} />
-                <DrawerRow icon="flag" title={t('userDrawer.reportBug')} onPress={() => openFeedback('bug')} />
-                <DrawerRow
-                  icon="open.external"
-                  title={t('userDrawer.joinDiscord')}
-                  tintColor={brandColors.primary}
-                  onPress={openDiscord}
-                  showSeparator={false}
-                />
-              </View>
-
-              <View style={[styles.menuGroup, { backgroundColor: systemColors.elevatedSurface }]}>
-                <DrawerRow
-                  icon="logout"
-                  title={t('userDrawer.logout')}
-                  tintColor={brandColors.error}
-                  onPress={handleSignOut}
-                  showSeparator={false}
-                />
-              </View>
-            </ScrollView>
-          </Animated.View>
-        </View>
-      </Modal>
+      {/* FeedbackSheet stays mounted at the provider ROOT — NOT inside the
+          user-drawer route. @expo/ui native sheets present off the root window's
+          view controller, so a sheet rendered inside the transparentModal drawer
+          route would present BEHIND that route and stay hidden. Mounting it here
+          and presenting it only after the route has fully unmounted (the route's
+          close(after) sequencing) keeps it on top with no concurrent-presentation
+          deadlock. */}
       <FeedbackSheet sheetRef={feedbackSheetRef} mode={feedbackMode} />
     </UserDrawerContext.Provider>
   );
 }
-
-type ProfileHeaderBodyProps = {
-  avatarUrl: string | null | undefined;
-  displayName: string;
-  email: string | null;
-};
-
-// The avatar + name + email block shared by the tappable (signed-in) and plain
-// (signed-out) header variants, so the markup lives in one place.
-function ProfileHeaderBody({ avatarUrl, displayName, email }: ProfileHeaderBodyProps) {
-  const { systemColors } = useTheme();
-  return (
-    <>
-      <Avatar uri={avatarUrl} name={displayName} size={60} />
-      <View style={styles.profileText}>
-        <Text variant="headline" numberOfLines={1} style={styles.profileName}>
-          {displayName}
-        </Text>
-        {email ? (
-          <Text variant="subheadline" color={systemColors.secondaryLabel} numberOfLines={1}>
-            {email}
-          </Text>
-        ) : null}
-      </View>
-    </>
-  );
-}
-
-type DrawerRowProps = {
-  icon: IconName;
-  title: string;
-  onPress: () => void;
-  showSeparator?: boolean;
-  tintColor?: string;
-};
-
-function DrawerRow({ icon, title, onPress, showSeparator = true, tintColor }: DrawerRowProps) {
-  const { systemColors } = useTheme();
-  const iconColor = tintColor ?? systemColors.label;
-  return (
-    <ListRow
-      title={title}
-      leading={<Icon name={icon} size={22} color={iconColor} />}
-      showChevron
-      showSeparator={showSeparator}
-      separatorInset={16}
-      onPress={onPress}
-      accessibilityLabel={title}
-      style={styles.drawerRow}
-    />
-  );
-}
-
-const styles = StyleSheet.create({
-  modalRoot: {
-    flex: 1,
-  },
-  backdrop: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-  },
-  drawer: {
-    height: '100%',
-    borderRightWidth: StyleSheet.hairlineWidth,
-  },
-  drawerContent: {
-    paddingHorizontal: spacing[3],
-    gap: spacing[3],
-  },
-  profileHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[3],
-    paddingHorizontal: spacing[2],
-    paddingBottom: spacing[3],
-  },
-  profileText: {
-    flex: 1,
-    minWidth: 0,
-  },
-  profileName: {
-    fontWeight: '700',
-  },
-  menuGroup: {
-    borderRadius: borderRadius.lg,
-    overflow: 'hidden',
-  },
-  drawerRow: {
-    minHeight: 48,
-  },
-});

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -51,14 +51,15 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
   const drawerWidth = Math.min(DRAWER_MAX_WIDTH, windowDimensions.width * DRAWER_SCREEN_FRACTION);
   const drawerProgress = useSharedValue(0);
   const [drawerMounted, setDrawerMounted] = useState(false);
-  // A navigation to run only AFTER the drawer's RN Modal has fully unmounted.
-  // Presenting a `presentation: 'modal'` route (e.g. /boards) while the drawer
-  // Modal is still on screen makes iOS try to present two modals at once — the
-  // push is dropped and the UI freezes. Closing the drawer first avoids it.
-  const pendingNavRef = useRef<(() => void) | null>(null);
+  // An action (route push, sheet present, or browser open) to run only AFTER the
+  // drawer's RN Modal has fully unmounted. Doing it while the Modal is still on
+  // screen makes iOS present two view controllers at once — and once a native
+  // @expo/ui sheet has been opened/closed, that concurrent presentation deadlocks
+  // UIKit, the close animation never completes, and the whole UI freezes. Closing
+  // the drawer first (see runAfterDrawerClosed) avoids it.
+  const pendingActionRef = useRef<(() => void) | null>(null);
   const feedbackSheetRef = useRef<BottomSheetModal>(null);
   const [feedbackMode, setFeedbackMode] = useState<FeedbackSheetMode>('rating');
-  const [feedbackOpenNonce, setFeedbackOpenNonce] = useState(0);
 
   const profileDisplayName = profile?.displayName ?? profile?.email ?? t('header.you');
   const profileEmail = profile?.email ?? null;
@@ -88,22 +89,28 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     });
   }, [drawerMounted, drawerProgress]);
 
-  useEffect(() => {
-    if (feedbackOpenNonce === 0) return;
-    feedbackSheetRef.current?.present();
-  }, [feedbackOpenNonce]);
-
-  // Run a queued navigation once the drawer Modal has unmounted (one frame after
-  // drawerMounted flips false), so a modal route never presents over the still-up
-  // drawer Modal.
+  // Run the queued action once the drawer Modal has unmounted (one frame after
+  // drawerMounted flips false), so nothing ever presents over the still-up drawer
+  // Modal.
   useEffect(() => {
     if (drawerMounted) return;
-    const nav = pendingNavRef.current;
-    if (!nav) return;
-    pendingNavRef.current = null;
-    const raf = requestAnimationFrame(nav);
+    const action = pendingActionRef.current;
+    if (!action) return;
+    pendingActionRef.current = null;
+    const raf = requestAnimationFrame(action);
     return () => cancelAnimationFrame(raf);
   }, [drawerMounted]);
+
+  // Queue an action to run after the drawer's RN Modal has fully unmounted, then
+  // start closing the drawer. Every row that navigates or presents goes through
+  // here so the Modal is always gone before a second view controller appears.
+  const runAfterDrawerClosed = useCallback(
+    (action: () => void) => {
+      pendingActionRef.current = action;
+      closeUserDrawer();
+    },
+    [closeUserDrawer],
+  );
 
   const backdropStyle = useAnimatedStyle(() => ({
     opacity: drawerProgress.value,
@@ -113,60 +120,50 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     transform: [{ translateX: -drawerWidth + drawerWidth * drawerProgress.value }],
   }));
 
-  // /boards is a `presentation: 'modal'` route — defer the push until the drawer
-  // Modal has closed (see pendingNavRef) so two modals never present at once.
+  // /boards is a `presentation: 'modal'` route — deferring keeps it from
+  // presenting over the still-up drawer Modal.
   const openBoards = useCallback(() => {
     const returnTo = currentBoardReturnTo(segments);
-    pendingNavRef.current = () => router.push({ pathname: '/boards', params: { returnTo } });
-    closeUserDrawer();
-  }, [closeUserDrawer, segments]);
+    runAfterDrawerClosed(() => router.push({ pathname: '/boards', params: { returnTo } }));
+  }, [runAfterDrawerClosed, segments]);
 
   // "My Boards" is now a management screen (edit / delete owned, unfollow
-  // followed), distinct from the board picker that "Change Board" opens. Also a
-  // modal route, so it defers the same way.
+  // followed), distinct from the board picker that "Change Board" opens.
   const openManageBoards = useCallback(() => {
-    pendingNavRef.current = () => router.push('/boards/manage');
-    closeUserDrawer();
-  }, [closeUserDrawer]);
+    runAfterDrawerClosed(() => router.push('/boards/manage'));
+  }, [runAfterDrawerClosed]);
 
   const openProfileSettings = useCallback(() => {
-    closeUserDrawer();
-    router.push('/(tabs)/profile/more');
-  }, [closeUserDrawer]);
+    runAfterDrawerClosed(() => router.push('/(tabs)/profile/more'));
+  }, [runAfterDrawerClosed]);
 
   const openEditProfile = useCallback(() => {
-    closeUserDrawer();
-    router.push('/(tabs)/profile/edit');
-  }, [closeUserDrawer]);
+    runAfterDrawerClosed(() => router.push('/(tabs)/profile/edit'));
+  }, [runAfterDrawerClosed]);
 
   const openPlaylists = useCallback(() => {
-    closeUserDrawer();
-    router.push('/(tabs)/discover/all');
-  }, [closeUserDrawer]);
+    runAfterDrawerClosed(() => router.push('/(tabs)/discover/all'));
+  }, [runAfterDrawerClosed]);
 
   const openAbout = useCallback(() => {
-    closeUserDrawer();
-    router.push('/about');
-  }, [closeUserDrawer]);
+    runAfterDrawerClosed(() => router.push('/about'));
+  }, [runAfterDrawerClosed]);
 
   const openFeedback = useCallback(
     (mode: FeedbackSheetMode) => {
-      closeUserDrawer();
       setFeedbackMode(mode);
-      setFeedbackOpenNonce((previousNonce) => previousNonce + 1);
+      runAfterDrawerClosed(() => feedbackSheetRef.current?.present());
     },
-    [closeUserDrawer],
+    [runAfterDrawerClosed],
   );
 
   const openDiscord = useCallback(() => {
-    closeUserDrawer();
-    void openDiscordInvite('user-drawer');
-  }, [closeUserDrawer]);
+    runAfterDrawerClosed(() => void openDiscordInvite('user-drawer'));
+  }, [runAfterDrawerClosed]);
 
   const handleSignOut = useCallback(() => {
-    closeUserDrawer();
-    void signOut('manual').catch(reportError);
-  }, [closeUserDrawer, signOut]);
+    runAfterDrawerClosed(() => void signOut('manual').catch(reportError));
+  }, [runAfterDrawerClosed, signOut]);
 
   const contextValue = useMemo(() => ({ openUserDrawer, closeUserDrawer }), [openUserDrawer, closeUserDrawer]);
 

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -1,19 +1,21 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 const browser = vi.hoisted(() => ({ openBrowserAsync: vi.fn().mockResolvedValue(undefined) }));
-const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
+const routerMock = vi.hoisted(() => ({ push: vi.fn(), back: vi.fn() }));
+const signOutMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+// Mutable so a test can set the focused tab before openUserDrawer captures the
+// board returnTo (the capture happens at open time, while the tab is still focused).
+const segmentsMock = vi.hoisted(() => ({ current: [] as string[] }));
 // withTiming completion callbacks are captured (not fired inline) so a test can
-// assert an action is deferred while the drawer is still up, then flush the close
-// animation to prove it runs only after the Modal unmounts.
+// flush the drawer's close animation on demand and assert router.back() fires
+// only once it settles.
 const reanimated = vi.hoisted(() => ({ closeCallbacks: [] as Array<(finished: boolean) => void> }));
 const feedbackPresent = vi.hoisted(() => vi.fn());
 
 vi.mock('react-native', () => ({
-  Modal: ({ children, visible }: { children?: ReactNode; visible: boolean }) =>
-    visible ? createElement('div', { 'data-modal': 'true' }, children) : null,
   Pressable: ({
     accessibilityLabel,
     children,
@@ -45,7 +47,7 @@ vi.mock('react-native-reanimated', () => ({
 
 vi.mock('expo-router', () => ({
   router: routerMock,
-  useSegments: () => [],
+  useSegments: () => segmentsMock.current,
 }));
 
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
@@ -75,7 +77,7 @@ vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));
 vi.mock('../../../providers/auth-provider', () => ({
-  useAuth: () => ({ isAuthenticated: true, signOut: vi.fn().mockResolvedValue(undefined) }),
+  useAuth: () => ({ isAuthenticated: true, signOut: signOutMock }),
 }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
@@ -86,6 +88,7 @@ vi.mock('../../../providers/theme-provider', () => ({
       secondaryBackground: '#f7f7f7',
       secondaryLabel: '#666',
       separator: '#ddd',
+      tertiaryLabel: '#999',
     },
   }),
 }));
@@ -118,6 +121,7 @@ vi.mock('../FeedbackSheet', () => ({
 
 import { DISCORD_INVITE_URL } from '../../../lib/discord';
 import { UserDrawerProvider, useUserDrawer } from '../UserDrawerProvider';
+import UserDrawerScreen from '../../../../app/user-drawer';
 
 function DrawerTrigger() {
   const { openUserDrawer } = useUserDrawer();
@@ -128,23 +132,41 @@ function DrawerTrigger() {
   );
 }
 
+// The provider stays mounted (so the root-mounted FeedbackSheet persists);
+// toggling `showScreen` mounts/unmounts the route screen the way router.push /
+// router.back would. Unmounting the screen is what fires its deferred action.
+function Harness({ showScreen }: { showScreen: boolean }) {
+  return (
+    <UserDrawerProvider>
+      <DrawerTrigger />
+      {showScreen ? <UserDrawerScreen /> : null}
+    </UserDrawerProvider>
+  );
+}
+
 beforeEach(() => {
   browser.openBrowserAsync.mockClear();
   routerMock.push.mockClear();
+  routerMock.back.mockClear();
+  signOutMock.mockClear();
   feedbackPresent.mockClear();
   reanimated.closeCallbacks.length = 0;
-  // The deferred action runs via requestAnimationFrame one frame after the Modal
-  // unmounts — run it inline so the flush below is synchronous.
+  segmentsMock.current = [];
+  // The route defers its post-close action one frame past unmount (so the route
+  // VC dismissal flushes before a sheet presents). Run rAF synchronously so the
+  // deferral resolves within the unmounting rerender the tests drive.
   vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
     callback(0);
-    return 1;
+    return 0;
   });
-  vi.stubGlobal('cancelAnimationFrame', () => {});
 });
 
-// Fire the captured drawer-close completion callback(s), which flip drawerMounted
-// to false and let the deferred action run. Mirrors the real close animation
-// finishing.
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Fire the captured close-animation completion callback(s), which mirror the
+// real slide-out finishing and pop the route via router.back().
 function flushDrawerClose() {
   act(() => {
     const callbacks = reanimated.closeCallbacks.splice(0);
@@ -152,23 +174,19 @@ function flushDrawerClose() {
   });
 }
 
-function openDrawer() {
-  fireEvent.click(screen.getByText('Open drawer'));
-}
+describe('UserDrawerProvider opens the drawer route', () => {
+  it('openUserDrawer pushes the user-drawer route', () => {
+    render(<Harness showScreen={false} />);
 
-function renderDrawer() {
-  return render(
-    <UserDrawerProvider>
-      <DrawerTrigger />
-    </UserDrawerProvider>,
-  );
-}
+    fireEvent.click(screen.getByText('Open drawer'));
 
-describe('UserDrawerProvider Discord CTA', () => {
-  it('renders Join Discord directly below Report a bug and opens the invite', () => {
-    const { container } = renderDrawer();
+    expect(routerMock.push).toHaveBeenCalledWith('/user-drawer');
+  });
+});
 
-    openDrawer();
+describe('user-drawer route Discord CTA', () => {
+  it('renders Join Discord directly below Report a bug and opens the invite after the route unmounts', () => {
+    const { container, rerender } = render(<Harness showScreen />);
 
     const rowTitles = Array.from(container.querySelectorAll('[data-row-title]')).map((row) =>
       row.getAttribute('data-row-title'),
@@ -180,64 +198,112 @@ describe('UserDrawerProvider Discord CTA', () => {
 
     fireEvent.click(screen.getByText('Join Discord'));
 
-    // Deferred until the drawer Modal has closed.
+    // Deferred: nothing opens while the drawer route is still mounted.
     expect(browser.openBrowserAsync).not.toHaveBeenCalled();
     flushDrawerClose();
+    expect(routerMock.back).toHaveBeenCalled();
+    expect(browser.openBrowserAsync).not.toHaveBeenCalled();
+
+    // The route's view controller is gone — now the invite opens.
+    rerender(<Harness showScreen={false} />);
     expect(browser.openBrowserAsync).toHaveBeenCalledWith(DISCORD_INVITE_URL);
   });
 });
 
-// Regression: tapping a drawer row must not navigate/present while the drawer's
-// RN Modal is still on screen — after a native @expo/ui sheet has been opened,
-// that concurrent presentation deadlocks UIKit and freezes the whole app. Every
-// row defers its action until the Modal has unmounted.
-describe('UserDrawerProvider defers navigation until the drawer closes', () => {
+// Every row animates the drawer closed, pops the route on settle, then runs its
+// action only once the route has unmounted — a single native presentation system
+// at every moment (no RN <Modal> stacked under a native @expo/ui sheet, the
+// dual-presentation freeze, issue #3211).
+describe('user-drawer route defers each action until the route unmounts', () => {
   it.each([
     ['Settings', '/(tabs)/profile/more'],
     ['My playlists', '/(tabs)/discover/all'],
     ['About', '/about'],
     ['My boards', '/boards/manage'],
-  ])('%s waits for the drawer to close, then pushes %s', (rowTitle, route) => {
-    renderDrawer();
-    openDrawer();
+  ])('%s closes the drawer, then pushes %s', (rowTitle, route) => {
+    const { rerender } = render(<Harness showScreen />);
 
     fireEvent.click(screen.getByText(rowTitle));
 
     expect(routerMock.push).not.toHaveBeenCalled();
     flushDrawerClose();
+    expect(routerMock.back).toHaveBeenCalled();
+    expect(routerMock.push).not.toHaveBeenCalled();
+
+    rerender(<Harness showScreen={false} />);
     expect(routerMock.push).toHaveBeenCalledWith(route);
   });
 
-  it('Change board waits for the drawer to close, then pushes the /boards modal route', () => {
-    renderDrawer();
-    openDrawer();
+  it('Change board closes the drawer, then pushes the /boards modal route with the returnTo', () => {
+    const { rerender } = render(<Harness showScreen />);
 
     fireEvent.click(screen.getByText('Change board'));
 
     expect(routerMock.push).not.toHaveBeenCalled();
     flushDrawerClose();
+    rerender(<Harness showScreen={false} />);
     expect(routerMock.push).toHaveBeenCalledWith({ pathname: '/boards', params: { returnTo: '/(tabs)/climbs' } });
   });
 
-  it('edit profile (header) waits for the drawer to close, then pushes the edit route', () => {
-    renderDrawer();
-    openDrawer();
+  it('captures the focused tab as the board returnTo at open time (from discover)', () => {
+    // Focused tab is discover when the drawer is opened — the returnTo must be
+    // captured THEN (before /user-drawer is pushed and useSegments would resolve
+    // to ['user-drawer']), so a later Change board returns to discover.
+    segmentsMock.current = ['(tabs)', 'discover'];
+    const { rerender } = render(<Harness showScreen={false} />);
+
+    fireEvent.click(screen.getByText('Open drawer'));
+    expect(routerMock.push).toHaveBeenCalledWith('/user-drawer');
+    routerMock.push.mockClear();
+
+    rerender(<Harness showScreen />);
+    fireEvent.click(screen.getByText('Change board'));
+    flushDrawerClose();
+    rerender(<Harness showScreen={false} />);
+    expect(routerMock.push).toHaveBeenCalledWith({ pathname: '/boards', params: { returnTo: '/(tabs)/discover' } });
+  });
+
+  it('edit profile (header) closes the drawer, then pushes the edit route', () => {
+    const { rerender } = render(<Harness showScreen />);
 
     fireEvent.click(screen.getByLabelText('profile.editAction'));
 
     expect(routerMock.push).not.toHaveBeenCalled();
     flushDrawerClose();
+    rerender(<Harness showScreen={false} />);
     expect(routerMock.push).toHaveBeenCalledWith('/(tabs)/profile/edit');
   });
 
-  it('feedback (Rate Boardsesh) waits for the drawer to close, then presents the sheet', () => {
-    renderDrawer();
-    openDrawer();
+  it('Rate Boardsesh closes the drawer, then presents the feedback sheet', () => {
+    const { rerender } = render(<Harness showScreen />);
 
     fireEvent.click(screen.getByText('Rate Boardsesh'));
 
     expect(feedbackPresent).not.toHaveBeenCalled();
     flushDrawerClose();
+    rerender(<Harness showScreen={false} />);
     expect(feedbackPresent).toHaveBeenCalled();
+  });
+
+  it('Report a bug closes the drawer, then presents the feedback sheet', () => {
+    const { rerender } = render(<Harness showScreen />);
+
+    fireEvent.click(screen.getByText('Report a bug'));
+
+    expect(feedbackPresent).not.toHaveBeenCalled();
+    flushDrawerClose();
+    rerender(<Harness showScreen={false} />);
+    expect(feedbackPresent).toHaveBeenCalled();
+  });
+
+  it('Log out closes the drawer, then signs out', () => {
+    const { rerender } = render(<Harness showScreen />);
+
+    fireEvent.click(screen.getByText('Log out'));
+
+    expect(signOutMock).not.toHaveBeenCalled();
+    flushDrawerClose();
+    rerender(<Harness showScreen={false} />);
+    expect(signOutMock).toHaveBeenCalledWith('manual');
   });
 });

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -1,9 +1,14 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 const browser = vi.hoisted(() => ({ openBrowserAsync: vi.fn().mockResolvedValue(undefined) }));
+const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
+// withTiming completion callbacks are captured (not fired inline) so a test can
+// assert an action is deferred while the drawer is still up, then flush the close
+// animation to prove it runs only after the Modal unmounts.
+const reanimated = vi.hoisted(() => ({ closeCallbacks: [] as Array<(finished: boolean) => void> }));
 
 vi.mock('react-native', () => ({
   Modal: ({ children, visible }: { children?: ReactNode; visible: boolean }) =>
@@ -32,13 +37,13 @@ vi.mock('react-native-reanimated', () => ({
   useAnimatedStyle: (factory: () => unknown) => factory(),
   useSharedValue: (initialValue: number) => ({ value: initialValue }),
   withTiming: (value: number, _config: unknown, callback?: (finished: boolean) => void) => {
-    callback?.(true);
+    if (callback) reanimated.closeCallbacks.push(callback);
     return value;
   },
 }));
 
 vi.mock('expo-router', () => ({
-  router: { push: vi.fn() },
+  router: routerMock,
   useSegments: () => [],
 }));
 
@@ -66,7 +71,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../../lib/error-reporting', () => ({ reportError: vi.fn() }));
 vi.mock('../../../lib/graphql/hooks', () => ({
-  useProfile: () => ({ data: { displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
+  useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));
 vi.mock('../../../providers/auth-provider', () => ({
   useAuth: () => ({ isAuthenticated: true, signOut: vi.fn().mockResolvedValue(undefined) }),
@@ -119,17 +124,44 @@ function DrawerTrigger() {
 
 beforeEach(() => {
   browser.openBrowserAsync.mockClear();
+  routerMock.push.mockClear();
+  reanimated.closeCallbacks.length = 0;
+  // The deferred action runs via requestAnimationFrame one frame after the Modal
+  // unmounts — run it inline so the flush below is synchronous.
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
 });
+
+// Fire the captured drawer-close completion callback(s), which flip drawerMounted
+// to false and let the deferred action run. Mirrors the real close animation
+// finishing.
+function flushDrawerClose() {
+  act(() => {
+    const callbacks = reanimated.closeCallbacks.splice(0);
+    callbacks.forEach((callback) => callback(true));
+  });
+}
+
+function openDrawer() {
+  fireEvent.click(screen.getByText('Open drawer'));
+}
+
+function renderDrawer() {
+  return render(
+    <UserDrawerProvider>
+      <DrawerTrigger />
+    </UserDrawerProvider>,
+  );
+}
 
 describe('UserDrawerProvider Discord CTA', () => {
   it('renders Join Discord directly below Report a bug and opens the invite', () => {
-    const { container } = render(
-      <UserDrawerProvider>
-        <DrawerTrigger />
-      </UserDrawerProvider>,
-    );
+    const { container } = renderDrawer();
 
-    fireEvent.click(screen.getByText('Open drawer'));
+    openDrawer();
 
     const rowTitles = Array.from(container.querySelectorAll('[data-row-title]')).map((row) =>
       row.getAttribute('data-row-title'),
@@ -141,6 +173,41 @@ describe('UserDrawerProvider Discord CTA', () => {
 
     fireEvent.click(screen.getByText('Join Discord'));
 
+    // Deferred until the drawer Modal has closed.
+    expect(browser.openBrowserAsync).not.toHaveBeenCalled();
+    flushDrawerClose();
     expect(browser.openBrowserAsync).toHaveBeenCalledWith(DISCORD_INVITE_URL);
+  });
+});
+
+// Regression: tapping a drawer row must not navigate/present while the drawer's
+// RN Modal is still on screen — after a native @expo/ui sheet has been opened,
+// that concurrent presentation deadlocks UIKit and freezes the whole app. Every
+// row defers its action until the Modal has unmounted.
+describe('UserDrawerProvider defers navigation until the drawer closes', () => {
+  it.each([
+    ['Settings', '/(tabs)/profile/more'],
+    ['My playlists', '/(tabs)/discover/all'],
+    ['About', '/about'],
+  ])('%s waits for the drawer to close, then pushes %s', (rowTitle, route) => {
+    renderDrawer();
+    openDrawer();
+
+    fireEvent.click(screen.getByText(rowTitle));
+
+    expect(routerMock.push).not.toHaveBeenCalled();
+    flushDrawerClose();
+    expect(routerMock.push).toHaveBeenCalledWith(route);
+  });
+
+  it('edit profile (header) waits for the drawer to close, then pushes the edit route', () => {
+    renderDrawer();
+    openDrawer();
+
+    fireEvent.click(screen.getByLabelText('profile.editAction'));
+
+    expect(routerMock.push).not.toHaveBeenCalled();
+    flushDrawerClose();
+    expect(routerMock.push).toHaveBeenCalledWith('/(tabs)/profile/edit');
   });
 });

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -306,4 +306,18 @@ describe('user-drawer route defers each action until the route unmounts', () => 
     rerender(<Harness showScreen={false} />);
     expect(signOutMock).toHaveBeenCalledWith('manual');
   });
+
+  it('does not pop the route if the slide-out settles after the screen has unmounted (mountedRef guard)', () => {
+    const { rerender } = render(<Harness showScreen />);
+
+    fireEvent.click(screen.getByText('About')); // close() captures the slide-out completion callback
+    // The screen unmounts first (e.g. the route popped by something else) — then
+    // the stale completion callback fires. popRoute must no-op, or it would
+    // router.back() the wrong, now-top route.
+    rerender(<Harness showScreen={false} />);
+    routerMock.back.mockClear();
+
+    flushDrawerClose();
+    expect(routerMock.back).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -9,6 +9,7 @@ const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
 // assert an action is deferred while the drawer is still up, then flush the close
 // animation to prove it runs only after the Modal unmounts.
 const reanimated = vi.hoisted(() => ({ closeCallbacks: [] as Array<(finished: boolean) => void> }));
+const feedbackPresent = vi.hoisted(() => vi.fn());
 
 vi.mock('react-native', () => ({
   Modal: ({ children, visible }: { children?: ReactNode; visible: boolean }) =>
@@ -108,7 +109,12 @@ vi.mock('../../ListRow', () => ({
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../FeedbackSheet', () => ({ FeedbackSheet: () => null }));
+vi.mock('../FeedbackSheet', () => ({
+  FeedbackSheet: ({ sheetRef }: { sheetRef?: { current: { present: () => void } | null } }) => {
+    if (sheetRef) sheetRef.current = { present: feedbackPresent };
+    return null;
+  },
+}));
 
 import { DISCORD_INVITE_URL } from '../../../lib/discord';
 import { UserDrawerProvider, useUserDrawer } from '../UserDrawerProvider';
@@ -125,6 +131,7 @@ function DrawerTrigger() {
 beforeEach(() => {
   browser.openBrowserAsync.mockClear();
   routerMock.push.mockClear();
+  feedbackPresent.mockClear();
   reanimated.closeCallbacks.length = 0;
   // The deferred action runs via requestAnimationFrame one frame after the Modal
   // unmounts — run it inline so the flush below is synchronous.
@@ -189,6 +196,7 @@ describe('UserDrawerProvider defers navigation until the drawer closes', () => {
     ['Settings', '/(tabs)/profile/more'],
     ['My playlists', '/(tabs)/discover/all'],
     ['About', '/about'],
+    ['My boards', '/boards/manage'],
   ])('%s waits for the drawer to close, then pushes %s', (rowTitle, route) => {
     renderDrawer();
     openDrawer();
@@ -200,6 +208,17 @@ describe('UserDrawerProvider defers navigation until the drawer closes', () => {
     expect(routerMock.push).toHaveBeenCalledWith(route);
   });
 
+  it('Change board waits for the drawer to close, then pushes the /boards modal route', () => {
+    renderDrawer();
+    openDrawer();
+
+    fireEvent.click(screen.getByText('Change board'));
+
+    expect(routerMock.push).not.toHaveBeenCalled();
+    flushDrawerClose();
+    expect(routerMock.push).toHaveBeenCalledWith({ pathname: '/boards', params: { returnTo: '/(tabs)/climbs' } });
+  });
+
   it('edit profile (header) waits for the drawer to close, then pushes the edit route', () => {
     renderDrawer();
     openDrawer();
@@ -209,5 +228,16 @@ describe('UserDrawerProvider defers navigation until the drawer closes', () => {
     expect(routerMock.push).not.toHaveBeenCalled();
     flushDrawerClose();
     expect(routerMock.push).toHaveBeenCalledWith('/(tabs)/profile/edit');
+  });
+
+  it('feedback (Rate Boardsesh) waits for the drawer to close, then presents the sheet', () => {
+    renderDrawer();
+    openDrawer();
+
+    fireEvent.click(screen.getByText('Rate Boardsesh'));
+
+    expect(feedbackPresent).not.toHaveBeenCalled();
+    flushDrawerClose();
+    expect(feedbackPresent).toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -25,6 +25,7 @@ import { SegmentedControl } from '../SegmentedControl';
 import { SwitchRow } from '../SwitchRow';
 import { GradeRangeRail } from '../grade';
 import { useTheme } from '../../providers/theme-provider';
+import { useManagedSheet } from '../../providers/sheet-presentation-provider';
 import { useGrades } from '../../lib/graphql/hooks';
 import { hapticSelection } from '../../lib/haptics';
 import { springs } from '../../theme/animations';
@@ -154,11 +155,23 @@ export function LogbookFilterSheet({
   // Bumped on Reset so the Refine/Advanced sections collapse back to default.
   const [sectionResetKey, setSectionResetKey] = useState(0);
 
-  // The sheet remounts on each open (it is conditionally rendered), so the draft
-  // initializes from the committed props above — no parent-sync effect needed.
+  // Commit-on-close: there's no Apply button — the draft applies when the sheet
+  // is dismissed (swipe down / scrim). The ref holds the latest draft so the
+  // stable dismiss handler commits the newest values, never a stale closure.
+  const draftRef = useRef({ filters: draftFilters, sort: draftSort });
   useEffect(() => {
-    sheetRef.current?.present();
-  }, []);
+    draftRef.current = { filters: draftFilters, sort: draftSort };
+  }, [draftFilters, draftSort]);
+
+  const handleDismiss = useCallback(() => {
+    onApply(draftRef.current.filters, draftRef.current.sort);
+    onDismiss();
+  }, [onApply, onDismiss]);
+
+  // The parent only mounts the sheet while it should be open, so present/dismiss
+  // route through the coordinator (serialized, no overlapping native transitions).
+  // A user pan-down / scrim tap fires onClose → handleDismiss (commit the draft).
+  const managed = useManagedSheet({ open: true, sheetRef, onClose: handleDismiss });
 
   const snapPoints = useMemo(() => androidSafeSnapPoints(['90%']), []);
   // One stable "today" ceiling so the To-date row's maximumDate prop keeps a
@@ -196,19 +209,6 @@ export function LogbookFilterSheet({
     },
     [updateFilters],
   );
-
-  // Commit-on-close: there's no Apply button — the draft applies when the sheet
-  // is dismissed (swipe down or tap the scrim). The ref holds the latest draft so
-  // the stable dismiss handler commits the newest values, never a stale closure.
-  const draftRef = useRef({ filters: draftFilters, sort: draftSort });
-  useEffect(() => {
-    draftRef.current = { filters: draftFilters, sort: draftSort };
-  }, [draftFilters, draftSort]);
-
-  const handleDismiss = useCallback(() => {
-    onApply(draftRef.current.filters, draftRef.current.sort);
-    onDismiss();
-  }, [onApply, onDismiss]);
 
   const handleReset = useCallback(() => {
     hapticSelection();
@@ -289,7 +289,7 @@ export function LogbookFilterSheet({
       snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose
-      onDismiss={handleDismiss}
+      onChange={managed.onChange}
       handleIndicatorStyle={styles.indicator}
     >
       <View style={styles.header}>

--- a/packages/mobile/src/components/you/__tests__/logbook-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-filter-sheet.test.tsx
@@ -41,16 +41,40 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
-// The sheet commits the draft on close (there's no Apply button), so capture the
-// onDismiss handler it hands BottomSheetModal — a test fires it to simulate the
+// The sheet commits the draft on close (there's no Apply button). The component
+// drives close through the coordinator's onChange(-1) (see the useManagedSheet
+// mock below, which forwards -1 to onClose → handleDismiss → onApply), so capture
+// the onChange it hands BottomSheetModal — a test fires -1 to simulate the
 // swipe/scrim close. Children render inline.
-const sheetMock = vi.hoisted(() => ({ onDismiss: undefined as (() => void) | undefined }));
+const sheetMock = vi.hoisted(() => ({ onChange: undefined as ((index: number) => void) | undefined }));
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  BottomSheetModal: ({ children, onDismiss }: { children?: ReactNode; onDismiss?: () => void }) => {
-    sheetMock.onDismiss = onDismiss;
+  BottomSheetModal: ({ children, onChange }: { children?: ReactNode; onChange?: (index: number) => void }) => {
+    sheetMock.onChange = onChange;
     return createElement('div', null, children);
   },
   BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+
+// Isolate the sheet from the presentation coordinator (its serialization is
+// covered by sheet-presentation-provider.test.tsx). These tests drive Apply /
+// Reset through the component's own controls, so a no-op managed handle is enough.
+vi.mock('../../../providers/sheet-presentation-provider', () => ({
+  useManagedSheet: ({ onClose }: { onClose?: () => void }) => ({
+    onChange: (index: number) => {
+      if (index === -1) onClose?.();
+    },
+    onFullyDismissed: () => {},
+    handle: {
+      present: () => {},
+      dismiss: () => {},
+      close: () => {},
+      forceClose: () => {},
+      snapToIndex: () => {},
+      snapToPosition: () => {},
+      expand: () => {},
+      collapse: () => {},
+    },
+  }),
 }));
 
 vi.mock('react-native-reanimated', () => ({
@@ -173,9 +197,10 @@ function lastApply(onApply: ReturnType<typeof vi.fn>): {
   return { filters, sort };
 }
 
-// Close the sheet (swipe/scrim) — this is what commits the draft via onApply.
+// Close the sheet (swipe/scrim) — a coordinator onChange(-1) → onClose →
+// handleDismiss, which commits the draft via onApply.
 function closeSheet() {
-  act(() => sheetMock.onDismiss?.());
+  act(() => sheetMock.onChange?.(-1));
 }
 
 beforeEach(() => {

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render } from '@testing-library/react';
-import { createElement } from 'react';
+import { render, act } from '@testing-library/react';
+import { createElement, useRef, type RefObject } from 'react';
+import type { BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
 
 // SETTLE_MS resolves from Platform.OS — pin it to iOS (550ms) for deterministic timers.
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
 
-import { SheetPresentationProvider, useSheetPresentation, type SheetCoordinator } from '../sheet-presentation-provider';
+import {
+  SheetPresentationProvider,
+  useSheetPresentation,
+  useManagedSheet,
+  type SheetCoordinator,
+} from '../sheet-presentation-provider';
 
 const SETTLE_MS = 550;
 
@@ -155,15 +161,107 @@ describe('SheetPresentationProvider coordinator', () => {
     expect(b.present).toHaveBeenCalledTimes(1);
   });
 
-  it('unregister clears a presented sheet and frees the group', () => {
+  it('opens a settle window when a presented sheet unmounts (no coordinator dismiss), then frees the group', () => {
     const a = makeSheet();
     const unregister = coordinator.register({ id: 'a', group: 'root', ...a });
     coordinator.setDesiredOpen('a', true);
     vi.advanceTimersByTime(SETTLE_MS);
     expect(coordinator.isPresented('a')).toBe(true);
 
+    // Parent unmounts the sheet while it's presented (e.g. a present-on-mount
+    // sheet dismissed by removing it). Its native teardown is still animating, so
+    // the group must stay busy — not be reported idle immediately (H1).
     unregister();
     expect(coordinator.isPresented('a')).toBe(false);
+    expect(coordinator.isBusy('root')).toBe(true);
+
+    vi.advanceTimersByTime(SETTLE_MS);
     expect(coordinator.isBusy('root')).toBe(false);
+  });
+
+  it('holds a same-group present until an unmounted-while-presented sheet has settled (H1)', () => {
+    const a = makeSheet();
+    const b = makeSheet();
+    const unregister = coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'root', ...b });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    unregister(); // A unmounts while presented → settle window opens
+    coordinator.setDesiredOpen('b', true);
+    expect(b.present).not.toHaveBeenCalled(); // must wait out A's native teardown
+
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(b.present).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The bridge consumers actually use. The selfDismissRef gate here is what tells a
+// user pan-down apart from a coordinator-driven dismiss — a misclassification is
+// exactly what would double-dismiss / present-over-dismiss and freeze the app.
+type SheetApiMock = Record<
+  'present' | 'dismiss' | 'snapToIndex' | 'snapToPosition' | 'expand' | 'collapse' | 'close' | 'forceClose',
+  ReturnType<typeof vi.fn>
+>;
+
+function makeSheetApi(): SheetApiMock {
+  return {
+    present: vi.fn(),
+    dismiss: vi.fn(),
+    snapToIndex: vi.fn(),
+    snapToPosition: vi.fn(),
+    expand: vi.fn(),
+    collapse: vi.fn(),
+    close: vi.fn(),
+    forceClose: vi.fn(),
+  };
+}
+
+let managed: ReturnType<typeof useManagedSheet> | null = null;
+let sheetApi: SheetApiMock;
+
+function ManagedHarness({ open, onClose }: { open?: boolean; onClose?: () => void }) {
+  const sheetRef = useRef(sheetApi as unknown as BottomSheetMethods);
+  managed = useManagedSheet({ open, sheetRef: sheetRef as RefObject<BottomSheetMethods | null>, onClose });
+  return null;
+}
+
+describe('useManagedSheet bridge', () => {
+  beforeEach(() => {
+    managed = null;
+    sheetApi = makeSheetApi();
+  });
+
+  it('presents on open (snapToIndex 0) and dismisses via the coordinator handle', () => {
+    render(createElement(SheetPresentationProvider, null, createElement(ManagedHarness, { open: true })));
+    expect(sheetApi.snapToIndex).toHaveBeenCalledWith(0);
+    vi.advanceTimersByTime(SETTLE_MS);
+    act(() => {
+      managed?.handle.dismiss();
+    });
+    expect(sheetApi.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('a user pan-down (onChange(-1)) fires onClose', () => {
+    const onClose = vi.fn();
+    render(createElement(SheetPresentationProvider, null, createElement(ManagedHarness, { open: true, onClose })));
+    vi.advanceTimersByTime(SETTLE_MS);
+    act(() => {
+      managed?.onChange(-1);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a coordinator-driven dismiss does NOT fire onClose (selfDismissRef gate)', () => {
+    const onClose = vi.fn();
+    render(createElement(SheetPresentationProvider, null, createElement(ManagedHarness, { open: true, onClose })));
+    vi.advanceTimersByTime(SETTLE_MS);
+    act(() => {
+      managed?.handle.dismiss(); // sets selfDismissRef + drives the native dismiss
+    });
+    act(() => {
+      managed?.onChange(-1); // the synchronous native callback that dismiss() triggers
+    });
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/sheet-presentation-provider.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+
+// SETTLE_MS resolves from Platform.OS — pin it to iOS (550ms) for deterministic timers.
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
+import { SheetPresentationProvider, useSheetPresentation, type SheetCoordinator } from '../sheet-presentation-provider';
+
+const SETTLE_MS = 550;
+
+let coordinator: SheetCoordinator;
+function Capture() {
+  coordinator = useSheetPresentation();
+  return null;
+}
+
+function makeSheet() {
+  return { present: vi.fn(), dismiss: vi.fn(), onFullyDismissed: vi.fn() };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('__DEV__', false);
+  render(createElement(SheetPresentationProvider, null, createElement(Capture)));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('SheetPresentationProvider coordinator', () => {
+  it('presents an opened sheet and reports it presented after the settle window', () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+
+    coordinator.setDesiredOpen('a', true);
+    expect(a.present).toHaveBeenCalledTimes(1);
+    expect(coordinator.isBusy('root')).toBe(true);
+    expect(coordinator.isPresented('a')).toBe(false); // still presenting
+
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(coordinator.isPresented('a')).toBe(true);
+    expect(coordinator.isBusy('root')).toBe(false);
+  });
+
+  it('serializes a sheet-over-sheet handoff: dismiss A, settle, then present B', () => {
+    const a = makeSheet();
+    const b = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'root', ...b });
+
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS); // a presented
+
+    // Request B while A is up — must not present B yet.
+    coordinator.setDesiredOpen('b', true);
+    expect(b.present).not.toHaveBeenCalled();
+    // The pump immediately dismisses A (the dismiss half of the handoff).
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(SETTLE_MS); // A dismiss settles
+    expect(b.present).toHaveBeenCalledTimes(1);
+    expect(coordinator.isPresented('a')).toBe(false);
+
+    vi.advanceTimersByTime(SETTLE_MS); // B present settles
+    expect(coordinator.isPresented('b')).toBe(true);
+  });
+
+  it('never presents two transitions at once (B waits while A is presenting)', () => {
+    const a = makeSheet();
+    const b = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'root', ...b });
+
+    coordinator.setDesiredOpen('a', true);
+    coordinator.setDesiredOpen('b', true); // while A's present is still in flight
+    expect(a.present).toHaveBeenCalledTimes(1);
+    expect(b.present).not.toHaveBeenCalled();
+    expect(a.dismiss).not.toHaveBeenCalled(); // can't dismiss mid-present either
+  });
+
+  it('early-resolves a dismiss via notifyFullyDismissed before the ceiling timer', () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    coordinator.setDesiredOpen('a', false);
+    expect(a.dismiss).toHaveBeenCalledTimes(1);
+    expect(coordinator.isBusy('root')).toBe(true);
+
+    coordinator.notifyFullyDismissed('a'); // native settle arrives early
+    expect(a.onFullyDismissed).toHaveBeenCalledTimes(1);
+    expect(coordinator.isPresented('a')).toBe(false);
+    expect(coordinator.isBusy('root')).toBe(false);
+
+    // The ceiling timer is cleared — advancing must not double-fire.
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(a.onFullyDismissed).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a settle window on a user-initiated close (notifyClosed) and fires onFullyDismissed at settle', () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+
+    // User pan-down: the native sheet is already animating out on its own.
+    coordinator.notifyClosed('a');
+    expect(a.dismiss).not.toHaveBeenCalled(); // coordinator didn't drive it
+    expect(coordinator.isBusy('root')).toBe(true);
+    expect(a.onFullyDismissed).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(a.onFullyDismissed).toHaveBeenCalledTimes(1);
+    expect(coordinator.isPresented('a')).toBe(false);
+  });
+
+  it('is a no-op to close a sheet that is not presented', () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', false);
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(a.present).not.toHaveBeenCalled();
+    expect(a.dismiss).not.toHaveBeenCalled();
+  });
+
+  it('coalesces a rapid open→close→open into a single settled-open with no dismiss', () => {
+    const a = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+
+    coordinator.setDesiredOpen('a', true); // present starts
+    coordinator.setDesiredOpen('a', false); // desired flips while presenting
+    coordinator.setDesiredOpen('a', true); // ...and back
+
+    vi.advanceTimersByTime(SETTLE_MS); // present settles; pump sees want === have
+    expect(a.present).toHaveBeenCalledTimes(1);
+    expect(a.dismiss).not.toHaveBeenCalled();
+    expect(coordinator.isPresented('a')).toBe(true);
+  });
+
+  it('does not serialize across independent presenter groups', () => {
+    const a = makeSheet();
+    const b = makeSheet();
+    coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.register({ id: 'b', group: 'drawer', ...b });
+
+    coordinator.setDesiredOpen('a', true);
+    coordinator.setDesiredOpen('b', true);
+    // Different groups → both present immediately, no waiting.
+    expect(a.present).toHaveBeenCalledTimes(1);
+    expect(b.present).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregister clears a presented sheet and frees the group', () => {
+    const a = makeSheet();
+    const unregister = coordinator.register({ id: 'a', group: 'root', ...a });
+    coordinator.setDesiredOpen('a', true);
+    vi.advanceTimersByTime(SETTLE_MS);
+    expect(coordinator.isPresented('a')).toBe(true);
+
+    unregister();
+    expect(coordinator.isPresented('a')).toBe(false);
+    expect(coordinator.isBusy('root')).toBe(false);
+  });
+});

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -127,6 +127,36 @@ type DrawerHostValue = {
 
 const DrawerHostContext = createContext<DrawerHostValue | null>(null);
 
+/**
+ * Data-backed sheet state that survives the dismiss animation. `open(value)`
+ * shows it; `close()` requests the animated close (flips `visible` false) but
+ * keeps the data mounted; `clearIfClosed()` (wired to the sheet's onFullyDismissed)
+ * drops the data only once the animation has settled and the sheet wasn't
+ * re-opened — so the native Host never unmounts mid-animation (an iOS freeze
+ * vector) and the content doesn't blank out while sliding away.
+ */
+function useDeferredSheetData<T>(): {
+  data: T | null;
+  visible: boolean;
+  open: (value: T) => void;
+  close: () => void;
+  clearIfClosed: () => void;
+} {
+  const [data, setData] = useState<T | null>(null);
+  const [visible, setVisible] = useState(false);
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+  const open = useCallback((value: T) => {
+    setData(value);
+    setVisible(true);
+  }, []);
+  const close = useCallback(() => setVisible(false), []);
+  const clearIfClosed = useCallback(() => {
+    if (!visibleRef.current) setData(null);
+  }, []);
+  return { data, visible, open, close, clearIfClosed };
+}
+
 export function useDrawerHost(): DrawerHostValue {
   const context = useContext(DrawerHostContext);
   if (!context) throw new Error('useDrawerHost must be used within DrawerHostProvider');
@@ -189,14 +219,36 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   const { isAuthenticated } = useAuth();
   const { data: myBoardsConn } = useMyBoards(undefined, { enabled: isAuthenticated });
   const [boardConfigOverride, setBoardConfigOverride] = useState<BoardConfig | null>(null);
-  const [logAscentInput, setLogAscentInput] = useState<LogAscentInput | null>(null);
+  // These sheets stay mounted through their dismiss animation (see
+  // useDeferredSheetData) so the native Host never tears down mid-animation. The
+  // open/close/clear callbacks are stable; only data/visible change, and those
+  // are read in render (not in the context value), so consumers don't churn.
+  const {
+    data: logAscentData,
+    visible: logAscentVisible,
+    open: openLogAscentSheet,
+    close: closeLogAscentSheet,
+    clearIfClosed: clearLogAscentSheet,
+  } = useDeferredSheetData<LogAscentInput>();
+  const {
+    data: playlistData,
+    visible: playlistVisible,
+    open: openPlaylistSheet,
+    close: closePlaylistSheet,
+    clearIfClosed: clearPlaylistSheet,
+  } = useDeferredSheetData<{ climb: Climb; boardConfig: BoardConfig }>();
+  const {
+    data: betaVideoData,
+    visible: betaVideoVisible,
+    open: openBetaVideoSheet,
+    close: closeBetaVideoSheet,
+    clearIfClosed: clearBetaVideoSheet,
+  } = useDeferredSheetData<{ climb: Climb; boardConfig: BoardConfig }>();
   const [climbActions, setClimbActions] = useState<{
     climb: Climb;
     boardConfig: BoardConfig;
     onEditEntry?: () => void;
   } | null>(null);
-  const [playlistClimb, setPlaylistClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
-  const [betaVideoClimb, setBetaVideoClimb] = useState<{ climb: Climb; boardConfig: BoardConfig } | null>(null);
   const { addToQueue, setSessionBoardPath, setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();
   const setActiveBoard = useSetActiveBoard();
@@ -354,11 +406,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     [activeBoard, boardConfigOverride, sessionId, setActiveBoard, setSessionBoardPath],
   );
 
-  const openLogAscent = useCallback((input: LogAscentInput) => {
-    setLogAscentInput(input);
-  }, []);
-
-  const dismissLogAscent = useCallback(() => setLogAscentInput(null), []);
+  const openLogAscent = openLogAscentSheet;
 
   // Snapshot the board config at open time so the sheet's per-row handlers
   // (queue / favorite / tick) keep operating on the same angle even if the
@@ -376,29 +424,31 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     setClimbActions(null);
   }, []);
 
-  const openAddToPlaylist = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
-    const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
-    if (!boardConfig) return;
-    setPlaylistClimb({ climb, boardConfig });
-  }, []);
+  const openAddToPlaylist = useCallback(
+    (climb: Climb, boardConfigOverride?: BoardConfig) => {
+      const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
+      if (!boardConfig) return;
+      openPlaylistSheet({ climb, boardConfig });
+    },
+    [openPlaylistSheet],
+  );
 
-  const closeAddToPlaylist = useCallback(() => {
-    setPlaylistClimb(null);
-  }, []);
+  const closeAddToPlaylist = closePlaylistSheet;
 
   // Single parameterized beta-video opener (mirrors openAddToPlaylist), used both by
   // the reaction menu's shared action list (useClimbActions) and by PlayDrawer.
   // Falls back to the stored active board, not the override-inclusive one, so a
   // temporary drawer board override can't leak into the beta-video surface.
-  const openAddBetaVideo = useCallback((climb: Climb, boardConfigOverride?: BoardConfig) => {
-    const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
-    if (!boardConfig) return;
-    setBetaVideoClimb({ climb, boardConfig });
-  }, []);
+  const openAddBetaVideo = useCallback(
+    (climb: Climb, boardConfigOverride?: BoardConfig) => {
+      const boardConfig = boardConfigOverride ?? storedActiveBoardConfigRef.current;
+      if (!boardConfig) return;
+      openBetaVideoSheet({ climb, boardConfig });
+    },
+    [openBetaVideoSheet],
+  );
 
-  const closeAddBetaVideo = useCallback(() => {
-    setBetaVideoClimb(null);
-  }, []);
+  const closeAddBetaVideo = closeBetaVideoSheet;
 
   // Present the always-mounted queue sheet imperatively. Calling `present()`
   // synchronously from the handler (rather than from a `visible`-prop effect)
@@ -615,42 +665,45 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     <DrawerHostContext.Provider value={value}>
       <PlayDrawerRouteContext.Provider value={routeValue}>
         {children}
-        {logAscentInput ? (
+        {logAscentData ? (
           <LogAscentSheet
-            visible
-            onDismiss={dismissLogAscent}
-            climbUuid={logAscentInput.climbUuid}
-            boardName={logAscentInput.boardName}
-            angle={logAscentInput.angle}
-            isMirror={logAscentInput.isMirror}
-            isBenchmark={logAscentInput.isBenchmark}
-            layoutId={logAscentInput.layoutId}
-            sizeId={logAscentInput.sizeId}
-            setIds={logAscentInput.setIds}
-            sessionId={logAscentInput.sessionId}
-            consensusGradeName={logAscentInput.consensusGradeName}
+            visible={logAscentVisible}
+            onClose={closeLogAscentSheet}
+            onFullyDismissed={clearLogAscentSheet}
+            climbUuid={logAscentData.climbUuid}
+            boardName={logAscentData.boardName}
+            angle={logAscentData.angle}
+            isMirror={logAscentData.isMirror}
+            isBenchmark={logAscentData.isBenchmark}
+            layoutId={logAscentData.layoutId}
+            sizeId={logAscentData.sizeId}
+            setIds={logAscentData.setIds}
+            sessionId={logAscentData.sessionId}
+            consensusGradeName={logAscentData.consensusGradeName}
           />
         ) : null}
-        {betaVideoClimb ? (
+        {betaVideoData ? (
           <AddBetaVideoSheet
-            visible
-            climb={betaVideoClimb.climb}
-            boardName={betaVideoClimb.boardConfig.boardName as BoardName}
-            layoutId={betaVideoClimb.boardConfig.layoutId}
-            angle={betaVideoClimb.boardConfig.angle}
+            visible={betaVideoVisible}
+            climb={betaVideoData.climb}
+            boardName={betaVideoData.boardConfig.boardName as BoardName}
+            layoutId={betaVideoData.boardConfig.layoutId}
+            angle={betaVideoData.boardConfig.angle}
             onClose={closeAddBetaVideo}
+            onFullyDismissed={clearBetaVideoSheet}
           />
         ) : null}
-        {playlistClimb ? (
+        {playlistData ? (
           <AddToPlaylistSheet
-            visible
-            climb={playlistClimb.climb}
-            boardName={playlistClimb.boardConfig.boardName as BoardName}
-            layoutId={playlistClimb.boardConfig.layoutId}
-            sizeId={playlistClimb.boardConfig.sizeId}
-            setIds={playlistClimb.boardConfig.setIds}
-            angle={playlistClimb.boardConfig.angle}
+            visible={playlistVisible}
+            climb={playlistData.climb}
+            boardName={playlistData.boardConfig.boardName as BoardName}
+            layoutId={playlistData.boardConfig.layoutId}
+            sizeId={playlistData.boardConfig.sizeId}
+            setIds={playlistData.boardConfig.setIds}
+            angle={playlistData.boardConfig.angle}
             onClose={closeAddToPlaylist}
+            onFullyDismissed={clearPlaylistSheet}
           />
         ) : null}
         {queueBoard ? (

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -191,14 +191,29 @@ export function SheetPresentationProvider({ children }: { children: ReactNode })
         groupState(reg.group);
         return () => {
           const state = groupState(reg.group);
+          // Was this sheet presented or mid-transition when it unmounted? If so its
+          // native teardown is still animating out, even though no coordinator
+          // dismiss was issued (e.g. a present-on-mount sheet the parent unmounts
+          // on select). We must keep the group "busy" across that teardown.
+          const involved = state.presentedId === reg.id || state.inFlight?.id === reg.id;
           if (state.inFlight?.id === reg.id) {
             clearTimeout(state.inFlight.timer);
             state.inFlight = null;
           }
-          if (state.presentedId === reg.id) state.presentedId = null;
           desired.current.delete(reg.id);
           registrations.current.delete(reg.id);
-          pump(reg.group);
+          if (involved) {
+            // Open a settle window so the next same-group present can't start while
+            // the unmounted sheet's native dismiss is still in flight — that overlap
+            // is the UIKit deadlock this provider exists to prevent. onSettle nulls
+            // presentedId and pumps; the registration is already gone so its
+            // onFullyDismissed is a no-op (the component unmounted).
+            state.presentedId = null;
+            const timer = setTimeout(() => onSettle(reg.group, true), SETTLE_MS);
+            state.inFlight = { op: 'dismiss', id: reg.id, timer };
+          } else {
+            pump(reg.group);
+          }
         };
       },
 

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -1,0 +1,379 @@
+/**
+ * SheetPresentationProvider — a global serializer for native bottom-sheet
+ * present/dismiss transitions.
+ *
+ * `@expo/ui/community/bottom-sheet` is a SwiftUI `.sheet(isPresented:)` wrapper.
+ * Every sheet presents off the SAME root window view controller, and the library
+ * does ZERO serialization: `present()` just flips `isPresented` true, `dismiss()`
+ * flips it false and fires its close callbacks SYNCHRONOUSLY (before the native
+ * animation finishes). UIKit forbids presenting/dismissing a view controller
+ * while another transition is in flight on the same presenter — overlap them and
+ * UIKit DEADLOCKS: the close animation never completes and the whole app freezes
+ * (renders, ignores every tap/gesture). See docs/mobile-sheets-vs-routes.md.
+ *
+ * This provider is a pure-JS scheduler (no native view, no React state, no
+ * re-renders) that enforces three invariants PER presenter group:
+ *   1. At most one present-or-dismiss transition is in flight at a time.
+ *   2. A queued `present` waits until the prior `dismiss` has actually SETTLED —
+ *      not merely "JS asked it to close."
+ *   3. One active sheet per exclusive group: presenting B while A is open
+ *      auto-sequences dismiss(A) → settle → present(B). This makes sheet-over-
+ *      sheet handoffs safe and enforces docs hard-rule 1 at runtime.
+ *
+ * "Settled" is detected two ways: a fixed per-platform timer (the baseline, works
+ * with no native support), upgraded to the real post-animation signal when the
+ * `@expo/ui` patch forwards SwiftUI's `onDismiss` (see notifyFullyDismissed). The
+ * timer then degrades to a ceiling/fallback.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+import { Platform } from 'react-native';
+import type { BottomSheetMethods } from '@expo/ui/community/bottom-sheet';
+
+export type PresenterGroup = 'root' | (string & {});
+
+/** How long after JS asks a native sheet to dismiss we treat it as still
+ * animating (the ceiling before we let the next transition run). iOS modal sheet
+ * present/dismiss is ~0.4-0.5s; Android material is quicker. Used as a fallback
+ * when the accurate native `onDismiss` signal isn't available (pre-patch, or when
+ * a Host was torn down mid-animation and the event never arrives). */
+const IOS_SHEET_SETTLE_MS = 550;
+const ANDROID_SHEET_SETTLE_MS = 350;
+const SETTLE_MS = Platform.OS === 'ios' ? IOS_SHEET_SETTLE_MS : ANDROID_SHEET_SETTLE_MS;
+
+type Registration = {
+  group: PresenterGroup;
+  present: () => void;
+  dismiss: () => void;
+  onFullyDismissed?: () => void;
+};
+
+type InFlight = {
+  op: 'present' | 'dismiss';
+  id: string;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type GroupState = {
+  /** The sheet currently presented (a present transition has settled and no
+   * dismiss has settled since). Null = nothing up in this group. */
+  presentedId: string | null;
+  inFlight: InFlight | null;
+};
+
+export type SheetCoordinator = {
+  register: (reg: { id: string } & Registration) => () => void;
+  /** Declarative entry point: the desired open/closed state for a sheet. The
+   * scheduler reconciles it against what's physically presented. */
+  setDesiredOpen: (id: string, open: boolean) => void;
+  /** The native sheet finished its dismiss animation (patched `@expo/ui`
+   * `onDismiss`). Early-resolves the settle so the next transition can start. */
+  notifyFullyDismissed: (id: string) => void;
+  /** The native sheet started closing on its own (user pan-down / backdrop tap),
+   * i.e. NOT driven by the coordinator. Opens a settle window so nothing presents
+   * over the still-animating dismiss. */
+  notifyClosed: (id: string) => void;
+  isPresented: (id: string) => boolean;
+  isBusy: (group?: PresenterGroup) => boolean;
+};
+
+const SheetPresentationContext = createContext<SheetCoordinator | null>(null);
+
+export function useSheetPresentation(): SheetCoordinator {
+  const context = useContext(SheetPresentationContext);
+  if (!context) throw new Error('useSheetPresentation must be used within SheetPresentationProvider');
+  return context;
+}
+
+export function SheetPresentationProvider({ children }: { children: ReactNode }) {
+  // All scheduler state lives in refs: this provider never re-renders, and the
+  // coordinator object below is stable for the app's lifetime.
+  const registrations = useRef(new Map<string, Registration>());
+  const desired = useRef(new Map<string, { open: boolean; seq: number }>());
+  const groups = useRef(new Map<PresenterGroup, GroupState>());
+  const seqCounter = useRef(0);
+
+  const coordinator = useMemo<SheetCoordinator>(() => {
+    function groupState(group: PresenterGroup): GroupState {
+      let state = groups.current.get(group);
+      if (!state) {
+        state = { presentedId: null, inFlight: null };
+        groups.current.set(group, state);
+      }
+      return state;
+    }
+
+    function groupOf(id: string): PresenterGroup | null {
+      return registrations.current.get(id)?.group ?? null;
+    }
+
+    // The single sheet that SHOULD be presented in a group: among ids marked
+    // open, the one most recently requested (highest seq). This makes a handoff
+    // (open B while A is still flagged open) resolve to B without the coordinator
+    // having to mutate A's desired state.
+    function computeWant(group: PresenterGroup): string | null {
+      let bestId: string | null = null;
+      let bestSeq = -1;
+      for (const [id, want] of desired.current) {
+        if (!want.open) continue;
+        if (registrations.current.get(id)?.group !== group) continue;
+        if (want.seq > bestSeq) {
+          bestSeq = want.seq;
+          bestId = id;
+        }
+      }
+      return bestId;
+    }
+
+    function onSettle(group: PresenterGroup, viaCeiling: boolean): void {
+      const state = groupState(group);
+      const inFlight = state.inFlight;
+      if (!inFlight) return;
+      clearTimeout(inFlight.timer);
+      state.inFlight = null;
+      if (inFlight.op === 'present') {
+        state.presentedId = inFlight.id;
+      } else {
+        state.presentedId = null;
+        registrations.current.get(inFlight.id)?.onFullyDismissed?.();
+        if (__DEV__ && viaCeiling) {
+          console.warn(
+            `[sheet-presentation] dismiss of "${inFlight.id}" settled via the ${SETTLE_MS}ms ceiling timer ` +
+              `(no native onDismiss). If this is frequent on a device, the dismiss animation outran the ceiling.`,
+          );
+        }
+      }
+      pump(group);
+    }
+
+    function startTransition(group: PresenterGroup, op: 'present' | 'dismiss', id: string): void {
+      const state = groupState(group);
+      const timer = setTimeout(() => onSettle(group, true), SETTLE_MS);
+      state.inFlight = { op, id, timer };
+      const registration = registrations.current.get(id);
+      if (op === 'present') registration?.present();
+      else registration?.dismiss();
+    }
+
+    function pump(group: PresenterGroup): void {
+      const state = groupState(group);
+      if (state.inFlight) return; // a transition is animating; re-pump on settle
+      const want = computeWant(group);
+      const have = state.presentedId;
+      if (have === want) return; // settled
+      if (have !== null) {
+        // Must clear the currently-presented sheet first (plain close OR the
+        // dismiss half of a handoff). present(want) runs after this settles.
+        startTransition(group, 'dismiss', have);
+      } else {
+        startTransition(group, 'present', want as string);
+      }
+    }
+
+    return {
+      register(reg) {
+        registrations.current.set(reg.id, {
+          group: reg.group,
+          present: reg.present,
+          dismiss: reg.dismiss,
+          onFullyDismissed: reg.onFullyDismissed,
+        });
+        groupState(reg.group);
+        return () => {
+          const state = groupState(reg.group);
+          if (state.inFlight?.id === reg.id) {
+            clearTimeout(state.inFlight.timer);
+            state.inFlight = null;
+          }
+          if (state.presentedId === reg.id) state.presentedId = null;
+          desired.current.delete(reg.id);
+          registrations.current.delete(reg.id);
+          pump(reg.group);
+        };
+      },
+
+      setDesiredOpen(id, open) {
+        const prev = desired.current.get(id);
+        const seq = open ? (seqCounter.current += 1) : (prev?.seq ?? 0);
+        desired.current.set(id, { open, seq });
+        const group = groupOf(id);
+        if (group) pump(group);
+      },
+
+      notifyFullyDismissed(id) {
+        const group = groupOf(id);
+        if (!group) return;
+        const state = groupState(group);
+        if (state.inFlight && state.inFlight.op === 'dismiss' && state.inFlight.id === id) {
+          onSettle(group, false);
+        }
+      },
+
+      notifyClosed(id) {
+        const group = groupOf(id);
+        if (!group) return;
+        const prev = desired.current.get(id);
+        desired.current.set(id, { open: false, seq: prev?.seq ?? 0 });
+        const state = groupState(group);
+        // The native sheet is already animating out on its own. Open a settle
+        // window (unless we were already driving a dismiss for it) so the next
+        // present waits for the animation, then reconcile.
+        if (state.presentedId === id && !state.inFlight) {
+          const timer = setTimeout(() => onSettle(group, true), SETTLE_MS);
+          state.inFlight = { op: 'dismiss', id, timer };
+        } else {
+          pump(group);
+        }
+      },
+
+      isPresented(id) {
+        const group = groupOf(id);
+        if (!group) return false;
+        return groupState(group).presentedId === id;
+      },
+
+      isBusy(group = 'root') {
+        return groupState(group).inFlight !== null;
+      },
+    };
+  }, []);
+
+  return <SheetPresentationContext.Provider value={coordinator}>{children}</SheetPresentationContext.Provider>;
+}
+
+/** The imperative shim a wrapper exposes via `forwardRef`. Source-compatible with
+ * `@expo/ui` `BottomSheetMethods` for the methods our call sites use, but
+ * present/dismiss/close route through the coordinator instead of the native ref. */
+export type ManagedSheetHandle = Pick<
+  BottomSheetMethods,
+  'present' | 'dismiss' | 'close' | 'forceClose' | 'snapToIndex' | 'snapToPosition' | 'expand' | 'collapse'
+>;
+
+type UseManagedSheetOptions = {
+  /** Controlled open state. Pass a boolean to drive the sheet declaratively;
+   * leave `undefined` for purely imperative consumers (drive via the returned
+   * `handle` / a forwarded ref) — then the prop never fights the ref. */
+  open?: boolean;
+  group?: PresenterGroup;
+  /** The native `@expo/ui` sheet ref the wrapper renders. */
+  sheetRef: RefObject<BottomSheetMethods | null>;
+  /** Fired when the user closes the sheet themselves (pan-down / backdrop), so
+   * the parent can clear the state that drove `open`. Not fired for coordinator-
+   * initiated closes (the parent already drove those). */
+  onClose?: () => void;
+  /** Fired AFTER the dismiss animation has really settled. */
+  onFullyDismissed?: () => void;
+  /** Snap index used when presenting (default 0). */
+  presentIndex?: number;
+};
+
+/**
+ * The bridge every sheet wrapper uses: registers with the coordinator, reconciles
+ * the controlled `open` prop, and returns the native `onChange`/`onFullyDismissed`
+ * handlers plus the imperative `handle`. All the "is it coordinator- or user-
+ * initiated" bookkeeping lives here, in one place, instead of a per-consumer
+ * `isPresentedRef` effect.
+ */
+export function useManagedSheet({
+  open,
+  group = 'root',
+  sheetRef,
+  onClose,
+  onFullyDismissed,
+  presentIndex = 0,
+}: UseManagedSheetOptions): {
+  onChange: (index: number) => void;
+  onFullyDismissed: () => void;
+  handle: ManagedSheetHandle;
+} {
+  const id = useId();
+  const coordinator = useSheetPresentation();
+  // True while the coordinator is the one dismissing, so the synchronous native
+  // close callback isn't mistaken for a user pan-down.
+  const selfDismissRef = useRef(false);
+  const desiredIndexRef = useRef(presentIndex);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const onFullyDismissedRef = useRef(onFullyDismissed);
+  onFullyDismissedRef.current = onFullyDismissed;
+
+  const present = useCallback(() => {
+    sheetRef.current?.snapToIndex(desiredIndexRef.current);
+  }, [sheetRef]);
+  const dismiss = useCallback(() => {
+    selfDismissRef.current = true;
+    sheetRef.current?.dismiss();
+  }, [sheetRef]);
+  const fireFullyDismissed = useCallback(() => {
+    onFullyDismissedRef.current?.();
+  }, []);
+
+  useEffect(
+    () => coordinator.register({ id, group, present, dismiss, onFullyDismissed: fireFullyDismissed }),
+    [coordinator, id, group, present, dismiss, fireFullyDismissed],
+  );
+
+  // Controlled mode only: an imperative consumer leaves `open` undefined so this
+  // effect never overrides a ref-driven present/dismiss.
+  useEffect(() => {
+    if (open === undefined) return;
+    coordinator.setDesiredOpen(id, open);
+  }, [coordinator, id, open]);
+
+  const handleNativeChange = useCallback(
+    (index: number) => {
+      if (index === -1) {
+        const self = selfDismissRef.current;
+        selfDismissRef.current = false;
+        if (!self) {
+          // User-initiated close (pan-down / backdrop). Let the parent clear its
+          // state and open a settle window in the coordinator.
+          onCloseRef.current?.();
+          coordinator.notifyClosed(id);
+        }
+      } else {
+        desiredIndexRef.current = index;
+      }
+    },
+    [coordinator, id],
+  );
+
+  const handleNativeFullyDismissed = useCallback(() => {
+    coordinator.notifyFullyDismissed(id);
+  }, [coordinator, id]);
+
+  const handle = useMemo<ManagedSheetHandle>(
+    () => ({
+      present: () => coordinator.setDesiredOpen(id, true),
+      dismiss: () => coordinator.setDesiredOpen(id, false),
+      close: () => coordinator.setDesiredOpen(id, false),
+      forceClose: () => coordinator.setDesiredOpen(id, false),
+      snapToIndex: (index: number) => {
+        if (index < 0) {
+          coordinator.setDesiredOpen(id, false);
+          return;
+        }
+        desiredIndexRef.current = index;
+        // Already up → just change the detent live; otherwise open at this index.
+        if (coordinator.isPresented(id)) sheetRef.current?.snapToIndex(index);
+        else coordinator.setDesiredOpen(id, true);
+      },
+      snapToPosition: (position: string | number) => sheetRef.current?.snapToPosition(position),
+      expand: () => sheetRef.current?.expand(),
+      collapse: () => sheetRef.current?.collapse(),
+    }),
+    [coordinator, id, sheetRef],
+  );
+
+  return { onChange: handleNativeChange, onFullyDismissed: handleNativeFullyDismissed, handle };
+}


### PR DESCRIPTION
## Summary

Fixes the recurring whole-app freeze on iOS where the UI renders but goes dead to touch (only a force-quit recovers). It reproduces after a native bottom sheet has been opened — close a sheet then open another, hand off between sheets, or open the sidebar and tap a row.

This generalises the narrow per-row deferral this PR originally shipped into a proper, systemic fix.

### Root cause (confirmed on-device)

`@expo/ui/community/bottom-sheet` is a SwiftUI `.sheet(isPresented:)` wrapper with two properties that combine badly:

1. **No serialization** — every sheet presents off the **same** root-window view controller, and the library never coordinates them. UIKit forbids presenting/dismissing a VC while another transition is in flight on the same presenter; overlapping them **deadlocks UIKit**.
2. **`dismiss()` lies about timing** — it fires its close callbacks (`onDismiss`/`onChange(-1)`) **synchronously**, before the native animation finishes. So any "now it's safe to present the next thing" logic built on that callback acts ~16 ms in while the real dismiss runs ~400–500 ms — it works only by luck (the flaky-freeze signature).

### The fix

- **`SheetPresentationProvider`** — a pure-JS coordinator (`packages/mobile/src/providers/sheet-presentation-provider.tsx`) that serialises every native present/dismiss **per presenter group**: one transition in flight at a time, a queued present waits out the prior dismiss's settle window, and presenting B while A is open auto-sequences `dismiss(A) → settle → present(B)`. Dedicated unit tests.
- **`useManagedSheet`** — the bridge the `ModalSheet`/`Sheet` wrappers and every raw-rendering consumer (`QueueSheet`, `BoardSheet`, `LogAscentSheet`, the filter/picker/session sheets, …) use instead of hand-rolled `isPresentedRef` effects.
- **drawer-host** keeps data-backed sheets (log-ascent / add-to-playlist / beta) **mounted through their dismiss animation** (`useDeferredSheetData`) so the native Host never tears down mid-animation.
- **User drawer → `transparentModal` route** — replaces the React Native core `<Modal>` (a second native presentation system) with a single-presentation route. `FeedbackSheet` stays at the provider root and is presented one frame after the route unmounts (an `@expo/ui` sheet rendered inside a transparentModal would render *behind* it).
- Reverts the exploratory BoardSheet mount/unmount experiment.

JS-only — rides OTA, no native change.

### Follow-ups (tracked, not blocking)

- A one-line `@expo/ui` patch to forward the SwiftUI layer's true post-animation `onDismiss` so the coordinator's settle is exact instead of a 550 ms timer (optimization; the coordinator is correct on the timer baseline).
- An import lint-guard so a future sheet can't bypass the coordinator.

## Release Notes

- Fixed an iOS freeze where the app could stop responding to taps after opening and closing sheets (board history, the queue, filters) or after using the sidebar.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — **2660 tests pass**, incl. new coordinator unit tests (handoff serialization, early settle, user-close, no-op close, rapid-toggle coalescing, group isolation) and updated consumer/user-drawer regressions
- `vp check` on changed files — clean (0 warnings)
- **On-device verified** (iPhone 17 Pro, iOS 26): the previously-freezing flows (BoardSheet → add-to-playlist / player, sidebar → Report a bug → Change board, pan-down-while-opening-another-sheet) no longer freeze
- Reviewed by a multi-agent adversarial pass over the coordinator + consumers + the new route; two real user-drawer defects it surfaced (a re-introduced feedback-row freeze and an invisible-backdrop touch-sink) are fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjETzDReFapvth6uTL9VsX
