### PR TITLE
chore(store): refresh iOS release notes for the post-2.0 update

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,12 +1,17 @@
-Boardsesh 2.0 is a full native rebuild. The whole app is rewritten, so it's fast where it used to lag. Lists scroll smooth, search is instant.
+Your Kilter logbook now comes with you, the full MoonBoard catalog is in, and boards light up more reliably on iPhone.
 
-Same app, just faster:
-- Search a climb and light the holds over Bluetooth on Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL.
-- Walk up to any wall and see what's on it right now: the lit climb, who lit it, the grade, angle and setter, live as people climb.
-- Climb with your crew in a live session: one shared queue anyone can add to, reorder and drive.
-- Run the session from your lock screen and Dynamic Island on iOS 17+ with Live Activities.
-- Build a Volume, Pyramid, Ladder or Grade Focus workout and fire the climbs to the wall one at a time.
-- Track sends, flashes and attempts, and watch your grades chart out on the Progress tab.
-- Save sessions to Apple Health and import your past Kilter and Tension logbook from Aurora Climbing.
+New:
+- Sign in with your Kilter username and password to pull your sends, attempts, ratings and circuits straight into Boardsesh.
+- The full MoonBoard catalog landed: thousands more problems with real grades, star ratings and send counts, plus the Mini 2025 and original 2010 boards. Original MoonBoard LED hardware lights up over Bluetooth too.
+- Tap any climb in a circuit or playlist and the whole list drops into your queue in order. Swipe back to revisit the boulders above, not just jump to the next.
+- Mix your own hold colours with a real colour picker, preview them through red-green and blue-yellow colour blindness, and pick a new octagon marker shape. MoonBoard hold circles are bigger and easier to read, too.
+- Sort your logbook by Hardest top to bottom, with the community consensus grade shown next to the one you logged.
+
+Fixed:
+- Kilter and Tension light up reliably on iPhone: climbs send to the wall instead of the board connecting but staying dark.
+- MoonBoard lights up on iPhone, recovers after a flaky Bluetooth moment, and now drives from the Dynamic Island.
+- Fixed an iOS freeze where the app could stop responding to taps after opening and closing sheets.
+- Filter by setter, hold type or board region again. The pickers open full screen and the whole sheet scrolls.
+- Live sessions reconnect after your login refreshes, and pause then refetch when you drop offline and come back.
 
 Free, no ads, open source.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,7 +1,6 @@
-Your Kilter logbook now comes with you, the full MoonBoard catalog is in, and boards light up more reliably on iPhone.
+The full MoonBoard catalog is in, hold colours are yours to tune, and boards light up more reliably on iPhone.
 
 New:
-- Sign in with your Kilter username and password to pull your sends, attempts, ratings and circuits straight into Boardsesh.
 - The full MoonBoard catalog landed: thousands more problems with real grades, star ratings and send counts, plus the Mini 2025 and original 2010 boards. Original MoonBoard LED hardware lights up over Bluetooth too.
 - Tap any climb in a circuit or playlist and the whole list drops into your queue in order. Swipe back to revisit the boulders above, not just jump to the next.
 - Mix your own hold colours with a real colour picker, preview them through red-green and blue-yellow colour blindness, and pick a new octagon marker shape. MoonBoard hold circles are bigger and easier to read, too.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,12 +1,17 @@
-Boardsesh 2.0 es una reconstrucción nativa completa. Toda la app está reescrita, así que va rápida donde antes se atascaba. Las listas ruedan suaves y la búsqueda es instantánea.
+Tu logbook de Kilter ahora viaja contigo, está el catálogo completo de MoonBoard y los plafones se encienden de forma más fiable en el iPhone.
 
