### PR TITLE
feat(mobile): attach Bluetooth diagnostics to bug reports

### DIFF
--- a/packages/backend/src/__tests__/discord-webhook.test.ts
+++ b/packages/backend/src/__tests__/discord-webhook.test.ts
@@ -137,6 +137,57 @@ describe('Discord webhook payload privacy', () => {
     expect(fields.find((f) => f.name === 'URL')?.value).toBe('/kilter/1/5/1,2/40');
     expect(fields.find((f) => f.name === 'User agent')?.value).toBe('Mozilla/5.0');
   });
+
+  it('renders a fenced Bluetooth diagnostics field when present', () => {
+    const body = buildWebhookBody({
+      feedbackId: 1,
+      rating: null,
+      comment: 'BLE flaky',
+      platform: 'ios',
+      appVersion: null,
+      source: 'drawer-bug',
+      context: { bleDiagnostics: 'Devices found (1):\n- Kilter A1B2 | id=xyz | rssi -52' },
+    });
+    const embed = (body.embeds as Array<Record<string, unknown>>)[0];
+    const fields = embed.fields as Array<{ name: string; value: string }>;
+    const ble = fields.find((f) => f.name === 'Bluetooth diagnostics');
+    expect(ble?.value).toContain('Kilter A1B2');
+    expect(ble?.value.startsWith('```')).toBe(true);
+    expect(ble?.value.endsWith('```')).toBe(true);
+  });
+
+  it('omits the Bluetooth diagnostics field when absent', () => {
+    const body = buildWebhookBody({
+      feedbackId: 1,
+      rating: null,
+      comment: 'broken',
+      platform: 'ios',
+      appVersion: null,
+      source: 'drawer-bug',
+      context: { climbName: 'My Project' },
+    });
+    const embed = (body.embeds as Array<Record<string, unknown>>)[0];
+    const fields = embed.fields as Array<{ name: string }>;
+    expect(fields.find((f) => f.name === 'Bluetooth diagnostics')).toBeUndefined();
+  });
+
+  it('keeps the Bluetooth diagnostics field within Discord 1024-char limit', () => {
+    const body = buildWebhookBody({
+      feedbackId: 1,
+      rating: null,
+      comment: 'long',
+      platform: 'ios',
+      appVersion: null,
+      source: 'drawer-bug',
+      context: { bleDiagnostics: 'x'.repeat(5000) },
+    });
+    const embed = (body.embeds as Array<Record<string, unknown>>)[0];
+    const fields = embed.fields as Array<{ name: string; value: string }>;
+    const ble = fields.find((f) => f.name === 'Bluetooth diagnostics');
+    expect(ble).toBeTruthy();
+    expect(ble?.value.length ?? 0).toBeLessThanOrEqual(1024);
+    expect(ble?.value).toContain('…');
+  });
 });
 
 describe('postFeedbackToDiscord', () => {

--- a/packages/backend/src/__tests__/feedback-validation.test.ts
+++ b/packages/backend/src/__tests__/feedback-validation.test.ts
@@ -175,5 +175,25 @@ describe('SubmitAppFeedbackInputSchema', () => {
       });
       expect(result.success).toBe(false);
     });
+
+    it('accepts a bleDiagnostics context string on a bug report', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({
+        ...BASE,
+        comment: 'bluetooth keeps dropping',
+        source: 'drawer-bug',
+        context: { bleDiagnostics: 'Devices found (1):\n- Kilter A1B2 | id=xyz | rssi -52' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects bleDiagnostics longer than 2000 chars', () => {
+      const result = SubmitAppFeedbackInputSchema.safeParse({
+        ...BASE,
+        comment: 'bluetooth keeps dropping',
+        source: 'drawer-bug',
+        context: { bleDiagnostics: 'x'.repeat(2001) },
+      });
+      expect(result.success).toBe(false);
+    });
   });
 });

--- a/packages/backend/src/services/discord.ts
+++ b/packages/backend/src/services/discord.ts
@@ -47,12 +47,13 @@ function formatBoard(payload: FeedbackDiscordPayload): string | null {
 // fenced code block (preserves the line-oriented layout) and truncate the text
 // so the fences always fit.
 const DISCORD_FIELD_MAX = 1024;
-const BLE_FENCE_OVERHEAD = '```\n\n```'.length;
+const BLE_FENCE_OPEN = '```\n';
+const BLE_FENCE_CLOSE = '\n```';
 
 function formatBleDiagnostics(report: string): string {
-  const budget = DISCORD_FIELD_MAX - BLE_FENCE_OVERHEAD;
+  const budget = DISCORD_FIELD_MAX - BLE_FENCE_OPEN.length - BLE_FENCE_CLOSE.length;
   const body = report.length > budget ? `${report.slice(0, budget - 1)}…` : report;
-  return `\`\`\`\n${body}\n\`\`\``;
+  return `${BLE_FENCE_OPEN}${body}${BLE_FENCE_CLOSE}`;
 }
 
 /** @internal exported for testing only; do not call from resolver code. */

--- a/packages/backend/src/services/discord.ts
+++ b/packages/backend/src/services/discord.ts
@@ -43,6 +43,18 @@ function formatBoard(payload: FeedbackDiscordPayload): string | null {
   return payload.angle != null ? `${base} @ ${payload.angle}°` : base;
 }
 
+// Discord caps an embed field value at 1024 chars. Wrap the BLE report in a
+// fenced code block (preserves the line-oriented layout) and truncate the text
+// so the fences always fit.
+const DISCORD_FIELD_MAX = 1024;
+const BLE_FENCE_OVERHEAD = '```\n\n```'.length;
+
+function formatBleDiagnostics(report: string): string {
+  const budget = DISCORD_FIELD_MAX - BLE_FENCE_OVERHEAD;
+  const body = report.length > budget ? `${report.slice(0, budget - 1)}…` : report;
+  return `\`\`\`\n${body}\n\`\`\``;
+}
+
 /** @internal exported for testing only; do not call from resolver code. */
 export function buildWebhookBody(payload: FeedbackDiscordPayload): Record<string, unknown> {
   const isBug = BUG_SOURCES.has(payload.source);
@@ -86,6 +98,9 @@ export function buildWebhookBody(payload: FeedbackDiscordPayload): Record<string
   }
   if (ctx?.url) fields.push({ name: 'URL', value: ctx.url, inline: false });
   if (ctx?.userAgent) fields.push({ name: 'User agent', value: ctx.userAgent, inline: false });
+  if (ctx?.bleDiagnostics) {
+    fields.push({ name: 'Bluetooth diagnostics', value: formatBleDiagnostics(ctx.bleDiagnostics), inline: false });
+  }
 
   return {
     username: 'Boardsesh Feedback',

--- a/packages/backend/src/validation/schemas/feedback.ts
+++ b/packages/backend/src/validation/schemas/feedback.ts
@@ -12,6 +12,7 @@ const FeedbackContextInputSchema = z
     sessionName: z.string().max(200).optional().nullable(),
     url: z.string().max(1000).optional().nullable(),
     userAgent: z.string().max(512).optional().nullable(),
+    bleDiagnostics: z.string().max(2000).optional().nullable(),
   })
   .strict();
 

