### PR TITLE
feat(mobile): post-publish OTA health check and rollback runbook

### DIFF
--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -359,3 +359,60 @@ jobs:
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"
+
+      # Post-publish OTA health gate — NON-BLOCKING. Production OTAs publish to our
+      # self-hosted server (not EAS), so `eas update:insights` can't see them.
+      # Instead we read the app's own launch telemetry from PostHog
+      # (OtaUpdateTracker → "OTA Update Status") and flag a spike in emergency
+      # launches — downloaded JS that failed to boot and fell back to the embedded
+      # bundle. continue-on-error keeps a tripped gate from ever failing the
+      # publish; the script itself exits 0 unless the emergency-launch rate clears
+      # the threshold AND the sample size is sufficient, so the low-volume minutes
+      # right after a publish can't false-trip it. This is a best-effort EARLY
+      # signal (the fleet relaunches over hours); the authoritative read is a
+      # manual/scheduled re-run later: `vp run mobile:ota-health-check`. Activates
+      # only once the POSTHOG_PERSONAL_API_KEY secret exists — the script skips
+      # (exit 0) without it, since secrets can't be referenced in a step `if:`.
+      # POSTHOG_PROJECT_ID / POSTHOG_HOST are left to the script defaults
+      # (project 412845, us.posthog.com), matching scripts/refresh-recommendations.ts.
+      # See docs/mobile-ota-updates.md ("Health monitoring & rollback").
+      - name: OTA health check (non-blocking)
+        id: health
+        if: github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
+        continue-on-error: true
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+        run: |
+          # Let early relaunches report the new bundle before we read. The window
+          # (--hours 6) picks the freshest production OTA for the adoption line; the
+          # gate uses the fleet-wide emergency-launch rate over that window.
+          sleep 120
+          vp run mobile:ota-health-check -- --hours 6 --out "$RUNNER_TEMP/ota-health.md"
+
+      # Surface the health verdict on the same Discord deploy channel as the
+      # publish announcement. Posts only when the check produced a summary (it
+      # writes nothing when skipped for a missing PostHog key). steps.health.outcome
+      # is 'failure' only when the gate tripped (continue-on-error turned the
+      # non-zero exit into a step failure without failing the job).
+      - name: Notify OTA health to Discord
+        if: github.ref == 'refs/heads/main' && steps.gate.outputs.configured == 'true' && (steps.publish_ios.outcome == 'success' || steps.publish_android.outcome == 'success')
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEALTH_OUTCOME: ${{ steps.health.outcome }}
+        run: |
+          SUMMARY_FILE="$RUNNER_TEMP/ota-health.md"
+          if [ ! -s "$SUMMARY_FILE" ]; then
+            echo "No OTA health summary (check skipped or produced no output) — nothing to post."
+            exit 0
+          fi
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          HEADER='🩺 **Production OTA health**'
+          [ "$HEALTH_OUTCOME" = "failure" ] && HEADER='🚨 **Production OTA health — emergency-launch spike**'
+          CONTENT=$(printf '%s\n%s\n<%s>' "$HEADER" "$(cat "$SUMMARY_FILE")" "$RUN_URL")
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -383,10 +383,13 @@ jobs:
         env:
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
         run: |
-          # Let early relaunches report the new bundle before we read. The window
-          # (--hours 6) picks the freshest production OTA for the adoption line; the
-          # gate uses the fleet-wide emergency-launch rate over that window.
-          sleep 120
+          # Short settle so a few early relaunches land for the adoption line. The
+          # GATE doesn't depend on it: it reads the fleet-wide emergency-launch rate
+          # over the whole --hours 6 window, which already carries plenty of samples
+          # from launches before this publish — a still-crashing prior OTA trips it
+          # immediately, while the just-published bundle's own telemetry trickles in
+          # over hours (re-run `vp run mobile:ota-health-check` later for that).
+          sleep 30
           vp run mobile:ota-health-check -- --hours 6 --out "$RUNNER_TEMP/ota-health.md"
 
       # Surface the health verdict on the same Discord deploy channel as the

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -209,6 +209,80 @@ still logs `[analytics] OTA Update Status …` to Metro so you can confirm the t
 In PostHog (project 412845), count distinct installs with `isEmbeddedLaunch = false` per `updateId` to
 measure how many pulled a given OTA.
 
+## Health monitoring & rollback
+
+A production OTA reaches **every** matching install on the next launch — there's no rollout
+percentage to cap the blast radius — and it publishes to our **self-hosted** server, so
+`eas update:insights` (which only sees EAS-hosted updates) is blind to it. The health signal
+therefore comes from the app's own launch telemetry above: an `OTA Update Status` event with
+`isEmergencyLaunch === true` is expo-updates' automatic safety net firing — the downloaded JS
+failed to boot, so the binary fell back to its **embedded** bundle. A spike in that rate across the
+production fleet right after a publish is the tell-tale of a broken bundle.
+
+### The health check (`scripts/mobile-ota-health-check.ts`)
+
+`vp run mobile:ota-health-check` queries PostHog (HogQL) for `OTA Update Status` events on the
+`production` channel over a window and reports launch count, distinct installs, and the
+emergency-launch rate:
+
+```bash
+vp run mobile:ota-health-check                                  # latest production update, last 24h
+vp run mobile:ota-health-check -- --hours 6                     # narrower window
+vp run mobile:ota-health-check -- --update-id <id>             # adoption context for a specific update
+vp run mobile:ota-health-check -- --min-samples 50 --threshold 0.1
+```
+
+It **exits non-zero only when the emergency-launch rate exceeds `--threshold` (default 10%) AND the
+window has at least `--min-samples` launches (default 30)** — so the low-volume minutes right after a
+publish, or a one-off device failure, never trip it. Every other outcome (healthy, inconclusive,
+missing key, API/network error) exits 0, so it's safe as a non-blocking gate.
+
+Two notes on what it measures:
+
+- An emergency launch runs the **embedded** bundle, so its `updateId` is the embedded one — you
+  can't attribute the failure to the bad update's id. The gate therefore measures the **fleet-wide**
+  production emergency rate over the window, not a per-`updateId` rate. The target update's adoption
+  (installs successfully running it) is reported separately, for context only.
+- The fleet relaunches over **hours**, so the value is a re-run later (manually, or wire it to a
+  schedule), not the seconds after a publish.
+
+**Required secret to activate the gate:** add `POSTHOG_PERSONAL_API_KEY` (a PostHog personal API key
+with read access) to the **Production** environment — the same secret
+`scripts/refresh-recommendations.ts` already uses. `POSTHOG_PROJECT_ID` (default `412845`) and
+`POSTHOG_HOST` (default `https://us.posthog.com`) are optional overrides. Without the key the check
+**skips and exits 0** — it never blocks a publish.
+
+### Post-publish CI step (non-blocking)
+
+`mobile-ota-production.yml` runs the health check after a successful publish (a short `sleep` lets
+early relaunches report), with `continue-on-error: true`, and posts the verdict to the same Discord
+deploy channel as the publish announcement. It's wired so it can **never** block or fail the
+publish: `continue-on-error` swallows a tripped gate, and the script no-ops (exit 0) until the
+`POSTHOG_PERSONAL_API_KEY` secret exists. The step's `outcome` going to `failure` is what flips the
+Discord header to the 🚨 emergency-spike variant.
+
+### Rollback (`scripts/mobile-ota-rollback.ts`)
+
+Because there's no rollout percentage, "rollback" means re-pointing the production branch on the
+self-hosted server. The canonical, durable fix is to **revert the offending JS commit on `main`** —
+this workflow then republishes a good bundle automatically. When you need installs reverted in
+**minutes**, before a revert PR can merge, use the helper (wraps the `eoas` CLI):
+
+```bash
+vp run mobile:ota-rollback                       # rollback to the embedded bundle, all platforms
+vp run mobile:ota-rollback -- --platform ios     # one platform only
+vp run mobile:ota-rollback -- --mode republish   # re-point to a previous update (interactive, run LOCALLY)
+```
+
+- **`--mode embedded` (default)** runs `eoas rollback`: publishes a rollback **directive** so every
+  install currently on the bad OTA reverts to the binary's embedded (shipped, known-good) bundle on
+  its next launch. Non-interactive — safe to run from CI.
+- **`--mode republish`** runs `eoas republish`: re-points the branch to a previous published update
+  you pick from a list. It's **interactive**, so run it locally, not in CI.
+
+Both need `EXPO_UPDATES_URL` + `EXPO_TOKEN` (same as the publish). After rolling back, land the real
+fix (a revert or a corrected commit) on `main` so the next publish moves the fleet forward again.
+
 ## PR-time OTA-compatibility signal
 
 The native gate above answers "should `main` rebuild?". `mobile-ota-check.yml` answers the same

--- a/scripts/__tests__/eoas.test.ts
+++ b/scripts/__tests__/eoas.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { bunxIsScriptShim, pathWithoutBrokenBunxShims } from '../lib/eoas';
+
+const createdDirs: string[] = [];
+
+/** Make a temp dir, optionally with a `bunx` file of the given contents. */
+function makeDirWithBunx(content: string | null): string {
+  const dir = mkdtempSync(join(tmpdir(), 'eoas-'));
+  createdDirs.push(dir);
+  if (content !== null) writeFileSync(join(dir, 'bunx'), content);
+  return dir;
+}
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    rmSync(createdDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('bunxIsScriptShim', () => {
+  it('flags a `#!` script shim (vp’s broken bunx)', () => {
+    expect(bunxIsScriptShim(makeDirWithBunx('#!/bin/sh\nexec bun "$@"\n'))).toBe(true);
+  });
+
+  it('treats a non-`#!` bunx as a real binary', () => {
+    expect(bunxIsScriptShim(makeDirWithBunx('\x7fELF...not a script'))).toBe(false);
+  });
+
+  it('returns false when the dir has no bunx', () => {
+    expect(bunxIsScriptShim(makeDirWithBunx(null))).toBe(false);
+  });
+});
+
+describe('pathWithoutBrokenBunxShims', () => {
+  it('drops only the dirs whose bunx is a `#!` shim', () => {
+    const shimDir = makeDirWithBunx('#!/bin/sh\nexec bun "$@"\n');
+    const realDir = makeDirWithBunx('\x7fELF...');
+    const emptyDir = makeDirWithBunx(null);
+
+    const result = pathWithoutBrokenBunxShims([shimDir, realDir, emptyDir].join(delimiter)).split(delimiter);
+
+    expect(result).toContain(realDir);
+    expect(result).toContain(emptyDir);
+    expect(result).not.toContain(shimDir);
+  });
+
+  it('returns an empty string for an undefined PATH', () => {
+    expect(pathWithoutBrokenBunxShims(undefined)).toBe('');
+  });
+});

--- a/scripts/__tests__/mobile-ota-health-check.test.ts
+++ b/scripts/__tests__/mobile-ota-health-check.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHealthQuery,
+  buildLatestUpdateQuery,
+  evaluateOtaHealth,
+  parseHealthCheckArgs,
+  sanitizeUpdateId,
+  summarizeVerdict,
+  type HealthMetrics,
+} from '../mobile-ota-health-check';
+
+describe('parseHealthCheckArgs', () => {
+  it('uses sane defaults with no flags', () => {
+    expect(parseHealthCheckArgs([])).toEqual({
+      updateId: null,
+      hours: 24,
+      minSamples: 30,
+      threshold: 0.1,
+      outFile: null,
+      json: false,
+    });
+  });
+
+  it('parses space-separated and = flag forms', () => {
+    const spaced = parseHealthCheckArgs([
+      '--update-id',
+      'abc-123',
+      '--hours',
+      '6',
+      '--min-samples',
+      '50',
+      '--threshold',
+      '0.2',
+      '--out',
+      'x.md',
+      '--json',
+    ]);
+    expect(spaced).toEqual({
+      updateId: 'abc-123',
+      hours: 6,
+      minSamples: 50,
+      threshold: 0.2,
+      outFile: 'x.md',
+      json: true,
+    });
+
+    const equals = parseHealthCheckArgs(['--update-id=abc-123', '--hours=6', '--threshold=0.2', '--out=x.md']);
+    expect(equals).toMatchObject({ updateId: 'abc-123', hours: 6, threshold: 0.2, outFile: 'x.md' });
+  });
+
+  it('clamps out-of-range numbers', () => {
+    expect(parseHealthCheckArgs(['--hours', '0', '--min-samples', '0', '--threshold', '5'])).toMatchObject({
+      hours: 1,
+      minSamples: 1,
+      threshold: 1,
+    });
+    expect(parseHealthCheckArgs(['--threshold', '-1'])).toMatchObject({ threshold: 0 });
+  });
+
+  it('treats a blank update id as none', () => {
+    expect(parseHealthCheckArgs(['--update-id', '   ']).updateId).toBeNull();
+  });
+});
+
+describe('sanitizeUpdateId', () => {
+  it('accepts update-id shapes', () => {
+    expect(sanitizeUpdateId('7f3c1e2a-9b8d-4c5e-a1b2-c3d4e5f60718')).toBe('7f3c1e2a-9b8d-4c5e-a1b2-c3d4e5f60718');
+    expect(sanitizeUpdateId('abc_123.v2:ios')).toBe('abc_123.v2:ios');
+  });
+
+  it('rejects injection attempts', () => {
+    expect(() => sanitizeUpdateId("x' OR '1'='1")).toThrow();
+    expect(() => sanitizeUpdateId('drop; select')).toThrow();
+    expect(() => sanitizeUpdateId('')).toThrow();
+  });
+});
+
+describe('buildHealthQuery / buildLatestUpdateQuery', () => {
+  it('inlines a sanitized update id and the adoption column when given an id', () => {
+    const query = buildHealthQuery({ hours: 6, updateId: 'abc-123' });
+    expect(query).toContain("properties.updateId = 'abc-123'");
+    expect(query).toContain('target_update_installs');
+    expect(query).toContain("event = 'OTA Update Status'");
+    expect(query).toContain("properties.channel = 'production'");
+    expect(query).toContain('INTERVAL 6 HOUR');
+  });
+
+  it('emits a constant 0 adoption column when no id is given', () => {
+    expect(buildHealthQuery({ hours: 24, updateId: null })).toContain('0 AS target_update_installs');
+  });
+
+  it('refuses to build a query for a malicious update id', () => {
+    expect(() => buildHealthQuery({ hours: 6, updateId: "x'; DROP TABLE events; --" })).toThrow();
+  });
+
+  it('scopes the latest-update lookup to production OTA launches', () => {
+    const query = buildLatestUpdateQuery(6);
+    expect(query).toContain("properties.channel = 'production'");
+    expect(query).toContain("toString(properties.isEmbeddedLaunch) = 'false'");
+    expect(query).toContain('ORDER BY last_seen DESC');
+    expect(query).toContain('LIMIT 1');
+  });
+});
+
+describe('evaluateOtaHealth', () => {
+  const metrics = (launches: number, emergencyLaunches: number): HealthMetrics => ({
+    launches,
+    emergencyLaunches,
+    installs: launches,
+    emergencyInstalls: emergencyLaunches,
+    targetUpdateInstalls: null,
+    updateId: null,
+  });
+
+  it('flags unhealthy only when rate beats threshold AND sample is sufficient', () => {
+    const verdict = evaluateOtaHealth(metrics(100, 20), { minSamples: 30, threshold: 0.1 });
+    expect(verdict).toMatchObject({ unhealthy: true, sufficientSample: true, exitCode: 1 });
+    expect(verdict.emergencyRate).toBeCloseTo(0.2);
+  });
+
+  it('does NOT flag a high rate on a tiny sample', () => {
+    const verdict = evaluateOtaHealth(metrics(10, 8), { minSamples: 30, threshold: 0.1 });
+    expect(verdict).toMatchObject({ unhealthy: false, sufficientSample: false, exitCode: 0 });
+  });
+
+  it('does NOT flag a healthy fleet with plenty of data', () => {
+    const verdict = evaluateOtaHealth(metrics(500, 5), { minSamples: 30, threshold: 0.1 });
+    expect(verdict).toMatchObject({ unhealthy: false, sufficientSample: true, exitCode: 0 });
+  });
+
+  it('does NOT trip exactly at the threshold (strict greater-than)', () => {
+    expect(evaluateOtaHealth(metrics(100, 10), { minSamples: 30, threshold: 0.1 })).toMatchObject({ unhealthy: false });
+  });
+
+  it('treats zero launches as a 0 rate (no divide-by-zero)', () => {
+    expect(evaluateOtaHealth(metrics(0, 0), { minSamples: 30, threshold: 0.1 })).toMatchObject({
+      emergencyRate: 0,
+      unhealthy: false,
+      exitCode: 0,
+    });
+  });
+});
+
+describe('summarizeVerdict', () => {
+  const args = parseHealthCheckArgs(['--hours', '6']);
+
+  it('renders an unhealthy verdict with the adoption line', () => {
+    const metrics: HealthMetrics = {
+      launches: 100,
+      emergencyLaunches: 20,
+      installs: 80,
+      emergencyInstalls: 18,
+      targetUpdateInstalls: 60,
+      updateId: 'abc-123',
+    };
+    const verdict = evaluateOtaHealth(metrics, { minSamples: args.minSamples, threshold: args.threshold });
+    const lines = summarizeVerdict(metrics, verdict, args);
+    expect(lines[0]).toContain('UNHEALTHY');
+    expect(lines.join('\n')).toContain('abc-123');
+    expect(lines.join('\n')).toContain('60 install(s)');
+  });
+
+  it('marks a low-sample result inconclusive and omits the adoption line without an id', () => {
+    const metrics: HealthMetrics = {
+      launches: 4,
+      emergencyLaunches: 2,
+      installs: 4,
+      emergencyInstalls: 2,
+      targetUpdateInstalls: null,
+      updateId: null,
+    };
+    const verdict = evaluateOtaHealth(metrics, { minSamples: args.minSamples, threshold: args.threshold });
+    const text = summarizeVerdict(metrics, verdict, args).join('\n');
+    expect(text).toContain('inconclusive');
+    expect(text).not.toContain('running it');
+  });
+});

--- a/scripts/__tests__/mobile-ota-health-check.test.ts
+++ b/scripts/__tests__/mobile-ota-health-check.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildHealthQuery,
   buildLatestUpdateQuery,
   evaluateOtaHealth,
   OTA_UPDATE_STATUS_EVENT,
   parseHealthCheckArgs,
+  runHealthCheck,
   safeSanitizeUpdateId,
   sanitizeUpdateId,
   summarizeVerdict,
+  type HealthCheckArgs,
   type HealthMetrics,
 } from '../mobile-ota-health-check';
 import { OTA_UPDATE_STATUS_EVENT as MOBILE_OTA_UPDATE_STATUS_EVENT } from '../../packages/mobile/src/lib/ota-telemetry';
@@ -194,5 +199,71 @@ describe('summarizeVerdict', () => {
     const text = summarizeVerdict(metrics, verdict, args).join('\n');
     expect(text).toContain('inconclusive');
     expect(text).not.toContain('running it');
+  });
+});
+
+describe('runHealthCheck (networked path)', () => {
+  const tmpDirs: string[] = [];
+  const baseArgs = (overrides: Partial<HealthCheckArgs> = {}): HealthCheckArgs => ({
+    updateId: 'abc-123', // pin the id so only the single health query runs (no latest-update lookup)
+    hours: 6,
+    minSamples: 30,
+    threshold: 0.1,
+    outFile: null,
+    json: false,
+    ...overrides,
+  });
+  const outPath = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'ota-health-'));
+    tmpDirs.push(dir);
+    return join(dir, 'health.md');
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    while (tmpDirs.length > 0) rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+  });
+
+  it('skips (exit 0) and writes nothing when the API key is absent', async () => {
+    vi.stubEnv('POSTHOG_PERSONAL_API_KEY', '');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const out = outPath();
+
+    await expect(runHealthCheck(baseArgs({ outFile: out }))).resolves.toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(() => readFileSync(out)).toThrow(); // no summary written
+  });
+
+  it('exits 1 and writes an UNHEALTHY summary when the emergency rate clears the gate', async () => {
+    vi.stubEnv('POSTHOG_PERSONAL_API_KEY', 'phx_test');
+    // [launches, emergency_launches, installs, emergency_installs, target_update_installs]
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ results: [[100, 20, 80, 18, 60]] }) })),
+    );
+    const out = outPath();
+
+    await expect(runHealthCheck(baseArgs({ outFile: out }))).resolves.toBe(1);
+    expect(readFileSync(out, 'utf8')).toContain('UNHEALTHY');
+  });
+
+  it('exits 0 when the fleet is healthy', async () => {
+    vi.stubEnv('POSTHOG_PERSONAL_API_KEY', 'phx_test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ results: [[500, 5, 400, 5, 300]] }) })),
+    );
+    await expect(runHealthCheck(baseArgs())).resolves.toBe(0);
+  });
+
+  it('exits 0 (operational error never reads as unhealthy) when PostHog returns an error', async () => {
+    vi.stubEnv('POSTHOG_PERSONAL_API_KEY', 'phx_test');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, text: async () => 'boom' })),
+    );
+    await expect(runHealthCheck(baseArgs())).resolves.toBe(0);
   });
 });

