### PR TITLE
feat(db): import the full MoonBoard catalog (all 7 boards)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -60,6 +60,7 @@
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",
     "db:import-moonboard-2024": "tsx scripts/import-moonboard-2024.ts",
+    "db:import-moonboard-catalog": "NODE_OPTIONS=--max-old-space-size=8192 tsx scripts/import-moonboard-catalog.ts",
     "db:import-aurora-unified": "tsx scripts/import-aurora-board-unified.ts",
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",

--- a/packages/db/scripts/import-moonboard-2024.ts
+++ b/packages/db/scripts/import-moonboard-2024.ts
@@ -16,6 +16,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // =============================================================================
 // MoonBoard 2024 authoritative import
 // =============================================================================
+// DEPRECATED: superseded by import-moonboard-catalog.ts, which imports all 7
+// boards (both angles) from the app-API scrape with real quality + ascensionist
+// data and merges in place. Kept for reference / the older single-file format.
+// =============================================================================
 // Imports the full MoonBoard 2024 catalog (~35k problems) at angle 40 from the
 // boardsesh/moonboard-scraper "Problems Moonboard 2024 40.json" file. The format
 // has no apiId/repeats/userRating and usually no date fields, so we derive a

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -1,0 +1,352 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { sql, eq } from 'drizzle-orm';
+import { boardClimbs, boardClimbStats, boardClimbHolds, boardClimbAliases } from '../src/schema/boards/unified.js';
+import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
+import {
+  HOLDSETUP_TO_LAYOUT,
+  catalogProblemToClimbs,
+  type MoonBoardCatalogFile,
+  type MappedCatalogClimb,
+} from './moonboard-catalog-helpers.js';
+import { getScriptDatabaseUrl } from './db-connection.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// =============================================================================
+// MoonBoard app-API catalog import (all 7 boards)
+// =============================================================================
+// Imports the full MoonBoard catalog scraped from the app's REST API
+// (boardsesh/moonboard-scraper app-catalog/). One file per board, each
+// { count, holdsetup, problems[] }. We write one climb row per (problem, graded
+// angle) across all 7 boards and both 25°/40° angles.
+//
+// MERGE IN PLACE (non-destructive): the new scrape re-keys identities (stable
+// problem id) vs the rows already in prod (keyed on apiId / name+setter). To
+// avoid duplicating ~163k existing MoonBoard climbs — and to keep their UUIDs,
+// URLs, ticks and favourites intact — we match each incoming climb to an
+// existing one by (layout_id, angle, hold_fingerprint), tie-breaking on
+// case-insensitive name. A match reuses the existing UUID (so the upsert updates
+// it in place, backfilling the 2024 quality/ascensionist gap); a miss mints a
+// stable id-based UUID and inserts. Stat upserts are monotonic — they never
+// overwrite an existing grade/quality with null or drop an ascent count.
+//
+// The ~390 MB of catalog files are NOT committed. Point the script at a local
+// copy of the app-catalog directory:
+//   DB_URL=<target> vp run db:import-moonboard-catalog "/path/to/app-catalog"
+// (DB_URL must be set inline — it beats the dev-db .env override and is how you
+// target prod vs local.)
+// =============================================================================
+
+const DEFAULT_DIR = path.join(__dirname, '../data/moonboard/app-catalog');
+// 2000 rows/insert keeps every table under Postgres's 65,535 bind-param limit
+// (widest is board_climbs at ~24 cols) while cutting round-trips ~4× vs 500.
+const BATCH_SIZE = 2000;
+
+type ExistingClimb = { uuid: string; name: string | null };
+
+/**
+ * Build the in-memory match index for the non-destructive merge:
+ * `${layoutId}|${angle}|${fingerprint}` → existing climbs with those holds.
+ * Existing MoonBoard climbs predate the fingerprint column (only layout 3 has
+ * it populated in prod), so we recompute every fingerprint from board_climb_holds.
+ * Holds are streamed with a cursor and folded per-climb so memory stays bounded.
+ */
+async function buildExistingIndex(
+  client: postgres.Sql,
+  db: ReturnType<typeof drizzle>,
+): Promise<Map<string, ExistingClimb[]>> {
+  console.info('   Building match index from existing MoonBoard climbs...');
+  const fingerprintByUuid = new Map<string, string>();
+  let currentUuid: string | null = null;
+  let currentHolds: { holdId: number; holdState: string }[] = [];
+  const flush = () => {
+    if (currentUuid !== null) fingerprintByUuid.set(currentUuid, fingerprintFromHolds(currentHolds));
+  };
+  const holdCursor = client<{ climb_uuid: string; hold_id: number; hold_state: string }[]>`
+    SELECT climb_uuid, hold_id, hold_state
+    FROM board_climb_holds
+    WHERE board_type = 'moonboard'
+    ORDER BY climb_uuid
+  `.cursor(50000);
+  for await (const rows of holdCursor) {
+    for (const row of rows) {
+      if (row.climb_uuid !== currentUuid) {
+        flush();
+        currentUuid = row.climb_uuid;
+        currentHolds = [];
+      }
+      currentHolds.push({ holdId: row.hold_id, holdState: row.hold_state });
+    }
+  }
+  flush();
+
+  const climbRows = await db
+    .select({
+      uuid: boardClimbs.uuid,
+      layoutId: boardClimbs.layoutId,
+      angle: boardClimbs.angle,
+      name: boardClimbs.name,
+    })
+    .from(boardClimbs)
+    .where(eq(boardClimbs.boardType, 'moonboard'));
+
+  const index = new Map<string, ExistingClimb[]>();
+  for (const row of climbRows) {
+    const fingerprint = fingerprintByUuid.get(row.uuid);
+    if (!fingerprint) continue;
+    const key = `${row.layoutId}|${row.angle}|${fingerprint}`;
+    const bucket = index.get(key);
+    if (bucket) bucket.push({ uuid: row.uuid, name: row.name });
+    else index.set(key, [{ uuid: row.uuid, name: row.name }]);
+  }
+  fingerprintByUuid.clear();
+  console.info(`   Indexed ${climbRows.length} existing climbs (${index.size} hold groups)`);
+  return index;
+}
+
+/**
+ * Resolve the UUID an incoming climb should use: an existing match (update in
+ * place) or its own minted id-based UUID (insert). Tie-break a fingerprint that
+ * maps to several climbs by case-insensitive name; if none matches, mint new
+ * rather than risk overwriting the wrong climb. `matched` reports whether an
+ * existing row was found — note a re-import matches its own id-based rows, whose
+ * UUID equals the minted one, so we can't infer `matched` from UUID equality.
+ */
+function resolveUuid(
+  mapped: MappedCatalogClimb,
+  index: Map<string, ExistingClimb[]>,
+): { uuid: string; matched: boolean } {
+  const candidates = index.get(`${mapped.layoutId}|${mapped.angle}|${mapped.holdFingerprint}`);
+  if (!candidates || candidates.length === 0) return { uuid: mapped.uuid, matched: false };
+  if (candidates.length === 1) return { uuid: candidates[0].uuid, matched: true };
+  const target = mapped.name.trim().toLowerCase();
+  const named = candidates.find((candidate) => (candidate.name ?? '').trim().toLowerCase() === target);
+  return named ? { uuid: named.uuid, matched: true } : { uuid: mapped.uuid, matched: false };
+}
+
+function parseFlag(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index !== -1 ? process.argv[index + 1] : undefined;
+}
+
+async function importMoonBoardCatalog() {
+  const positional = process.argv.slice(2).find((arg) => !arg.startsWith('--'));
+  const catalogDir = positional ? path.resolve(process.cwd(), positional) : DEFAULT_DIR;
+  const onlyHoldsetup = parseFlag('--holdsetup') ? Number(parseFlag('--holdsetup')) : undefined;
+
+  if (!fs.existsSync(catalogDir) || !fs.statSync(catalogDir).isDirectory()) {
+    console.error(`❌ Catalog directory not found: ${catalogDir}`);
+    console.error('   Usage: vp run db:import-moonboard-catalog [/path/to/app-catalog]');
+    process.exit(1);
+  }
+
+  const files = fs
+    .readdirSync(catalogDir)
+    .filter((name) => name.toLowerCase().endsWith('.json'))
+    .sort();
+  if (files.length === 0) {
+    console.error(`❌ No .json catalog files in ${catalogDir}`);
+    process.exit(1);
+  }
+
+  const databaseUrl = getScriptDatabaseUrl();
+  const dbHost = databaseUrl.split('@')[1]?.split('/')[0] || 'unknown';
+  console.info(`🔄 Importing MoonBoard catalog to: ${dbHost}`);
+  console.info(`📂 Reading catalog from: ${catalogDir} (${files.length} files)`);
+
+  const client = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(client);
+
+  const totals = { matched: 0, inserted: 0, climbs: 0, stats: 0, holds: 0, skippedProblems: 0 };
+
+  try {
+    const existingIndex = await buildExistingIndex(client, db);
+
+    for (const file of files) {
+      const raw = fs.readFileSync(path.join(catalogDir, file), 'utf-8');
+      const dump: MoonBoardCatalogFile = JSON.parse(raw);
+      const layoutId = HOLDSETUP_TO_LAYOUT[dump.holdsetup];
+      if (!layoutId) {
+        console.warn(`⚠️  ${file}: unknown holdsetup ${dump.holdsetup}, skipping`);
+        continue;
+      }
+      if (onlyHoldsetup !== undefined && dump.holdsetup !== onlyHoldsetup) continue;
+
+      console.info(`\n📖 ${file} — holdsetup ${dump.holdsetup} → layout ${layoutId}, ${dump.problems.length} problems`);
+
+      // Dedupe in memory (last wins) keyed per conflict target so a single batch
+      // never proposes the same target twice ("ON CONFLICT cannot affect row a
+      // second time").
+      const climbByUuid = new Map<string, typeof boardClimbs.$inferInsert>();
+      const statsByUuid = new Map<string, typeof boardClimbStats.$inferInsert>();
+      const holdsByKey = new Map<string, typeof boardClimbHolds.$inferInsert>();
+      const aliasByUuid = new Map<string, typeof boardClimbAliases.$inferInsert>();
+      let matched = 0;
+      let inserted = 0;
+      let skippedProblems = 0;
+
+      for (const problem of dump.problems) {
+        const climbs = catalogProblemToClimbs(problem, layoutId);
+        if (climbs.length === 0) {
+          skippedProblems++;
+          continue;
+        }
+        for (const mapped of climbs) {
+          const { uuid, matched: matchedExisting } = resolveUuid(mapped, existingIndex);
+          if (matchedExisting) matched++;
+          else inserted++;
+
+          climbByUuid.set(uuid, {
+            uuid,
+            boardType: 'moonboard',
+            layoutId: mapped.layoutId,
+            setterId: null,
+            setterUsername: mapped.setterUsername,
+            name: mapped.name,
+            description: mapped.description,
+            hsm: null,
+            edgeLeft: null,
+            edgeRight: null,
+            edgeBottom: null,
+            edgeTop: null,
+            angle: mapped.angle,
+            framesCount: 1,
+            framesPace: 0,
+            frames: mapped.frames,
+            isDraft: false,
+            isListed: true,
+            createdAt: mapped.createdAt,
+            synced: true,
+            syncError: null,
+            userId: null,
+            holdFingerprint: mapped.holdFingerprint,
+            characteristics: mapped.characteristics,
+          });
+
+          statsByUuid.set(uuid, {
+            boardType: 'moonboard',
+            climbUuid: uuid,
+            angle: mapped.angle,
+            displayDifficulty: mapped.difficultyId ?? null,
+            benchmarkDifficulty: mapped.isBenchmark && mapped.difficultyId !== undefined ? mapped.difficultyId : null,
+            ascensionistCount: mapped.ascensionistCount,
+            difficultyAverage: mapped.difficultyId ?? null,
+            qualityAverage: mapped.qualityAverage,
+            qualityNormalized: true,
+            faUsername: null,
+            faAt: null,
+          });
+
+          for (const hold of mapped.holds) {
+            holdsByKey.set(`${uuid}:${hold.holdId}`, {
+              boardType: 'moonboard',
+              climbUuid: uuid,
+              holdId: hold.holdId,
+              frameNumber: 0,
+              holdState: hold.holdState,
+            });
+          }
+
+          aliasByUuid.set(uuid, {
+            boardType: 'moonboard',
+            aliasUuid: uuid,
+            canonicalUuid: uuid,
+            source: 'moonboard-catalog-import',
+          });
+        }
+      }
+
+      const climbRecords = [...climbByUuid.values()];
+      const statsRecords = [...statsByUuid.values()];
+      const holdsRecords = [...holdsByKey.values()];
+      const aliasRecords = [...aliasByUuid.values()];
+
+      console.info(`   ${matched} matched existing, ${inserted} new; ${skippedProblems} problems skipped`);
+
+      // One transaction per board: a crash mid-file never leaves a climb without
+      // its holds/aliases, and completed boards stay committed for an idempotent
+      // re-run.
+      await db.transaction(async (tx) => {
+        // Climbs — for matched rows the identity columns are already correct, so
+        // refresh only the method-derived fields (characteristics/description).
+        for (let i = 0; i < climbRecords.length; i += BATCH_SIZE) {
+          await tx
+            .insert(boardClimbs)
+            .values(climbRecords.slice(i, i + BATCH_SIZE))
+            .onConflictDoUpdate({
+              target: boardClimbs.uuid,
+              set: { characteristics: sql`excluded.characteristics`, description: sql`excluded.description` },
+            });
+        }
+
+        // Stats — monotonic merge: take the new grade/benchmark, but never null
+        // out an existing grade/quality or shrink an ascent count.
+        for (let i = 0; i < statsRecords.length; i += BATCH_SIZE) {
+          await tx
+            .insert(boardClimbStats)
+            .values(statsRecords.slice(i, i + BATCH_SIZE))
+            .onConflictDoUpdate({
+              target: [boardClimbStats.boardType, boardClimbStats.climbUuid, boardClimbStats.angle],
+              // Existing-side refs must be table-qualified — a bare column name is
+              // ambiguous between the target row and `excluded` in ON CONFLICT.
+              set: {
+                displayDifficulty: sql`coalesce(excluded.display_difficulty, ${boardClimbStats.displayDifficulty})`,
+                benchmarkDifficulty: sql`excluded.benchmark_difficulty`,
+                difficultyAverage: sql`coalesce(excluded.difficulty_average, ${boardClimbStats.difficultyAverage})`,
+                ascensionistCount: sql`greatest(coalesce(excluded.ascensionist_count, 0), coalesce(${boardClimbStats.ascensionistCount}, 0))`,
+                qualityAverage: sql`coalesce(excluded.quality_average, ${boardClimbStats.qualityAverage})`,
+                qualityNormalized: sql`true`,
+              },
+            });
+        }
+
+        for (let i = 0; i < holdsRecords.length; i += BATCH_SIZE) {
+          await tx
+            .insert(boardClimbHolds)
+            .values(holdsRecords.slice(i, i + BATCH_SIZE))
+            .onConflictDoNothing();
+        }
+
+        // Self-aliases so resolveCanonicalClimbUuid always hits.
+        for (let i = 0; i < aliasRecords.length; i += BATCH_SIZE) {
+          await tx
+            .insert(boardClimbAliases)
+            .values(aliasRecords.slice(i, i + BATCH_SIZE))
+            .onConflictDoUpdate({
+              target: [boardClimbAliases.boardType, boardClimbAliases.aliasUuid],
+              set: { lastSeenAt: sql`now()` },
+            });
+        }
+      });
+
+      console.info(`   ✓ climbs ${climbRecords.length}, stats ${statsRecords.length}, holds ${holdsRecords.length}`);
+      totals.matched += matched;
+      totals.inserted += inserted;
+      totals.climbs += climbRecords.length;
+      totals.stats += statsRecords.length;
+      totals.holds += holdsRecords.length;
+      totals.skippedProblems += skippedProblems;
+    }
+
+    console.info('\n✅ Import completed!');
+    console.info(`   Matched existing: ${totals.matched}`);
+    console.info(`   Newly inserted:   ${totals.inserted}`);
+    console.info(`   Climbs upserted:  ${totals.climbs}`);
+    console.info(`   Stats upserted:   ${totals.stats}`);
+    console.info(`   Holds upserted:   ${totals.holds}`);
+    console.info(`   Problems skipped: ${totals.skippedProblems}`);
+
+    await client.end();
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Import failed:', error);
+    await client.end();
+    process.exit(1);
+  }
+}
+
+void importMoonBoardCatalog();

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -21,6 +21,10 @@ import { moonBoardMethodToCharacteristic } from '@boardsesh/shared-schema/charac
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // =============================================================================
+// DEPRECATED for prod: superseded by import-moonboard-catalog.ts (app-API scrape,
+// all 7 boards, both angles, merge-in-place). Still used by the dev-db Docker
+// bootstrap, which bakes in the 2023 community dump — leave it wired there.
+// =============================================================================
 // Data Source
 // =============================================================================
 // MoonBoard problem data comes from a community-provided dump:

