### PR TITLE
feat(mobile): move the lit wall climb to an "On the wall" strip

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1158,9 +1158,10 @@ function ClimbListInner() {
 
       <ClimbTopChrome
         searchMode={useNativeSearch ? 'native' : 'custom'}
-        // With the chip row on, the active filters live in the token row, so the
-        // centre title drops the filter summary and reads as a plain header.
-        title={showFilterChips ? t('mobile.search.allClimbs') : searchTitle}
+        // With the chip row on, the active filters live in the token row and the
+        // tab itself names the screen, so the centre title is dropped entirely —
+        // the redundant "All climbs" label added nothing.
+        title={showFilterChips ? undefined : searchTitle}
         canCreate={isAuthenticated && hasBoardConfig}
         onCreate={handleCreateClimb}
         onOpenBoardDetail={handleOpenBoardDetail}

--- a/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingLargeTitleHeader.tsx
@@ -14,6 +14,12 @@ type CollapsingLargeTitleHeaderProps = {
    *  (e.g. the Climbs filter summary). Always visible when set; omit for no
    *  centred title (Discover/Profile/Record). */
   centerTitle?: string;
+  /** Optional interactive element rendered in the centre slot instead of the plain
+   *  title (e.g. the Climbs "On the wall" capsule). Takes precedence over
+   *  `centerTitle` when present. The centre is `box-none`, so this stays tappable
+   *  while empty space still falls through (status-bar scroll-to-top is unaffected
+   *  — it's a status-bar-window behaviour, not the nav row's). */
+  centerContent?: ReactNode;
   /** Report the measured chrome height so the list can inset its top padding. */
   onHeightChange: (height: number) => void;
   /** Glass island(s) anchored to the left of the islands row. */
@@ -35,6 +41,7 @@ type CollapsingLargeTitleHeaderProps = {
  */
 export function CollapsingLargeTitleHeader({
   centerTitle,
+  centerContent,
   onHeightChange,
   leftActions,
   rightActions,
@@ -66,22 +73,24 @@ export function CollapsingLargeTitleHeader({
         {/* Left island. */}
         {leftActions}
 
-        {/* Flexible centre: the optional persistent plain title (Climbs filter
-            summary) — plain text over the progressive blur, no pill; otherwise the
-            spacer that holds the right island to the edge. Non-interactive —
-            status-bar tap handles scroll-to-top. */}
-        <View pointerEvents="none" style={styles.centerSection}>
-          {centerTitle != null ? (
-            <Text
-              variant="headline"
-              numberOfLines={1}
-              ellipsizeMode="tail"
-              color={systemColors.label}
-              style={styles.centerTitle}
-            >
-              {centerTitle}
-            </Text>
-          ) : null}
+        {/* Flexible centre: an optional interactive element (Climbs "On the wall"
+            capsule) takes precedence; otherwise the optional persistent plain title
+            (Climbs filter summary) — plain text over the progressive blur; otherwise
+            the spacer that holds the right island to the edge. `box-none` so the
+            capsule stays tappable while empty space falls through. */}
+        <View pointerEvents="box-none" style={styles.centerSection}>
+          {centerContent ??
+            (centerTitle != null ? (
+              <Text
+                variant="headline"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                color={systemColors.label}
+                style={styles.centerTitle}
+              >
+                {centerTitle}
+              </Text>
+            ) : null)}
         </View>
 
         {/* Right island. */}

--- a/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
+++ b/packages/mobile/src/components/chrome/CollapsingTopChrome.tsx
@@ -38,6 +38,9 @@ type CollapsingTopChromeProps = {
   onHeightChange: (height: number) => void;
   /** Optional persistent plain centre title (Climbs filter summary). */
   centerTitle?: string;
+  /** Optional interactive element for the centre slot (Climbs "On the wall"
+   *  capsule), taking precedence over `centerTitle`. */
+  centerContent?: ReactNode;
   /** Optional glass action(s) docked at the far right of the right toolbar (e.g. the
    *  Record tab's share/invite + End controls). Discover/Climbs pass none. */
   trailingAction?: ReactNode;
@@ -82,6 +85,7 @@ export function CollapsingTopChrome({
   boardBadge = false,
   onHeightChange,
   centerTitle,
+  centerContent,
   trailingAction,
   trailingActionCount,
   leadingAction,
@@ -146,19 +150,24 @@ export function CollapsingTopChrome({
   // A fragment/element of leading actions reads as one element, so callers passing
   // several supply the explicit count; otherwise reserve a slot only for a real one.
   const leadingActions = leadingActionCount ?? (isValidElement(leadingAction) ? 1 : 0);
-  const leftActionCount = 1 + leadingActions + (canCreate ? 1 : 0) + (canOpenAngle ? 1 : 0);
+  // Left island = identity + authoring: avatar (+ optional leading) + create. The
+  // angle moved to the right island with the board glyph (both board-config
+  // controls that act on the displayed list), so it's no longer counted here.
+  const leftActionCount = 1 + leadingActions + (canCreate ? 1 : 0);
 
-  // The right glass toolbar holds the board glyph, the lightbulb, and an optional
-  // trailing action — a fixed-width island sized to whichever of those are live.
+  // The right glass toolbar holds the angle, the board glyph, the lightbulb, and an
+  // optional trailing action — a fixed-width island sized to whichever are live.
   // The board glyph shows whenever a board is set; the lightbulb is hidden when
-  // `hideLight` (e.g. the active-session header).
+  // `hideLight` (e.g. the active-session header / climbs tab). The angle slot is
+  // counted only when adjustable so fixed-angle boards don't get a phantom slot.
+  const angleActions = canOpenAngle ? 1 : 0;
   const boardActions = activeBoard ? 1 : 0;
   const lightActions = bluetooth && !hideLight ? 1 : 0;
   // Reserve a slot only for a real element — a `false`/`null` from a `cond && <…>`
   // caller must not widen the toolbar by a phantom 48px. Callers passing a fragment
   // of several actions supply `trailingActionCount` explicitly.
   const trailingActions = trailingActionCount ?? (isValidElement(trailingAction) ? 1 : 0);
-  const rightActionCount = boardActions + lightActions + trailingActions;
+  const rightActionCount = angleActions + boardActions + lightActions + trailingActions;
   const rightToolbarWidth = rightActionCount * TOP_ACTION_SIZE;
 
   const leftActions = (
@@ -170,13 +179,13 @@ export function CollapsingTopChrome({
           <Icon name="plus" size={24} color={systemColors.label} />
         </GlassToolbarAction>
       ) : null}
-      <AngleToolbarAction />
     </GlassActionToolbar>
   );
 
-  // Right glass toolbar: board glyph + lightbulb (+ optional trailing action),
-  // fixed width. Order reads board → light → trailing (session controls furthest
-  // right).
+  // Right glass toolbar: angle + board glyph + lightbulb (+ optional trailing
+  // action), fixed width. Order reads angle → board → light → trailing — the angle
+  // sits inboard (less-extreme corner for a frequently-tapped control) next to the
+  // board glyph (both board-config controls), board keeps its trailing anchor.
   const rightActions =
     rightToolbarWidth > 0 ? (
       <View
@@ -195,6 +204,7 @@ export function CollapsingTopChrome({
           style={StyleSheet.absoluteFill}
           pointerEvents="none"
         />
+        <AngleToolbarAction />
         {activeBoard ? (
           <BoardToolbarAction
             onPress={onOpenBoardSwitcher}
@@ -210,6 +220,7 @@ export function CollapsingTopChrome({
   return (
     <CollapsingLargeTitleHeader
       centerTitle={centerTitle}
+      centerContent={centerContent}
       onHeightChange={onHeightChange}
       leftActions={leftActions}
       rightActions={rightActions}

--- a/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
+++ b/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
@@ -9,7 +9,7 @@
 import { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Appbar } from 'react-native-paper';
+import { Appbar, Chip } from 'react-native-paper';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard, useSetActiveBoard } from '../../lib/graphql/use-active-board';
 import { hapticLight } from '../../lib/haptics';
@@ -19,14 +19,45 @@ import { Text } from '../Text';
 import { iconMap } from '../icon-map';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
 
-export function MaterialAngleAction() {
-  const { systemColors } = useTheme();
-  const { t: tSession } = useTranslation('session');
+/**
+ * Shared angle state for the Material angle controls: reads the active board, owns
+ * the selector sheet's open state, and writes the chosen angle back (re-grading the
+ * list).
+ *
+ * Each consumer gets its OWN instance (and its own `visible` state) — that's by
+ * design, not a bug: `MaterialAngleAction` (Discover's app bar) and
+ * `MaterialAngleChip` (the Climbs quick row) never co-render on the same screen
+ * (Climbs dropped the app-bar action when the angle moved to the chip row), so
+ * there is no shared sheet-open state to diverge.
+ */
+function useMaterialAngleControl() {
   const { data: activeBoard } = useActiveBoard();
   const setActiveBoard = useSetActiveBoard();
   const [visible, setVisible] = useState(false);
 
   const canAdjust = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
+  const open = useCallback(() => {
+    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
+    hapticLight();
+    setVisible(true);
+  }, [activeBoard]);
+  const close = useCallback(() => setVisible(false), []);
+  const change = useCallback(
+    (newAngle: number) => {
+      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
+      void setActiveBoard({ ...activeBoard, angle: newAngle });
+    },
+    [activeBoard, setActiveBoard],
+  );
+
+  return { activeBoard, canAdjust, visible, open, close, change };
+}
+
+export function MaterialAngleAction() {
+  const { systemColors } = useTheme();
+  const { t: tSession } = useTranslation('session');
+  const { activeBoard, canAdjust, visible, open, close, change } = useMaterialAngleControl();
+
   const angleIcon = useCallback(
     () => (
       <Text variant="caption1" style={[styles.materialAngleText, { color: systemColors.label }]}>
@@ -35,36 +66,54 @@ export function MaterialAngleAction() {
     ),
     [activeBoard?.angle, systemColors.label],
   );
-  const handleOpen = useCallback(() => {
-    if (!activeBoard || activeBoard.isAngleAdjustable === false || activeBoard.angle == null) return;
-    hapticLight();
-    setVisible(true);
-  }, [activeBoard]);
-  const handleClose = useCallback(() => setVisible(false), []);
-  const handleAngleChange = useCallback(
-    (newAngle: number) => {
-      if (!activeBoard || activeBoard.isAngleAdjustable === false || newAngle === activeBoard.angle) return;
-      void setActiveBoard({ ...activeBoard, angle: newAngle });
-    },
-    [activeBoard, setActiveBoard],
-  );
 
   if (!activeBoard || !canAdjust) return null;
 
   return (
     <>
-      <Appbar.Action
-        icon={angleIcon}
-        onPress={handleOpen}
-        accessibilityLabel={tSession('mobile.angleSelector.title')}
-      />
+      <Appbar.Action icon={angleIcon} onPress={open} accessibilityLabel={tSession('mobile.angleSelector.title')} />
       <AngleSelectorSheet
         visible={visible}
-        onClose={handleClose}
+        onClose={close}
         boardName={activeBoard.boardType}
         layoutId={activeBoard.layoutId}
         currentAngle={activeBoard.angle}
-        onAngleChange={handleAngleChange}
+        onAngleChange={change}
+      />
+    </>
+  );
+}
+
+/**
+ * The Material angle control as an M3 quick-row chip (Climbs). Angle re-grades the
+ * whole list, so it belongs with the other list parameters (grade / filters) one
+ * tap away, not buried — and it keeps the over-budget app bar lean. Renders nothing
+ * for fixed-angle boards (or none).
+ */
+export function MaterialAngleChip() {
+  const { t: tSession } = useTranslation('session');
+  const { activeBoard, canAdjust, visible, open, close, change } = useMaterialAngleControl();
+
+  if (!activeBoard || !canAdjust) return null;
+
+  return (
+    <>
+      <Chip
+        compact
+        mode="outlined"
+        onPress={open}
+        accessibilityLabel={tSession('mobile.angleSelector.title')}
+        textStyle={styles.materialChipText}
+      >
+        {`${activeBoard.angle}°`}
+      </Chip>
+      <AngleSelectorSheet
+        visible={visible}
+        onClose={close}
+        boardName={activeBoard.boardType}
+        layoutId={activeBoard.layoutId}
+        currentAngle={activeBoard.angle}
+        onAngleChange={change}
       />
     </>
   );
@@ -109,5 +158,8 @@ const styles = StyleSheet.create({
   materialAngleText: {
     fontWeight: '700',
     textAlign: 'center',
+  },
+  materialChipText: {
+    fontWeight: '700',
   },
 });

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-large-title-header.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-large-title-header.test.tsx
@@ -108,6 +108,19 @@ describe('CollapsingLargeTitleHeader', () => {
     expect(container.textContent).not.toContain('V4–V6 · Quality');
   });
 
+  it('renders centerContent in place of the title when both are provided', () => {
+    const { container } = render(
+      <CollapsingLargeTitleHeader
+        {...makeProps({
+          centerTitle: 'V4–V6 · Quality',
+          centerContent: createElement('div', { 'data-testid': 'center-content' }),
+        })}
+      />,
+    );
+    expect(container.querySelector('[data-testid="center-content"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('V4–V6 · Quality');
+  });
+
   it('renders the progressive blur behind the header islands', () => {
     const { container } = render(<CollapsingLargeTitleHeader {...makeProps()} />);
     // ProgressiveBlur renders a MaskedView wrapping the BlurView (both stubbed in

--- a/packages/mobile/src/components/chrome/index.ts
+++ b/packages/mobile/src/components/chrome/index.ts
@@ -6,4 +6,4 @@ export { LightbulbToolbarAction } from './LightbulbToolbarAction';
 export { CollapsingLargeTitleHeader } from './CollapsingLargeTitleHeader';
 export { CollapsingTopChrome } from './CollapsingTopChrome';
 export { DiscoverTopChrome } from './DiscoverTopChrome';
-export { MaterialAngleAction, MaterialLightbulbAction } from './MaterialBoardActions';
+export { MaterialAngleAction, MaterialAngleChip, MaterialLightbulbAction } from './MaterialBoardActions';

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -19,7 +19,6 @@ import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-pro
 import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './AccessoryBarSurface';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
-import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 import { useBoardConnectionState } from '../ble/use-board-connection-state';
 import { BoardControlIndicator } from './BoardControlIndicator';
 
@@ -86,9 +85,8 @@ export function ClimbCapsule({
   // Read from the single source so the bar can't disagree with the drawer bulb.
   const { boardConnection, bluetooth } = useBoardConnectionState();
 
-  // Source-of-truth flip: show the wall's lit climb when a board feed is live
-  // (flag-gated), else the local queue head.
-  const currentClimb = useWallOrQueueCurrentClimb(currentItem?.climb ?? null);
+  // Queue head only — the wall's lit climb lives in the top "On the wall" strip.
+  const currentClimb = currentItem?.climb ?? null;
   // Board art needs the active board config; matches the iOS 26 native accessory.
   const showThumbnail = boardConfig != null;
   // Show the connect control once a board is bound (the BLE context exists).

--- a/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
+++ b/packages/mobile/src/components/queue-control/QueueBottomAccessory.tsx
@@ -9,7 +9,6 @@ import {
   NATIVE_BOTTOM_ACCESSORY_SCREEN_GUTTER,
 } from '../../theme/layout';
 import { NativeAccessoryClimbRow } from './NativeAccessoryClimbRow';
-import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 
 /**
  * Hold the last shown climb while this component stays mounted. The mount itself
@@ -43,10 +42,10 @@ export function QueueBottomAccessory() {
   const placement = NativeTabs.BottomAccessory.usePlacement();
   const { width: screenWidth } = useWindowDimensions();
   const { state } = useQueue();
-  // Show the accessory when there's a local queue climb OR a live wall climb
-  // (the flag-gated source flip — see useWallOrQueueCurrentClimb), retained across
-  // a presence blip so the live platter never blanks while the host is held open.
-  const resolvedClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  // The accessory shows the local queue head only — never the wall's lit climb
+  // (that lives in the top "On the wall" strip now). Retained across a presence
+  // blip so the live platter never blanks while the host is held open.
+  const resolvedClimb = state.currentClimbQueueItem?.climb ?? null;
   const currentClimb = useRetainedAccessoryClimb(resolvedClimb);
 
   const accessoryWidth = useMemo(() => {

--- a/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
@@ -1,0 +1,194 @@
+// The "On the wall" status capsule — a compact pill that surfaces the climb
+// currently LIT on the physical board (when it differs from the user's own queue
+// head, e.g. a teammate is driving the wall in a party session). It sits in the
+// centre of the top-header islands row (iOS) / a slim row under the app bar
+// (Android) — the home for "what's lit right now" that the bottom queue accessory
+// used to overload.
+//
+// Leads with the SENDER's avatar (whoever sent the climb to the board), so the
+// capsule answers "who lit it + what's lit" at a glance — the core party-session
+// signal a lightbulb never carried. The avatar is INERT here (one Pressable opens
+// the read-only wall preview; the tap-sender-to-profile affordance lives in that
+// preview sheet, which has room for a full target). Fully-anonymous senders fall
+// back to an amber person glyph — never a lightbulb (a bistable leading slot
+// breaks the visual scan + VoiceOver grammar) and never a literal "?".
+//
+// Deliberately a NON-glass pill (HIG: no glass-on-glass over the header's
+// progressive blur) with a warm "lit" tint — now the sole at-a-glance "live"
+// carrier. Compact by design — the name truncates, the grade stays.
+
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { AccessibilityInfo, Pressable, StyleSheet, View } from 'react-native';
+import Animated, { FadeIn, useReducedMotion } from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { useTheme } from '../../providers/theme-provider';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { spacing } from '../../theme/tokens';
+import { withAlpha } from '../../theme/colors';
+import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
+import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { BoardDriverAvatar } from '../board-presence/BoardDriverAvatar';
+import { useOpenWallPreview } from './use-open-wall-preview';
+
+const CAPSULE_HEIGHT = 32;
+// 20pt reads unambiguously as a face above M3's ~18dp floor while protecting the
+// truncating climb name in the tight centre slot (M3 would prefer 24; default to
+// 20). Fixed — does not scale with Dynamic Type.
+const AVATAR_SIZE = 20;
+// Debounce assistive-tech announcements so a fast party session (rapid wall
+// changes) doesn't spam the speech queue.
+const ANNOUNCE_DEBOUNCE_MS = 600;
+
+type WallStatusCapsuleProps = {
+  /** The wall's lit climb (already resolved as distinct from the queue head). */
+  climb: BoardPresenceClimb;
+};
+
+// memo'd so a ClimbTopChrome re-render (filter/board/search change) doesn't rebuild
+// the capsule's hooks while the wall climb is unchanged — the `climb` prop is the
+// stable BoardPresenceClimb from useWallClimbIfDistinct (changes only on a wall event).
+function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
+  const { t } = useTranslation('session');
+  const { systemColors, brandColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+  const reduceMotion = useReducedMotion();
+  const openWallPreview = useOpenWallPreview();
+
+  const name = climb.name ?? '';
+  const formattedGrade = formatGrade(climb.grade ?? '');
+  const gradeColor = getGradeColor(climb.grade ?? '') ?? DEFAULT_GRADE_COLOR;
+  const senderName = climb.sentByDisplayName?.trim() || null;
+  const hasSenderIdentity = climb.sentByAvatarUrl != null || senderName != null;
+
+  const a11yLabel = senderName
+    ? t('mobile.boardPresence.stripA11yLabelWithSender', { name, grade: formattedGrade ?? '', sender: senderName })
+    : t('mobile.boardPresence.stripA11yLabel', { name, grade: formattedGrade ?? '' });
+
+  // Announce peer-driven changes the user didn't initiate (debounced + de-duped on
+  // the climb's uuid so a re-render doesn't re-announce the same climb). Done
+  // explicitly rather than via accessibilityLiveRegion, because the capsule remounts
+  // on each climb change (keyed Animated.View) — a fresh node has no "content
+  // change" for a live region to catch.
+  const announceLabel = senderName
+    ? t('mobile.boardPresence.stripAnnounceWithSender', { name, grade: formattedGrade ?? '', sender: senderName })
+    : t('mobile.boardPresence.stripAnnounce', { name, grade: formattedGrade ?? '' });
+  const climbUuid = climb.climbUuid;
+  // De-dupe on the announced TEXT, not the uuid: a re-render with an unchanged label
+  // shouldn't re-announce, but a locale switch (same climb, new label) should.
+  const lastAnnouncedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (lastAnnouncedRef.current === announceLabel) return;
+    const handle = setTimeout(() => {
+      lastAnnouncedRef.current = announceLabel;
+      AccessibilityInfo.announceForAccessibility(announceLabel);
+    }, ANNOUNCE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [announceLabel]);
+
+  const tintStyle = useMemo(
+    () => [StyleSheet.absoluteFill, { backgroundColor: withAlpha(brandColors.warning, 0.14) }],
+    [brandColors.warning],
+  );
+
+  const handlePress = useCallback(() => openWallPreview(boardPresenceClimbToClimb(climb)), [openWallPreview, climb]);
+
+  return (
+    <Animated.View
+      // Fades IN on mount and on each wall-climb change (keyed remount). Removal is
+      // an instant cut — Reanimated can't reliably intercept an `exiting` whose
+      // wrapping parent unmounts in the same commit (the Material under-app-bar row),
+      // so we don't promise a fade-out the layout can't deliver.
+      key={climbUuid}
+      entering={reduceMotion ? undefined : FadeIn.duration(180)}
+      style={[
+        styles.capsule,
+        { backgroundColor: systemColors.secondaryBackground, borderColor: withAlpha(brandColors.warning, 0.35) },
+      ]}
+    >
+      <View pointerEvents="none" style={tintStyle} />
+      <Pressable
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityLabel={a11yLabel}
+        accessibilityHint={t('mobile.boardPresence.stripA11yHint')}
+        style={styles.pressable}
+      >
+        {/* The sender, leading. Inert + a11y-hidden so the pill reads as one node
+            (the profile tap lives in the wall-preview sheet). `userId={null}` is
+            deliberate — it only suppresses the avatar's own profile-link tap; the
+            face still resolves from `sentByAvatarUrl` (Avatar renders the image off
+            `uri`, not `userId`), so this never degrades a known sender's photo. A
+            sender with only a userId (no photo, no display name) has nothing
+            renderable as a face/monogram, so it correctly takes the person glyph. */}
+        <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+          {hasSenderIdentity ? (
+            <BoardDriverAvatar
+              uri={climb.sentByAvatarUrl}
+              name={senderName}
+              userId={null}
+              size={AVATAR_SIZE}
+              status="none"
+            />
+          ) : (
+            <Icon name="profile.fill" size={18} color={brandColors.warning} />
+          )}
+        </View>
+        <Text
+          variant="footnote"
+          color={systemColors.label}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+          style={styles.name}
+        >
+          {name}
+        </Text>
+        {formattedGrade ? (
+          <Text
+            variant="footnote"
+            numberOfLines={1}
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={[styles.grade, { color: gradeColor }]}
+          >
+            {formattedGrade}
+          </Text>
+        ) : null}
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+export const WallStatusCapsule = memo(WallStatusCapsuleImpl);
+
+const styles = StyleSheet.create({
+  capsule: {
+    flexShrink: 1,
+    maxWidth: '100%',
+    height: CAPSULE_HEIGHT,
+    borderRadius: CAPSULE_HEIGHT / 2,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+  },
+  pressable: {
+    flexShrink: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: '100%',
+    paddingLeft: spacing[1],
+    paddingRight: spacing[3],
+    gap: spacing[2],
+  },
+  name: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontWeight: '600',
+  },
+  grade: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
+  },
+});

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -162,12 +162,6 @@ vi.mock('../../../hooks/use-native-glass', () => ({ useNativeGlass: () => false 
 // assertions hold.
 vi.mock('../../../hooks/use-effective-surface-mode', () => ({ useEffectiveSurfaceMode: () => 'glass' }));
 
-// Board-presence source flip: default identity passthrough (flag off / no wall
-// feed) so the capsule renders the local queue head exactly as today.
-vi.mock('../use-wall-or-queue-climb', () => ({
-  useWallOrQueueCurrentClimb: (localClimb: unknown) => localClimb,
-}));
-
 import { ClimbCapsule } from '../ClimbCapsule';
 
 function makeClimb(over: Partial<Climb> = {}): Climb {

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -259,12 +259,6 @@ vi.mock('../LogAscentToolbarButton', () => ({
     }),
 }));
 
-// Board-presence source flip: identity passthrough (flag off / no wall feed) so
-// the row renders the local queue head exactly as today.
-vi.mock('../use-wall-or-queue-climb', () => ({
-  useWallOrQueueCurrentClimb: (localClimb: unknown) => localClimb,
-}));
-
 import { NativeAccessoryClimbRow } from '../NativeAccessoryClimbRow';
 
 function makeClimb(overrides: Partial<Climb> = {}): Climb {

--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -12,7 +12,6 @@ const cfg = vi.hoisted(() => ({
   onAuthRoute: false,
   onPlayerRoute: false,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
-  wallClimb: null as null | { uuid: string; angle: number },
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
   measuredTabBarHeight: null as number | null,
   nativeAccessoryActive: false,
@@ -118,13 +117,6 @@ vi.mock('../ClimbCapsule', () => ({
       endAction,
     ),
 }));
-vi.mock('../use-wall-or-queue-climb', () => ({
-  useWallOrQueueCurrentClimb: (localClimb: { uuid: string; angle: number } | null) => cfg.wallClimb ?? localClimb,
-  useIsWallPinned: () => cfg.wallClimb != null,
-  // Presence-only wall signal fed into the real useBottomChromeMetrics →
-  // useHasAccessoryClimb, so the JS-vs-native arbitration is wall-aware here too.
-  useHasWallClimb: () => cfg.wallClimb != null,
-}));
 vi.mock('../LogAscentFab', () => ({
   LogAscentFab: ({ climb }: { climb: { uuid: string } }) =>
     createElement('div', { 'data-tick': 'true', 'data-climb-uuid': climb.uuid }),
@@ -144,7 +136,6 @@ describe('PersistentQueueBar', () => {
     cfg.onAuthRoute = false;
     cfg.onPlayerRoute = false;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
-    cfg.wallClimb = null;
     cfg.variant = 'liquidGlass';
     cfg.measuredTabBarHeight = null;
     cfg.nativeAccessoryActive = false;
@@ -241,25 +232,11 @@ describe('PersistentQueueBar', () => {
     expect(container.querySelector('[data-tick]')).toBeNull();
   });
 
-  it('uses the wall climb for the fallback tick when the local queue is empty', () => {
+  it('renders nothing when the local queue is empty — the wall climb lives in the top strip now', () => {
+    // The bar shows the user's own queue head only; a climb lit on the wall (e.g. a
+    // teammate's) is surfaced by the top "On the wall" strip, never this bottom bar.
     cfg.currentClimbQueueItem = null;
-    cfg.wallClimb = { uuid: 'wall-climb', angle: 40 };
     const { container } = render(<PersistentQueueBar />);
-    expect(container.querySelector('[data-capsule]')).not.toBeNull();
-    expect(container.querySelector('[data-tick]')?.getAttribute('data-climb-uuid')).toBe('wall-climb');
-  });
-
-  it('defers to the native accessory for a wall-only climb on glass + tabs', () => {
-    // Wall climb, no local queue: the native accessory owns the slot (it mounts on
-    // the same wall-aware presence gate), so the JS bar must stay hidden — no
-    // doubling with the native pill.
-    cfg.currentClimbQueueItem = null;
-    cfg.wallClimb = { uuid: 'wall-climb', angle: 40 };
-    cfg.nativeAccessoryActive = true;
-    cfg.insideTabs = true;
-
-    const { container } = render(<PersistentQueueBar />);
-
     expect(container.querySelector('[data-capsule]')).toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();
   });

--- a/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/queue-bottom-accessory.test.tsx
@@ -44,13 +44,6 @@ vi.mock('../NativeAccessoryClimbRow', () => ({
       'data-row-width': String(width),
     }),
 }));
-// Board-presence source flip: identity passthrough (flag off / no wall feed), so
-// the accessory render-gate keys on the local queue head exactly as today.
-vi.mock('../use-wall-or-queue-climb', () => ({
-  useWallOrQueueCurrentClimb: (localClimb: unknown) => localClimb,
-  useIsWallPinned: () => false,
-}));
-
 import { QueueBottomAccessory } from '../QueueBottomAccessory';
 
 describe('QueueBottomAccessory', () => {

--- a/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-accessory-climb-tap.test.tsx
@@ -9,11 +9,6 @@ const queue = vi.hoisted(() => ({
 
 const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
 
-// The accessory shows the wall's lit climb when a feed is live, else the local
-// head — `useWallOrQueueCurrentClimb` mirrors that here so we can assert tap opens
-// whatever the bar is showing.
-const wall = vi.hoisted(() => ({ climb: null as Climb | null }));
-
 // Capture the tap's onEnd worklet so a test can fire it like a real tap.
 const tap = vi.hoisted(() => ({ onEnd: null as ((...args: unknown[]) => unknown) | null }));
 
@@ -25,13 +20,7 @@ vi.mock('../../../providers/drawer-host-provider', () => ({
   useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer }),
 }));
 
-vi.mock('../use-wall-or-queue-climb', () => ({
-  useWallOrQueueCurrentClimb: (localClimb: Climb | null) => wall.climb ?? localClimb,
-}));
-
 vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
-
-vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
 
 vi.mock('react-native-reanimated', () => ({
   runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
@@ -75,7 +64,6 @@ describe('useAccessoryClimbTap', () => {
     drawer.openPlayDrawer.mockClear();
     queue.state.currentClimbQueueItem = makeItem('head');
     queue.state.queue = [queue.state.currentClimbQueueItem];
-    wall.climb = null;
     tap.onEnd = null;
   });
 
@@ -84,31 +72,16 @@ describe('useAccessoryClimbTap', () => {
     expect(result.current.currentItem?.uuid).toBe('head');
   });
 
-  it('opens the local queue head active on tap (it already is current)', () => {
+  it('opens the local queue head active on tap (it already is current — never the wall climb)', () => {
     renderHook(() => useAccessoryClimbTap());
     tap.onEnd?.();
-    // The bar shows the current climb, so it opens active — no preview.
     expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-head' }), {
       source: 'current_queue_item',
     });
   });
 
-  it('opens a peer-driven wall climb as a read-only "Now on the wall" view when a board feed is live', () => {
-    wall.climb = makeClimb('wall');
-    renderHook(() => useAccessoryClimbTap());
-    tap.onEnd?.();
-    // The wall climb isn't the local current and is physically lit, so it opens
-    // view-only with `previewIsWallClimb` (no "Set active" takeover).
-    expect(drawer.openPlayDrawer).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'climb-wall' }), {
-      previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'climb-wall' }) }),
-      previewIsWallClimb: true,
-      source: 'current_queue_item',
-    });
-  });
-
-  it('does nothing on tap when there is no climb to open', () => {
+  it('does nothing on tap when there is no queue head to open', () => {
     queue.state.currentClimbQueueItem = null;
-    wall.climb = null;
     renderHook(() => useAccessoryClimbTap());
     tap.onEnd?.();
     expect(drawer.openPlayDrawer).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/queue-control/__tests__/use-open-wall-preview.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-open-wall-preview.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Climb } from '@boardsesh/queue';
+
+const drawer = vi.hoisted(() => ({ openPlayDrawer: vi.fn() }));
+const haptics = vi.hoisted(() => ({ hapticLight: vi.fn() }));
+
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ openPlayDrawer: drawer.openPlayDrawer }),
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticLight: haptics.hapticLight }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+
+import { useOpenWallPreview } from '../use-open-wall-preview';
+
+function makeClimb(): Climb {
+  return {
+    uuid: 'wall-1',
+    name: 'Wax On',
+    frames: '',
+    setter_username: 'someone',
+    angle: 40,
+    ascensionist_count: 9,
+    difficulty: 'V5',
+    quality_average: '3',
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+  } as Climb;
+}
+
+describe('useOpenWallPreview', () => {
+  beforeEach(() => {
+    drawer.openPlayDrawer.mockClear();
+    haptics.hapticLight.mockClear();
+  });
+
+  it('opens the climb read-only as a wall preview, with haptics', () => {
+    const climb = makeClimb();
+    const { result } = renderHook(() => useOpenWallPreview());
+    result.current(climb);
+
+    expect(haptics.hapticLight).toHaveBeenCalledTimes(1);
+    expect(drawer.openPlayDrawer).toHaveBeenCalledWith(
+      climb,
+      expect.objectContaining({
+        previewIsWallClimb: true,
+        previewQueueItem: expect.objectContaining({ climb: expect.objectContaining({ uuid: 'wall-1' }) }),
+        source: 'board_presence',
+      }),
+    );
+  });
+});

--- a/packages/mobile/src/components/queue-control/__tests__/use-wall-or-queue-climb.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-wall-or-queue-climb.test.tsx
@@ -5,50 +5,67 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const cfg = vi.hoisted(() => ({
   enabled: true,
   boardId: 1 as number | null,
-  hasWallClimb: true,
+  isLive: true,
+  wallClimb: { climbUuid: 'wall-1', name: 'Wax On', difficulty: 15 } as {
+    climbUuid: string;
+    name: string;
+    difficulty: number;
+  } | null,
 }));
 
 vi.mock('../../../providers/board-presence-provider', () => ({
   useBoardPresenceControls: () => ({ enabled: cfg.enabled, boardId: cfg.boardId }),
 }));
 vi.mock('@boardsesh/board-presence-react', () => ({
-  useBoardPresenceHasClimb: () => cfg.hasWallClimb,
-  // Imported at module top for the sibling hooks; unused by useHasWallClimb.
-  useBoardPresenceCurrent: () => ({ currentClimb: null, isLive: false }),
-}));
-vi.mock('../../../lib/board-presence/presence-climb', () => ({
-  boardPresenceClimbToClimb: (climb: unknown) => climb,
+  useBoardPresenceCurrent: () => ({ currentClimb: cfg.wallClimb, isLive: cfg.isLive }),
 }));
 
-import { useHasWallClimb } from '../use-wall-or-queue-climb';
+import { useWallClimbIfDistinct } from '../use-wall-or-queue-climb';
 
-describe('useHasWallClimb', () => {
+describe('useWallClimbIfDistinct', () => {
   beforeEach(() => {
     cfg.enabled = true;
     cfg.boardId = 1;
-    cfg.hasWallClimb = true;
+    cfg.isLive = true;
+    cfg.wallClimb = { climbUuid: 'wall-1', name: 'Wax On', difficulty: 15 };
   });
 
-  it('is true when the feature is enabled, a board is bound, and a wall climb is live', () => {
-    const { result } = renderHook(() => useHasWallClimb());
-    expect(result.current).toBe(true);
+  it('returns the wall climb when live and it differs from the queue head', () => {
+    const { result } = renderHook(() => useWallClimbIfDistinct('queue-head'));
+    expect(result.current).toEqual(cfg.wallClimb);
   });
 
-  it('is false when the feature is disabled', () => {
+  it('returns the wall climb when the local queue is empty (null head — solo/fresh session)', () => {
+    const { result } = renderHook(() => useWallClimbIfDistinct(null));
+    expect(result.current).toEqual(cfg.wallClimb);
+  });
+
+  it('returns null when the wall climb IS the queue head (solo case)', () => {
+    const { result } = renderHook(() => useWallClimbIfDistinct('wall-1'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the feature is disabled', () => {
     cfg.enabled = false;
-    const { result } = renderHook(() => useHasWallClimb());
-    expect(result.current).toBe(false);
+    const { result } = renderHook(() => useWallClimbIfDistinct('queue-head'));
+    expect(result.current).toBeNull();
   });
 
-  it('is false when no board is bound', () => {
+  it('returns null when no board is bound', () => {
     cfg.boardId = null;
-    const { result } = renderHook(() => useHasWallClimb());
-    expect(result.current).toBe(false);
+    const { result } = renderHook(() => useWallClimbIfDistinct('queue-head'));
+    expect(result.current).toBeNull();
   });
 
-  it('is false when the live feed has no current climb', () => {
-    cfg.hasWallClimb = false;
-    const { result } = renderHook(() => useHasWallClimb());
-    expect(result.current).toBe(false);
+  it('returns null when the feed is not live', () => {
+    cfg.isLive = false;
+    const { result } = renderHook(() => useWallClimbIfDistinct('queue-head'));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the live feed has no current climb', () => {
+    cfg.wallClimb = null;
+    const { result } = renderHook(() => useWallClimbIfDistinct('queue-head'));
+    expect(result.current).toBeNull();
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+
+const spies = vi.hoisted(() => ({ openWallPreview: vi.fn(), announce: vi.fn(), reduceMotion: false }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityRole,
+    accessibilityLabel,
+    accessibilityHint,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityRole?: string;
+    accessibilityLabel?: string;
+    accessibilityHint?: string;
+  }) =>
+    createElement(
+      'button',
+      {
+        'data-pressable': 'true',
+        'data-role': accessibilityRole,
+        'data-label': accessibilityLabel,
+        'data-hint': accessibilityHint,
+        onClick: onPress,
+      },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
+  AccessibilityInfo: { announceForAccessibility: spies.announce },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-animated': 'true' }, children),
+  },
+  FadeIn: { duration: () => ({}) },
+  useReducedMotion: () => spies.reduceMotion,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => (params ? `${key}:${Object.values(params).join(',')}` : key),
+  }),
+}));
+
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: (grade: string | null | undefined) => (grade === 'V5' ? '#FF0000' : undefined),
+  DEFAULT_GRADE_COLOR: '#808080',
+}));
+
+vi.mock('../use-open-wall-preview', () => ({ useOpenWallPreview: () => spies.openWallPreview }));
+vi.mock('../../../lib/board-presence/presence-climb', () => ({
+  boardPresenceClimbToClimb: (c: { climbUuid: string }) => ({ uuid: c.climbUuid, _converted: true }),
+}));
+vi.mock('../../board-presence/BoardDriverAvatar', () => ({
+  BoardDriverAvatar: ({ uri, name }: { uri?: string | null; name?: string | null }) =>
+    createElement('span', { 'data-driver-avatar': 'true', 'data-uri': uri ?? '', 'data-name': name ?? '' }),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { label: '#111', secondaryBackground: '#222' },
+    brandColors: { warning: '#FBBF24' },
+  }),
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    formatGrade: (grade: string | null | undefined) => (grade ? `${grade} 6C` : null),
+  }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
+vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => color }));
+vi.mock('../../../theme/typography', () => ({ CHROME_LABEL_MAX_FONT_SCALE: 1.2 }));
+
+import { WallStatusCapsule } from '../WallStatusCapsule';
+
+function makeClimb(over: Partial<BoardPresenceClimb> = {}): BoardPresenceClimb {
+  return {
+    climbUuid: 'wall-1',
+    name: 'Wax On',
+    grade: 'V5',
+    frames: '',
+    angle: 40,
+    setter: 'someone',
+    sentByDisplayName: 'Casey',
+    sentByAvatarUrl: 'https://example.com/casey.jpg',
+    sentByUserId: 'u-casey',
+    sentAt: '2026-01-01T00:00:00Z',
+    seq: 1,
+    ...over,
+  } as BoardPresenceClimb;
+}
+
+describe('WallStatusCapsule', () => {
+  beforeEach(() => {
+    spies.openWallPreview.mockClear();
+    spies.announce.mockClear();
+    spies.reduceMotion = false;
+  });
+
+  it('renders without the entering animation when Reduce Motion is on', () => {
+    spies.reduceMotion = true;
+    const { container, getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(getByText('Wax On')).not.toBeNull();
+  });
+
+  it('renders the wall climb name and grade', () => {
+    const { container, getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(getByText('Wax On')).not.toBeNull();
+    expect(getByText('V5 6C')).not.toBeNull();
+  });
+
+  it('renders without crashing when the climb name is null (empty name, grade kept)', () => {
+    const { container, getByText } = render(<WallStatusCapsule climb={makeClimb({ name: null })} />);
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(getByText('V5 6C')).not.toBeNull();
+  });
+
+  it('omits the grade text when the climb grade is null (name + avatar kept)', () => {
+    const { container, getByText } = render(<WallStatusCapsule climb={makeClimb({ grade: null })} />);
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(getByText('Wax On')).not.toBeNull();
+    expect(container.querySelector('[data-driver-avatar]')).not.toBeNull();
+  });
+
+  it("leads with the sender's avatar when there is a sender", () => {
+    const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+    const avatar = container.querySelector('[data-driver-avatar]');
+    expect(avatar).not.toBeNull();
+    expect(avatar?.getAttribute('data-uri')).toBe('https://example.com/casey.jpg');
+    expect(avatar?.getAttribute('data-name')).toBe('Casey');
+    // No lightbulb / person-glyph fallback when a sender is present.
+    expect(container.querySelector('[data-icon="profile.fill"]')).toBeNull();
+  });
+
+  it('falls back to an amber person glyph (never a lightbulb) for a fully anonymous sender', () => {
+    const climb = makeClimb({ sentByDisplayName: null, sentByAvatarUrl: null, sentByUserId: null });
+    const { container } = render(<WallStatusCapsule climb={climb} />);
+    expect(container.querySelector('[data-driver-avatar]')).toBeNull();
+    expect(container.querySelector('[data-icon="profile.fill"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();
+  });
+
+  it('shows the person glyph for a userId-only sender (no photo, no display name)', () => {
+    // A known id but nothing renderable as a face/monogram — the person glyph is
+    // the correct fallback (and the avatar stays inert regardless of userId).
+    const climb = makeClimb({ sentByDisplayName: null, sentByAvatarUrl: null, sentByUserId: 'u-x' });
+    const { container } = render(<WallStatusCapsule climb={climb} />);
+    expect(container.querySelector('[data-driver-avatar]')).toBeNull();
+    expect(container.querySelector('[data-icon="profile.fill"]')).not.toBeNull();
+  });
+
+  it('opens the read-only wall preview (converted climb) on tap', () => {
+    const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+    fireEvent.click(container.querySelector('[data-pressable]') as Element);
+    expect(spies.openWallPreview).toHaveBeenCalledWith({ uuid: 'wall-1', _converted: true });
+  });
+
+  it('exposes a button label that names the climb and the sender', () => {
+    const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+    const pressable = container.querySelector('[data-pressable]');
+    expect(pressable?.getAttribute('data-role')).toBe('button');
+    expect(pressable?.getAttribute('data-label')).toContain('Wax On');
+    expect(pressable?.getAttribute('data-label')).toContain('Casey');
+  });
+
+  it('announces the wall climb to assistive tech after the debounce', () => {
+    vi.useFakeTimers();
+    try {
+      render(<WallStatusCapsule climb={makeClimb()} />);
+      expect(spies.announce).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(600);
+      expect(spies.announce).toHaveBeenCalledWith(expect.stringContaining('Wax On'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -27,7 +27,6 @@ import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
 import { LogAscentFab } from './LogAscentFab';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
-import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 
 // Re-export so layout consumers that already import toolbar metrics from this
 // module don't need to know which file owns them. Source of truth: theme/layout.
@@ -39,7 +38,8 @@ export function PersistentQueueBar() {
   const segments = useSegments();
   const bottomChrome = useBottomChromeMetrics();
 
-  const currentClimb = useWallOrQueueCurrentClimb(state.currentClimbQueueItem?.climb ?? null);
+  // Queue head only — the wall's lit climb lives in the top "On the wall" strip.
+  const currentClimb = state.currentClimbQueueItem?.climb ?? null;
 
   if (!currentClimb) return null;
   // The sign-in / sign-up flow is pre-auth — a leftover queued or "on the wall"

--- a/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
+++ b/packages/mobile/src/components/queue-control/use-accessory-climb-tap.ts
@@ -4,27 +4,21 @@ import { runOnJS } from 'react-native-reanimated';
 import type { ClimbQueueItem } from '@boardsesh/queue';
 import { useQueue } from '../../providers/queue-provider';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
-import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import { hapticLight } from '../../lib/haptics';
-import { useWallOrQueueCurrentClimb } from './use-wall-or-queue-climb';
 
 /**
  * Tap-to-open behind the bottom accessory bar (`ClimbCapsule` and the iOS 26
- * native bottom accessory `NativeAccessoryClimbRow`). The bar now mirrors the
- * board's status (the wall's lit climb when a feed is live), so the old
- * swipe-to-step-the-queue carousel and its peeking neighbours were removed — a
- * single tap opens whatever the bar is showing.
+ * native bottom accessory `NativeAccessoryClimbRow`). The bar shows the local
+ * queue head, so a single tap opens it. (The wall's lit climb has its own surface
+ * — the top "On the wall" strip — which opens its own read-only preview via
+ * {@link useOpenWallPreview}.)
  */
 export type AccessoryClimbTap = {
-  /** Tap → open the play drawer for the displayed climb. */
+  /** Tap → open the play drawer for the queue head. */
   openGesture: GestureType;
-  /**
-   * The same open-the-displayed-climb action as a plain callback, for non-gesture
-   * callers (e.g. the bar's board control opening the read-only "Now on the wall"
-   * view when a teammate drives).
-   */
+  /** The same open-the-queue-head action as a plain callback, for non-gesture callers. */
   openPlay: () => void;
-  /** Local queue head; the wrappers re-apply `useWallOrQueueCurrentClimb` for display. */
+  /** Local queue head. */
   currentItem: ClimbQueueItem | null | undefined;
 };
 
@@ -33,32 +27,14 @@ export function useAccessoryClimbTap(): AccessoryClimbTap {
   const { openPlayDrawer } = useDrawerHost();
   const { currentClimbQueueItem } = state;
 
-  // Open whatever the accessory is showing: the wall's lit climb when a feed is
-  // live, else the local queue head — useWallOrQueueCurrentClimb already folds the
-  // local head in as its fallback, so this is the single source of truth for the
-  // open target.
-  const accessoryClimb = useWallOrQueueCurrentClimb(currentClimbQueueItem?.climb ?? null);
+  const accessoryClimb = currentClimbQueueItem?.climb ?? null;
 
   const handleOpenPlay = useCallback(() => {
     if (!accessoryClimb) return;
     hapticLight();
-    // When the bar mirrors the local queue head, open it active (it already IS
-    // current, so openDrawer won't re-append it). When a live feed makes the bar
-    // show a peer-driven WALL climb that isn't your current, open it as a
-    // read-only "Now on the wall" view (`previewIsWallClimb`) — it's physically
-    // lit right now, so there's no "Set active" takeover; you're just looking at
-    // someone else's wall. Both are queue-bar opens, so keep the
-    // `current_queue_item` analytics source.
-    if (accessoryClimb.uuid === currentClimbQueueItem?.climb.uuid) {
-      openPlayDrawer(accessoryClimb, { source: 'current_queue_item' });
-    } else {
-      openPlayDrawer(accessoryClimb, {
-        previewQueueItem: climbToQueueItem(accessoryClimb),
-        previewIsWallClimb: true,
-        source: 'current_queue_item',
-      });
-    }
-  }, [openPlayDrawer, accessoryClimb, currentClimbQueueItem]);
+    // It already IS current, so openDrawer won't re-append it.
+    openPlayDrawer(accessoryClimb, { source: 'current_queue_item' });
+  }, [openPlayDrawer, accessoryClimb]);
 
   const openGesture = useMemo(
     () =>

--- a/packages/mobile/src/components/queue-control/use-open-wall-preview.ts
+++ b/packages/mobile/src/components/queue-control/use-open-wall-preview.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import type { Climb } from '@boardsesh/queue';
+import { useDrawerHost } from '../../providers/drawer-host-provider';
+import { climbToQueueItem } from '../../lib/climb-to-queue-item';
+import { hapticLight } from '../../lib/haptics';
+
+/**
+ * Opens a wall climb (the one lit on the board, distinct from your queue head) as
+ * a read-only "Now on the wall" preview in the play drawer. It's physically lit
+ * right now, so there's no "set active" takeover — you're just looking at what's
+ * on the wall (possibly a teammate's pick). Used by {@link WallStatusCapsule}.
+ */
+export function useOpenWallPreview(): (wallClimb: Climb) => void {
+  const { openPlayDrawer } = useDrawerHost();
+  return useCallback(
+    (wallClimb: Climb) => {
+      hapticLight();
+      openPlayDrawer(wallClimb, {
+        previewQueueItem: climbToQueueItem(wallClimb),
+        previewIsWallClimb: true,
+        // Distinct from a queue-item open — this is a peek at what's lit on the
+        // wall (often a teammate's), opened from the "On the wall" capsule.
+        source: 'board_presence',
+      });
+    },
+    [openPlayDrawer],
+  );
+}

--- a/packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts
+++ b/packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts
@@ -1,68 +1,49 @@
-// Source-of-truth selector for the current-climb accessory.
+// Source-of-truth selector for the "On the wall" status strip.
 //
-// When the `board-presence` flag is on AND a board feed is live with a current
-// climb, the accessory should reflect the wall's actual lit climb instead of the
-// local queue head. Otherwise it stays on the local queue head (today's
-// behaviour).
+// The wall's lit climb used to override the bottom accessory (the queue bar). It
+// no longer does — the accessory shows the local queue head only. Instead, the
+// wall's lit climb gets its own surface (the WallStatusCapsule), and only when it
+// DIFFERS from the local queue head: in the common solo case the climb you lit IS
+// your queue head, so the bottom bar already shows it and the strip stays hidden.
 //
-// PERF (RN hot-path checklist): this read is O(1) — it uses only the current
-// wall climb from the split presence context and never scans history.
+// PERF (RN hot-path checklist): this read is O(1) — it uses only the current wall
+// climb from the split presence context and never scans history. It re-renders on
+// a wall event (bounded, not per-frame), which is exactly when the strip's content
+// must change.
 
 import { useMemo } from 'react';
-import type { Climb } from '@boardsesh/queue';
-import { useBoardPresenceCurrent, useBoardPresenceHasClimb } from '@boardsesh/board-presence-react';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
-import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
 
 /**
- * Returns the climb the accessory should show. With the flag off (or no live
- * wall feed / no wall climb), returns `localClimb` unchanged so behaviour is
- * exactly as today. With a live wall feed, returns the wall's current climb.
+ * Returns the wall's lit climb ONLY when a board feed is live AND that climb is
+ * different from the local queue head; otherwise `null`.
  *
- * Pass the local queue head as `localClimb`; the override never affects queue
- * navigation/swipe — only what the leading slot displays.
+ * Returns the RAW `BoardPresenceClimb` (not the minimal converted `Climb`) so the
+ * capsule can show the sender — `sentByDisplayName`/`sentByAvatarUrl`/`sentByUserId`
+ * — which `boardPresenceClimbToClimb` drops. Convert to a `Climb` at the point of
+ * use (e.g. opening the play drawer).
+ *
+ * Pass the local queue head's uuid as `localClimbUuid` (e.g. from the narrow
+ * `useActiveClimbUuid()` selector, so the caller doesn't subscribe to the whole
+ * reducer state). When the wall climb equals it (the solo case — you lit your own
+ * current climb), this returns `null` so the capsule stays hidden and the climb
+ * isn't shown twice (top capsule + bottom queue bar). The capsule self-gates on a
+ * `null` return, so no separate presence gate is needed.
  */
-export function useWallOrQueueCurrentClimb(localClimb: Climb | null): Climb | null {
+export function useWallClimbIfDistinct(localClimbUuid: string | null): BoardPresenceClimb | null {
   const { enabled, boardId } = useBoardPresenceControls();
   const { currentClimb: wallClimb, isLive } = useBoardPresenceCurrent();
 
-  const useWall = enabled && boardId !== null && isLive && wallClimb !== null;
-
+  // `wallClimb` only changes on a wall event (bounded, not per-frame), so the memo
+  // recomputes off a stable input set and the read stays O(1) on the hot path.
   return useMemo(() => {
-    if (useWall && wallClimb) {
-      if (localClimb?.uuid === wallClimb.climbUuid) {
-        return localClimb;
-      }
-      return boardPresenceClimbToClimb(wallClimb);
-    }
-    return localClimb;
-    // `wallClimb` only changes on a wall event (bounded, not per-frame), so
-    // recomputing when its identity changes keeps the read O(1) on the hot path.
-  }, [useWall, wallClimb, localClimb]);
-}
-
-/**
- * True when the accessory is pinned to a live wall feed — i.e. the leading slot
- * is showing the wall's lit climb rather than the local queue head. The carousel
- * uses this to (a) open the wall climb on tap and (b) suppress the horizontal
- * prev/next swipe, which would otherwise step the invisible local queue while
- * the pinned label never moves (so the swipe looks dead). O(1) read.
- */
-export function useIsWallPinned(): boolean {
-  const { enabled, boardId } = useBoardPresenceControls();
-  const { currentClimb: wallClimb, isLive } = useBoardPresenceCurrent();
-  return enabled && boardId !== null && isLive && wallClimb !== null;
-}
-
-/**
- * Presence-only sibling of {@link useIsWallPinned}: true when a live wall feed has
- * a current climb. Reads the presence-only `useBoardPresenceHasClimb` boolean
- * instead of `useBoardPresenceCurrent`, so consumers re-render only when wall
- * presence appears/disappears — NOT on every board-level climb change. Use this
- * (not `useIsWallPinned`) to gate chrome that mounts the accessory / tab tree.
- */
-export function useHasWallClimb(): boolean {
-  const { enabled, boardId } = useBoardPresenceControls();
-  const hasWallClimb = useBoardPresenceHasClimb();
-  return enabled && boardId !== null && hasWallClimb;
+    const live = enabled && boardId !== null && isLive && wallClimb !== null;
+    if (!live || !wallClimb) return null;
+    // Hide when the wall is showing the user's own current climb — the bottom
+    // queue bar already carries it.
+    if (wallClimb.climbUuid === localClimbUuid) return null;
+    return wallClimb;
+  }, [enabled, boardId, isLive, wallClimb, localClimbUuid]);
 }

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -16,13 +16,17 @@ import { Appbar, Chip } from 'react-native-paper';
 import type { Grade } from '@boardsesh/shared-schema';
 import type { GradeBound } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { selectByVariant } from '../../theme/variants';
 import { spacing } from '../../theme/tokens';
 import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { iconMap } from '../icon-map';
-import { BoardSwitcherButton, CollapsingTopChrome, MaterialAngleAction, TOP_ACTION_SIZE } from '../chrome';
+import { BoardSwitcherButton, CollapsingTopChrome, MaterialAngleChip, TOP_ACTION_SIZE } from '../chrome';
 import { GradeRangeRail } from '../grade';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
+import { WallStatusCapsule } from '../queue-control/WallStatusCapsule';
+import { useWallClimbIfDistinct } from '../queue-control/use-wall-or-queue-climb';
+import { useActiveClimbUuid } from '../../providers/queue-provider';
 import { FilterButton } from './FilterButton';
 import { GradeFilterControl } from './GradeFilterControl';
 
@@ -32,11 +36,11 @@ const MATERIAL_SEARCH_HEIGHT = 48;
 
 type ClimbTopChromeProps = {
   searchMode?: 'custom' | 'native';
-  /** The active filter summary (e.g. "V4–V6 · Quality"), or "All climbs" when no
-   *  filter is active. Shown as a plain inline title once scrolled; the caller
-   *  renders the matching large in-body title at the top of the list. (Unused by
-   *  the Material variant.) */
-  title: string;
+  /** Optional persistent plain centre title (the legacy filter summary, e.g.
+   *  "V4–V6 · Quality"). Omitted when the persistent filter chips carry the filter
+   *  state — the centre then reads empty (the redundant "All climbs" label is
+   *  dropped). Unused by the Material variant. */
+  title?: string;
   canCreate: boolean;
   onCreate: () => void;
   onOpenBoardDetail: () => void;
@@ -100,8 +104,21 @@ export function ClimbTopChrome({
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, variant } = useTheme();
+  const { data: activeBoard } = useActiveBoard();
   const insets = useSafeAreaInsets();
   const usesCustomSearch = searchMode === 'custom';
+  // The Material angle control moved out of the (over-budget) app bar into the
+  // quick row beside the grade/filter chips. Gate the quick row on it OR a filter
+  // summary so the row never renders an empty gap.
+  const angleAdjustable = activeBoard?.isAngleAdjustable !== false && activeBoard?.angle != null;
+
+  // "On the wall" capsule: own the gate here so a falsy centre slot falls back to
+  // the title, and the capsule gets a clean mount/unmount (entering/exiting fade).
+  // Only present when a board feed lights a climb that differs from the user's own
+  // current climb (hidden in the solo case).
+  const currentClimbUuid = useActiveClimbUuid();
+  const wallClimb = useWallClimbIfDistinct(currentClimbUuid);
+  const wallCapsule = wallClimb ? <WallStatusCapsule climb={wallClimb} /> : undefined;
 
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => onHeightChange(event.nativeEvent.layout.height),
@@ -167,11 +184,20 @@ export function ClimbTopChrome({
               accessibilityLabel={t('mobile.create.fab.ariaLabel')}
             />
           ) : null}
-          <MaterialAngleAction />
-          {/* No toolbar lightbulb on the climbs tab — board-LED control lives on
-              the queue bar / current-climb pill (BoardControlIndicator). Keeps
-              the Material path in step with the glass `hideLight` above. */}
+          {/* Angle is a quick-row chip below (it re-grades the whole list — a list
+              param, not an app-bar action). No toolbar lightbulb on the climbs tab
+              either — board-LED control lives on the queue bar / current-climb pill
+              (BoardControlIndicator), in step with the glass `hideLight`. */}
         </Appbar.Header>
+
+        {/* "On the wall" status — a compact capsule in a slim centred row under the
+            app bar (M3 has no centre-slot in the bar), only when a board feed lights
+            a climb that differs from the user's own queue head. */}
+        {wallCapsule ? (
+          <View pointerEvents="box-none" style={styles.materialWallStatusRow}>
+            {wallCapsule}
+          </View>
+        ) : null}
 
         {usesCustomSearch ? (
           <View pointerEvents="box-none" style={styles.materialSearchStack}>
@@ -208,21 +234,24 @@ export function ClimbTopChrome({
               {onOpenFilters ? <FilterButton activeFilterCount={nonGradeFilterCount} onPress={onOpenFilters} /> : null}
             </View>
 
-            {visibleFilterSummary ? (
+            {angleAdjustable || visibleFilterSummary ? (
               <View pointerEvents="box-none" style={styles.materialQuickRow}>
-                <Chip
-                  compact
-                  mode="flat"
-                  icon={iconMap.filter.android}
-                  onPress={visibleFilterSummary.onClear}
-                  onClose={visibleFilterSummary.onClear}
-                  closeIcon={iconMap.close.android}
-                  accessibilityLabel={visibleFilterSummary.text}
-                  style={styles.materialChip}
-                  textStyle={styles.materialChipText}
-                >
-                  {visibleFilterSummary.text}
-                </Chip>
+                <MaterialAngleChip />
+                {visibleFilterSummary ? (
+                  <Chip
+                    compact
+                    mode="flat"
+                    icon={iconMap.filter.android}
+                    onPress={visibleFilterSummary.onClear}
+                    onClose={visibleFilterSummary.onClear}
+                    closeIcon={iconMap.close.android}
+                    accessibilityLabel={visibleFilterSummary.text}
+                    style={styles.materialChip}
+                    textStyle={styles.materialChipText}
+                  >
+                    {visibleFilterSummary.text}
+                  </Chip>
+                ) : null}
               </View>
             ) : null}
 
@@ -255,6 +284,11 @@ export function ClimbTopChrome({
   return (
     <CollapsingTopChrome
       centerTitle={title}
+      // "On the wall" status — a compact capsule in the centre islands slot (where
+      // the title used to sit) when a board feed lights a climb that differs from
+      // the user's own current climb; otherwise undefined, so the centre falls back
+      // to the title.
+      centerContent={wallCapsule}
       canCreate={canCreate}
       onCreate={onCreate}
       createAccessibilityLabel={t('mobile.create.fab.ariaLabel')}
@@ -316,6 +350,13 @@ const styles = StyleSheet.create({
   materialAppbar: {
     elevation: 0,
     shadowOpacity: 0,
+  },
+  materialWallStatusRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
   },
   materialSearchStack: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -22,6 +22,7 @@ const ctrl = vi.hoisted(() => ({
   bluetooth: null as BluetoothCtx,
   setActiveBoard: vi.fn(),
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  wallClimb: null as { climbUuid: string; name: string } | null,
 }));
 const haptics = vi.hoisted(() => ({ light: vi.fn(), selection: vi.fn() }));
 
@@ -174,7 +175,10 @@ vi.mock('../../../providers/ble-control-sheet-provider', () => ({
 vi.mock('../../../providers/board-presence-provider', () => ({ useBoardPresenceControls: () => ({ boardId: null }) }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueSessionControls: () => ({ isSessionWallLit: false, sessionId: null }),
+  useActiveClimbUuid: () => null,
 }));
+// No distinct wall climb in these layout tests, so the centre capsule never mounts.
+vi.mock('../../queue-control/use-wall-or-queue-climb', () => ({ useWallClimbIfDistinct: () => ctrl.wallClimb }));
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -334,6 +338,13 @@ vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
       'data-avatar-variant': variant,
     }),
 }));
+// Stub the "On the wall" capsule (its own spec covers internals) but render a
+// marker so this test can assert the wallClimb → capsule wiring (glass
+// centerContent / Material under-app-bar row).
+vi.mock('../../queue-control/WallStatusCapsule', () => ({
+  WallStatusCapsule: ({ climb }: { climb: { climbUuid: string } }) =>
+    createElement('div', { 'data-wall-capsule': climb.climbUuid }),
+}));
 
 import { ClimbTopChrome } from '../ClimbTopChrome';
 
@@ -359,6 +370,10 @@ const createAction = (root: HTMLElement) =>
   root.querySelector('[data-pressable="mobile.create.fab.ariaLabel"]') as HTMLButtonElement | null;
 const angleAction = (root: HTMLElement) =>
   root.querySelector('[data-pressable="mobile.angleSelector.title"]') as HTMLButtonElement | null;
+// Material variant: the angle is an M3 quick-row chip (Paper Chip), not a glass
+// toolbar action — the paper mock renders it as `[data-chip="<a11y label>"]`.
+const materialAngleChip = (root: HTMLElement) =>
+  root.querySelector('[data-chip="mobile.angleSelector.title"]') as HTMLButtonElement | null;
 const lightbulb = (root: HTMLElement) =>
   (root.querySelector('[data-pressable="ble.connectBoard"]') ??
     root.querySelector('[data-pressable="lightControl.disconnect"]')) as HTMLButtonElement | null;
@@ -389,6 +404,7 @@ describe('ClimbTopChrome', () => {
     ctrl.board = null;
     ctrl.bluetooth = null;
     ctrl.variant = 'liquidGlass';
+    ctrl.wallClimb = null;
     ctrl.setActiveBoard.mockClear();
     haptics.light.mockClear();
     haptics.selection.mockClear();
@@ -432,11 +448,33 @@ describe('ClimbTopChrome', () => {
     expect(onCreate).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the angle selector as the second left toolbar button', () => {
+  it('renders the angle selector in the right toolbar group (with the board glyph)', () => {
     ctrl.board = typedBoard;
     const { container } = render(<ClimbTopChrome {...makeProps({ canCreate: true })} />);
     expect(angleAction(container)).not.toBeNull();
     expect(angleAction(container)?.textContent).toBe('40°');
+  });
+
+  it('mounts the "On the wall" capsule (glass centre slot) when a distinct wall climb is live', () => {
+    ctrl.board = typedBoard;
+    ctrl.wallClimb = { climbUuid: 'wall-9', name: 'Angel Eyes' };
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    expect(container.querySelector('[data-wall-capsule="wall-9"]')).not.toBeNull();
+  });
+
+  it('omits the "On the wall" capsule when there is no distinct wall climb', () => {
+    ctrl.board = typedBoard;
+    ctrl.wallClimb = null;
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    expect(container.querySelector('[data-wall-capsule]')).toBeNull();
+  });
+
+  it('mounts the "On the wall" capsule under the Material app bar when a wall climb is live', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    ctrl.wallClimb = { climbUuid: 'wall-9', name: 'Angel Eyes' };
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    expect(container.querySelector('[data-wall-capsule="wall-9"]')).not.toBeNull();
   });
 
   it('hides the angle selector for fixed-angle boards', () => {
@@ -513,6 +551,32 @@ describe('ClimbTopChrome', () => {
     };
     const { container } = render(<ClimbTopChrome {...makeProps()} />);
     expect(lightbulb(container)).toBeNull();
+  });
+
+  it('renders the angle as a Material quick-row chip (not an app-bar action)', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    const chip = materialAngleChip(container);
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain('40°');
+  });
+
+  it('omits the Material angle chip for fixed-angle boards', () => {
+    ctrl.variant = 'material';
+    ctrl.board = { ...typedBoard, isAngleAdjustable: false };
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    expect(materialAngleChip(container)).toBeNull();
+  });
+
+  it('opens the angle sheet from the Material chip and persists the selection', () => {
+    ctrl.variant = 'material';
+    ctrl.board = typedBoard;
+    const { container } = render(<ClimbTopChrome {...makeProps()} />);
+    fireEvent.click(materialAngleChip(container)!);
+    expect(container.querySelector('[data-angle-selector]')).not.toBeNull();
+    fireEvent.click(container.querySelector('[data-angle-selector]') as HTMLButtonElement);
+    expect(ctrl.setActiveBoard).toHaveBeenCalledWith({ ...typedBoard, angle: 45 });
   });
 
   it('reports its measured height through onHeightChange via onLayout', () => {

--- a/packages/mobile/src/hooks/__tests__/use-has-accessory-climb.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-has-accessory-climb.test.ts
@@ -2,13 +2,10 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const cfg = vi.hoisted(() => ({ local: false, wall: false }));
+const cfg = vi.hoisted(() => ({ local: false }));
 
 vi.mock('../../providers/queue-provider', () => ({
   useHasActiveClimb: () => cfg.local,
-}));
-vi.mock('../../components/queue-control/use-wall-or-queue-climb', () => ({
-  useHasWallClimb: () => cfg.wall,
 }));
 
 import { useHasAccessoryClimb } from '../use-has-accessory-climb';
@@ -16,29 +13,15 @@ import { useHasAccessoryClimb } from '../use-has-accessory-climb';
 describe('useHasAccessoryClimb', () => {
   beforeEach(() => {
     cfg.local = false;
-    cfg.wall = false;
   });
 
-  it('is false when neither a local nor a wall climb is present', () => {
+  it('is false when there is no local queue climb', () => {
     const { result } = renderHook(() => useHasAccessoryClimb());
     expect(result.current).toBe(false);
   });
 
-  it('is true for a local-only climb', () => {
+  it('is true when a local queue climb is present', () => {
     cfg.local = true;
-    const { result } = renderHook(() => useHasAccessoryClimb());
-    expect(result.current).toBe(true);
-  });
-
-  it('is true for a wall-only climb (no local queue)', () => {
-    cfg.wall = true;
-    const { result } = renderHook(() => useHasAccessoryClimb());
-    expect(result.current).toBe(true);
-  });
-
-  it('is true when both a local and a wall climb are present', () => {
-    cfg.local = true;
-    cfg.wall = true;
     const { result } = renderHook(() => useHasAccessoryClimb());
     expect(result.current).toBe(true);
   });

--- a/packages/mobile/src/hooks/use-has-accessory-climb.ts
+++ b/packages/mobile/src/hooks/use-has-accessory-climb.ts
@@ -1,22 +1,24 @@
 import { useHasActiveClimb } from '../providers/queue-provider';
-import { useHasWallClimb } from '../components/queue-control/use-wall-or-queue-climb';
 
 /**
  * Presence-only signal for "the bottom accessory has a climb to show": the local
- * queue head OR a live wall (board-presence) climb. Both inputs are presence-only
- * booleans (flip on appear/disappear, not on climb-to-climb change), so the
- * combined value is too.
+ * queue head. A presence-only boolean (flips on appear/disappear, not on
+ * climb-to-climb change), so gating the native accessory mount on it doesn't churn
+ * the tab tree on queue mutations.
  *
- * Gating the native accessory mount and the bottom-chrome arbitration on THIS —
- * rather than the local-queue-only `useHasActiveClimb` — keeps the UIKit
- * `NativeTabs.BottomAccessory` host mounted while a wall climb is continuously
- * present. Without it, a board-level climb change churned local presence, the host
- * unmounted/remounted, and UIKit left a stale snapshot stacked under the new one
- * (the doubled name + grade). It also lets a wall-only climb (no local queue) show
- * the accessory at all.
+ * The accessory shows the queue head only now (the wall's lit climb moved to the
+ * top "On the wall" capsule), so this is exactly `useHasActiveClimb` — kept as a
+ * named hook so `useStickyAccessoryPresence` and the bottom-chrome arbitration have
+ * one stable import for "should the accessory be mounted."
+ *
+ * Deliberately NOT `|| useHasWallClimb()` (the old behaviour). The accessory no
+ * longer renders the wall climb, so for a spectator with no personal queue there is
+ * nothing of theirs to show — mounting it on wall presence would float an EMPTY
+ * UIKit host (`QueueBottomAccessory` reads the queue head and returns null). And
+ * because no host is mounted in that case, there is no `NativeTabs.BottomAccessory`
+ * snapshot to leave a doubled name on a presence-reconnect blip; the wall climb is
+ * surfaced by the top capsule, a plain RN view immune to that UIKit issue.
  */
 export function useHasAccessoryClimb(): boolean {
-  const hasLocalClimb = useHasActiveClimb();
-  const hasWallClimb = useHasWallClimb();
-  return hasLocalClimb || hasWallClimb;
+  return useHasActiveClimb();
 }

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -94,7 +94,7 @@ export type OpenPlayDrawerOptions = PlayDrawerOpenOptions & {
    *  `previewQueueItem`, so the default `current_queue_item`/`mobile` heuristic
    *  can't tell them apart. Pulled out before the rest of the options reach
    *  `PlayDrawer.open`, so it never leaks into the drawer itself. */
-  source?: 'climb_view' | 'current_queue_item' | 'mobile';
+  source?: 'climb_view' | 'current_queue_item' | 'mobile' | 'board_presence';
 };
 
 type DrawerHostValue = {

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -387,6 +387,11 @@
     },
     "boardPresence": {
       "title": "Now on the wall",
+      "stripA11yLabel": "On the wall: {{name}}, {{grade}}",
+      "stripA11yLabelWithSender": "On the wall: {{name}}, {{grade}}, lit by {{sender}}",
+      "stripA11yHint": "Opens the wall climb",
+      "stripAnnounce": "Now on the wall: {{name}}, {{grade}}",
+      "stripAnnounceWithSender": "Now on the wall: {{name}}, {{grade}}, lit by {{sender}}",
       "switchBoard": "Switch board",
       "switchBoardAria": "Switch to a different board",
       "close": "Close",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -387,6 +387,11 @@
     },
     "boardPresence": {
       "title": "Ahora en el muro",
+      "stripA11yLabel": "En el muro: {{name}}, {{grade}}",
+      "stripA11yLabelWithSender": "En el muro: {{name}}, {{grade}}, encendido por {{sender}}",
+      "stripA11yHint": "Abre el bloque del muro",
+      "stripAnnounce": "Ahora en el muro: {{name}}, {{grade}}",
+      "stripAnnounceWithSender": "Ahora en el muro: {{name}}, {{grade}}, encendido por {{sender}}",
       "switchBoard": "Cambiar de muro",
       "switchBoardAria": "Cambiar a otro muro",
       "close": "Cerrar",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -387,6 +387,11 @@
     },
     "boardPresence": {
       "title": "Sur le mur maintenant",
+      "stripA11yLabel": "Sur le mur : {{name}}, {{grade}}",
+      "stripA11yLabelWithSender": "Sur le mur : {{name}}, {{grade}}, allumé par {{sender}}",
+      "stripA11yHint": "Ouvre le bloc du mur",
+      "stripAnnounce": "Sur le mur maintenant : {{name}}, {{grade}}",
+      "stripAnnounceWithSender": "Sur le mur maintenant : {{name}}, {{grade}}, allumé par {{sender}}",
       "switchBoard": "Changer de mur",
       "switchBoardAria": "Passer à un autre mur",
       "close": "Fermer",


### PR DESCRIPTION
## Summary

The bottom queue accessory was doing double duty: the moment a board feed went live it showed the climb **lit on the wall** (in a party session, possibly a teammate's), overriding the user's own queue. People read that bar as "my queue", so the overload was confusing.

This splits the two surfaces and reworks the climbs header (reviewed across two Apple HIG + Material 3 design panels):

- **Bottom accessory → queue only.** The iOS native accessory and the Android `PersistentQueueBar` now show the local queue head, never the wall override. The wall-vs-queue flip was removed from all four places it was re-derived (`ClimbCapsule`, `useAccessoryClimbTap`, the two bars) plus the mount gate.
- **New "On the wall" capsule** (`WallStatusCapsule`) — a compact non-glass pill in the **centre islands slot** (iOS) / a slim row under the app bar (Android), shown **only when the wall lights a climb that differs from the user's current climb** (hidden in the common solo case). It **leads with the avatar of whoever sent the climb to the board** (`BoardDriverAvatar`; amber person-glyph fallback when anonymous — never a lightbulb), then the climb name + grade. The whole pill is one tap → the existing read-only "Now on the wall" preview; the sender folds into the a11y label; peer changes announce to assistive tech (debounced); warm amber "lit" tint, fade in/out (Reduce-Motion-gated).
- **Angle selector grouped with the board glyph** in the **right toolbar island** on iOS (`[40°][▦]` — both board-config controls that act on the displayed list); the left island collapses to `[avatar][+]`. Shared via `CollapsingTopChrome`, so Discover/Record get it consistently. **Android** keeps the angle as a quick-row `MaterialAngleChip` beside grade/filters (no app-bar islands).
- **Dropped the redundant centre "All climbs" title** — the persistent chips carry filter state and the tab names the screen.

Builds on the persistent filter chips from #3245 (now merged to main).

## Release Notes

- See who's on the wall at a glance — when a crewmate lights up a different climb, their face and the climb show in a capsule up top, and the bottom bar stays your own queue.

## Test plan

- `vp run typecheck:mobile` — green
- `vp run test:mobile` — 2757 passing (accessory/selector specs moved to the queue-only contract; new `WallStatusCapsule` specs cover the sender avatar + anonymous person-glyph fallback + the announce; `collapsing-top-chrome` covers the angle in the right island)
- `vp check` (lint/format + `check:mobile-variants`) — clean
- `vp run check:mobile-bundle` — android bundle OK
- On-device follow-ups (noted by the design panels, non-blocking): narrowest-device centre crowding (wider right island vs the truncating capsule), and whether the angle should be suppressed on the Record tab during a session. The "wall-differs" state needs a live board-presence feed (party session / BLE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