-La misma app, solo que más rápida:
-- Busca una vía y enciende las presas por Bluetooth en Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper y So iLL.
-- Llégate a cualquier pared y mira lo que hay puesto ahora mismo: la vía encendida, quién la encendió, el grado, el ángulo y el aperturista, en vivo según la gente escala.
-- Escala con tu equipo en una sesión en vivo: una cola compartida a la que cualquiera añade, reordena y lleva.
-- Lleva la sesión desde la pantalla de bloqueo y el Dynamic Island en iOS 17+ con Live Activities.
-- Monta un entrenamiento de Volumen, Pirámide, Escalera o Foco en grado y envía las vías al muro de una en una.
-- Apunta encadenes, flashes e intentos y mira cómo tus grados se dibujan en la pestaña Progreso.
-- Guarda tus sesiones en Apple Health e importa tu logbook antiguo de Kilter y Tension desde Aurora Climbing.
+Nuevo:
+- Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenes, intentos, valoraciones y circuitos directamente a Boardsesh.
+- Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
+- Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
+- Crea tus propios colores de presa con un selector de color de verdad, prevísualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
+- Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.
+
+Arreglado:
+- Kilter y Tension se encienden de forma fiable en el iPhone: las vías se envían al muro en vez de que el plafón conecte y se quede apagado.
+- El MoonBoard se enciende en el iPhone, se recupera tras un fallo puntual de Bluetooth y ahora se controla desde el Dynamic Island.
+- Arreglado un bloqueo en iOS en el que la app podía dejar de responder a los toques tras abrir y cerrar paneles.
+- Vuelve a filtrar por setter, tipo de presa o región del plafón. Los selectores se abren a pantalla completa y todo el panel se desplaza.
+- Las sesiones en vivo se reconectan cuando se refresca tu sesión, y se pausan y recargan cuando te quedas sin conexión y vuelves.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,7 +1,6 @@
-Tu logbook de Kilter ahora viaja contigo, está el catálogo completo de MoonBoard y los plafones se encienden de forma más fiable en el iPhone.
+Está el catálogo completo de MoonBoard, puedes ajustar a tu gusto los colores de las presas y los plafones se encienden de forma más fiable en el iPhone.
 
 Nuevo:
-- Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenes, intentos, valoraciones y circuitos directamente a Boardsesh.
 - Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
 - Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
 - Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -4,7 +4,7 @@ Nuevo:
 - Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenes, intentos, valoraciones y circuitos directamente a Boardsesh.
 - Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
 - Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
-- Crea tus propios colores de presa con un selector de color de verdad, prevísualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
+- Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
 - Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.
 
 Arreglado:

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,12 +1,17 @@
-Boardsesh 2.0 es una reconstrucción nativa completa. Toda la app está reescrita, así que va rápida donde antes se atascaba. Las listas ruedan suaves y la búsqueda es instantánea.
+Tu logbook de Kilter ahora viaja contigo, está el catálogo completo de MoonBoard y los plafones se encienden de forma más fiable en el iPhone.
 
-La misma app, solo que más rápida:
-- Busca una vía y enciende las presas por Bluetooth en Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper y So iLL.
-- Llégate a cualquier pared y mira lo que hay puesto ahora mismo: la vía encendida, quién la encendió, el grado, el ángulo y el aperturista, en vivo según la gente escala.
-- Escala con tu equipo en una sesión en vivo: una cola compartida a la que cualquiera añade, reordena y lleva.
-- Lleva la sesión desde la pantalla de bloqueo y el Dynamic Island en iOS 17+ con Live Activities.
-- Monta un entrenamiento de Volumen, Pirámide, Escalera o Foco en grado y envía las vías al muro de una en una.
-- Apunta encadenes, flashes e intentos y mira cómo tus grados se dibujan en la pestaña Progreso.
-- Guarda tus sesiones en Apple Health e importa tu logbook antiguo de Kilter y Tension desde Aurora Climbing.
+Nuevo:
+- Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenes, intentos, valoraciones y circuitos directamente a Boardsesh.
+- Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
+- Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
+- Crea tus propios colores de presa con un selector de color de verdad, prevísualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
+- Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.
+
+Arreglado:
+- Kilter y Tension se encienden de forma fiable en el iPhone: las vías se envían al muro en vez de que el plafón conecte y se quede apagado.
+- El MoonBoard se enciende en el iPhone, se recupera tras un fallo puntual de Bluetooth y ahora se controla desde el Dynamic Island.
+- Arreglado un bloqueo en iOS en el que la app podía dejar de responder a los toques tras abrir y cerrar paneles.
+- Vuelve a filtrar por setter, tipo de presa o región del plafón. Los selectores se abren a pantalla completa y todo el panel se desplaza.
+- Las sesiones en vivo se reconectan cuando se refresca tu sesión, y se pausan y recargan cuando te quedas sin conexión y vuelves.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,7 +1,6 @@
-Tu logbook de Kilter ahora viaja contigo, está el catálogo completo de MoonBoard y los plafones se encienden de forma más fiable en el iPhone.
+Está el catálogo completo de MoonBoard, puedes ajustar a tu gusto los colores de las presas y los plafones se encienden de forma más fiable en el iPhone.
 
 Nuevo:
-- Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenes, intentos, valoraciones y circuitos directamente a Boardsesh.
 - Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
 - Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
 - Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -4,7 +4,7 @@ Nuevo:
 - Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenes, intentos, valoraciones y circuitos directamente a Boardsesh.
 - Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
 - Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
-- Crea tus propios colores de presa con un selector de color de verdad, prevísualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
+- Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
 - Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.
 
 Arreglado:

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,12 +1,17 @@
-Boardsesh 2.0, c'est une version native entièrement repensée. Toute l'appli a été réécrite : ça file là où ça ramait avant. Les listes défilent sans accroc, la recherche est instantanée.
+Ton logbook Kilter te suit maintenant, le catalogue MoonBoard complet est là, et les boards s'allument plus fiablement sur iPhone.
 
-La même appli, juste plus rapide :
-- Cherche une voie et allume les prises en Bluetooth sur Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper et So iLL.
-- Arrive devant n'importe quel mur et vois ce qu'il y a dessus tout de suite : la voie allumée, qui l'a allumée, la cotation, l'inclinaison et l'ouvreur, en direct au fil des grimpeurs.
-- Grimpe avec ta crew dans une session live : une seule file partagée que tout le monde peut alimenter, réorganiser et piloter.
-- Pilote la session depuis ton écran verrouillé et la Dynamic Island sous iOS 17+ avec les Live Activities.
-- Monte un entraînement Volume, Pyramide, Échelle ou Cotation ciblée et envoie les voies au mur une par une.
-- Suis tes sends, tes flashs et tes essais, et regarde tes cotations se tracer dans l'onglet Progression.
-- Enregistre tes sessions dans Apple Health et importe ton ancien carnet Kilter et Tension depuis Aurora Climbing.
+Nouveau :
+- Connecte-toi avec ton identifiant et ton mot de passe Kilter pour rapatrier tes sends, essais, notes et circuits directement dans Boardsesh.
+- Le catalogue MoonBoard complet est arrivé : des milliers de blocs en plus avec de vraies cotations, des notes en étoiles et le nombre de sends, plus le Mini 2025 et l'original de 2010. Le matériel LED du MoonBoard d'origine s'allume aussi en Bluetooth.
+- Touche n'importe quelle voie d'un circuit ou d'une playlist et toute la liste passe dans ta file dans l'ordre. Reviens en arrière d'un glissement pour repasser sur les blocs précédents, pas seulement sauter au suivant.
+- Compose tes propres couleurs de prise avec un vrai sélecteur de couleur, prévisualise-les en daltonisme rouge-vert et bleu-jaune, et choisis une nouvelle forme de marqueur octogonale. Les cercles des prises MoonBoard sont aussi plus gros et plus lisibles.
+- Trie ton logbook par Plus dur de haut en bas, avec la cotation consensus de la communauté à côté de celle que tu as notée.
+
+Corrigé :
+- Kilter et Tension s'allument de façon fiable sur iPhone : les voies partent au mur au lieu de rester éteintes une fois connecté.
+- Le MoonBoard s'allume sur iPhone, récupère après un accroc Bluetooth, et se pilote maintenant depuis la Dynamic Island.
+- Corrigé un gel sur iOS où l'appli pouvait ne plus répondre aux touchers après l'ouverture et la fermeture de panneaux.
+- Filtre à nouveau par ouvreur, type de prise ou région du mur. Les sélecteurs s'ouvrent en plein écran et tout le panneau défile.
+- Les sessions live se reconnectent après le rafraîchissement de ta connexion, et se mettent en pause puis se rechargent quand tu perds le réseau puis reviens.
 
 Gratuit, sans pub, open source.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,7 +1,6 @@
