### PR TITLE
perf(mobile): pilot React Compiler (draft — measure before merge)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -296,6 +296,7 @@
         "@bacons/apple-targets": "^4.0.7",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
+        "babel-plugin-react-compiler": "1.0.0",
         "jsdom": "^28.1.0",
         "react-dom": "19.2.3",
         "typescript": "~6.0.3",

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -203,6 +203,23 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     icon: iconPath,
     userInterfaceStyle: 'automatic',
     newArchEnabled: true,
+    // PILOT (draft — measure before merge): React Compiler auto-memoization.
+    // SDK 56's babel-preset-expo enables babel-plugin-react-compiler when Expo
+    // CLI sees experiments.reactCompiler — it forwards it as the metro
+    // `customTransformOptions.reactCompiler` flag, which the babel transformer
+    // turns into the `supportsReactCompiler` babel caller the preset reads. No
+    // babel.config.js is required (the project has none; the preset is applied
+    // by Expo's metro transformer). Requires New Architecture (enabled above)
+    // and is compiler-safe-by-default: it skips any component that violates the
+    // Rules of React rather than miscompiling it. We don't use NativeWind (the
+    // one SDK 56 incompatibility). This is a structural attack on the
+    // missed-memoization re-render cliffs in the Android-16 freeze work, but it
+    // changes memoization behaviour app-wide, so it MUST be measured on a
+    // preview build (compiler on vs off) before this draft is promoted.
+    experiments: {
+      ...config.experiments,
+      reactCompiler: true,
+    },
     // Mobile-only; opting out of web keeps `expo export --platform=all` from
     // failing on missing `react-native-web` during EAS Update publishes.
     platforms: ['ios', 'android'],

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -106,6 +106,7 @@
     "@bacons/apple-targets": "^4.0.7",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
+    "babel-plugin-react-compiler": "1.0.0",
     "jsdom": "^28.1.0",
     "react-dom": "19.2.3",
     "typescript": "~6.0.3",


### PR DESCRIPTION
## What this does

Enables **React Compiler** auto-memoization on the mobile app (Expo SDK 56 / React 19.2 / RN 0.85) the SDK-56-canonical way. **Draft on purpose** — React Compiler changes runtime memoization behaviour app-wide and must be measured before it merges (there is active Android-16 freeze investigation).

### Changes
- `packages/mobile/app.config.ts` — `experiments.reactCompiler: true` (merged over any base `config.experiments`), grouped with `newArchEnabled` (the compiler requires New Architecture).
- `packages/mobile/package.json` — pin `babel-plugin-react-compiler` to `1.0.0` (exact, no caret) in `devDependencies`. This is the version `babel-preset-expo@56.0.15` resolves via `^1.0.0`; pinning it makes the build-time dependency explicit and reproducible.
- `bun.lock` — lockfile update for the pinned plugin.

No `babel.config.js` was added (the project has none). Expo's metro transformer applies `babel-preset-expo` automatically, and the compiler is switched on entirely by the app-config flag: Expo CLI forwards `experiments.reactCompiler` as the metro `customTransformOptions.reactCompiler`, the babel transformer turns that into the `supportsReactCompiler` babel caller, and `babel-preset-expo` reads it to enable `babel-plugin-react-compiler`.

### Why
The repo's own React Native performance checklist already assumes auto-memoization, but it was never enabled. Turning it on is the cleanest structural attack on the missed-memoization re-render cliffs behind the Android-16 climb-list freeze work — without a large per-component refactor.

## Bundle result (the critical gate)
`vp run check:mobile-bundle` exports both platforms cleanly with the compiler active:

| Platform | Result | Size | Modules |
| --- | --- | --- | --- |
| iOS | OK | 12.5 MB | 4169 |
| Android | OK | 12.6 MB | 4255 |

Both logs print `React Compiler enabled`. **No components were rejected** — there were no compiler bail / skip / Rules-of-React warnings in either export. React Compiler is safe-by-default: any component it can't safely optimize it silently opts out of, rather than miscompiling, so the pilot is non-destructive even where app code doesn't follow the Rules of React perfectly.

The project uses `StyleSheet` + a theme provider, **not NativeWind** — the one known SDK 56 React Compiler incompatibility — so that caveat doesn't apply here.

## Validation
- `vp run check:mobile-bundle` — PASS (iOS + Android, compiler enabled, no bails)
- `vp run typecheck:mobile` — PASS
- `vp run test:mobile` — PASS (364 files, 2717 tests)
- `vp check` — my changed files format-clean (two unrelated pre-existing format hits on `main` left untouched)

## How to measure BEFORE promoting from draft
This branch auto-publishes a JS-only OTA preview (`mobile-eas-update.yml` on push). React Compiler is a build-time babel transform that rides the JS bundle, so a preview build carries the compiled output with no native change.

1. **A/B the compiler.** Compare two preview bundles: this branch (compiler on) vs `main` (compiler off), same device. Pin a preview channel to each branch (`bunx eas-cli@16 channel:edit preview-N --branch <branch>`), or flip `experiments.reactCompiler` off in a sibling preview.
2. **Android-16 climb-list interaction** (the live freeze case, S24 / Pixel 10): exercise the climb-list scroll + board-activation flow that triggers the main-thread hang, with and without the compiler. Watch for change in the freeze frequency / duration.
3. **Frame + launch timings.** Capture cold-start and interaction frame timings on both builds — `expo-observe` (cold/warm launch, TTR/TTI, frame rate) plus the existing PostHog session-length / freeze telemetry keyed on `$app_build` ↔ the published `rn-android-2.0.NNN` build.
4. **Regression sweep.** Smoke the queue / play-drawer / board-render paths on a preview build — auto-memoization can surface latent effect-dependency bugs that manual memoization hid.

Promote to ready only once the measurements show a neutral-or-better result (especially no regression on the Android-16 freeze) and no behavioural regressions.

## Release Notes
Draft pilot enabling React Compiler auto-memoization; not yet shipped — pending measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMykAw5PcpxfEMpTAJKNke