--- a/packages/db/src/schema/app/feedback.ts
+++ b/packages/db/src/schema/app/feedback.ts
@@ -9,6 +9,8 @@ export type FeedbackContext = {
   sessionName?: string;
   url?: string;
   userAgent?: string;
+  /** Opt-in BLE diagnostics text attached to bug reports. */
+  bleDiagnostics?: string;
 };
 
 export const appFeedback = pgTable(

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -8,6 +8,7 @@ import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { PressableSurface } from '../PressableSurface';
 import { SessionRecordingSwitchRow } from '../settings/SessionRecordingSwitchRow';
+import { SwitchRow } from '../SwitchRow';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -38,6 +39,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   const { mutateAsync, isPending, reset } = useSubmitMobileAppFeedback();
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [comment, setComment] = useState('');
+  const [includeBleDiagnostics, setIncludeBleDiagnostics] = useState(false);
 
   const isBugReport = mode === 'bug';
   const trimmedComment = comment.trim();
@@ -50,6 +52,7 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   useEffect(() => {
     setSelectedRating(null);
     setComment('');
+    setIncludeBleDiagnostics(false);
     reset();
   }, [mode, reset]);
 
@@ -67,11 +70,13 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
         source: isBugReport ? 'drawer-bug' : 'drawer-feedback',
         rating: isBugReport ? null : selectedRating,
         comment: trimmedComment.length > 0 ? trimmedComment : null,
+        includeBleDiagnostics: isBugReport && includeBleDiagnostics,
       });
       sheetRef.current?.dismiss();
       showToast(isBugReport ? t('feedbackDialog.successBug') : t('feedbackDialog.successRating'), 'success');
       setSelectedRating(null);
       setComment('');
+      setIncludeBleDiagnostics(false);
     } catch {
       showToast(t('feedbackDialog.errorRating'), 'error');
     }
@@ -146,6 +151,17 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
           <SessionRecordingSwitchRow
             label={t('feedbackForm.sessionRecordingLabel')}
             description={t('feedbackForm.sessionRecordingDescription')}
+          />
+        </View>
+      ) : null}
+
+      {isBugReport ? (
+        <View style={[styles.recordingCard, { backgroundColor: systemColors.secondaryBackground }]}>
+          <SwitchRow
+            label={t('feedbackForm.bleDiagnosticsLabel')}
+            description={t('feedbackForm.bleDiagnosticsDescription')}
+            value={includeBleDiagnostics}
+            onValueChange={setIncludeBleDiagnostics}
           />
         </View>
       ) : null}

