### PR TITLE
fix(mobile): keep Aurora BLE writes on write-without-response (iOS boards stalled)

### DIFF
--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -212,6 +212,9 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "moonboard"), .withResponse)
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .writeWithoutResponse, boardName: "moonboard"), .withoutResponse)
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.write, .writeWithoutResponse], boardName: "moonboard"), .withoutResponse)
+        // Defensive default: a characteristic advertising neither write property
+        // can't be written either way (CoreBluetooth drops/ rejects the write and
+        // the wall stays dark) — we just don't pick the unacknowledged path for it.
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read], boardName: "moonboard"), .withResponse)
     }
 }

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -190,19 +190,28 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertTrue(url?.absoluteString.contains("include_background=1") ?? false)
     }
 
-    // Regression for the iOS-only "MoonBoard connects but LEDs stay dark" bug:
-    // CoreBluetooth silently drops a `.withoutResponse` write to a characteristic
-    // that lacks the property. Aurora UART advertises `.writeWithoutResponse`
-    // (fast path); the original MoonBoard LED box advertises only `.write`, so it
-    // must use `.withResponse`.
-    func testPreferredWriteTypeSelectsByCharacteristicProperties() {
-        // Aurora (Kilter/Tension): supports write-without-response → fast path.
-        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .writeWithoutResponse), .withoutResponse)
-        // Original MoonBoard LED box: write-with-response only.
-        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write), .withResponse)
-        // Supports both → prefer the unacknowledged fast path.
-        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.write, .writeWithoutResponse]), .withoutResponse)
-        // Defensive default when neither write property is advertised.
-        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read]), .withResponse)
+    // The write type is gated on board family. Aurora (Kilter/Tension) drove the
+    // wall with write-without-response through the entire Capacitor era and the
+    // first RN port, so it ALWAYS takes that path — even when iOS reports the
+    // characteristic without the `.writeWithoutResponse` bit (seen on iOS 26.x,
+    // which routed Aurora to a stalling write-with-response path). Only the
+    // original MoonBoard LED box (UART advertises `.write` only; CoreBluetooth
+    // silently drops a `.withoutResponse` write to it) falls back to
+    // `.withResponse`.
+    func testPreferredWriteTypeIsMoonboardGated() {
+        // Aurora: always without-response, regardless of advertised properties.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .writeWithoutResponse, boardName: "kilter"), .withoutResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "kilter"), .withoutResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "tension"), .withoutResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read], boardName: "tension"), .withoutResponse)
+        // Unknown / nil board (e.g. a JS write before configureBoard): safe
+        // without-response default, never the stalling with-response path.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: nil), .withoutResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read], boardName: nil), .withoutResponse)
+        // MoonBoard: choose from the advertised properties (the 00bda53a2 fix).
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "moonboard"), .withResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .writeWithoutResponse, boardName: "moonboard"), .withoutResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.write, .writeWithoutResponse], boardName: "moonboard"), .withoutResponse)
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read], boardName: "moonboard"), .withResponse)
     }
 }

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -18,16 +18,30 @@ struct BoardBlePacketResult: Equatable {
 }
 
 enum BoardBleEncoding {
-    /// Picks the CoreBluetooth write type for a Nordic UART RX characteristic
-    /// from its advertised properties. Aurora (Kilter/Tension) controllers
-    /// advertise `.writeWithoutResponse` — the fast, unacknowledged path.
-    /// The original MoonBoard LED box advertises only `.write`; CoreBluetooth
-    /// SILENTLY DROPS a `.withoutResponse` write to a characteristic that lacks
-    /// the property, which left the MoonBoard wall dark on iOS while Android
-    /// (whose GATT stack sends no-response writes regardless) worked fine. So
-    /// fall back to `.withResponse` whenever `.writeWithoutResponse` is absent.
-    static func preferredWriteType(for properties: CBCharacteristicProperties) -> CBCharacteristicWriteType {
-        properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
+    /// Picks the CoreBluetooth write type for a Nordic UART RX characteristic,
+    /// gated on the board family.
+    ///
+    /// Aurora (Kilter/Tension) controllers drove the wall with write-WITHOUT-
+    /// response for the entire Capacitor era and the first RN port, and that path
+    /// is proven on the hardware — so Aurora (and an unknown / `nil` board) ALWAYS
+    /// take it, even when iOS reports the characteristic without the
+    /// `.writeWithoutResponse` property bit (observed on iOS 26.x). Routing Aurora
+    /// to write-with-response made boards whose ATT ack never arrives stall on
+    /// every write — the status LED lights but the climb never displays.
+    ///
+    /// Only the original MoonBoard LED box needs write-with-response: its UART RX
+    /// characteristic advertises only `.write`, and CoreBluetooth SILENTLY DROPS a
+    /// `.withoutResponse` write to a characteristic that lacks the property (which
+    /// left the MoonBoard wall dark on iOS while Android — whose GATT stack sends
+    /// no-response writes regardless — worked). So for MoonBoard, and only
+    /// MoonBoard, fall back to `.withResponse` whenever `.writeWithoutResponse` is
+    /// absent.
+    static func preferredWriteType(
+        for properties: CBCharacteristicProperties,
+        boardName: String?
+    ) -> CBCharacteristicWriteType {
+        guard boardName == "moonboard" else { return .withoutResponse }
+        return properties.contains(.writeWithoutResponse) ? .withoutResponse : .withResponse
     }
 
     private struct HoldRoleInfo {

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -13,6 +13,19 @@ struct BoardBleScanResult {
     let serviceUuids: [String]
 }
 
+/// Connect-time BLE write diagnostics, surfaced to JS (Sentry tags + analytics)
+/// so a "bulb lights but the board doesn't respond" report can be diagnosed
+/// without Console.app: we can see whether the characteristic advertised
+/// `.writeWithoutResponse` (firmware) or not (which on iOS 26.x routed Aurora to
+/// the stalling write-with-response path), and the negotiated write lengths.
+struct BoardBleConnectionDiagnostics {
+    let characteristicProperties: Int   // CBCharacteristicProperties.rawValue
+    let supportsWriteWithoutResponse: Bool
+    let chosenWriteType: String         // "withoutResponse" | "withResponse"
+    let maxWriteWithResponse: Int
+    let maxWriteWithoutResponse: Int
+}
+
 enum BoardBleError: LocalizedError {
     case bluetoothUnavailable
     case deviceNotFound
@@ -188,11 +201,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// nil. Exposed to JS as `getConnectedDevice` so a foregrounding app can
     /// adopt a connection established while it was backgrounded (widget
     /// reconnect) even if the `connected` event was missed.
-    var connectedDeviceInfo: (deviceId: String, name: String?)? {
+    var connectedDeviceInfo: (deviceId: String, name: String?, diagnostics: BoardBleConnectionDiagnostics)? {
         runOnBleQueueSync {
-            guard let peripheral = connectedPeripheral, writeCharacteristic != nil else { return nil }
+            guard let peripheral = connectedPeripheral, let characteristic = writeCharacteristic else { return nil }
             let deviceId = peripheral.identifier.uuidString
-            return (deviceId, discoveredNames[deviceId] ?? peripheral.name)
+            let diagnostics = connectionDiagnosticsOnBleQueue(peripheral: peripheral, characteristic: characteristic)
+            return (deviceId, discoveredNames[deviceId] ?? peripheral.name, diagnostics)
         }
     }
 
@@ -947,6 +961,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         persistLastConnectedPeripheral(peripheral)
         completePendingConnect(.success(()))
         logger.info("Connected to board BLE peripheral \(peripheral.identifier.uuidString, privacy: .public)")
+        // One-time write diagnostics (#3181 follow-up): records what the UART RX
+        // characteristic actually advertises and which write type we'll use, so a
+        // stalling board can be diagnosed from Console.app (also surfaced to JS →
+        // Sentry via connectedDeviceInfo / getConnectedDevice).
+        let connectionDiagnostics = connectionDiagnosticsOnBleQueue(peripheral: peripheral, characteristic: characteristic)
+        logger.info("BLE write diagnostics for \(peripheral.identifier.uuidString, privacy: .public): properties=\(connectionDiagnostics.characteristicProperties, privacy: .public) supportsWriteWithoutResponse=\(connectionDiagnostics.supportsWriteWithoutResponse, privacy: .public) chosenWriteType=\(connectionDiagnostics.chosenWriteType, privacy: .public) maxWriteWithResponse=\(connectionDiagnostics.maxWriteWithResponse, privacy: .public) maxWriteWithoutResponse=\(connectionDiagnostics.maxWriteWithoutResponse, privacy: .public)")
         // Tell JS the link is usable. This is the single success point for
         // every connect path (JS connect, widget reconnect, state
         // restoration), so the JS layer can adopt connections it didn't
@@ -1048,6 +1068,21 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         drainWaiters.signalAll()
     }
 
+    private func connectionDiagnosticsOnBleQueue(
+        peripheral: CBPeripheral,
+        characteristic: CBCharacteristic
+    ) -> BoardBleConnectionDiagnostics {
+        let properties = characteristic.properties
+        let writeType = BoardBleEncoding.preferredWriteType(for: properties, boardName: configuration?.boardName)
+        return BoardBleConnectionDiagnostics(
+            characteristicProperties: Int(properties.rawValue),
+            supportsWriteWithoutResponse: properties.contains(.writeWithoutResponse),
+            chosenWriteType: writeType == .withoutResponse ? "withoutResponse" : "withResponse",
+            maxWriteWithResponse: peripheral.maximumWriteValueLength(for: .withResponse),
+            maxWriteWithoutResponse: peripheral.maximumWriteValueLength(for: .withoutResponse)
+        )
+    }
+
     private func apiLevelOnBleQueue(configuration: BoardBleConfiguration) -> Int {
         let connectedDeviceName: String?
         if let connectedPeripheral {
@@ -1138,7 +1173,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        let writeType = BoardBleEncoding.preferredWriteType(for: characteristic.properties)
+        let writeType = BoardBleEncoding.preferredWriteType(
+            for: characteristic.properties,
+            boardName: configuration?.boardName
+        )
 
         if writeType == .withoutResponse {
             guard peripheral.canSendWriteWithoutResponse else {

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -139,9 +139,16 @@ public class BoardBleModule: Module {
         // connection adoption) — see BoardBleNativeModule in src/index.ts.
         AsyncFunction("getConnectedDevice") { () -> [String: Any]? in
             guard let device = BoardBleManager.shared.connectedDeviceInfo else { return nil }
+            let diagnostics = device.diagnostics
             return [
                 "deviceId": device.deviceId,
-                "name": device.name ?? ""
+                "name": device.name ?? "",
+                // Write diagnostics (additive; older JS bundles ignore them).
+                "characteristicProperties": diagnostics.characteristicProperties,
+                "supportsWriteWithoutResponse": diagnostics.supportsWriteWithoutResponse,
+                "chosenWriteType": diagnostics.chosenWriteType,
+                "maxWriteWithResponse": diagnostics.maxWriteWithResponse,
+                "maxWriteWithoutResponse": diagnostics.maxWriteWithoutResponse
             ]
         }
 

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -27,6 +27,17 @@ export type NativeBleConnectedEvent = {
 export type NativeBleConnectedDevice = {
   deviceId: string;
   name?: string;
+  /**
+   * Connect-time BLE write diagnostics. Only present on binaries new enough to
+   * report them (gate on a field being defined, not just on `getConnectedDevice`
+   * existing). Used to diagnose write stalls: whether the UART RX characteristic
+   * advertised write-without-response, and which write type was chosen.
+   */
+  characteristicProperties?: number;
+  supportsWriteWithoutResponse?: boolean;
+  chosenWriteType?: 'withoutResponse' | 'withResponse';
+  maxWriteWithResponse?: number;
+  maxWriteWithoutResponse?: number;
 };
 
 export type NativeBleConfigureBoardOptions = {

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -16,6 +16,7 @@ vi.mock('@sentry/react-native', () => ({
 
 import * as Sentry from '@sentry/react-native';
 import {
+  applyBleDiagnosticsToScope,
   applyErrorContextToScope,
   captureToSentry,
   flushSentry,
@@ -111,5 +112,49 @@ describe('applyErrorContextToScope', () => {
     expect(scope.setLevel).not.toHaveBeenCalled();
     expect(scope.setTag).not.toHaveBeenCalled();
     expect(scope.setExtra).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyBleDiagnosticsToScope', () => {
+  function makeScope() {
+    return { setTag: vi.fn() };
+  }
+
+  it('sets each provided tag and stringifies the boolean for filter-friendliness', () => {
+    const scope = makeScope();
+    applyBleDiagnosticsToScope(scope, {
+      chosenWriteType: 'withoutResponse',
+      supportsWriteWithoutResponse: false,
+      characteristicProperties: 12,
+      maxWriteWithResponse: 512,
+      maxWriteWithoutResponse: 185,
+    });
+    expect(scope.setTag).toHaveBeenCalledWith('ble_chosen_write_type', 'withoutResponse');
+    expect(scope.setTag).toHaveBeenCalledWith('ble_supports_without_response', 'false'); // string, not boolean
+    expect(scope.setTag).toHaveBeenCalledWith('ble_char_properties', 12);
+    expect(scope.setTag).toHaveBeenCalledWith('ble_max_with_response', 512);
+    expect(scope.setTag).toHaveBeenCalledWith('ble_max_without_response', 185);
+  });
+
+  it('skips fields that are undefined', () => {
+    const scope = makeScope();
+    applyBleDiagnosticsToScope(scope, { chosenWriteType: 'withResponse' });
+    expect(scope.setTag).toHaveBeenCalledTimes(1);
+    expect(scope.setTag).toHaveBeenCalledWith('ble_chosen_write_type', 'withResponse');
+  });
+
+  it('clears every BLE tag (sets undefined) when given null', () => {
+    const scope = makeScope();
+    applyBleDiagnosticsToScope(scope, null);
+    expect(scope.setTag).toHaveBeenCalledTimes(5);
+    for (const key of [
+      'ble_chosen_write_type',
+      'ble_supports_without_response',
+      'ble_char_properties',
+      'ble_max_with_response',
+      'ble_max_without_response',
+    ]) {
+      expect(scope.setTag).toHaveBeenCalledWith(key, undefined);
+    }
   });
 });

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -33,7 +33,7 @@ import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types
 import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
-import { setBleDiagnosticsTags } from '../sentry';
+import { clearBleDiagnosticsTags, setBleDiagnosticsTags } from '../sentry';
 import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
 
 // Exported for testing. Decides how a connect-failure category reaches error
@@ -385,6 +385,9 @@ export function useBoardBluetooth({
     writeChainRef.current = Promise.resolve();
     setIsConnected(false);
     onConnectionChange?.(false);
+    // Drop the connect-time BLE diagnostic tags so a later unrelated error
+    // doesn't carry stale ble_* tags from this (now-dead) connection.
+    clearBleDiagnosticsTags();
     // Two callers reach here: the adapter's own disconnect event (the adapter
     // already self-cleaned, so disconnect() is now a no-op), and the
     // write-failure drop path (isDisconnectionError). In the latter the
@@ -737,7 +740,10 @@ export function useBoardBluetooth({
         // Sentry tags so they ride any later write-stall report, and recorded on
         // the success event so PostHog can correlate the chosen write type with
         // send failures (#3181 follow-up).
-        const connectionDiagnostics = await getNativeBleConnectedDevice();
+        // Never let a diagnostics fetch failure skip the success analytics below
+        // (getNativeBleConnectedDevice already swallows native errors → null, but
+        // be explicit so analytics parity can't regress).
+        const connectionDiagnostics = await getNativeBleConnectedDevice().catch(() => null);
         setBleDiagnosticsTags(connectionDiagnostics);
         // apiLevel is the level parseApiLevel actually picked; deviceNamePresent
         // records whether an advertised name was even available. parseApiLevel
@@ -756,6 +762,10 @@ export function useBoardBluetooth({
           bleChosenWriteType: connectionDiagnostics?.chosenWriteType,
           bleSupportsWithoutResponse: connectionDiagnostics?.supportsWriteWithoutResponse,
           bleCharProperties: connectionDiagnostics?.characteristicProperties,
+          // Negotiated write lengths too, so a future MTU-related stall (vs a
+          // write-type one) is visible in PostHog (see #3230).
+          bleMaxWriteWithResponse: connectionDiagnostics?.maxWriteWithResponse,
+          bleMaxWriteWithoutResponse: connectionDiagnostics?.maxWriteWithoutResponse,
         });
         return true;
       } catch (error) {
@@ -866,6 +876,7 @@ export function useBoardBluetooth({
     writeChainRef.current = Promise.resolve();
     setIsConnected(false);
     onConnectionChange?.(false);
+    clearBleDiagnosticsTags();
     await adapter?.disconnect();
   }, [onConnectionChange]);
 
@@ -964,7 +975,10 @@ export function useBoardBluetooth({
       onConnectSuccess?.(serial);
       // Surface this adopted connection's write diagnostics to Sentry too
       // (widget reconnect / state restoration paths, not just JS connect).
-      void getNativeBleConnectedDevice().then(setBleDiagnosticsTags);
+      // Fire-and-forget; a native rejection is intentionally ignored.
+      void getNativeBleConnectedDevice()
+        .then(setBleDiagnosticsTags)
+        .catch(() => {});
     };
 
     const connectedSubscription = subscribeNativeBleConnected((payload) => {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -33,6 +33,7 @@ import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types
 import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
+import { setBleDiagnosticsTags } from '../sentry';
 import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
 
 // Exported for testing. Decides how a connect-failure category reaches error
@@ -731,6 +732,13 @@ export function useBoardBluetooth({
         setIsConnected(true);
         onConnectionChange?.(true);
         onConnectSuccess?.(parsedSerial);
+        // Connect-time BLE write diagnostics (iOS native adapter only; null on
+        // Android/web and on binaries too old to report them). Set as global
+        // Sentry tags so they ride any later write-stall report, and recorded on
+        // the success event so PostHog can correlate the chosen write type with
+        // send failures (#3181 follow-up).
+        const connectionDiagnostics = await getNativeBleConnectedDevice();
+        setBleDiagnosticsTags(connectionDiagnostics);
         // apiLevel is the level parseApiLevel actually picked; deviceNamePresent
         // records whether an advertised name was even available. parseApiLevel
         // silently defaults to v2 when the name is missing/unparseable, and v2
@@ -745,6 +753,9 @@ export function useBoardBluetooth({
           deviceNamePresent: !!connection.deviceName,
           boardId: analyticsBoardId ?? undefined,
           connectedViaMismatchOverride: getConnectedViaMismatchOverride?.() ?? false,
+          bleChosenWriteType: connectionDiagnostics?.chosenWriteType,
+          bleSupportsWithoutResponse: connectionDiagnostics?.supportsWriteWithoutResponse,
+          bleCharProperties: connectionDiagnostics?.characteristicProperties,
         });
         return true;
       } catch (error) {
@@ -951,6 +962,9 @@ export function useBoardBluetooth({
       setIsConnected(true);
       onConnectionChange?.(true);
       onConnectSuccess?.(serial);
+      // Surface this adopted connection's write diagnostics to Sentry too
+      // (widget reconnect / state restoration paths, not just JS connect).
+      void getNativeBleConnectedDevice().then(setBleDiagnosticsTags);
     };
 
     const connectedSubscription = subscribeNativeBleConnected((payload) => {

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -120,7 +120,9 @@ const BLE_DIAGNOSTIC_TAG_KEYS = [
 export type BleConnectionDiagnostics = {
   characteristicProperties?: number;
   supportsWriteWithoutResponse?: boolean;
-  chosenWriteType?: string;
+  // Mirrors NativeBleConnectedDevice.chosenWriteType so a new write-type string
+  // is caught at this boundary rather than silently widened.
+  chosenWriteType?: 'withoutResponse' | 'withResponse';
   maxWriteWithResponse?: number;
   maxWriteWithoutResponse?: number;
 };
@@ -168,13 +170,14 @@ const bleTagScope: BleTagScope = { setTag: (key, value) => Sentry.setTag(key, va
  * per-event `withScope` tags) so they ride later `ble-send` error reports —
  * which is the point: a `write_timeout`/`write_recovery_failed` report can then
  * show whether the board advertised write-without-response and which write type
- * was chosen. Cleared on disconnect via clearBleDiagnosticsTags. No-op when
- * Sentry is disabled or no diagnostics are available (Android / web / a binary
- * too old to report them).
+ * was chosen. Cleared on disconnect via clearBleDiagnosticsTags. Passing
+ * null/undefined diagnostics clears too — so the adopt path (which resolves to
+ * null on a binary that can't report them) drops any stale tags rather than
+ * leaving the previous connection's behind. No-op when Sentry is disabled.
  */
 export function setBleDiagnosticsTags(diagnostics: BleConnectionDiagnostics | null | undefined): void {
-  if (!isSentryEnabled || !diagnostics) return;
-  applyBleDiagnosticsToScope(bleTagScope, diagnostics);
+  if (!isSentryEnabled) return;
+  applyBleDiagnosticsToScope(bleTagScope, diagnostics ?? null);
 }
 
 /**

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -107,6 +107,42 @@ export function captureToSentry(error: unknown, context?: ErrorReportContext): v
   });
 }
 
+/**
+ * BLE write diagnostics captured at connect, kept as GLOBAL scope tags (not the
+ * per-event `withScope` tags) so they ride later `ble-send` error reports —
+ * which is the point: a `write_timeout`/`write_recovery_failed` report can then
+ * show whether the board advertised write-without-response and which write type
+ * was chosen. No-op when Sentry is disabled or no diagnostics are available
+ * (Android / web / a binary too old to report them).
+ */
+export function setBleDiagnosticsTags(
+  diagnostics:
+    | {
+        characteristicProperties?: number;
+        supportsWriteWithoutResponse?: boolean;
+        chosenWriteType?: string;
+        maxWriteWithResponse?: number;
+        maxWriteWithoutResponse?: number;
+      }
+    | null
+    | undefined,
+): void {
+  if (!isSentryEnabled || !diagnostics) return;
+  if (diagnostics.chosenWriteType !== undefined) Sentry.setTag('ble_chosen_write_type', diagnostics.chosenWriteType);
+  if (diagnostics.supportsWriteWithoutResponse !== undefined) {
+    Sentry.setTag('ble_supports_without_response', diagnostics.supportsWriteWithoutResponse);
+  }
+  if (diagnostics.characteristicProperties !== undefined) {
+    Sentry.setTag('ble_char_properties', diagnostics.characteristicProperties);
+  }
+  if (diagnostics.maxWriteWithResponse !== undefined) {
+    Sentry.setTag('ble_max_with_response', diagnostics.maxWriteWithResponse);
+  }
+  if (diagnostics.maxWriteWithoutResponse !== undefined) {
+    Sentry.setTag('ble_max_without_response', diagnostics.maxWriteWithoutResponse);
+  }
+}
+
 /** Best-effort flush so a report survives a later hard crash. */
 export function flushSentry(): Promise<boolean> {
   return isSentryEnabled ? Sentry.flush() : Promise.resolve(true);

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -107,9 +107,8 @@ export function captureToSentry(error: unknown, context?: ErrorReportContext): v
   });
 }
 
-// The global-scope tag keys written by setBleDiagnosticsTags, cleared together
-// by clearBleDiagnosticsTags so a disconnect can't leave stale BLE tags on a
-// later unrelated event.
+// The global-scope tag keys written on connect, cleared together on disconnect
+// so a non-BLE error firing afterwards can't carry stale BLE tags.
 const BLE_DIAGNOSTIC_TAG_KEYS = [
   'ble_chosen_write_type',
   'ble_supports_without_response',
@@ -117,6 +116,52 @@ const BLE_DIAGNOSTIC_TAG_KEYS = [
   'ble_max_with_response',
   'ble_max_without_response',
 ] as const;
+
+export type BleConnectionDiagnostics = {
+  characteristicProperties?: number;
+  supportsWriteWithoutResponse?: boolean;
+  chosenWriteType?: string;
+  maxWriteWithResponse?: number;
+  maxWriteWithoutResponse?: number;
+};
+
+// A scope whose tags accept `undefined` (the clear value) — wider than
+// SentryScopeLike, which only models the set path. Structural so the mapping is
+// unit-testable with a plain fake, like applyErrorContextToScope.
+type BleTagScope = { setTag: (key: string, value: string | number | boolean | undefined) => void };
+
+/**
+ * Pure mapping of BLE diagnostics onto a scope's tags. `null` diagnostics =
+ * clear: every BLE key is set to `undefined`, which drops it from serialized
+ * events (this SDK's Scope exposes no `removeTag`; `setTag(key, undefined)` is
+ * the supported clear). Extracted (no enablement gate, no SDK) so the set/clear
+ * + boolean-stringify behaviour is directly unit-testable.
+ */
+export function applyBleDiagnosticsToScope(scope: BleTagScope, diagnostics: BleConnectionDiagnostics | null): void {
+  if (!diagnostics) {
+    for (const key of BLE_DIAGNOSTIC_TAG_KEYS) scope.setTag(key, undefined);
+    return;
+  }
+  if (diagnostics.chosenWriteType !== undefined) scope.setTag('ble_chosen_write_type', diagnostics.chosenWriteType);
+  // Sentry stores/queries tag values as strings; stringify the boolean so a
+  // filter reads `true`/`false` rather than a coerced primitive.
+  if (diagnostics.supportsWriteWithoutResponse !== undefined) {
+    scope.setTag('ble_supports_without_response', String(diagnostics.supportsWriteWithoutResponse));
+  }
+  if (diagnostics.characteristicProperties !== undefined) {
+    scope.setTag('ble_char_properties', diagnostics.characteristicProperties);
+  }
+  if (diagnostics.maxWriteWithResponse !== undefined) {
+    scope.setTag('ble_max_with_response', diagnostics.maxWriteWithResponse);
+  }
+  if (diagnostics.maxWriteWithoutResponse !== undefined) {
+    scope.setTag('ble_max_without_response', diagnostics.maxWriteWithoutResponse);
+  }
+}
+
+// Adapts the top-level functional API to a BleTagScope. `Sentry.setTag` accepts
+// `undefined` (Primitive), so it carries the clear path too.
+const bleTagScope: BleTagScope = { setTag: (key, value) => Sentry.setTag(key, value) };
 
 /**
  * BLE write diagnostics captured at connect, kept as GLOBAL scope tags (not the
@@ -127,46 +172,18 @@ const BLE_DIAGNOSTIC_TAG_KEYS = [
  * Sentry is disabled or no diagnostics are available (Android / web / a binary
  * too old to report them).
  */
-export function setBleDiagnosticsTags(
-  diagnostics:
-    | {
-        characteristicProperties?: number;
-        supportsWriteWithoutResponse?: boolean;
-        chosenWriteType?: string;
-        maxWriteWithResponse?: number;
-        maxWriteWithoutResponse?: number;
-      }
-    | null
-    | undefined,
-): void {
+export function setBleDiagnosticsTags(diagnostics: BleConnectionDiagnostics | null | undefined): void {
   if (!isSentryEnabled || !diagnostics) return;
-  if (diagnostics.chosenWriteType !== undefined) Sentry.setTag('ble_chosen_write_type', diagnostics.chosenWriteType);
-  // Sentry stores/queries tag values as strings; stringify the boolean so a
-  // filter reads `true`/`false` rather than a coerced primitive.
-  if (diagnostics.supportsWriteWithoutResponse !== undefined) {
-    Sentry.setTag('ble_supports_without_response', String(diagnostics.supportsWriteWithoutResponse));
-  }
-  if (diagnostics.characteristicProperties !== undefined) {
-    Sentry.setTag('ble_char_properties', diagnostics.characteristicProperties);
-  }
-  if (diagnostics.maxWriteWithResponse !== undefined) {
-    Sentry.setTag('ble_max_with_response', diagnostics.maxWriteWithResponse);
-  }
-  if (diagnostics.maxWriteWithoutResponse !== undefined) {
-    Sentry.setTag('ble_max_without_response', diagnostics.maxWriteWithoutResponse);
-  }
+  applyBleDiagnosticsToScope(bleTagScope, diagnostics);
 }
 
 /**
- * Drop the global BLE diagnostic tags set on connect. Called on disconnect so a
- * non-BLE error firing after a board drop doesn't carry stale `ble_*` tags from
- * the previous connection.
+ * Drop the global BLE diagnostic tags set on connect, so a non-BLE error firing
+ * after a board drop doesn't carry stale `ble_*` tags from the previous link.
  */
 export function clearBleDiagnosticsTags(): void {
   if (!isSentryEnabled) return;
-  for (const key of BLE_DIAGNOSTIC_TAG_KEYS) {
-    Sentry.setTag(key, undefined);
-  }
+  applyBleDiagnosticsToScope(bleTagScope, null);
 }
 
 /** Best-effort flush so a report survives a later hard crash. */

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -107,13 +107,25 @@ export function captureToSentry(error: unknown, context?: ErrorReportContext): v
   });
 }
 
+// The global-scope tag keys written by setBleDiagnosticsTags, cleared together
+// by clearBleDiagnosticsTags so a disconnect can't leave stale BLE tags on a
+// later unrelated event.
+const BLE_DIAGNOSTIC_TAG_KEYS = [
+  'ble_chosen_write_type',
+  'ble_supports_without_response',
+  'ble_char_properties',
+  'ble_max_with_response',
+  'ble_max_without_response',
+] as const;
+
 /**
  * BLE write diagnostics captured at connect, kept as GLOBAL scope tags (not the
  * per-event `withScope` tags) so they ride later `ble-send` error reports —
  * which is the point: a `write_timeout`/`write_recovery_failed` report can then
  * show whether the board advertised write-without-response and which write type
- * was chosen. No-op when Sentry is disabled or no diagnostics are available
- * (Android / web / a binary too old to report them).
+ * was chosen. Cleared on disconnect via clearBleDiagnosticsTags. No-op when
+ * Sentry is disabled or no diagnostics are available (Android / web / a binary
+ * too old to report them).
  */
 export function setBleDiagnosticsTags(
   diagnostics:
@@ -129,8 +141,10 @@ export function setBleDiagnosticsTags(
 ): void {
   if (!isSentryEnabled || !diagnostics) return;
   if (diagnostics.chosenWriteType !== undefined) Sentry.setTag('ble_chosen_write_type', diagnostics.chosenWriteType);
+  // Sentry stores/queries tag values as strings; stringify the boolean so a
+  // filter reads `true`/`false` rather than a coerced primitive.
   if (diagnostics.supportsWriteWithoutResponse !== undefined) {
-    Sentry.setTag('ble_supports_without_response', diagnostics.supportsWriteWithoutResponse);
+    Sentry.setTag('ble_supports_without_response', String(diagnostics.supportsWriteWithoutResponse));
   }
   if (diagnostics.characteristicProperties !== undefined) {
     Sentry.setTag('ble_char_properties', diagnostics.characteristicProperties);
@@ -140,6 +154,18 @@ export function setBleDiagnosticsTags(
   }
   if (diagnostics.maxWriteWithoutResponse !== undefined) {
     Sentry.setTag('ble_max_without_response', diagnostics.maxWriteWithoutResponse);
+  }
+}
+
+/**
+ * Drop the global BLE diagnostic tags set on connect. Called on disconnect so a
+ * non-BLE error firing after a board drop doesn't carry stale `ble_*` tags from
+ * the previous connection.
+ */
+export function clearBleDiagnosticsTags(): void {
+  if (!isSentryEnabled) return;
+  for (const key of BLE_DIAGNOSTIC_TAG_KEYS) {
+    Sentry.setTag(key, undefined);
   }
 }
 


### PR DESCRIPTION
## Summary

A tester on a **Kilter/Tension (Aurora)** board, iPhone 15 Pro, **iOS 26.5**, hit a fresh cluster of BLE errors (Sentry: `BOARDSESH-7Y` write_timeout ×8, `BOARDSESH-81` write_recovery_failed, `BOARDSESH-7Z` disconnected, `BOARDSESH-80` connect_failed) — the board connects and its status LED lights, but climbs never reach the wall. `write_timeout` has **zero history in the prior 90 days**; it started ~2.5h after commit `00bda53a2` ("pick BLE write type from characteristic") merged.

`00bda53a2` changed the iOS native writer from *always* write-without-response to choosing the CoreBluetooth write type from the characteristic's advertised properties. On iOS, Aurora UART RX characteristics that don't advertise the `.writeWithoutResponse` bit got routed to the new write-**with**-response path, which only advances on a `didWriteValueFor` ATT ack. The board never sends that ack → every write stalls at the 5s watchdog → the #3181 recovery cycles the link until it gives up.

The old Capacitor app (same Swift Live Activity + native BLE, which we ported from) and the first RN port both wrote `.withoutResponse` **unconditionally** for every board, and that worked on this hardware for months. This change:

- **Gates write-with-response to MoonBoard only.** `BoardBleEncoding.preferredWriteType` now takes `boardName`; Aurora (and an unknown / `nil` board) always use write-without-response — byte-for-byte the pre-`00bda53a2` path. The MoonBoard LED-box fix from `00bda53a2` is preserved.
- **Adds connect-time write diagnostics** (advertised characteristic properties, `supportsWriteWithoutResponse`, chosen write type, negotiated write lengths) surfaced to Sentry tags + the `Bluetooth Connection Success` event, so we can tell whether a board genuinely lacks the property bit (firmware) or iOS 26.5 reports it differently — the latter would be a broader latent regression worth a follow-up.

The MoonBoard auto-fallback-to-without-response idea was **deliberately deferred**: for a genuine `.write`-only box, CoreBluetooth silently drops the without-response retry and the write would report success against a dark wall — re-opening the exact bug `00bda53a2` fixed.

Closes BOARDSESH-7Y, BOARDSESH-81, BOARDSESH-7Z, BOARDSESH-80.

## Release Notes

- Kilter and Tension boards light up reliably again on iPhone — climbs send to the wall instead of the board connecting but staying dark.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2713 pass
- `vp check` (scoped to changed TS) — pass
- iOS Swift unit test `testPreferredWriteTypeIsMoonboardGated` updated for the new signature; runs in `ios-rn-ci.yml` (BoardseshTests).
- **Manual (pending):** install on a physical iPhone (iOS 26.x) with a Kilter/Tension board, send a climb, confirm the wall lights and no `write_timeout`/`write_recovery_failed`; confirm the new Sentry tags (`ble_chosen_write_type`, `ble_supports_without_response`, …) appear on connect. If a MoonBoard LED box is available, confirm it still lights.
- This is a **native** change — it reaches testers only via a new native build (TestFlight / `vp run mobile:preview-build`), not OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyZrUjhTHLHCpDTskUrCFK
