### PR TITLE
feat(shared): make MoonBoard hold circles 50% larger

### DIFF
--- a/packages/shared/board-config/src/moonboard-config.ts
+++ b/packages/shared/board-config/src/moonboard-config.ts
@@ -250,7 +250,7 @@ export function getMoonBoardDetails({ layout_id, set_ids }: { layout_id: number;
   // Compute all 198 hold positions from grid for WASM/canvas rendering pipeline
   const cellWidth = MOONBOARD_SIZE.width / MOONBOARD_GRID.numColumns;
   const cellHeight = MOONBOARD_SIZE.height / MOONBOARD_GRID.numRows;
-  const holdRadius = Math.min(cellWidth, cellHeight) * 0.35;
+  const holdRadius = Math.min(cellWidth, cellHeight) * 0.525;
 
   const holdsData = Array.from({ length: MOONBOARD_GRID.numColumns * MOONBOARD_GRID.numRows }, (_, i) => {
     const holdId = i + 1;


### PR DESCRIPTION
## What

Bumps the MoonBoard hold-circle radius multiplier from `0.35` to `0.525` (×1.5) in `packages/shared/board-config/src/moonboard-config.ts`. The circles drawn around lit-up holds on MoonBoard climbs now render 50% larger.

This is the single source of truth for MoonBoard hold radius — it flows through `getMoonBoardDetails()` into `holdsData[].r`, so both web (SVG renderer) and mobile pick up the change. Kilter/Tension (Aurora boards) use a separate `xSpacing * 4` multiplier and are untouched.

## Notes

`0.525` slightly exceeds half the smaller grid-cell dimension (~0.5), so circles may sit a touch tighter against neighbours. Worth a quick visual check on a busy MoonBoard problem to confirm they don't visibly clip.

## Release Notes

MoonBoard hold circles are now bigger and easier to read at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBST45NLJeFxsGsX4kf9nQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBST45NLJeFxsGsX4kf9nQ)_