### PR TITLE
test(mobile): cover queue-grow path in playlist activation; drop dead code

### DIFF
--- a/docs/i18n-spanish-glossary.md
+++ b/docs/i18n-spanish-glossary.md
@@ -54,6 +54,8 @@ These are already used consistently in the catalogs — keep using them so we do
 
 Kept in English by convention (technical board-config terms): **layout**, **set / sets**, **logbook**, **setter**, **beta**.
 
+**`playlist` / `playlists`** also stay in English — used throughout `es/playlists.json` (_Compartir playlist_, _¿Iniciar playlist?_, _Playlist eliminada_). Feminine: _la playlist_, _esta playlist_, _las playlists_. Never _lista de reproducción_.
+
 ## Process
 
 - Add every new key to **all** locales (`en-US`, `es`, `fr`) — `catalog-completeness.test.ts` fails on missing keys.

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -475,6 +475,8 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       });
       const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
       expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b', 'c']);
+      // The second confirm runs the full replace, so the ordered playlist is fetched.
+      expect(fetchPage).toHaveBeenCalledOnce();
     });
 
     it('cancelling the warning leaves the queue untouched', async () => {

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -434,6 +434,49 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       });
     });
 
+    it('bumps the warning count and requires a second confirm when the queue grows before confirming', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [tapped, makeClimb('c')], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(result.current.queueReplaceSheet.futureQueueCount).toBe(1);
+
+      // A second future item lands between opening the sheet and confirming.
+      mocks.queueState = {
+        queue: [current, future, makeQueueItem('q-future-2', 'future-2')],
+        currentClimbQueueItem: current,
+      };
+
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+
+      // The first confirm only bumps the count to the new total and short-circuits
+      // — nothing is cleared and no fetch fires, so the user re-confirms against the
+      // count they can actually see.
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(result.current.queueReplaceSheet.futureQueueCount).toBe(2);
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+      expect(fetchPage).not.toHaveBeenCalled();
+
+      // The second confirm (count unchanged this time) goes through and replaces the queue.
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+      await waitFor(() => {
+        expect(mocks.setQueue).toHaveBeenCalled();
+      });
+      const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+      expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b', 'c']);
+    });
+
     it('cancelling the warning leaves the queue untouched', async () => {
       const current = makeQueueItem('q-current', 'current');
       const future = makeQueueItem('q-future', 'future');

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -111,7 +111,6 @@ function buildPlaylistQueue(
 ): { queue: ClimbQueueItem[]; currentItem: ClimbQueueItem } {
   const queue: ClimbQueueItem[] = [];
   let currentItem: ClimbQueueItem | null = null;
-  let includesActivatedClimb = false;
   const reusableCurrentItem = activatedQueueItem?.climb.uuid === activatedClimb.uuid ? activatedQueueItem : null;
   const seen = new Set<string>();
 
@@ -124,19 +123,15 @@ function buildPlaylistQueue(
         : climbToQueueItem(toSchemaClimb(climb));
     queue.push(item);
     if (climb.uuid === activatedClimb.uuid) {
-      includesActivatedClimb = true;
       currentItem = item;
     }
   }
 
-  if (!includesActivatedClimb) {
+  // The activated climb wasn't in the list (or the list was empty): append it so
+  // the queue always contains — and is anchored on — the current climb.
+  if (!currentItem) {
     currentItem = reusableCurrentItem ?? climbToQueueItem(toSchemaClimb(activatedClimb));
     queue.push(currentItem);
-  }
-
-  if (!currentItem) {
-    currentItem = queue[0] ?? climbToQueueItem(toSchemaClimb(activatedClimb));
-    if (queue.length === 0) queue.push(currentItem);
   }
 
   return { queue, currentItem };


### PR DESCRIPTION
## Summary

Addresses three review findings on the mobile playlist-activation hook (`packages/mobile/src/lib/playlists/use-playlist-activation.ts`):

1. **Missing test for the count-bump path in `confirmQueueReplacement`.** When the queue grows between opening the confirmation sheet and pressing Confirm, the hook bumps the displayed warning count and short-circuits, forcing a second confirm so the user never clears items they haven't seen counted. This path had no coverage. Added a test that grows the queue while the sheet is open, asserts the count bumps (1 → 2) with no `setQueue`/fetch, then asserts the second confirm goes through and replaces the queue.

2. **Dead code in `buildPlaylistQueue`.** The trailing `if (!currentItem)` block was unreachable — the activated climb is always assigned to `currentItem` (either in the loop or the preceding append). Collapsed the redundant `includesActivatedClimb` flag into the `currentItem` null-check and removed the dead block, keeping the function type-safe (the remaining guard still narrows `currentItem` to non-null).

3. **Spanish glossary.** `docs/i18n-spanish-glossary.md` didn't list `playlist`, so the existing `es/playlists.json` strings (including the new `queueReplace` keys) couldn't be verified against it. The borrowed-English `playlist` is the established convention throughout that catalog; documented it in the glossary (feminine: _la playlist_; never _lista de reproducción_) so it's no longer flagged.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project mobile use-playlist-activation` — 22 passed (was 21).
- `vp run typecheck:mobile` — clean.
- `vp lint` + `vp fmt --check` on the three changed files — 0 warnings/errors, correctly formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XT6hyppvBAAerw8NM6aMGi

---
_Generated by [Claude Code](https://claude.ai/code/session_01XT6hyppvBAAerw8NM6aMGi)_