--- a/scripts/__tests__/mobile-ota-health-check.test.ts
+++ b/scripts/__tests__/mobile-ota-health-check.test.ts
@@ -3,11 +3,32 @@ import {
   buildHealthQuery,
   buildLatestUpdateQuery,
   evaluateOtaHealth,
+  OTA_UPDATE_STATUS_EVENT,
   parseHealthCheckArgs,
+  safeSanitizeUpdateId,
   sanitizeUpdateId,
   summarizeVerdict,
   type HealthMetrics,
 } from '../mobile-ota-health-check';
+import { OTA_UPDATE_STATUS_EVENT as MOBILE_OTA_UPDATE_STATUS_EVENT } from '../../packages/mobile/src/lib/ota-telemetry';
+
+describe('event-name parity with the mobile telemetry source of truth', () => {
+  it('queries the exact event the app fires', () => {
+    expect(OTA_UPDATE_STATUS_EVENT).toBe(MOBILE_OTA_UPDATE_STATUS_EVENT);
+  });
+});
+
+describe('safeSanitizeUpdateId', () => {
+  it('passes a valid id through', () => {
+    expect(safeSanitizeUpdateId('abc-123')).toBe('abc-123');
+  });
+
+  it('returns null for a non-string or malformed value (untrusted PostHog response)', () => {
+    expect(safeSanitizeUpdateId(null)).toBeNull();
+    expect(safeSanitizeUpdateId(42)).toBeNull();
+    expect(safeSanitizeUpdateId("x'; DROP TABLE events; --")).toBeNull();
+  });
+});
 
 describe('parseHealthCheckArgs', () => {
   it('uses sane defaults with no flags', () => {

--- a/scripts/__tests__/mobile-ota-rollback.test.ts
+++ b/scripts/__tests__/mobile-ota-rollback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildEoasArgs, parseRollbackArgs } from '../mobile-ota-rollback';
+import { buildEoasArgs, parseRollbackArgs, validateRollbackOptions } from '../mobile-ota-rollback';
 
 describe('parseRollbackArgs', () => {
   it('defaults to rolling the production branch back to embedded, all platforms', () => {
@@ -44,5 +44,23 @@ describe('buildEoasArgs', () => {
       '--platform',
       'ios',
     ]);
+  });
+});
+
+describe('validateRollbackOptions', () => {
+  it('accepts valid mode + platform', () => {
+    expect(validateRollbackOptions({ branch: 'production', platform: 'all', mode: 'embedded' })).toBeNull();
+  });
+
+  it('rejects an invalid mode', () => {
+    expect(validateRollbackOptions({ branch: 'production', platform: 'all', mode: 'bogus' as never })).toContain(
+      '--mode',
+    );
+  });
+
+  it('rejects an invalid platform', () => {
+    expect(validateRollbackOptions({ branch: 'production', platform: 'web', mode: 'embedded' })).toContain(
+      '--platform',
+    );
   });
 });

--- a/scripts/__tests__/mobile-ota-rollback.test.ts
+++ b/scripts/__tests__/mobile-ota-rollback.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildEoasArgs, parseRollbackArgs } from '../mobile-ota-rollback';
+
+describe('parseRollbackArgs', () => {
+  it('defaults to rolling the production branch back to embedded, all platforms', () => {
+    expect(parseRollbackArgs([])).toEqual({ branch: 'production', platform: 'all', mode: 'embedded' });
+  });
+
+  it('parses space-separated flags', () => {
+    expect(parseRollbackArgs(['--branch', 'staging', '--platform', 'ios', '--mode', 'republish'])).toEqual({
+      branch: 'staging',
+      platform: 'ios',
+      mode: 'republish',
+    });
+  });
+
+  it('parses = flag forms', () => {
+    expect(parseRollbackArgs(['--branch=staging', '--platform=android', '--mode=republish'])).toEqual({
+      branch: 'staging',
+      platform: 'android',
+      mode: 'republish',
+    });
+  });
+});
+
+describe('buildEoasArgs', () => {
+  it('maps the embedded mode to `eoas rollback`', () => {
+    expect(buildEoasArgs({ branch: 'production', platform: 'all', mode: 'embedded' })).toEqual([
+      'eoas@2',
+      'rollback',
+      '--branch',
+      'production',
+      '--platform',
+      'all',
+    ]);
+  });
+
+  it('maps the republish mode to `eoas republish`', () => {
+    expect(buildEoasArgs({ branch: 'production', platform: 'ios', mode: 'republish' })).toEqual([
+      'eoas@2',
+      'republish',
+      '--branch',
+      'production',
+      '--platform',
+      'ios',
+    ]);
+  });
+});

--- a/scripts/lib/eoas.ts
+++ b/scripts/lib/eoas.ts
@@ -1,0 +1,41 @@
+/// <reference types="node" />
+
+/**
+ * Shared helpers for invoking the self-hosted OTA CLI (`eoas`, the expo-open-ota
+ * client) via `bunx`. Used by both the production publish (scripts/mobile-publish.ts)
+ * and the rollback runbook (scripts/mobile-ota-rollback.ts). Kept dependency-free
+ * so the lib layer never imports a sibling orchestrator script.
+ */
+
+import { closeSync, openSync, readSync } from 'node:fs';
+import { join, delimiter } from 'node:path';
+
+// vp (Vite+) prepends its own bun shim directory to PATH, and that shim's `bunx`
+// is a `/bin/sh` wrapper that forwards to `bun` WITHOUT switching to x-mode — so
+// `bunx <pkg>` runs as `bun <pkg>` (script mode) and dies with
+// `Script not found "<pkg>"`. The real bunx (from bun / setup-bun) is a binary
+// symlink, never a `#!` script. Under `vp run` this breaks BOTH the eoas/eas
+// invocation AND the `expo export` eoas spawns via --packageRunner bunx (it
+// inherits this env). Drop any PATH entry whose `bunx` is a `#!` script shim so a
+// working bunx wins — fixes CI (vp on PATH) and local `vp run` invocations.
+export function bunxIsScriptShim(dir: string): boolean {
+  let fd: number | undefined;
+  try {
+    fd = openSync(join(dir, 'bunx'), 'r');
+    const head = Buffer.alloc(2);
+    readSync(fd, head, 0, 2, 0);
+    return head[0] === 0x23 && head[1] === 0x21; // "#!"
+  } catch {
+    return false; // no readable bunx here → not a shim we need to drop
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+/** Strip PATH entries whose `bunx` is a `#!` shim, so a real bunx binary wins. */
+export function pathWithoutBrokenBunxShims(rawPath: string | undefined): string {
+  return (rawPath ?? '')
+    .split(delimiter)
+    .filter((dir) => dir.length > 0 && !bunxIsScriptShim(dir))
+    .join(delimiter);
+}

--- a/scripts/mobile-ota-health-check.ts
+++ b/scripts/mobile-ota-health-check.ts
@@ -1,0 +1,309 @@
+/// <reference types="node" />
+
+/**
+ * Post-publish health gate for production self-hosted OTA updates.
+ *
+ * Production OTAs publish to our self-hosted expo-open-ota server (NOT EAS), so
+ * `eas update:insights` can't see them. Instead we read the app's own launch
+ * telemetry: `OtaUpdateTracker` (packages/mobile/src/components/analytics/
+ * OtaUpdateTracker.tsx) fires an `OTA Update Status` event to PostHog once per
+ * launch with `{ isEmbeddedLaunch, isEmergencyLaunch, emergencyLaunchReason,
+ * updateId, channel, runtimeVersion, ... }`.
+ *
+ * An `isEmergencyLaunch === true` launch is expo-updates' automatic safety net:
+ * the downloaded JS failed to boot, so the binary fell back to its EMBEDDED
+ * bundle. A spike in the emergency-launch RATE across the production fleet after
+ * a publish is the tell-tale of a broken OTA. (Note: an emergency launch runs the
+ * embedded bundle, so its `updateId` is the embedded one — you CANNOT attribute
+ * the failure to the bad update's id. That's why the gate measures the
+ * fleet-wide production emergency rate over a window, not a per-updateId rate.
+ * The target update's adoption is reported separately, for context only.)
+ *
+ * Exit code is non-zero ONLY when the emergency-launch rate exceeds the threshold
+ * AND the sample size is sufficient — so low-volume noise (the minutes right after
+ * a publish, before installs relaunch) never trips it. Every other outcome
+ * (healthy / insufficient sample / missing key / API error) exits 0, so the CI
+ * step stays non-blocking.
+ *
+ * Usage:
+ *   tsx scripts/mobile-ota-health-check.ts                      # latest production update, last 24h
+ *   tsx scripts/mobile-ota-health-check.ts --update-id <id>     # adoption context for a specific update
+ *   tsx scripts/mobile-ota-health-check.ts --hours 6 --min-samples 50 --threshold 0.1
+ *   tsx scripts/mobile-ota-health-check.ts --out health.md      # also write a Discord-ready summary
+ *
+ * Env (read at run time, defaults match scripts/refresh-recommendations.ts):
+ *   POSTHOG_PERSONAL_API_KEY  required — without it the check is SKIPPED (exit 0).
+ *   POSTHOG_PROJECT_ID        optional — defaults to 412845 (not a secret).
+ *   POSTHOG_HOST              optional — defaults to https://us.posthog.com.
+ *
+ * See docs/mobile-ota-updates.md ("Health monitoring & rollback").
+ */
+
+import { writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Source of truth for the literal is packages/mobile/src/lib/ota-telemetry.ts
+// (OTA_UPDATE_STATUS_EVENT), guarded by that package's unit tests. Mirrored here
+// rather than imported so this root script never pulls a mobile module graph.
+const OTA_UPDATE_STATUS_EVENT = 'OTA Update Status';
+const PRODUCTION_CHANNEL = 'production';
+
+const DEFAULT_HOURS = 24;
+const DEFAULT_MIN_SAMPLES = 30;
+const DEFAULT_THRESHOLD = 0.1; // 10% of production launches falling back to embedded
+
+export interface HealthCheckArgs {
+  updateId: string | null;
+  hours: number;
+  minSamples: number;
+  threshold: number;
+  outFile: string | null;
+  json: boolean;
+}
+
+export interface HealthMetrics {
+  launches: number;
+  emergencyLaunches: number;
+  installs: number;
+  emergencyInstalls: number;
+  /** Distinct installs running the target update id (isEmbeddedLaunch false). null when no id resolved. */
+  targetUpdateInstalls: number | null;
+  updateId: string | null;
+}
+
+export interface HealthVerdict {
+  emergencyRate: number;
+  sufficientSample: boolean;
+  unhealthy: boolean;
+  exitCode: 0 | 1;
+}
+
+/** Parse CLI flags only. Env is read in `main` so this stays pure + testable. */
+export function parseHealthCheckArgs(argv: string[]): HealthCheckArgs {
+  let updateId: string | null = null;
+  let hours = DEFAULT_HOURS;
+  let minSamples = DEFAULT_MIN_SAMPLES;
+  let threshold = DEFAULT_THRESHOLD;
+  let outFile: string | null = null;
+  let json = false;
+
+  const readNumber = (raw: string | undefined, fallback: number): number => {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === '--') continue;
+
+    if (argument === '--update-id' || argument === '-u') {
+      updateId = argv[++index] ?? null;
+    } else if (argument.startsWith('--update-id=')) {
+      updateId = argument.slice('--update-id='.length);
+    } else if (argument === '--hours') {
+      hours = readNumber(argv[++index], DEFAULT_HOURS);
+    } else if (argument.startsWith('--hours=')) {
+      hours = readNumber(argument.slice('--hours='.length), DEFAULT_HOURS);
+    } else if (argument === '--min-samples') {
+      minSamples = readNumber(argv[++index], DEFAULT_MIN_SAMPLES);
+    } else if (argument.startsWith('--min-samples=')) {
+      minSamples = readNumber(argument.slice('--min-samples='.length), DEFAULT_MIN_SAMPLES);
+    } else if (argument === '--threshold') {
+      threshold = readNumber(argv[++index], DEFAULT_THRESHOLD);
+    } else if (argument.startsWith('--threshold=')) {
+      threshold = readNumber(argument.slice('--threshold='.length), DEFAULT_THRESHOLD);
+    } else if (argument === '--out') {
+      outFile = argv[++index] ?? null;
+    } else if (argument.startsWith('--out=')) {
+      outFile = argument.slice('--out='.length);
+    } else if (argument === '--json') {
+      json = true;
+    }
+  }
+
+  // Clamp to sane bounds so a bad flag can't widen the window or invert the gate.
+  hours = Math.max(1, Math.floor(hours));
+  minSamples = Math.max(1, Math.floor(minSamples));
+  threshold = Math.min(1, Math.max(0, threshold));
+
+  return { updateId: updateId?.trim() || null, hours, minSamples, threshold, outFile, json };
+}
+
+/**
+ * Reject anything that isn't an expo update id shape before it reaches HogQL.
+ * Update ids are uuids / base64url-ish; this whitelist forecloses SQL injection
+ * via an attacker-controlled `--update-id`.
+ */
+export function sanitizeUpdateId(raw: string): string {
+  if (!/^[A-Za-z0-9._:-]{1,128}$/.test(raw)) {
+    throw new Error(`Invalid --update-id "${raw}" (allowed: A–Z a–z 0–9 . _ : -, max 128 chars).`);
+  }
+  return raw;
+}
+
+/** Most-recently-seen production updateId actually running on installs (OTA, not embedded). */
+export function buildLatestUpdateQuery(hours: number): string {
+  return `
+    SELECT properties.updateId AS update_id, max(timestamp) AS last_seen, count() AS launches
+    FROM events
+    WHERE event = '${OTA_UPDATE_STATUS_EVENT}'
+      AND properties.channel = '${PRODUCTION_CHANNEL}'
+      AND toString(properties.isEmbeddedLaunch) = 'false'
+      AND properties.updateId IS NOT NULL
+      AND properties.updateId != ''
+      AND timestamp > now() - INTERVAL ${Math.floor(hours)} HOUR
+    GROUP BY update_id
+    ORDER BY last_seen DESC
+    LIMIT 1
+  `;
+}
+
+/**
+ * Fleet health over the window: total production launches, how many fell back to
+ * the embedded bundle (emergency), and — when a target id is known — how many
+ * distinct installs are successfully running it.
+ */
+export function buildHealthQuery(options: { hours: number; updateId: string | null }): string {
+  const { hours, updateId } = options;
+  const targetInstalls =
+    updateId !== null
+      ? `count(DISTINCT if(properties.updateId = '${sanitizeUpdateId(updateId)}' AND toString(properties.isEmbeddedLaunch) = 'false', person_id, NULL))`
+      : '0';
+  return `
+    SELECT
+      count() AS launches,
+      countIf(toString(properties.isEmergencyLaunch) = 'true') AS emergency_launches,
+      count(DISTINCT person_id) AS installs,
+      count(DISTINCT if(toString(properties.isEmergencyLaunch) = 'true', person_id, NULL)) AS emergency_installs,
+      ${targetInstalls} AS target_update_installs
+    FROM events
+    WHERE event = '${OTA_UPDATE_STATUS_EVENT}'
+      AND properties.channel = '${PRODUCTION_CHANNEL}'
+      AND timestamp > now() - INTERVAL ${Math.floor(hours)} HOUR
+  `;
+}
+
+/** The gate: unhealthy iff the emergency-launch rate beats the threshold AND there's enough data. */
+export function evaluateOtaHealth(
+  metrics: HealthMetrics,
+  options: { minSamples: number; threshold: number },
+): HealthVerdict {
+  const emergencyRate = metrics.launches > 0 ? metrics.emergencyLaunches / metrics.launches : 0;
+  const sufficientSample = metrics.launches >= options.minSamples;
+  const unhealthy = sufficientSample && emergencyRate > options.threshold;
+  return { emergencyRate, sufficientSample, unhealthy, exitCode: unhealthy ? 1 : 0 };
+}
+
+const formatPercent = (rate: number): string => `${(rate * 100).toFixed(1)}%`;
+
+/** Human-readable verdict lines (also reused as the Discord summary body). */
+export function summarizeVerdict(metrics: HealthMetrics, verdict: HealthVerdict, args: HealthCheckArgs): string[] {
+  const status = verdict.unhealthy
+    ? '🚨 UNHEALTHY'
+    : verdict.sufficientSample
+      ? '✅ healthy'
+      : '➖ inconclusive (too few launches)';
+  const lines = [
+    `OTA health: ${status}`,
+    `• window: last ${args.hours}h • channel: ${PRODUCTION_CHANNEL}`,
+    `• launches: ${metrics.launches} (from ${metrics.installs} installs)`,
+    `• emergency launches: ${metrics.emergencyLaunches} → rate ${formatPercent(verdict.emergencyRate)} (threshold ${formatPercent(args.threshold)}, min ${args.minSamples})`,
+  ];
+  if (metrics.updateId) {
+    const adoption = metrics.targetUpdateInstalls ?? 0;
+    lines.push(`• latest update ${metrics.updateId}: ${adoption} install(s) running it`);
+  }
+  return lines;
+}
+
+interface PostHogQueryResponse {
+  results?: unknown[][];
+}
+
+async function queryPostHog(host: string, projectId: string, apiKey: string, hogql: string): Promise<unknown[][]> {
+  const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query: hogql } }),
+  });
+  if (!response.ok) {
+    throw new Error(`PostHog query failed (${response.status}): ${await response.text()}`);
+  }
+  const payload = (await response.json()) as PostHogQueryResponse;
+  return payload.results ?? [];
+}
+
+const toCount = (value: unknown): number => {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export async function runHealthCheck(args: HealthCheckArgs): Promise<number> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  // `||` (not `??`) so an empty CI var — `vars.X` resolves to '' when unset —
+  // falls back to the default instead of producing a broken project id / host.
+  const projectId = process.env.POSTHOG_PROJECT_ID || '412845';
+  const host = process.env.POSTHOG_HOST || 'https://us.posthog.com';
+
+  if (!apiKey) {
+    console.log('[ota-health] POSTHOG_PERSONAL_API_KEY not set — skipping health check (non-blocking, exit 0).');
+    console.log('[ota-health] Add the secret to activate the gate. See docs/mobile-ota-updates.md.');
+    return 0;
+  }
+
+  try {
+    // Resolve the target update id: explicit flag, else the freshest production
+    // OTA actually seen on installs. Used only for the adoption context line.
+    let updateId = args.updateId ? sanitizeUpdateId(args.updateId) : null;
+    if (!updateId) {
+      const latest = await queryPostHog(host, projectId, apiKey, buildLatestUpdateQuery(args.hours));
+      const row = latest[0];
+      updateId = row && typeof row[0] === 'string' ? row[0] : null;
+    }
+
+    const rows = await queryPostHog(host, projectId, apiKey, buildHealthQuery({ hours: args.hours, updateId }));
+    const row = rows[0] ?? [];
+    const metrics: HealthMetrics = {
+      launches: toCount(row[0]),
+      emergencyLaunches: toCount(row[1]),
+      installs: toCount(row[2]),
+      emergencyInstalls: toCount(row[3]),
+      targetUpdateInstalls: updateId ? toCount(row[4]) : null,
+      updateId,
+    };
+
+    const verdict = evaluateOtaHealth(metrics, { minSamples: args.minSamples, threshold: args.threshold });
+    const lines = summarizeVerdict(metrics, verdict, args);
+
+    if (args.json) {
+      console.log(JSON.stringify({ metrics, verdict }, null, 2));
+    } else {
+      for (const line of lines) console.log(`[ota-health] ${line}`);
+    }
+
+    if (args.outFile) {
+      writeFileSync(args.outFile, `${lines.join('\n')}\n`);
+    }
+
+    if (verdict.unhealthy) {
+      console.error(
+        `[ota-health] FAILED — emergency-launch rate ${formatPercent(verdict.emergencyRate)} over ${metrics.launches} launches exceeds the ${formatPercent(args.threshold)} threshold.`,
+      );
+    }
+    return verdict.exitCode;
+  } catch (error) {
+    // Operational failures (network, auth, parse) must NOT read as "unhealthy" —
+    // the gate is reserved for a real emergency-launch spike. Warn loudly, exit 0.
+    console.error(`[ota-health] WARNING — could not evaluate OTA health: ${(error as Error).message}`);
+    return 0;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runHealthCheck(parseHealthCheckArgs(process.argv.slice(2)))
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`[ota-health] WARNING — unexpected error: ${(error as Error).message}`);
+      process.exit(0);
+    });
+}

