### PR TITLE
chore(mobile): surface screenshot auto sign-in failures in CI logs

### DIFF
--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -129,11 +129,25 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         // "Save Password?" dialog. Inert in normal builds (dead-strips when
         // EXPO_PUBLIC_SCREENSHOT_MODE is unset — the comparison stays inlined here so the
         // release minifier folds it in place rather than across a module boundary).
-        if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' && SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
-          const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
-          if (screenshotSignIn.success) {
-            setIsAuthenticated(true);
-            return;
+        if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') {
+          // Diagnostics land in Metro's stdout (which the capture orchestrator tees to
+          // a log it polls), so a silent sign-in failure is no longer invisible in CI.
+          if (SCREENSHOT_USER_EMAIL && SCREENSHOT_USER_PASSWORD) {
+            const screenshotSignIn = await authSignInWithCredentials(SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD);
+            if (screenshotSignIn.success) {
+              console.info('[screenshot] auto sign-in succeeded; rendering straight into home');
+              setIsAuthenticated(true);
+              return;
+            }
+            console.warn(
+              `[screenshot] auto sign-in FAILED — status=${screenshotSignIn.status ?? 'null'} error=${screenshotSignIn.error}` +
+                ` (emailLen=${SCREENSHOT_USER_EMAIL.length} passwordLen=${SCREENSHOT_USER_PASSWORD.length})`,
+            );
+          } else {
+            console.warn(
+              `[screenshot] auto sign-in SKIPPED — credentials not inlined into the bundle` +
+                ` (emailSet=${Boolean(SCREENSHOT_USER_EMAIL)} passwordSet=${Boolean(SCREENSHOT_USER_PASSWORD)})`,
+            );
           }
         }
         await handleSignedOutTransition();


### PR DESCRIPTION
## Why

The iOS **and** Android screenshot workflows failed silently across every locale from 2026-06-25 onward (`app did not reach the home screen (auto sign-in / bundle load)`). The auth-provider's screenshot-mode auto sign-in swallowed the actual failure, so CI gave no way to distinguish a rejected credential (401) from a network error or un-inlined env — the diagnosis took far longer than it should have.

Root cause turned out to be a stale `SCREENSHOT_USER_PASSWORD` secret (the test account's password had been rotated). That's already fixed by updating the secret; this PR adds the observability so the *next* silent failure is a one-line log read, not an investigation.

## What

In `auth-provider.tsx`'s screenshot-mode branch, log the outcome of the auto sign-in to Metro's stdout (which the capture orchestrator already tees + polls):

- success → `[screenshot] auto sign-in succeeded; rendering straight into home`
- failure → `[screenshot] auto sign-in FAILED — status=<code> error=<msg> (emailLen=… passwordLen=…)`
- creds not inlined → `[screenshot] auto sign-in SKIPPED — credentials not inlined into the bundle (emailSet=… passwordSet=…)`

Gated entirely within the existing `EXPO_PUBLIC_SCREENSHOT_MODE === '1'` block, so it compiles out of release bundles. Lengths (not values) are logged because GitHub masks the secret email/password in logs anyway.

Verified live: this logging printed `status=401 error=Invalid email or password (emailLen=18 passwordLen=8)` in CI, which is exactly what pinpointed the stale secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)