### PR TITLE
fix(mobile): pick BLE write type from characteristic on iOS (MoonBoard LEDs dark)

### DIFF
--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -1,3 +1,4 @@
+import CoreBluetooth
 import XCTest
 
 @available(iOS 17.0, *)
@@ -187,5 +188,21 @@ final class LiveActivityWidgetTests: XCTestCase {
         // 2.0: the thumbnail is composited server-side (matches the Capacitor app);
         // the on-device bundled-art compositing is deferred to the revisit issue.
         XCTAssertTrue(url?.absoluteString.contains("include_background=1") ?? false)
+    }
+
+    // Regression for the iOS-only "MoonBoard connects but LEDs stay dark" bug:
+    // CoreBluetooth silently drops a `.withoutResponse` write to a characteristic
+    // that lacks the property. Aurora UART advertises `.writeWithoutResponse`
+    // (fast path); the original MoonBoard LED box advertises only `.write`, so it
+    // must use `.withResponse`.
+    func testPreferredWriteTypeSelectsByCharacteristicProperties() {
+        // Aurora (Kilter/Tension): supports write-without-response → fast path.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .writeWithoutResponse), .withoutResponse)
+        // Original MoonBoard LED box: write-with-response only.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write), .withResponse)
+        // Supports both → prefer the unacknowledged fast path.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.write, .writeWithoutResponse]), .withoutResponse)
+        // Defensive default when neither write property is advertised.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read]), .withResponse)
     }
 }

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -1,3 +1,4 @@
+import CoreBluetooth
 import Foundation
 
 struct BoardBleConfiguration: Codable, Equatable {
@@ -17,6 +18,18 @@ struct BoardBlePacketResult: Equatable {
 }
 
 enum BoardBleEncoding {
+    /// Picks the CoreBluetooth write type for a Nordic UART RX characteristic
+    /// from its advertised properties. Aurora (Kilter/Tension) controllers
+    /// advertise `.writeWithoutResponse` — the fast, unacknowledged path.
+    /// The original MoonBoard LED box advertises only `.write`; CoreBluetooth
+    /// SILENTLY DROPS a `.withoutResponse` write to a characteristic that lacks
+    /// the property, which left the MoonBoard wall dark on iOS while Android
+    /// (whose GATT stack sends no-response writes regardless) worked fine. So
+    /// fall back to `.withResponse` whenever `.writeWithoutResponse` is absent.
+    static func preferredWriteType(for properties: CBCharacteristicProperties) -> CBCharacteristicWriteType {
+        properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
+    }
+
     private struct HoldRoleInfo {
         let state: String
         let color: String

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -127,6 +127,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var isWriting = false
     private var pendingWriteResume: (() -> Void)?
     private var pendingWriteResumeWatchdog: DispatchWorkItem?
+    // Write-WITH-response pacing (the original MoonBoard LED box, whose UART RX
+    // characteristic advertises only `.write`). The `didWriteValueFor` ack is
+    // the resume signal — the with-response analogue of `pendingWriteResume`.
+    private var pendingWriteAck: (() -> Void)?
+    private var pendingWriteAckWatchdog: DispatchWorkItem?
     // Write-stall recovery (#3181). `writeStallRecoveries` counts consecutive
     // stalls (reset on any drained write). `writeStallRecoveringPeripheralId` is
     // the board whose congested link we deliberately cycled; it is set across the
@@ -967,6 +972,36 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         resume?()
     }
 
+    // The ack for the write-WITH-response path. Mirrors `peripheralIsReady`:
+    // cancel the stall watchdog, then capture-and-nil the parked continuation
+    // BEFORE invoking it so a duplicate callback (or one racing a teardown that
+    // already nil'd it) no-ops. Stale-generation acks are caught by
+    // `writeChunk`'s generation guard when the continuation re-enters.
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        pendingWriteAckWatchdog?.cancel()
+        pendingWriteAckWatchdog = nil
+        let ack = pendingWriteAck
+        pendingWriteAck = nil
+        if let error {
+            // Fail ONLY the in-flight queued write; don't proactively disconnect.
+            // A genuine link drop is owned by didDisconnectPeripheral (which runs
+            // failQueuedWrites + onDisconnect); a transient ATT error shouldn't
+            // tear down the link. Mirrors the mid-write `notConnected` handling.
+            logger.error("BLE write-with-response failed: \(error.localizedDescription, privacy: .public)")
+            guard !writeQueue.isEmpty else {
+                isWriting = false
+                processWriteQueue()
+                return
+            }
+            let request = writeQueue.removeFirst()
+            request.completion(error)
+            isWriting = false
+            processWriteQueue()
+            return
+        }
+        ack?()
+    }
+
     // MARK: - Private
 
     private func runOnBleQueue(_ operation: @escaping () -> Void) {
@@ -1103,32 +1138,52 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        guard peripheral.canSendWriteWithoutResponse else {
-            pendingWriteResume = { [weak self] in
+        let writeType = BoardBleEncoding.preferredWriteType(for: characteristic.properties)
+
+        if writeType == .withoutResponse {
+            guard peripheral.canSendWriteWithoutResponse else {
+                pendingWriteResume = { [weak self] in
+                    self?.writeChunk(
+                        requestIndex: requestIndex,
+                        chunkIndex: chunkIndex,
+                        connectionGeneration: connectionGeneration,
+                        writeGeneration: writeGeneration
+                    )
+                }
+                // Watchdog: peripheralIsReady is the ONLY resume signal, and a
+                // marginal link can simply never deliver it (without ever
+                // disconnecting either). Unbounded, `isWriting` would stay true
+                // forever and the wall would freeze until a manual disconnect.
+                let watchdog = DispatchWorkItem { [weak self] in
+                    guard let self, self.pendingWriteResume != nil else { return }
+                    self.logger.error("BLE write stalled: peripheral never became ready for write-without-response; attempting recovery")
+                    self.handleWriteStall()
+                }
+                pendingWriteResumeWatchdog?.cancel()
+                pendingWriteResumeWatchdog = watchdog
+                bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: watchdog)
+                return
+            }
+
+            peripheral.writeValue(request.chunks[chunkIndex], for: characteristic, type: .withoutResponse)
+            bleQueue.asyncAfter(deadline: .now() + chunkDelay) { [weak self] in
                 self?.writeChunk(
                     requestIndex: requestIndex,
-                    chunkIndex: chunkIndex,
+                    chunkIndex: chunkIndex + 1,
                     connectionGeneration: connectionGeneration,
                     writeGeneration: writeGeneration
                 )
             }
-            // Watchdog: peripheralIsReady is the ONLY resume signal, and a
-            // marginal link can simply never deliver it (without ever
-            // disconnecting either). Unbounded, `isWriting` would stay true
-            // forever and the wall would freeze until a manual disconnect.
-            let watchdog = DispatchWorkItem { [weak self] in
-                guard let self, self.pendingWriteResume != nil else { return }
-                self.logger.error("BLE write stalled: peripheral never became ready for write-without-response; attempting recovery")
-                self.handleWriteStall()
-            }
-            pendingWriteResumeWatchdog?.cancel()
-            pendingWriteResumeWatchdog = watchdog
-            bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: watchdog)
             return
         }
 
-        peripheral.writeValue(request.chunks[chunkIndex], for: characteristic, type: .withoutResponse)
-        bleQueue.asyncAfter(deadline: .now() + chunkDelay) { [weak self] in
+        // Write-WITH-response path (e.g. the original MoonBoard LED box, whose
+        // UART RX characteristic advertises only `.write`). CoreBluetooth would
+        // silently drop a `.withoutResponse` write to it — so pace on the
+        // `didWriteValueFor` ack instead of `canSendWriteWithoutResponse` /
+        // `peripheralIsReady`. The ack is itself the backpressure signal, so the
+        // fixed `chunkDelay` isn't needed here.
+        pendingWriteAck = { [weak self] in
             self?.writeChunk(
                 requestIndex: requestIndex,
                 chunkIndex: chunkIndex + 1,
@@ -1136,6 +1191,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 writeGeneration: writeGeneration
             )
         }
+        // Watchdog mirrors the without-response stall path: if the board never
+        // acks within writeResumeTimeout, recover by cycling the link (#3181).
+        let ackWatchdog = DispatchWorkItem { [weak self] in
+            guard let self, self.pendingWriteAck != nil else { return }
+            self.logger.error("BLE write stalled: peripheral never acked write-with-response; attempting recovery")
+            self.handleWriteStall()
+        }
+        pendingWriteAckWatchdog?.cancel()
+        pendingWriteAckWatchdog = ackWatchdog
+        bleQueue.asyncAfter(deadline: .now() + writeResumeTimeout, execute: ackWatchdog)
+        peripheral.writeValue(request.chunks[chunkIndex], for: characteristic, type: .withResponse)
     }
 
     private func failQueuedWrites(_ error: Error) {
@@ -1146,6 +1212,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         pendingWriteResume = nil
         pendingWriteResumeWatchdog?.cancel()
         pendingWriteResumeWatchdog = nil
+        pendingWriteAck = nil
+        pendingWriteAckWatchdog?.cancel()
+        pendingWriteAckWatchdog = nil
         for request in queuedWrites {
             request.completion(error)
         }


### PR DESCRIPTION
## Summary

On iOS, connecting to a MoonBoard succeeds but the LEDs never light. The same hardware works on Android, running the **same** shared JS encoder — so it isn't the protocol. I confirmed the encoding is correct by cross-checking `getMoonboardBluetoothPacket` against two reverse-engineering references ([e-sr/moonboard](https://github.com/e-sr/moonboard), [FabianRig/ArduinoMoonBoardLED](https://github.com/FabianRig/ArduinoMoonBoardLED)): the `l#…#` frame format, the `S`/`P`/`E` hold types, the zigzag strip serial mapping, and our row-major holdId numbering all match.

The bug is iOS-native only. `BoardBleManager` always wrote with CoreBluetooth `.withoutResponse`, which **CoreBluetooth silently drops** when the target characteristic doesn't advertise the `writeWithoutResponse` property. The original MoonBoard LED box's Nordic UART RX characteristic (`6e400002`) supports only `.write` (with response) — e-sr declares it `['write']` — whereas Aurora (Kilter/Tension) boards support without-response, which is why Aurora works on iOS. Android's GATT stack delivers no-response writes regardless of declared properties, hiding the bug there.

**Fix:** pick the write type from the discovered characteristic's actual `properties` (`BoardBleEncoding.preferredWriteType`). Keep the unacknowledged fast path for Aurora (no behaviour change), fall back to write-with-response for the MoonBoard box. The with-response path is paced by a new `didWriteValueFor` ack (the natural backpressure signal) instead of `canSendWriteWithoutResponse`/`peripheralIsReady`, with a stall watchdog that reuses the existing #3181 link-cycle recovery.

Changes (all iOS-native): `BoardBleEncoding.swift` (testable write-type helper), `BoardBleManager.swift` (branch the write pump + new `didWriteValueFor` delegate + ack cleanup in `failQueuedWrites`), and a unit test.

## Release Notes

- MoonBoard holds now light up on iPhone — connect and your problem shows on the wall.

## Test plan

- [x] Encoder verified against the e-sr and FabianRig references (frame format, hold types, serial-position zigzag, hold numbering).
- [x] `vp run typecheck:mobile` green.
- [x] Added an XCTest for `preferredWriteType` (Aurora → without-response; MoonBoard-only-`.write` → with-response; both → without-response; neither → with-response). Runs in the iOS-sim `BoardseshTests` job.
- [x] Aurora write path left byte-for-byte unchanged (no regression).
- [ ] **Native build required — cannot ship via OTA** (CoreBluetooth change → new fingerprint). Pending: a tester with a real MoonBoard LED box on `vp run mobile:preview-build` confirms (1) a multi-chunk climb lights fully, (2) Aurora still lights with no added latency, (3) the Live Activity re-light path works on MoonBoard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