--- a/scripts/mobile-ota-health-check.ts
+++ b/scripts/mobile-ota-health-check.ts
@@ -43,9 +43,11 @@ import { writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 // Source of truth for the literal is packages/mobile/src/lib/ota-telemetry.ts
-// (OTA_UPDATE_STATUS_EVENT), guarded by that package's unit tests. Mirrored here
-// rather than imported so this root script never pulls a mobile module graph.
-const OTA_UPDATE_STATUS_EVENT = 'OTA Update Status';
+// (OTA_UPDATE_STATUS_EVENT), mirrored here rather than imported so this root
+// script never pulls a mobile module graph. Exported so a unit test can assert it
+// stays equal to the mobile constant — a drift would silently query the wrong
+// event and report a healthy fleet.
+export const OTA_UPDATE_STATUS_EVENT = 'OTA Update Status';
 const PRODUCTION_CHANNEL = 'production';
 
 const DEFAULT_HOURS = 24;
@@ -139,6 +141,16 @@ export function sanitizeUpdateId(raw: string): string {
     throw new Error(`Invalid --update-id "${raw}" (allowed: A–Z a–z 0–9 . _ : -, max 128 chars).`);
   }
   return raw;
+}
+
+/** Sanitize an update id from an untrusted source (the PostHog response); null if it doesn't fit the shape. */
+export function safeSanitizeUpdateId(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    return sanitizeUpdateId(raw);
+  } catch {
+    return null;
+  }
 }
 
 /** Most-recently-seen production updateId actually running on installs (OTA, not embedded). */
