### PR TITLE
fix(mobile): show playlist-create errors inline instead of behind the sheet

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -175,6 +175,10 @@ export default function PlaylistDetail() {
   const [editVisible, setEditVisible] = useState(false);
   const [actionsVisible, setActionsVisible] = useState(false);
   const [savingEdit, setSavingEdit] = useState(false);
+  // Update failures surface INLINE in the edit sheet, not via a root toast — a
+  // toast fired while the native sheet is open renders behind it and is invisible.
+  // The sheet stays open on failure so the user can fix and retry.
+  const [editError, setEditError] = useState<string | null>(null);
 
   // Climbs edit mode (reorder + remove). `editClimbs` is a frozen snapshot of the
   // loaded list seeded on entry; the list renders from it while editing so
@@ -370,6 +374,7 @@ export default function PlaylistDetail() {
     async (values: PlaylistFormValues) => {
       if (!playlist) return;
       setSavingEdit(true);
+      setEditError(null);
       try {
         const updated = await updatePlaylist({
           playlistId: playlist.uuid,
@@ -392,7 +397,9 @@ export default function PlaylistDetail() {
       } catch (err) {
         console.error('Failed to update playlist:', err);
         reportHandledError(err, { tags: { source: 'playlist', op: 'update' } });
-        showToast(t('edit.messages.updateFailed'), 'error');
+        // Inline, not a toast: the sheet is still open, so a root toast would be
+        // hidden behind it.
+        setEditError(t('edit.messages.updateFailed'));
       } finally {
         setSavingEdit(false);
       }
@@ -425,7 +432,10 @@ export default function PlaylistDetail() {
 
   // Cog (shown in edit mode) → open the edit-details sheet directly. No menu is
   // involved, so no sheet-handoff dance is needed.
-  const openEditDetails = useCallback(() => setEditVisible(true), []);
+  const openEditDetails = useCallback(() => {
+    setEditError(null);
+    setEditVisible(true);
+  }, []);
 
   // Collapsed overflow menu (owner): Pin toggles in place; Delete confirms; Edit
   // enters the climbs edit mode once the menu sheet has dismissed (deferred via
@@ -641,8 +651,12 @@ export default function PlaylistDetail() {
         visible={editVisible}
         submitting={savingEdit}
         playlist={playlist ?? null}
+        submitError={editError}
         onSubmit={handleEditSubmit}
-        onClose={() => setEditVisible(false)}
+        onClose={() => {
+          setEditVisible(false);
+          setEditError(null);
+        }}
       />
 
       <PlaylistQueueReplaceSheet {...playlistActivation.queueReplaceSheet} />

--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -69,6 +69,7 @@ const pinnedHook = vi.hoisted(() => ({
 const createPlaylist = vi.hoisted(() => vi.fn());
 const pinPlaylist = vi.hoisted(() => vi.fn());
 const unpinPlaylist = vi.hoisted(() => vi.fn());
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 const discoverOptions = vi.hoisted(() => [] as DiscoverOptions[]);
 const asyncStorage = vi.hoisted(() => ({
   storage: new Map<string, string>(),
@@ -144,7 +145,7 @@ vi.mock('../../../../src/providers/auth-provider', () => ({
   useAuth: () => ({ isAuthenticated: true, isLoading: false }),
 }));
 vi.mock('../../../../src/providers/toast-provider', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => toast,
 }));
 vi.mock('../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ data: 'token' }) }));
 vi.mock('../../../../src/lib/graphql/hooks', () => ({ useProfile: () => ({ data: { id: 'me' } }) }));
@@ -250,8 +251,23 @@ vi.mock('../../../../src/components/playlist', () => ({
       createElement('span', null, metaLabel ? `${name} ${metaLabel}` : name),
       onTogglePin ? createElement('button', { 'aria-label': `pin-${name}`, onClick: onTogglePin }, 'pin') : null,
     ),
-  PlaylistFormSheet: ({ onSubmit }: { onSubmit: (values: typeof FORM_VALUES) => void }) =>
-    createElement('button', { 'aria-label': 'submit-create', onClick: () => onSubmit(FORM_VALUES) }, 'submit'),
+  PlaylistFormSheet: ({
+    visible,
+    submitError,
+    onSubmit,
+  }: {
+    visible: boolean;
+    submitError?: string | null;
+    onSubmit: (values: typeof FORM_VALUES) => void;
+  }) =>
+    visible
+      ? createElement(
+          'div',
+          null,
+          submitError ? createElement('span', { 'data-create-error': 'true' }, submitError) : null,
+          createElement('button', { 'aria-label': 'submit-create', onClick: () => onSubmit(FORM_VALUES) }, 'submit'),
+        )
+      : null,
 }));
 vi.mock('../../../../src/components/HorizontalScrollSection', () => ({
   HorizontalScrollSection: ({ children, title }: { children?: ReactNode; title: string }) =>
@@ -313,6 +329,7 @@ beforeEach(() => {
   createPlaylist.mockReset();
   pinPlaylist.mockReset();
   unpinPlaylist.mockReset();
+  toast.showToast.mockClear();
   discoverOptions.length = 0;
 });
 
@@ -585,5 +602,25 @@ describe('DiscoverLibrary create flow', () => {
 
     const cached = queryClient.getQueryData<Array<{ uuid: string }>>(['userPlaylists']);
     expect(cached?.map((playlist) => playlist.uuid)).toEqual(['p-new', 'p-old']);
+  });
+
+  it('shows the create failure inline in the sheet (not a toast) and keeps the sheet open', async () => {
+    createPlaylist.mockRejectedValue(new Error('create failed'));
+
+    const { getByLabelText, container } = renderHub();
+
+    fireEvent.click(getByLabelText('open-create'));
+    await act(async () => {
+      fireEvent.click(getByLabelText('submit-create'));
+    });
+
+    // The error renders in the sheet's inline slot, not via the root toast (which
+    // would be hidden behind the native sheet).
+    expect(container.querySelector('[data-create-error="true"]')?.textContent).toBe(
+      'bottomTabBar.createPlaylistFailed',
+    );
+    expect(toast.showToast).not.toHaveBeenCalledWith('bottomTabBar.createPlaylistFailed', 'error');
+    // The sheet stays open so the user can correct and retry.
+    expect(getByLabelText('submit-create')).toBeTruthy();
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -255,10 +255,12 @@ vi.mock('../../../../src/components/playlist', () => ({
     visible,
     submitError,
     onSubmit,
+    onClose,
   }: {
     visible: boolean;
     submitError?: string | null;
     onSubmit: (values: typeof FORM_VALUES) => void;
+    onClose: () => void;
   }) =>
     visible
       ? createElement(
@@ -266,6 +268,7 @@ vi.mock('../../../../src/components/playlist', () => ({
           null,
           submitError ? createElement('span', { 'data-create-error': 'true' }, submitError) : null,
           createElement('button', { 'aria-label': 'submit-create', onClick: () => onSubmit(FORM_VALUES) }, 'submit'),
+          createElement('button', { 'aria-label': 'close-create', onClick: onClose }, 'close'),
         )
       : null,
 }));
@@ -619,8 +622,29 @@ describe('DiscoverLibrary create flow', () => {
     expect(container.querySelector('[data-create-error="true"]')?.textContent).toBe(
       'bottomTabBar.createPlaylistFailed',
     );
-    expect(toast.showToast).not.toHaveBeenCalledWith('bottomTabBar.createPlaylistFailed', 'error');
+    // No toast at all on create failure — a root toast would be hidden behind the
+    // native sheet.
+    expect(toast.showToast).not.toHaveBeenCalled();
     // The sheet stays open so the user can correct and retry.
     expect(getByLabelText('submit-create')).toBeTruthy();
+  });
+
+  it('clears the create error after the sheet is closed and reopened', async () => {
+    createPlaylist.mockRejectedValue(new Error('create failed'));
+
+    const { getByLabelText, queryByLabelText, container } = renderHub();
+
+    fireEvent.click(getByLabelText('open-create'));
+    await act(async () => {
+      fireEvent.click(getByLabelText('submit-create'));
+    });
+    expect(container.querySelector('[data-create-error="true"]')).not.toBeNull();
+
+    fireEvent.click(getByLabelText('close-create'));
+    expect(queryByLabelText('submit-create')).toBeNull();
+
+    fireEvent.click(getByLabelText('open-create'));
+    // Reopened with a clean slate — no stale error from the previous attempt.
+    expect(container.querySelector('[data-create-error="true"]')).toBeNull();
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -43,6 +43,7 @@ vi.mock('../../../../src/lib/graphql/client', () => ({
 // query.refetch (for the retry) and allClimbs here.
 const climbsRefetch = vi.hoisted(() => vi.fn());
 const updatePlaylistMock = vi.hoisted(() => vi.fn());
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 vi.mock('@boardsesh/playlists-react', () => ({
   usePlaylistClimbs: () => ({
     query: {
@@ -97,7 +98,7 @@ vi.mock('../../../../src/providers/theme-provider', () => ({
   useTheme: () => ({ systemColors: { label: '#000', fill: '#eee' }, brandColors: { primary: '#6D28D9' } }),
 }));
 vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
-vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => toast }));
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
   usePlaylistActivation: (options: CapturedActivationOptions) => {
     playlistMocks.activationOptions = options;
@@ -140,15 +141,26 @@ vi.mock('../../../../src/components/playlist', () => ({
   SKELETON_PLACEHOLDERS: ['a', 'b'],
   // Surface the edit submit so the cache-patch test can drive handleEditSubmit
   // without the real gorhom sheet.
-  PlaylistFormSheet: ({ onSubmit }: { onSubmit?: (values: unknown) => void }) =>
+  PlaylistFormSheet: ({
+    submitError,
+    onSubmit,
+  }: {
+    submitError?: string | null;
+    onSubmit?: (values: unknown) => void;
+  }) =>
     createElement(
-      'button',
-      {
-        'data-form-submit': 'true',
-        onClick: () =>
-          onSubmit?.({ name: 'Bad climbs', description: '', color: '#1F2937', icon: '💀', isPublic: false }),
-      },
-      'form-submit',
+      'div',
+      null,
+      submitError ? createElement('span', { 'data-edit-error': 'true' }, submitError) : null,
+      createElement(
+        'button',
+        {
+          'data-form-submit': 'true',
+          onClick: () =>
+            onSubmit?.({ name: 'Bad climbs', description: '', color: '#1F2937', icon: '💀', isPublic: false }),
+        },
+        'form-submit',
+      ),
     ),
   PlaylistActionsMenu: () => null,
   PlaylistFollowButton: () => null,
@@ -175,6 +187,7 @@ beforeEach(() => {
   requestMock.mockReset();
   climbsRefetch.mockClear();
   updatePlaylistMock.mockReset();
+  toast.showToast.mockClear();
   playlistMocks.allClimbs = [];
   playlistMocks.activationOptions = null;
   playlistMocks.renderBoardResult = { renderBoard: null, banner: null };
@@ -319,5 +332,20 @@ describe('PlaylistDetail edit cache propagation', () => {
     });
     // The detail hero cache is updated to the full server response.
     expect(queryClient.getQueryData(['playlist', 'p-1'])).toEqual(updated);
+  });
+
+  it('shows an update failure inline in the edit sheet (not a toast)', async () => {
+    requestMock.mockResolvedValue({ playlist: basePlaylist });
+    updatePlaylistMock.mockRejectedValue(new Error('update failed'));
+
+    const { findByText, container } = renderDetail();
+
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-edit-error="true"]')?.textContent).toBe('edit.messages.updateFailed');
+    });
+    // A root toast would render behind the native sheet and be invisible.
+    expect(toast.showToast).not.toHaveBeenCalledWith('edit.messages.updateFailed', 'error');
   });
 });

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -302,6 +302,10 @@ export default function DiscoverLibrary() {
 
   const [createVisible, setCreateVisible] = useState(false);
   const [creating, setCreating] = useState(false);
+  // Create failures surface INLINE in the sheet (its error slot), not via a root
+  // toast — a toast fired while the native sheet is open renders behind it and is
+  // invisible. The sheet stays open on failure so the user can fix and retry.
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const handleCreatePress = useCallback(() => {
     if (!createBoard) {
@@ -309,6 +313,7 @@ export default function DiscoverLibrary() {
       router.push('/boards');
       return;
     }
+    setCreateError(null);
     setCreateVisible(true);
   }, [createBoard, showToast, t]);
 
@@ -316,6 +321,7 @@ export default function DiscoverLibrary() {
     async (values: PlaylistFormValues) => {
       if (!createBoard) return;
       setCreating(true);
+      setCreateError(null);
       try {
         const created = await createPlaylist({
           boardType: createBoard.boardType,
@@ -339,7 +345,9 @@ export default function DiscoverLibrary() {
       } catch (err) {
         console.error('Failed to create playlist:', err);
         reportHandledError(err, { tags: { source: 'playlist', op: 'create' } });
-        showToast(t('bottomTabBar.createPlaylistFailed'), 'error');
+        // Inline, not a toast: the sheet is still open, so a root toast would be
+        // hidden behind it.
+        setCreateError(t('bottomTabBar.createPlaylistFailed'));
       } finally {
         setCreating(false);
       }
@@ -651,8 +659,12 @@ export default function DiscoverLibrary() {
         mode="create"
         visible={createVisible}
         submitting={creating}
+        submitError={createError}
         onSubmit={handleCreateSubmit}
-        onClose={() => setCreateVisible(false)}
+        onClose={() => {
+          setCreateVisible(false);
+          setCreateError(null);
+        }}
       />
     </View>
   );

--- a/packages/mobile/src/components/AddToPlaylistSheet.tsx
+++ b/packages/mobile/src/components/AddToPlaylistSheet.tsx
@@ -54,6 +54,10 @@ function AddToPlaylistSheet({
   const { playlists, addToPlaylist, createPlaylist, isLoading, isAuthenticated } = usePlaylistsContext();
   const [createVisible, setCreateVisible] = useState(false);
   const [creating, setCreating] = useState(false);
+  // Create failures surface INLINE in the nested create sheet, not via a root
+  // toast — a toast fired while the native sheet is open renders behind it and is
+  // invisible. The sheet stays open on failure so the user can fix and retry.
+  const [createError, setCreateError] = useState<string | null>(null);
   // Mirror the latest open intent so an in-flight create can tell whether the
   // sheet is still open (replaces the old isPresentedRef gate).
   const visibleRef = useRef(visible);
@@ -98,6 +102,7 @@ function AddToPlaylistSheet({
       createRequestIdRef.current = createRequestId;
       const isCurrentCreateRequest = () => createRequestIdRef.current === createRequestId && visibleRef.current;
       setCreating(true);
+      setCreateError(null);
       try {
         const created = await createPlaylist(values.name, values.description, values.color, values.icon, {
           boardType: boardName,
@@ -132,7 +137,9 @@ function AddToPlaylistSheet({
             error,
           });
         }
-        showToast(t('actions.playlist.toast.createFailed'), 'error');
+        // Inline, not a toast: the create sheet is still open, so a root toast
+        // would be hidden behind it.
+        setCreateError(t('actions.playlist.toast.createFailed'));
       } finally {
         if (createRequestIdRef.current === createRequestId) setCreating(false);
       }
@@ -146,10 +153,12 @@ function AddToPlaylistSheet({
     createRequestIdRef.current += 1;
     setCreateVisible(false);
     setCreating(false);
+    setCreateError(null);
     onFullyDismissed?.();
   }, [onFullyDismissed]);
 
   const handleShowCreate = useCallback(() => {
+    setCreateError(null);
     setCreateVisible(true);
   }, []);
 
@@ -157,6 +166,7 @@ function AddToPlaylistSheet({
     createRequestIdRef.current += 1;
     setCreateVisible(false);
     setCreating(false);
+    setCreateError(null);
   }, []);
 
   const snapPoints = useMemo(() => ['50%', '90%'], []);
@@ -238,6 +248,7 @@ function AddToPlaylistSheet({
         mode="create"
         visible={createVisible}
         submitting={creating}
+        submitError={createError}
         onSubmit={handleCreatePlaylist}
         onClose={handleCloseCreate}
       />

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -121,11 +121,13 @@ vi.mock('../playlist', () => ({
   PlaylistFormSheet: ({
     visible,
     submitting,
+    submitError,
     onSubmit,
     onClose,
   }: {
     visible: boolean;
     submitting?: boolean;
+    submitError?: string | null;
     onSubmit: (values: { name: string; description?: string; color?: string; icon?: string }) => void;
     onClose: () => void;
   }) =>
@@ -133,6 +135,7 @@ vi.mock('../playlist', () => ({
       ? createElement(
           'div',
           null,
+          submitError ? createElement('span', { 'data-create-error': 'true' }, submitError) : null,
           createElement(
             'button',
             {
@@ -378,16 +381,20 @@ describe('AddToPlaylistSheet', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('keeps the create sheet open when playlist creation fails', async () => {
+  it('shows the create failure inline (not a toast) and keeps the sheet open', async () => {
     playlistContext.createPlaylist.mockRejectedValueOnce(new Error('create failed'));
-    const { getByLabelText, onClose } = renderSheet();
+    const { getByLabelText, container, onClose } = renderSheet();
 
     fireEvent.click(getByLabelText('actions.playlist.popover.createNew'));
     fireEvent.click(getByLabelText('submit-created-playlist'));
 
     await waitFor(() => {
-      expect(toast.showToast).toHaveBeenCalledWith('actions.playlist.toast.createFailed', 'error');
+      expect(container.querySelector('[data-create-error="true"]')?.textContent).toBe(
+        'actions.playlist.toast.createFailed',
+      );
     });
+    // A root toast would render behind the native sheet and be invisible.
+    expect(toast.showToast).not.toHaveBeenCalledWith('actions.playlist.toast.createFailed', 'error');
     expect(getByLabelText('submit-created-playlist')).not.toBeNull();
     expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/AddToPlaylistSheet.test.tsx
@@ -393,8 +393,8 @@ describe('AddToPlaylistSheet', () => {
         'actions.playlist.toast.createFailed',
       );
     });
-    // A root toast would render behind the native sheet and be invisible.
-    expect(toast.showToast).not.toHaveBeenCalledWith('actions.playlist.toast.createFailed', 'error');
+    // No toast at all — a root toast would render behind the native sheet.
+    expect(toast.showToast).not.toHaveBeenCalled();
     expect(getByLabelText('submit-created-playlist')).not.toBeNull();
     expect(playlistContext.addToPlaylist).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -72,6 +72,14 @@ export function PlaylistFormSheet({
   const [icon, setIcon] = useState<string | undefined>(undefined);
   const [isPublic, setIsPublic] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A parent submit failure shows until the user edits a field (a signal they're
+  // acting on it) or retries, so a stale server error doesn't linger over an
+  // already-corrected form. Reset whenever a fresh submitError arrives.
+  const [submitErrorDismissed, setSubmitErrorDismissed] = useState(false);
+  useEffect(() => {
+    setSubmitErrorDismissed(false);
+  }, [submitError]);
+  const dismissSubmitError = useCallback(() => setSubmitErrorDismissed(true), []);
 
   // Seed (edit) or clear (create) the fields when the sheet opens, then drive
   // the modal off the `visible` prop. `isPresentedRef` guards against calling
@@ -126,7 +134,7 @@ export function PlaylistFormSheet({
   // Local validation takes precedence over a parent submit failure: a fresh
   // validation message (e.g. empty name) is the more actionable feedback, and
   // the parent clears `submitError` at the start of each retry anyway.
-  const visibleError = error ?? submitError ?? null;
+  const visibleError = error ?? (submitErrorDismissed ? null : submitError) ?? null;
 
   const title = isEdit ? t('edit.title') : t('create.drawerTitle');
   const submitLabel = isEdit
@@ -168,7 +176,10 @@ export function PlaylistFormSheet({
         </Text>
         <BottomSheetTextInput
           value={name}
-          onChangeText={setName}
+          onChangeText={(text) => {
+            dismissSubmitError();
+            setName(text);
+          }}
           placeholder={t('create.fields.namePlaceholder')}
           placeholderTextColor={systemColors.tertiaryLabel}
           maxLength={NAME_MAX}
@@ -181,7 +192,10 @@ export function PlaylistFormSheet({
         </Text>
         <BottomSheetTextInput
           value={description}
-          onChangeText={setDescription}
+          onChangeText={(text) => {
+            dismissSubmitError();
+            setDescription(text);
+          }}
           placeholder={t('create.fields.descriptionPlaceholder')}
           placeholderTextColor={systemColors.tertiaryLabel}
           maxLength={DESCRIPTION_MAX}
@@ -231,6 +245,7 @@ export function PlaylistFormSheet({
             // Store the trimmed value (capped to a single glyph by maxLength); the
             // header preview mirrors it live. Empty clears back to the generic tag.
             onChangeText={(text) => {
+              dismissSubmitError();
               const trimmed = text.trim();
               setIcon(trimmed.length > 0 ? trimmed : undefined);
             }}

--- a/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistFormSheet.tsx
@@ -34,6 +34,13 @@ type PlaylistFormSheetProps = {
   submitting?: boolean;
   /** Seed values for edit mode. */
   playlist?: Playlist | null;
+  /**
+   * Inline submit failure from the parent's mutation (e.g. create/update
+   * rejected). Surfaced in this sheet's error slot — never via the root toast,
+   * which renders behind the native sheet and would be invisible. The parent
+   * keeps the sheet open on failure so the user can correct and retry.
+   */
+  submitError?: string | null;
   onSubmit: (values: PlaylistFormValues) => void;
   onClose: () => void;
 };
@@ -45,7 +52,15 @@ type PlaylistFormSheetProps = {
  * an icon picker + a public/private toggle. Validation + reset-on-open mirror
  * web; the parent owns the mutation, toasts, and cache refresh.
  */
-export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmit, onClose }: PlaylistFormSheetProps) {
+export function PlaylistFormSheet({
+  mode,
+  visible,
+  submitting,
+  playlist,
+  submitError,
+  onSubmit,
+  onClose,
+}: PlaylistFormSheetProps) {
   const { t } = useTranslation('playlists');
   const { systemColors, brandColors } = useTheme();
   const sheetRef = useRef<BottomSheetModal>(null);
@@ -107,6 +122,11 @@ export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmi
     setError(null);
     onSubmit(result.values);
   }, [mode, name, description, color, icon, isPublic, onSubmit, t]);
+
+  // Local validation takes precedence over a parent submit failure: a fresh
+  // validation message (e.g. empty name) is the more actionable feedback, and
+  // the parent clears `submitError` at the start of each retry anyway.
+  const visibleError = error ?? submitError ?? null;
 
   const title = isEdit ? t('edit.title') : t('create.drawerTitle');
   const submitLabel = isEdit
@@ -278,9 +298,9 @@ export function PlaylistFormSheet({ mode, visible, submitting, playlist, onSubmi
           </View>
         ) : null}
 
-        {error ? (
+        {visibleError ? (
           <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.error}>
-            {error}
+            {visibleError}
           </Text>
         ) : null}
       </View>

--- a/packages/mobile/src/providers/toast-provider.tsx
+++ b/packages/mobile/src/providers/toast-provider.tsx
@@ -51,6 +51,12 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
+      {/* This overlay is a root-level JS View, so it renders BEHIND any native
+          surface above it — an @expo/ui sheet (ModalSheet / BottomSheetModal) or
+          a `presentation: 'modal'` route. Pattern: feedback for an action taken
+          INSIDE such a sheet must stay inline (e.g. the sheet's own error slot);
+          only call showToast once the sheet is fully dismissed, or it'll be
+          invisible behind it. */}
       <View style={styles.overlay} pointerEvents="none">
         {toasts.map((toast) => (
           <Toast key={toast.id} toast={toast} onDismiss={dismissToast} />


### PR DESCRIPTION
## What

The global Toast overlay is a root-level JS `<View>` (`src/providers/toast-provider.tsx`), so any `showToast` fired while a native `@expo/ui` sheet (`ModalSheet` / `BottomSheetModal`) is open renders **behind** the native surface and is invisible.

Three playlist flows toasted a create/update **failure** while their `PlaylistFormSheet` stayed open, so the user saw nothing and the sheet looked like it silently did nothing:

- **Discover create** (`app/(tabs)/discover/index.tsx`) — the verified case.
- **Discover edit** (`app/(tabs)/discover/[playlist_uuid].tsx`) — same `PlaylistFormSheet`, stays open on failure.
- **Add-to-Playlist create sheet** (`src/components/AddToPlaylistSheet.tsx`) — nested `PlaylistFormSheet`, stays open on failure.

## How

- Added a `submitError?: string | null` prop to `PlaylistFormSheet` that surfaces in its existing inline error slot (local validation still takes precedence). The sheet stays open on failure so the user can correct and retry.
- Each parent now sets a `*Error` state on the mutation catch (cleared on open / new submit / close) instead of calling `showToast(...)`.
- **Success toasts are untouched** — they fire after the sheet dismisses, so they're already visible.
- Added a short pattern note on the toast overlay: feedback for an action taken inside a sheet must stay inline; only toast once the sheet is fully dismissed.

## Tests

- Discover create: new test asserts the failure renders in the inline slot, no failure toast, sheet stays open.
- Discover edit: new test asserts inline error, no toast.
- Add-to-Playlist: updated the existing "keeps the create sheet open" test to assert the inline error instead of the toast.

Full mobile suite (2719 tests), `typecheck:mobile`, `vp check`, and `check:mobile-bundle` all pass.

## Release Notes

Playlist creation errors now appear inside the sheet instead of an invisible toast behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMykAw5PcpxfEMpTAJKNke