--- a/packages/db/scripts/moonboard-catalog-helpers.test.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.test.ts
@@ -1,0 +1,174 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { uuidv5, MOONBOARD_UUID_NAMESPACE } from './moonboard-helpers.js';
+import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
+import {
+  HOLDSETUP_TO_LAYOUT,
+  angleFromConfiguration,
+  roleLetterToHoldState,
+  parseMovesString,
+  holdsToFrames,
+  catalogClimbUuid,
+  isImportableProblem,
+  isImportableConfig,
+  mapCatalogConfig,
+  catalogProblemToClimbs,
+  type MoonBoardCatalogProblem,
+} from './moonboard-catalog-helpers.js';
+
+// "Porridge & Salt" (Joe Wallace) — id 541453, MoonBoard 2024 (holdsetup 21).
+// Its 40° configuration matches the row already in prod, which lets us pin the
+// fingerprint and prove the merge updates that row in place.
+const PORRIDGE: MoonBoardCatalogProblem = {
+  id: 541453,
+  name: 'Porridge & Salt',
+  setter: 'Joe Wallace',
+  setbyId: 'abc',
+  climbMethod: 'Any marked holds',
+  moves: 'r~E10~|r~E13~|e~I18~|r~J8~|r~J12~|s~K1~|s~K6~',
+  holdsetup: 21,
+  dateInserted: '2023-11-23T18:00:15.227',
+  dateDeleted: null,
+  Active: true,
+  configurations: [
+    {
+      apiId: 2,
+      grade: '', // never graded at 25° — a phantom config we skip
+      userGrade: '',
+      userRating: 0,
+      isBenchmark: false,
+      configuration: '25°',
+      repeats: 0,
+      dateDeleted: null,
+    },
+    {
+      apiId: 3,
+      grade: '7A+',
+      userGrade: '7A',
+      userRating: 4,
+      isBenchmark: true,
+      configuration: '40°',
+      repeats: 812,
+      dateDeleted: null,
+    },
+  ],
+};
+
+void test('HOLDSETUP_TO_LAYOUT covers all 7 boards', () => {
+  assert.deepEqual(HOLDSETUP_TO_LAYOUT, { 1: 2, 15: 4, 17: 5, 19: 6, 21: 3, 22: 7, 23: 1 });
+});
+
+void test('angleFromConfiguration parses the degree string', () => {
+  assert.equal(angleFromConfiguration('40°'), 40);
+  assert.equal(angleFromConfiguration('25°'), 25);
+  assert.equal(angleFromConfiguration(''), undefined);
+  assert.equal(angleFromConfiguration(null), undefined);
+});
+
+void test('roleLetterToHoldState maps start/end and folds the rest to HAND', () => {
+  assert.equal(roleLetterToHoldState('s'), 'STARTING');
+  assert.equal(roleLetterToHoldState('e'), 'FINISH');
+  for (const hand of ['l', 'r', 'm', 'p', 'f']) {
+    assert.equal(roleLetterToHoldState(hand), 'HAND');
+  }
+});
+
+void test('parseMovesString recomputes hold ids and states from the cell', () => {
+  const holds = parseMovesString(PORRIDGE.moves ?? '');
+  assert.deepEqual(holds, [
+    { holdId: 104, holdState: 'HAND' }, // E10
+    { holdId: 137, holdState: 'HAND' }, // E13
+    { holdId: 196, holdState: 'FINISH' }, // I18
+    { holdId: 87, holdState: 'HAND' }, // J8
+    { holdId: 131, holdState: 'HAND' }, // J12
+    { holdId: 11, holdState: 'STARTING' }, // K1
+    { holdId: 66, holdState: 'STARTING' }, // K6
+  ]);
+});
+
+// The whole non-destructive merge hinges on this: parsing the new `moves` string
+// must reproduce the exact fingerprint already stored for this climb in prod, so
+// the importer matches and updates the existing row instead of duplicating it.
+void test('fingerprint reproduces the value stored in prod (merge will match)', () => {
+  const holds = parseMovesString(PORRIDGE.moves ?? '');
+  assert.equal(fingerprintFromHolds(holds), 'e3d1a03797dc0aafc89034dc42e500a4c030700c5b1323f2b5afba5f97f50b10');
+});
+
+void test('holdsToFrames encodes p{holdId}r{roleCode} in move order', () => {
+  const holds = parseMovesString(PORRIDGE.moves ?? '');
+  assert.equal(holdsToFrames(holds), 'p104r43p137r43p196r44p87r43p131r43p11r42p66r42');
+});
+
+void test('catalogClimbUuid is deterministic, id+angle keyed, distinct per angle', () => {
+  const uuid = catalogClimbUuid({ id: 541453, angle: 40 });
+  assert.equal(uuid, uuidv5('moonboard:541453:40', MOONBOARD_UUID_NAMESPACE));
+  assert.match(uuid, /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  assert.notEqual(uuid, catalogClimbUuid({ id: 541453, angle: 25 }));
+});
+
+void test('isImportableProblem rejects deleted / inactive / holdless / config-less problems', () => {
+  assert.equal(isImportableProblem(PORRIDGE), true);
+  assert.equal(isImportableProblem({ ...PORRIDGE, dateDeleted: '2025-01-01T00:00:00' }), false);
+  assert.equal(isImportableProblem({ ...PORRIDGE, Active: false }), false);
+  assert.equal(isImportableProblem({ ...PORRIDGE, moves: null }), false);
+  assert.equal(isImportableProblem({ ...PORRIDGE, moves: '' }), false);
+  assert.equal(isImportableProblem({ ...PORRIDGE, configurations: null }), false);
+  assert.equal(isImportableProblem({ ...PORRIDGE, configurations: [] }), false);
+});
+
+void test('isImportableConfig skips empty-grade and deleted configs', () => {
+  assert.equal(isImportableConfig(PORRIDGE.configurations![0]), false); // 25° empty grade
+  assert.equal(isImportableConfig(PORRIDGE.configurations![1]), true); // 40° 7A+
+  assert.equal(isImportableConfig({ ...PORRIDGE.configurations![1], dateDeleted: '2025-01-01' }), false);
+});
+
+void test('mapCatalogConfig fills stats from the configuration', () => {
+  const mapped = mapCatalogConfig(PORRIDGE, PORRIDGE.configurations![1], { layoutId: 3, angle: 40 });
+  assert.equal(mapped.uuid, catalogClimbUuid({ id: 541453, angle: 40 }));
+  assert.equal(mapped.difficultyId, 23); // 7A+
+  assert.equal(mapped.isBenchmark, true);
+  assert.equal(mapped.ascensionistCount, 812);
+  assert.equal(mapped.qualityAverage, 4);
+  assert.equal(mapped.setterUsername, 'Joe Wallace');
+  assert.equal(mapped.createdAt, '2023-11-23T18:00:15.227');
+  assert.equal(mapped.characteristics, null); // "Any marked holds" → no token
+});
+
+void test('userRating 0 becomes null quality (0 is off the 1-5 scale)', () => {
+  const mapped = mapCatalogConfig(
+    PORRIDGE,
+    { ...PORRIDGE.configurations![1], userRating: 0 },
+    { layoutId: 3, angle: 40 },
+  );
+  assert.equal(mapped.qualityAverage, null);
+});
+
+void test('catalogProblemToClimbs yields one climb per graded angle, skipping phantoms', () => {
+  const climbs = catalogProblemToClimbs(PORRIDGE, 3);
+  // Only the graded 40° config is imported; the empty-grade 25° phantom is dropped.
+  assert.equal(climbs.length, 1);
+  assert.equal(climbs[0].angle, 40);
+  assert.equal(climbs[0].difficultyId, 23);
+
+  // Both angles graded → two rows.
+  const bothGraded = catalogProblemToClimbs(
+    { ...PORRIDGE, configurations: [{ ...PORRIDGE.configurations![0], grade: '6C' }, PORRIDGE.configurations![1]] },
+    3,
+  );
+  assert.deepEqual(
+    bothGraded.map((climb) => climb.angle).sort((a, b) => a - b),
+    [25, 40],
+  );
+
+  // A deleted / holdless problem yields nothing.
+  assert.deepEqual(catalogProblemToClimbs({ ...PORRIDGE, dateDeleted: '2025-01-01' }, 3), []);
+});
+
+void test('unmappable grades map to undefined difficulty', () => {
+  const mapped = mapCatalogConfig(
+    PORRIDGE,
+    { ...PORRIDGE.configurations![1], grade: '9Z' },
+    { layoutId: 3, angle: 40 },
+  );
+  assert.equal(mapped.difficultyId, undefined);
+});

--- a/packages/db/scripts/moonboard-catalog-helpers.ts
+++ b/packages/db/scripts/moonboard-catalog-helpers.ts
@@ -1,0 +1,215 @@
+import {
+  coordinateToHoldId,
+  uuidv5,
+  MOONBOARD_UUID_NAMESPACE,
+  HOLD_STATE_CODES,
+  moonBoardGradeToDifficultyId,
+} from './moonboard-helpers.js';
+import { fingerprintFromHolds, methodDescription } from './moonboard-2024-helpers.js';
+import { moonBoardMethodToCharacteristic } from '@boardsesh/shared-schema/characteristics';
+
+// =============================================================================
+// MoonBoard app-API catalog (boardsesh/moonboard-scraper app-catalog/)
+// =============================================================================
+// The MoonBoard iOS app's REST API (rest-v1.moonclimbing.com) returns one file
+// per board ({ count, holdsetup, problems[] }), covering all 7 boards. Unlike
+// the older community dump and the degraded 2024 export, every problem carries a
+// stable `id`, per-angle `configurations` (grade + userRating + repeats +
+// isBenchmark), and the holds as a single `moves` string ("s~G5~|l~C12~|e~C18~").
+//
+// We import one climb row per (problem, graded angle). Empty-grade configurations
+// are the non-primary angle a setter never graded — they carry no grade, rating
+// or ascents, so we skip them rather than flood the catalog with phantom climbs.
+// =============================================================================
+
+// In-file `holdsetup` id → our internal layout id (see @boardsesh/board-config
+// MOONBOARD_LAYOUTS). 2010 reuses the existing layout 1; Mini 2025 is layout 7.
+export const HOLDSETUP_TO_LAYOUT: Record<number, number> = {
+  1: 2, // MoonBoard 2016
+  15: 4, // MoonBoard Masters 2017
+  17: 5, // MoonBoard Masters 2019
+  19: 6, // Mini MoonBoard 2020
+  21: 3, // MoonBoard 2024
+  22: 7, // Mini MoonBoard 2025
+  23: 1, // MoonBoard 2010
+};
+
+export type MoonBoardCatalogConfiguration = {
+  apiId: number;
+  grade: string; // e.g. "6C+"; "" for the angle a setter never graded
+  userGrade?: string | null;
+  userRating?: number | null; // 1-5 community stars; 0 = no rating
+  isBenchmark?: boolean;
+  isPrimary?: boolean;
+  configuration: string; // "25°" | "40°"
+  primaryAngle?: string;
+  repeats?: number | null;
+  dateDeleted?: string | null;
+};
+
+export type MoonBoardCatalogProblem = {
+  id: number;
+  name: string;
+  setter?: string | null;
+  setbyId?: string | null;
+  climbMethod?: string | null;
+  moves: string | null; // "<role>~<cell>~|<role>~<cell>~|…"
+  holdsetup?: number;
+  dateInserted?: string | null;
+  dateDeleted?: string | null;
+  Active?: boolean;
+  configurations: MoonBoardCatalogConfiguration[] | null;
+};
+
+export type MoonBoardCatalogFile = {
+  count: number;
+  holdsetup: number;
+  problems: MoonBoardCatalogProblem[];
+};
+
+export type MoonBoardCatalogHold = {
+  holdId: number;
+  holdState: string; // 'STARTING' | 'HAND' | 'FINISH'
+};
+
+export type MappedCatalogClimb = {
+  // The id-based UUID a *new* climb gets. The importer overrides this with a
+  // matched existing UUID when a climb with the same holds already exists (so
+  // the merge updates in place instead of duplicating).
+  uuid: string;
+  layoutId: number;
+  angle: number;
+  name: string;
+  setterUsername: string | null;
+  frames: string;
+  holdFingerprint: string;
+  // undefined for an unmappable grade — caller decides (we only emit graded configs).
+  difficultyId: number | undefined;
+  isBenchmark: boolean;
+  ascensionistCount: number;
+  // null when userRating is 0/absent — 0 isn't on the 1-5 quality scale.
+  qualityAverage: number | null;
+  createdAt: string | null;
+  holds: MoonBoardCatalogHold[];
+  characteristics: string[] | null;
+  description: string;
+};
+
+const STATE_TO_ROLE: Record<string, number> = {
+  STARTING: HOLD_STATE_CODES.start,
+  HAND: HOLD_STATE_CODES.hand,
+  FINISH: HOLD_STATE_CODES.finish,
+};
+
+/**
+ * Map a `moves` role letter to a hold state. The app uses `s`=start, `e`=end
+ * (finish), and several letters for the holds in between — `l`/`r` (left/right
+ * hand), `m` (match), `p` (intermediate), `f` (foot). Boardsesh only models
+ * STARTING/HAND/FINISH, so everything that isn't a start or end is a HAND.
+ */
+export function roleLetterToHoldState(role: string): string {
+  if (role === 's') return 'STARTING';
+  if (role === 'e') return 'FINISH';
+  return 'HAND';
+}
+
+/**
+ * Parse the pipe-separated `moves` string into (holdId, holdState) tuples. Each
+ * token is `<role>~<cell>~` (e.g. "s~G5~"); the hold id is recomputed from the
+ * cell with the same formula the rest of the codebase uses, so the ids match
+ * what's already stored for MoonBoard climbs.
+ */
+export function parseMovesString(moves: string): MoonBoardCatalogHold[] {
+  return moves
+    .split('|')
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .map((token) => {
+      const [role, cell] = token.split('~').filter((part) => part.length > 0);
+      if (!cell) throw new Error(`Malformed move token: "${token}"`);
+      return { holdId: coordinateToHoldId(cell), holdState: roleLetterToHoldState(role) };
+    });
+}
+
+/** Encode holds as the `p{holdId}r{roleCode}` frames string. */
+export function holdsToFrames(holds: MoonBoardCatalogHold[]): string {
+  return holds.map((hold) => `p${hold.holdId}r${STATE_TO_ROLE[hold.holdState]}`).join('');
+}
+
+/** "40°" → 40, "25°" → 25; undefined when no angle is present. */
+export function angleFromConfiguration(configuration: string | null | undefined): number | undefined {
+  const match = (configuration ?? '').match(/(\d+)/);
+  return match ? Number(match[1]) : undefined;
+}
+
+/**
+ * Deterministic, idempotent UUID for a newly-inserted climb, keyed off the
+ * stable MoonBoard problem id + angle. A re-scrape yields the same id, so the
+ * same climb maps to the same UUID across runs.
+ */
+export function catalogClimbUuid(args: { id: number; angle: number }): string {
+  return uuidv5(`moonboard:${args.id}:${args.angle}`, MOONBOARD_UUID_NAMESPACE);
+}
+
+/** A problem is importable if it isn't soft-deleted and has holds + configs. */
+export function isImportableProblem(problem: MoonBoardCatalogProblem): boolean {
+  if (problem.dateDeleted) return false;
+  if (problem.Active === false) return false;
+  if (!problem.moves || problem.moves.trim().length === 0) return false;
+  if (!problem.configurations || problem.configurations.length === 0) return false;
+  return true;
+}
+
+/** A configuration is importable if it isn't soft-deleted and the setter graded it. */
+export function isImportableConfig(config: MoonBoardCatalogConfiguration): boolean {
+  if (config.dateDeleted) return false;
+  if (!config.grade || config.grade.trim().length === 0) return false;
+  return true;
+}
+
+/** Map a single (problem, configuration) into the climb/stats/holds payload. */
+export function mapCatalogConfig(
+  problem: MoonBoardCatalogProblem,
+  config: MoonBoardCatalogConfiguration,
+  options: { layoutId: number; angle: number },
+): MappedCatalogClimb {
+  const { layoutId, angle } = options;
+  const holds = parseMovesString(problem.moves ?? '');
+  const frames = holdsToFrames(holds);
+  const method = problem.climbMethod ?? undefined;
+  const characteristic = moonBoardMethodToCharacteristic(method);
+  const rating = config.userRating ?? 0;
+  return {
+    uuid: catalogClimbUuid({ id: problem.id, angle }),
+    layoutId,
+    angle,
+    name: problem.name,
+    setterUsername: problem.setter ?? null,
+    frames,
+    holdFingerprint: fingerprintFromHolds(holds),
+    difficultyId: moonBoardGradeToDifficultyId(config.grade),
+    isBenchmark: Boolean(config.isBenchmark),
+    ascensionistCount: config.repeats ?? 0,
+    qualityAverage: rating > 0 ? rating : null,
+    createdAt: problem.dateInserted ?? null,
+    holds,
+    characteristics: characteristic ? [characteristic] : null,
+    description: methodDescription(method, characteristic, problem.name),
+  };
+}
+
+/**
+ * Expand a problem into one mapped climb per graded, non-deleted configuration
+ * (i.e. one row per angle). Returns [] for a problem we skip entirely.
+ */
+export function catalogProblemToClimbs(problem: MoonBoardCatalogProblem, layoutId: number): MappedCatalogClimb[] {
+  if (!isImportableProblem(problem)) return [];
+  const climbs: MappedCatalogClimb[] = [];
+  for (const config of problem.configurations ?? []) {
+    if (!isImportableConfig(config)) continue;
+    const angle = angleFromConfiguration(config.configuration);
+    if (angle === undefined) continue;
+    climbs.push(mapCatalogConfig(problem, config, { layoutId, angle }));
+  }
+  return climbs;
+}

--- a/packages/location-sync/src/config.test.ts
+++ b/packages/location-sync/src/config.test.ts
@@ -84,9 +84,10 @@ describe('location sync config helpers', () => {
 
   it('creates every MoonBoard layout and angle config', () => {
     const configs = getMoonBoardLocationConfigs();
-    expect(configs).toHaveLength(12);
+    expect(configs).toHaveLength(14);
     expect(configs.map((config) => `${config.layoutId}:${config.angle}`)).toContain('2:25');
     expect(configs.map((config) => `${config.layoutId}:${config.angle}`)).toContain('2:40');
+    expect(configs.map((config) => `${config.layoutId}:${config.angle}`)).toContain('7:40');
     expect(configs.every((config) => config.sizeId === 1)).toBe(true);
   });
 });

--- a/packages/mobile/src/lib/custom-board-options.ts
+++ b/packages/mobile/src/lib/custom-board-options.ts
@@ -17,7 +17,11 @@ import {
   type MoonBoardLayoutKey,
 } from '@boardsesh/board-config';
 
-const HIDDEN_CUSTOM_MOONBOARD_LAYOUT_IDS = new Set<number>([MOONBOARD_LAYOUTS['mini-moonboard-2020'].id]);
+// Mini boards are hidden from the custom-board picker until their board art exists.
+const HIDDEN_CUSTOM_MOONBOARD_LAYOUT_IDS = new Set<number>([
+  MOONBOARD_LAYOUTS['mini-moonboard-2020'].id,
+  MOONBOARD_LAYOUTS['mini-moonboard-2025'].id,
+]);
 
 const MOONBOARD_PRODUCT_SIZE: ProductSizeData = {
   id: MOONBOARD_SIZE.id,

--- a/packages/moonboard-sync/src/sync/locations-sync.test.ts
+++ b/packages/moonboard-sync/src/sync/locations-sync.test.ts
@@ -16,9 +16,10 @@ describe('buildMoonBoardLocationRecords', () => {
       },
     ]);
 
-    expect(records).toHaveLength(12);
+    expect(records).toHaveLength(14);
     expect(records.map((record) => `${record.layoutId}:${record.angle}`)).toContain('2:25');
     expect(records.map((record) => `${record.layoutId}:${record.angle}`)).toContain('2:40');
+    expect(records.map((record) => `${record.layoutId}:${record.angle}`)).toContain('7:40');
     expect(records.find((record) => record.layoutId === 2 && record.angle === 40)?.sourceKey).toBe(
       'moonboard:Board House:-33.86:151.2',
     );

--- a/packages/shared/board-config/src/moonboard-config.ts
+++ b/packages/shared/board-config/src/moonboard-config.ts
@@ -50,6 +50,7 @@ export const MOONBOARD_LAYOUTS = {
     folder: 'moonboardmasters2019',
   },
   'mini-moonboard-2020': { id: 6, name: 'Mini MoonBoard 2020', folder: 'minimoonboard2020' },
+  'mini-moonboard-2025': { id: 7, name: 'Mini MoonBoard 2025', folder: 'minimoonboard2025' },
 } as const;
 
 export type MoonBoardLayoutKey = keyof typeof MOONBOARD_LAYOUTS;
