### PR TITLE
fix(mobile): hide current-climb bar on the boards picker/builder

### DIFF
--- a/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/persistent-queue-bar.test.tsx
@@ -11,6 +11,7 @@ const cfg = vi.hoisted(() => ({
   onGymDiscovery: false,
   onAuthRoute: false,
   onPlayerRoute: false,
+  onBoardsRoute: false,
   currentClimbQueueItem: { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem | null,
   wallClimb: null as null | { uuid: string; angle: number },
   variant: 'liquidGlass' as 'liquidGlass' | 'material',
@@ -56,6 +57,7 @@ vi.mock('../../../lib/route-segments', () => ({
   isGymDiscoveryRoute: () => cfg.onGymDiscovery,
   isAuthRoute: () => cfg.onAuthRoute,
   isPlayerRoute: () => cfg.onPlayerRoute,
+  isBoardsRoute: () => cfg.onBoardsRoute,
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({ state: { currentClimbQueueItem: cfg.currentClimbQueueItem } }),
@@ -143,6 +145,7 @@ describe('PersistentQueueBar', () => {
     cfg.onGymDiscovery = false;
     cfg.onAuthRoute = false;
     cfg.onPlayerRoute = false;
+    cfg.onBoardsRoute = false;
     cfg.currentClimbQueueItem = { climb: { uuid: 'c1', angle: 40 } } as unknown as ClimbQueueItem;
     cfg.wallClimb = null;
     cfg.variant = 'liquidGlass';
@@ -186,6 +189,16 @@ describe('PersistentQueueBar', () => {
     // native accessory hides this, but on Android (no native accessory) the bar
     // would otherwise float over the player, so it's suppressed by route.
     cfg.onPlayerRoute = true;
+    const { container } = render(<PersistentQueueBar />);
+    expect(container.querySelector('[data-capsule]')).toBeNull();
+    expect(container.querySelector('[data-tick]')).toBeNull();
+  });
+
+  it('renders nothing on the boards picker / builder route', () => {
+    // The /boards stack is a modal board picker/builder. The bar would float over
+    // its pinned create button and has nothing to act on while choosing a board,
+    // so it's suppressed by route even with a current climb.
+    cfg.onBoardsRoute = true;
     const { container } = render(<PersistentQueueBar />);
     expect(container.querySelector('[data-capsule]')).toBeNull();
     expect(container.querySelector('[data-tick]')).toBeNull();

--- a/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
+++ b/packages/mobile/src/components/queue-control/persistent-queue-bar.tsx
@@ -21,7 +21,7 @@ import { MATERIAL_ACTIVE_CONTEXT_BAR_HEIGHT, TOOLBAR_RESERVE, TAB_BAR_HEIGHT, gl
 import { useQueue } from '../../providers/queue-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
-import { isAuthRoute, isGymDiscoveryRoute, isPlayerRoute } from '../../lib/route-segments';
+import { isAuthRoute, isBoardsRoute, isGymDiscoveryRoute, isPlayerRoute } from '../../lib/route-segments';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { ActiveContextBar } from './ActiveContextBar';
 import { ClimbCapsule } from './ClimbCapsule';
@@ -48,6 +48,9 @@ export function PersistentQueueBar() {
   // The gym-discovery screen is a full-bleed map with its own bottom sheet — the
   // climb accessory would overlap it, so suppress it there.
   if (isGymDiscoveryRoute(segments)) return null;
+  // The boards stack is a modal board picker / builder; the climb bar would float
+  // over its pinned create button and has nothing to act on there.
+  if (isBoardsRoute(segments)) return null;
   // The full-screen player owns the whole surface (with its own queue UI). On iOS
   // the line below already hides this via the mounted native accessory, but on
   // Android (no native accessory) the bar would otherwise show over the player.

--- a/packages/mobile/src/lib/__tests__/route-segments.test.ts
+++ b/packages/mobile/src/lib/__tests__/route-segments.test.ts
@@ -48,6 +48,7 @@ describe('isBoardsRoute', () => {
     expect(isBoardsRoute(['boards'])).toBe(true);
     expect(isBoardsRoute(['boards', 'create'])).toBe(true);
     expect(isBoardsRoute(['boards', 'manage'])).toBe(true);
+    expect(isBoardsRoute(['boards', 'edit'])).toBe(true);
   });
 
   it('is false outside the boards stack', () => {

--- a/packages/mobile/src/lib/__tests__/route-segments.test.ts
+++ b/packages/mobile/src/lib/__tests__/route-segments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTabsRoute, isClimbsTabRoute, isAuthRoute } from '../route-segments';
+import { isTabsRoute, isClimbsTabRoute, isAuthRoute, isBoardsRoute } from '../route-segments';
 
 describe('isTabsRoute', () => {
   it('is true anywhere inside the tab navigator', () => {
@@ -40,5 +40,19 @@ describe('isAuthRoute', () => {
     expect(isAuthRoute(['(tabs)', 'climbs'])).toBe(false);
     expect(isAuthRoute(['gyms'])).toBe(false);
     expect(isAuthRoute([])).toBe(false);
+  });
+});
+
+describe('isBoardsRoute', () => {
+  it('is true anywhere inside the boards stack', () => {
+    expect(isBoardsRoute(['boards'])).toBe(true);
+    expect(isBoardsRoute(['boards', 'create'])).toBe(true);
+    expect(isBoardsRoute(['boards', 'manage'])).toBe(true);
+  });
+
+  it('is false outside the boards stack', () => {
+    expect(isBoardsRoute(['(tabs)', 'climbs'])).toBe(false);
+    expect(isBoardsRoute(['gyms'])).toBe(false);
+    expect(isBoardsRoute([])).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/route-segments.ts
+++ b/packages/mobile/src/lib/route-segments.ts
@@ -14,6 +14,7 @@ const CLIMBS_TAB = 'climbs';
 const GYMS_ROUTE = 'gyms';
 const AUTH_GROUP = 'auth';
 const PLAYER_ROUTE = 'play';
+const BOARDS_ROUTE = 'boards';
 
 /** True when the focused route lives inside the bottom-tab navigator. */
 export function isTabsRoute(segments: Segments): boolean {
@@ -77,4 +78,16 @@ export function isGymDiscoveryRoute(segments: Segments): boolean {
  */
 export function isPlayerRoute(segments: Segments): boolean {
   return segments[0] === PLAYER_ROUTE;
+}
+
+/**
+ * True anywhere inside the boards stack (`/boards/*` — the picker `index`, the
+ * `create` / `edit` builder, and `manage`). This stack is presented as a modal
+ * over the tabs, so the root-mounted persistent climb bar would float on top of
+ * it — directly over the builder's pinned create button. The climb toolbar has
+ * nothing to act on while you're choosing or building a board, so it's
+ * suppressed across the whole stack.
+ */
+export function isBoardsRoute(segments: Segments): boolean {
+  return segments[0] === BOARDS_ROUTE;
 }


### PR DESCRIPTION
## Summary

When a climb is currently set, the root-mounted `PersistentQueueBar` floats over every screen — including the modal `/boards` stack (picker, builder, manage, edit). On the board builder it sat directly on top of the pinned create/save button: that footer only reserves the safe-area inset, not the floating bar's height, so on the boards modal (`insideTabs === false`) the bar anchors right over it. The result was that the current-climb bar constantly covered the board-creation buttons.

This suppresses the bar across the whole `/boards` stack via a new `isBoardsRoute` guard, matching the existing `auth` / `gyms` / `play` suppressions. The climb toolbar has nothing to act on while you're choosing or building a board, so hiding it there is both the fix and the correct behaviour.

- `route-segments.ts` — new `isBoardsRoute(segments)` helper (covers `index`, `create`, `manage`, `edit`)
- `persistent-queue-bar.tsx` — early-return guard alongside the existing route guards
- Tests added in `route-segments.test.ts` and `persistent-queue-bar.test.tsx`

## Release Notes

- Fixed the now-playing climb bar covering the buttons on the board picker, so you can pick or build a board again

## Test plan

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` (route-segments + persistent-queue-bar) — 21 passed
- `vp run check:mobile-bundle` — OK
- Manual: with a current climb set, open the board picker and the builder; the climb bar no longer floats over the mode cards or the pinned Create button, and it reappears on returning to a tab. (Simulator verification pending — no device in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQQkkKifsA6hqYj3kjVGjw

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQQkkKifsA6hqYj3kjVGjw)_