### PR TITLE
fix(mobile): stop iOS filter chips clipping their glass press

### DIFF
--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -109,7 +109,11 @@ function FilterChipRowComponent({
   return (
     <Host matchContents={{ vertical: true }} style={styles.host}>
       <ScrollView axes="horizontal" showsIndicators={false}>
-        <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4] })]}>
+        {/* Vertical padding gives the Liquid Glass press-expansion room inside the
+            host. `matchContents={{ vertical: true }}` fixes the host to the chips'
+            resting height and the SwiftUI ScrollView clips to it, so without slack
+            a pressed chip's growing glass lens is cut off top/bottom. */}
+        <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
           {/* Filters · N → the long-tail sheet. A button, not a menu. */}
           <Button
             label={filtersLabel}


### PR DESCRIPTION
## Summary

On iOS, tapping a persistent filter chip (Recent / Grade range / Show / Tall / Wide) made the chip's native iOS 26 Liquid Glass press effect visibly grow, but the growth was cut off at the top and bottom by an "invisible barrier" — the chip looked squashed mid-press.

**Root cause:** `FilterChipRow.ios.tsx` wraps its `@expo/ui/swift-ui` glass chips in `<Host matchContents={{ vertical: true }}>`, which compiles to SwiftUI `.fixedSize(vertical: true)` and sizes the host to the chips' *resting* height. The inner SwiftUI `ScrollView` clips to that frame, and the chip `HStack` only had horizontal padding — zero vertical slack — so a pressed chip's expanding glass lens had nowhere to render and got clipped.

`@expo/ui@56.0.18` exposes no `scrollClipDisabled` modifier, so the fix is to give the content vertical breathing room: add 8px (`spacing[2]`) vertical padding to the `HStack`. The matched host height grows to include the slack, the press-expansion renders into it, and the list inset adjusts automatically (the chrome reports its new height via the existing `onLayout` → `paddingTop` flow). One-line modifier change, no new imports.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — clean
- `vp check` on the changed file — no lint/format errors
- `vp run test:mobile` — 2767 tests pass
- Pending on-device check (iOS 26): press-and-hold each chip and confirm the glass expansion is no longer clipped top/bottom. The press-expansion is a device Liquid Glass behavior the simulator may not fully reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEzdYWgTauhDdVDbPMq39i