### PR TITLE
feat(mobile): now-playing accessory bar — status, not a directive

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -313,6 +313,8 @@ This ensures `BoardSessionBridge` only calls `activateSession()` when the actual
 
 Board presence powers the mobile "now on the wall" feed, board sheet history, and board sheet stats. It is independent of party-session join: the mobile app resolves a board id for the wall feed before subscribing to `boardNowPlaying` or fetching board-presence history/stats.
 
+It also drives the accessory bar's "now playing" eyebrow (`deriveAccessoryContext`): when a session peer holds the wall (`boardConnection === 'heldByPeer'`), the bar reads `{name} on the wall` and hides the tick — a peer's lit climb is read-only to you (you can't log someone else's send).
+
 Mobile resolves the feed board id in this order:
 
 1. `resolveBoardForUuid(boardUuid)` for the selected named board. This is the default board-sheet path and binds to the actual `user_boards` row, so stats/history are available before Bluetooth connects and stay aligned with board-scoped ticks.

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -187,7 +187,9 @@ export function ClimbCapsule({
         <View
           style={[styles.tapArea, { height, borderRadius: capsuleRadius }]}
           accessibilityRole="button"
-          accessibilityLabel={currentClimb.name}
+          // Announce the status caption (live / on the wall / up next) too, so a
+          // screen reader gets the same context the eyebrow gives sighted users.
+          accessibilityLabel={eyebrowText ? `${eyebrowText}, ${currentClimb.name}` : currentClimb.name}
         >
           <View style={[styles.labelSlot, { left: labelLeft, right: labelRight }]}>
             <ClimbLabel

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -20,6 +20,7 @@ import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './Access
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
+import { useAccessoryEyebrow } from './use-accessory-presentation';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -30,32 +31,59 @@ type ClimbLabelProps = {
   gradeColor: string;
   showThumbnail: boolean;
   boardConfig: BoardConfig | null;
+  // The status caption above the name ("On the wall · live" / "Tara on the wall"
+  // / "Up next"). This is the whole disambiguator: it turns a bare climb name
+  // from a directive into a labelled status.
+  eyebrow: string;
+  eyebrowColor: ColorValue;
 };
 
-function ClimbLabel({ climb, labelColor, formattedGrade, gradeColor, showThumbnail, boardConfig }: ClimbLabelProps) {
+function ClimbLabel({
+  climb,
+  labelColor,
+  formattedGrade,
+  gradeColor,
+  showThumbnail,
+  boardConfig,
+  eyebrow,
+  eyebrowColor,
+}: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
-      <Text
-        variant="subheadline"
-        color={labelColor}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-        maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-        style={styles.name}
-      >
-        {climb.name}
-      </Text>
-      {formattedGrade ? (
+      <View style={styles.labelTextColumn}>
         <Text
-          variant="headline"
+          variant="caption1"
+          color={eyebrowColor}
           numberOfLines={1}
           maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-          style={[styles.gradeText, { color: gradeColor }]}
+          style={styles.eyebrow}
         >
-          {formattedGrade}
+          {eyebrow}
         </Text>
-      ) : null}
+        <View style={styles.nameRow}>
+          <Text
+            variant="subheadline"
+            color={labelColor}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={styles.name}
+          >
+            {climb.name}
+          </Text>
+          {formattedGrade ? (
+            <Text
+              variant="headline"
+              numberOfLines={1}
+              maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+              style={[styles.gradeText, { color: gradeColor }]}
+            >
+              {formattedGrade}
+            </Text>
+          ) : null}
+        </View>
+      </View>
     </View>
   );
 }
@@ -85,6 +113,8 @@ export function ClimbCapsule({
   // Connection state drives the leading control + the "you have control" glow.
   // Read from the single source so the bar can't disagree with the drawer bulb.
   const { boardConnection, bluetooth } = useBoardConnectionState();
+  // Status caption that labels what the bar is showing (live / peer / up next).
+  const { text: eyebrowText, tone: eyebrowTone } = useAccessoryEyebrow();
 
   // Source-of-truth flip: show the wall's lit climb when a board feed is live
   // (flag-gated), else the local queue head.
@@ -124,6 +154,9 @@ export function ClimbCapsule({
   // stripe recolors to the brand violet so it reads as a control-on edge marker.
   const showGradeAccent = surfaceTreatment === 'docked';
   const gradeAccentColor = connected ? brandColors.primary : grades.currentColor;
+  // "live" runs hot in the brand accent; peer / up-next stay quiet so they read
+  // as ambient status rather than a call to action.
+  const eyebrowColor = eyebrowTone === 'live' ? brandColors.primary : systemColors.secondaryLabel;
 
   return (
     <AccessoryBarSurface
@@ -154,6 +187,8 @@ export function ClimbCapsule({
               gradeColor={grades.currentColor}
               showThumbnail={showThumbnail}
               boardConfig={boardConfig}
+              eyebrow={eyebrowText}
+              eyebrowColor={eyebrowColor}
             />
           </View>
         </View>
@@ -218,6 +253,24 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[2],
+  },
+  // Two-line text block beside the thumbnail: eyebrow caption over the name+grade
+  // row. Centered so it stays vertically balanced against the 40px thumbnail.
+  labelTextColumn: {
+    flex: 1,
+    minWidth: 0,
+    justifyContent: 'center',
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  // Small uppercase status caption; the disambiguator between queue / live / peer.
+  eyebrow: {
+    fontWeight: '700',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
   },
   gradeText: {
     // Colorized like the list rows; right-aligned with a reserved min width

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -9,9 +9,10 @@ import { View, StyleSheet, type ColorValue } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import type { Climb } from '@boardsesh/queue';
+import { deriveAccessoryContext } from '@boardsesh/play-view';
 import { TOOLBAR_CAPSULE_HEIGHT, TOOLBAR_CAPSULE_MAX_WIDTH, glassSize } from '../../theme/layout';
 import { spacing } from '../../theme/tokens';
-import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
+import { CHROME_LABEL_MAX_FONT_SCALE, ACCESSORY_EYEBROW_TEXT_STYLE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
@@ -20,7 +21,7 @@ import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './Access
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
-import { useAccessoryEyebrow } from './use-accessory-presentation';
+import { useAccessoryEyebrowText } from './use-accessory-presentation';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -33,8 +34,9 @@ type ClimbLabelProps = {
   boardConfig: BoardConfig | null;
   // The status caption above the name ("On the wall · live" / "Tara on the wall"
   // / "Up next"). This is the whole disambiguator: it turns a bare climb name
-  // from a directive into a labelled status.
-  eyebrow: string;
+  // from a directive into a labelled status. Nullable to match the native row,
+  // which drops it in the minimized `inline` placement.
+  eyebrow: string | null;
   eyebrowColor: ColorValue;
 };
 
@@ -58,7 +60,7 @@ function ClimbLabel({
             color={eyebrowColor}
             numberOfLines={1}
             maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-            style={styles.eyebrow}
+            style={ACCESSORY_EYEBROW_TEXT_STYLE}
           >
             {eyebrow}
           </Text>
@@ -113,10 +115,15 @@ export function ClimbCapsule({
   const { formatGrade } = useGradeFormat();
   const { openGesture, currentItem } = useAccessoryClimbTap();
   // Connection state drives the leading control + the "you have control" glow.
-  // Read from the single source so the bar can't disagree with the drawer bulb.
-  const { boardConnection, bluetooth } = useBoardConnectionState();
+  // Read from the single source so the bar can't disagree with the drawer bulb,
+  // and feed the same read into the eyebrow so it isn't subscribed to twice.
+  const { boardConnection, bluetooth, holderDisplayName } = useBoardConnectionState();
   // Status caption that labels what the bar is showing (live / peer / up next).
-  const { text: eyebrowText, tone: eyebrowTone } = useAccessoryEyebrow();
+  const accessoryContext = useMemo(
+    () => deriveAccessoryContext({ boardConnection, holderDisplayName }),
+    [boardConnection, holderDisplayName],
+  );
+  const { text: eyebrowText, tone: eyebrowTone } = useAccessoryEyebrowText(accessoryContext);
 
   // Source-of-truth flip: show the wall's lit climb when a board feed is live
   // (flag-gated), else the local queue head.
@@ -267,12 +274,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[2],
-  },
-  // Small uppercase status caption; the disambiguator between queue / live / peer.
-  eyebrow: {
-    fontWeight: '700',
-    letterSpacing: 0.4,
-    textTransform: 'uppercase',
   },
   gradeText: {
     // Colorized like the list rows; right-aligned with a reserved min width

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -22,6 +22,7 @@ import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 import { useAccessoryEyebrowFromContext, accessoryEyebrowColor } from './use-accessory-presentation';
+import { useAccessoryNowPlayingEnabled } from './use-accessory-now-playing-flag';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -119,9 +120,11 @@ export function ClimbCapsule({
   // and feed the same read into the eyebrow so it isn't subscribed to twice.
   const { boardConnection, bluetooth, holderDisplayName } = useBoardConnectionState();
   // Status caption that labels what the bar is showing (live / peer / up next).
+  // Flag off → null eyebrow (the pre-redesign bar).
+  const nowPlayingEnabled = useAccessoryNowPlayingEnabled();
   const accessoryContext = useMemo(
-    () => deriveAccessoryContext({ boardConnection, holderDisplayName }),
-    [boardConnection, holderDisplayName],
+    () => deriveAccessoryContext({ boardConnection, holderDisplayName, enabled: nowPlayingEnabled }),
+    [boardConnection, holderDisplayName, nowPlayingEnabled],
   );
   const { text: eyebrowText, tone: eyebrowTone } = useAccessoryEyebrowFromContext(accessoryContext);
 

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -21,7 +21,7 @@ import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './Access
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
-import { useAccessoryEyebrowText } from './use-accessory-presentation';
+import { useAccessoryEyebrowFromContext, accessoryEyebrowColor } from './use-accessory-presentation';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -123,7 +123,7 @@ export function ClimbCapsule({
     () => deriveAccessoryContext({ boardConnection, holderDisplayName }),
     [boardConnection, holderDisplayName],
   );
-  const { text: eyebrowText, tone: eyebrowTone } = useAccessoryEyebrowText(accessoryContext);
+  const { text: eyebrowText, tone: eyebrowTone } = useAccessoryEyebrowFromContext(accessoryContext);
 
   // Source-of-truth flip: show the wall's lit climb when a board feed is live
   // (flag-gated), else the local queue head.
@@ -163,9 +163,7 @@ export function ClimbCapsule({
   // stripe recolors to the brand violet so it reads as a control-on edge marker.
   const showGradeAccent = surfaceTreatment === 'docked';
   const gradeAccentColor = connected ? brandColors.primary : grades.currentColor;
-  // "live" runs hot in the brand accent; peer / up-next stay quiet so they read
-  // as ambient status rather than a call to action.
-  const eyebrowColor = eyebrowTone === 'live' ? brandColors.primary : systemColors.secondaryLabel;
+  const eyebrowColor = accessoryEyebrowColor(eyebrowTone, brandColors.primary, systemColors.secondaryLabel);
 
   return (
     <AccessoryBarSurface

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -52,15 +52,17 @@ function ClimbLabel({
     <View style={styles.labelInner}>
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
       <View style={styles.labelTextColumn}>
-        <Text
-          variant="caption1"
-          color={eyebrowColor}
-          numberOfLines={1}
-          maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-          style={styles.eyebrow}
-        >
-          {eyebrow}
-        </Text>
+        {eyebrow ? (
+          <Text
+            variant="caption1"
+            color={eyebrowColor}
+            numberOfLines={1}
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={styles.eyebrow}
+          >
+            {eyebrow}
+          </Text>
+        ) : null}
         <View style={styles.nameRow}>
           <Text
             variant="subheadline"

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -10,6 +10,7 @@ import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
+import { useAccessoryEyebrow } from './use-accessory-presentation';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -36,33 +37,60 @@ type ClimbLabelProps = {
   formattedGrade: string | null;
   showThumbnail: boolean;
   boardConfig: BoardConfig | null;
+  // Status caption shown above the name in the `regular` placement only (null in
+  // `inline`, where the minimized platter has no vertical room for a second line).
+  eyebrow: string | null;
+  eyebrowColor: ColorValue;
 };
 
-function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardConfig }: ClimbLabelProps) {
+function ClimbLabel({
+  climb,
+  labelColor,
+  formattedGrade,
+  showThumbnail,
+  boardConfig,
+  eyebrow,
+  eyebrowColor,
+}: ClimbLabelProps) {
   return (
     <View style={styles.labelInner}>
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
-      <Text
-        variant="subheadline"
-        color={labelColor}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-        maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-        style={styles.name}
-      >
-        {climb.name}
-      </Text>
-      {formattedGrade ? (
-        <Text
-          variant="subheadline"
-          color={labelColor}
-          numberOfLines={1}
-          maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-          style={styles.gradeText}
-        >
-          {formattedGrade}
-        </Text>
-      ) : null}
+      <View style={styles.labelTextColumn}>
+        {eyebrow ? (
+          <Text
+            variant="caption1"
+            color={eyebrowColor}
+            numberOfLines={1}
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={styles.eyebrow}
+          >
+            {eyebrow}
+          </Text>
+        ) : null}
+        <View style={styles.nameRow}>
+          <Text
+            variant="subheadline"
+            color={labelColor}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={styles.name}
+          >
+            {climb.name}
+          </Text>
+          {formattedGrade ? (
+            <Text
+              variant="subheadline"
+              color={labelColor}
+              numberOfLines={1}
+              maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+              style={styles.gradeText}
+            >
+              {formattedGrade}
+            </Text>
+          ) : null}
+        </View>
+      </View>
     </View>
   );
 }
@@ -79,13 +107,20 @@ function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardCon
  */
 export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAccessoryClimbRowProps) {
   const { boardConfig } = useDrawerHost();
-  const { systemColors } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { formatGrade } = useGradeFormat();
   const { openGesture } = useAccessoryClimbTap();
+  // Eyebrow labels what the platter is showing; the tick is hidden for a peer's
+  // climb (you can't log someone else's send). This adds/removes content WITHIN
+  // the live row — it never re-gates the whole row, so the platter never blanks.
+  const { text: eyebrowText, tone, showTick } = useAccessoryEyebrow();
 
   const showThumbnail = placement === 'regular' && boardConfig !== null;
   const rowHeight = placement === 'inline' ? glassSize.inline : glassSize.standard;
   const currentFormattedGrade = formatGrade(climb.difficulty);
+  // Only the roomier `regular` placement has space for the second line.
+  const eyebrow = placement === 'regular' ? eyebrowText : null;
+  const eyebrowColor = tone === 'live' ? brandColors.primary : systemColors.secondaryLabel;
 
   return (
     <View style={[styles.row, { width, height: rowHeight }]}>
@@ -100,13 +135,17 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
               formattedGrade={currentFormattedGrade}
               showThumbnail={showThumbnail}
               boardConfig={boardConfig}
+              eyebrow={eyebrow}
+              eyebrowColor={eyebrowColor}
             />
           </View>
         </View>
       </GestureDetector>
-      <View style={[styles.tickSlot, { width: glassSize.inline, height: rowHeight }]}>
-        <LogAscentToolbarButton climb={climb} size={glassSize.inline} iconSize={24} />
-      </View>
+      {showTick ? (
+        <View style={[styles.tickSlot, { width: glassSize.inline, height: rowHeight }]}>
+          <LogAscentToolbarButton climb={climb} size={glassSize.inline} iconSize={24} />
+        </View>
+      ) : null}
       {/* Leading board control as a content-layer element (the platter is
           UIKit-owned, so the glow lives here, not on the glass). Static state
           swap; no long-press recognizer — it would fight UIKit's own gestures.
@@ -160,6 +199,22 @@ const styles = StyleSheet.create({
     gap: spacing[2],
     paddingLeft: spacing[2],
     paddingRight: spacing[1],
+  },
+  labelTextColumn: {
+    flex: 1,
+    minWidth: 0,
+    justifyContent: 'center',
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minWidth: 0,
+    gap: spacing[2],
+  },
+  eyebrow: {
+    fontWeight: '700',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
   },
   name: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -147,11 +147,13 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
           </View>
         </View>
       </GestureDetector>
-      {showTick ? (
-        <View style={[styles.tickSlot, { width: glassSize.inline, height: rowHeight }]}>
-          <LogAscentToolbarButton climb={climb} size={glassSize.inline} iconSize={24} />
-        </View>
-      ) : null}
+      {/* Always reserve the tick slot's width, even when the tick is hidden (a
+          peer driving the wall). Removing it would let the label area expand and
+          relayout the live UIKit platter mid-session when control passes — a
+          visible pop. The button inside is what comes and goes, not the slot. */}
+      <View style={[styles.tickSlot, { width: glassSize.inline, height: rowHeight }]}>
+        {showTick ? <LogAscentToolbarButton climb={climb} size={glassSize.inline} iconSize={24} /> : null}
+      </View>
       {/* Leading board control as a content-layer element (the platter is
           UIKit-owned, so the glow lives here, not on the glass). Static state
           swap; no long-press recognizer — it would fight UIKit's own gestures.

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -126,8 +126,14 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
     <View style={[styles.row, { width, height: rowHeight }]}>
       <GestureDetector gesture={openGesture}>
         {/* tapClip reserves the leading slot via paddingLeft (not a real child),
-            so the climb thumbnail tucks in close to the lightbulb. */}
-        <View style={styles.tapClip} accessibilityRole="button" accessibilityLabel={climb.name}>
+            so the climb thumbnail tucks in close to the lightbulb. Announce the
+            status caption too (even in `inline`, where it isn't drawn) so a screen
+            reader gets the live / on-the-wall / up-next context. */}
+        <View
+          style={styles.tapClip}
+          accessibilityRole="button"
+          accessibilityLabel={eyebrowText ? `${eyebrowText}, ${climb.name}` : climb.name}
+        >
           <View style={styles.labelSlot}>
             <ClimbLabel
               climb={climb}

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -10,7 +10,7 @@ import { CHROME_LABEL_MAX_FONT_SCALE, ACCESSORY_EYEBROW_TEXT_STYLE } from '../..
 import { Text } from '../Text';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
-import { useAccessoryEyebrow } from './use-accessory-presentation';
+import { useAccessoryEyebrow, accessoryEyebrowColor } from './use-accessory-presentation';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -120,7 +120,7 @@ export function NativeAccessoryClimbRow({ climb, placement, width }: NativeAcces
   const currentFormattedGrade = formatGrade(climb.difficulty);
   // Only the roomier `regular` placement has space for the second line.
   const eyebrow = placement === 'regular' ? eyebrowText : null;
-  const eyebrowColor = tone === 'live' ? brandColors.primary : systemColors.secondaryLabel;
+  const eyebrowColor = accessoryEyebrowColor(tone, brandColors.primary, systemColors.secondaryLabel);
 
   return (
     <View style={[styles.row, { width, height: rowHeight }]}>

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
 import { spacing } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
-import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
+import { CHROME_LABEL_MAX_FONT_SCALE, ACCESSORY_EYEBROW_TEXT_STYLE } from '../../theme/typography';
 import { Text } from '../Text';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
@@ -62,7 +62,7 @@ function ClimbLabel({
             color={eyebrowColor}
             numberOfLines={1}
             maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-            style={styles.eyebrow}
+            style={ACCESSORY_EYEBROW_TEXT_STYLE}
           >
             {eyebrow}
           </Text>
@@ -210,11 +210,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     minWidth: 0,
     gap: spacing[2],
-  },
-  eyebrow: {
-    fontWeight: '700',
-    letterSpacing: 0.4,
-    textTransform: 'uppercase',
   },
   name: {
     flex: 1,

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -261,6 +261,20 @@ describe('ClimbCapsule', () => {
     expect(eyebrowNode?.textContent).not.toContain('peerAnon');
   });
 
+  it('falls back to the anonymous peer eyebrow when the holder has no name', () => {
+    board.boardConnection = 'heldByPeer';
+    board.holderDisplayName = null;
+    const item = makeItem(makeClimb());
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+
+    const { container } = render(<ClimbCapsule />);
+
+    const texts = Array.from(container.querySelectorAll('[data-text]'));
+    const eyebrowNode = texts.find((node) => (node.textContent ?? '').includes('queueBar.nowPlaying.peerAnon'));
+    expect(eyebrowNode).toBeTruthy();
+  });
+
   it('renders the climb name when a climb is active', () => {
     const item = makeItem(makeClimb({ name: 'The Crimp Ladder' }));
     queue.state.currentClimbQueueItem = item;

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -14,11 +14,13 @@ const queue = vi.hoisted(() => ({
   previousClimb: vi.fn(),
 }));
 const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
-// Per-test board-connection state so the eyebrow (live / peer / up-next) can be exercised.
+// Per-test board-connection state so the eyebrow (live / peer / up-next) can be
+// exercised. `nowPlaying` is the redesign flag — default on so the eyebrow shows.
 const board = vi.hoisted(() => ({
   boardConnection: 'disconnected' as 'disconnected' | 'connectedByMe' | 'heldByPeer',
   bluetooth: null as unknown,
   holderDisplayName: null as string | null,
+  nowPlaying: true,
 }));
 
 // --- RN surface: View → div ---------------------------------------------------
@@ -133,6 +135,10 @@ vi.mock('../BoardControlIndicator', () => ({ BoardControlIndicator: () => null }
 vi.mock('../../ble/use-board-connection-state', () => ({
   useBoardConnectionState: () => ({ ...board }),
 }));
+// The now-playing redesign flag (default on so the eyebrow renders).
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useFeatureFlag: () => board.nowPlaying,
+}));
 
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: queue.state, nextClimb: queue.nextClimb, previousClimb: queue.previousClimb }),
@@ -207,6 +213,23 @@ describe('ClimbCapsule', () => {
     board.boardConnection = 'disconnected';
     board.bluetooth = null;
     board.holderDisplayName = null;
+    board.nowPlaying = true;
+  });
+
+  it('shows no eyebrow when the now-playing redesign flag is off', () => {
+    // Flag off = pre-redesign bar: even while driving the wall, no eyebrow caption.
+    board.nowPlaying = false;
+    board.boardConnection = 'connectedByMe';
+    const item = makeItem(makeClimb({ name: 'The Crimp Ladder' }));
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+
+    const { container } = render(<ClimbCapsule />);
+
+    const texts = Array.from(container.querySelectorAll('[data-text]'));
+    expect(texts.some((node) => (node.textContent ?? '').includes('queueBar.nowPlaying'))).toBe(false);
+    // The bar itself is unchanged — the climb name still renders.
+    expect(container.textContent).toContain('The Crimp Ladder');
   });
 
   it('renders nothing when there is no current climb', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -14,6 +14,12 @@ const queue = vi.hoisted(() => ({
   previousClimb: vi.fn(),
 }));
 const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
+// Per-test board-connection state so the eyebrow (live / peer / up-next) can be exercised.
+const board = vi.hoisted(() => ({
+  boardConnection: 'disconnected' as 'disconnected' | 'connectedByMe' | 'heldByPeer',
+  bluetooth: null as unknown,
+  holderDisplayName: null as string | null,
+}));
 
 // --- RN surface: View → div ---------------------------------------------------
 // Forward testID and the resolved backgroundColor so a test can assert the leading
@@ -114,7 +120,7 @@ vi.mock('../../GlassSurface', () => ({
 
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
-    systemColors: { label: '#111111', separator: '#cccccc', elevatedSurface: '#f0f0f0' },
+    systemColors: { label: '#111111', secondaryLabel: '#666666', separator: '#cccccc', elevatedSurface: '#f0f0f0' },
     brandColors: { primary: '#6D28D9', warning: '#FBBF24' },
   }),
 }));
@@ -125,7 +131,7 @@ vi.mock('../BoardControlIndicator', () => ({ BoardControlIndicator: () => null }
 
 // No board bound by default → no control rendered, disconnected glow state.
 vi.mock('../../ble/use-board-connection-state', () => ({
-  useBoardConnectionState: () => ({ boardConnection: 'disconnected', bluetooth: null }),
+  useBoardConnectionState: () => ({ ...board }),
 }));
 
 vi.mock('../../../providers/queue-provider', () => ({
@@ -198,6 +204,9 @@ describe('ClimbCapsule', () => {
     drawer.openPlayDrawer.mockClear();
     queue.nextClimb.mockClear();
     queue.previousClimb.mockClear();
+    board.boardConnection = 'disconnected';
+    board.bluetooth = null;
+    board.holderDisplayName = null;
   });
 
   it('renders nothing when there is no current climb', () => {
@@ -205,6 +214,51 @@ describe('ClimbCapsule', () => {
     expect(container.querySelector('[data-text]')).toBeNull();
     // No glass surface either — the whole capsule short-circuits.
     expect(container.querySelector('[data-glass]')).toBeNull();
+  });
+
+  // The mocked t() returns the key, so the eyebrow text IS the i18n key here.
+  it('shows the up-next eyebrow in a quiet colour when disconnected', () => {
+    const item = makeItem(makeClimb());
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+
+    const { container } = render(<ClimbCapsule />);
+
+    const texts = Array.from(container.querySelectorAll('[data-text]'));
+    const eyebrowNode = texts.find((node) => (node.textContent ?? '').includes('queueBar.nowPlaying.upNext'));
+    expect(eyebrowNode).toBeTruthy();
+    // up-next is the quiet secondary-label colour, not the brand accent.
+    expect(eyebrowNode?.getAttribute('data-color')).toBe('#666666');
+  });
+
+  it('shows the live eyebrow in the brand accent when this device is driving the wall', () => {
+    board.boardConnection = 'connectedByMe';
+    const item = makeItem(makeClimb());
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+
+    const { container } = render(<ClimbCapsule />);
+
+    const texts = Array.from(container.querySelectorAll('[data-text]'));
+    const eyebrowNode = texts.find((node) => (node.textContent ?? '').includes('queueBar.nowPlaying.live'));
+    expect(eyebrowNode).toBeTruthy();
+    expect(eyebrowNode?.getAttribute('data-color')).toBe('#6D28D9');
+  });
+
+  it('names the peer in the eyebrow when a teammate is driving the wall', () => {
+    board.boardConnection = 'heldByPeer';
+    board.holderDisplayName = 'Tara';
+    const item = makeItem(makeClimb());
+    queue.state.currentClimbQueueItem = item;
+    queue.state.queue = [item];
+
+    const { container } = render(<ClimbCapsule />);
+
+    // t() returns the key; the peer branch resolves the named key (not peerAnon).
+    const texts = Array.from(container.querySelectorAll('[data-text]'));
+    const eyebrowNode = texts.find((node) => (node.textContent ?? '').includes('queueBar.nowPlaying.peer'));
+    expect(eyebrowNode).toBeTruthy();
+    expect(eyebrowNode?.textContent).not.toContain('peerAnon');
   });
 
   it('renders the climb name when a climb is active', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -356,6 +356,17 @@ describe('NativeAccessoryClimbRow', () => {
     expect(container.textContent).toContain("Alvin's Nuts");
   });
 
+  it('shows the up-next eyebrow (queue only, no board) in the regular placement', () => {
+    eyebrow.tone = 'upNext';
+    eyebrow.text = 'Up next';
+
+    const { container } = renderRow('regular');
+
+    expect(container.textContent).toContain('Up next');
+    // Tick still shows for your own queue head when disconnected.
+    expect(container.querySelector('[data-tick]')).not.toBeNull();
+  });
+
   it('hides the tick when a peer is driving the wall (read-only)', () => {
     eyebrow.tone = 'peer';
     eyebrow.text = 'Tara on the wall';

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -164,7 +164,8 @@ vi.mock('../../Text', () => ({
 
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
-    systemColors: { label: '#111111' },
+    systemColors: { label: '#111111', secondaryLabel: '#666666' },
+    brandColors: { primary: '#6D28D9' },
   }),
 }));
 
@@ -263,6 +264,11 @@ vi.mock('../LogAscentToolbarButton', () => ({
 // the row renders the local queue head exactly as today.
 vi.mock('../use-wall-or-queue-climb', () => ({
   useWallOrQueueCurrentClimb: (localClimb: unknown) => localClimb,
+}));
+// Eyebrow/tick context — mocked so the real hook doesn't pull the board-connection
+// (expo) chain into the jsdom test. `showTick: true` keeps the tick assertions.
+vi.mock('../use-accessory-presentation', () => ({
+  useAccessoryEyebrow: () => ({ text: 'On the wall · live', tone: 'live', showTick: true, tier: 'nowPlaying' }),
 }));
 
 import { NativeAccessoryClimbRow } from '../NativeAccessoryClimbRow';

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -279,6 +279,7 @@ vi.mock('../use-wall-or-queue-climb', () => ({
 // (expo) chain into the jsdom test. `showTick: true` keeps the tick assertions.
 vi.mock('../use-accessory-presentation', () => ({
   useAccessoryEyebrow: () => ({ ...eyebrow }),
+  accessoryEyebrowColor: (tone: string, live: string, idle: string) => (tone === 'live' ? live : idle),
 }));
 
 import { NativeAccessoryClimbRow } from '../NativeAccessoryClimbRow';

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -24,6 +24,16 @@ const boardRender = vi.hoisted(() => ({
   boardHeight: 1920,
 }));
 
+// Per-test-configurable eyebrow context. Defaults to "you're driving, lit" so the
+// existing tick/thumbnail assertions hold; flipped to a peer (showTick: false) in
+// the read-only test.
+const eyebrow = vi.hoisted(() => ({
+  text: 'On the wall · live',
+  tone: 'live' as 'live' | 'peer' | 'upNext',
+  showTick: true,
+  tier: 'nowPlaying' as 'nowPlaying' | 'resume',
+}));
+
 function styleDataValue(styleValue: unknown): string {
   if (styleValue == null) return '';
   if (typeof styleValue === 'string' || typeof styleValue === 'number' || typeof styleValue === 'boolean') {
@@ -268,7 +278,7 @@ vi.mock('../use-wall-or-queue-climb', () => ({
 // Eyebrow/tick context — mocked so the real hook doesn't pull the board-connection
 // (expo) chain into the jsdom test. `showTick: true` keeps the tick assertions.
 vi.mock('../use-accessory-presentation', () => ({
-  useAccessoryEyebrow: () => ({ text: 'On the wall · live', tone: 'live', showTick: true, tier: 'nowPlaying' }),
+  useAccessoryEyebrow: () => ({ ...eyebrow }),
 }));
 
 import { NativeAccessoryClimbRow } from '../NativeAccessoryClimbRow';
@@ -326,6 +336,34 @@ describe('NativeAccessoryClimbRow', () => {
     queue.nextClimb.mockClear();
     queue.previousClimb.mockClear();
     drawer.openPlayDrawer.mockClear();
+    eyebrow.text = 'On the wall · live';
+    eyebrow.tone = 'live';
+    eyebrow.showTick = true;
+    eyebrow.tier = 'nowPlaying';
+  });
+
+  it('shows the eyebrow caption in the regular placement', () => {
+    const { container } = renderRow('regular');
+    expect(container.textContent).toContain('On the wall · live');
+  });
+
+  it('drops the eyebrow caption in the minimized inline placement', () => {
+    // The inline platter has no vertical room for a second line.
+    const { container } = renderRow('inline');
+    expect(container.textContent).not.toContain('On the wall · live');
+    // The climb name still renders inline.
+    expect(container.textContent).toContain("Alvin's Nuts");
+  });
+
+  it('hides the tick when a peer is driving the wall (read-only)', () => {
+    eyebrow.tone = 'peer';
+    eyebrow.text = 'Tara on the wall';
+    eyebrow.showTick = false;
+
+    const { container } = renderRow('regular');
+
+    expect(container.textContent).toContain('Tara on the wall');
+    expect(container.querySelector('[data-tick]')).toBeNull();
   });
 
   it('renders a regular now-climbing row with thumbnail, grade, and integrated tick', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -17,6 +17,12 @@ const cfg = vi.hoisted(() => ({
   measuredTabBarHeight: null as number | null,
   nativeAccessoryActive: false,
   nativeTabBar: false,
+  // Now-playing presentation + the social-surface gate (default: board live,
+  // tick shown, flag off — i.e. today's behaviour).
+  tier: 'nowPlaying' as 'nowPlaying' | 'resume',
+  showTick: true,
+  onSocialSurface: false,
+  nowPlayingFlag: false,
 }));
 
 // useAccessoryClimbTap builds a preview queue item via climbToQueueItem, which
@@ -56,6 +62,20 @@ vi.mock('../../../lib/route-segments', () => ({
   isGymDiscoveryRoute: () => cfg.onGymDiscovery,
   isAuthRoute: () => cfg.onAuthRoute,
   isPlayerRoute: () => cfg.onPlayerRoute,
+  isSocialSurface: () => cfg.onSocialSurface,
+}));
+// Now-playing context + the feature flag that gates social-surface hiding.
+// Mocked so the real ones don't pull the board-connection / analytics (expo)
+// chains into the jsdom test.
+vi.mock('../use-accessory-presentation', () => ({
+  useAccessoryPresentation: () => ({
+    tier: cfg.tier,
+    showTick: cfg.showTick,
+    eyebrow: { kind: 'live', name: null },
+  }),
+}));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useFeatureFlag: () => cfg.nowPlayingFlag,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
@@ -149,6 +169,10 @@ describe('PersistentQueueBar', () => {
     cfg.measuredTabBarHeight = null;
     cfg.nativeAccessoryActive = false;
     cfg.nativeTabBar = false;
+    cfg.tier = 'nowPlaying';
+    cfg.showTick = true;
+    cfg.onSocialSurface = false;
+    cfg.nowPlayingFlag = false;
   });
 
   it('renders nothing when no climb is current', () => {
@@ -199,6 +223,64 @@ describe('PersistentQueueBar', () => {
     const { container } = render(<PersistentQueueBar />);
 
     expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  it('hides a queue-only bar on a social surface when the now-playing flag is on', () => {
+    // Browsing the feed/profile/discover with only a queue (nothing lit) — the bar
+    // would read as a directive, so it's suppressed once the flag is enabled.
+    cfg.nowPlayingFlag = true;
+    cfg.tier = 'resume';
+    cfg.onSocialSurface = true;
+    cfg.onClimbsTab = false;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  it('keeps the bar on a social surface when a board is live (now-playing tier)', () => {
+    // Status, not a directive: while a board is lit the now-playing bar persists
+    // across every tab, exactly like a media mini-player.
+    cfg.nowPlayingFlag = true;
+    cfg.tier = 'nowPlaying';
+    cfg.onSocialSurface = true;
+    cfg.onClimbsTab = false;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).not.toBeNull();
+  });
+
+  it('keeps a queue-only social bar when the flag is off (today’s behaviour)', () => {
+    cfg.nowPlayingFlag = false;
+    cfg.tier = 'resume';
+    cfg.onSocialSurface = true;
+    cfg.onClimbsTab = false;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).not.toBeNull();
+  });
+
+  it('keeps a queue-only bar on a board-control surface even with the flag on', () => {
+    // The heavily-used /climbs and /record shortcut is preserved when disconnected.
+    cfg.nowPlayingFlag = true;
+    cfg.tier = 'resume';
+    cfg.onSocialSurface = false;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).not.toBeNull();
+  });
+
+  it('hides the tick when showTick is false (a peer is driving the wall)', () => {
+    cfg.showTick = false;
+
+    const { container } = render(<PersistentQueueBar />);
+
+    expect(container.querySelector('[data-capsule]')).not.toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();
   });
 

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -74,6 +74,10 @@ vi.mock('../use-accessory-presentation', () => ({
     eyebrow: { kind: 'live', name: null },
   }),
 }));
+// Shared by the bar AND the (real) bottom-chrome metrics — mirror the predicate.
+vi.mock('../use-queue-bar-hidden', () => ({
+  useQueueBarHiddenOnSocial: () => cfg.nowPlayingFlag && cfg.tier === 'resume' && cfg.onSocialSurface,
+}));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useFeatureFlag: () => cfg.nowPlayingFlag,
 }));

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -74,10 +74,9 @@ vi.mock('../use-accessory-presentation', () => ({
     eyebrow: { kind: 'live', name: null },
   }),
 }));
-// Shared by the bar AND the (real) bottom-chrome metrics — mirror the predicate.
-vi.mock('../use-queue-bar-hidden', () => ({
-  useQueueBarHiddenOnSocial: () => cfg.nowPlayingFlag && cfg.tier === 'resume' && cfg.onSocialSurface,
-}));
+// NB: '../use-queue-bar-hidden' is NOT mocked — the real pure predicate runs,
+// driven by the useFeatureFlag / isSocialSurface / useAccessoryPresentation mocks
+// above, so the test never re-implements the hide condition.
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useFeatureFlag: () => cfg.nowPlayingFlag,
 }));

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -23,13 +23,14 @@ import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 import { useAccessoryPresentation } from './use-accessory-presentation';
-import { useQueueBarHiddenOnSocial } from './use-queue-bar-hidden';
+import { shouldHideQueueBarOnSocial } from './use-queue-bar-hidden';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -42,11 +43,13 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
-  // `showTick` hides the tick for a peer's climb. The social-surface hide (the
-  // one behavioural change we A/B) is shared with the bottom-chrome metrics so a
-  // hidden bar also stops reserving its space — see useQueueBarHiddenOnSocial.
-  const { showTick } = useAccessoryPresentation();
-  const hiddenOnSocial = useQueueBarHiddenOnSocial();
+  // One connection-state read here: `showTick` hides the tick for a peer's climb,
+  // and `tier` feeds the social-surface hide. The hide uses the same pure
+  // predicate as useBottomChromeMetrics (which drops the reserved space), so a
+  // hidden bar never strands a gap — see shouldHideQueueBarOnSocial.
+  const { showTick, tier } = useAccessoryPresentation();
+  const nowPlayingFlag = useFeatureFlag('accessory-now-playing') === true;
+  const hiddenOnSocial = shouldHideQueueBarOnSocial(nowPlayingFlag, tier, segments);
 
   if (!currentClimb) return null;
   // The sign-in / sign-up flow is pre-auth — a leftover queued or "on the wall"

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -23,7 +23,6 @@ import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
@@ -31,6 +30,7 @@ import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 import { useAccessoryPresentation } from './use-accessory-presentation';
 import { shouldHideQueueBarOnSocial } from './use-queue-bar-hidden';
+import { useAccessoryNowPlayingEnabled } from './use-accessory-now-playing-flag';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -48,7 +48,7 @@ export function PersistentQueueBar() {
   // predicate as useBottomChromeMetrics (which drops the reserved space), so a
   // hidden bar never strands a gap — see shouldHideQueueBarOnSocial.
   const { showTick, tier } = useAccessoryPresentation();
-  const nowPlayingFlag = useFeatureFlag('accessory-now-playing') === true;
+  const nowPlayingFlag = useAccessoryNowPlayingEnabled();
   const hiddenOnSocial = shouldHideQueueBarOnSocial(nowPlayingFlag, tier, segments);
 
   if (!currentClimb) return null;

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,15 +21,15 @@ import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, gl
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
-import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute, isSocialSurface } from '../../lib/route-segments';
+import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
-import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 import { useAccessoryPresentation } from './use-accessory-presentation';
+import { useQueueBarHiddenOnSocial } from './use-queue-bar-hidden';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -42,12 +42,11 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
-  // Now-playing context: `tier` gates social-surface visibility; `showTick`
-  // hides the tick for a peer's climb.
-  const { tier, showTick } = useAccessoryPresentation();
-  // Hiding the queue-only bar on social surfaces is the one behavioural change
-  // we A/B — gate it so we can compare accessory-open rates before rolling out.
-  const nowPlayingGateEnabled = useFeatureFlag('accessory-now-playing') === true;
+  // `showTick` hides the tick for a peer's climb. The social-surface hide (the
+  // one behavioural change we A/B) is shared with the bottom-chrome metrics so a
+  // hidden bar also stops reserving its space — see useQueueBarHiddenOnSocial.
+  const { showTick } = useAccessoryPresentation();
+  const hiddenOnSocial = useQueueBarHiddenOnSocial();
 
   if (!currentClimb) return null;
   // The sign-in / sign-up flow is pre-auth — a leftover queued or "on the wall"
@@ -62,7 +61,7 @@ export function PersistentQueueBar() {
   if (isPlayerRoute(segments)) return null;
   // On social/browsing tabs a queue-only bar (nothing lit) reads as a directive,
   // so hide it there. When a board is live the now-playing bar persists as status.
-  if (nowPlayingGateEnabled && tier === 'resume' && isSocialSurface(segments)) return null;
+  if (hiddenOnSocial) return null;
   if (!bottomChrome.jsQueueToolbarVisible && bottomChrome.nativeAccessoryMounted) return null;
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,13 +21,15 @@ import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, gl
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
-import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute } from '../../lib/route-segments';
+import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute, isSocialSurface } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
 import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
+import { useAccessoryPresentation } from './use-accessory-presentation';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -40,6 +42,12 @@ export function PersistentQueueBar() {
   const bottomChrome = useBottomChromeMetrics();
 
   const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  // Now-playing context: `tier` gates social-surface visibility; `showTick`
+  // hides the tick for a peer's climb.
+  const { tier, showTick } = useAccessoryPresentation();
+  // Hiding the queue-only bar on social surfaces is the one behavioural change
+  // we A/B — gate it so we can compare accessory-open rates before rolling out.
+  const nowPlayingGateEnabled = useFeatureFlag('accessory-now-playing') === true;
 
   if (!currentClimb) return null;
   // The sign-in / sign-up flow is pre-auth — a leftover queued or "on the wall"
@@ -52,6 +60,9 @@ export function PersistentQueueBar() {
   // the line below already hides this via the mounted native accessory, but on
   // Android (no native accessory) the bar would otherwise show over the player.
   if (isPlayerRoute(segments)) return null;
+  // On social/browsing tabs a queue-only bar (nothing lit) reads as a directive,
+  // so hide it there. When a board is live the now-playing bar persists as status.
+  if (nowPlayingGateEnabled && tier === 'resume' && isSocialSurface(segments)) return null;
   if (!bottomChrome.jsQueueToolbarVisible && bottomChrome.nativeAccessoryMounted) return null;
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
@@ -66,7 +77,7 @@ export function PersistentQueueBar() {
             fillWidth
             height={MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT}
             surfaceTreatment="docked"
-            endAction={<LogAscentToolbarButton climb={currentClimb} size={glassSize.inline} />}
+            endAction={showTick ? <LogAscentToolbarButton climb={currentClimb} size={glassSize.inline} /> : undefined}
             endActionSize={glassSize.inline}
           />
         }
@@ -74,5 +85,10 @@ export function PersistentQueueBar() {
     );
   }
 
-  return <ActiveContextBar primary={<ClimbCapsule />} trailing={<LogAscentFab climb={currentClimb} />} />;
+  return (
+    <ActiveContextBar
+      primary={<ClimbCapsule />}
+      trailing={showTick ? <LogAscentFab climb={currentClimb} /> : undefined}
+    />
+  );
 }

--- a/packages/mobile/src/components/queue-control/use-accessory-now-playing-flag.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-now-playing-flag.ts
@@ -1,0 +1,14 @@
+// Single read of the now-playing redesign flag. Its own leaf module (imports only
+// the feature-flags provider) so the components that gate on it can mock just this
+// in tests without pulling the analytics/expo stack.
+
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
+
+/**
+ * Whether the now-playing accessory redesign is enabled. Flag off = the bar
+ * behaves exactly as it did before the redesign (no eyebrow, tick always shown,
+ * never hidden on social tabs).
+ */
+export function useAccessoryNowPlayingEnabled(): boolean {
+  return useFeatureFlag('accessory-now-playing') === true;
+}

--- a/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
@@ -1,0 +1,47 @@
+// Bridges the board-connection state into the renderer-agnostic
+// `deriveAccessoryContext` (from @boardsesh/play-view) and resolves the eyebrow
+// caption text. Shared by the floating capsule (ClimbCapsule), the iOS 26 native
+// platter row (NativeAccessoryClimbRow), and the bar's visibility gate
+// (persistent-queue-bar). All reads are O(1) on the hot path.
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { deriveAccessoryContext, type AccessoryContext, type AccessoryEyebrowKind } from '@boardsesh/play-view';
+import { useBoardConnectionState } from '../ble/use-board-connection-state';
+
+/** The raw now-playing context (tier / eyebrow kind / tick) for this device. */
+export function useAccessoryPresentation(): AccessoryContext {
+  const { boardConnection, holderDisplayName } = useBoardConnectionState();
+  return useMemo(
+    () => deriveAccessoryContext({ boardConnection, holderDisplayName }),
+    [boardConnection, holderDisplayName],
+  );
+}
+
+export type AccessoryEyebrow = {
+  /** Localized eyebrow caption, e.g. "On the wall · live" / "Tara on the wall". */
+  text: string;
+  /** Which status this is — drives the caption colour (live = brand accent). */
+  tone: AccessoryEyebrowKind;
+  showTick: boolean;
+  tier: AccessoryContext['tier'];
+};
+
+/** The presentation plus its localized eyebrow caption, ready to render. */
+export function useAccessoryEyebrow(): AccessoryEyebrow {
+  const { t } = useTranslation('session');
+  const { tier, eyebrow, showTick } = useAccessoryPresentation();
+
+  const text = useMemo(() => {
+    switch (eyebrow.kind) {
+      case 'live':
+        return t('queueBar.nowPlaying.live');
+      case 'peer':
+        return eyebrow.name ? t('queueBar.nowPlaying.peer', { name: eyebrow.name }) : t('queueBar.nowPlaying.peerAnon');
+      case 'upNext':
+        return t('queueBar.nowPlaying.upNext');
+    }
+  }, [t, eyebrow.kind, eyebrow.name]);
+
+  return { text, tone: eyebrow.kind, showTick, tier };
+}

--- a/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
@@ -27,10 +27,13 @@ export type AccessoryEyebrow = {
   tier: AccessoryContext['tier'];
 };
 
-/** The presentation plus its localized eyebrow caption, ready to render. */
-export function useAccessoryEyebrow(): AccessoryEyebrow {
+/**
+ * Localizes an already-derived context into the eyebrow caption. Takes the
+ * context as input so a component that already reads the connection state (e.g.
+ * ClimbCapsule) can derive it once and not subscribe to that state twice.
+ */
+export function useAccessoryEyebrowText({ tier, eyebrow, showTick }: AccessoryContext): AccessoryEyebrow {
   const { t } = useTranslation('session');
-  const { tier, eyebrow, showTick } = useAccessoryPresentation();
 
   const text = useMemo(() => {
     switch (eyebrow.kind) {
@@ -44,4 +47,9 @@ export function useAccessoryEyebrow(): AccessoryEyebrow {
   }, [t, eyebrow.kind, eyebrow.name]);
 
   return { text, tone: eyebrow.kind, showTick, tier };
+}
+
+/** Convenience for components that don't already read the connection state. */
+export function useAccessoryEyebrow(): AccessoryEyebrow {
+  return useAccessoryEyebrowText(useAccessoryPresentation());
 }

--- a/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
@@ -5,6 +5,7 @@
 // (persistent-queue-bar). All reads are O(1) on the hot path.
 
 import { useMemo } from 'react';
+import { type ColorValue } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { deriveAccessoryContext, type AccessoryContext, type AccessoryEyebrowKind } from '@boardsesh/play-view';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
@@ -23,16 +24,16 @@ export type AccessoryEyebrow = {
   text: string;
   /** Which status this is — drives the caption colour (live = brand accent). */
   tone: AccessoryEyebrowKind;
+  /** Whether the trailing tick shows (hidden for a peer's read-only climb). */
   showTick: boolean;
-  tier: AccessoryContext['tier'];
 };
 
 /**
- * Localizes an already-derived context into the eyebrow caption. Takes the
- * context as input so a component that already reads the connection state (e.g.
- * ClimbCapsule) can derive it once and not subscribe to that state twice.
+ * Localizes an already-derived context into the eyebrow caption (+ tick gate).
+ * Takes the context as input so a component that already reads the connection
+ * state (e.g. ClimbCapsule) can derive it once and not subscribe to it twice.
  */
-export function useAccessoryEyebrowText({ tier, eyebrow, showTick }: AccessoryContext): AccessoryEyebrow {
+export function useAccessoryEyebrowFromContext({ eyebrow, showTick }: AccessoryContext): AccessoryEyebrow {
   const { t } = useTranslation('session');
 
   const text = useMemo(() => {
@@ -46,10 +47,19 @@ export function useAccessoryEyebrowText({ tier, eyebrow, showTick }: AccessoryCo
     }
   }, [t, eyebrow.kind, eyebrow.name]);
 
-  return { text, tone: eyebrow.kind, showTick, tier };
+  return { text, tone: eyebrow.kind, showTick };
 }
 
 /** Convenience for components that don't already read the connection state. */
 export function useAccessoryEyebrow(): AccessoryEyebrow {
-  return useAccessoryEyebrowText(useAccessoryPresentation());
+  return useAccessoryEyebrowFromContext(useAccessoryPresentation());
+}
+
+/**
+ * The eyebrow caption colour: "live" runs hot in the brand accent; the quieter
+ * peer / up-next states use the secondary label so they read as ambient status.
+ * One place so the capsule and the native platter row can't drift.
+ */
+export function accessoryEyebrowColor(tone: AccessoryEyebrowKind, live: ColorValue, idle: ColorValue): ColorValue {
+  return tone === 'live' ? live : idle;
 }

--- a/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
@@ -9,21 +9,27 @@ import { type ColorValue } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { deriveAccessoryContext, type AccessoryContext, type AccessoryEyebrowKind } from '@boardsesh/play-view';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
+import { useAccessoryNowPlayingEnabled } from './use-accessory-now-playing-flag';
 
-/** The raw now-playing context (tier / eyebrow kind / tick) for this device. */
+/**
+ * The raw now-playing context (tier / eyebrow kind / tick) for this device. The
+ * redesign flag is folded in here, so flag-off yields the pre-redesign context
+ * (no eyebrow, tick always shown) at the single source.
+ */
 export function useAccessoryPresentation(): AccessoryContext {
   const { boardConnection, holderDisplayName } = useBoardConnectionState();
+  const enabled = useAccessoryNowPlayingEnabled();
   return useMemo(
-    () => deriveAccessoryContext({ boardConnection, holderDisplayName }),
-    [boardConnection, holderDisplayName],
+    () => deriveAccessoryContext({ boardConnection, holderDisplayName, enabled }),
+    [boardConnection, holderDisplayName, enabled],
   );
 }
 
 export type AccessoryEyebrow = {
-  /** Localized eyebrow caption, e.g. "On the wall · live" / "Tara on the wall". */
-  text: string;
+  /** Localized eyebrow caption, or `null` when the redesign is off (no eyebrow). */
+  text: string | null;
   /** Which status this is — drives the caption colour (live = brand accent). */
-  tone: AccessoryEyebrowKind;
+  tone: AccessoryEyebrowKind | null;
   /** Whether the trailing tick shows (hidden for a peer's read-only climb). */
   showTick: boolean;
 };
@@ -32,11 +38,13 @@ export type AccessoryEyebrow = {
  * Localizes an already-derived context into the eyebrow caption (+ tick gate).
  * Takes the context as input so a component that already reads the connection
  * state (e.g. ClimbCapsule) can derive it once and not subscribe to it twice.
+ * A `null` eyebrow (redesign off) yields `text: null` — no caption.
  */
 export function useAccessoryEyebrowFromContext({ eyebrow, showTick }: AccessoryContext): AccessoryEyebrow {
   const { t } = useTranslation('session');
 
   const text = useMemo(() => {
+    if (!eyebrow) return null;
     switch (eyebrow.kind) {
       case 'live':
         return t('queueBar.nowPlaying.live');
@@ -45,9 +53,9 @@ export function useAccessoryEyebrowFromContext({ eyebrow, showTick }: AccessoryC
       case 'upNext':
         return t('queueBar.nowPlaying.upNext');
     }
-  }, [t, eyebrow.kind, eyebrow.name]);
+  }, [t, eyebrow]);
 
-  return { text, tone: eyebrow.kind, showTick };
+  return { text, tone: eyebrow?.kind ?? null, showTick };
 }
 
 /** Convenience for components that don't already read the connection state. */
@@ -60,6 +68,10 @@ export function useAccessoryEyebrow(): AccessoryEyebrow {
  * peer / up-next states use the secondary label so they read as ambient status.
  * One place so the capsule and the native platter row can't drift.
  */
-export function accessoryEyebrowColor(tone: AccessoryEyebrowKind, live: ColorValue, idle: ColorValue): ColorValue {
+export function accessoryEyebrowColor(
+  tone: AccessoryEyebrowKind | null,
+  live: ColorValue,
+  idle: ColorValue,
+): ColorValue {
   return tone === 'live' ? live : idle;
 }

--- a/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-presentation.ts
@@ -52,10 +52,16 @@ export function useAccessoryEyebrowFromContext({ eyebrow, showTick }: AccessoryC
         return eyebrow.name ? t('queueBar.nowPlaying.peer', { name: eyebrow.name }) : t('queueBar.nowPlaying.peerAnon');
       case 'upNext':
         return t('queueBar.nowPlaying.upNext');
+      default:
+        // A new AccessoryEyebrowKind without a case here is a compile error.
+        eyebrow.kind satisfies never;
+        return null;
     }
   }, [t, eyebrow]);
 
-  return { text, tone: eyebrow?.kind ?? null, showTick };
+  const tone = eyebrow?.kind ?? null;
+  // Stable identity so a future React.memo / context consumer doesn't churn.
+  return useMemo(() => ({ text, tone, showTick }), [text, tone, showTick]);
 }
 
 /** Convenience for components that don't already read the connection state. */

--- a/packages/mobile/src/components/queue-control/use-queue-bar-hidden.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-bar-hidden.ts
@@ -4,8 +4,8 @@
 import { useSegments } from 'expo-router';
 import type { AccessoryTier } from '@boardsesh/play-view';
 import { isSocialSurface, type Segments } from '../../lib/route-segments';
-import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { useAccessoryPresentation } from './use-accessory-presentation';
+import { useAccessoryNowPlayingEnabled } from './use-accessory-now-playing-flag';
 
 /**
  * Pure predicate (single source of truth): the queue-only ("up next") bar is
@@ -25,6 +25,6 @@ export function shouldHideQueueBarOnSocial(flagEnabled: boolean, tier: Accessory
 export function useQueueBarHiddenOnSocial(): boolean {
   const segments = useSegments();
   const { tier } = useAccessoryPresentation();
-  const flagEnabled = useFeatureFlag('accessory-now-playing') === true;
+  const flagEnabled = useAccessoryNowPlayingEnabled();
   return shouldHideQueueBarOnSocial(flagEnabled, tier, segments);
 }

--- a/packages/mobile/src/components/queue-control/use-queue-bar-hidden.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-bar-hidden.ts
@@ -1,23 +1,30 @@
-// The flag-gated "hide the queue-only bar on social tabs" predicate. Lives in its
-// own module (not use-accessory-presentation) so the eyebrow hooks stay free of
-// expo-router / feature-flag deps — components that only render the eyebrow don't
-// transitively pull the navigation + flag stack into their tests.
+// The flag-gated "hide the queue-only bar on social tabs" predicate. Its own
+// module so the eyebrow hooks stay free of expo-router / feature-flag deps.
 
 import { useSegments } from 'expo-router';
-import { isSocialSurface } from '../../lib/route-segments';
+import type { AccessoryTier } from '@boardsesh/play-view';
+import { isSocialSurface, type Segments } from '../../lib/route-segments';
 import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { useAccessoryPresentation } from './use-accessory-presentation';
 
 /**
- * Whether the queue-only ("up next") bar is hidden on the current social surface
- * (flag-gated). Single source of truth shared by PersistentQueueBar (which then
- * renders nothing) and useBottomChromeMetrics (which then drops the reserved
- * toolbar space), so a hidden bar never strands a blank gap or over-lifts the
- * floating controls on home / profile / discover.
+ * Pure predicate (single source of truth): the queue-only ("up next") bar is
+ * hidden on a social/browsing surface when the flag is on. A component that
+ * already reads the tier (PersistentQueueBar) calls this directly so it doesn't
+ * subscribe to the connection state a second time.
+ */
+export function shouldHideQueueBarOnSocial(flagEnabled: boolean, tier: AccessoryTier, segments: Segments): boolean {
+  return flagEnabled && tier === 'resume' && isSocialSurface(segments);
+}
+
+/**
+ * Hook form for consumers that don't already hold the tier (useBottomChromeMetrics
+ * drops the reserved toolbar space so a hidden bar never strands a blank gap or
+ * over-lifts the floating controls on home / profile / discover).
  */
 export function useQueueBarHiddenOnSocial(): boolean {
   const segments = useSegments();
   const { tier } = useAccessoryPresentation();
   const flagEnabled = useFeatureFlag('accessory-now-playing') === true;
-  return flagEnabled && tier === 'resume' && isSocialSurface(segments);
+  return shouldHideQueueBarOnSocial(flagEnabled, tier, segments);
 }

--- a/packages/mobile/src/components/queue-control/use-queue-bar-hidden.ts
+++ b/packages/mobile/src/components/queue-control/use-queue-bar-hidden.ts
@@ -1,0 +1,23 @@
+// The flag-gated "hide the queue-only bar on social tabs" predicate. Lives in its
+// own module (not use-accessory-presentation) so the eyebrow hooks stay free of
+// expo-router / feature-flag deps — components that only render the eyebrow don't
+// transitively pull the navigation + flag stack into their tests.
+
+import { useSegments } from 'expo-router';
+import { isSocialSurface } from '../../lib/route-segments';
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
+import { useAccessoryPresentation } from './use-accessory-presentation';
+
+/**
+ * Whether the queue-only ("up next") bar is hidden on the current social surface
+ * (flag-gated). Single source of truth shared by PersistentQueueBar (which then
+ * renders nothing) and useBottomChromeMetrics (which then drops the reserved
+ * toolbar space), so a hidden bar never strands a blank gap or over-lifts the
+ * floating controls on home / profile / discover.
+ */
+export function useQueueBarHiddenOnSocial(): boolean {
+  const segments = useSegments();
+  const { tier } = useAccessoryPresentation();
+  const flagEnabled = useFeatureFlag('accessory-now-playing') === true;
+  return flagEnabled && tier === 'resume' && isSocialSurface(segments);
+}

--- a/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
+++ b/packages/mobile/src/hooks/__tests__/bottom-chrome-metrics.test.ts
@@ -168,6 +168,46 @@ describe('computeBottomChromeMetrics', () => {
     expect(metrics.jsQueueToolbarVisible).toBe(false);
   });
 
+  it('drops the JS toolbar reserve when suppressed on a social surface', () => {
+    // Flag-gated social hide: the bar returns null, so its reserve must vanish too
+    // — otherwise home/discover/profile strand a toolbar-sized gap + lifted FABs.
+    const base = {
+      uiVariant: 'liquidGlass' as const,
+      usesNativeTabBar: false,
+      insetsBottom: 0,
+      insideTabs: true,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: false,
+    };
+    const shown = computeBottomChromeMetrics({ ...base, jsQueueToolbarSuppressed: false });
+    const hidden = computeBottomChromeMetrics({ ...base, jsQueueToolbarSuppressed: true });
+
+    expect(shown.jsQueueToolbarVisible).toBe(true);
+    expect(shown.jsQueueReserve).toBe(TOOLBAR_RESERVE);
+
+    expect(hidden.jsQueueToolbarVisible).toBe(false);
+    expect(hidden.jsQueueReserve).toBe(0);
+    // No reserved gap, and the FAB sits right above the tab bar.
+    expect(hidden.scrollBottomPadding).toBe(MATERIAL_TAB_BAR_HEIGHT);
+    expect(hidden.floatingControlBottom).toBe(MATERIAL_TAB_BAR_HEIGHT);
+  });
+
+  it('does not affect the native accessory reserve (the hide is JS-path only)', () => {
+    const metrics = computeBottomChromeMetrics({
+      uiVariant: 'liquidGlass',
+      usesNativeTabBar: true,
+      insetsBottom: 0,
+      insideTabs: true,
+      hasCurrentClimb: true,
+      nativeAccessoryMounted: true,
+      jsQueueToolbarSuppressed: true,
+    });
+    // Native platter keeps its reserve — the social hide only governs the JS bar.
+    expect(metrics.nativeAccessoryVisible).toBe(true);
+    expect(metrics.nativeAccessoryReserve).toBe(NATIVE_ACCESSORY_RESERVE);
+    expect(metrics.floatingControlBottom).toBe(TAB_BAR_HEIGHT + NATIVE_ACCESSORY_RESERVE);
+  });
+
   it('never reports both the JS toolbar and the native accessory as visible at once', () => {
     for (const hasCurrentClimb of [true, false]) {
       for (const nativeAccessoryMounted of [true, false]) {

--- a/packages/mobile/src/hooks/bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/bottom-chrome-metrics.ts
@@ -40,6 +40,14 @@ export type BottomChromeInputs = {
   hasCurrentClimb: boolean;
   /** Whether the iOS 26 native bottom accessory is mounted (it replaces the JS toolbar). */
   nativeAccessoryMounted: boolean;
+  /**
+   * Whether the JS queue toolbar is suppressed on this surface despite a current
+   * climb — the flag-gated social-tab hide. Drops the reserve so a hidden bar
+   * doesn't strand a toolbar-sized gap. JS-path only (the native accessory keeps
+   * its own reserve), matching where the hide actually applies. Defaults to
+   * `false` (today's behaviour) when omitted.
+   */
+  jsQueueToolbarSuppressed?: boolean;
 };
 
 export type BottomChromeMetrics = {
@@ -102,9 +110,10 @@ export function computeBottomChromeMetrics({
   insideTabs,
   hasCurrentClimb,
   nativeAccessoryMounted,
+  jsQueueToolbarSuppressed = false,
 }: BottomChromeInputs): BottomChromeMetrics {
   const nativeAccessoryVisible = nativeAccessoryMounted && hasCurrentClimb;
-  const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted;
+  const jsQueueToolbarVisible = hasCurrentClimb && !nativeAccessoryMounted && !jsQueueToolbarSuppressed;
   // The native iOS tab bar is 49pt; the JS M3 `MaterialTabBar` is taller. Key this
   // on the *rendered* bar, not the variant — Liquid Glass on iOS < 26 / Android
   // falls back to the JS bar. Floating overlays (FAB, snackbar) and scroll padding

--- a/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
+++ b/packages/mobile/src/hooks/use-bottom-chrome-metrics.ts
@@ -5,6 +5,7 @@ import { useTheme } from '../providers/theme-provider';
 import { isTabsChromeRoute } from '../lib/route-segments';
 import { useStickyAccessoryPresence } from './use-sticky-accessory-presence';
 import { useNativeAccessoryActive, useNativeTabBar } from './use-bottom-accessory';
+import { useQueueBarHiddenOnSocial } from '../components/queue-control/use-queue-bar-hidden';
 import { computeBottomChromeMetrics } from './bottom-chrome-metrics';
 
 /**
@@ -32,6 +33,9 @@ export function useBottomChromeMetrics() {
   const nativeAccessoryMounted = insideTabs && nativeAccessoryActive;
   const nativeTabBar = useNativeTabBar();
   const usesNativeTabBar = insideTabs && nativeTabBar;
+  // The flag-gated social hide also drops the JS toolbar's reserved space, so a
+  // hidden bar doesn't leave a toolbar-sized gap / over-lift the FABs.
+  const jsQueueToolbarSuppressed = useQueueBarHiddenOnSocial();
 
   return useMemo(
     () =>
@@ -42,7 +46,16 @@ export function useBottomChromeMetrics() {
         insideTabs,
         hasCurrentClimb,
         nativeAccessoryMounted,
+        jsQueueToolbarSuppressed,
       }),
-    [variant, usesNativeTabBar, insets.bottom, insideTabs, hasCurrentClimb, nativeAccessoryMounted],
+    [
+      variant,
+      usesNativeTabBar,
+      insets.bottom,
+      insideTabs,
+      hasCurrentClimb,
+      nativeAccessoryMounted,
+      jsQueueToolbarSuppressed,
+    ],
   );
 }

--- a/packages/mobile/src/lib/__tests__/route-segments.test.ts
+++ b/packages/mobile/src/lib/__tests__/route-segments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTabsRoute, isClimbsTabRoute, isAuthRoute } from '../route-segments';
+import { isTabsRoute, isClimbsTabRoute, isAuthRoute, isSocialSurface } from '../route-segments';
 
 describe('isTabsRoute', () => {
   it('is true anywhere inside the tab navigator', () => {
@@ -26,6 +26,23 @@ describe('isClimbsTabRoute', () => {
     expect(isClimbsTabRoute(['(tabs)'])).toBe(false);
     expect(isClimbsTabRoute(['auth'])).toBe(false);
     expect(isClimbsTabRoute([])).toBe(false);
+  });
+});
+
+describe('isSocialSurface', () => {
+  it('is true on the social/browsing tabs and their sub-routes', () => {
+    expect(isSocialSurface(['(tabs)', 'home'])).toBe(true);
+    expect(isSocialSurface(['(tabs)', 'profile'])).toBe(true);
+    expect(isSocialSurface(['(tabs)', 'discover'])).toBe(true);
+    expect(isSocialSurface(['(tabs)', 'discover', '[playlist_uuid]'])).toBe(true);
+  });
+
+  it('is false on the board-control tabs and outside the tabs group', () => {
+    expect(isSocialSurface(['(tabs)', 'climbs'])).toBe(false);
+    expect(isSocialSurface(['(tabs)', 'record'])).toBe(false);
+    expect(isSocialSurface(['(tabs)'])).toBe(false);
+    expect(isSocialSurface(['auth'])).toBe(false);
+    expect(isSocialSurface([])).toBe(false);
   });
 });
 

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -7,7 +7,7 @@
 // safely — and centralise the "which surface am I on" checks so callers never
 // index raw segment positions.
 
-type Segments = readonly string[];
+export type Segments = readonly string[];
 
 const TABS_GROUP = '(tabs)';
 const CLIMBS_TAB = 'climbs';

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -11,9 +11,23 @@ type Segments = readonly string[];
 
 const TABS_GROUP = '(tabs)';
 const CLIMBS_TAB = 'climbs';
+const RECORD_TAB = 'record';
+const HOME_TAB = 'home';
+const PROFILE_TAB = 'profile';
+const DISCOVER_TAB = 'discover';
 const GYMS_ROUTE = 'gyms';
 const AUTH_GROUP = 'auth';
 const PLAYER_ROUTE = 'play';
+
+// Tabs where the user is browsing rather than working a board: the feed,
+// their profile, and playlist discovery. The persistent now-playing bar is
+// demoted/hidden here when it's only a local queue (nothing lit). Telemetry:
+// these surfaces drive ~2:1 the navigation of the board tabs but only ~17% of
+// accessory-bar opens, so a queue-only bar there is mostly noise.
+const SOCIAL_TABS: ReadonlySet<string> = new Set([HOME_TAB, PROFILE_TAB, DISCOVER_TAB]);
+// Tabs where the user is actively discovering/controlling climbs on the board,
+// so the active-climb shortcut earns its place even when nothing is lit yet.
+const BOARD_CONTROL_TABS: ReadonlySet<string> = new Set([CLIMBS_TAB, RECORD_TAB]);
 
 /** True when the focused route lives inside the bottom-tab navigator. */
 export function isTabsRoute(segments: Segments): boolean {
@@ -53,6 +67,24 @@ export function isAuthRoute(segments: Segments): boolean {
 /** True when the focused route is the Climbs tab (or one of its sub-routes). */
 export function isClimbsTabRoute(segments: Segments): boolean {
   return segments[0] === TABS_GROUP && segments[1] === CLIMBS_TAB;
+}
+
+/**
+ * True on the social/browsing tabs (home / profile / discover), keyed on the tab
+ * root so sub-routes (e.g. a playlist detail) inherit the classification. Used to
+ * hide the queue-only ("up next") accessory bar where it reads as a directive
+ * rather than a board-control shortcut.
+ */
+export function isSocialSurface(segments: Segments): boolean {
+  return segments[0] === TABS_GROUP && SOCIAL_TABS.has(segments[1] ?? '');
+}
+
+/**
+ * True on the board-control tabs (climbs / record), where the active-climb
+ * shortcut is heavily used and is kept even when nothing is lit yet.
+ */
+export function isBoardControlSurface(segments: Segments): boolean {
+  return segments[0] === TABS_GROUP && BOARD_CONTROL_TABS.has(segments[1] ?? '');
 }
 
 /**

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -11,7 +11,6 @@ type Segments = readonly string[];
 
 const TABS_GROUP = '(tabs)';
 const CLIMBS_TAB = 'climbs';
-const RECORD_TAB = 'record';
 const HOME_TAB = 'home';
 const PROFILE_TAB = 'profile';
 const DISCOVER_TAB = 'discover';
@@ -21,13 +20,10 @@ const PLAYER_ROUTE = 'play';
 
 // Tabs where the user is browsing rather than working a board: the feed,
 // their profile, and playlist discovery. The persistent now-playing bar is
-// demoted/hidden here when it's only a local queue (nothing lit). Telemetry:
-// these surfaces drive ~2:1 the navigation of the board tabs but only ~17% of
+// hidden here when it's only a local queue (nothing lit). Telemetry: these
+// surfaces drive ~2:1 the navigation of the board tabs but only ~17% of
 // accessory-bar opens, so a queue-only bar there is mostly noise.
 const SOCIAL_TABS: ReadonlySet<string> = new Set([HOME_TAB, PROFILE_TAB, DISCOVER_TAB]);
-// Tabs where the user is actively discovering/controlling climbs on the board,
-// so the active-climb shortcut earns its place even when nothing is lit yet.
-const BOARD_CONTROL_TABS: ReadonlySet<string> = new Set([CLIMBS_TAB, RECORD_TAB]);
 
 /** True when the focused route lives inside the bottom-tab navigator. */
 export function isTabsRoute(segments: Segments): boolean {
@@ -77,14 +73,6 @@ export function isClimbsTabRoute(segments: Segments): boolean {
  */
 export function isSocialSurface(segments: Segments): boolean {
   return segments[0] === TABS_GROUP && SOCIAL_TABS.has(segments[1] ?? '');
-}
-
-/**
- * True on the board-control tabs (climbs / record), where the active-climb
- * shortcut is heavily used and is kept even when nothing is lit yet.
- */
-export function isBoardControlSurface(segments: Segments): boolean {
-  return segments[0] === TABS_GROUP && BOARD_CONTROL_TABS.has(segments[1] ?? '');
 }
 
 /**

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -46,7 +46,7 @@ export const FEATURE_FLAG_DEFINITIONS = [
     key: 'accessory-now-playing',
     label: 'Now-playing accessory bar',
     description:
-      'Hide the queue-only active-climb bar on social tabs (home / profile / discover); it stays when a board is live.',
+      'Now-playing redesign: a status eyebrow on the bar (live / on the wall / up next), a peer’s climb is read-only (tick hidden), and the queue-only bar is hidden on social tabs (home / profile / discover). Off = the bar exactly as before.',
   },
 ] as const satisfies readonly FeatureFlagDefinition[];
 

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -42,6 +42,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
     label: 'Kilter account linking',
     description: 'Show the Kilter username/password sign-in card in Integrations.',
   },
+  {
+    key: 'accessory-now-playing',
+    label: 'Now-playing accessory bar',
+    description:
+      'Hide the queue-only active-climb bar on social tabs (home / profile / discover); it stays when a board is live.',
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 // The literal key union (e.g. `'strava-integration'`), preserved via the

--- a/packages/mobile/src/theme/typography.ts
+++ b/packages/mobile/src/theme/typography.ts
@@ -160,3 +160,12 @@ export type TextVariant = keyof typeof textStyles;
  * platter. Surfaces that can grow with their content keep the 1.5× default.
  */
 export const CHROME_LABEL_MAX_FONT_SCALE = 1.2;
+
+// Status eyebrow above the climb name in the accessory bar — a small uppercase
+// caption. Shared by the floating capsule and the iOS 26 native platter row so
+// the two can't drift apart.
+export const ACCESSORY_EYEBROW_TEXT_STYLE: TextStyle = {
+  fontWeight: '700',
+  letterSpacing: 0.4,
+  textTransform: 'uppercase',
+};

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -223,6 +223,12 @@
     "goal": "Goal: {{goal}}"
   },
   "queueBar": {
+    "nowPlaying": {
+      "live": "On the wall · live",
+      "peer": "{{name}} on the wall",
+      "peerAnon": "Someone on the wall",
+      "upNext": "Up next"
+    },
     "cancelReconnectConfirm": "Cancelling will leave the session. Is that what you want?",
     "shellMessage": "No climb selected",
     "startSesh": "Start sesh",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -227,7 +227,7 @@
       "live": "En el muro · en directo",
       "peer": "{{name}} en el muro",
       "peerAnon": "Alguien en el muro",
-      "upNext": "Siguiente"
+      "upNext": "A continuación"
     },
     "cancelReconnectConfirm": "Cancelar te sacará de la sesión. ¿Es lo que quieres?",
     "shellMessage": "Sin bloque seleccionado",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -223,6 +223,12 @@
     "goal": "Objetivo: {{goal}}"
   },
   "queueBar": {
+    "nowPlaying": {
+      "live": "En el muro · en directo",
+      "peer": "{{name}} en el muro",
+      "peerAnon": "Alguien en el muro",
+      "upNext": "Siguiente"
+    },
     "cancelReconnectConfirm": "Cancelar te sacará de la sesión. ¿Es lo que quieres?",
     "shellMessage": "Sin bloque seleccionado",
     "startSesh": "Empezar sesh",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -223,6 +223,12 @@
     "goal": "Objectif : {{goal}}"
   },
   "queueBar": {
+    "nowPlaying": {
+      "live": "Sur le mur · en direct",
+      "peer": "{{name}} sur le mur",
+      "peerAnon": "Quelqu'un sur le mur",
+      "upNext": "À suivre"
+    },
     "cancelReconnectConfirm": "Annuler quittera la session. C'est ce que tu veux ?",
     "shellMessage": "Aucun bloc sélectionné",
     "startSesh": "Lancer la sesh",

--- a/packages/shared/play-view/src/__tests__/accessory-context.test.ts
+++ b/packages/shared/play-view/src/__tests__/accessory-context.test.ts
@@ -42,7 +42,9 @@ describe('deriveAccessoryContext', () => {
     }
   });
 
-  it('enabled defaults to true (the redesign is on unless explicitly disabled)', () => {
+  // The pure function defaults `enabled` to true for callers that omit it; the
+  // mobile app always passes the live flag, which is off by default in production.
+  it('defaults the pure function to enabled when the param is omitted', () => {
     const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: null });
     expect(context.eyebrow).toEqual({ kind: 'live', name: null });
   });

--- a/packages/shared/play-view/src/__tests__/accessory-context.test.ts
+++ b/packages/shared/play-view/src/__tests__/accessory-context.test.ts
@@ -3,34 +3,42 @@ import { deriveAccessoryContext } from '../accessory-context';
 
 describe('deriveAccessoryContext', () => {
   it('disconnected → resume tier with an up-next eyebrow and a usable tick', () => {
-    const context = deriveAccessoryContext({ boardConnection: 'disconnected', holderDisplayName: null });
+    const context = deriveAccessoryContext({ boardConnection: 'disconnected', holderDisplayName: null, enabled: true });
     expect(context.tier).toBe('resume');
     expect(context.eyebrow).toEqual({ kind: 'upNext', name: null });
     expect(context.showTick).toBe(true);
   });
 
   it('connectedByMe → now-playing tier with a live eyebrow and the tick enabled', () => {
-    const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: null });
+    const context = deriveAccessoryContext({
+      boardConnection: 'connectedByMe',
+      holderDisplayName: null,
+      enabled: true,
+    });
     expect(context.tier).toBe('nowPlaying');
     expect(context.eyebrow).toEqual({ kind: 'live', name: null });
     expect(context.showTick).toBe(true);
   });
 
   it('heldByPeer → now-playing tier, names the peer, and hides the tick', () => {
-    const context = deriveAccessoryContext({ boardConnection: 'heldByPeer', holderDisplayName: 'Tara' });
+    const context = deriveAccessoryContext({ boardConnection: 'heldByPeer', holderDisplayName: 'Tara', enabled: true });
     expect(context.tier).toBe('nowPlaying');
     expect(context.eyebrow).toEqual({ kind: 'peer', name: 'Tara' });
     expect(context.showTick).toBe(false);
   });
 
   it('heldByPeer with no resolved name keeps the peer kind and a null name', () => {
-    const context = deriveAccessoryContext({ boardConnection: 'heldByPeer', holderDisplayName: null });
+    const context = deriveAccessoryContext({ boardConnection: 'heldByPeer', holderDisplayName: null, enabled: true });
     expect(context.eyebrow).toEqual({ kind: 'peer', name: null });
     expect(context.showTick).toBe(false);
   });
 
   it('ignores a stray holder name when you are the one driving', () => {
-    const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: 'Tara' });
+    const context = deriveAccessoryContext({
+      boardConnection: 'connectedByMe',
+      holderDisplayName: 'Tara',
+      enabled: true,
+    });
     expect(context.eyebrow).toEqual({ kind: 'live', name: null });
   });
 
@@ -42,19 +50,12 @@ describe('deriveAccessoryContext', () => {
     }
   });
 
-  // The pure function defaults `enabled` to true for callers that omit it; the
-  // mobile app always passes the live flag, which is off by default in production.
-  it('defaults the pure function to enabled when the param is omitted', () => {
-    const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: null });
-    expect(context.eyebrow).toEqual({ kind: 'live', name: null });
-  });
-
-  it('only the peer state suppresses the tick', () => {
+  it('only the peer state suppresses the tick (when enabled)', () => {
     const states = ['disconnected', 'connectedByMe', 'heldByPeer'] as const;
     const tickByState = Object.fromEntries(
       states.map((boardConnection) => [
         boardConnection,
-        deriveAccessoryContext({ boardConnection, holderDisplayName: 'x' }).showTick,
+        deriveAccessoryContext({ boardConnection, holderDisplayName: 'x', enabled: true }).showTick,
       ]),
     );
     expect(tickByState).toEqual({ disconnected: true, connectedByMe: true, heldByPeer: false });

--- a/packages/shared/play-view/src/__tests__/accessory-context.test.ts
+++ b/packages/shared/play-view/src/__tests__/accessory-context.test.ts
@@ -34,6 +34,19 @@ describe('deriveAccessoryContext', () => {
     expect(context.eyebrow).toEqual({ kind: 'live', name: null });
   });
 
+  it('disabled → no eyebrow and the tick always shows, regardless of board state', () => {
+    for (const boardConnection of ['disconnected', 'connectedByMe', 'heldByPeer'] as const) {
+      const context = deriveAccessoryContext({ boardConnection, holderDisplayName: 'Tara', enabled: false });
+      expect(context.eyebrow).toBeNull();
+      expect(context.showTick).toBe(true);
+    }
+  });
+
+  it('enabled defaults to true (the redesign is on unless explicitly disabled)', () => {
+    const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: null });
+    expect(context.eyebrow).toEqual({ kind: 'live', name: null });
+  });
+
   it('only the peer state suppresses the tick', () => {
     const states = ['disconnected', 'connectedByMe', 'heldByPeer'] as const;
     const tickByState = Object.fromEntries(

--- a/packages/shared/play-view/src/__tests__/accessory-context.test.ts
+++ b/packages/shared/play-view/src/__tests__/accessory-context.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { deriveAccessoryContext } from '../accessory-context';
+
+describe('deriveAccessoryContext', () => {
+  it('disconnected → resume tier with an up-next eyebrow and a usable tick', () => {
+    const context = deriveAccessoryContext({ boardConnection: 'disconnected', holderDisplayName: null });
+    expect(context.tier).toBe('resume');
+    expect(context.eyebrow).toEqual({ kind: 'upNext', name: null });
+    expect(context.showTick).toBe(true);
+  });
+
+  it('connectedByMe → now-playing tier with a live eyebrow and the tick enabled', () => {
+    const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: null });
+    expect(context.tier).toBe('nowPlaying');
+    expect(context.eyebrow).toEqual({ kind: 'live', name: null });
+    expect(context.showTick).toBe(true);
+  });
+
+  it('heldByPeer → now-playing tier, names the peer, and hides the tick', () => {
+    const context = deriveAccessoryContext({ boardConnection: 'heldByPeer', holderDisplayName: 'Tara' });
+    expect(context.tier).toBe('nowPlaying');
+    expect(context.eyebrow).toEqual({ kind: 'peer', name: 'Tara' });
+    expect(context.showTick).toBe(false);
+  });
+
+  it('heldByPeer with no resolved name keeps the peer kind and a null name', () => {
+    const context = deriveAccessoryContext({ boardConnection: 'heldByPeer', holderDisplayName: null });
+    expect(context.eyebrow).toEqual({ kind: 'peer', name: null });
+    expect(context.showTick).toBe(false);
+  });
+
+  it('ignores a stray holder name when you are the one driving', () => {
+    const context = deriveAccessoryContext({ boardConnection: 'connectedByMe', holderDisplayName: 'Tara' });
+    expect(context.eyebrow).toEqual({ kind: 'live', name: null });
+  });
+
+  it('only the peer state suppresses the tick', () => {
+    const states = ['disconnected', 'connectedByMe', 'heldByPeer'] as const;
+    const tickByState = Object.fromEntries(
+      states.map((boardConnection) => [
+        boardConnection,
+        deriveAccessoryContext({ boardConnection, holderDisplayName: 'x' }).showTick,
+      ]),
+    );
+    expect(tickByState).toEqual({ disconnected: true, connectedByMe: true, heldByPeer: false });
+  });
+});

--- a/packages/shared/play-view/src/accessory-context.ts
+++ b/packages/shared/play-view/src/accessory-context.ts
@@ -47,10 +47,11 @@ export type AccessoryContextInput = {
   holderDisplayName: string | null;
   /**
    * When `false`, returns the pre-redesign bar: no eyebrow caption and the tick
-   * always available (today's behaviour). Defaults to `true`. The whole
+   * always available (today's behaviour). Required (no default) so a caller can
+   * never silently get the redesign — it must pass the live flag. The whole
    * now-playing redesign rides one flag, so off = byte-identical to today.
    */
-  enabled?: boolean;
+  enabled: boolean;
 };
 
 /**
@@ -64,7 +65,7 @@ export type AccessoryContextInput = {
 export function deriveAccessoryContext({
   boardConnection,
   holderDisplayName,
-  enabled = true,
+  enabled,
 }: AccessoryContextInput): AccessoryContext {
   if (!enabled) {
     // Flag off — the bar exactly as it was before the redesign.

--- a/packages/shared/play-view/src/accessory-context.ts
+++ b/packages/shared/play-view/src/accessory-context.ts
@@ -1,0 +1,79 @@
+// Renderer-agnostic logic for the persistent "active climb" accessory bar.
+//
+// The bar historically rendered an identical climb name in three different
+// situations — your queue head, the climb lit on a board YOU drive, and a peer's
+// lit climb in a party session — so on social/browsing screens a bare name read
+// as a directive ("climb this now") rather than status ("this is what's lit").
+//
+// This derives a small "now playing" context from the board-connection state so
+// the UI can label each situation distinctly (the eyebrow caption) and demote the
+// queue-only case. Inputs are primitives so web and mobile can share it.
+
+/** Tri-state board ownership (mirrors the mobile `BoardConnection` union). */
+export type AccessoryBoardConnection = 'disconnected' | 'connectedByMe' | 'heldByPeer';
+
+/** Visual tier: the loud branded now-playing bar vs the quiet resume affordance. */
+export type AccessoryTier = 'nowPlaying' | 'resume';
+
+/**
+ * Which status the eyebrow caption announces:
+ * - `live`   — you are driving a connected board (this is what's lit).
+ * - `peer`   — a session teammate is driving the board (read-only to you).
+ * - `upNext` — nothing is lit; this is just your next queued climb.
+ */
+export type AccessoryEyebrowKind = 'live' | 'peer' | 'upNext';
+
+export type AccessoryContext = {
+  tier: AccessoryTier;
+  eyebrow: {
+    kind: AccessoryEyebrowKind;
+    /** Peer display name for the `peer` kind, else `null`. */
+    name: string | null;
+  };
+  /**
+   * Whether the trailing tick (log ascent) should show. Hidden for a peer's
+   * climb — you can't log someone else's send from the status bar.
+   */
+  showTick: boolean;
+};
+
+export type AccessoryContextInput = {
+  boardConnection: AccessoryBoardConnection;
+  /** Display name of the peer driving the wall, when `heldByPeer` (else `null`). */
+  holderDisplayName: string | null;
+};
+
+/**
+ * Maps the board-connection state to the accessory's now-playing context.
+ *
+ * - `heldByPeer`    → now-playing, eyebrow names the peer, no tick (read-only).
+ * - `connectedByMe` → now-playing, "live" eyebrow, tick enabled.
+ * - `disconnected`  → resume tier, "up next" eyebrow (just your queue head).
+ */
+export function deriveAccessoryContext({
+  boardConnection,
+  holderDisplayName,
+}: AccessoryContextInput): AccessoryContext {
+  if (boardConnection === 'heldByPeer') {
+    return {
+      tier: 'nowPlaying',
+      eyebrow: { kind: 'peer', name: holderDisplayName },
+      showTick: false,
+    };
+  }
+  if (boardConnection === 'connectedByMe') {
+    return {
+      tier: 'nowPlaying',
+      eyebrow: { kind: 'live', name: null },
+      showTick: true,
+    };
+  }
+  // Disconnected — a local queue with nothing lit. Keep the tick so an offline
+  // send can still be logged; the eyebrow + (on social surfaces) hiding the bar
+  // is what stops it reading as a directive.
+  return {
+    tier: 'resume',
+    eyebrow: { kind: 'upNext', name: null },
+    showTick: true,
+  };
+}

--- a/packages/shared/play-view/src/accessory-context.ts
+++ b/packages/shared/play-view/src/accessory-context.ts
@@ -68,6 +68,9 @@ export function deriveAccessoryContext({
       showTick: true,
     };
   }
+  // Exhaustiveness: after the cases above, only 'disconnected' remains. Adding a
+  // new BoardConnection variant without a case here becomes a compile error.
+  boardConnection satisfies 'disconnected';
   // Disconnected — a local queue with nothing lit. Keep the tick so an offline
   // send can still be logged; the eyebrow + (on social surfaces) hiding the bar
   // is what stops it reading as a directive.

--- a/packages/shared/play-view/src/accessory-context.ts
+++ b/packages/shared/play-view/src/accessory-context.ts
@@ -25,11 +25,15 @@ export type AccessoryEyebrowKind = 'live' | 'peer' | 'upNext';
 
 export type AccessoryContext = {
   tier: AccessoryTier;
+  /**
+   * The status caption to show, or `null` when the redesign is disabled (the
+   * pre-redesign bar shows no eyebrow at all).
+   */
   eyebrow: {
     kind: AccessoryEyebrowKind;
     /** Peer display name for the `peer` kind, else `null`. */
     name: string | null;
-  };
+  } | null;
   /**
    * Whether the trailing tick (log ascent) should show. Hidden for a peer's
    * climb — you can't log someone else's send from the status bar.
@@ -41,11 +45,18 @@ export type AccessoryContextInput = {
   boardConnection: AccessoryBoardConnection;
   /** Display name of the peer driving the wall, when `heldByPeer` (else `null`). */
   holderDisplayName: string | null;
+  /**
+   * When `false`, returns the pre-redesign bar: no eyebrow caption and the tick
+   * always available (today's behaviour). Defaults to `true`. The whole
+   * now-playing redesign rides one flag, so off = byte-identical to today.
+   */
+  enabled?: boolean;
 };
 
 /**
  * Maps the board-connection state to the accessory's now-playing context.
  *
+ * - `enabled === false` → no eyebrow, tick always shown (pre-redesign bar).
  * - `heldByPeer`    → now-playing, eyebrow names the peer, no tick (read-only).
  * - `connectedByMe` → now-playing, "live" eyebrow, tick enabled.
  * - `disconnected`  → resume tier, "up next" eyebrow (just your queue head).
@@ -53,7 +64,12 @@ export type AccessoryContextInput = {
 export function deriveAccessoryContext({
   boardConnection,
   holderDisplayName,
+  enabled = true,
 }: AccessoryContextInput): AccessoryContext {
+  if (!enabled) {
+    // Flag off — the bar exactly as it was before the redesign.
+    return { tier: 'resume', eyebrow: null, showTick: true };
+  }
   if (boardConnection === 'heldByPeer') {
     return {
       tier: 'nowPlaying',

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './queue-navigation';
 export * from './queue-list-model';
 export * from './grade-display';
+export * from './accessory-context';
 export * from './tick-utils';
 export * from './quick-tick-state';
 export * from './board-utils';


### PR DESCRIPTION
## Summary

> **Rollout:** the entire redesign (eyebrow, peer read-only tick, social-tab hide) is gated by one flag — `accessory-now-playing`. Off (default) = byte-identical to today's bar; on = the full behaviour. Flip it to A/B.

Reworks the persistent "active climb" accessory bar into a **now-playing** model so it stops reading as a directive while you browse social features.

The bar collapsed three different meanings into one identical surface on every tab:
- your **queue head**,
- a climb lit on a board **you** drive,
- a **peer's** lit climb in a party session.

So on the feed / profile / discover tabs a bare climb name looked like "climb this now" instead of "this is what's lit". PostHog (90d) backs the problem: social/browsing tabs out-navigate the board tab ~2:1, yet only ~17% of accessory-bar opens happen there — it's noise while browsing, but heavily used on the board tabs (5,680 opens on `/climbs`). So the fix is disambiguation + context-awareness, **not** removal.

### What changed
- **Eyebrow caption** (ships on): a status line above the climb name — `On the wall · live` (you're driving), `{name} on the wall` (a crew-mate is), or `Up next` (just your queue). Turns a directive into status.
- **A peer's climb is read-only**: the tick hides when a teammate is driving the wall — you can't log someone else's send.
- **Context-aware presence** (behind the `accessory-now-playing` flag): a queue-only bar is hidden on the social tabs (home / profile / discover) but **persists as status whenever a board is live**; the board-control tabs (climbs / record) are unchanged.

Disambiguation logic is a renderer-agnostic `deriveAccessoryContext` in `@boardsesh/play-view` (with unit tests) — web can adopt the eyebrow later. The iOS 26 native platter is never mount-gated per tab (avoids the UIKit doubled-text snapshot) — only its content changes. No new animations, so Android touch is untouched.

> Direction set by a multi-agent design team (7 approaches → adversarial critique → 3-judge panel). The now-playing model was the unanimous winner across user-clarity, engineering-feasibility, and design-craft.

## Release Notes

- [x] No release note needed (internal / technical change)

_The whole now-playing redesign ships behind the `accessory-now-playing` flag, off by default — no user-facing change in this build. The release note lands when the flag is enabled in a later build._

## Test plan

- `vp run typecheck:mobile` + `vp run typecheck:shared` — pass
- `vp run test:mobile` — 2686 pass; new `deriveAccessoryContext` unit tests + social-gate / tick coverage added to `persistent-queue-bar.test`
- i18n catalog parity (`catalog-completeness`) — new `queueBar.nowPlaying.*` keys in en-US / es / fr
- `vp run check:mobile-bundle` — Android bundle OK (12.3 MB)
- `vp check` — 0 errors
- **Manual QA (to do, both variants × iOS sim + Android emulator):** drive no-board / your-lit / wall-not-yours / peer / mid-session on a board tab and a social tab. Confirm: flag-on hides the queue-only social bar; eyebrow text matches state; no doubled-text on iOS 26 player open/close; tick hidden for a peer's climb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRxL6eZCa236V51hvaa2GS

