### PR TITLE
fix(mobile): clarify that custom hold colours light up the board

### DIFF
--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -18,7 +18,7 @@
       "metroServersSubtitle": "Switch between Tailnet bundlers",
       "accessibility": {
         "title": "Accessibility",
-        "description": "Pick hold colours and marker shapes that are easier to tell apart. Shape, size, and brush changes only affect the app overlay, not the board lights.",
+        "description": "Pick hold colours and marker shapes that are easier to tell apart. Colour changes also light up your board; shape, size, and brush only change the in-app overlay.",
         "rowSubtitleShort": "Hold colours and shapes for colour vision",
         "markersTitle": "Hold markers",
         "resetAll": "Reset hold markers",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -216,7 +216,7 @@
       "metroServersSubtitle": "Cambia entre bundlers de Tailnet",
       "accessibility": {
         "title": "Accesibilidad",
-        "description": "Elige colores de presas que sean más fáciles de distinguir. Predeterminado usa los colores normales de cada plafón y no envía cambios por Bluetooth.",
+        "description": "Elige colores de presas y formas de marcadores más fáciles de distinguir. Los cambios de color también encienden tu plafón; la forma, el tamaño y el grosor solo cambian la superposición de la app.",
         "rowSubtitleShort": "Colores y formas de presas para la visión del color",
         "markersTitle": "Marcadores de presa",
         "resetAll": "Restablecer marcadores de presa",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -18,7 +18,7 @@
       "metroServersSubtitle": "Basculer entre les bundlers Tailnet",
       "accessibility": {
         "title": "Accessibilité",
-        "description": "Choisis des couleurs de prises plus faciles à distinguer. Par défaut utilise les couleurs normales de chaque board et n'envoie aucune surcharge Bluetooth.",
+        "description": "Choisis des couleurs de prises et des formes de marqueurs plus faciles à distinguer. Les changements de couleur allument aussi ton board ; la forme, la taille et l'épaisseur ne modifient que la superposition de l'app.",
         "rowSubtitleShort": "Couleurs et formes des prises pour la vision des couleurs",
         "markersTitle": "Marqueurs de prise",
         "resetAll": "Réinitialiser les marqueurs de prise",


### PR DESCRIPTION
Fixes #3207.

## What's going on

Custom hold colours still light up the board — the feature works. But the Accessibility settings description only ever called out what *doesn't* reach the LEDs:

> Shape, size, and brush changes only affect the app overlay, not the board lights.

It never said colour changes *do* carry through to the lights. A collaborator read it, assumed custom LED colours were gone, and didn't even try them ([the thread](https://github.com/boardsesh/boardsesh/issues/3207#issuecomment-4807462282)). The copy was burying the good news.

## The change

Lead with the win, then list the in-app-only bits:

> Pick hold colours and marker shapes that are easier to tell apart. Colour changes also light up your board; shape, size, and brush only change the in-app overlay.

The Spanish and French strings had drifted — they still described the old default-mode/Bluetooth wording and never mentioned shape, size, or brush at all — so they're brought in line with the English (Spanish keeps _plafón_; French keeps _board_ to match the surrounding catalog).

Mobile-only; the web app has no equivalent string. Only existing keys were edited, so catalog parity is unchanged.

## Release Notes

The Accessibility settings now make it clear that custom hold colours light up your board, not just the in-app markers — so the feature stops looking like it's missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138PheewirFns5HSsiUyTHj)_