### PR TITLE
chore(mobile): condense filter-chip padding comment to one line

### DIFF
--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -109,10 +109,7 @@ function FilterChipRowComponent({
   return (
     <Host matchContents={{ vertical: true }} style={styles.host}>
       <ScrollView axes="horizontal" showsIndicators={false}>
-        {/* Vertical padding gives the Liquid Glass press-expansion room inside the
-            host. `matchContents={{ vertical: true }}` fixes the host to the chips'
-            resting height and the SwiftUI ScrollView clips to it, so without slack
-            a pressed chip's growing glass lens is cut off top/bottom. */}
+        {/* Vertical slack lets a pressed chip's Liquid Glass lens expand without the host's fixed height clipping it. */}
         <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
           {/* Filters · N → the long-tail sheet. A button, not a menu. */}
           <Button


### PR DESCRIPTION
## Summary

Follow-up to #3250 (already merged). That PR fixed the iOS filter chips getting clipped on touch by adding vertical padding to the chip `HStack`. The automated review left one optional note: the inline rationale comment was longer than the project's comment-brevity guideline.

This trims that comment from four lines to one. **Comment-only change — no behavior change.**

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` on the changed file — no lint/format errors
- Diff is a single comment line; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEzdYWgTauhDdVDbPMq39i