### PR TITLE
chore(mobile): fix iOS Pods cache key + appVersionSource, align version, drop patch artifact

### DIFF
--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -86,11 +86,18 @@ jobs:
         working-directory: packages/mobile
         run: bunx expo prebuild --platform ios --clean --no-install
 
+      # Key on the native inputs that decide the Pods, NOT ios/Podfile.lock: there
+      # is no committed ios/ (CNG — `expo prebuild` generates it), and this step
+      # runs BEFORE `pod install`, so hashFiles('packages/mobile/ios/Podfile.lock')
+      # matched nothing and the key collapsed to a constant that froze the cache at
+      # its first save. The native deps + plugins + patches are what move the Pods,
+      # so hash those (mirrors ios-testflight-rn.yml; restore-keys still falls back
+      # to that workflow's bucket).
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
           path: packages/mobile/ios/Pods
-          key: ${{ runner.os }}-pods-rn-ci-${{ hashFiles('packages/mobile/ios/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-rn-ci-${{ hashFiles('packages/mobile/package.json', 'bun.lock', 'packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'patches/**') }}
           restore-keys: |
             ${{ runner.os }}-pods-rn-ci-
             ${{ runner.os }}-pods-rn-

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -211,11 +211,18 @@ jobs:
         working-directory: packages/mobile
         run: bunx expo prebuild --platform ios --clean --no-install
 
+      # Key on the native inputs that decide the Pods, NOT ios/Podfile.lock: there
+      # is no committed ios/ (CNG — `expo prebuild` generates it), and this step
+      # runs BEFORE `pod install`, so hashFiles('packages/mobile/ios/Podfile.lock')
+      # matched nothing and the key collapsed to a constant that froze the cache at
+      # its first save. The native deps + plugins + patches are what move the Pods,
+      # so hash those (mirrors the gradle key in android-apk-rn.yml and the .app key
+      # in mobile-screenshots-ios.yml).
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
           path: packages/mobile/ios/Pods
-          key: ${{ runner.os }}-pods-rn-${{ hashFiles('packages/mobile/ios/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-rn-${{ hashFiles('packages/mobile/package.json', 'bun.lock', 'packages/mobile/app.config.ts', 'packages/mobile/plugins/**', 'packages/mobile/modules/**', 'patches/**') }}
           restore-keys: |
             ${{ runner.os }}-pods-rn-
 

--- a/packages/mobile/eas.json
+++ b/packages/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.0.0",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@boardsesh/mobile",
-  "version": "2.0.0",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/patches/react-native-screens@4.25.2.patch
+++ b/patches/react-native-screens@4.25.2.patch
@@ -1,6 +1,3 @@
-diff --git a/node_modules/react-native-screens/.bun-tag-4d17c8a3a14d1b96 b/.bun-tag-4d17c8a3a14d1b96
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/ios/helpers/scroll-view/RNSScrollViewFinder.h b/ios/helpers/scroll-view/RNSScrollViewFinder.h
 index 04d40b38bad73bedd79c6aa8b85125dc79093db7..ea25d1b0b36fcc6afeed44b5d603b8cbd15be6c0 100644
 --- a/ios/helpers/scroll-view/RNSScrollViewFinder.h


### PR DESCRIPTION
Four independent, low-risk CI/build hygiene fixes the review surfaced. No app behaviour changes.

## What changed

**1. iOS Pods cache key was inert under CNG.** `ios-testflight-rn.yml` and `ios-rn-ci.yml` keyed `actions/cache` on `hashFiles('packages/mobile/ios/Podfile.lock')`, but there is no committed `ios/` (Continuous Native Generation — `expo prebuild` generates it) and the cache step runs *before* `pod install`, so `hashFiles` matched nothing → the key collapsed to a constant and the Pods cache froze at its first save (never re-saved on a dep change, so every run cold-installed Pods anyway). Re-keyed on the native inputs that actually move the Pods — `packages/mobile/package.json`, `bun.lock`, `app.config.ts`, `plugins/**`, `modules/**`, `patches/**` — mirroring the gradle key in `android-apk-rn.yml` and the `.app` key in `mobile-screenshots-ios.yml`. Each workflow keeps its existing key prefix and restore-keys (CI still falls back to the TestFlight bucket).

**2. `appVersionSource: "remote"` → `"local"`** in `eas.json`. EAS is not the source of truth: fastlane + App Store Connect/Play own the build numbers and `app.config.ts` owns the marketing version. The only `eas build` consumers are the internal preview/dev-client shells (`development`, `development-device`, `preview`), never store-submitted, so the remote version store was inert.

**3. Version drift.** `packages/mobile/package.json` `"version"` was `2.0.0` while the real source of truth `packages/mobile/app.config.ts` is `2.0.1`. **Chose to drop the unused field** rather than keep two values in lockstep: nothing reads `package.json`'s `version` (the CI workflows resolve the version via regex from `app.config.ts`, and `scripts/mobile-auto-version-bump.ts` writes only `app.config.ts`), and the package is `"private": true`. Dropping it leaves `app.config.ts` as the single source of truth with no drift surface.

**4. Dropped the stray `.bun-tag` artifact** from `patches/react-native-screens@4.25.2.patch` (an empty-file hunk a bun-patch run captured into the diff), leaving the two real iOS-26 fixes (the FlashList content-scroll-view finder + the post-appearance bottom-accessory relayout) byte-for-byte untouched. Verified `bun install --frozen-lockfile` still applies the patch cleanly with both fixes present and `bun.lock` unchanged (it pins the patch by filename, not content). bun recreates its own internal `.bun-tag` marker at install time independent of the committed diff, so removing the hunk only cleans the source patch.

## Validation

- `vp check` — lint clean; the only formatting hits are two pre-existing files unrelated to this PR (`docs/embedded-architecture.md`, `embedded/scripts/generate-board-data.mjs`, zero diff vs `origin/main`).
- `vp run typecheck:mobile` — pass.
- `vp run test:mobile` — 2717 tests pass (364 files).
- `vp run check:mobile-bundle` — Android bundle OK (12.3 MB).
- `bun install --frozen-lockfile` — applies all patches cleanly, no lockfile change.

## Release Notes

Internal CI/build hygiene — no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMykAw5PcpxfEMpTAJKNke