### PR TITLE
ci(mobile): run check:mobile-deps in the mobile-checks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,6 +535,12 @@ jobs:
       # push-to-main. Runs before the heavier Metro bundle so it fails fast.
       - name: Check native build-phase deps resolve
         run: vp run check:mobile-native-deps
+      # Read-only `expo install --check`: fails the moment a native module drifts
+      # from the Expo SDK pin (the caret-drift class behind the 2.0.0 launch
+      # crash). Intentional deviations live in expo.install.exclude. Cheap, so it
+      # runs before the heavier Metro bundle.
+      - name: Mobile dep-health check
+        run: vp run check:mobile-deps
       # A Bun patch is keyed by an exact version, so an Expo/RN bump can silently
       # drop it: install only warns, and typecheck + the Metro bundle stay green
       # while a native-only behavior (e.g. the iOS 26 tab-bar minimize tracking


### PR DESCRIPTION
## What & why

Follow-up to #3237, which added the `vp run check:mobile-deps` task (a read-only `expo install --check` guard against native-module version drift from the Expo SDK pins) but did not wire it into CI. As a reviewer noted, the guard was therefore opt-in only — the exact gap behind the 2.0.0 caret-drift launch crash, where a native module silently resolved to a version the installed Expo SDK was never tested against.

This adds the step to the `mobile-checks` job in `.github/workflows/ci.yml`, next to `check:mobile-native-deps` and before the heavier Metro bundle so it fails fast.

## Change

```yaml
- name: Mobile dep-health check
  run: vp run check:mobile-deps
```

The step is **read-only** (`expo install --check`, never `--fix`) and runs offline — Expo compares installed versions against the SDK-56 `bundledNativeModules.json` that ships in `packages/mobile/node_modules/expo`, so it needs no network and is not flaky. The four intentional SDK-pin deviations (`@react-native-async-storage/async-storage`, `@sentry/react-native`, `@shopify/flash-list`, `react-native-pager-view`) are already listed in `expo.install.exclude`, so the step is green today.

## Validation

- `vp run check:mobile-deps` — `Dependencies are up to date` (the excluded packages skipped); exits 0.
- `vp check .github/workflows/ci.yml` — correctly formatted.
- Diff is the six-line workflow addition only; no code, package, or lockfile changes, so the typecheck/test/bundle suites are unaffected.

## Release Notes

Internal CI change — no user-facing or runtime behavior change. Wires the existing mobile dependency-health check into the CI pipeline so native-module drift from the Expo SDK fails the build instead of being opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMykAw5PcpxfEMpTAJKNke