-Ton logbook Kilter te suit maintenant, le catalogue MoonBoard complet est là, et les boards s'allument plus fiablement sur iPhone.
+Le catalogue MoonBoard complet est là, tu règles les couleurs de prises à ta main, et les boards s'allument plus fiablement sur iPhone.
 
 Nouveau :
-- Connecte-toi avec ton identifiant et ton mot de passe Kilter pour rapatrier tes sends, essais, notes et circuits directement dans Boardsesh.
 - Le catalogue MoonBoard complet est arrivé : des milliers de blocs en plus avec de vraies cotations, des notes en étoiles et le nombre de sends, plus le Mini 2025 et l'original de 2010. Le matériel LED du MoonBoard d'origine s'allume aussi en Bluetooth.
 - Touche n'importe quelle voie d'un circuit ou d'une playlist et toute la liste passe dans ta file dans l'ordre. Reviens en arrière d'un glissement pour repasser sur les blocs précédents, pas seulement sauter au suivant.
 - Compose tes propres couleurs de prise avec un vrai sélecteur de couleur, prévisualise-les en daltonisme rouge-vert et bleu-jaune, et choisis une nouvelle forme de marqueur octogonale. Les cercles des prises MoonBoard sont aussi plus gros et plus lisibles.

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.0.1',
+    version: '2.1.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,


### PR DESCRIPTION
## Summary

The current App Store build (399) shipped with the Boardsesh 2.0 launch copy in `fastlane/metadata/*/release_notes.txt`. This replaces that with fresh "What's New" notes for the next submission, covering everything user-facing merged since the 2.0.1 version bump (commit `5094b488`, 2026-06-26) that wrote those launch notes. It also bumps the app version to **2.1.0** for the next release.

Highlights pulled from the merged PRs in that window:
- Full MoonBoard catalog: Mini 2025 + original 2010, real grades/stars/send counts, original MoonBoard LED over Bluetooth (#3214, #3233), bigger hold circles (#3218)
- Circuit/playlist load the whole list into the queue in order (#2773)
- OKHSL hold colour picker with colour-blindness preview + octagon marker (#3212)
- Hardest sort top-to-bottom with community consensus grades (#3202)
- iPhone BLE reliability for Kilter/Tension/MoonBoard (#3228, #3225, #3219), iOS sheet-freeze fix (#3211), filter pickers restored (#3236), live-session reconnect (#3242)

**Intentionally excluded:** the Kilter username/password login + send-import feature (#3170) is still behind a disabled feature flag, so it's not advertised in these notes yet (per review feedback).

### Version bump

`packages/mobile/app.config.ts` `version` → **2.1.0**. The single Expo `version` drives both iOS `CFBundleShortVersionString` and Android `versionName`; the iOS build number and Android `versionCode` stay CI-auto-incremented.

### Localization

Translated for `en-US`, `es-ES`, `es-MX`, and `fr-FR`, following `docs/i18n-spanish-glossary.md` (plafón for board, etc.) and the climber voice of the existing notes. All four files stay well under the App Store 4000-char limit.

## Release Notes

- [x] No release note needed (internal / technical change)

App Store metadata copy + version bump only; no in-app behaviour changes.

## Test plan

- `wc -m` on each locale to confirm under the 4000-char App Store limit.
- Manual read-through of each translation against the Spanish glossary and the existing French/Spanish notes for terminology and voice consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