--- a/packages/mobile/src/lib/ble/__tests__/ble-diagnostics-log.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/ble-diagnostics-log.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildBleDiagnosticsReport,
+  clearBleDiagnosticsLog,
+  getBleDiagnosticsEvents,
+  recordBleEvent,
+} from '../ble-diagnostics-log';
+
+describe('ble-diagnostics-log', () => {
+  beforeEach(() => {
+    clearBleDiagnosticsLog();
+  });
+
+  it('returns null when nothing has been recorded', () => {
+    expect(buildBleDiagnosticsReport()).toBeNull();
+  });
+
+  it('lists devices found and recent connection events', () => {
+    recordBleEvent({ type: 'device_found', deviceId: 'dev-1', name: 'Kilter A1B2', rssi: -52 });
+    recordBleEvent({
+      type: 'connect_failure',
+      boardName: 'kilter',
+      failureCategory: 'board_not_found',
+      message: 'timeout',
+    });
+
+    const report = buildBleDiagnosticsReport();
+    expect(report).toContain('Devices found (1):');
+    expect(report).toContain('Kilter A1B2');
+    expect(report).toContain('id=dev-1');
+    expect(report).toContain('rssi -52');
+    expect(report).toContain('connect_failure kilter category=board_not_found');
+  });
+
+  it('renders the chosen write type and MTU on a successful connect', () => {
+    recordBleEvent({
+      type: 'connect_success',
+      boardName: 'kilter',
+      layoutId: 1,
+      apiLevel: 3,
+      deviceNamePresent: true,
+      diagnostics: {
+        chosenWriteType: 'withoutResponse',
+        supportsWriteWithoutResponse: true,
+        maxWriteWithoutResponse: 244,
+      },
+    });
+
+    const report = buildBleDiagnosticsReport();
+    expect(report).toContain('connect_success kilter/layout 1 api v3');
+    expect(report).toContain('write=withoutResponse');
+    expect(report).toContain('maxNoResp=244');
+  });
+
+  it('flags a connect with no advertised name', () => {
+    recordBleEvent({ type: 'connect_success', boardName: 'kilter', deviceNamePresent: false });
+    expect(buildBleDiagnosticsReport()).toContain('(no advertised name)');
+  });
+
+  it('dedupes the device list by id, keeping the latest rssi', () => {
+    recordBleEvent({ type: 'device_found', deviceId: 'dev-1', name: 'Kilter A1B2', rssi: -70 });
+    recordBleEvent({ type: 'device_found', deviceId: 'dev-1', name: 'Kilter A1B2', rssi: -40 });
+
+    const report = buildBleDiagnosticsReport() ?? '';
+    expect(report).toContain('Devices found (1):');
+    expect(report).toContain('rssi -40');
+    expect(report).not.toContain('rssi -70');
+  });
+
+  it('caps the buffer and evicts oldest events', () => {
+    for (let index = 0; index < 60; index += 1) {
+      recordBleEvent({ type: 'disconnect', boardName: `board-${index}`, kind: 'dropped' });
+    }
+    const events = getBleDiagnosticsEvents();
+    expect(events.length).toBe(40);
+    // Oldest (board-0..19) evicted; newest retained.
+    expect(events[events.length - 1]).toMatchObject({ boardName: 'board-59' });
+    expect(events.some((event) => 'boardName' in event && event.boardName === 'board-0')).toBe(false);
+  });
+
+  it('lists the event timeline newest first', () => {
+    recordBleEvent({ type: 'send_failure', boardName: 'kilter', failureReason: 'write_timeout', message: 'a' });
+    recordBleEvent({ type: 'disconnect', boardName: 'kilter', kind: 'stolen' });
+
+    const report = buildBleDiagnosticsReport() ?? '';
+    const disconnectIndex = report.indexOf('disconnect kilter (stolen)');
+    const sendFailureIndex = report.indexOf('send_failure kilter reason=write_timeout');
+    expect(disconnectIndex).toBeGreaterThan(-1);
+    expect(sendFailureIndex).toBeGreaterThan(-1);
+    expect(disconnectIndex).toBeLessThan(sendFailureIndex);
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -118,6 +118,7 @@ import {
   dispatchMoonboardPacket,
   useBoardBluetooth,
 } from '../use-board-bluetooth';
+import { clearBleDiagnosticsLog, getBleDiagnosticsEvents } from '../ble-diagnostics-log';
 
 // ── Factory helpers ────────────────────────────────────────────────────────
 
@@ -145,6 +146,7 @@ describe('useBoardBluetooth', () => {
     vi.clearAllMocks();
     resetReactNativePermissionHarness();
     mockBleManager.state.mockResolvedValue('PoweredOn');
+    clearBleDiagnosticsLog();
   });
 
   it('shows permission copy and stops before adapter availability when Android BLE permission is denied', async () => {
@@ -242,6 +244,9 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).not.toHaveBeenCalled();
+    // A user-cancel is not a connection issue — it must NOT pollute the
+    // opt-in bug-report diagnostics with a phantom connect_failure.
+    expect(getBleDiagnosticsEvents().some((event) => event.type === 'connect_failure')).toBe(false);
   });
 
   it('maps a connect timeout to the connect-failed copy', async () => {
@@ -259,6 +264,9 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+    // A real (non-cancel) connect failure IS recorded for the bug report.
+    const connectFailure = getBleDiagnosticsEvents().find((event) => event.type === 'connect_failure');
+    expect(connectFailure).toMatchObject({ type: 'connect_failure', failureCategory: 'connect_failed' });
   });
 
   it('serialises overlapping sendFramesToBoard calls so chunks never interleave', async () => {
@@ -478,6 +486,21 @@ describe('useBoardBluetooth', () => {
 
     expect(fakeAdapter.disconnect).toHaveBeenCalled();
     expect(result.current.isConnected).toBe(false);
+
+    // Exactly one disconnect is logged for the stolen write, labelled 'stolen'.
+    const disconnectsAfterWrite = getBleDiagnosticsEvents().filter((event) => event.type === 'disconnect');
+    expect(disconnectsAfterWrite).toHaveLength(1);
+    expect(disconnectsAfterWrite[0]).toMatchObject({ type: 'disconnect', kind: 'stolen' });
+
+    // Some BLE stacks ALSO fire the adapter's own disconnect event for the same
+    // physical drop. The per-generation guard must keep that from double-logging.
+    const adapterDisconnectHandler = (fakeAdapter.onDisconnect.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | (() => void)
+      | undefined;
+    await act(async () => {
+      adapterDisconnectHandler?.();
+    });
+    expect(getBleDiagnosticsEvents().filter((event) => event.type === 'disconnect')).toHaveLength(1);
   });
 
   it('tracks incompatible_climb with skip counts and the provided send context', async () => {

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -11,6 +11,7 @@ import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
 import { isLikelyBoardDevice } from './board-device-filter';
 import { upsertDiscoveredDevice } from './scan-device-cache';
+import { recordBleEvent } from './ble-diagnostics-log';
 import type { BluetoothAdapter, BleConnection, BoardScanFamily, DevicePickerFn, DiscoveredDevice } from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
@@ -112,6 +113,10 @@ export class RNBleAdapter implements BluetoothAdapter {
         };
         if (upsertDiscoveredDevice(devices, device)) {
           pushDevices();
+          // Record only newly-surfaced devices (upsert returns true on a fresh
+          // entry) so the bug-report buffer holds one line per board, not one
+          // per advertisement packet.
+          recordBleEvent({ type: 'device_found', deviceId: device.deviceId, name: device.name, rssi: device.rssi });
         }
 
         // Auto-select the stored board only until the picker takes over.

--- a/packages/mobile/src/lib/ble/ble-diagnostics-log.ts
+++ b/packages/mobile/src/lib/ble/ble-diagnostics-log.ts
@@ -1,0 +1,170 @@
+import type { BleFailureCategory, BleSendFailureReason } from '@boardsesh/ble-protocol';
+import type { BleConnectionDiagnostics } from '../sentry';
+
+// In-session ring buffer of BLE events, attached (opt-in) to a bug report so a
+// triager can see which board, which failure mode, and which write path was
+// chosen — instead of starting from "Bluetooth doesn't work" with no signal.
+//
+// Module-level singleton with no React: events originate deep in the low-level
+// adapter and the connection hook and are read exactly once at submit time, so
+// there's nothing to subscribe to. Mirrors the module-store shape used by
+// `bluetooth-status-store.ts`. Lives for the app session only — "recent" here
+// means "this run", which is the scope a user reporting a live BLE problem
+// cares about.
+
+const MAX_EVENTS = 40;
+// Discord caps an embed field value at 1024 chars; we cap the whole report well
+// under that × a couple of fields' worth so the DB row stays compact and the
+// webhook never has to hard-truncate mid-line.
+const MAX_REPORT_LENGTH = 1800;
+
+type BleEventBase = {
+  /** Epoch ms (`Date.now()`), used only for ordering + a HH:MM:SS stamp. */
+  at: number;
+};
+
+export type BleDiagnosticsEvent =
+  | (BleEventBase & {
+      type: 'device_found';
+      deviceId: string;
+      name?: string;
+      rssi: number;
+    })
+  | (BleEventBase & {
+      type: 'connect_success';
+      boardName: string;
+      layoutId?: number;
+      sizeId?: number;
+      apiLevel?: number;
+      deviceNamePresent: boolean;
+      diagnostics?: BleConnectionDiagnostics | null;
+    })
+  | (BleEventBase & {
+      type: 'connect_failure';
+      boardName?: string;
+      failureCategory: BleFailureCategory;
+      message: string;
+    })
+  | (BleEventBase & {
+      type: 'send_failure';
+      boardName?: string;
+      failureReason: BleSendFailureReason;
+      message: string;
+    })
+  | (BleEventBase & {
+      type: 'disconnect';
+      boardName?: string;
+      kind: 'stolen' | 'dropped';
+    });
+
+export type BleDiagnosticsEventInput = DistributiveOmit<BleDiagnosticsEvent, 'at'>;
+
+// `Omit` collapses a union to its common keys; this preserves each member so
+// callers pass a single discriminated event without an `at` they don't own.
+type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
+
+const events: BleDiagnosticsEvent[] = [];
+
+/** Append an event, evicting the oldest once the buffer is full. */
+export function recordBleEvent(event: BleDiagnosticsEventInput): void {
+  events.push({ ...event, at: Date.now() } as BleDiagnosticsEvent);
+  if (events.length > MAX_EVENTS) events.splice(0, events.length - MAX_EVENTS);
+}
+
+/** Snapshot of the buffer in insertion order (oldest first). */
+export function getBleDiagnosticsEvents(): readonly BleDiagnosticsEvent[] {
+  return events.slice();
+}
+
+/** Drop everything — for tests and a deliberate reset only. */
+export function clearBleDiagnosticsLog(): void {
+  events.length = 0;
+}
+
+function formatClock(at: number): string {
+  // `new Date(ms)` with an argument is deterministic from the stamp.
+  return new Date(at).toISOString().slice(11, 19);
+}
+
+function formatDiagnostics(diagnostics: BleConnectionDiagnostics | null | undefined): string {
+  if (!diagnostics) return '';
+  const parts: string[] = [];
+  if (diagnostics.chosenWriteType) parts.push(`write=${diagnostics.chosenWriteType}`);
+  if (diagnostics.supportsWriteWithoutResponse !== undefined) {
+    parts.push(`supportsNoResp=${diagnostics.supportsWriteWithoutResponse}`);
+  }
+  if (diagnostics.characteristicProperties !== undefined)
+    parts.push(`charProps=${diagnostics.characteristicProperties}`);
+  if (diagnostics.maxWriteWithResponse !== undefined) parts.push(`maxResp=${diagnostics.maxWriteWithResponse}`);
+  if (diagnostics.maxWriteWithoutResponse !== undefined) {
+    parts.push(`maxNoResp=${diagnostics.maxWriteWithoutResponse}`);
+  }
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+function formatEvent(event: BleDiagnosticsEvent): string {
+  const clock = formatClock(event.at);
+  switch (event.type) {
+    case 'connect_success': {
+      const board = [event.boardName, event.layoutId != null ? `layout ${event.layoutId}` : null]
+        .filter(Boolean)
+        .join('/');
+      const api = event.apiLevel != null ? ` api v${event.apiLevel}` : '';
+      const named = event.deviceNamePresent ? '' : ' (no advertised name)';
+      return `${clock} connect_success ${board}${api}${named}${formatDiagnostics(event.diagnostics)}`;
+    }
+    case 'connect_failure':
+      return `${clock} connect_failure ${event.boardName ?? '?'} category=${event.failureCategory} — ${event.message}`;
+    case 'send_failure':
+      return `${clock} send_failure ${event.boardName ?? '?'} reason=${event.failureReason} — ${event.message}`;
+    case 'disconnect':
+      return `${clock} disconnect ${event.boardName ?? '?'} (${event.kind})`;
+    case 'device_found':
+      return '';
+  }
+}
+
+/**
+ * Render the session's BLE activity as a compact text block, or null when the
+ * buffer is empty. Devices are deduped by id (latest name/rssi wins); the event
+ * timeline lists newest first and excludes device_found (covered by the device
+ * list). Capped to MAX_REPORT_LENGTH.
+ */
+export function buildBleDiagnosticsReport(): string | null {
+  if (events.length === 0) return null;
+
+  const latestById = new Map<string, Extract<BleDiagnosticsEvent, { type: 'device_found' }>>();
+  for (const event of events) {
+    if (event.type === 'device_found') latestById.set(event.deviceId, event);
+  }
+
+  const lines: string[] = [];
+  lines.push('BLE diagnostics (this app session)');
+  // iOS native scans enumerate peripherals in Swift, so the device list can be
+  // sparse there; connection events below are captured on every platform.
+
+  if (latestById.size > 0) {
+    lines.push(`Devices found (${latestById.size}):`);
+    for (const device of latestById.values()) {
+      lines.push(`- ${device.name ?? '(no name)'} | id=${device.deviceId} | rssi ${device.rssi}`);
+    }
+  } else {
+    lines.push('Devices found: none recorded');
+  }
+
+  const timeline = events
+    .filter((event) => event.type !== 'device_found')
+    .reverse()
+    .map(formatEvent)
+    .filter((line) => line.length > 0);
+
+  if (timeline.length > 0) {
+    lines.push('Recent events (newest first):');
+    for (const line of timeline) lines.push(`- ${line}`);
+  } else {
+    lines.push('Recent connection events: none recorded');
+  }
+
+  const report = lines.join('\n');
+  return report.length > MAX_REPORT_LENGTH ? `${report.slice(0, MAX_REPORT_LENGTH - 1)}…` : report;
+}

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -34,6 +34,7 @@ import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
 import { clearBleDiagnosticsTags, setBleDiagnosticsTags } from '../sentry';
+import { recordBleEvent } from './ble-diagnostics-log';
 import { buildHoldColorOverrideSignature, type HoldColorOverrides } from '../hold-color-overrides';
 
 // Exported for testing. Decides how a connect-failure category reaches error
@@ -547,6 +548,12 @@ export function useBoardBluetooth({
             ...boardAnalyticsProperties,
             failureReason: bleFailureReason,
           });
+          recordBleEvent({
+            type: 'send_failure',
+            boardName,
+            failureReason: bleFailureReason,
+            message: error instanceof Error ? error.message : String(error),
+          });
           // A dropped link is routine on these last-connection-wins boards
           // (another climber grabbed it, or it disconnected mid-session), so keep
           // it a filterable warning rather than a full error that drowns real
@@ -567,6 +574,7 @@ export function useBoardBluetooth({
             // failed on a dead link. On a shared board this is usually another
             // device having grabbed it. Recorded so the two-climber case is visible.
             track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
+            recordBleEvent({ type: 'disconnect', boardName, kind: 'stolen' });
             handleDisconnection();
           }
           return false;
@@ -665,7 +673,14 @@ export function useBoardBluetooth({
         apiLevelRef.current = parseApiLevel(connection.deviceName);
         configuredDeviceNameRef.current = connection.deviceName;
 
-        unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
+        unsubDisconnectRef.current = adapter.onDisconnect(() => {
+          // The adapter's own disconnect event: the board dropped the link (powered
+          // off / out of range), distinct from the mid-write 'stolen' drop recorded
+          // in sendFramesToBoard — that path calls handleDisconnection directly, so
+          // this wrapper can't double-count it.
+          recordBleEvent({ type: 'disconnect', boardName, kind: 'dropped' });
+          handleDisconnection();
+        });
         adapterRef.current = adapter;
 
         // Push board configuration into the native BoardBleManager so the
@@ -745,6 +760,15 @@ export function useBoardBluetooth({
         // be explicit so analytics parity can't regress).
         const connectionDiagnostics = await getNativeBleConnectedDevice().catch(() => null);
         setBleDiagnosticsTags(connectionDiagnostics);
+        recordBleEvent({
+          type: 'connect_success',
+          boardName,
+          layoutId,
+          sizeId,
+          apiLevel: apiLevelRef.current,
+          deviceNamePresent: !!connection.deviceName,
+          diagnostics: connectionDiagnostics,
+        });
         // apiLevel is the level parseApiLevel actually picked; deviceNamePresent
         // records whether an advertised name was even available. parseApiLevel
         // silently defaults to v2 when the name is missing/unparseable, and v2
@@ -784,6 +808,14 @@ export function useBoardBluetooth({
           reportHandledError(error, {
             level: reportLevel,
             tags: { source: 'ble-connect', failure_category: failureCategory },
+          });
+          // Recorded for an opt-in bug report. A user-cancel (reportLevel null)
+          // isn't a connection issue, so it's deliberately left out.
+          recordBleEvent({
+            type: 'connect_failure',
+            boardName,
+            failureCategory,
+            message: error instanceof Error ? error.message : String(error),
           });
         }
         setIsConnected(false);
@@ -952,7 +984,14 @@ export function useBoardBluetooth({
       adapter.adoptConnection(deviceId);
       apiLevelRef.current = parseApiLevel(deviceName);
       configuredDeviceNameRef.current = deviceName;
-      unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
+      unsubDisconnectRef.current = adapter.onDisconnect(() => {
+        // The adapter's own disconnect event: the board dropped the link (powered
+        // off / out of range), distinct from the mid-write 'stolen' drop recorded
+        // in sendFramesToBoard — that path calls handleDisconnection directly, so
+        // this wrapper can't double-count it.
+        recordBleEvent({ type: 'disconnect', boardName, kind: 'dropped' });
+        handleDisconnection();
+      });
       adapterRef.current = adapter;
       void adapter
         .configureBoard({

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -301,6 +301,15 @@ export function useBoardBluetooth({
   // would otherwise race the in-flight native disconnect and re-establish the
   // connection the user just closed.
   const adoptionSuppressedRef = useRef(false);
+  // One disconnect diagnostics record per connection generation. Both involuntary
+  // drop paths — the adapter's own disconnect event and the write-failure
+  // detection in sendFramesToBoard — funnel through clearConnectionAfterDrop,
+  // and on some BLE stacks a stolen-link write failure ALSO fires the adapter
+  // event, so without this guard a single physical drop logs twice. Reset to
+  // false when a new connection is established; the send path raises the kind to
+  // 'stolen' before tearing down so the more-specific label wins when it's known.
+  const disconnectRecordedRef = useRef(false);
+  const pendingDisconnectKindRef = useRef<'stolen' | 'dropped'>('dropped');
   // The configKey the live connection was established for. Lets the
   // config-switch effect tell a genuine board/layout/size change (tear down)
   // from an unrelated re-render (no-op), and is the key cleared on every drop.
@@ -375,6 +384,12 @@ export function useBoardBluetooth({
   }, []);
 
   const clearConnectionAfterDrop = useCallback(() => {
+    // Only involuntary drops reach here (a deliberate user disconnect goes
+    // through teardownConnection), so log exactly one disconnect per generation.
+    if (!disconnectRecordedRef.current) {
+      disconnectRecordedRef.current = true;
+      recordBleEvent({ type: 'disconnect', boardName, kind: pendingDisconnectKindRef.current });
+    }
     unsubDisconnectRef.current?.();
     unsubDisconnectRef.current = null;
     const adapter = adapterRef.current;
@@ -395,7 +410,7 @@ export function useBoardBluetooth({
     // RNBleAdapter's onDeviceDisconnected subscription and a possibly half-alive
     // native link would otherwise leak — dispose explicitly.
     void adapter?.disconnect().catch(() => {});
-  }, [onConnectionChange]);
+  }, [boardName, onConnectionChange]);
 
   const handleDisconnection = useCallback(() => {
     clearConnectionAfterDrop();
@@ -574,7 +589,10 @@ export function useBoardBluetooth({
             // failed on a dead link. On a shared board this is usually another
             // device having grabbed it. Recorded so the two-climber case is visible.
             track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
-            recordBleEvent({ type: 'disconnect', boardName, kind: 'stolen' });
+            // Mark this drop as 'stolen' (write failed on a dead link) so the
+            // disconnect record clearConnectionAfterDrop writes carries the more
+            // specific label rather than the generic 'dropped'.
+            pendingDisconnectKindRef.current = 'stolen';
             handleDisconnection();
           }
           return false;
@@ -673,14 +691,11 @@ export function useBoardBluetooth({
         apiLevelRef.current = parseApiLevel(connection.deviceName);
         configuredDeviceNameRef.current = connection.deviceName;
 
-        unsubDisconnectRef.current = adapter.onDisconnect(() => {
-          // The adapter's own disconnect event: the board dropped the link (powered
-          // off / out of range), distinct from the mid-write 'stolen' drop recorded
-          // in sendFramesToBoard — that path calls handleDisconnection directly, so
-          // this wrapper can't double-count it.
-          recordBleEvent({ type: 'disconnect', boardName, kind: 'dropped' });
-          handleDisconnection();
-        });
+        // New connection generation: re-arm the one-shot disconnect record and
+        // default its label to 'dropped' (the send path raises it to 'stolen').
+        disconnectRecordedRef.current = false;
+        pendingDisconnectKindRef.current = 'dropped';
+        unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
         adapterRef.current = adapter;
 
         // Push board configuration into the native BoardBleManager so the
@@ -984,14 +999,11 @@ export function useBoardBluetooth({
       adapter.adoptConnection(deviceId);
       apiLevelRef.current = parseApiLevel(deviceName);
       configuredDeviceNameRef.current = deviceName;
-      unsubDisconnectRef.current = adapter.onDisconnect(() => {
-        // The adapter's own disconnect event: the board dropped the link (powered
-        // off / out of range), distinct from the mid-write 'stolen' drop recorded
-        // in sendFramesToBoard — that path calls handleDisconnection directly, so
-        // this wrapper can't double-count it.
-        recordBleEvent({ type: 'disconnect', boardName, kind: 'dropped' });
-        handleDisconnection();
-      });
+      // New connection generation: re-arm the one-shot disconnect record and
+      // default its label to 'dropped' (the send path raises it to 'stolen').
+      disconnectRecordedRef.current = false;
+      pendingDisconnectKindRef.current = 'dropped';
+      unsubDisconnectRef.current = adapter.onDisconnect(handleDisconnection);
       adapterRef.current = adapter;
       void adapter
         .configureBoard({

--- a/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
+++ b/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
@@ -68,6 +68,27 @@ describe('buildMobileFeedbackEnrichment', () => {
     });
   });
 
+  it('attaches bleDiagnostics to context when provided', () => {
+    const result = buildMobileFeedbackEnrichment({
+      activeBoard,
+      currentClimbQueueItem,
+      sessionId: 'session-1',
+      pathname: '/(tabs)/climbs',
+      bleDiagnostics: 'Devices found (1):\n- Kilter A1B2 | id=xyz | rssi -52',
+    });
+    expect(result.context?.bleDiagnostics).toBe('Devices found (1):\n- Kilter A1B2 | id=xyz | rssi -52');
+  });
+
+  it('omits bleDiagnostics from context when not provided', () => {
+    const result = buildMobileFeedbackEnrichment({
+      activeBoard,
+      currentClimbQueueItem,
+      sessionId: 'session-1',
+      pathname: '/(tabs)/climbs',
+    });
+    expect(result.context?.bleDiagnostics).toBeUndefined();
+  });
+
   it('returns null board and context fields when no useful context exists', () => {
     expect(
       buildMobileFeedbackEnrichment({

--- a/packages/mobile/src/lib/feedback/feedback-enrichment.ts
+++ b/packages/mobile/src/lib/feedback/feedback-enrichment.ts
@@ -14,6 +14,8 @@ export type BuildMobileFeedbackEnrichmentArgs = {
   currentClimbQueueItem: ClimbQueueItem | null;
   sessionId: string | null;
   pathname: string | null | undefined;
+  /** Opt-in BLE diagnostics dump; only set when the reporter ticks the toggle. */
+  bleDiagnostics?: string | null;
 };
 
 export function clipFeedbackString(value: string | null | undefined, maxLength: number): string | undefined {
@@ -58,6 +60,7 @@ export function buildMobileFeedbackEnrichment(args: BuildMobileFeedbackEnrichmen
       difficulty: currentClimb?.difficulty,
       sessionId: args.sessionId,
       url: clipFeedbackString(args.pathname, URL_MAX),
+      bleDiagnostics: args.bleDiagnostics ?? undefined,
     }),
   };
 }

--- a/packages/mobile/src/lib/feedback/use-submit-app-feedback.ts
+++ b/packages/mobile/src/lib/feedback/use-submit-app-feedback.ts
@@ -11,12 +11,19 @@ import type { SubmitAppFeedbackInput } from '@boardsesh/shared-schema';
 import { getHttpClient } from '../graphql/client';
 import { useActiveBoard } from '../graphql/use-active-board';
 import { useQueue, useQueueSessionId } from '../../providers/queue-provider';
+import { buildBleDiagnosticsReport } from '../ble/ble-diagnostics-log';
 import { buildMobileFeedbackEnrichment } from './feedback-enrichment';
 
 export type MobileSubmitAppFeedbackPayload = Omit<
   SubmitAppFeedbackInput,
   'platform' | 'appVersion' | 'boardName' | 'layoutId' | 'sizeId' | 'setIds' | 'angle' | 'context'
->;
+> & {
+  /**
+   * UI-only flag (stripped before the GraphQL request). When true, the
+   * session's BLE diagnostics are attached to the report's debug context.
+   */
+  includeBleDiagnostics?: boolean;
+};
 
 function getMobilePlatform(): SubmitAppFeedbackInput['platform'] {
   return Platform.OS === 'android' ? 'android' : Platform.OS === 'ios' ? 'ios' : 'web';
@@ -43,14 +50,17 @@ export function useSubmitMobileAppFeedback() {
 
   return useMutation({
     mutationFn: (payload: MobileSubmitAppFeedbackPayload): Promise<boolean> => {
+      // `includeBleDiagnostics` is a UI flag — keep it out of the GraphQL input.
+      const { includeBleDiagnostics, ...feedbackInput } = payload;
       const enrichment = buildMobileFeedbackEnrichment({
         activeBoard: activeBoardQuery.data,
         currentClimbQueueItem: queueContext.state.currentClimbQueueItem,
         sessionId,
         pathname,
+        bleDiagnostics: includeBleDiagnostics ? buildBleDiagnosticsReport() : null,
       });
       return submitMobileAppFeedback({
-        ...payload,
+        ...feedbackInput,
         ...enrichment,
         platform: getMobilePlatform(),
         appVersion: getNativeAppVersion(),

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -5713,6 +5713,13 @@ input FeedbackContextInput {
   sessionName: String
   url: String
   userAgent: String
+
+  """
+  Opt-in Bluetooth diagnostics for bug reports: a compact text dump of the
+  boards found and recent connection issues this session (write type, MTU,
+  failure category/reason). Present only when the reporter ticks the toggle.
+  """
+  bleDiagnostics: String
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1386,6 +1386,12 @@ export type FavoritesCount = {
  * may carry only `url` / `userAgent`.
  */
 export type FeedbackContextInput = {
+  /**
+   * Opt-in Bluetooth diagnostics for bug reports: a compact text dump of the
+   * boards found and recent connection issues this session (write type, MTU,
+   * failure category/reason). Present only when the reporter ticks the toggle.
+   */
+  bleDiagnostics?: InputMaybe<Scalars['String']['input']>;
   climbName?: InputMaybe<Scalars['String']['input']>;
   climbUuid?: InputMaybe<Scalars['String']['input']>;
   difficulty?: InputMaybe<Scalars['String']['input']>;

--- a/packages/shared-schema/src/schema/feedback.ts
+++ b/packages/shared-schema/src/schema/feedback.ts
@@ -12,6 +12,13 @@ export const feedbackTypeDefs = /* GraphQL */ `
     sessionName: String
     url: String
     userAgent: String
+
+    """
+    Opt-in Bluetooth diagnostics for bug reports: a compact text dump of the
+    boards found and recent connection issues this session (write type, MTU,
+    failure category/reason). Present only when the reporter ticks the toggle.
+    """
+    bleDiagnostics: String
   }
 
   """

--- a/packages/shared-schema/src/types/feedback.ts
+++ b/packages/shared-schema/src/types/feedback.ts
@@ -20,6 +20,12 @@ export type FeedbackContextInput = {
   sessionName?: string | null;
   url?: string | null;
   userAgent?: string | null;
+  /**
+   * Opt-in Bluetooth diagnostics for bug reports: a compact text dump of boards
+   * found and recent connection issues this session. Present only when the
+   * reporter ticks the toggle.
+   */
+  bleDiagnostics?: string | null;
 };
 
 export type SubmitAppFeedbackInput = {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1383,6 +1383,12 @@ export type FavoritesCount = {
  * may carry only `url` / `userAgent`.
  */
 export type FeedbackContextInput = {
+  /**
+   * Opt-in Bluetooth diagnostics for bug reports: a compact text dump of the
+   * boards found and recent connection issues this session (write type, MTU,
+   * failure category/reason). Present only when the reporter ticks the toggle.
+   */
+  bleDiagnostics?: InputMaybe<Scalars['String']['input']>;
   climbName?: InputMaybe<Scalars['String']['input']>;
   climbUuid?: InputMaybe<Scalars['String']['input']>;
   difficulty?: InputMaybe<Scalars['String']['input']>;

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -333,6 +333,8 @@
     "remainingChars": "{{count}} more characters to go",
     "sessionRecordingLabel": "Turn on session recording",
     "sessionRecordingDescription": "Help us fix your bug faster by turning on session recording and reproducing the bug. You can turn it off after.",
+    "bleDiagnosticsLabel": "Attach Bluetooth diagnostics",
+    "bleDiagnosticsDescription": "Includes nearby boards we found and recent connection errors so we can debug Bluetooth faster.",
     "starRating_one": "{{count}} star",
     "starRating_other": "{{count}} stars",
     "nextAria": "Next"

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -335,6 +335,8 @@
     "starRating_other": "{{count}} estrellas",
     "sessionRecordingLabel": "Activar grabación de sesión",
     "sessionRecordingDescription": "Ayúdanos a corregir tu error más rápido activando la grabación de sesión y reproduciendo el problema. Puedes desactivarla después.",
+    "bleDiagnosticsLabel": "Adjuntar diagnóstico de Bluetooth",
+    "bleDiagnosticsDescription": "Incluye los plafones cercanos que encontramos y los errores de conexión recientes para depurar el Bluetooth más rápido.",
     "nextAria": "Siguiente"
   },
   "feedbackBanner": {

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -335,6 +335,8 @@
     "starRating_other": "{{count}} étoiles",
     "sessionRecordingLabel": "Activer l'enregistrement de session",
     "sessionRecordingDescription": "Aidez-nous à corriger votre bug plus vite en activant l'enregistrement de session et en reproduisant le problème. Vous pourrez le désactiver ensuite.",
+    "bleDiagnosticsLabel": "Joindre le diagnostic Bluetooth",
+    "bleDiagnosticsDescription": "Inclut les boards détectés à proximité et les erreurs de connexion récentes pour déboguer le Bluetooth plus vite.",
     "nextAria": "Suivant"
   },
   "feedbackBanner": {


### PR DESCRIPTION
## Summary

Users keep reporting Bluetooth problems, but analytics show most users connect fine — the failures are concentrated in a minority of devices/boards we can't see. Today a mobile bug report carries a comment plus board/climb/session context but **no BLE signal**, so a "Bluetooth doesn't work" report is unactionable.

This adds an opt-in **"Attach Bluetooth diagnostics"** switch to the mobile bug report sheet (defaults **off**). When on, the report attaches an in-session dump of the boards found and recent connection issues (connect failures, send failures, disconnects) with the write-type / MTU diagnostics we already compute at connect — so a triager sees *which* board, *which* failure mode, and *which* write path was chosen.

### How it works
- **New `ble-diagnostics-log.ts`** — a module-level ring buffer (40 events, in-session only) recording `device_found`, `connect_success`, `connect_failure`, `send_failure`, `disconnect`. It **reuses** the existing `classifyBleFailure` / `classifyBleFailureReason` / `isDisconnectionError` and the connect-time `getNativeBleConnectedDevice()` diagnostics rather than duplicating them.
- **Instrumented** `adapter.ts` (devices found) and `use-board-bluetooth.ts` (connect/send/disconnect) at the spots that already classify these failures.
- **Carried end-to-end** via `context.bleDiagnostics` (a string in the existing `app_feedback.context` jsonb column — **no DB migration**) → GraphQL → backend → Discord, rendered as a fenced field truncated to Discord's 1024-char limit.
- **Toggle** is local per-report state in `FeedbackSheet`, default off; raw device name + id are included (most debuggable, per product decision).

Scope is **mobile only** (web's bug dialog has no toggles and uses Web Bluetooth — possible follow-up). Device identifiers are sent **raw**.

## Release Notes

- When Bluetooth acts up, flip on **Attach Bluetooth diagnostics** in your bug report so we can see what your phone saw — the boards it found and where the connection dropped.

## Test plan

- `vp run typecheck:mobile`, `:backend`, `:db`, `:web` — all green.
- `vp run codegen` — generated types updated, no drift.
- `vp test run --project mobile` (2726 pass) and `--project backend` (1816 pass), incl. new suites:
  - `ble-diagnostics-log.test.ts` — buffer cap/eviction, dedupe, empty→null, write-type/MTU rendering, newest-first timeline.
  - `discord-webhook.test.ts` — fenced field rendered when present, omitted when absent, truncated under 1024.
  - `feedback-validation.test.ts` — `bleDiagnostics` accepted, capped at 2000.
  - `use-submit-app-feedback.test.ts` — enrichment includes/omits `bleDiagnostics` per flag.
- `vp check` on changed files — 0 errors; i18n catalog parity (en-US/es/fr) holds.
- Manual (pending): force a BLE failure on device, open bug report, flip the toggle on, submit, confirm the Discord message shows a Bluetooth diagnostics block; confirm a report with it off carries no BLE field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AH7cFT6wWPAzHriynK4XS