### PR TITLE
refactor(mobile): simplify buildPlaylistQueue and cover the queue-replace re-confirm path

### DIFF
--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -434,6 +434,44 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       });
     });
 
+    it('bumps the count and requires a second confirm when the queue grows while the sheet is open', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [tapped, makeClimb('c')], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(result.current.queueReplaceSheet.futureQueueCount).toBe(1);
+
+      // Another future item lands before the user confirms.
+      const extraFuture = makeQueueItem('q-future-2', 'future-2');
+      mocks.queueState = { queue: [current, future, extraFuture], currentClimbQueueItem: current };
+
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+
+      // First confirm only bumps the warning to the new count — it does NOT clear
+      // the queue, so the user re-acknowledges what they're about to lose.
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(result.current.queueReplaceSheet.futureQueueCount).toBe(2);
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+
+      // Second confirm (count now stable) goes through.
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+      await waitFor(() => {
+        expect(mocks.setQueue).toHaveBeenCalled();
+      });
+      expect(fetchPage).toHaveBeenCalled();
+    });
+
     it('cancelling the warning leaves the queue untouched', async () => {
       const current = makeQueueItem('q-current', 'current');
       const future = makeQueueItem('q-future', 'future');

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -111,7 +111,6 @@ function buildPlaylistQueue(
 ): { queue: ClimbQueueItem[]; currentItem: ClimbQueueItem } {
   const queue: ClimbQueueItem[] = [];
   let currentItem: ClimbQueueItem | null = null;
-  let includesActivatedClimb = false;
   const reusableCurrentItem = activatedQueueItem?.climb.uuid === activatedClimb.uuid ? activatedQueueItem : null;
   const seen = new Set<string>();
 
@@ -123,23 +122,16 @@ function buildPlaylistQueue(
         ? reusableCurrentItem
         : climbToQueueItem(toSchemaClimb(climb));
     queue.push(item);
-    if (climb.uuid === activatedClimb.uuid) {
-      includesActivatedClimb = true;
-      currentItem = item;
-    }
+    if (climb.uuid === activatedClimb.uuid) currentItem = item;
   }
 
-  if (!includesActivatedClimb) {
-    currentItem = reusableCurrentItem ?? climbToQueueItem(toSchemaClimb(activatedClimb));
-    queue.push(currentItem);
-  }
+  if (currentItem) return { queue, currentItem };
 
-  if (!currentItem) {
-    currentItem = queue[0] ?? climbToQueueItem(toSchemaClimb(activatedClimb));
-    if (queue.length === 0) queue.push(currentItem);
-  }
-
-  return { queue, currentItem };
+  // The activated climb wasn't in the loaded list (or the list was empty) —
+  // append it so the queue always contains and centres on the tapped climb.
+  const appended = reusableCurrentItem ?? climbToQueueItem(toSchemaClimb(activatedClimb));
+  queue.push(appended);
+  return { queue, currentItem: appended };
 }
 
 /** Returns playlist activation controls to wire onto a climb row tap. */


### PR DESCRIPTION
## Summary

Post-merge review follow-up for #2773 (already merged). Addresses the two actionable points from the final Claude review that landed just as the PR was merged:

- **Dead code in `buildPlaylistQueue`.** The trailing `if (!currentItem)` fallback was unreachable at runtime (the loop or the no-match append always set it) but was load-bearing for type-narrowing. Replaced with an early return after the loop plus a no-match append that returns a provably non-null item, so the dead guard is gone and the return stays type-safe.
- **Untested re-confirm path.** `confirmQueueReplacement` re-checks the live future-item count and, if the queue grew while the sheet was open, bumps the warning and requires a second confirm instead of clearing. That branch had no coverage; added a test that grows the queue between sheet-open and confirm and asserts the first confirm only re-warns (no `setQueue`), the second goes through.

No behaviour change — the removed branch never executed at runtime.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan
- `vp test run --project mobile packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx` — 22 pass
- `vp check` on both changed files — format + lint + types clean