### PR TITLE
feat(mobile): original MoonBoard (RedBearLab) BLE support + protocol tests

### DIFF
--- a/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
@@ -302,25 +302,18 @@ Used when `getAPILevel() < 3` (or API level not specified in device name, defaul
 Byte 1 (POS_LO): Position[7:0]
                   Lower 8 bits of LED position
 
-Byte 2 (COLOR):  Position[9:8] | Green[1:0] | Red[1:0] | Blue[1:0]
+Byte 2 (COLOR):  Red[1:0] | Green[1:0] | Blue[1:0] | Position[9:8]
 
-  Bit layout of Byte 2:
-  +----+----+----+----+----+----+----+----+
-  | R1 | R0 | G1 | G0 | -- | -- | B1 | B0 |
-  +----+----+----+----+----+----+----+----+
-    7    6    5    4    3    2    1    0
-
-  Actually (from code):
-  color_byte = (scaled_red << 6) | (scaled_green << 4) | position_hi | (scaled_blue << 2)
+  color_byte = (scaled_red << 6) | (scaled_green << 4) | (scaled_blue << 2) | position_hi
 
   Where:
-  - position_hi = (position >> 8) & 0x03   (bits 1:0)
   - scaled_red << 6                        (bits 7:6)
   - scaled_green << 4                      (bits 5:4)
   - scaled_blue << 2                       (bits 3:2)
+  - position_hi = (position >> 8) & 0x03   (bits 1:0)
 ```
 
-**Bit layout of Byte 2 (corrected):**
+**Bit layout of Byte 2:**
 
 ```
   Bit 7   Bit 6   Bit 5   Bit 4   Bit 3   Bit 2   Bit 1   Bit 0
@@ -915,14 +908,14 @@ payload = [0x50, 0x0A, 0x30, 0x00, 0x0D, 0xF4, 0xC1]
 **Step 3: Checksum**
 
 ```
-sum = (0x50 + 0x0A + 0x30 + 0x00 + 0x0D + 0xF4 + 0xC1) & 0xFF = 0x56
-checksum = ~0x56 & 0xFF = 0xA9
+sum = (0x50 + 0x0A + 0x30 + 0x00 + 0x0D + 0xF4 + 0xC1) & 0xFF = 0x4C
+checksum = ~0x4C & 0xFF = 0xB3
 ```
 
 **Step 4: Frame**
 
 ```
-[0x01, 0x07, 0xA9, 0x02, 0x50, 0x0A, 0x30, 0x00, 0x0D, 0xF4, 0xC1, 0x03]
+[0x01, 0x07, 0xB3, 0x02, 0x50, 0x0A, 0x30, 0x00, 0x0D, 0xF4, 0xC1, 0x03]
  SOH   LEN   CHK   STX   P     ---------- LED data ----------        ETX
 ```
 

--- a/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md
@@ -873,7 +873,7 @@ pos_hi = (10 >> 8) & 0x03 = 0x00
 R = floor(0x00 * 1.0) / 64 = 0
 G = floor(0xFF * 1.0) / 64 = 3
 B = floor(0x00 * 1.0) / 64 = 0
-color_byte = (0 << 6) | (3 << 4) | 0x00 | (0 << 2) = 0x30
+color_byte = (0 << 6) | (3 << 4) | (0 << 2) | 0x00 = 0x30
 bytes: [0x0A, 0x30]
 ```
 
@@ -883,7 +883,7 @@ LED 2 (pos=256, color="0000FF"):
 pos_lo = 256 & 0xFF = 0x00
 pos_hi = (256 >> 8) & 0x03 = 0x01
 R = 0, G = 0, B = floor(0xFF * 1.0) / 64 = 3
-color_byte = (0 << 6) | (0 << 4) | 0x01 | (3 << 2) = 0x0D
+color_byte = (0 << 6) | (0 << 4) | (3 << 2) | 0x01 = 0x0D
 bytes: [0x00, 0x0D]
 ```
 
@@ -894,7 +894,7 @@ pos_lo = 500 & 0xFF = 0xF4
 pos_hi = (500 >> 8) & 0x03 = 0x01
 R = floor(0xFF * 1.0) / 64 = 3
 G = 0, B = 0
-color_byte = (3 << 6) | (0 << 4) | 0x01 | (0 << 2) = 0xC1
+color_byte = (3 << 6) | (0 << 4) | (0 << 2) | 0x01 = 0xC1
 bytes: [0xF4, 0xC1]
 ```
 

--- a/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md
+++ b/docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md
@@ -10,12 +10,12 @@
 
 ## What this document is
 
-Boardsesh already ships a working MoonBoard BLE client (`packages/shared/ble-protocol/src/moonboard.ts`). That implementation was reconstructed from **open-source MoonBoard LED projects** — community Arduino/ESP controllers and third-party apps — and it only knows the Nordic-UART hardware path.
+Boardsesh already ships a working MoonBoard BLE client (`packages/shared/ble-protocol/src/moonboard.ts`). That implementation was reconstructed from **open-source MoonBoard LED projects** — community Arduino/ESP controllers and third-party apps — and originally knew only the Nordic-UART hardware path. (Acting on this document, the client now also discovers and writes the original RedBearLab service as a fallback — see §8.)
 
 This spec is a **separate, independent read** of the protocol taken from the **official Moon Climbing app**, written to:
 
 1. **Cross-validate** the format Boardsesh already emits, and
-2. **Capture what the open-source-derived implementation is missing** — most importantly, a second controller hardware generation (the original RedBearLab-based boards) that the current client does not recognise at all.
+2. **Capture what the open-source-derived implementation was missing** — most importantly, a second controller hardware generation (the original RedBearLab-based boards) the client did not recognise. That path is now wired as a fallback (see §8).
 
 It is a companion to the working code, not a replacement for it. Where the official app and the open-source format agree, that is noted; where they diverge, the divergence is the point.
 
@@ -79,7 +79,7 @@ For completeness on the stack (not part of the LED path): the app is Flutter (Da
 | RedBearLab service   | `713d0000-503e-4c75-ba94-3148f18d941e` | Data service on the original boards | ✅  |
 | Write characteristic | `713d0003-503e-4c75-ba94-3148f18d941e` | App **writes** LED commands here    | ✅  |
 
-This is the well-known **RedBearLab BLE Shield** UUID family, and `713d0003` is that module's central→peripheral write characteristic. The original MoonBoard LED kit is widely documented as having shipped on a RedBearLab BLE module, so this is the original-hardware path (the "original vs. newer" split is an inference from the two UUID families + that public history, not something the static inspection proves on its own). Either way, **Boardsesh's current open-source-derived client does not know this service at all** — it is the single biggest gap this document fills.
+This is the well-known **RedBearLab BLE Shield** UUID family, and `713d0003` is that module's central→peripheral write characteristic. The original MoonBoard LED kit is widely documented as having shipped on a RedBearLab BLE module, so this is the original-hardware path (the "original vs. newer" split is an inference from the two UUID families + that public history, not something the static inspection proves on its own). This was the single biggest gap this document identified; Boardsesh now discovers and writes this service as a fallback after the Nordic UART one (`REDBEARLAB_SERVICE_UUID` / `REDBEARLAB_WRITE_CHARACTERISTIC_UUID` in [`transport.ts`](../packages/shared/ble-protocol/src/transport.ts)), though the path is not yet verified on an original board (see §8).
 
 ### 2.2 Newer hardware — Nordic UART service
 
@@ -208,7 +208,9 @@ The position index is a property of the **physical LED string**, so it is identi
 
 ### 5.4 BLE chunking
 
-🔁 The ASCII string is split into BLE writes. The classic transport size is **20 bytes per write** (`MAX_BLUETOOTH_MESSAGE_SIZE` in `transport.ts`); chunking is a transport detail and does not change the message. Writes use **Write Without Response**.
+🔁 The ASCII string is split into BLE writes. The classic transport size is **20 bytes per write** (`MAX_BLUETOOTH_MESSAGE_SIZE` in `transport.ts`); chunking is a transport detail and does not change the message.
+
+**Write type depends on the controller generation.** The newer Nordic-UART RX characteristic (`6e400002`) supports **Write Without Response**. The original RedBearLab write characteristic (`713d0003`), however, advertises only the plain `.write` property — on iOS, CoreBluetooth **silently drops** a write-without-response to a characteristic that lacks the no-response property, leaving the wall dark. So an interoperable iOS client must use **write-with-response** for the RedBearLab box (pacing on the GATT write ack), and may use write-without-response for the Nordic-UART boards. Android's GATT stack issues no-response writes regardless of the advertised property, so the same write call works on both there. Boardsesh implements exactly this gating (`BoardBleEncoding.preferredWriteType` in `packages/mobile/modules/live-activity/ios/`): MoonBoard falls back to write-with-response whenever the chosen write characteristic doesn't advertise `.writeWithoutResponse`.
 
 ---
 
@@ -230,17 +232,19 @@ This is the hook an interoperable client should adopt: **record which service a 
 
 ## 8. Differences from the open-source-derived client — summary
 
-| Aspect                                | Boardsesh today (`moonboard.ts`) | Official Moon Climbing app                                    |
-| ------------------------------------- | -------------------------------- | ------------------------------------------------------------- |
-| Controller generations                | Nordic UART only                 | **Two**: RedBearLab `713d0000` **and** Nordic UART `6e400001` |
-| Original-hardware boards              | Not supported (service unknown)  | Writes to `713d0003` on the RedBearLab service                |
-| Per-board hardware version            | None                             | `led_version` persisted per board                             |
-| Notify channel                        | —                                | None — write-only on both generations                         |
-| Bonding                               | —                                | Explicitly **unbonded** ("DO NOT pair")                       |
-| Payload (`l#…#`, markers, serpentine) | As documented here               | **Same** 🔁                                                   |
-| Extra UUIDs                           | —                                | Two present, non-BLE (uuid-package / SDK realm) ❓            |
+| Aspect                                | Boardsesh today (`moonboard.ts` + adapters)                                             | Official Moon Climbing app                                    |
+| ------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Controller generations                | **Two**: RedBearLab `713d0000` **and** Nordic UART `6e400001` (discovery wired)¹        | **Two**: RedBearLab `713d0000` **and** Nordic UART `6e400001` |
+| Original-hardware boards              | Discovers + writes `713d0003` (write-with-response on iOS); **unverified on hardware**¹ | Writes to `713d0003` on the RedBearLab service                |
+| Per-board hardware version            | None (probes UART → RedBearLab on each connect)                                         | `led_version` persisted per board                             |
+| Notify channel                        | None — write-only                                                                       | None — write-only on both generations                         |
+| Bonding                               | Plain GATT connect, no bond                                                             | Explicitly **unbonded** ("DO NOT pair")                       |
+| Payload (`l#…#`, markers, serpentine) | As documented here                                                                      | **Same** 🔁                                                   |
+| Extra UUIDs                           | Ignored                                                                                 | Two present, non-BLE (uuid-package / SDK realm) ❓            |
 
-**Bottom line for interop:** the `l#<marker><pos>,…#` payload Boardsesh emits is correct for the Nordic UART boards. The actionable gap is **hardware coverage**: to match the official app, the client should (1) also discover and write the **RedBearLab `713d0000` / `713d0003`** service, (2) **connect without bonding**, and (3) **remember which service a board exposed** (mirroring the app's `led_version`) so original-hardware boards work, not just the newer ones.
+¹ The RedBearLab discovery/write path (scan filter, characteristic-discovery fallback, write-with-response gating) is implemented across web, React Native, and native iOS and unit-tested, but has **not** been verified against an original MoonBoard LED box. See the constants `REDBEARLAB_SERVICE_UUID` / `REDBEARLAB_WRITE_CHARACTERISTIC_UUID` in `packages/shared/ble-protocol/src/transport.ts`.
+
+**Bottom line for interop:** the `l#<marker><pos>,…#` payload Boardsesh emits is correct for the Nordic UART boards, and the client now also discovers and writes the **RedBearLab `713d0000` / `713d0003`** service (with the iOS write-with-response gating that path requires) and **connects without bonding**. Remaining work: **verify the RedBearLab path on an original board** and optionally persist which service a board exposed (mirroring the app's `led_version`) to skip the probe on reconnect.
 
 ---
 

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -290,7 +290,7 @@ final class LiveActivityWidgetTests: XCTestCase {
         )
         // Malformed overrides fall back to the canonical color (green 0x1C), NOT
         // black — parity with the TS SIX_DIGIT_HEX_PATTERN guard.
-        for bad in ["#fff", "red", "#FF00FF00", "12345g"] {
+        for bad in ["#fff", "red", "#FF00FF00", "12345g", "ab#cdef"] {
             XCTAssertEqual(
                 singleLedColorByte(
                     BoardBleEncoding.makeAuroraPacket(

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -217,4 +217,110 @@ final class LiveActivityWidgetTests: XCTestCase {
         // the wall stays dark) — we just don't pick the unacknowledged path for it.
         XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: [.read], boardName: "moonboard"), .withResponse)
     }
+
+    // MARK: - Aurora packet encoding (parity with @boardsesh/ble-protocol)
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Color byte of a single-LED v3 packet:
+    /// [SOH, LEN, CHK, STX, T, posLo, posHi, color, ETX].
+    private func singleLedColorByte(_ result: BoardBlePacketResult) -> UInt8? {
+        let bytes = [UInt8](result.packet)
+        guard bytes.count == 9 else { return nil }
+        return bytes[7]
+    }
+
+    func testAuroraPacketByteExactMatchesValidatedKilter12x12() {
+        // 3rd-party validated payload for Kilter Original 12x12 (Layout 1) — the
+        // same ground-truth fixture as the web bluetooth-packet.test.ts. Locks
+        // Swift ↔ TS ↔ hardware parity for the v3 encoder.
+        let result = BoardBleEncoding.makeAuroraPacket(
+            frames: "p1379r44p1395r44p1447r45p1464r45",
+            placementPositions: [1379: 68, 1395: 476, 1447: 0, 1464: 33],
+            boardName: "kilter"
+        )
+        XCTAssertEqual(hex(result.packet), "010dbb02544400e3dc01e30000f42100f403")
+    }
+
+    func testAuroraPacketByteExactMatchesValidatedKilter8x12Original() {
+        let result = BoardBleEncoding.makeAuroraPacket(
+            frames: "p1382r44p1392r44p1450r45p1461r45",
+            placementPositions: [1382: 56, 1392: 311, 1450: 0, 1461: 21],
+            boardName: "kilter"
+        )
+        XCTAssertEqual(hex(result.packet), "010d7802543800e33701e30000f41500f403")
+    }
+
+    func testAuroraHoldStateColorsMatchCanonicalMap() {
+        // Indirect holdStateMap parity: each role's canonical LED color must
+        // encode to the same v3 color byte as @boardsesh/board-constants. A drift
+        // in the hand-copied Swift map would flip one of these bytes.
+        func color(_ frames: String, _ board: String) -> UInt8? {
+            singleLedColorByte(
+                BoardBleEncoding.makeAuroraPacket(frames: frames, placementPositions: [1: 10], boardName: board)
+            )
+        }
+        // kilter: 42 STARTING #00FF00, 43 HAND #00FFFF, 44 FINISH #FF00FF, 45 FOOT #FFAA00
+        XCTAssertEqual(color("p1r42", "kilter"), 0x1C)
+        XCTAssertEqual(color("p1r43", "kilter"), 0x1F)
+        XCTAssertEqual(color("p1r44", "kilter"), 0xE3)
+        XCTAssertEqual(color("p1r45", "kilter"), 0xF4)
+        // tension: 1 STARTING #00FF00, 3 FINISH #FF0000
+        XCTAssertEqual(color("p1r1", "tension"), 0x1C)
+        XCTAssertEqual(color("p1r3", "tension"), 0xE0)
+        // decoy (common Aurora role map): 3 FINISH #FF0000
+        XCTAssertEqual(color("p1r3", "decoy"), 0xE0)
+    }
+
+    func testAuroraColorOverrideSanitization() {
+        let positions = [1: 10]
+        // A valid 6-digit hex override is honoured (red).
+        XCTAssertEqual(
+            singleLedColorByte(
+                BoardBleEncoding.makeAuroraPacket(
+                    frames: "p1r42",
+                    placementPositions: positions,
+                    boardName: "kilter",
+                    colorOverrides: ["STARTING": "#FF0000"]
+                )
+            ),
+            0xE0
+        )
+        // Malformed overrides fall back to the canonical color (green 0x1C), NOT
+        // black — parity with the TS SIX_DIGIT_HEX_PATTERN guard.
+        for bad in ["#fff", "red", "#FF00FF00", "12345g"] {
+            XCTAssertEqual(
+                singleLedColorByte(
+                    BoardBleEncoding.makeAuroraPacket(
+                        frames: "p1r42",
+                        placementPositions: positions,
+                        boardName: "kilter",
+                        colorOverrides: ["STARTING": bad]
+                    )
+                ),
+                0x1C,
+                "override \"\(bad)\" should fall back to the canonical green"
+            )
+        }
+    }
+
+    func testParseApiLevelMatchesFirstAtSign() {
+        XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: "Kilter Board#abc123@3"), 3)
+        XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: "Kilter Board"), 2)
+        XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: nil), 2)
+        XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: "Board@4"), 4)
+        // The FIRST '@' with digits wins (mirrors TS /@(\d+)/), not the last —
+        // the old `.backwards` implementation would have returned 9 here.
+        XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: "Board@2@9"), 2)
+        // First '@' has no digits after it; fall through to the next.
+        XCTAssertEqual(BoardBleEncoding.parseApiLevel(deviceName: "Board@x@5"), 5)
+    }
+
+    func testRedBearLabWriteCharacteristicUsesWriteWithResponse() {
+        // The original MoonBoard (RedBearLab) write characteristic (713d0003)
+        // advertises `.write` only, so iOS must pace it with write-with-response.
+        XCTAssertEqual(BoardBleEncoding.preferredWriteType(for: .write, boardName: "moonboard"), .withResponse)
+    }
 }

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -117,15 +117,19 @@ enum BoardBleEncoding {
     ]
 
     static func parseApiLevel(deviceName: String?) -> Int {
-        guard let deviceName,
-              let atRange = deviceName.range(of: "@", options: .backwards)
-        else {
-            return 2
+        guard let deviceName else { return 2 }
+        // Mirror the TS regex /@(\d+)/: the FIRST '@' immediately followed by one
+        // or more ASCII digits. (Using `.backwards`/last-'@' diverges from TS on
+        // pathological multi-'@' names.) Defaults to 2 when absent.
+        var searchStart = deviceName.startIndex
+        while let atRange = deviceName.range(of: "@", range: searchStart..<deviceName.endIndex) {
+            let digits = deviceName[atRange.upperBound...].prefix { ("0"..."9").contains($0) }
+            if let value = Int(digits) {
+                return value
+            }
+            searchStart = atRange.upperBound
         }
-
-        let suffix = deviceName[atRange.upperBound...]
-        let digits = suffix.prefix { $0.isNumber }
-        return Int(digits) ?? 2
+        return 2
     }
 
     static func checksum(_ payload: [UInt8]) -> UInt8 {
@@ -207,7 +211,7 @@ enum BoardBleEncoding {
                 continue
             }
 
-            let color = colorOverrides[roleInfo.state] ?? roleInfo.color
+            let color = sanitizedOverride(colorOverrides[roleInfo.state]) ?? roleInfo.color
             ledEntries.append(LedEntry(position: ledPosition, color: color))
         }
 
@@ -389,6 +393,18 @@ enum BoardBleEncoding {
 
     private static func ledsPerHold(boardName: String) -> Int {
         boardName == "kilter" ? 2 : 1
+    }
+
+    /// Mirrors the TS `SIX_DIGIT_HEX_PATTERN` guard: only honour a colour
+    /// override that is exactly six hex digits (after an optional leading '#').
+    /// Anything else (shorthand "#fff", a named colour, an 8-digit RGBA) falls
+    /// back to the canonical role colour instead of rendering black or a
+    /// silently truncated colour to the wall.
+    private static func sanitizedOverride(_ override: String?) -> String? {
+        guard let override else { return nil }
+        let stripped = override.hasPrefix("#") ? String(override.dropFirst()) : override
+        guard stripped.count == 6, stripped.allSatisfy(\.isHexDigit) else { return nil }
+        return override
     }
 
     private static func normalizeColor(_ color: String) -> String {

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -911,11 +911,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     // MARK: - CBPeripheralDelegate
 
-    /// Services to probe after connect. MoonBoard spans two controller
-    /// generations, so probe the Nordic UART service first and the original
-    /// RedBearLab service as a fallback; Aurora boards are always Nordic UART.
+    /// Services to probe after connect, Nordic UART first then the original
+    /// RedBearLab service. Probed UNCONDITIONALLY — not gated on
+    /// `configuration?.boardName` — because `configuration` is set by
+    /// configureBoard() only AFTER requestAndConnect resolves, so it is nil (fresh
+    /// install) or stale during discovery. Gating here meant an original
+    /// RedBearLab MoonBoard (which exposes no UART service) failed discovery on
+    /// first connect and never reached configureBoard — a catch-22. Discovering
+    /// an absent service is harmless on CoreBluetooth: Aurora and newer MoonBoards
+    /// simply won't expose RedBearLab, the ordered list keeps the UART preference,
+    /// and writeCharacteristicUuid(for:) keys on the discovered service.
     private func writeServiceUuids() -> [CBUUID] {
-        configuration?.boardName == "moonboard" ? [uartServiceUuid, redBearLabServiceUuid] : [uartServiceUuid]
+        [uartServiceUuid, redBearLabServiceUuid]
     }
 
     /// The write characteristic UUID paired with a discovered service UUID.
@@ -976,6 +983,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         let writeCharUuid = writeCharacteristicUuid(for: service.uuid)
         guard let characteristic = service.characteristics?.first(where: { $0.uuid == writeCharUuid }) else {
+            // Known minor divergence from the web/RN adapters, which retry the
+            // other controller service when the chosen one exposes no write
+            // characteristic. Not retried here because real boards are a single
+            // controller generation (a UART service WITHOUT its write char while
+            // ALSO exposing RedBearLab is not a real device), so this can't bite
+            // hardware. Revisit if a hybrid controller ever ships.
             failConnectionSetup(peripheral, error: BoardBleError.writeCharacteristicMissing)
             return
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -93,6 +93,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private let auroraServiceUuid = CBUUID(string: "4488B571-7806-4DF6-BCFF-A2897E4953FF")
     private let uartServiceUuid = CBUUID(string: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
     private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+    // Original MoonBoard (RedBearLab) LED box: a second controller generation
+    // whose write characteristic (713d0003, `.write`-only) lives on its own
+    // service. Probed as a fallback after the Nordic UART one for the moonboard
+    // family. See docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md §2.1.
+    private let redBearLabServiceUuid = CBUUID(string: "713D0000-503E-4C75-BA94-3148F18D941E")
+    private let redBearLabWriteCharacteristicUuid = CBUUID(string: "713D0003-503E-4C75-BA94-3148F18D941E")
     private let chunkSize = 20
     private let chunkDelay: TimeInterval = 0.005
     private let connectTimeout: TimeInterval = 8
@@ -504,10 +510,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         reconnectScanTimeoutWorkItem = timeout
         bleQueue.asyncAfter(deadline: .now() + connectTimeout, execute: timeout)
 
-        // Filter on both the Aurora advertised service and the UART service so a
-        // MoonBoard (which advertises UART) is matchable too, mirroring the JS
-        // adapter's scan filter.
-        startScanOnBleQueue(serviceUuids: [auroraServiceUuid.uuidString, uartServiceUuid.uuidString]) { [weak self] result in
+        // Filter on the Aurora advertised service, the Nordic UART service, and
+        // the original RedBearLab service so any board generation — Aurora,
+        // newer MoonBoard (UART), or original MoonBoard (RedBearLab) — is
+        // matchable, mirroring the JS adapter's scan filter.
+        startScanOnBleQueue(serviceUuids: [
+            auroraServiceUuid.uuidString,
+            uartServiceUuid.uuidString,
+            redBearLabServiceUuid.uuidString,
+        ]) { [weak self] result in
             if case .failure(let error) = result {
                 self?.failReconnectScan(error)
             }
@@ -763,7 +774,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             peripheralGenerations[peripheral.identifier] = connectionGeneration
             connectedPeripheral = peripheral
             logger.info("Restored BLE peripheral \(deviceId, privacy: .public)")
-            peripheral.discoverServices([uartServiceUuid])
+            peripheral.discoverServices(writeServiceUuids())
         case .connecting:
             // The restored connect request is still pending; didConnect will
             // run service discovery when the link comes up (the generation set
@@ -825,7 +836,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
         peripheral.delegate = self
-        peripheral.discoverServices([uartServiceUuid])
+        peripheral.discoverServices(writeServiceUuids())
     }
 
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
@@ -900,6 +911,18 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     // MARK: - CBPeripheralDelegate
 
+    /// Services to probe after connect. MoonBoard spans two controller
+    /// generations, so probe the Nordic UART service first and the original
+    /// RedBearLab service as a fallback; Aurora boards are always Nordic UART.
+    private func writeServiceUuids() -> [CBUUID] {
+        configuration?.boardName == "moonboard" ? [uartServiceUuid, redBearLabServiceUuid] : [uartServiceUuid]
+    }
+
+    /// The write characteristic UUID paired with a discovered service UUID.
+    private func writeCharacteristicUuid(for serviceUuid: CBUUID) -> CBUUID {
+        serviceUuid == redBearLabServiceUuid ? redBearLabWriteCharacteristicUuid : uartWriteCharacteristicUuid
+    }
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         // Identity AND generation, mirroring didConnect: a stale discovery
         // callback from a superseded connect attempt to the same device must
@@ -912,12 +935,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        guard let service = peripheral.services?.first(where: { $0.uuid == uartServiceUuid }) else {
+        // Prefer the Nordic UART service; fall back to RedBearLab for the
+        // original MoonBoard LED box. writeServiceUuids() is ordered, so the
+        // compactMap keeps that preference.
+        guard let service = writeServiceUuids().compactMap({ uuid in
+            peripheral.services?.first(where: { $0.uuid == uuid })
+        }).first else {
             failConnectionSetup(peripheral, error: BoardBleError.uartServiceMissing)
             return
         }
 
-        peripheral.discoverCharacteristics([uartWriteCharacteristicUuid], for: service)
+        peripheral.discoverCharacteristics([writeCharacteristicUuid(for: service.uuid)], for: service)
     }
 
     /// A connection that reached service discovery but can't become
@@ -946,7 +974,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return
         }
 
-        guard let characteristic = service.characteristics?.first(where: { $0.uuid == uartWriteCharacteristicUuid }) else {
+        let writeCharUuid = writeCharacteristicUuid(for: service.uuid)
+        guard let characteristic = service.characteristics?.first(where: { $0.uuid == writeCharUuid }) else {
             failConnectionSetup(peripheral, error: BoardBleError.writeCharacteristicMissing)
             return
         }

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { DevicePickerFn } from '../types';
+import type { DevicePickerFn, BoardScanFamily } from '../types';
 
 // ── Hoisted mocks (available inside vi.mock factories) ──────────────────
 
@@ -35,6 +35,8 @@ vi.mock('@boardsesh/ble-protocol', () => ({
   AURORA_ADVERTISED_SERVICE_UUID: 'aurora-uuid',
   UART_SERVICE_UUID: 'uart-uuid',
   UART_WRITE_CHARACTERISTIC_UUID: 'uart-write-uuid',
+  REDBEARLAB_SERVICE_UUID: 'redbearlab-uuid',
+  REDBEARLAB_WRITE_CHARACTERISTIC_UUID: 'redbearlab-write-uuid',
   splitMessages: vi.fn((passedData: Uint8Array) => [passedData]),
   INTER_CHUNK_DELAY_MS: 0,
   parseSerialNumber: vi.fn(),
@@ -51,6 +53,43 @@ import { State } from 'react-native-ble-plx';
 
 function createMockDevicePicker(): DevicePickerFn {
   return vi.fn();
+}
+
+// Wires up the scan → auto-pick → connect → discover flow for a single board so
+// a test only has to supply the per-service characteristic lookup. The adapter
+// is returned NOT yet connected so callers can either await
+// requestAndConnect() (success) or assert on its rejection (no write char).
+function setupConnectableAdapter(
+  family: BoardScanFamily,
+  deviceId: string,
+  characteristicsForService: ReturnType<typeof vi.fn>,
+): RNBleAdapter {
+  mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+  mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+
+  // MoonBoards advertise no service UUID (unfiltered scan); Aurora boards carry
+  // the advertised service so they survive the UUID-filtered scan.
+  const scanName = family === 'aurora' ? 'Kilter Board#TEST@3' : 'MoonBoard A1';
+  const serviceUUIDs = family === 'aurora' ? ['aurora-uuid'] : undefined;
+  mockBleManager.startDeviceScan.mockImplementation(
+    (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+      callback(null, { id: deviceId, localName: scanName, name: scanName, rssi: -40, serviceUUIDs });
+    },
+  );
+
+  const mockDeviceWithServices = {
+    id: deviceId,
+    characteristicsForService,
+    requestMTU: vi.fn().mockResolvedValue(undefined),
+    discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+  };
+  mockBleManager.connectToDevice.mockResolvedValue({
+    id: deviceId,
+    requestMTU: vi.fn().mockResolvedValue(undefined),
+    discoverAllServicesAndCharacteristics: vi.fn().mockReturnValue(mockDeviceWithServices),
+  });
+
+  return new RNBleAdapter(() => Promise.resolve(deviceId), family);
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -910,6 +949,145 @@ describe('RNBleAdapter', () => {
       const unsubscribe2 = adapter.onDisconnect(secondCallback);
 
       expect(typeof unsubscribe2).toBe('function');
+    });
+  });
+
+  describe('requestAndConnect — original MoonBoard (RedBearLab) fallback', () => {
+    it('falls back to the RedBearLab service for moonboard when the UART service exposes no write characteristic', async () => {
+      const redbearCharacteristic = {
+        uuid: 'redbearlab-write-uuid',
+        isWritableWithoutResponse: false,
+        writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+        writeWithResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      // UART service is present but carries no matching write characteristic.
+      const characteristicsForService = vi.fn().mockImplementation((serviceUuid: string) => {
+        if (serviceUuid === 'uart-uuid') return Promise.resolve([]);
+        if (serviceUuid === 'redbearlab-uuid') return Promise.resolve([redbearCharacteristic]);
+        return Promise.resolve([]);
+      });
+
+      const adapter = setupConnectableAdapter('moonboard', 'redbear-empty-device', characteristicsForService);
+      await adapter.requestAndConnect();
+
+      // UART queried first, RedBearLab queried as the fallback.
+      expect(characteristicsForService).toHaveBeenCalledWith('uart-uuid');
+      expect(characteristicsForService).toHaveBeenCalledWith('redbearlab-uuid');
+
+      const data = new Uint8Array([0x01]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      // Subsequent writes target the RedBearLab characteristic.
+      expect(redbearCharacteristic.writeWithResponse).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to the RedBearLab service for moonboard when the UART service lookup throws', async () => {
+      const redbearCharacteristic = {
+        uuid: 'redbearlab-write-uuid',
+        isWritableWithoutResponse: false,
+        writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+        writeWithResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      // react-native-ble-plx throws when the UART service isn't present at all.
+      const characteristicsForService = vi.fn().mockImplementation((serviceUuid: string) => {
+        if (serviceUuid === 'uart-uuid') return Promise.reject(new Error('Service not found'));
+        if (serviceUuid === 'redbearlab-uuid') return Promise.resolve([redbearCharacteristic]);
+        return Promise.resolve([]);
+      });
+
+      const adapter = setupConnectableAdapter('moonboard', 'redbear-throw-device', characteristicsForService);
+      await adapter.requestAndConnect();
+
+      expect(characteristicsForService).toHaveBeenCalledWith('uart-uuid');
+      expect(characteristicsForService).toHaveBeenCalledWith('redbearlab-uuid');
+
+      const data = new Uint8Array([0x01]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      expect(redbearCharacteristic.writeWithResponse).toHaveBeenCalledOnce();
+    });
+
+    it('does not fall back to RedBearLab on aurora and throws when the UART write characteristic is absent', async () => {
+      const redbearCharacteristic = {
+        uuid: 'redbearlab-write-uuid',
+        writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+        writeWithResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      // The RedBearLab service WOULD match if queried — proving aurora never asks.
+      const characteristicsForService = vi.fn().mockImplementation((serviceUuid: string) => {
+        if (serviceUuid === 'uart-uuid') return Promise.resolve([]);
+        return Promise.resolve([redbearCharacteristic]);
+      });
+
+      const adapter = setupConnectableAdapter('aurora', 'aurora-no-fallback-device', characteristicsForService);
+
+      await expect(adapter.requestAndConnect()).rejects.toThrow('UART write characteristic not found');
+      expect(characteristicsForService).toHaveBeenCalledWith('uart-uuid');
+      expect(characteristicsForService).not.toHaveBeenCalledWith('redbearlab-uuid');
+      // The dead connection is torn down before the error surfaces.
+      expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledWith('aurora-no-fallback-device');
+    });
+  });
+
+  describe('write — write-type gating', () => {
+    it('uses writeWithResponse for a moonboard characteristic that is not writable without response', async () => {
+      const characteristic = {
+        uuid: 'uart-write-uuid',
+        isWritableWithoutResponse: false,
+        writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+        writeWithResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      const characteristicsForService = vi.fn().mockResolvedValue([characteristic]);
+      const adapter = setupConnectableAdapter('moonboard', 'moon-with-response', characteristicsForService);
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      expect(characteristic.writeWithResponse).toHaveBeenCalledOnce();
+      expect(characteristic.writeWithoutResponse).not.toHaveBeenCalled();
+    });
+
+    it('uses writeWithoutResponse for a moonboard characteristic that is writable without response', async () => {
+      const characteristic = {
+        uuid: 'uart-write-uuid',
+        isWritableWithoutResponse: true,
+        writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+        writeWithResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      const characteristicsForService = vi.fn().mockResolvedValue([characteristic]);
+      const adapter = setupConnectableAdapter('moonboard', 'moon-without-response', characteristicsForService);
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      expect(characteristic.writeWithoutResponse).toHaveBeenCalledOnce();
+      expect(characteristic.writeWithResponse).not.toHaveBeenCalled();
+    });
+
+    it('always uses writeWithoutResponse for aurora even when the characteristic is not writable without response', async () => {
+      const characteristic = {
+        uuid: 'uart-write-uuid',
+        isWritableWithoutResponse: false,
+        writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+        writeWithResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      const characteristicsForService = vi.fn().mockResolvedValue([characteristic]);
+      const adapter = setupConnectableAdapter('aurora', 'aurora-no-response-prop', characteristicsForService);
+      await adapter.requestAndConnect();
+
+      const data = new Uint8Array([0x01]);
+      vi.mocked(splitMessages).mockReturnValue([data]);
+      await adapter.write(data);
+
+      // Family gate wins over the characteristic's reported property.
+      expect(characteristic.writeWithoutResponse).toHaveBeenCalledOnce();
+      expect(characteristic.writeWithResponse).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('@boardsesh/ble-protocol', () => ({
   AURORA_ADVERTISED_SERVICE_UUID: 'AURORA-UUID',
   UART_SERVICE_UUID: 'UART-UUID',
+  REDBEARLAB_SERVICE_UUID: 'REDBEARLAB-UUID',
   parseSerialNumber: (name?: string) => name?.match(/#([^@]+)/)?.[1] ?? undefined,
 }));
 
@@ -456,5 +457,30 @@ describe('NativeIosBleAdapter on newer binaries (adoption surface present)', () 
     await vi.runAllTimersAsync();
     await connectPromise;
     expect(nativeMock.connect).toHaveBeenCalledWith('aurora-1');
+  });
+});
+
+describe('NativeIosBleAdapter on older binaries (no adoption surface)', () => {
+  beforeEach(() => {
+    // Older native binary: getConnectedDevice absent → no unfiltered scan, so
+    // MoonBoard must filter on BOTH controller generations.
+    delete (nativeMock as Record<string, unknown>).getConnectedDevice;
+  });
+
+  it('filters a MoonBoard scan on both the UART and RedBearLab services', async () => {
+    const adapter = new NativeIosBleAdapter(
+      (subscribe) =>
+        new Promise<string>(() => {
+          subscribe(() => {});
+        }),
+      'moonboard',
+    );
+    void adapter.requestAndConnect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Original RedBearLab MoonBoards advertise their own service, newer ones the
+    // Nordic UART service — without an unfiltered scan we must list both.
+    expect(nativeMock.startScan).toHaveBeenCalledWith(['UART-UUID', 'REDBEARLAB-UUID']);
   });
 });

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -3,6 +3,8 @@ import {
   AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
   UART_WRITE_CHARACTERISTIC_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
   splitMessages,
   INTER_CHUNK_DELAY_MS,
   parseSerialNumber,
@@ -17,6 +19,26 @@ import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-proto
 const CONNECTION_TIMEOUT_MS = 12_000;
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Find a write characteristic by service + characteristic UUID, returning
+ * undefined when the service isn't present (react-native-ble-plx throws for an
+ * absent service) so callers can fall back to another controller generation.
+ */
+async function findWriteCharacteristic(
+  device: Device,
+  serviceUuid: string,
+  characteristicUuid: string,
+): Promise<Characteristic | undefined> {
+  try {
+    const characteristics = await device.characteristicsForService(serviceUuid);
+    return characteristics.find(
+      (characteristic) => characteristic.uuid.toLowerCase() === characteristicUuid.toLowerCase(),
+    );
+  } catch {
+    return undefined;
+  }
+}
 
 export class RNBleAdapter implements BluetoothAdapter {
   private connectedDevice: Device | null = null;
@@ -188,18 +210,29 @@ export class RNBleAdapter implements BluetoothAdapter {
 
     const deviceWithServices = await connected.discoverAllServicesAndCharacteristics();
 
-    const characteristics = await deviceWithServices.characteristicsForService(UART_SERVICE_UUID);
-    const uartWrite = characteristics.find(
-      (characteristic) => characteristic.uuid.toLowerCase() === UART_WRITE_CHARACTERISTIC_UUID.toLowerCase(),
+    // Newer controllers expose the write characteristic on the Nordic UART
+    // service. The original MoonBoard (RedBearLab) LED box uses a different
+    // service, so fall back to it for the moonboard family.
+    let writeCharacteristic = await findWriteCharacteristic(
+      deviceWithServices,
+      UART_SERVICE_UUID,
+      UART_WRITE_CHARACTERISTIC_UUID,
     );
+    if (!writeCharacteristic && this.scanFamily === 'moonboard') {
+      writeCharacteristic = await findWriteCharacteristic(
+        deviceWithServices,
+        REDBEARLAB_SERVICE_UUID,
+        REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
+      );
+    }
 
-    if (!uartWrite) {
+    if (!writeCharacteristic) {
       await bleManager.cancelDeviceConnection(selectedDeviceId);
       throw new Error('UART write characteristic not found');
     }
 
     this.connectedDevice = deviceWithServices;
-    this.writeCharacteristic = uartWrite;
+    this.writeCharacteristic = writeCharacteristic;
 
     this.disconnectSubscription = bleManager.onDeviceDisconnected(selectedDeviceId, (_error, _device) => {
       this.connectedDevice = null;
@@ -262,8 +295,21 @@ export class RNBleAdapter implements BluetoothAdapter {
       const chunk = chunks[chunkIndex];
       const base64Chunk = uint8ArrayToBase64(chunk);
 
+      // Aurora boards always use write-without-response (proven path; on some
+      // iOS versions the characteristic under-reports the property but still
+      // needs no-response). Only the original MoonBoard (RedBearLab) write
+      // characteristic — which advertises `.write` only — falls back to
+      // write-with-response, mirroring the native preferredWriteType gating.
+      // Android sends no-response writes regardless, so this only matters on
+      // Expo Go iOS.
+      const useWithoutResponse = this.scanFamily !== 'moonboard' || (characteristic.isWritableWithoutResponse ?? true);
+
       try {
-        await characteristic.writeWithoutResponse(base64Chunk);
+        if (useWithoutResponse) {
+          await characteristic.writeWithoutResponse(base64Chunk);
+        } else {
+          await characteristic.writeWithResponse(base64Chunk);
+        }
       } catch (error) {
         // react-native-ble-plx surfaces a mid-write drop as a BleError whose
         // message (e.g. CharacteristicWriteFailed — "Characteristic … write

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -1,4 +1,9 @@
-import { AURORA_ADVERTISED_SERVICE_UUID, UART_SERVICE_UUID, parseSerialNumber } from '@boardsesh/ble-protocol';
+import {
+  AURORA_ADVERTISED_SERVICE_UUID,
+  UART_SERVICE_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  parseSerialNumber,
+} from '@boardsesh/ble-protocol';
 import {
   boardBleNative,
   type NativeBleConfigureBoardOptions,
@@ -142,7 +147,10 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
           ? [AURORA_ADVERTISED_SERVICE_UUID]
           : supportsUnfilteredScan
             ? []
-            : [UART_SERVICE_UUID];
+            : // MoonBoard spans two controller generations: newer boards
+              // advertise Nordic UART, the original RedBearLab box its own
+              // service. Filter on both when an unfiltered scan isn't available.
+              [UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID];
       await native.startScan(scanServiceUuids);
 
       // Grace window: if the stored serial hasn't matched shortly, open the

--- a/packages/shared/ble-protocol/src/__tests__/aurora-spec.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/aurora-spec.test.ts
@@ -1,0 +1,593 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checksum,
+  wrapBytes,
+  encodePositionV3,
+  encodeColorV3,
+  encodePositionAndColorV3,
+  encodePositionAndColorV2,
+  scaledColorV2,
+  computeV2Scale,
+  getAuroraBluetoothPacket,
+} from '../aurora';
+import { splitMessages } from '../transport';
+
+/**
+ * Comprehensive Aurora BLE protocol tests for the CANONICAL encoder
+ * (`@boardsesh/ble-protocol`, consumed directly by the React Native app).
+ *
+ * Validated against:
+ * - docs/AURORA_BLUETOOTH_PROTOCOL_SPEC.md (Kilter Board Android App v3.6.4)
+ * - Byte-exact payloads captured from Aurora's official Kilter app
+ * - 3rd-party validated payloads for Kilter Original boards
+ *
+ * The web package has an equivalent suite that exercises the same functions via
+ * its re-export wrapper; this one pins the shared package itself so a future
+ * refactor can't regress the encoder the mobile app ships. Spec sections are
+ * referenced in comments (e.g. "§6" = Section 6 of the spec).
+ */
+
+// ---- Test helpers ----
+
+function toHex(data: Uint8Array | number[]): string {
+  return Array.from(data)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Decode v3 LED data (3 bytes per LED) from a single framed packet. */
+function decodeLedPositionsV3(input: Uint8Array | string): { position: number; color: number }[] {
+  const bytes =
+    typeof input === 'string'
+      ? Array.from({ length: input.length / 2 }, (_, i) => parseInt(input.substring(i * 2, i * 2 + 2), 16))
+      : Array.from(input);
+  // SOH(1) Length(1) Checksum(1) STX(1) Command(1) ...ledData... ETX(1)
+  const ledData = bytes.slice(5, -1);
+  const leds: { position: number; color: number }[] = [];
+  for (let i = 0; i < ledData.length; i += 3) {
+    leds.push({ position: ledData[i] | (ledData[i + 1] << 8), color: ledData[i + 2] });
+  }
+  return leds;
+}
+
+/** Parse concatenated framed data into individual frames (command byte + payload length). */
+function parseFrames(packet: Uint8Array): { commandByte: number; payloadLength: number }[] {
+  const bytes = Array.from(packet);
+  const frames: { commandByte: number; payloadLength: number }[] = [];
+  let i = 0;
+  while (i < bytes.length) {
+    if (bytes[i] !== 0x01) break; // not a valid frame start
+    const payloadLen = bytes[i + 1];
+    const cmdByte = bytes[i + 4]; // SOH(1)+LEN(1)+CHK(1)+STX(1) → index 4
+    frames.push({ commandByte: cmdByte, payloadLength: payloadLen });
+    i += payloadLen + 5; // header(4) + payload + ETX(1)
+  }
+  return frames;
+}
+
+/** Decode ALL v2 LEDs from a multi-frame packet. */
+function decodeAllV2Leds(packet: Uint8Array): { position: number; colorByte: number }[] {
+  const bytes = Array.from(packet);
+  const leds: { position: number; colorByte: number }[] = [];
+  let i = 0;
+  while (i < bytes.length) {
+    if (bytes[i] !== 0x01) break;
+    const payloadLen = bytes[i + 1];
+    const ledStart = i + 5;
+    const ledEnd = i + 4 + payloadLen;
+    for (let j = ledStart; j < ledEnd; j += 2) {
+      const posLo = bytes[j];
+      const byte2 = bytes[j + 1];
+      leds.push({ position: posLo | ((byte2 & 0x03) << 8), colorByte: byte2 });
+    }
+    i += payloadLen + 5;
+  }
+  return leds;
+}
+
+/** Decode ALL v3 LEDs from a multi-frame packet. */
+function decodeAllV3Leds(packet: Uint8Array): { position: number; color: number }[] {
+  const bytes = Array.from(packet);
+  const leds: { position: number; color: number }[] = [];
+  let i = 0;
+  while (i < bytes.length) {
+    if (bytes[i] !== 0x01) break;
+    const payloadLen = bytes[i + 1];
+    const ledStart = i + 5;
+    const ledEnd = i + 4 + payloadLen;
+    for (let j = ledStart; j < ledEnd; j += 3) {
+      leds.push({ position: bytes[j] | (bytes[j + 1] << 8), color: bytes[j + 2] });
+    }
+    i += payloadLen + 5;
+  }
+  return leds;
+}
+
+// =============================================================================
+// §6 — Message Framing Protocol
+// =============================================================================
+
+describe('§6 Message Framing Protocol', () => {
+  describe('checksum (bitwise NOT of 8-bit sum)', () => {
+    it('matches spec Example 1 payload', () => {
+      // sum([0x54,0x2A,0x00,0x1C]) & 0xFF = 0x9A; ~0x9A & 0xFF = 0x65
+      expect(checksum([0x54, 0x2a, 0x00, 0x1c])).toBe(0x65);
+    });
+
+    it('handles single bytes', () => {
+      expect(checksum([0x00])).toBe(0xff);
+      expect(checksum([0xff])).toBe(0x00);
+    });
+
+    it('wraps on overflow', () => {
+      // 0x80 + 0x80 = 0x100 & 0xFF = 0x00; ~0x00 & 0xFF = 0xFF
+      expect(checksum([0x80, 0x80])).toBe(0xff);
+    });
+
+    it('matches the byte-exact validated 12x12 payload checksum (0xBB)', () => {
+      const payload = [0x54, 0x44, 0x00, 0xe3, 0xdc, 0x01, 0xe3, 0x00, 0x00, 0xf4, 0x21, 0x00, 0xf4];
+      expect(wrapBytes(payload)[2]).toBe(0xbb);
+    });
+  });
+
+  describe('wrapBytes (SOH/LEN/CHK/STX/PAYLOAD/ETX)', () => {
+    it('produces the correct frame for spec Example 1 payload', () => {
+      const payload = [0x54, 0x2a, 0x00, 0x1c];
+      const frame = wrapBytes(payload);
+      expect(frame[0]).toBe(0x01); // SOH
+      expect(frame[1]).toBe(4); // LEN = payload length
+      expect(frame[2]).toBe(0x65); // CHK
+      expect(frame[3]).toBe(0x02); // STX
+      expect(frame.slice(4, 8)).toEqual(payload);
+      expect(frame[8]).toBe(0x03); // ETX
+    });
+
+    it('total frame size = payload_length + 5', () => {
+      expect(wrapBytes([1, 2, 3, 4, 5]).length).toBe(10);
+    });
+
+    it('returns empty array when payload exceeds 255 bytes', () => {
+      expect(wrapBytes(new Array(256).fill(0))).toEqual([]);
+    });
+
+    it('accepts exactly 255 bytes (max payload)', () => {
+      const frame = wrapBytes(new Array(255).fill(0));
+      expect(frame.length).toBe(260);
+      expect(frame[1]).toBe(255);
+    });
+
+    it('handles an empty payload', () => {
+      expect(wrapBytes([])).toEqual([0x01, 0x00, 0xff, 0x02, 0x03]);
+    });
+  });
+});
+
+// =============================================================================
+// §7.2 — API v3 Encoding (3 bytes per LED)
+// =============================================================================
+
+describe('§7.2 API v3 Encoding', () => {
+  describe('encodePositionV3 (16-bit little-endian)', () => {
+    it.each([
+      [0, [0x00, 0x00]],
+      [42, [0x2a, 0x00]],
+      [256, [0x00, 0x01]],
+      [389, [0x85, 0x01]], // Kilter 8x12 max range
+      [527, [0x0f, 0x02]], // Kilter 12x14 max
+      [65535, [0xff, 0xff]], // 16-bit max
+    ])('encodes position %i', (position, expected) => {
+      expect(encodePositionV3(position)).toEqual(expected);
+    });
+  });
+
+  describe('encodeColorV3 (3:3:2 RGB)', () => {
+    it.each([
+      ['00FF00', 0x1c], // green: G=7<<2
+      ['FF0000', 0xe0], // red: R=7<<5
+      ['0000FF', 0x03], // blue: B=3
+      ['FFFFFF', 0xff], // white: R=7,G=7,B=3
+      ['000000', 0x00], // black
+      ['FF00FF', 0xe3], // magenta
+      ['FFAA00', 0xf4], // orange: R=7<<5, G=5<<2
+    ])('encodes "%s" -> 0x%s', (color, expected) => {
+      expect(encodeColorV3(color)).toBe(expected);
+    });
+  });
+
+  describe('encodePositionAndColorV3', () => {
+    it('produces 3 bytes per LED', () => {
+      expect(encodePositionAndColorV3(42, '00FF00')).toHaveLength(3);
+    });
+
+    it('matches spec Example 1: position=42, color="00FF00"', () => {
+      expect(encodePositionAndColorV3(42, '00FF00')).toEqual([0x2a, 0x00, 0x1c]);
+    });
+
+    it('max LEDs per v3 frame = 84 (254 / 3)', () => {
+      expect(Math.floor(254 / 3)).toBe(84);
+    });
+  });
+});
+
+// =============================================================================
+// §7.1 — API v2 Encoding (2 bytes per LED)
+// =============================================================================
+
+describe('§7.1 API v2 Encoding', () => {
+  describe('scaledColorV2', () => {
+    it.each([
+      [0xff, 1.0, 3],
+      [0x00, 1.0, 0],
+      [0x00, 0.5, 0],
+      [0xff, 0.5, 1], // floor(127.5) >> 6 = 1
+      [0xff, 0.1, 0], // floor(25.5) >> 6 = 0
+    ])('scales 0x%s at %f -> %i', (value, scale, expected) => {
+      expect(scaledColorV2(value, scale)).toBe(expected);
+    });
+
+    it('is always a 2-bit value (0-3)', () => {
+      expect(scaledColorV2(0xff, 1.0)).toBeLessThanOrEqual(3);
+      expect(scaledColorV2(0xff, 1.0)).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('encodePositionAndColorV2', () => {
+    it('produces 2 bytes per LED', () => {
+      expect(encodePositionAndColorV2(10, '00FF00', 1.0)).toHaveLength(2);
+    });
+
+    it('matches spec Example 2 LED 1: pos=10, "00FF00", scale=1.0', () => {
+      // color_byte = (0<<6)|(3<<4)|(0<<2)|0x00 = 0x30
+      expect(encodePositionAndColorV2(10, '00FF00', 1.0)).toEqual([0x0a, 0x30]);
+    });
+
+    it('matches spec Example 2 LED 2: pos=256, "0000FF", scale=1.0', () => {
+      // color_byte = (0<<6)|(0<<4)|(3<<2)|0x01 = 0x0D
+      expect(encodePositionAndColorV2(256, '0000FF', 1.0)).toEqual([0x00, 0x0d]);
+    });
+
+    it('matches spec Example 2 LED 3: pos=500, "FF0000", scale=1.0', () => {
+      // color_byte = (3<<6)|(0<<4)|(0<<2)|0x01 = 0xC1
+      expect(encodePositionAndColorV2(500, 'FF0000', 1.0)).toEqual([0xf4, 0xc1]);
+    });
+
+    it('packs position bits [9:8] into color byte bits [1:0]', () => {
+      expect(encodePositionAndColorV2(768, '000000', 1.0)[1] & 0x03).toBe(3); // 0x300
+    });
+
+    it('returns empty array for position > 1023 (10-bit limit)', () => {
+      expect(encodePositionAndColorV2(1024, 'FF0000', 1.0)).toEqual([]);
+    });
+
+    it('encodes position 1023 (10-bit max)', () => {
+      const result = encodePositionAndColorV2(1023, '000000', 1.0);
+      expect(result[0] | ((result[1] & 0x03) << 8)).toBe(1023);
+    });
+
+    it('applies the power scale to colors', () => {
+      const full = encodePositionAndColorV2(0, 'FF0000', 1.0);
+      const half = encodePositionAndColorV2(0, 'FF0000', 0.5);
+      expect((full[1] >> 6) & 0x03).toBe(3); // R=3
+      expect((half[1] >> 6) & 0x03).toBe(1); // R=1
+    });
+
+    it('max LEDs per v2 frame = 127 (254 / 2)', () => {
+      expect(Math.floor(254 / 2)).toBe(127);
+    });
+  });
+});
+
+// =============================================================================
+// §10 — Power Management (v2 only)
+// =============================================================================
+
+describe('§10 Power Management (v2)', () => {
+  it('returns 1.0 for a small number of LEDs', () => {
+    expect(computeV2Scale([{ position: 0, color: 'FF0000' }], 1)).toBe(1.0);
+  });
+
+  it('scales down when total power exceeds the 18W budget', () => {
+    const leds = Array.from({ length: 40 }, (_, i) => ({ position: i, color: 'FFFFFF' }));
+    const scale = computeV2Scale(leds, 2); // Kilter
+    expect(scale).toBeLessThan(1.0);
+    expect(scale).toBeGreaterThan(0);
+  });
+
+  it('Kilter (ledsPerHold=2) scales down at least as hard as Tension (ledsPerHold=1)', () => {
+    const leds = Array.from({ length: 40 }, (_, i) => ({ position: i, color: 'FFFFFF' }));
+    expect(computeV2Scale(leds, 2)).toBeLessThanOrEqual(computeV2Scale(leds, 1));
+  });
+
+  it('only ever returns a value from the spec progression', () => {
+    const leds = Array.from({ length: 200 }, (_, i) => ({ position: i, color: 'FFFFFF' }));
+    expect([1.0, 0.8, 0.6, 0.4, 0.2, 0.1, 0.05, 0]).toContain(computeV2Scale(leds, 2));
+  });
+
+  it('black LEDs always fit at scale 1.0', () => {
+    const leds = Array.from({ length: 500 }, (_, i) => ({ position: i, color: '000000' }));
+    expect(computeV2Scale(leds, 2)).toBe(1.0);
+  });
+
+  it('power per LED = (r+g+b)/30 at the budget boundary', () => {
+    // white LED at scale 1.0: R=G=B=3 → 0.3W. 59 LEDs * 0.3 = 17.7W ≤ 18W → 1.0
+    const leds59 = Array.from({ length: 59 }, (_, i) => ({ position: i, color: 'FFFFFF' }));
+    expect(computeV2Scale(leds59, 1)).toBe(1.0);
+    // 61 LEDs * 0.3 = 18.3W > 18W; scale 0.8 still floors to 3, so it drops to 0.6
+    const leds61 = Array.from({ length: 61 }, (_, i) => ({ position: i, color: 'FFFFFF' }));
+    expect(computeV2Scale(leds61, 1)).toBe(0.6);
+  });
+});
+
+// =============================================================================
+// §8 — Multi-Part Message Sequencing
+// =============================================================================
+
+describe('§8 Multi-Part Message Sequencing', () => {
+  it('v3 single-frame uses T (84)', () => {
+    const frames = parseFrames(getAuroraBluetoothPacket('p1r42', { 1: 10 }, 'kilter', 3).packet);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].commandByte).toBe(84);
+  });
+
+  it('v3 multi-frame uses R/Q/S (82/81/83)', () => {
+    const positions: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 100; i++) {
+      positions[i] = i;
+      frames += `p${i}r42`;
+    }
+    const parsed = parseFrames(getAuroraBluetoothPacket(frames, positions, 'kilter', 3).packet);
+    expect(parsed.length).toBeGreaterThan(1);
+    expect(parsed[0].commandByte).toBe(82); // R = Start
+    expect(parsed[parsed.length - 1].commandByte).toBe(83); // S = End
+    for (let i = 1; i < parsed.length - 1; i++) expect(parsed[i].commandByte).toBe(81); // Q
+  });
+
+  it('v2 single-frame uses P (80)', () => {
+    const frames = parseFrames(getAuroraBluetoothPacket('p1r42', { 1: 10 }, 'kilter', 2).packet);
+    expect(frames[0].commandByte).toBe(80);
+  });
+
+  it('v2 multi-frame uses N/M/O (78/77/79)', () => {
+    const positions: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 200; i++) {
+      positions[i] = i;
+      frames += `p${i}r42`;
+    }
+    const parsed = parseFrames(getAuroraBluetoothPacket(frames, positions, 'kilter', 2).packet);
+    expect(parsed.length).toBeGreaterThan(1);
+    expect(parsed[0].commandByte).toBe(78); // N
+    expect(parsed[parsed.length - 1].commandByte).toBe(79); // O
+    for (let i = 1; i < parsed.length - 1; i++) expect(parsed[i].commandByte).toBe(77); // M
+  });
+
+  it('no frame payload exceeds 255 bytes', () => {
+    const positions: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 300; i++) {
+      positions[i] = i;
+      frames += `p${i}r42`;
+    }
+    const parsed = parseFrames(getAuroraBluetoothPacket(frames, positions, 'kilter', 3).packet);
+    for (const frame of parsed) expect(frame.payloadLength).toBeLessThanOrEqual(255);
+  });
+
+  it('all LEDs survive multi-frame splitting (v3, no data loss)', () => {
+    const positions: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 200; i++) {
+      positions[i] = i;
+      frames += `p${i}r42`;
+    }
+    const leds = decodeAllV3Leds(getAuroraBluetoothPacket(frames, positions, 'kilter', 3).packet);
+    expect(leds.map((l) => l.position).sort((a, b) => a - b)).toEqual(Array.from({ length: 200 }, (_, i) => i));
+  });
+
+  it('all LEDs survive multi-frame splitting (v2, no data loss)', () => {
+    const positions: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 200; i++) {
+      positions[i] = i;
+      frames += `p${i}r42`;
+    }
+    const leds = decodeAllV2Leds(getAuroraBluetoothPacket(frames, positions, 'kilter', 2).packet);
+    expect(leds.map((l) => l.position).sort((a, b) => a - b)).toEqual(Array.from({ length: 200 }, (_, i) => i));
+  });
+});
+
+// =============================================================================
+// §7.5 — Empty-frames "clear all" packet
+// =============================================================================
+
+describe('clear-all packet (empty frames)', () => {
+  it('emits a single ONLY-command frame with no LED data on v3', () => {
+    const parsed = parseFrames(getAuroraBluetoothPacket('', {}, 'kilter', 3).packet);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].commandByte).toBe(84); // T
+    expect(parsed[0].payloadLength).toBe(1); // command byte only
+  });
+
+  it('emits a single ONLY-command frame on v2 (P)', () => {
+    const parsed = parseFrames(getAuroraBluetoothPacket('', {}, 'kilter', 2).packet);
+    expect(parsed[0].commandByte).toBe(80);
+    expect(parsed[0].payloadLength).toBe(1);
+  });
+
+  it('does not take the clear path when all placements are skipped', () => {
+    const result = getAuroraBluetoothPacket('p999r42', {}, 'kilter', 3);
+    expect(result.packet.length).toBe(0); // not a clear — a render miss
+    expect(result.skippedPositionCount).toBe(1);
+  });
+});
+
+// =============================================================================
+// §17 — Worked Examples (byte-exact)
+// =============================================================================
+
+describe('§17 Worked Examples', () => {
+  it('Example 1: single LED v3, position=42, color="00FF00"', () => {
+    const payload = [0x54, ...encodePositionAndColorV3(42, '00FF00')];
+    expect(payload).toEqual([0x54, 0x2a, 0x00, 0x1c]);
+    expect(checksum(payload)).toBe(0x65);
+    expect(toHex(wrapBytes(payload))).toBe('01046502542a001c03');
+  });
+
+  it('Example 2: three LEDs v2, scale=1.0 (corrected checksum 0xB3)', () => {
+    const led1 = encodePositionAndColorV2(10, '00FF00', 1.0);
+    const led2 = encodePositionAndColorV2(256, '0000FF', 1.0);
+    const led3 = encodePositionAndColorV2(500, 'FF0000', 1.0);
+    expect(led1).toEqual([0x0a, 0x30]);
+    expect(led2).toEqual([0x00, 0x0d]);
+    expect(led3).toEqual([0xf4, 0xc1]);
+
+    const payload = [0x50, ...led1, ...led2, ...led3];
+    expect(payload).toEqual([0x50, 0x0a, 0x30, 0x00, 0x0d, 0xf4, 0xc1]);
+    // The spec doc originally mis-stated this checksum as 0xA9; the real value
+    // (and the one the hardware accepts) is 0xB3 = ~(0x4C).
+    expect(checksum(payload)).toBe(0xb3);
+    expect(toHex(wrapBytes(payload))).toBe('0107b302500a30000df4c103');
+  });
+});
+
+// =============================================================================
+// API-level selection
+// =============================================================================
+
+describe('getAuroraBluetoothPacket — API level selection', () => {
+  const positions: Record<number, number> = { 1: 10 };
+
+  it('defaults to v3 encoding when apiLevel is omitted', () => {
+    const frames = parseFrames(getAuroraBluetoothPacket('p1r42', positions, 'kilter').packet);
+    expect(frames[0].commandByte).toBe(84); // T
+  });
+
+  it('uses v3 for apiLevel=3 (3 bytes/LED)', () => {
+    const bytes = Array.from(getAuroraBluetoothPacket('p1r42', positions, 'kilter', 3).packet);
+    expect(bytes[1]).toBe(4); // cmd + 3-byte LED
+    expect(bytes[4]).toBe(84);
+  });
+
+  it('uses v2 for apiLevel=2 (2 bytes/LED)', () => {
+    const bytes = Array.from(getAuroraBluetoothPacket('p1r42', positions, 'kilter', 2).packet);
+    expect(bytes[1]).toBe(3); // cmd + 2-byte LED
+    expect(bytes[4]).toBe(80);
+  });
+
+  it('uses v2 for apiLevel=1', () => {
+    const frames = parseFrames(getAuroraBluetoothPacket('p1r42', positions, 'kilter', 1).packet);
+    expect(frames[0].commandByte).toBe(80);
+  });
+});
+
+// =============================================================================
+// v2 10-bit position skipping
+// =============================================================================
+
+describe('getAuroraBluetoothPacket — v2 position limits', () => {
+  it('skips v2 positions over the 10-bit limit rather than throwing', () => {
+    const result = getAuroraBluetoothPacket('p1r42p2r42', { 1: 39, 2: 1024 }, 'kilter', 2);
+    expect(result.skippedPositionCount).toBe(1);
+    expect(result.totalPlacements).toBe(2);
+    expect(result.packet.length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty packet when every v2 position exceeds the limit', () => {
+    const result = getAuroraBluetoothPacket('p1r42p2r42', { 1: 1024, 2: 2000 }, 'kilter', 2);
+    expect(result.skippedPositionCount).toBe(2);
+    expect(result.packet.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// Color overrides (sanitization parity with the Swift encoder)
+// =============================================================================
+
+describe('getAuroraBluetoothPacket — color overrides', () => {
+  it('honours a valid 6-digit hex override', () => {
+    const result = getAuroraBluetoothPacket('p100r12', { 100: 5 }, 'kilter', 3, { STARTING: '#FF0000' });
+    expect(result.packet).toEqual(Uint8Array.from(wrapBytes([84, 5, 0, 224])));
+  });
+
+  it('ignores a malformed override and falls back to the canonical color', () => {
+    const positions = { 100: 5 };
+    const canonical = getAuroraBluetoothPacket('p100r12', positions, 'kilter', 3);
+    for (const bad of ['#fff', 'red', '#FF00FF00', '12345g']) {
+      expect(getAuroraBluetoothPacket('p100r12', positions, 'kilter', 3, { STARTING: bad }).packet).toEqual(
+        canonical.packet,
+      );
+    }
+  });
+});
+
+// =============================================================================
+// Byte-exact captured Aurora payloads (ground truth from the official app)
+// =============================================================================
+
+const AURORA_8x12_HEX = '01134002542700e38501e31400f41300f40100f40000f403';
+const AURORA_10x12_HEX = '0113e202545000e3ae01e30400f40300f41700f41600f403';
+const CLIMB_FRAMES = 'p4131r42p4421r42p4669r45p4655r45p4665r45p4678r45';
+const CORRECT_8x12_POSITIONS: Record<number, number> = { 4131: 39, 4421: 389, 4669: 20, 4655: 19, 4665: 1, 4678: 0 };
+const CORRECT_10x12_POSITIONS: Record<number, number> = { 4131: 80, 4421: 430, 4669: 4, 4655: 3, 4665: 23, 4678: 22 };
+
+describe('Captured Aurora payloads — position verification', () => {
+  it('Kilter 10x12 Full Ride positions match the Aurora app', () => {
+    const ours = decodeLedPositionsV3(getAuroraBluetoothPacket(CLIMB_FRAMES, CORRECT_10x12_POSITIONS, 'kilter').packet);
+    expect(ours.map((l) => l.position)).toEqual(decodeLedPositionsV3(AURORA_10x12_HEX).map((l) => l.position));
+  });
+
+  it('Kilter 8x12 Full Ride positions match the Aurora app', () => {
+    const ours = decodeLedPositionsV3(getAuroraBluetoothPacket(CLIMB_FRAMES, CORRECT_8x12_POSITIONS, 'kilter').packet);
+    expect(ours.map((l) => l.position)).toEqual(decodeLedPositionsV3(AURORA_8x12_HEX).map((l) => l.position));
+  });
+});
+
+// 3rd-party validated payloads for Kilter Original (Layout 1) — FULL byte-exact
+const VALIDATED_12x12_HEX = '010dbb02544400e3dc01e30000f42100f403';
+const VALIDATED_8x12_ORIGINAL_HEX = '010d7802543800e33701e30000f41500f403';
+const CORNERS_12x12_FRAMES = 'p1379r44p1395r44p1447r45p1464r45';
+const CORNERS_8x12_ORIGINAL_FRAMES = 'p1382r44p1392r44p1450r45p1461r45';
+const CORRECT_12x12_POSITIONS: Record<number, number> = { 1379: 68, 1395: 476, 1447: 0, 1464: 33 };
+const CORRECT_8x12_ORIGINAL_POSITIONS: Record<number, number> = { 1382: 56, 1392: 311, 1450: 0, 1461: 21 };
+
+describe('Kilter Original (Layout 1) — 3rd-party validated payloads (byte-exact)', () => {
+  it('12x12 full packet byte-exact match', () => {
+    const packet = getAuroraBluetoothPacket(CORNERS_12x12_FRAMES, CORRECT_12x12_POSITIONS, 'kilter').packet;
+    expect(toHex(packet)).toBe(VALIDATED_12x12_HEX);
+  });
+
+  it('8x12 Original full packet byte-exact match', () => {
+    const packet = getAuroraBluetoothPacket(
+      CORNERS_8x12_ORIGINAL_FRAMES,
+      CORRECT_8x12_ORIGINAL_POSITIONS,
+      'kilter',
+    ).packet;
+    expect(toHex(packet)).toBe(VALIDATED_8x12_ORIGINAL_HEX);
+  });
+});
+
+// =============================================================================
+// §9 — BLE Transmission chunking (protocol-agnostic)
+// =============================================================================
+
+describe('§9 BLE Transmission — splitMessages over a real packet', () => {
+  it('chunks a multi-frame packet into 20-byte segments that reassemble', () => {
+    const positions: Record<number, number> = {};
+    let frames = '';
+    for (let i = 0; i < 120; i++) {
+      positions[i] = i;
+      frames += `p${i}r42`;
+    }
+    const packet = getAuroraBluetoothPacket(frames, positions, 'kilter', 3).packet;
+    const chunks = splitMessages(packet);
+    expect(chunks.length).toBe(Math.ceil(packet.length / 20));
+    for (let i = 0; i < chunks.length - 1; i++) expect(chunks[i].length).toBe(20);
+    const reassembled = new Uint8Array(packet.length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      reassembled.set(chunk, offset);
+      offset += chunk.length;
+    }
+    expect(reassembled).toEqual(packet);
+  });
+});

--- a/packages/shared/ble-protocol/src/__tests__/aurora-spec.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/aurora-spec.test.ts
@@ -203,8 +203,20 @@ describe('§7.2 API v3 Encoding', () => {
       expect(encodePositionAndColorV3(42, '00FF00')).toEqual([0x2a, 0x00, 0x1c]);
     });
 
-    it('max LEDs per v3 frame = 84 (254 / 3)', () => {
-      expect(Math.floor(254 / 3)).toBe(84);
+    it('splits at 84 LEDs per v3 frame (the encoder, not arithmetic)', () => {
+      // 85 v3 LEDs (3 bytes each) overflow one 255-byte frame: 84 fit
+      // (1 cmd + 84*3 = 253), the 85th starts a second frame.
+      const positions: Record<number, number> = {};
+      let frames = '';
+      for (let i = 0; i < 85; i++) {
+        positions[i] = i;
+        frames += `p${i}r42`;
+      }
+      const packet = getAuroraBluetoothPacket(frames, positions, 'kilter', 3).packet;
+      const parsed = parseFrames(packet);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].payloadLength).toBe(1 + 84 * 3);
+      expect(decodeAllV3Leds(packet)).toHaveLength(85);
     });
   });
 });
@@ -271,8 +283,20 @@ describe('§7.1 API v2 Encoding', () => {
       expect((half[1] >> 6) & 0x03).toBe(1); // R=1
     });
 
-    it('max LEDs per v2 frame = 127 (254 / 2)', () => {
-      expect(Math.floor(254 / 2)).toBe(127);
+    it('splits at 127 LEDs per v2 frame (the encoder, not arithmetic)', () => {
+      // 128 v2 LEDs (2 bytes each): 127 fit (1 cmd + 127*2 = 255), the 128th
+      // starts a second frame.
+      const positions: Record<number, number> = {};
+      let frames = '';
+      for (let i = 0; i < 128; i++) {
+        positions[i] = i;
+        frames += `p${i}r42`;
+      }
+      const packet = getAuroraBluetoothPacket(frames, positions, 'kilter', 2).packet;
+      const parsed = parseFrames(packet);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].payloadLength).toBe(1 + 127 * 2);
+      expect(decodeAllV2Leds(packet)).toHaveLength(128);
     });
   });
 });
@@ -512,7 +536,9 @@ describe('getAuroraBluetoothPacket — color overrides', () => {
   it('ignores a malformed override and falls back to the canonical color', () => {
     const positions = { 100: 5 };
     const canonical = getAuroraBluetoothPacket('p100r12', positions, 'kilter', 3);
-    for (const bad of ['#fff', 'red', '#FF00FF00', '12345g']) {
+    // 'ab#cdef' (interior '#') must be rejected too — anchored pattern, parity
+    // with the Swift encoder which only strips a leading '#'.
+    for (const bad of ['#fff', 'red', '#FF00FF00', '12345g', 'ab#cdef']) {
       expect(getAuroraBluetoothPacket('p100r12', positions, 'kilter', 3, { STARTING: bad }).packet).toEqual(
         canonical.packet,
       );

--- a/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/moonboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getMoonboardSerialPosition, isMoonboardDeviceName, getMoonboardBluetoothPacket } from '../moonboard';
+import { splitMessages, MAX_BLUETOOTH_MESSAGE_SIZE } from '../transport';
 
 describe('getMoonboardSerialPosition', () => {
   it('returns correct position for hold 1 (first column, first row)', () => {
@@ -100,5 +101,70 @@ describe('getMoonboardBluetoothPacket', () => {
     expect(decoded).toBe('l#S0#');
     expect(result.skippedRoleCount).toBe(1);
     expect(result.totalPlacements).toBe(2);
+  });
+
+  it('maps all three wire markers (S/P/E)', () => {
+    // 42='S' start, 43='P' problem/intermediate, 44='E' end.
+    const result = getMoonboardBluetoothPacket('p1r42p2r43p198r44');
+    expect(new TextDecoder().decode(result.packet)).toBe('l#S0,P35,E197#');
+  });
+});
+
+// =============================================================================
+// §5.3 — Serpentine LED numbering (full wiring verification)
+// =============================================================================
+
+describe('getMoonboardSerialPosition — serpentine wiring (spec §5.3)', () => {
+  // Spec worked checks: holdId 1 → 0, 2 → 35, 12 → 1, 198 → 197.
+  it.each([
+    [1, 0],
+    [2, 35],
+    [11, 180], // col 10 (even, last column), row 0
+    [12, 1], // col 0, row 1
+    [13, 34], // col 1 (odd), row 1 → 18 + (17-1)
+    [23, 2], // col 0, row 2
+    [198, 197], // col 10 (even), row 17
+  ])('holdId %i → position %i', (holdId, position) => {
+    expect(getMoonboardSerialPosition(holdId)).toBe(position);
+  });
+
+  it('wires even column A bottom-to-top (ascending 0..17)', () => {
+    // Column A holds are holdId 1, 12, 23, … (every 11th). Even column → row order.
+    const columnA = Array.from({ length: 18 }, (_, row) => getMoonboardSerialPosition(1 + row * 11));
+    expect(columnA).toEqual(Array.from({ length: 18 }, (_, row) => row));
+  });
+
+  it('wires odd column B top-to-bottom (descending 35..18)', () => {
+    // Column B holds are holdId 2, 13, 24, …; odd column → reversed row order.
+    const columnB = Array.from({ length: 18 }, (_, row) => getMoonboardSerialPosition(2 + row * 11));
+    expect(columnB).toEqual(Array.from({ length: 18 }, (_, row) => 18 + (17 - row)));
+  });
+
+  it('covers the whole 0..197 range with no gaps or collisions', () => {
+    const positions = Array.from({ length: 198 }, (_, i) => getMoonboardSerialPosition(i + 1)).sort((a, b) => a - b);
+    expect(positions).toEqual(Array.from({ length: 198 }, (_, i) => i));
+  });
+});
+
+// =============================================================================
+// §5.4 — BLE chunking (transport detail, does not change the ASCII message)
+// =============================================================================
+
+describe('MoonBoard frame chunking', () => {
+  it('splits a long l#…# frame into 20-byte writes that reassemble to the frame', () => {
+    // Every column-A hold lit as a start hold → a frame well over 20 bytes.
+    const frames = Array.from({ length: 18 }, (_, row) => `p${1 + row * 11}r42`).join('');
+    const { packet } = getMoonboardBluetoothPacket(frames);
+    expect(packet.length).toBeGreaterThan(MAX_BLUETOOTH_MESSAGE_SIZE);
+
+    const chunks = splitMessages(packet);
+    expect(chunks.length).toBe(Math.ceil(packet.length / MAX_BLUETOOTH_MESSAGE_SIZE));
+    const reassembled = new Uint8Array(packet.length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      reassembled.set(chunk, offset);
+      offset += chunk.length;
+    }
+    expect(new TextDecoder().decode(reassembled)).toBe(new TextDecoder().decode(packet));
   });
 });

--- a/packages/shared/ble-protocol/src/__tests__/transport.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/transport.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { splitMessages, MAX_BLUETOOTH_MESSAGE_SIZE } from '../transport';
+import {
+  splitMessages,
+  MAX_BLUETOOTH_MESSAGE_SIZE,
+  AURORA_ADVERTISED_SERVICE_UUID,
+  UART_SERVICE_UUID,
+  UART_WRITE_CHARACTERISTIC_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
+} from '../transport';
+
+describe('BLE service/characteristic UUID constants', () => {
+  // These are the spec UUIDs (lowercased); changing one silently breaks
+  // scanning/discovery on every platform, so pin them exactly.
+  it('matches the documented Aurora + Nordic UART UUIDs', () => {
+    expect(AURORA_ADVERTISED_SERVICE_UUID).toBe('4488b571-7806-4df6-bcff-a2897e4953ff');
+    expect(UART_SERVICE_UUID).toBe('6e400001-b5a3-f393-e0a9-e50e24dcca9e');
+    expect(UART_WRITE_CHARACTERISTIC_UUID).toBe('6e400002-b5a3-f393-e0a9-e50e24dcca9e');
+  });
+
+  it('matches the documented original-MoonBoard (RedBearLab) UUIDs', () => {
+    // docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md §2.1.
+    expect(REDBEARLAB_SERVICE_UUID).toBe('713d0000-503e-4c75-ba94-3148f18d941e');
+    expect(REDBEARLAB_WRITE_CHARACTERISTIC_UUID).toBe('713d0003-503e-4c75-ba94-3148f18d941e');
+  });
+});
 
 describe('splitMessages', () => {
   it('splits a buffer larger than 20 bytes into chunks', () => {

--- a/packages/shared/ble-protocol/src/aurora.ts
+++ b/packages/shared/ble-protocol/src/aurora.ts
@@ -19,8 +19,10 @@ export type LedPlacements = Record<number, number>;
 export type LedColorOverrides = Partial<Record<HoldState, string>>;
 
 // The colour encoders parseInt fixed 2-char slices, so only exactly six hex
-// digits (after an optional leading '#') produce valid bytes.
-const SIX_DIGIT_HEX_PATTERN = /^[0-9a-fA-F]{6}$/;
+// digits with an optional LEADING '#' produce valid bytes. Anchored so an
+// interior '#' ("ab#cdef") is rejected — this keeps byte-for-byte parity with
+// the Swift `sanitizedOverride`, which only strips a leading '#'.
+const SIX_DIGIT_HEX_PATTERN = /^#?[0-9a-fA-F]{6}$/;
 
 // --- API v3 command bytes (3 bytes per LED, 16-bit positions) ---
 const V3_PACKET_MIDDLE = 81; // 'Q'
@@ -245,7 +247,7 @@ export const getAuroraBluetoothPacket = (
     // encoders and stream garbage to the wall. Fall back to the canonical
     // state colour instead of honouring a malformed override.
     const sanitizedOverride =
-      overrideForState && SIX_DIGIT_HEX_PATTERN.test(overrideForState.replace('#', '')) ? overrideForState : undefined;
+      overrideForState && SIX_DIGIT_HEX_PATTERN.test(overrideForState) ? overrideForState : undefined;
     const colorSource = sanitizedOverride ?? state.color;
     const color = colorSource.replace('#', '');
     ledEntries.push({ position: ledPosition, color });

--- a/packages/shared/ble-protocol/src/transport.ts
+++ b/packages/shared/ble-protocol/src/transport.ts
@@ -8,6 +8,15 @@ export const AURORA_ADVERTISED_SERVICE_UUID = '4488b571-7806-4df6-bcff-a2897e495
 export const UART_SERVICE_UUID = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 export const UART_WRITE_CHARACTERISTIC_UUID = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 
+// Original MoonBoard LED box (RedBearLab BLE Shield) — the first-generation
+// controller the official Moon app still drives. Its data service is the
+// RedBearLab UUID family and LED commands are written to 713d0003, which
+// advertises only `.write` (no write-without-response). Newer MoonBoard
+// controllers use the Nordic UART service above. See
+// docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md §2.1.
+export const REDBEARLAB_SERVICE_UUID = '713d0000-503e-4c75-ba94-3148f18d941e';
+export const REDBEARLAB_WRITE_CHARACTERISTIC_UUID = '713d0003-503e-4c75-ba94-3148f18d941e';
+
 export const INTER_CHUNK_DELAY_MS = 5;
 
 export const splitMessages = (buffer: Uint8Array) =>

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-moonboard.test.ts
@@ -1,7 +1,37 @@
 import { describe, expect, it, vi } from 'vite-plus/test';
 import { coordinateToHoldId } from '@/app/lib/moonboard-config';
-import { getMoonboardBluetoothPacket, getMoonboardSerialPosition } from '../bluetooth-moonboard';
-import { splitMessages } from '../bluetooth-shared';
+import {
+  getMoonboardBluetoothPacket,
+  getMoonboardSerialPosition,
+  MOONBOARD_REQUEST_DEVICE_OPTIONS,
+} from '../bluetooth-moonboard';
+import { splitMessages, REDBEARLAB_SERVICE_UUID, UART_SERVICE_UUID } from '../bluetooth-shared';
+
+describe('MOONBOARD_REQUEST_DEVICE_OPTIONS', () => {
+  // RequestDeviceOptions is a union without `filters` on the accept-all variant;
+  // narrow to the filter shape this constant actually uses.
+  const options = MOONBOARD_REQUEST_DEVICE_OPTIONS as {
+    filters?: Array<{ services?: string[]; namePrefix?: string }>;
+    optionalServices?: string[];
+  };
+
+  it('filters on each controller service SEPARATELY (OR), not both at once', () => {
+    // The filters are load-bearing: a single { services: [UART, RedBearLab] }
+    // entry would require a board to advertise BOTH (no real board does), so a
+    // per-service entry is required for any MoonBoard to appear in the chooser.
+    const serviceFilters = (options.filters ?? [])
+      .map((filter) => filter.services)
+      .filter((services): services is string[] => Array.isArray(services));
+    expect(serviceFilters).toContainEqual([UART_SERVICE_UUID]);
+    expect(serviceFilters).toContainEqual([REDBEARLAB_SERVICE_UUID]);
+    // No single filter lists both services together.
+    expect(serviceFilters).not.toContainEqual([UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID]);
+  });
+
+  it('lists both controller services in optionalServices so getPrimaryService can reach either', () => {
+    expect(options.optionalServices).toEqual(expect.arrayContaining([UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID]));
+  });
+});
 
 describe('getMoonboardSerialPosition', () => {
   it('maps representative holds to the controller strip order', () => {

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-shared.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-shared.test.ts
@@ -88,24 +88,36 @@ function makeWritableCharacteristic(writeWithoutResponse?: boolean) {
   };
 }
 
-describe('writeCharacteristicSeries (write-type gating)', () => {
-  it('uses write-without-response when the characteristic advertises it (Nordic UART path)', async () => {
-    const characteristic = makeWritableCharacteristic(true);
+describe('writeCharacteristicSeries (family-gated write-type)', () => {
+  const moonboard = { allowWithResponseFallback: true };
+
+  it('forces write-without-response for Aurora EVEN when the property reads false (invariant)', async () => {
+    // The critical Aurora invariant: never route Aurora to write-with-response,
+    // even if iOS under-reports the characteristic property (it stalls boards).
+    // No options / fallback disallowed → always without-response.
+    const characteristic = makeWritableCharacteristic(false);
     await writeCharacteristicSeries(characteristic, [new Uint8Array([1, 2, 3])]);
     expect(characteristic.writeValueWithoutResponse).toHaveBeenCalledTimes(1);
     expect(characteristic.writeValueWithResponse).not.toHaveBeenCalled();
   });
 
-  it('uses write-with-response when the characteristic lacks the no-response property (RedBearLab path)', async () => {
+  it('uses write-without-response for a Moonboard Nordic-UART characteristic', async () => {
+    const characteristic = makeWritableCharacteristic(true);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1, 2, 3])], undefined, moonboard);
+    expect(characteristic.writeValueWithoutResponse).toHaveBeenCalledTimes(1);
+    expect(characteristic.writeValueWithResponse).not.toHaveBeenCalled();
+  });
+
+  it('uses write-with-response for a Moonboard RedBearLab characteristic (no-response unsupported)', async () => {
     const characteristic = makeWritableCharacteristic(false);
-    await writeCharacteristicSeries(characteristic, [new Uint8Array([1, 2, 3])]);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1, 2, 3])], undefined, moonboard);
     expect(characteristic.writeValueWithResponse).toHaveBeenCalledTimes(1);
     expect(characteristic.writeValueWithoutResponse).not.toHaveBeenCalled();
   });
 
-  it('defaults to write-without-response when properties are unavailable', async () => {
+  it('defaults a Moonboard write to without-response when properties are unavailable', async () => {
     const characteristic = makeWritableCharacteristic(undefined);
-    await writeCharacteristicSeries(characteristic, [new Uint8Array([1])]);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1])], undefined, moonboard);
     expect(characteristic.writeValueWithoutResponse).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-shared.test.ts
+++ b/packages/web/app/components/board-bluetooth-control/__tests__/bluetooth-shared.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import {
+  getMoonboardWriteCharacteristic,
+  writeCharacteristicSeries,
+  UART_SERVICE_UUID,
+  UART_WRITE_CHARACTERISTIC_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
+} from '../bluetooth-shared';
+
+// Map of serviceUuid -> { characteristicUuid -> characteristic object }.
+type ServiceMap = Record<string, Record<string, object>>;
+
+function makeServer(serviceMap: ServiceMap) {
+  return {
+    getPrimaryService: vi.fn(async (uuid: string) => {
+      const characteristics = serviceMap[uuid];
+      if (!characteristics) throw new Error(`GATT service ${uuid} not found`);
+      return {
+        getCharacteristic: vi.fn(async (characteristicUuid: string) => {
+          const characteristic = characteristics[characteristicUuid];
+          if (!characteristic) throw new Error(`Characteristic ${characteristicUuid} not found`);
+          return characteristic;
+        }),
+      };
+    }),
+  };
+}
+
+function makeDevice(serviceMap: ServiceMap | 'no-gatt') {
+  if (serviceMap === 'no-gatt') {
+    return { gatt: undefined } as unknown as BluetoothDevice;
+  }
+  const server = makeServer(serviceMap);
+  return { gatt: { connect: vi.fn(async () => server) } } as unknown as BluetoothDevice;
+}
+
+const uartChar = { id: 'uart-write' };
+const redBearLabChar = { id: 'redbearlab-write' };
+
+describe('getMoonboardWriteCharacteristic (UART → RedBearLab fallback)', () => {
+  it('returns the Nordic UART write characteristic when present', async () => {
+    const device = makeDevice({ [UART_SERVICE_UUID]: { [UART_WRITE_CHARACTERISTIC_UUID]: uartChar } });
+    expect(await getMoonboardWriteCharacteristic(device)).toBe(uartChar);
+  });
+
+  it('falls back to the RedBearLab write characteristic when UART is absent', async () => {
+    const device = makeDevice({
+      [REDBEARLAB_SERVICE_UUID]: { [REDBEARLAB_WRITE_CHARACTERISTIC_UUID]: redBearLabChar },
+    });
+    expect(await getMoonboardWriteCharacteristic(device)).toBe(redBearLabChar);
+  });
+
+  it('prefers UART when both controller generations are present', async () => {
+    const device = makeDevice({
+      [UART_SERVICE_UUID]: { [UART_WRITE_CHARACTERISTIC_UUID]: uartChar },
+      [REDBEARLAB_SERVICE_UUID]: { [REDBEARLAB_WRITE_CHARACTERISTIC_UUID]: redBearLabChar },
+    });
+    expect(await getMoonboardWriteCharacteristic(device)).toBe(uartChar);
+  });
+
+  it('falls back to RedBearLab when the UART service exists but lacks its write characteristic', async () => {
+    const device = makeDevice({
+      [UART_SERVICE_UUID]: {},
+      [REDBEARLAB_SERVICE_UUID]: { [REDBEARLAB_WRITE_CHARACTERISTIC_UUID]: redBearLabChar },
+    });
+    expect(await getMoonboardWriteCharacteristic(device)).toBe(redBearLabChar);
+  });
+
+  it('returns undefined when neither controller generation is present', async () => {
+    const device = makeDevice({});
+    expect(await getMoonboardWriteCharacteristic(device)).toBeUndefined();
+  });
+
+  it('returns undefined when the device has no GATT server', async () => {
+    expect(await getMoonboardWriteCharacteristic(makeDevice('no-gatt'))).toBeUndefined();
+  });
+});
+
+function makeWritableCharacteristic(writeWithoutResponse?: boolean) {
+  return {
+    properties: writeWithoutResponse === undefined ? undefined : { writeWithoutResponse },
+    writeValueWithoutResponse: vi.fn().mockResolvedValue(undefined),
+    writeValueWithResponse: vi.fn().mockResolvedValue(undefined),
+  } as unknown as BluetoothRemoteGATTCharacteristic & {
+    writeValueWithoutResponse: ReturnType<typeof vi.fn>;
+    writeValueWithResponse: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('writeCharacteristicSeries (write-type gating)', () => {
+  it('uses write-without-response when the characteristic advertises it (Nordic UART path)', async () => {
+    const characteristic = makeWritableCharacteristic(true);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1, 2, 3])]);
+    expect(characteristic.writeValueWithoutResponse).toHaveBeenCalledTimes(1);
+    expect(characteristic.writeValueWithResponse).not.toHaveBeenCalled();
+  });
+
+  it('uses write-with-response when the characteristic lacks the no-response property (RedBearLab path)', async () => {
+    const characteristic = makeWritableCharacteristic(false);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1, 2, 3])]);
+    expect(characteristic.writeValueWithResponse).toHaveBeenCalledTimes(1);
+    expect(characteristic.writeValueWithoutResponse).not.toHaveBeenCalled();
+  });
+
+  it('defaults to write-without-response when properties are unavailable', async () => {
+    const characteristic = makeWritableCharacteristic(undefined);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1])]);
+    expect(characteristic.writeValueWithoutResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes every chunk in sequence', async () => {
+    const characteristic = makeWritableCharacteristic(true);
+    await writeCharacteristicSeries(characteristic, [new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])]);
+    expect(characteristic.writeValueWithoutResponse).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws AbortError when the signal is already aborted', async () => {
+    const characteristic = makeWritableCharacteristic(true);
+    const controller = new AbortController();
+    controller.abort();
+    await expect(writeCharacteristicSeries(characteristic, [new Uint8Array([1])], controller.signal)).rejects.toThrow(
+      'Write aborted',
+    );
+    expect(characteristic.writeValueWithoutResponse).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-moonboard.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-moonboard.ts
@@ -6,15 +6,19 @@ export {
   type MoonboardPacketResult,
 } from '@boardsesh/ble-protocol/moonboard';
 
-import { UART_SERVICE_UUID } from '@boardsesh/ble-protocol/transport';
+import { REDBEARLAB_SERVICE_UUID, UART_SERVICE_UUID } from '@boardsesh/ble-protocol/transport';
 import { MOONBOARD_DEVICE_NAME_PREFIXES } from '@boardsesh/board-constants/moonboard';
 
-export const MOONBOARD_SCAN_SERVICE_UUIDS = [UART_SERVICE_UUID] as const;
-export const MOONBOARD_OPTIONAL_SERVICE_UUIDS = [UART_SERVICE_UUID] as const;
+// Newer controllers advertise the Nordic UART service; the original RedBearLab
+// LED box advertises the RedBearLab service. List both so a board advertising
+// either is discoverable, and so getPrimaryService can reach either after
+// connect (Web Bluetooth blocks access to services not in optionalServices).
+export const MOONBOARD_SCAN_SERVICE_UUIDS = [UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID] as const;
+export const MOONBOARD_OPTIONAL_SERVICE_UUIDS = [UART_SERVICE_UUID, REDBEARLAB_SERVICE_UUID] as const;
 
 export const MOONBOARD_REQUEST_DEVICE_OPTIONS: RequestDeviceOptions = {
   filters: [
-    { services: [...MOONBOARD_SCAN_SERVICE_UUIDS] },
+    ...MOONBOARD_SCAN_SERVICE_UUIDS.map((service) => ({ services: [service] })),
     ...MOONBOARD_DEVICE_NAME_PREFIXES.map((namePrefix) => ({ namePrefix })),
   ],
   optionalServices: [...MOONBOARD_OPTIONAL_SERVICE_UUIDS],

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-shared.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-shared.ts
@@ -5,12 +5,16 @@ export {
   AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
   UART_WRITE_CHARACTERISTIC_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
   splitMessages,
 } from '@boardsesh/ble-protocol/transport';
 
 import {
   UART_SERVICE_UUID,
   UART_WRITE_CHARACTERISTIC_UUID,
+  REDBEARLAB_SERVICE_UUID,
+  REDBEARLAB_WRITE_CHARACTERISTIC_UUID,
   INTER_CHUNK_DELAY_MS,
 } from '@boardsesh/ble-protocol/transport';
 
@@ -23,6 +27,14 @@ export const writeCharacteristicSeries = async (
   messages: Uint8Array[],
   signal?: AbortSignal,
 ) => {
+  // The Nordic-UART RX characteristic supports write-without-response; the
+  // original MoonBoard (RedBearLab) write characteristic advertises only
+  // `.write`, and Web Bluetooth throws NotSupportedError if you call
+  // writeValueWithoutResponse on a characteristic that lacks the property. So
+  // pick the write method from the advertised property — mirrors the native
+  // `preferredWriteType` gating. Default to without-response when properties
+  // are unavailable to preserve the proven Aurora path.
+  const supportsWithoutResponse = characteristic.properties?.writeWithoutResponse ?? true;
   for (let i = 0; i < messages.length; i++) {
     if (signal?.aborted) {
       throw new DOMException('Write aborted', 'AbortError');
@@ -30,15 +42,48 @@ export const writeCharacteristicSeries = async (
     if (i > 0) {
       await delay(INTER_CHUNK_DELAY_MS);
     }
-    await characteristic.writeValueWithoutResponse(new Uint8Array(messages[i]));
+    const chunk = new Uint8Array(messages[i]);
+    if (supportsWithoutResponse) {
+      await characteristic.writeValueWithoutResponse(chunk);
+    } else {
+      await characteristic.writeValueWithResponse(chunk);
+    }
   }
 };
 
 export const requestBluetoothDevice = async (options: RequestDeviceOptions) =>
   navigator.bluetooth.requestDevice(options);
 
+const tryGetWriteCharacteristic = async (
+  server: BluetoothRemoteGATTServer,
+  serviceUuid: string,
+  characteristicUuid: string,
+): Promise<BluetoothRemoteGATTCharacteristic | undefined> => {
+  try {
+    const service = await server.getPrimaryService(serviceUuid);
+    return await service.getCharacteristic(characteristicUuid);
+  } catch {
+    // getPrimaryService / getCharacteristic reject when the service or
+    // characteristic isn't present — let the caller fall back to the next path.
+    return undefined;
+  }
+};
+
 export const getUartCharacteristic = async (device: BluetoothDevice) => {
   const server = await device.gatt?.connect();
   const service = await server?.getPrimaryService(UART_SERVICE_UUID);
   return await service?.getCharacteristic(UART_WRITE_CHARACTERISTIC_UUID);
+};
+
+/**
+ * Resolve the MoonBoard write characteristic, trying the newer Nordic-UART
+ * controller first and falling back to the original RedBearLab LED box. Returns
+ * undefined when neither generation exposes its write characteristic.
+ */
+export const getMoonboardWriteCharacteristic = async (device: BluetoothDevice) => {
+  const server = await device.gatt?.connect();
+  if (!server) return undefined;
+  const uart = await tryGetWriteCharacteristic(server, UART_SERVICE_UUID, UART_WRITE_CHARACTERISTIC_UUID);
+  if (uart) return uart;
+  return tryGetWriteCharacteristic(server, REDBEARLAB_SERVICE_UUID, REDBEARLAB_WRITE_CHARACTERISTIC_UUID);
 };

--- a/packages/web/app/components/board-bluetooth-control/bluetooth-shared.ts
+++ b/packages/web/app/components/board-bluetooth-control/bluetooth-shared.ts
@@ -26,15 +26,19 @@ export const writeCharacteristicSeries = async (
   characteristic: BluetoothRemoteGATTCharacteristic,
   messages: Uint8Array[],
   signal?: AbortSignal,
+  options?: { allowWithResponseFallback?: boolean },
 ) => {
-  // The Nordic-UART RX characteristic supports write-without-response; the
-  // original MoonBoard (RedBearLab) write characteristic advertises only
-  // `.write`, and Web Bluetooth throws NotSupportedError if you call
-  // writeValueWithoutResponse on a characteristic that lacks the property. So
-  // pick the write method from the advertised property — mirrors the native
-  // `preferredWriteType` gating. Default to without-response when properties
-  // are unavailable to preserve the proven Aurora path.
-  const supportsWithoutResponse = characteristic.properties?.writeWithoutResponse ?? true;
+  // Aurora (Kilter/Tension) MUST always use write-without-response: it is the
+  // proven path, and routing it to write-with-response stalls boards whose ATT
+  // ack never arrives (the iOS-26 regression that #3228 fixed). Only the
+  // MoonBoard family may fall back to write-with-response, and only for the
+  // original RedBearLab box whose characteristic advertises `.write` only (Web
+  // Bluetooth throws NotSupportedError if you call writeValueWithoutResponse on
+  // it). This mirrors the RN adapter's scanFamily gate and the native
+  // preferredWriteType. Default (no fallback allowed) preserves the proven
+  // Aurora path exactly.
+  const useWithResponse =
+    (options?.allowWithResponseFallback ?? false) && characteristic.properties?.writeWithoutResponse === false;
   for (let i = 0; i < messages.length; i++) {
     if (signal?.aborted) {
       throw new DOMException('Write aborted', 'AbortError');
@@ -43,10 +47,10 @@ export const writeCharacteristicSeries = async (
       await delay(INTER_CHUNK_DELAY_MS);
     }
     const chunk = new Uint8Array(messages[i]);
-    if (supportsWithoutResponse) {
-      await characteristic.writeValueWithoutResponse(chunk);
-    } else {
+    if (useWithResponse) {
       await characteristic.writeValueWithResponse(chunk);
+    } else {
+      await characteristic.writeValueWithoutResponse(chunk);
     }
   }
 };

--- a/packages/web/app/lib/ble/__tests__/web-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/web-adapter.test.ts
@@ -4,6 +4,7 @@ import { MOONBOARD_REQUEST_DEVICE_OPTIONS } from '@/app/components/board-bluetoo
 import type {
   requestBluetoothDevice as _requestBluetoothDevice,
   getUartCharacteristic as _getUartCharacteristic,
+  getMoonboardWriteCharacteristic as _getMoonboardWriteCharacteristic,
   writeCharacteristicSeries as _writeCharacteristicSeries,
 } from '@/app/components/board-bluetooth-control/bluetooth-shared';
 import { WebBluetoothAdapter } from '../web-adapter';
@@ -11,6 +12,7 @@ import { WebBluetoothAdapter } from '../web-adapter';
 // Mock the shared Bluetooth transport helpers
 const mockRequestDevice = vi.fn();
 const mockGetCharacteristic = vi.fn();
+const mockGetMoonboardCharacteristic = vi.fn();
 const mockSplitMessages = vi.fn((data: Uint8Array) => [data]);
 const mockWriteCharacteristicSeries = vi.fn();
 
@@ -20,6 +22,8 @@ vi.mock('@/app/components/board-bluetooth-control/bluetooth-shared', async (impo
     ...actual,
     requestBluetoothDevice: (...args: Parameters<typeof _requestBluetoothDevice>) => mockRequestDevice(...args),
     getUartCharacteristic: (...args: Parameters<typeof _getUartCharacteristic>) => mockGetCharacteristic(...args),
+    getMoonboardWriteCharacteristic: (...args: Parameters<typeof _getMoonboardWriteCharacteristic>) =>
+      mockGetMoonboardCharacteristic(...args),
     splitMessages: (data: Uint8Array) => mockSplitMessages(data),
     writeCharacteristicSeries: (...args: Parameters<typeof _writeCharacteristicSeries>) =>
       mockWriteCharacteristicSeries(...args),
@@ -101,15 +105,19 @@ describe('WebBluetoothAdapter', () => {
       expect(mockGetCharacteristic).toHaveBeenCalledWith(mockDevice);
     });
 
-    it('uses Moonboard request options for Moonboard controllers', async () => {
+    it('uses Moonboard request options and the Moonboard write-characteristic probe', async () => {
       const moonboardAdapter = new WebBluetoothAdapter('moonboard');
       const mockDevice = createMockDevice();
       mockRequestDevice.mockResolvedValue(mockDevice);
-      mockGetCharacteristic.mockResolvedValue(createMockCharacteristic());
+      mockGetMoonboardCharacteristic.mockResolvedValue(createMockCharacteristic());
 
       await moonboardAdapter.requestAndConnect();
 
       expect(mockRequestDevice).toHaveBeenCalledWith(MOONBOARD_REQUEST_DEVICE_OPTIONS);
+      // MoonBoard spans two controller generations, so it probes both via the
+      // dedicated helper rather than the UART-only getUartCharacteristic.
+      expect(mockGetMoonboardCharacteristic).toHaveBeenCalledWith(mockDevice);
+      expect(mockGetCharacteristic).not.toHaveBeenCalled();
     });
 
     it('registers gattserverdisconnected listener', async () => {

--- a/packages/web/app/lib/ble/__tests__/web-adapter.test.ts
+++ b/packages/web/app/lib/ble/__tests__/web-adapter.test.ts
@@ -211,7 +211,26 @@ describe('WebBluetoothAdapter', () => {
       await adapter.write(data);
 
       expect(mockSplitMessages).toHaveBeenCalledWith(data);
-      expect(mockWriteCharacteristicSeries).toHaveBeenCalledWith(mockCharacteristic, [chunk1, chunk2], undefined);
+      // Aurora (default board) never allows the write-with-response fallback.
+      expect(mockWriteCharacteristicSeries).toHaveBeenCalledWith(mockCharacteristic, [chunk1, chunk2], undefined, {
+        allowWithResponseFallback: false,
+      });
+    });
+
+    it('allows the write-with-response fallback only for Moonboard', async () => {
+      const moonboardAdapter = new WebBluetoothAdapter('moonboard');
+      mockRequestDevice.mockResolvedValue(createMockDevice());
+      const mockCharacteristic = createMockCharacteristic();
+      mockGetMoonboardCharacteristic.mockResolvedValue(mockCharacteristic);
+      await moonboardAdapter.requestAndConnect();
+
+      const data = new Uint8Array([1, 2, 3]);
+      mockSplitMessages.mockReturnValueOnce([data]);
+      await moonboardAdapter.write(data);
+
+      expect(mockWriteCharacteristicSeries).toHaveBeenCalledWith(mockCharacteristic, [data], undefined, {
+        allowWithResponseFallback: true,
+      });
     });
   });
 

--- a/packages/web/app/lib/ble/web-adapter.ts
+++ b/packages/web/app/lib/ble/web-adapter.ts
@@ -2,6 +2,7 @@ import type { BoardName } from '@/app/lib/types';
 import { AURORA_REQUEST_DEVICE_OPTIONS } from '@/app/components/board-bluetooth-control/bluetooth-aurora';
 import { MOONBOARD_REQUEST_DEVICE_OPTIONS } from '@/app/components/board-bluetooth-control/bluetooth-moonboard';
 import {
+  getMoonboardWriteCharacteristic,
   getUartCharacteristic,
   requestBluetoothDevice,
   splitMessages,
@@ -30,7 +31,12 @@ export class WebBluetoothAdapter implements BluetoothAdapter {
       this.boardName === 'moonboard' ? MOONBOARD_REQUEST_DEVICE_OPTIONS : AURORA_REQUEST_DEVICE_OPTIONS;
 
     const device = await requestBluetoothDevice(requestOptions);
-    const characteristic = await getUartCharacteristic(device);
+    // MoonBoard spans two controller generations (Nordic UART + original
+    // RedBearLab), so probe both; Aurora boards are always Nordic UART.
+    const characteristic =
+      this.boardName === 'moonboard'
+        ? await getMoonboardWriteCharacteristic(device)
+        : await getUartCharacteristic(device);
 
     if (!characteristic) {
       throw new Error('Failed to get UART characteristic');

--- a/packages/web/app/lib/ble/web-adapter.ts
+++ b/packages/web/app/lib/ble/web-adapter.ts
@@ -67,7 +67,11 @@ export class WebBluetoothAdapter implements BluetoothAdapter {
       throw new Error('Not connected');
     }
     const messages = splitMessages(data);
-    await writeCharacteristicSeries(this.characteristic, messages, signal);
+    // Only MoonBoard may fall back to write-with-response (original RedBearLab
+    // box); Aurora is always write-without-response.
+    await writeCharacteristicSeries(this.characteristic, messages, signal, {
+      allowWithResponseFallback: this.boardName === 'moonboard',
+    });
   }
 
   onDisconnect(callback: () => void): () => void {


### PR DESCRIPTION
## Summary

A thorough review of the three Bluetooth LED protocol implementations — the shared `@boardsesh/ble-protocol` TS encoder, the native iOS `BoardBleEncoding.swift` parallel encoder, and the platform adapters (web / React Native / native iOS) — against the Aurora and MoonBoard spec docs, with discrepancies corrected and the protocol locked down by comprehensive tests.

**Review result:** the byte-level encoders are correct. The shared Aurora encoder (checksum, SOH/LEN/CHK/STX/ETX framing, v2/v3 LED encoding, power budget, multi-frame sequencing) and the MoonBoard serpentine encoder match the spec **and** real-hardware byte-exact captures. No encoding bug found.

### What changed

- **Original MoonBoard (RedBearLab) controller support** — the spec's headline gap. The client only knew the Nordic UART controller; this adds the RedBearLab service/write-characteristic (`713d0000` / `713d0003`) discovery + write path across web, RN, and native iOS, as a fallback after Nordic UART, with the write-with-response gating that characteristic needs on iOS. ⚠️ Wired and unit-tested, but **not verified on an original MoonBoard LED box** (no hardware available) — see the MoonBoard spec §8 note.
- **Comprehensive tests for the canonical shared package** — the full byte-exact suite previously lived only in the web package (testing re-exports). Ported into `@boardsesh/ble-protocol` (the package the RN app imports directly): Aurora v2/v3 framing, power-budget progression, multi-frame command-byte sequencing with no-data-loss checks, validated hardware payloads, and full MoonBoard serpentine wiring + chunking. Plus RedBearLab fallback selection-logic tests on web + RN, and byte-exact `makeAuroraPacket` parity tests on Swift.
- **Swift parity fixes** — `BoardBleEncoding` now sanitizes malformed colour overrides to the canonical colour (previously rendered black) and matches `parseApiLevel` to the first `@` (mirroring the TS regex).
- **Spec-doc corrections** — fixed the Aurora §17 Example 2 checksum arithmetic (`0x56`→`0x4C`, `0xA9`→`0xB3`) and removed the self-contradictory v2 byte-2 bit-layout diagram; added a MoonBoard §5.4 note reconciling the write-with-response requirement for the RedBearLab box.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --reporter=agent packages/shared/ble-protocol` — **206 passed** (new byte-exact Aurora suite, expanded MoonBoard + transport).
- `vp test run --project web ... board-bluetooth-control lib/ble` — **548 passed** (new `bluetooth-shared.test.ts` fallback + write-type gating, updated web-adapter).
- `vp run test:mobile` — **2722 passed** (incl. 6 new RN adapter RedBearLab tests).
- `vp run typecheck:web`, `vp run typecheck:mobile`, `vp check` (changed files) — green.
- `vp run check:mobile-bundle` — OK.
- Native iOS Swift tests (`BoardseshTests` target) run by the **iOS CI (React Native)** workflow (prebuild → pod install → `xcodebuild test`); added byte-exact `makeAuroraPacket` parity, holdStateMap colour checks, override sanitization, and `parseApiLevel` first-`@` tests.
- ⚠️ Not verified on an original RedBearLab MoonBoard LED box (no hardware). RedBearLab is wired + unit-tested only; the What's New note is deliberately held until a follow-up verifies it on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6syqubJrJcCpDfXo4WpxV
