### PR TITLE
fix(mobile): accessibility picker review follow-ups

### DIFF
--- a/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/AccessibilitySettingsScreen.tsx
@@ -43,7 +43,6 @@ import {
   getDefaultHoldRoleColor,
   getEffectiveHoldRoleColor,
   getEffectiveHoldRoleShape,
-  hasHoldMarkerOverrides,
   normalizeBrushThickness,
   normalizeHoldShapeSize,
   useHoldColorOverrides,
@@ -133,7 +132,6 @@ export function AccessibilitySettingsScreen() {
   const boardName = boardNameFromActiveBoard(activeBoard?.boardType);
   const {
     overrides,
-    markerOverrides,
     shapes,
     brushThickness,
     shapeSize,
@@ -147,7 +145,9 @@ export function AccessibilitySettingsScreen() {
   const [thicknessSheetOpen, setThicknessSheetOpen] = useState(false);
   const [sizeSheetOpen, setSizeSheetOpen] = useState(false);
   const [cvdMode, setCvdMode] = useState<CvdMode>('none');
-  const hasOverrides = renderSignature !== DEFAULT_HOLD_COLOR_SIGNATURE && hasHoldMarkerOverrides(markerOverrides);
+  // renderSignature is buildHoldRenderOverrideSignature(markerOverrides), so this
+  // alone is equivalent to hasHoldMarkerOverrides(markerOverrides).
+  const hasOverrides = renderSignature !== DEFAULT_HOLD_COLOR_SIGNATURE;
 
   const cvdOptions = useMemo<{ key: CvdMode; label: string }[]>(
     () => [

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -26,7 +26,8 @@ const SL_STOPS = 12;
 const DEFAULT_OKHSL: Okhsl = { h: 0, s: 0, l: 0.5 };
 
 function sampleGradient(count: number, at: (t: number) => string): { offset: number; color: string }[] {
-  if (count <= 1) return [{ offset: 0, color: at(0) }];
+  if (count <= 0) return [];
+  if (count === 1) return [{ offset: 0, color: at(0) }];
   const stops: { offset: number; color: string }[] = [];
   for (let i = 0; i < count; i += 1) {
     const t = i / (count - 1);

--- a/packages/mobile/src/components/settings/OkhslColorPicker.tsx
+++ b/packages/mobile/src/components/settings/OkhslColorPicker.tsx
@@ -12,15 +12,21 @@ import { useTranslation } from 'react-i18next';
 import Svg, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg';
 import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
 import { hexToOkhsl, okhslToHex, type Okhsl } from '../../lib/okhsl';
 import { normalizeHexColor } from '../../lib/hold-color-overrides';
 import { borderRadius, spacing } from '../../theme/tokens';
+
+// Destructive red for the invalid-hex state (matches AuthTextInput's error
+// border) — the accent token reads as a focused/selected field, not an error.
+const ERROR_COLOR = iosSystemColors.systemRed;
 
 const HUE_STOPS = 13;
 const SL_STOPS = 12;
 const DEFAULT_OKHSL: Okhsl = { h: 0, s: 0, l: 0.5 };
 
 function sampleGradient(count: number, at: (t: number) => string): { offset: number; color: string }[] {
+  if (count <= 1) return [{ offset: 0, color: at(0) }];
   const stops: { offset: number; color: string }[] = [];
   for (let i = 0; i < count; i += 1) {
     const t = i / (count - 1);
@@ -240,7 +246,7 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
     {
       backgroundColor: systemColors.fill,
       color: systemColors.label,
-      borderColor: hexValid ? systemColors.separator : systemColors.accent,
+      borderColor: hexValid ? systemColors.separator : ERROR_COLOR,
     },
   ];
 
@@ -290,7 +296,7 @@ export function OkhslColorPicker({ value, onChange }: OkhslColorPickerProps) {
         />
       </View>
       {hexValid ? null : (
-        <Text variant="footnote" color={systemColors.accent}>
+        <Text variant="footnote" color={ERROR_COLOR}>
           {t('mobile.more.accessibility.invalidHex')}
         </Text>
       )}

--- a/packages/mobile/src/lib/cvd-simulation.ts
+++ b/packages/mobile/src/lib/cvd-simulation.ts
@@ -4,10 +4,12 @@
 // the three dichromacies, so they can confirm the four hold roles stay
 // distinguishable. This is a visualisation aid, not a clinical tool.
 //
-// Uses the Machado, Oliveira & Fernandes (2009) severity-1.0 matrices. These are
-// applied directly to gamma-encoded sRGB (no linearisation) — the form Machado's
-// own implementation and the common ports use, so the simulated colours match
-// the reference look other CVD tools produce. Pure TS, no React Native imports.
+// Uses the Machado, Oliveira & Fernandes (2009) severity-1.0 matrices. The paper
+// derives them in linear light, but here they're applied directly to
+// gamma-encoded sRGB (no linearisation) — this matches the behaviour of common
+// web CVD tools/simulators and keeps the preview visually consistent with them.
+// It's a perceptual aid, not a colorimetrically exact simulation. Pure TS, no
+// React Native imports.
 
 export type CvdType = 'deuteranopia' | 'protanopia' | 'tritanopia';
 


### PR DESCRIPTION
## Summary

Addresses the post-merge review feedback on the OKHSL hold picker from #3212.

- **Invalid-hex error colour** (`OkhslColorPicker.tsx`) — the invalid-hex border + footnote used `systemColors.accent` (the teal/blue *action* colour), so a bad hex looked like a focused field. Now uses the destructive red (`iosSystemColors.systemRed`, matching `AuthTextInput`) so it reads as an error.
- **CVD matrix comment accuracy** (`cvd-simulation.ts`) — Machado, Oliveira & Fernandes (2009) derive their matrices in linear light. The header wrongly attributed gamma-domain application to "Machado's own implementation"; reworded to say it matches common web CVD simulators and is a perceptual aid, not a colorimetrically exact simulation. (No behaviour change — the gamma-domain application is intentional.)
- **Redundant `hasOverrides`** (`AccessibilitySettingsScreen.tsx`) — `renderSignature !== DEFAULT` already equals `hasHoldMarkerOverrides(markerOverrides)` (both are `buildHoldRenderOverrideSignature` of the same data), so dropped the redundant `&&` and the now-unused import/destructure.
- **`sampleGradient` NaN guard** (`OkhslColorPicker.tsx`) — `i / (count - 1)` is `0/0` when `count === 1`. Unreachable with the current constants, but guarded for reuse safety.

The remaining review note — slider gradient recompute pressure on drag (low-end Android) — is tracked as a separate follow-up: #3216.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean
- `vp check` (changed files) — no warnings/errors
- No functional change beyond the error-colour swap; the OKHSL/CVD unit tests are unaffected by the comment/guard edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCNrfUN6hEpnsvV2E6CzRL