### PR TITLE
fix(mobile): native iOS re-light supports MoonBoard (was Aurora-only)

### DIFF
--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -132,6 +132,43 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertNil(SharedQueueState.currentItem(from: defaults))
     }
 
+    func testMoonboardPacketEncodesRolesAndSerialPositions() {
+        // Parity with packages/shared/ble-protocol/src/__tests__/moonboard.test.ts:
+        // p1r42 -> S at serial position 0, p2r43 -> P at serial position 35.
+        let result = BoardBleEncoding.makeMoonboardPacket(frames: "p1r42p2r43")
+
+        XCTAssertEqual(String(decoding: result.packet, as: UTF8.self), "l#S0,P35#")
+        XCTAssertEqual(result.skippedRoleCount, 0)
+        XCTAssertEqual(result.skippedPositionCount, 0)
+        XCTAssertEqual(result.totalPlacements, 2)
+    }
+
+    func testMoonboardPacketSkipsUnknownRolesAndOutOfRangeHolds() {
+        // Role 45 (foot) is not a MoonBoard LED role; hold id 199 is past the
+        // 198-hold grid. Both are dropped, the valid start hold still lights.
+        let result = BoardBleEncoding.makeMoonboardPacket(frames: "p1r42p5r45p199r43")
+
+        XCTAssertEqual(String(decoding: result.packet, as: UTF8.self), "l#S0#")
+        XCTAssertEqual(result.skippedRoleCount, 1)
+        XCTAssertEqual(result.skippedPositionCount, 1)
+        XCTAssertEqual(result.totalPlacements, 3)
+    }
+
+    func testMoonboardPacketIsEmptyWhenNothingEncodes() {
+        // No clear-all: an empty or all-skipped frame must produce no packet so
+        // the BLE manager refuses to write and leaves the wall lit as-is.
+        XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "").packet.isEmpty)
+        XCTAssertTrue(BoardBleEncoding.makeMoonboardPacket(frames: "p1r45").packet.isEmpty)
+    }
+
+    func testMoonboardSerialPositionMirrorsGridMath() {
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 1), 0)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 2), 35)
+        XCTAssertEqual(BoardBleEncoding.moonboardSerialPosition(holdId: 198), 197)
+        XCTAssertNil(BoardBleEncoding.moonboardSerialPosition(holdId: 0))
+        XCTAssertNil(BoardBleEncoding.moonboardSerialPosition(holdId: 199))
+    }
+
     func testBoardRenderUrlUsesSharedBoardContext() {
         defaults.set("https://www.boardsesh.com", forKey: SharedConstants.serverUrlKey)
         defaults.set("kilter", forKey: SharedConstants.boardNameKey)

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -244,6 +244,75 @@ enum BoardBleEncoding {
         )
     }
 
