### PR TITLE
fix(mobile): improve ascents-by-angle chart for many/skewed angles

### DIFF
--- a/packages/mobile/src/components/play-drawer/CommunitySection.tsx
+++ b/packages/mobile/src/components/play-drawer/CommunitySection.tsx
@@ -81,7 +81,11 @@ export const CommunitySection = memo(function CommunitySection({
           <Text variant="footnote" color={iosSystemColors.systemGray}>
             {t('mobile.community.ascentsByAngle')}
           </Text>
-          <DifficultyByAngleChart data={angleBars} accessibilityLabel={t('mobile.community.ascentsByAngle')} />
+          <DifficultyByAngleChart
+            data={angleBars}
+            accessibilityLabel={t('mobile.community.ascentsByAngle')}
+            logScaleLabel={t('mobile.community.logScale')}
+          />
         </View>
       )}
     </View>

--- a/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
@@ -23,6 +23,10 @@ const ROTATED_AXIS_LABEL_SIZE = 10;
 const BAR_RADIUS = borderRadius.sm;
 const PEAK_BAR_RADIUS = borderRadius.md;
 const TOP_LABEL_HEIGHT = 16;
+// Measurement box for the grade label above each bar — wide enough that even a
+// long combined grade ("V13 / 8B") never clips to "…", while a short grade stays
+// centred over the bar.
+const GRADE_LABEL_WIDTH = 60;
 const MIN_BAR_WIDTH = 10;
 // Width reserved for the y-axis ascent-count labels (e.g. "120", "1.2k").
 const Y_AXIS_LABEL_WIDTH = 32;
@@ -72,15 +76,22 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
         barBorderBottomLeftRadius: 0,
         barBorderBottomRightRadius: 0,
         topLabelComponentHeight: TOP_LABEL_HEIGHT,
+        // gifted sizes the top-label box to ~1.5× the bar, so on a narrow bar
+        // the grade clips to "V…". Wrap it in a fixed, wider centred box and pin
+        // the font (no Dynamic Type growth) so the grade always reads in full —
+        // the short label still sits centred over the bar without overlapping.
         topLabelComponent: (): ReactNode => (
-          <Text
-            variant="caption2"
-            color={fill}
-            style={isHardest ? styles.topLabelPeak : styles.topLabel}
-            numberOfLines={1}
-          >
-            {bar.gradeName}
-          </Text>
+          <View style={styles.topLabelWrap} pointerEvents="none">
+            <Text
+              variant="caption2"
+              color={fill}
+              style={isHardest ? styles.topLabelPeak : styles.topLabel}
+              numberOfLines={1}
+              allowFontScaling={false}
+            >
+              {bar.gradeName}
+            </Text>
+          </View>
         ),
       };
     });
@@ -181,6 +192,10 @@ const styles = StyleSheet.create({
   },
   topLabelContainer: {
     marginBottom: spacing[1],
+  },
+  topLabelWrap: {
+    width: GRADE_LABEL_WIDTH,
+    alignItems: 'center',
   },
   topLabel: {
     fontWeight: '600',

--- a/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
@@ -10,6 +10,9 @@ import { borderRadius, spacing } from '../../theme/tokens';
 type DifficultyByAngleChartProps = {
   data: AngleGradeBar[];
   accessibilityLabel?: string;
+  /** Localised "Log scale" caption, shown (and folded into the a11y label) only
+   *  when the y-axis switches to log. */
+  logScaleLabel?: string;
 };
 
 const CHART_HEIGHT = 150;
@@ -43,6 +46,7 @@ const ROTATED_LABEL_EXTRA_HEIGHT = 28;
 export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   data,
   accessibilityLabel,
+  logScaleLabel,
 }: DifficultyByAngleChartProps) {
   const { chartColors, colorScheme } = useTheme();
   const [width, setWidth] = useState(0);
@@ -85,6 +89,7 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
       maxValue: scale.maxValue,
       noOfSections: scale.noOfSections,
       yAxisLabelTexts: scale.yAxisLabelTexts,
+      isLog: scale.isLog,
     };
   }, [data, colorScheme]);
 
