### PR TITLE
chore(store): add "On the wall" to release notes, refresh Android changelog

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,1 +1,7 @@
-Boardsesh 2.0 is rebuilt native, so lists scroll smooth and search is instant. No more lag. Search a climb and light the holds over Bluetooth on Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL. Walk up to a board and a live feed shows what's lit right now. Start a session and your crew shares one queue, so no passing the phone. Build Volume, Pyramid, Ladder or Grade Focus workouts. Track sends and import your Kilter and Tension logbook. Free, no ads, open source.
+New:
+- Full MoonBoard catalog — thousands of problems with grades, stars and send counts, plus Mini 2025 and the original 2010. Original MoonBoard LEDs light up over Bluetooth.
+- Tap any circuit or playlist climb and the whole list drops into your queue in order.
+- See who's on the wall when a crewmate lights up a different climb.
+- Mix your own hold colours with colour-blind previews.
+
+Fixed: boards light up more reliably over Bluetooth, and live sessions reconnect after a drop.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -2,6 +2,7 @@ The full MoonBoard catalog is in, hold colours are yours to tune, and boards lig
 
 New:
 - The full MoonBoard catalog landed: thousands more problems with real grades, star ratings and send counts, plus the Mini 2025 and original 2010 boards. Original MoonBoard LED hardware lights up over Bluetooth too.
+- See who's on the wall at a glance: when a crewmate lights up a different climb, their face and that climb show in a capsule up top, while the bottom bar stays your own queue.
 - Tap any climb in a circuit or playlist and the whole list drops into your queue in order. Swipe back to revisit the boulders above, not just jump to the next.
 - Mix your own hold colours with a real colour picker, preview them through red-green and blue-yellow colour blindness, and pick a new octagon marker shape. MoonBoard hold circles are bigger and easier to read, too.
 - Sort your logbook by Hardest top to bottom, with the community consensus grade shown next to the one you logged.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -2,6 +2,7 @@ Está el catálogo completo de MoonBoard, puedes ajustar a tu gusto los colores 
 
 Nuevo:
 - Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
+- Mira de un vistazo quién está en el muro: cuando alguien de tu peña enciende otra vía, su cara y esa vía aparecen en una cápsula arriba, mientras la barra de abajo sigue siendo tu propia cola.
 - Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
 - Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
 - Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -2,6 +2,7 @@ Está el catálogo completo de MoonBoard, puedes ajustar a tu gusto los colores 
 
 Nuevo:
 - Ya está el catálogo completo de MoonBoard: miles de bloques más con grados reales, valoraciones por estrellas y número de encadenes, además del Mini 2025 y el original de 2010. El hardware LED del MoonBoard original también se enciende por Bluetooth.
+- Mira de un vistazo quién está en el muro: cuando alguien de tu peña enciende otra vía, su cara y esa vía aparecen en una cápsula arriba, mientras la barra de abajo sigue siendo tu propia cola.
 - Toca cualquier vía de un circuito o una playlist y la lista entera entra en tu cola en orden. Desliza hacia atrás para volver a los bloques anteriores, no solo saltar al siguiente.
 - Crea tus propios colores de presa con un selector de color de verdad, previsualízalos con daltonismo rojo-verde y azul-amarillo y elige una nueva forma de marcador octogonal. Además, los círculos de las presas del MoonBoard son más grandes y fáciles de ver.
 - Ordena tu logbook por Más difícil de arriba abajo, con el grado de consenso de la comunidad junto al que tú apuntaste.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -2,6 +2,7 @@ Le catalogue MoonBoard complet est là, tu règles les couleurs de prises à ta 
 
 Nouveau :
 - Le catalogue MoonBoard complet est arrivé : des milliers de blocs en plus avec de vraies cotations, des notes en étoiles et le nombre de sends, plus le Mini 2025 et l'original de 2010. Le matériel LED du MoonBoard d'origine s'allume aussi en Bluetooth.
+- Vois d'un coup d'œil qui est sur le mur : quand un pote allume une autre voie, son visage et cette voie s'affichent dans une capsule en haut, pendant que la barre du bas reste ta propre file.
 - Touche n'importe quelle voie d'un circuit ou d'une playlist et toute la liste passe dans ta file dans l'ordre. Reviens en arrière d'un glissement pour repasser sur les blocs précédents, pas seulement sauter au suivant.
 - Compose tes propres couleurs de prise avec un vrai sélecteur de couleur, prévisualise-les en daltonisme rouge-vert et bleu-jaune, et choisis une nouvelle forme de marqueur octogonale. Les cercles des prises MoonBoard sont aussi plus gros et plus lisibles.
 - Trie ton logbook par Plus dur de haut en bas, avec la cotation consensus de la communauté à côté de celle que tu as notée.


### PR DESCRIPTION
## Summary

Refresh the Fastlane store "What's New" copy for the current release after reviewing what's merged since the notes were last finalized.

- **iOS release notes** (`en-US`, `es-ES`, `es-MX`, `fr-FR`): added the **#3247 "On the wall" capsule** — see who's on the wall when a crewmate lights up a different climb, while the bottom bar stays your own queue. Placed after the marquee MoonBoard catalog bullet; Spanish follows the project glossary (peña / cola / "en el muro"), `es-ES` and `es-MX` kept identical.
- **Android en-US changelog** (`android/en-US/changelogs/default.txt`): was stale — still the 2.0 launch pitch and never refreshed for the post-2.0 batch. Rewritten as this release's "What's new" (MoonBoard catalog, circuit/playlist queue, on-the-wall, custom hold colours, Bluetooth/live-session fixes), kept under Play's 500-char cap (486).

Nothing else merged since the notes were finalized is user-facing copy worth advertising: the rest is internal (CI #3248, React Compiler pilot #3239, native-module pinning) or feature-flagged (#3245 native filter chips).

**Kilter username/password sync (#3170) stays out** — still behind a disabled feature flag, as it was already removed in `b186eb41`.

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- Store-listing copy only; no in-app behaviour change. -->

## Test plan

- `wc -m` on the Android en-US changelog → 486 chars (≤ 500 Play cap).
- `git diff` confirms only the intended additions/refresh and that no Kilter username/password bullet appears in any locale.
- iOS files unchanged except the single new `New:` bullet per locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8N6DxRnXYTpjskwX5Cc2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8N6DxRnXYTpjskwX5Cc2Y)_