+    // MARK: - MoonBoard
+
+    // MoonBoard speaks a different protocol from the Aurora boards: an ASCII
+    // frame `l#{holds}#` where each hold is a role letter plus a serial LED
+    // position derived straight from its grid coordinate — no per-board LED
+    // placement map and no binary packet wrapper. Ported from
+    // packages/shared/ble-protocol/src/moonboard.ts; keep the two in lockstep
+    // (parity asserted in LiveActivityWidgetTests).
+    private static let moonboardGridColumns = 11
+    private static let moonboardGridRows = 18
+    private static let moonboardRoleMap: [Int: String] = [42: "S", 43: "P", 44: "E"]
+    private static let moonboardFramePrefix = "l#"
+    private static let moonboardFrameSuffix = "#"
+
+    static func moonboardSerialPosition(holdId: Int) -> Int? {
+        let maxHoldId = moonboardGridColumns * moonboardGridRows
+        guard holdId >= 1, holdId <= maxHoldId else { return nil }
+
+        let zeroBasedHoldId = holdId - 1
+        let colIndex = zeroBasedHoldId % moonboardGridColumns
+        let rowIndex = zeroBasedHoldId / moonboardGridColumns
+
+        // Odd columns are wired bottom-to-top, so their row order is reversed.
+        if colIndex % 2 == 0 {
+            return colIndex * moonboardGridRows + rowIndex
+        }
+        return colIndex * moonboardGridRows + (moonboardGridRows - 1 - rowIndex)
+    }
+
+    static func makeMoonboardPacket(frames: String) -> BoardBlePacketResult {
+        var encodedHolds: [String] = []
+        var skippedRoleCount = 0
+        var skippedPositionCount = 0
+
+        let parsedFrames = parseFrames(frames)
+        for frame in parsedFrames {
+            guard let roleLetter = moonboardRoleMap[frame.roleCode] else {
+                skippedRoleCount += 1
+                continue
+            }
+            guard let position = moonboardSerialPosition(holdId: frame.placementId) else {
+                skippedPositionCount += 1
+                continue
+            }
+            encodedHolds.append("\(roleLetter)\(position)")
+        }
+
+        // No clear-all for MoonBoard: an empty `l##` frame is a no-op on the
+        // controller, so when nothing encodes (unrecognised roles, out-of-range
+        // ids, or no holds) return an empty packet and let the caller refuse to
+        // write — matching dispatchMoonboardPacket on the JS side.
+        guard !encodedHolds.isEmpty else {
+            return BoardBlePacketResult(
+                packet: Data(),
+                skippedPositionCount: skippedPositionCount,
+                skippedRoleCount: skippedRoleCount,
+                totalPlacements: parsedFrames.count
+            )
+        }
+
+        let payload = moonboardFramePrefix + encodedHolds.joined(separator: ",") + moonboardFrameSuffix
+        return BoardBlePacketResult(
+            packet: Data(payload.utf8),
+            skippedPositionCount: skippedPositionCount,
+            skippedRoleCount: skippedRoleCount,
+            totalPlacements: parsedFrames.count
+        )
+    }
+
     static func mirroredFrames(frames: String, boardName: String, layoutId: Int) -> String? {
         var mirroredFrames = ""
         for frame in parseFrames(frames) {

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -591,6 +591,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard let configuration else { return }
         guard connectedPeripheral != nil, writeCharacteristic != nil else { return }
 
+        // MoonBoard has no clear-all command (an empty `l##` frame is a no-op on
+        // the controller and the JS layer refuses to send it), so leave the wall
+        // lit as-is rather than writing an Aurora clear packet to it.
+        if configuration.boardName == "moonboard" { return }
+
         let result = BoardBleEncoding.makeAuroraPacket(
             frames: "",
             placementPositions: [:],
@@ -610,6 +615,30 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private func displayItemOnBleQueue(_ item: SharedQueueItem) {
         guard let configuration else { return }
         guard connectedPeripheral != nil, writeCharacteristic != nil else { return }
+
+        // MoonBoard encodes straight from grid coordinates into the ASCII `l#…#`
+        // frame format — it has no LED placement map and the Aurora binary
+        // encoder can't drive it (no `moonboard` role map). Without this branch a
+        // native re-light (widget intent or write-stall recovery reconnect) would
+        // silently write nothing and the wall would stay dark. Mirroring isn't
+        // supported on MoonBoard (boardSupportsMirroring is false), so frames go
+        // out as-is.
+        if configuration.boardName == "moonboard" {
+            let result = BoardBleEncoding.makeMoonboardPacket(frames: item.frames)
+            guard !result.packet.isEmpty else {
+                // Every hold was unrecognised/out-of-range, or the climb has no
+                // holds. Refuse to write rather than dark the wall — there is no
+                // MoonBoard clear-all.
+                logger.warning("Skipping MoonBoard BLE write: no encodable holds for climb \(item.climbUuid, privacy: .public)")
+                return
+            }
+            writeOnBleQueue(data: result.packet) { [weak self] error in
+                if let error {
+                    self?.logger.error("BLE write failed: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+            return
+        }
 
         let ledPlacements = BoardPlacementData.getLedPlacements(
             boardName: configuration.boardName,

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -21,6 +21,14 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/LiveActivitySources/ClimbSessionAttributes.swift',
   },
   {
+    sourcePath: '../modules/live-activity/ios/BoardBleEncoding.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/BoardBleEncoding.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/BoardPlacementData.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/BoardPlacementData.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/SharedConstants.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/SharedConstants.swift',
   },


### PR DESCRIPTION
## Summary

MoonBoard LED control over Bluetooth broke on iOS. Root cause is in the **live-activity native module**: the native re-light path (`displaySharedCurrentItemOnBleQueue` → `displayItemOnBleQueue` / `clearBoardOnBleQueue`) only knew the Aurora protocol.

- `BoardBleEncoding.makeAuroraPacket` has no `moonboard` entry in its `holdStateMap`, and a MoonBoard uses no LED placement map (it encodes straight from grid coordinates). So a native MoonBoard re-light wrote an **empty packet** and the wall stayed dark.
- This surfaced after the write-stall recovery (#3181, merged Jun 25): a marginal-link write stall now **cycles the connection natively** and re-lights via that Aurora-only path, while reporting `writeTimedOut` to JS (so JS keeps `isConnected` and does **not** re-send via `dispatchMoonboardPacket`). On **iOS + MoonBoard**, a single stall therefore left the wall dark indefinitely.
- The same gap meant the Live Activity Dynamic Island intents (next / previous / reconnect) never drove a MoonBoard either.

Android is unaffected — its adapter has no native recovery / native re-light and sends MoonBoard frames through JS.

### The fix

Add a native MoonBoard encoder, `BoardBleEncoding.makeMoonboardPacket`, mirroring the canonical JS encoder `packages/shared/ble-protocol/src/moonboard.ts`:

- grid-coordinate serial positions (11×18, odd columns reversed),
- role codes `42/43/44 → S/P/E` (others skipped),
- ASCII `l#…#` frame format,
- **no clear-all** — an empty / all-skipped frame produces no packet so the caller refuses to write and leaves the wall as-is.

`displayItemOnBleQueue` and `clearBoardOnBleQueue` branch on `boardName == "moonboard"`; the Aurora path is byte-for-byte unchanged.

## Release Notes

- MoonBoard on iPhone now recovers and re-lights the wall after a flaky Bluetooth moment instead of going dark, and the Dynamic Island climb controls drive a MoonBoard too.

## Test plan

- **Added Swift XCTests** (`LiveActivityWidgetTests`) asserting parity with the JS vectors: `p1r42p2r43 → l#S0,P35#`, unknown roles / out-of-range hold ids are skipped, and nothing-to-light yields no write. Wired `BoardBleEncoding.swift` + `BoardPlacementData.swift` into the `BoardseshTests` target (`ios-rn-ci.yml` runs them on a simulator).
- Confirmed the canonical JS suite (`moonboard.test.ts`, 17 tests) and the widget-target-drift guard pass locally via `vp test run`.
- `vp check` runs clean on the changed files (Swift isn't linted; the one repo-wide lint error is pre-existing in `packages/db/scripts/refresh-recommendations.ts`, untouched here).
- **Pending on-device (iOS + a real MoonBoard):** connect → tap a climb lights the wall; force a write stall → after native recovery the MoonBoard re-lights instead of going dark; Dynamic Island next/prev/reconnect light the MoonBoard; regression-check the same stall flow on Kilter/Tension still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD72vps2umF37J1yNpLTs3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TD72vps2umF37J1yNpLTs3)_