@@ -104,15 +109,25 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   // Once the bars get too narrow for a horizontal angle label, rotate the labels
   // and give each its own wider box so the angle reads in full instead of "…".
   const rotateLabels = plotWidth > 0 && barWidth + barSpacing < MIN_HORIZONTAL_LABEL_WIDTH;
+  // Flag the log axis in the caption + a11y label so a bar twice as tall isn't
+  // misread as twice the ascents (it's 10× per section on a log scale).
+  const showLogScale = model.isLog && !!logScaleLabel;
+  const chartAccessibilityLabel =
+    showLogScale && accessibilityLabel ? `${accessibilityLabel}, ${logScaleLabel}` : accessibilityLabel;
 
   return (
     <View
       style={[styles.container, rotateLabels && styles.containerRotated]}
       onLayout={onLayout}
-      accessible={accessibilityLabel ? true : undefined}
-      accessibilityRole={accessibilityLabel ? 'image' : undefined}
-      accessibilityLabel={accessibilityLabel}
+      accessible={chartAccessibilityLabel ? true : undefined}
+      accessibilityRole={chartAccessibilityLabel ? 'image' : undefined}
+      accessibilityLabel={chartAccessibilityLabel}
     >
+      {showLogScale ? (
+        <Text variant="caption2" color={chartColors.secondaryLabel} style={styles.logScaleLabel}>
+          {logScaleLabel}
+        </Text>
+      ) : null}
       {width > 0 ? (
         <BarChart
           data={model.barData}
@@ -159,6 +174,10 @@ const styles = StyleSheet.create({
   },
   containerRotated: {
     minHeight: CHART_HEIGHT + spacing[6] + ROTATED_LABEL_EXTRA_HEIGHT,
+  },
+  logScaleLabel: {
+    alignSelf: 'flex-end',
+    marginBottom: spacing[1],
   },
   topLabelContainer: {
     marginBottom: spacing[1],

--- a/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
+++ b/packages/mobile/src/components/play-drawer/DifficultyByAngleChart.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useState, type ReactNode } from 'react';
 import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 import { BarChart } from 'react-native-gifted-charts';
 import { Text } from '../Text';
-import { buildAscentScale, type AngleGradeBar } from './community-utils';
+import { buildAscentChartScale, type AngleGradeBar } from './community-utils';
 import { useTheme } from '../../providers/theme-provider';
 import { gradeChartColor } from '../you/profile-chart-colors';
 import { borderRadius, spacing } from '../../theme/tokens';
@@ -14,6 +14,8 @@ type DifficultyByAngleChartProps = {
 
 const CHART_HEIGHT = 150;
 const AXIS_LABEL_SIZE = 11;
+// Slightly smaller x-axis labels once they rotate, so the diagonal stack stays tight.
+const ROTATED_AXIS_LABEL_SIZE = 10;
 // Default top-corner radius for bars; the hardest angle gets a softer, larger cap.
 const BAR_RADIUS = borderRadius.sm;
 const PEAK_BAR_RADIUS = borderRadius.md;
@@ -21,19 +23,23 @@ const TOP_LABEL_HEIGHT = 16;
 const MIN_BAR_WIDTH = 10;
 // Width reserved for the y-axis ascent-count labels (e.g. "120", "1.2k").
 const Y_AXIS_LABEL_WIDTH = 32;
-
-// Compact tick label: whole numbers below 1k, "1.2k" above so labels stay narrow.
-function formatCount(value: number): string {
-  return value >= 1000 ? `${Math.round(value / 100) / 10}k` : String(value);
-}
+// A horizontal angle label ("70°") needs ~22px; once a bar + its gap is tighter
+// than this the label clips to "…", so we rotate the labels instead.
+const MIN_HORIZONTAL_LABEL_WIDTH = 22;
+// Label-box width for rotated angle labels — enough to hold "70°" before the
+// 60° transform fans them out diagonally.
+const ROTATED_LABEL_WIDTH = 30;
+// Extra room below the plot for the rotated diagonal labels.
+const ROTATED_LABEL_EXTRA_HEIGHT = 28;
 
 // Ascents-by-angle column chart: x-axis angles, bar height = the number of
 // ascents (ascensionist count) at that angle, the bar drawn in the grade's
 // scheme-aware colour with the grade label above it and the ascent count on the
-// y-axis. The hardest angle is flagged with a non-colour cue (bold label + larger
-// cap) so the hardest grade survives colour-blindness and both schemes/variants —
-// note that, since height now means ascents, the hardest angle is no longer
-// necessarily the tallest bar.
+// y-axis. The y-axis switches to a log scale when one angle dominates, so
+// rarely-climbed angles stay legible. The hardest angle is flagged with a
+// non-colour cue (bold label + larger cap) so the hardest grade survives
+// colour-blindness and both schemes/variants — note that, since height now means
+// ascents, the hardest angle is no longer necessarily the tallest bar.
 export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   data,
   accessibilityLabel,
@@ -46,7 +52,7 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
   // closures) every time.
   const model = useMemo(() => {
     if (data.length === 0) return null;
-    const scale = buildAscentScale(Math.max(...data.map((bar) => bar.sends)));
+    const scale = buildAscentChartScale(data.map((bar) => bar.sends));
     // The single hardest angle (first max wins on ties) gets the redundant cue.
     const hardestAngle = data.reduce((peak, bar) => (bar.difficulty > peak.difficulty ? bar : peak)).angle;
     const barData = data.map((bar) => {
@@ -54,7 +60,7 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
       const isHardest = bar.angle === hardestAngle;
       const topRadius = isHardest ? PEAK_BAR_RADIUS : BAR_RADIUS;
       return {
-        value: bar.sends,
+        value: scale.plot(bar.sends),
         frontColor: fill,
         label: `${bar.angle}°`,
         barBorderTopLeftRadius: topRadius,
@@ -74,10 +80,12 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
         ),
       };
     });
-    const yAxisLabelTexts = Array.from({ length: scale.noOfSections + 1 }, (_, index) =>
-      formatCount(index * scale.step),
-    );
-    return { barData, maxValue: scale.maxValue, noOfSections: scale.noOfSections, yAxisLabelTexts };
+    return {
+      barData,
+      maxValue: scale.maxValue,
+      noOfSections: scale.noOfSections,
+      yAxisLabelTexts: scale.yAxisLabelTexts,
+    };
   }, [data, colorScheme]);
 
   const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
@@ -93,10 +101,13 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
     plotWidth > 0
       ? Math.max(MIN_BAR_WIDTH, Math.floor((plotWidth - initialSpacing * 2 - barSpacing * count) / count))
       : MIN_BAR_WIDTH;
+  // Once the bars get too narrow for a horizontal angle label, rotate the labels
+  // and give each its own wider box so the angle reads in full instead of "…".
+  const rotateLabels = plotWidth > 0 && barWidth + barSpacing < MIN_HORIZONTAL_LABEL_WIDTH;
 
   return (
     <View
-      style={styles.container}
+      style={[styles.container, rotateLabels && styles.containerRotated]}
       onLayout={onLayout}
       accessible={accessibilityLabel ? true : undefined}
       accessibilityRole={accessibilityLabel ? 'image' : undefined}
@@ -114,13 +125,19 @@ export const DifficultyByAngleChart = memo(function DifficultyByAngleChart({
           noOfSections={model.noOfSections}
           yAxisLabelTexts={model.yAxisLabelTexts}
           yAxisLabelWidth={Y_AXIS_LABEL_WIDTH}
+          rotateLabel={rotateLabels}
+          labelWidth={rotateLabels ? ROTATED_LABEL_WIDTH : undefined}
+          labelsExtraHeight={rotateLabels ? ROTATED_LABEL_EXTRA_HEIGHT : undefined}
           topLabelContainerStyle={styles.topLabelContainer}
           rulesColor={chartColors.separator}
           rulesType="solid"
           yAxisThickness={0}
           xAxisThickness={StyleSheet.hairlineWidth}
           xAxisColor={chartColors.separator}
-          xAxisLabelTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
+          xAxisLabelTextStyle={{
+            color: chartColors.secondaryLabel,
+            fontSize: rotateLabels ? ROTATED_AXIS_LABEL_SIZE : AXIS_LABEL_SIZE,
+          }}
           yAxisTextStyle={{ color: chartColors.secondaryLabel, fontSize: AXIS_LABEL_SIZE }}
           // gifted-charts' entry animation is unreliable on Android when the chart
           // mounts inside the collapsible's FadeIn transition — bars flash then
@@ -139,6 +156,9 @@ const styles = StyleSheet.create({
   container: {
     minHeight: CHART_HEIGHT + spacing[6],
     justifyContent: 'center',
+  },
+  containerRotated: {
+    minHeight: CHART_HEIGHT + spacing[6] + ROTATED_LABEL_EXTRA_HEIGHT,
   },
   topLabelContainer: {
     marginBottom: spacing[1],

--- a/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { ClimbStatsHistoryEntry } from '@boardsesh/graphql/operations';
-import { buildAngleGradeBars, buildAscentScale, niceStep } from '../community-utils';
+import { buildAngleGradeBars, buildAscentChartScale, buildAscentScale, niceStep } from '../community-utils';
 
 function makeEntry(overrides: Partial<ClimbStatsHistoryEntry> = {}): ClimbStatsHistoryEntry {
   return {
@@ -112,5 +112,53 @@ describe('buildAscentScale', () => {
   it('stays sane for an empty / single-ascent chart', () => {
     expect(buildAscentScale(0)).toEqual({ maxValue: 2, noOfSections: 2, step: 1 });
     expect(buildAscentScale(1)).toEqual({ maxValue: 2, noOfSections: 2, step: 1 });
+  });
+});
+
+describe('buildAscentChartScale', () => {
+  it('keeps a linear axis for tight spreads', () => {
+    const scale = buildAscentChartScale([10, 8, 6]);
+    expect(scale.isLog).toBe(false);
+    expect(scale.plot(8)).toBe(8);
+    expect(scale).toMatchObject({ maxValue: 15, noOfSections: 3, yAxisLabelTexts: ['0', '5', '10', '15'] });
+  });
+
+  it('keeps a linear axis when one angle leads but the peak is still small', () => {
+    // peak 10 (< the log peak threshold) → linear even though 10× the floor.
+    expect(buildAscentChartScale([10, 1]).isLog).toBe(false);
+  });
+
+  it('keeps a linear axis for a big-but-even chart', () => {
+    // peak 100 clears the threshold, but a 1.1× spread would only flatten on log.
+    expect(buildAscentChartScale([100, 90]).isLog).toBe(false);
+  });
+
+  it('switches to a log axis when one angle dominates', () => {
+    const scale = buildAscentChartScale([2000, 50, 2]);
+    expect(scale.isLog).toBe(true);
+    expect(scale).toMatchObject({
+      maxValue: 5,
+      noOfSections: 5,
+      yAxisLabelTexts: ['0', '1', '10', '100', '1k', '10k'],
+    });
+    // log10(v) + 1: a single ascent still clears a whole section off the baseline.
+    expect(scale.plot(1)).toBeCloseTo(1);
+    expect(scale.plot(10)).toBeCloseTo(2);
+    expect(scale.plot(2000)).toBeCloseTo(Math.log10(2000) + 1);
+    expect(scale.plot(0)).toBe(0);
+  });
+
+  it('keeps the top tick above the tallest bar on the log axis', () => {
+    // peak 100 sits exactly on a decade, so it must gain a section for headroom.
+    const scale = buildAscentChartScale([100, 1]);
+    expect(scale.isLog).toBe(true);
+    expect(scale.noOfSections).toBe(4);
+    expect(scale.maxValue).toBeGreaterThan(scale.plot(100));
+  });
+
+  it('stays sane for an all-zero chart', () => {
+    const scale = buildAscentChartScale([0, 0]);
+    expect(scale.isLog).toBe(false);
+    expect(scale).toMatchObject({ maxValue: 2, noOfSections: 2, yAxisLabelTexts: ['0', '1', '2'] });
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/community-utils.test.ts
@@ -156,6 +156,11 @@ describe('buildAscentChartScale', () => {
     expect(scale.maxValue).toBeGreaterThan(scale.plot(100));
   });
 
+  it('stays linear for a single angle (no spread to measure)', () => {
+    // One bar means floor === peak, so the ratio is 1 and the linear axis wins.
+    expect(buildAscentChartScale([500]).isLog).toBe(false);
+  });
+
   it('stays sane for an all-zero chart', () => {
     const scale = buildAscentChartScale([0, 0]);
     expect(scale.isLog).toBe(false);

--- a/packages/mobile/src/components/play-drawer/community-utils.ts
+++ b/packages/mobile/src/components/play-drawer/community-utils.ts
@@ -2,6 +2,7 @@ import type { ClimbStatsHistoryEntry } from '@boardsesh/graphql/operations';
 import { formatGrade, type GradeDisplayFormat } from '@boardsesh/play-view';
 import { BOULDER_GRADES, type BoulderGrade } from '@boardsesh/board-constants/boulder-grade-mapping';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { formatCount } from '../../lib/format-climb-stats';
 
 export type AngleGradeBar = {
   angle: number;
@@ -32,6 +33,59 @@ export function buildAscentScale(maxSends: number): { maxValue: number; noOfSect
   let noOfSections = Math.ceil(peak / step);
   if (step * noOfSections <= peak) noOfSections += 1;
   return { maxValue: step * noOfSections, noOfSections, step };
+}
+
+export type AscentChartScale = {
+  /** Top of the y-axis in plotted units. */
+  maxValue: number;
+  noOfSections: number;
+  /** Tick labels bottom→top, one per section boundary (noOfSections + 1 entries). */
+  yAxisLabelTexts: string[];
+  /** Maps a raw ascent count to the value plotted on the chart — identity on a
+   *  linear axis, a log10 position on a log axis. */
+  plot: (sends: number) => number;
+  /** True when the y-axis is logarithmic. */
+  isLog: boolean;
+};
+
+// A log axis only earns its keep once one angle dwarfs the rest: a climb sent
+// 2,000× at 40° but twice at 15° draws the 15° bar one pixel tall on a linear
+// axis. Past this peak and spread we switch to log10 so the rarely-climbed
+// angles stay legible; tighter spreads keep the linear axis, since log would
+// squash near-equal bars into one indistinguishable band.
+const LOG_MIN_PEAK = 50;
+const LOG_SPREAD_RATIO = 30;
+
+// Y-scale for the ascents-by-angle chart. Picks a linear or log axis from the
+// spread of counts and returns everything the chart needs to plot + label it.
+export function buildAscentChartScale(sends: number[]): AscentChartScale {
+  const counts = sends.filter((count) => count > 0);
+  const peak = counts.length ? Math.max(...counts) : 0;
+  const floor = counts.length ? Math.min(...counts) : 0;
+  const useLog = peak >= LOG_MIN_PEAK && floor > 0 && peak / floor >= LOG_SPREAD_RATIO;
+
+  if (useLog) {
+    // One section per power of ten. Section 1 is a count of 1 (10⁰), so a single
+    // ascent still draws a visible bar; the zero baseline sits below it.
+    const top = Math.log10(peak) + 1;
+    let noOfSections = Math.ceil(top);
+    // Keep the top tick strictly above the tallest bar for top-label headroom.
+    if (noOfSections <= top) noOfSections += 1;
+    const yAxisLabelTexts = Array.from({ length: noOfSections + 1 }, (_, index) =>
+      index === 0 ? '0' : formatCount(10 ** (index - 1)),
+    );
+    return {
+      maxValue: noOfSections,
+      noOfSections,
+      yAxisLabelTexts,
+      plot: (count: number) => (count > 0 ? Math.log10(count) + 1 : 0),
+      isLog: true,
+    };
+  }
+
+  const { maxValue, noOfSections, step } = buildAscentScale(peak);
+  const yAxisLabelTexts = Array.from({ length: noOfSections + 1 }, (_, index) => formatCount(index * step));
+  return { maxValue, noOfSections, yAxisLabelTexts, plot: (count: number) => count, isLog: false };
 }
 
 const GRADE_BY_ID = new Map<number, BoulderGrade>(BOULDER_GRADES.map((grade) => [grade.difficulty_id, grade]));

--- a/packages/mobile/src/components/play-drawer/community-utils.ts
+++ b/packages/mobile/src/components/play-drawer/community-utils.ts
@@ -60,8 +60,9 @@ const LOG_SPREAD_RATIO = 30;
 // spread of counts and returns everything the chart needs to plot + label it.
 export function buildAscentChartScale(sends: number[]): AscentChartScale {
   const counts = sends.filter((count) => count > 0);
-  const peak = counts.length ? Math.max(...counts) : 0;
-  const floor = counts.length ? Math.min(...counts) : 0;
+  // reduce, not Math.max(...counts), so a long angle list can't blow the stack.
+  const peak = counts.reduce((max, count) => Math.max(max, count), 0);
+  const floor = counts.reduce((min, count) => Math.min(min, count), counts[0] ?? 0);
   const useLog = peak >= LOG_MIN_PEAK && floor > 0 && peak / floor >= LOG_SPREAD_RATIO;
 
   if (useLog) {

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -306,7 +306,8 @@
       "ascensionists_one": "{{count}} ascensionist",
       "ascensionists_other": "{{count}} ascensionists",
       "avgQuality": "Average quality",
-      "ascentsByAngle": "Ascents by angle"
+      "ascentsByAngle": "Ascents by angle",
+      "logScale": "Log scale"
     },
     "betaVideos": {
       "title": "Beta Videos",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -306,7 +306,8 @@
       "ascensionists_one": "{{count}} ascensionista",
       "ascensionists_other": "{{count}} ascensionistas",
       "avgQuality": "Calidad promedio",
-      "ascentsByAngle": "Ascensos por ángulo"
+      "ascentsByAngle": "Ascensos por ángulo",
+      "logScale": "Escala logarítmica"
     },
     "betaVideos": {
       "title": "Videos Beta",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -306,7 +306,8 @@
       "ascensionists_one": "{{count}} grimpeur",
       "ascensionists_other": "{{count}} grimpeurs",
       "avgQuality": "Qualite moyenne",
-      "ascentsByAngle": "Ascensions par angle"
+      "ascentsByAngle": "Ascensions par angle",
+      "logScale": "Echelle logarithmique"
     },
     "betaVideos": {
       "title": "Videos Beta",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -307,7 +307,7 @@
       "ascensionists_other": "{{count}} grimpeurs",
       "avgQuality": "Qualite moyenne",
       "ascentsByAngle": "Ascensions par angle",
-      "logScale": "Echelle logarithmique"
+      "logScale": "Échelle logarithmique"
     },
     "betaVideos": {
       "title": "Videos Beta",


### PR DESCRIPTION
## Summary

Closes #3203.

The mobile climb **Ascents by angle** chart (in the community section) had two problems once a climb was popular at many angles:

1. **X-axis labels clipped to "…".** With ascents at many angles, the bars get narrow and each angle label (`40°`, `45°`, …) collapsed to an ellipsis.
2. **Sparse angles invisible.** When one angle (say 40°) has thousands of ascents and others a handful, every other bar flattened to ~1px on the linear y-axis, so you couldn't tell whether a rare angle had 2 or 200 sends.

### What changed

- **Rotate the angle labels** once the bars get too narrow for a horizontal label — each label gets its own wider box and a slightly smaller font, so the angle reads in full instead of `…`. Wide bars keep the upright labels.
- **Log y-axis when one angle dominates.** The chart switches to a base-10 log scale (decade ticks `0 / 1 / 10 / 100 / 1k …`) when the peak is large and the spread is wide, so rarely-climbed angles stay legible. A single ascent still clears a whole section off the baseline. Tighter, more even spreads keep the linear axis, where log would just squash near-equal bars together.

The scale choice lives in a pure helper (`buildAscentChartScale`) with unit tests covering the linear/log switch, the decade ticks, and the log positions.

## Release Notes

- The Ascents by angle chart now reads clearly when a climb is popular at lots of angles — angle labels stay readable and rarely-climbed angles no longer vanish next to a dominant one.

## Test plan

- `vp run typecheck:mobile` — passes
- `vp test run --project mobile` — 2687 passed (includes new `buildAscentChartScale` tests)
- `vp run check:mobile-bundle` — OK
- `vp lint` on the changed files — 0 warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WQcHmV53kfuH9CKWaRMUR

---
_Generated by [Claude Code](https://claude.ai/code/session_019WQcHmV53kfuH9CKWaRMUR)_