@@ -93,6 +94,10 @@ export const MOONBOARD_SETS: Record<MoonBoardLayoutKey, { id: number; name: stri
     { id: 26, name: 'Wooden Holds B', imageFile: 'woodenholdsb.png' },
     { id: 27, name: 'Wooden Holds C', imageFile: 'woodenholdsc.png' },
   ],
+  // Mini 2025 (holdsetup 22). Board-art images aren't in the repo yet (the Mini
+  // 2020 art is also still missing) — climbs import and holds render; the board
+  // photo overlay is a follow-up.
+  'mini-moonboard-2025': [{ id: 28, name: 'Wooden Holds', imageFile: 'woodenholds.png' }],
 };
 
 // MoonBoard grid configuration (same for all standard layouts)


### PR DESCRIPTION
## What this does

Replaces the patchwork MoonBoard data (a stale 2023 community dump for 2016/2017/2019/Mini 2020, and a degraded 2024 import with no ratings or send counts) with the full catalog scraped from the MoonBoard app's REST API — all 7 boards, both 25° and 40°, with real grades, star ratings and ascent counts.

A new importer (`import-moonboard-catalog.ts`) reads the per-board `app-catalog/*.json` files and **merges in place**: each incoming climb is matched to an existing one by `(layout_id, angle, hold_fingerprint)` (tie-broken on name), so existing UUIDs, climb URLs, ticks and favourites stay intact. Matches update grade/quality/ascensionist in place (fixing the 2024 stats gap); misses insert under a stable problem-id UUID. Stat upserts are monotonic — they never null out an existing grade/quality or shrink an ascent count.

Two new boards are registered: **Mini MoonBoard 2025** (new layout 7) and the original **MoonBoard 2010** (existing layout 1).

## Notes

- Rendering is driven entirely by the static `@boardsesh/board-config`, so no DB config/migration is needed.
- Mini board art images aren't in the repo yet (Mini 2020 also lacks them) — climbs import and holds render; the board photo overlay is a follow-up. Minis are hidden from the custom-board picker until then.
- The ~390 MB of catalog JSON is not committed. The actual prod import is a manual run: `DB_URL=<prod> vp run db:import-moonboard-catalog "/path/to/app-catalog"`.
- The old `import-moonboard-2024.ts` / `import-moonboard-problems.ts` are marked deprecated (the latter still feeds the dev-db Docker bootstrap).

## Release Notes

Thousands more MoonBoard problems, now with real grades, star ratings and send counts — and the Mini 2025 and original 2010 boards join the lineup. Your 25° sessions on the 2016 and 2024 boards finally have their own graded problems too.