@@ -257,8 +269,9 @@ export async function runHealthCheck(args: HealthCheckArgs): Promise<number> {
     let updateId = args.updateId ? sanitizeUpdateId(args.updateId) : null;
     if (!updateId) {
       const latest = await queryPostHog(host, projectId, apiKey, buildLatestUpdateQuery(args.hours));
-      const row = latest[0];
-      updateId = row && typeof row[0] === 'string' ? row[0] : null;
+      // Sanitize at the point of receipt — don't rely on buildHealthQuery's
+      // later sanitize being kept in a refactor.
+      updateId = safeSanitizeUpdateId(latest[0]?.[0]);
     }
 
     const rows = await queryPostHog(host, projectId, apiKey, buildHealthQuery({ hours: args.hours, updateId }));

--- a/scripts/mobile-ota-rollback.ts
+++ b/scripts/mobile-ota-rollback.ts
@@ -1,0 +1,152 @@
+/// <reference types="node" />
+
+/**
+ * Emergency rollback for a production self-hosted OTA. Production has no rollout
+ * percentage — every install on the bad bundle is on it — so "rollback" means
+ * re-pointing the production branch on the expo-open-ota server. Two modes, both
+ * via the eoas CLI (the same client scripts/mobile-publish.ts uses):
+ *
+ *   --mode embedded   (default) → `eoas rollback`   Publishes a rollback
+ *       DIRECTIVE: every install currently on the bad OTA reverts to the binary's
+ *       EMBEDDED bundle on its next launch. Non-interactive, CI-safe. Use this to
+ *       stop the bleeding fast — it always lands on a known-good (shipped) bundle.
+ *
+ *   --mode republish            → `eoas republish`  Re-points the branch to a
+ *       PREVIOUS published update you pick from a list. Interactive (eoas prompts
+ *       for the update), so run it LOCALLY, not in CI.
+ *
+ * The cleaner long-term fix is still to revert the offending JS commit on `main`
+ * — the production OTA workflow then republishes a good bundle automatically. Use
+ * a rollback directive when you need installs reverted in minutes, before a
+ * revert PR can merge + republish. See docs/mobile-ota-updates.md.
+ *
+ * Usage:
+ *   vp run mobile:ota-rollback                       # rollback to embedded, all platforms
+ *   vp run mobile:ota-rollback -- --platform ios     # one platform
+ *   vp run mobile:ota-rollback -- --mode republish   # re-point to a previous update (interactive, local)
+ *
+ * Env: EXPO_UPDATES_URL (server manifest endpoint) + EXPO_TOKEN (Expo API auth),
+ * same as the production publish.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathWithoutBrokenBunxShims } from './lib/eoas';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
+
+export type RollbackMode = 'embedded' | 'republish';
+
+export interface RollbackOptions {
+  branch: string;
+  platform: string;
+  mode: RollbackMode;
+}
+
+const VALID_PLATFORMS = ['ios', 'android', 'all'] as const;
+const VALID_MODES: readonly RollbackMode[] = ['embedded', 'republish'];
+
+export function parseRollbackArgs(argv: string[]): RollbackOptions {
+  let branch = 'production';
+  let platform = 'all';
+  let mode: RollbackMode = 'embedded';
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument === '--') continue;
+
+    if (argument === '--branch' || argument === '-b') {
+      branch = argv[++index] ?? branch;
+    } else if (argument.startsWith('--branch=')) {
+      branch = argument.slice('--branch='.length);
+    } else if (argument === '--platform' || argument === '-p') {
+      platform = argv[++index] ?? platform;
+    } else if (argument.startsWith('--platform=')) {
+      platform = argument.slice('--platform='.length);
+    } else if (argument === '--mode' || argument === '-m') {
+      mode = (argv[++index] as RollbackMode) ?? mode;
+    } else if (argument.startsWith('--mode=')) {
+      mode = argument.slice('--mode='.length) as RollbackMode;
+    }
+  }
+
+  return { branch, platform, mode };
+}
+
+/** The eoas argv for a rollback mode. `eoas@2` pins the major, matching mobile-publish.ts. */
+export function buildEoasArgs(options: RollbackOptions): string[] {
+  const subcommand = options.mode === 'embedded' ? 'rollback' : 'republish';
+  return ['eoas@2', subcommand, '--branch', options.branch, '--platform', options.platform];
+}
+
+function validate(options: RollbackOptions): string | null {
+  if (!VALID_MODES.includes(options.mode)) {
+    return `Invalid --mode "${options.mode}". Must be one of: ${VALID_MODES.join(', ')}`;
+  }
+  if (!VALID_PLATFORMS.includes(options.platform as (typeof VALID_PLATFORMS)[number])) {
+    return `Invalid --platform "${options.platform}". Must be one of: ${VALID_PLATFORMS.join(', ')}`;
+  }
+  return null;
+}
+
+function main(): number {
+  const options = parseRollbackArgs(process.argv.slice(2));
+
+  const invalid = validate(options);
+  if (invalid) {
+    console.error(`[ota-rollback] ${invalid}`);
+    return 1;
+  }
+
+  const serverUrl = process.env.EXPO_UPDATES_URL;
+  if (!serverUrl) {
+    console.error('[ota-rollback] Requires EXPO_UPDATES_URL (the expo-open-ota manifest endpoint).');
+    console.error('[ota-rollback] See docs/mobile-ota-updates.md.');
+    return 1;
+  }
+  if (!process.env.EXPO_TOKEN) {
+    console.error('[ota-rollback] Requires EXPO_TOKEN (Expo API auth). Run `bunx eas login` locally or set it in CI.');
+    return 1;
+  }
+
+  const eoasArgs = buildEoasArgs(options);
+
+  console.log(
+    `[ota-rollback] Mode:     ${options.mode === 'embedded' ? 'rollback to embedded bundle' : 'republish a previous update'}`,
+  );
+  console.log(`[ota-rollback] Server:   ${serverUrl}`);
+  console.log(`[ota-rollback] Branch:   ${options.branch}`);
+  console.log(`[ota-rollback] Platform: ${options.platform}`);
+  console.log('');
+  console.log(`[ota-rollback] Running: bunx ${eoasArgs.join(' ')}`);
+  console.log('');
+
+  // EXPO_UPDATES_URL must resolve in app.config so eoas finds the server; strip a
+  // stray EAS_BUILD (which would flip app.config back to the EAS URL) and drop
+  // vp's broken bunx shim dir — same guards as the production publish.
+  const eoasEnv = { ...process.env };
+  delete eoasEnv.EAS_BUILD;
+  eoasEnv.PATH = pathWithoutBrokenBunxShims(process.env.PATH);
+
+  const result = spawnSync('bunx', eoasArgs, {
+    cwd: MOBILE_DIR,
+    stdio: 'inherit', // republish is interactive; rollback streams progress
+    env: eoasEnv,
+  });
+
+  if (result.status !== 0) {
+    console.error('');
+    console.error('[ota-rollback] eoas failed.');
+    return result.status ?? 1;
+  }
+
+  console.log('');
+  console.log(`[ota-rollback] Done. Installs on branch "${options.branch}" pick up the change on next launch.`);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/scripts/mobile-ota-rollback.ts
+++ b/scripts/mobile-ota-rollback.ts
@@ -81,7 +81,8 @@ export function buildEoasArgs(options: RollbackOptions): string[] {
   return ['eoas@2', subcommand, '--branch', options.branch, '--platform', options.platform];
 }
 
-function validate(options: RollbackOptions): string | null {
+/** Returns an error message for an invalid mode/platform, or null when the options are usable. */
+export function validateRollbackOptions(options: RollbackOptions): string | null {
   if (!VALID_MODES.includes(options.mode)) {
     return `Invalid --mode "${options.mode}". Must be one of: ${VALID_MODES.join(', ')}`;
   }
@@ -94,7 +95,7 @@ function validate(options: RollbackOptions): string | null {
 function main(): number {
   const options = parseRollbackArgs(process.argv.slice(2));
 
-  const invalid = validate(options);
+  const invalid = validateRollbackOptions(options);
   if (invalid) {
     console.error(`[ota-rollback] ${invalid}`);
     return 1;

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -21,41 +21,12 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { closeSync, openSync, readSync } from 'node:fs';
-import { resolve, dirname, join, delimiter } from 'node:path';
+import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { pathWithoutBrokenBunxShims } from './lib/eoas';
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
-
-// vp (Vite+) prepends its own bun shim directory to PATH, and that shim's `bunx`
-// is a `/bin/sh` wrapper that forwards to `bun` WITHOUT switching to x-mode — so
-// `bunx <pkg>` runs as `bun <pkg>` (script mode) and dies with
-// `Script not found "<pkg>"`. The real bunx (from bun / setup-bun) is a binary
-// symlink, never a `#!` script. Under `vp run` this breaks BOTH the eoas/eas
-// invocation below AND the `expo export` eoas spawns via --packageRunner bunx
-// (it inherits this env). Drop any PATH entry whose `bunx` is a `#!` script shim
-// so a working bunx wins — fixes CI (vp on PATH) and local `vp run mobile:publish`.
-function bunxIsScriptShim(dir: string): boolean {
-  let fd: number | undefined;
-  try {
-    fd = openSync(join(dir, 'bunx'), 'r');
-    const head = Buffer.alloc(2);
-    readSync(fd, head, 0, 2, 0);
-    return head[0] === 0x23 && head[1] === 0x21; // "#!"
-  } catch {
-    return false; // no readable bunx here → not a shim we need to drop
-  } finally {
-    if (fd !== undefined) closeSync(fd);
-  }
-}
-
-function pathWithoutBrokenBunxShims(rawPath: string | undefined): string {
-  return (rawPath ?? '')
-    .split(delimiter)
-    .filter((dir) => dir.length > 0 && !bunxIsScriptShim(dir))
-    .join(delimiter);
-}
 
 function resolveCurrentBranchName(): string | null {
   try {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -598,6 +598,14 @@ export default defineConfig({
         command: 'tsx scripts/mobile-ota-setup.ts',
         cache: false,
       },
+      'mobile:ota-health-check': {
+        command: 'tsx scripts/mobile-ota-health-check.ts',
+        cache: false,
+      },
+      'mobile:ota-rollback': {
+        command: 'tsx scripts/mobile-ota-rollback.ts',
+        cache: false,
+      },
       'mobile:preview-build': {
         command: 'tsx scripts/mobile-preview-build.ts',
         cache: false,


### PR DESCRIPTION
## What & why

Production OTAs auto-publish to **every** user on every push to `main` — there's no health gate, no rollout percentage, and they go to our **self-hosted** expo-open-ota server, so `eas update:insights` can't see them. The app already emits launch telemetry (`OtaUpdateTracker` → PostHog `OTA Update Status` with `isEmergencyLaunch` / `updateId` / `runtimeVersion`), so this PR turns that into a non-blocking health gate plus a documented rollback path.

## Changes

- **`scripts/mobile-ota-health-check.ts`** — queries PostHog (HogQL, same API + `POSTHOG_PERSONAL_API_KEY` convention as `scripts/refresh-recommendations.ts`) for `OTA Update Status` launches over a window. Computes launch count + the **fleet-wide emergency-launch rate** (a downloaded bundle that failed to boot falls back to the embedded one, so failures can't be attributed to the bad `updateId` — the gate measures the window-wide rate; the target update's adoption is reported for context). Exits non-zero **only** when the rate exceeds `--threshold` (default 10%) **and** the window has at least `--min-samples` launches (default 30), so low-volume noise can't trip it. Skips (exit 0) without the key. Runnable manually: `vp run mobile:ota-health-check`.
- **`.github/workflows/mobile-ota-production.yml`** — post-publish step after a successful publish: short `sleep` for telemetry, `continue-on-error: true` (never blocks the publish), no-ops until `POSTHOG_PERSONAL_API_KEY` exists, and posts the verdict to the existing Discord deploy channel.
- **`scripts/mobile-ota-rollback.ts`** — `vp run mobile:ota-rollback` wraps the `eoas` CLI: `--mode embedded` (default) runs `eoas rollback` (revert installs to the binary's embedded bundle, CI-safe), `--mode republish` runs `eoas republish` (re-point to a previous update, interactive/local).
- **`scripts/lib/eoas.ts`** — extracts the shared bunx-shim PATH fix out of `mobile-publish.ts` so both the publish and rollback paths reuse it (no behavior change to publish).
- **`docs/mobile-ota-updates.md`** — new "Health monitoring & rollback" section; documents that adding `POSTHOG_PERSONAL_API_KEY` to the **Production** environment activates the gate.
- Tests for the pure logic (arg parsing, threshold/sample gate, HogQL injection-safety, eoas arg mapping).

## Validation

- `vp test run --project scripts` — 254 passed (incl. new tests + `mobile-ci-env-parity`).
- `vp check` — clean for all touched files (remaining repo-wide format flags are pre-existing `embedded/` files, untouched here).
- Throwaway-tsconfig `tsc --noEmit` on the new scripts — clean.
- Smoke-tested: health check skips (exit 0) without the key; rollback rejects a bad `--mode` / missing `EXPO_UPDATES_URL`.

## Activation

The gate is **inert until** `POSTHOG_PERSONAL_API_KEY` (a PostHog personal API key with read access) is added to the Production environment. Until then the post-publish step is a green no-op.

## Release Notes

Internal/ops change — no user-facing behavior change. Adds a non-blocking post-publish health check for production OTA updates and a documented rollback runbook. The health gate ships inert and activates once the `POSTHOG_PERSONAL_API_KEY` repo secret is added to the Production environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMykAw5PcpxfEMpTAJKNke