### PR TITLE
fix(mobile): show full climb names (#3105)

### DIFF
--- a/packages/mobile/src/components/MarqueeText.tsx
+++ b/packages/mobile/src/components/MarqueeText.tsx
@@ -1,0 +1,213 @@
+// A single-line label that slowly scrolls its text back and forth when it would
+// otherwise truncate — the "now playing" treatment used on the queue bar so a
+// long climb name can be read in full. Mirrors the web climb chrome
+// (`packages/web/app/components/climb-card/marquee-text.tsx`); the pacing math is
+// shared via `@boardsesh/play-view` so both platforms scroll at the same speed.
+//
+// Falls back to a plain tail-ellipsis Text when it isn't the active item, when
+// the name fits, or when Reduce Motion is on — so the scrolling is a strict
+// enhancement and the reanimated path never mounts in the static case.
+
+import { memo, useCallback, useEffect, useState, type ReactNode } from 'react';
+import {
+  View,
+  StyleSheet,
+  type ColorValue,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+import Animated, {
+  Easing,
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { computeMarqueeDurationS } from '@boardsesh/play-view';
+import { Text } from './Text';
+import type { TextVariant } from '../theme/typography';
+import { useReduceMotion } from '../hooks/use-reduce-motion';
+
+// Cycle shape, mirroring the web keyframes (marquee-text.module.css): dwell at the
+// start, travel to the end, dwell, travel back, short end dwell. Fractions of the
+// full cycle, summing to 1.
+const START_DWELL_FRACTION = 0.12;
+const TRAVEL_FRACTION = 0.36;
+const MID_DWELL_FRACTION = 0.12;
+const END_DWELL_FRACTION = 0.04;
+// Below this much overflow it's not worth the motion — just ellipsize.
+const MIN_OVERFLOW_PX = 2;
+// The off-screen measurer needs room to lay the name out on one unclamped line.
+// An absolutely-positioned node with no width is otherwise sized to its container
+// and (with numberOfLines=1) truncates to it — reporting the clip width, so
+// overflow reads as ~0 and the marquee never starts. A large fixed width frees it.
+const MEASURE_MAX_WIDTH = 100000;
+
+type MarqueeTextProps = {
+  /** The label content (a climb name). */
+  children: ReactNode;
+  /**
+   * Only the active/head item scrolls; everything else stays ellipsized. The bar
+   * callsites pass `true` (they only ever render the queue head); the prop exists
+   * so this can be reused in list rows where only the focused row should scroll.
+   */
+  active: boolean;
+  variant?: TextVariant;
+  color?: ColorValue;
+  /** Clip container style — put the flex sizing (e.g. `flex: 1`) here. */
+  style?: StyleProp<ViewStyle>;
+  /** Text style (e.g. `fontWeight`). */
+  textStyle?: StyleProp<TextStyle>;
+  maxFontSizeMultiplier?: number;
+  /**
+   * Lines for the non-scrolling fallback (name fits, not active, or Reduce Motion).
+   * Defaults to 1 (tail-ellipsis) for the fixed-height bars. A roomy surface like
+   * the play-drawer header passes 2 so a Reduce-Motion user still reads the whole
+   * name (wrapped) instead of a truncation.
+   */
+  fallbackLines?: number;
+};
+
+export const MarqueeText = memo(function MarqueeText({
+  children,
+  active,
+  variant = 'body',
+  color,
+  style,
+  textStyle,
+  maxFontSizeMultiplier,
+  fallbackLines = 1,
+}: MarqueeTextProps) {
+  const reduceMotion = useReduceMotion();
+  const [clipWidth, setClipWidth] = useState(0);
+  const [contentWidth, setContentWidth] = useState(0);
+
+  const overflow = contentWidth - clipWidth;
+  const shouldScroll = active && !reduceMotion && clipWidth > 0 && overflow > MIN_OVERFLOW_PX;
+
+  const onClipLayout = useCallback((event: LayoutChangeEvent) => {
+    const width = Math.round(event.nativeEvent.layout.width);
+    setClipWidth((previous) => (previous === width ? previous : width));
+  }, []);
+  const onContentLayout = useCallback((event: LayoutChangeEvent) => {
+    const width = Math.ceil(event.nativeEvent.layout.width);
+    setContentWidth((previous) => (previous === width ? previous : width));
+  }, []);
+
+  return (
+    <View style={[styles.clip, style]} onLayout={onClipLayout}>
+      {/* Off-layout measurer: a row sizes its child to content width (the main
+          axis never stretches), so this reports the name's true single-line width
+          even when the visible copy is clamped to the clip. */}
+      <View
+        style={styles.measure}
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <Text
+          variant={variant}
+          color={color}
+          numberOfLines={1}
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+          style={textStyle}
+          onLayout={onContentLayout}
+        >
+          {children}
+        </Text>
+      </View>
+
+      {shouldScroll ? (
+        <MarqueeScroller overflow={overflow}>
+          {/* Pin to the full measured width and clip (don't ellipsize): otherwise
+              RN measures numberOfLines=1 against the clip width and the scrolling
+              copy keeps a "…" at the edge while it slides. */}
+          <Text
+            variant={variant}
+            color={color}
+            numberOfLines={1}
+            ellipsizeMode="clip"
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
+            style={[textStyle, { width: contentWidth }]}
+          >
+            {children}
+          </Text>
+        </MarqueeScroller>
+      ) : (
+        <Text
+          variant={variant}
+          color={color}
+          numberOfLines={fallbackLines}
+          ellipsizeMode="tail"
+          maxFontSizeMultiplier={maxFontSizeMultiplier}
+          style={textStyle}
+        >
+          {children}
+        </Text>
+      )}
+    </View>
+  );
+});
+
+type MarqueeScrollerProps = {
+  overflow: number;
+  children: ReactNode;
+};
+
+// Drives the back-and-forth translateX. Mounted only while actually scrolling, so
+// the reanimated hooks never run in the static/fallback case.
+function MarqueeScroller({ overflow, children }: MarqueeScrollerProps) {
+  const translateX = useSharedValue(0);
+
+  useEffect(() => {
+    const totalMs = computeMarqueeDurationS(overflow) * 1000;
+    const startDwellMs = totalMs * START_DWELL_FRACTION;
+    const travelMs = totalMs * TRAVEL_FRACTION;
+    const midDwellMs = totalMs * MID_DWELL_FRACTION;
+    const endDwellMs = totalMs * END_DWELL_FRACTION;
+    const easing = Easing.inOut(Easing.ease);
+    translateX.value = withRepeat(
+      withSequence(
+        withTiming(0, { duration: startDwellMs }),
+        withTiming(-overflow, { duration: travelMs, easing }),
+        withTiming(-overflow, { duration: midDwellMs }),
+        withTiming(0, { duration: travelMs, easing }),
+        withTiming(0, { duration: endDwellMs }),
+      ),
+      -1,
+    );
+    return () => cancelAnimation(translateX);
+  }, [overflow, translateX]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
+
+  return <Animated.View style={[styles.scrollRow, animatedStyle]}>{children}</Animated.View>;
+}
+
+const styles = StyleSheet.create({
+  clip: {
+    overflow: 'hidden',
+    justifyContent: 'center',
+  },
+  measure: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    opacity: 0,
+    flexDirection: 'row',
+    // Unclamp the measurer so the single-line text reports its true width (see
+    // MEASURE_MAX_WIDTH). It's opacity-0 and clipped, so the width is inert.
+    width: MEASURE_MAX_WIDTH,
+  },
+  scrollRow: {
+    flexDirection: 'row',
+    // Shrink-wrap to the text's full width (like the measurer) instead of being
+    // stretched to the clip — so the name reliably overflows and scrolls, rather
+    // than depending on the child overflowing a stretched parent.
+    alignSelf: 'flex-start',
+  },
+});

--- a/packages/mobile/src/components/__tests__/marquee-text.test.tsx
+++ b/packages/mobile/src/components/__tests__/marquee-text.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode } from 'react';
+
+// Controllable layout so a test can simulate an overflowing name (jsdom never
+// lays out on its own).
+const layout = vi.hoisted(() => ({ clipWidth: 0, contentWidth: 0 }));
+const reanim = vi.hoisted(() => ({ withRepeat: vi.fn() }));
+
+// The clip View fires onLayout with the configured clip width.
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: unknown) => void }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: layout.clipWidth, height: 20 } } });
+    }, [onLayout]);
+    return createElement('div', {}, children);
+  },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+// Reanimated: spy on the repeat loop and tag the animated wrapper so we can tell
+// the scrolling branch apart from the static one.
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-animated': 'true' }, children),
+  },
+  Easing: { inOut: () => () => 0, ease: () => 0 },
+  cancelAnimation: () => {},
+  useAnimatedStyle: (fn: () => unknown) => fn(),
+  useSharedValue: (value: unknown) => ({ value }),
+  withRepeat: (...args: unknown[]) => reanim.withRepeat(...args),
+  withSequence: (...values: unknown[]) => values,
+  withTiming: (value: unknown) => value,
+}));
+
+vi.mock('@boardsesh/play-view', () => ({ computeMarqueeDurationS: () => 10 }));
+
+// Text → span. The measurer is the only Text with onLayout, so it reports the
+// content width; the data-* attrs let us read numberOfLines / ellipsizeMode.
+vi.mock('../Text', () => ({
+  Text: ({
+    children,
+    numberOfLines,
+    ellipsizeMode,
+    onLayout,
+  }: {
+    children?: ReactNode;
+    numberOfLines?: number;
+    ellipsizeMode?: string;
+    onLayout?: (event: unknown) => void;
+  }) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: layout.contentWidth, height: 16 } } });
+    }, [onLayout]);
+    return createElement(
+      'span',
+      { 'data-text': 'true', 'data-lines': String(numberOfLines ?? ''), 'data-ellipsize': ellipsizeMode ?? '' },
+      children,
+    );
+  },
+}));
+
+const reduceMotion = vi.hoisted(() => ({ value: true }));
+vi.mock('../../hooks/use-reduce-motion', () => ({ useReduceMotion: () => reduceMotion.value }));
+
+import { MarqueeText } from '../MarqueeText';
+
+describe('MarqueeText', () => {
+  beforeEach(() => {
+    reduceMotion.value = true;
+    layout.clipWidth = 0;
+    layout.contentWidth = 0;
+    reanim.withRepeat.mockClear();
+  });
+
+  it('renders a single-line tail-ellipsized label when Reduce Motion is on', () => {
+    reduceMotion.value = true;
+    const { container } = render(<MarqueeText active>Super Long Boulder Name That Overflows</MarqueeText>);
+
+    const tail = container.querySelector('[data-ellipsize="tail"]');
+    expect(tail).not.toBeNull();
+    expect(tail?.getAttribute('data-lines')).toBe('1');
+    expect(tail?.textContent).toContain('Super Long Boulder Name');
+    // No scrolling animation kicked off.
+    expect(container.querySelector('[data-animated]')).toBeNull();
+    expect(reanim.withRepeat).not.toHaveBeenCalled();
+  });
+
+  it('renders the static label (no scroll) when not the active item', () => {
+    reduceMotion.value = false;
+    layout.clipWidth = 100;
+    layout.contentWidth = 320;
+    const { container } = render(<MarqueeText active={false}>Another Very Long Climb Name Here</MarqueeText>);
+
+    const tail = container.querySelector('[data-ellipsize="tail"]');
+    expect(tail).not.toBeNull();
+    expect(container.querySelector('[data-animated]')).toBeNull();
+    expect(reanim.withRepeat).not.toHaveBeenCalled();
+  });
+
+  it('scrolls (starts the loop) when active, overflowing, and Reduce Motion is off', () => {
+    reduceMotion.value = false;
+    layout.clipWidth = 100;
+    layout.contentWidth = 320;
+    const { container } = render(<MarqueeText active>Some Really Long Climb Name That Overflows The Bar</MarqueeText>);
+
+    // The scrolling copy lives in an Animated.View, and the back-and-forth loop ran.
+    expect(container.querySelector('[data-animated]')).not.toBeNull();
+    expect(reanim.withRepeat).toHaveBeenCalled();
+  });
+
+  it('stays static when the name fits the clip', () => {
+    reduceMotion.value = false;
+    layout.clipWidth = 320;
+    layout.contentWidth = 100;
+    const { container } = render(<MarqueeText active>Short Name</MarqueeText>);
+
+    expect(container.querySelector('[data-ellipsize="tail"]')).not.toBeNull();
+    expect(container.querySelector('[data-animated]')).toBeNull();
+    expect(reanim.withRepeat).not.toHaveBeenCalled();
+  });
+
+  it('stays static at exactly the overflow threshold (2px)', () => {
+    reduceMotion.value = false;
+    layout.clipWidth = 100;
+    layout.contentWidth = 102; // overflow === MIN_OVERFLOW_PX → no scroll
+    const { container } = render(<MarqueeText active>Name Right At The Threshold</MarqueeText>);
+
+    expect(container.querySelector('[data-animated]')).toBeNull();
+    expect(reanim.withRepeat).not.toHaveBeenCalled();
+  });
+
+  it('scrolls one pixel past the threshold (3px)', () => {
+    reduceMotion.value = false;
+    layout.clipWidth = 100;
+    layout.contentWidth = 103; // overflow > MIN_OVERFLOW_PX → scroll
+    const { container } = render(<MarqueeText active>Name Just Over The Threshold</MarqueeText>);
+
+    expect(container.querySelector('[data-animated]')).not.toBeNull();
+    expect(reanim.withRepeat).toHaveBeenCalled();
+  });
+
+  it('wraps the fallback to fallbackLines under Reduce Motion (full name, no scroll)', () => {
+    reduceMotion.value = true;
+    layout.clipWidth = 100;
+    layout.contentWidth = 320;
+    const { container } = render(
+      <MarqueeText active fallbackLines={2}>
+        A Long Name A Reduce Motion User Should Still Read In Full
+      </MarqueeText>,
+    );
+
+    const fallback = container.querySelector('[data-ellipsize="tail"]');
+    expect(fallback?.getAttribute('data-lines')).toBe('2');
+    expect(container.querySelector('[data-animated]')).toBeNull();
+    expect(reanim.withRepeat).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { formatSends, formatQuality } from '../../lib/format-climb-stats';
 import { Text } from '../Text';
+import { MarqueeText } from '../MarqueeText';
 import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -60,6 +61,10 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
       center={
         <>
           <View style={styles.nameRow}>
+            {/* Long-press copies the name; the name itself is a single-line marquee
+                that scrolls when it overflows, so the header height — and the board
+                below it — stays constant per climb. Under Reduce Motion it falls
+                back to a 2-line wrap (full name). */}
             <Pressable
               onLongPress={onLongPressName}
               disabled={!onLongPressName}
@@ -68,9 +73,9 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
               accessibilityHint={onLongPressName ? t('mobile.climbActions.copyNameHint') : undefined}
               style={styles.namePressable}
             >
-              <Text variant="body" style={styles.nameText} numberOfLines={1}>
+              <MarqueeText active variant="body" style={styles.nameClip} textStyle={styles.nameText} fallbackLines={2}>
                 {name}
-              </Text>
+              </MarqueeText>
             </Pressable>
             <ClimbAttributeIcons benchmarkDifficulty={benchmarkDifficulty} characteristics={characteristics} />
           </View>
@@ -100,17 +105,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     minWidth: 0,
   },
-  // Shrinks with the name so a long title still truncates while the attribute
-  // glyphs stay visible; the long-press target is the name text itself.
+  // Shrinks with the name so a long title scrolls within the available width while
+  // the attribute glyphs stay visible; the long-press target is the name itself.
   namePressable: {
     flexShrink: 1,
+    minWidth: 0,
+  },
+  // The marquee clip fills the (shrinking) pressable so it's bounded enough to
+  // detect overflow and scroll; it hugs its content when the name fits.
+  nameClip: {
+    alignSelf: 'stretch',
     minWidth: 0,
   },
   nameText: {
     fontWeight: '700',
     textAlign: 'center',
-    // Shrink so a long name truncates while the attribute glyphs stay visible.
-    flexShrink: 1,
   },
   subtitleText: {
     color: iosSystemColors.systemGray,

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
@@ -40,6 +40,11 @@ vi.mock('../../../lib/format-climb-stats', () => ({
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
+// MarqueeText (the scrolling climb-name label) has its own unit test; here it's a
+// plain text node so the long-press wrapper + name lookup work without Reanimated.
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
 vi.mock('../../DrawerHeader', () => ({
   // Render the center column so the name Pressable is in the tree.
   DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),

--- a/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/ClimbCapsule.tsx
@@ -14,6 +14,7 @@ import { spacing } from '../../theme/tokens';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { useGradeFormat } from '../../hooks/use-grade-format';
 import { Text } from '../Text';
+import { MarqueeText } from '../MarqueeText';
 import { useTheme } from '../../providers/theme-provider';
 import { useDrawerHost, type BoardConfig } from '../../providers/drawer-host-provider';
 import { AccessoryBarSurface, type AccessoryBarSurfaceTreatment } from './AccessoryBarSurface';
@@ -35,16 +36,18 @@ function ClimbLabel({ climb, labelColor, formattedGrade, gradeColor, showThumbna
   return (
     <View style={styles.labelInner}>
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
-      <Text
+      {/* The head climb's name scrolls when it overflows (Reduce-Motion-gated) so a
+          long name reads in full; the grade stays pinned to the right. */}
+      <MarqueeText
+        active
         variant="subheadline"
         color={labelColor}
-        numberOfLines={1}
-        ellipsizeMode="tail"
         maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
         style={styles.name}
+        textStyle={styles.nameText}
       >
         {climb.name}
-      </Text>
+      </MarqueeText>
       {formattedGrade ? (
         <Text
           variant="headline"
@@ -227,6 +230,9 @@ const styles = StyleSheet.create({
   },
   name: {
     flex: 1,
+    minWidth: 0,
+  },
+  nameText: {
     fontWeight: '600',
   },
 });

--- a/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
+++ b/packages/mobile/src/components/queue-control/NativeAccessoryClimbRow.tsx
@@ -8,6 +8,7 @@ import { spacing } from '../../theme/tokens';
 import { glassSize } from '../../theme/layout';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { Text } from '../Text';
+import { MarqueeText } from '../MarqueeText';
 import { AccessoryClimbThumbnail } from './AccessoryClimbThumbnail';
 import { useAccessoryClimbTap } from './use-accessory-climb-tap';
 import { LogAscentToolbarButton } from './LogAscentToolbarButton';
@@ -42,16 +43,18 @@ function ClimbLabel({ climb, labelColor, formattedGrade, showThumbnail, boardCon
   return (
     <View style={styles.labelInner}>
       {showThumbnail ? <AccessoryClimbThumbnail climb={climb} boardConfig={boardConfig} /> : null}
-      <Text
+      {/* Scrolls a long name when it overflows (Reduce-Motion-gated); the grade
+          stays pinned. Falls back to tail-ellipsis when it fits or motion is off. */}
+      <MarqueeText
+        active
         variant="subheadline"
         color={labelColor}
-        numberOfLines={1}
-        ellipsizeMode="tail"
         maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
         style={styles.name}
+        textStyle={styles.nameText}
       >
         {climb.name}
-      </Text>
+      </MarqueeText>
       {formattedGrade ? (
         <Text
           variant="subheadline"
@@ -164,6 +167,8 @@ const styles = StyleSheet.create({
   name: {
     flex: 1,
     minWidth: 0,
+  },
+  nameText: {
     fontWeight: '500',
   },
   gradeText: {

--- a/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/climb-capsule.test.tsx
@@ -107,6 +107,13 @@ vi.mock('../../Text', () => ({
     createElement('span', { 'data-text': 'true', 'data-color': readColor(props) }, props.children),
 }));
 
+// MarqueeText (the scrolling climb-name label) has its own unit test; here it's
+// just a coloured text node so the capsule's layout/colour assertions hold.
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: (props: TextMockProps) =>
+    createElement('span', { 'data-text': 'true', 'data-color': readColor(props) }, props.children),
+}));
+
 vi.mock('../../GlassSurface', () => ({
   GlassSurface: ({ tintColor }: { tintColor?: string }) =>
     createElement('div', { 'data-glass': 'true', 'data-tint': tintColor ?? '' }),

--- a/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/native-accessory-climb-row.test.tsx
@@ -162,6 +162,22 @@ vi.mock('../../Text', () => ({
     ),
 }));
 
+// MarqueeText (the scrolling climb-name label) has its own unit test; here it's
+// a coloured text node. Font weight rides `textStyle`, so read it from there.
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: (props: TextMockProps & { textStyle?: TextMockProps['style'] }) =>
+    createElement(
+      'span',
+      {
+        'data-text': 'true',
+        'data-color': readColor(props),
+        'data-font-weight': readTextStyleValue({ style: props.textStyle }, 'fontWeight'),
+        'data-variant': props.variant ?? '',
+      },
+      props.children,
+    ),
+}));
+
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { label: '#111111' },

--- a/packages/shared/play-view/src/__tests__/marquee-timing.test.ts
+++ b/packages/shared/play-view/src/__tests__/marquee-timing.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeMarqueeDurationS,
+  MARQUEE_MIN_DURATION_S,
+  MARQUEE_MAX_DURATION_S,
+  MARQUEE_PIXELS_PER_SECOND,
+} from '../marquee-timing';
+
+describe('computeMarqueeDurationS', () => {
+  it('returns 0 when nothing overflows', () => {
+    expect(computeMarqueeDurationS(0)).toBe(0);
+    expect(computeMarqueeDurationS(-50)).toBe(0);
+  });
+
+  it('floors a small overflow at the minimum duration', () => {
+    // overflow/30 + 6 = 7s for 30px, below the 8s floor.
+    expect(computeMarqueeDurationS(30)).toBe(MARQUEE_MIN_DURATION_S);
+  });
+
+  it('caps a huge overflow at the maximum duration', () => {
+    expect(computeMarqueeDurationS(10_000)).toBe(MARQUEE_MAX_DURATION_S);
+  });
+
+  it('follows overflow/speed + 6 in the mid range', () => {
+    const overflowPx = 300;
+    expect(computeMarqueeDurationS(overflowPx)).toBeCloseTo(overflowPx / MARQUEE_PIXELS_PER_SECOND + 6);
+  });
+});

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './queue-navigation';
 export * from './queue-list-model';
 export * from './grade-display';
+export * from './marquee-timing';
 export * from './tick-utils';
 export * from './quick-tick-state';
 export * from './board-utils';

--- a/packages/shared/play-view/src/marquee-timing.ts
+++ b/packages/shared/play-view/src/marquee-timing.ts
@@ -1,0 +1,21 @@
+// Shared timing for the "scroll a long climb name back and forth" marquee, used
+// by both the web climb chrome (CSS keyframes, `marquee-text.tsx`) and the mobile
+// now-playing bar (Reanimated, `MarqueeText.tsx`). Keeping the speed + duration
+// math here means both platforms scroll at the same pace from one source.
+
+/** Scroll speed. Slow enough to read a long name without it feeling frantic. */
+export const MARQUEE_PIXELS_PER_SECOND = 30;
+/** A short name that barely overflows still gets a calm, readable cycle. */
+export const MARQUEE_MIN_DURATION_S = 8;
+/** A very long name never crawls for more than this. */
+export const MARQUEE_MAX_DURATION_S = 24;
+
+/**
+ * Full back-and-forth cycle length (seconds) for a name overflowing its slot by
+ * `overflowPx`. The `+ 6` reserves time for the end-of-travel dwells so the cycle
+ * isn't all motion. Returns 0 when nothing overflows (no animation needed).
+ */
+export function computeMarqueeDurationS(overflowPx: number): number {
+  if (overflowPx <= 0) return 0;
+  return Math.min(MARQUEE_MAX_DURATION_S, Math.max(MARQUEE_MIN_DURATION_S, overflowPx / MARQUEE_PIXELS_PER_SECOND + 6));
+}

--- a/packages/web/app/components/climb-card/marquee-text.tsx
+++ b/packages/web/app/components/climb-card/marquee-text.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { computeMarqueeDurationS } from '@boardsesh/play-view';
 import styles from './marquee-text.module.css';
 
 type MarqueeTextProps = {
@@ -9,10 +10,6 @@ type MarqueeTextProps = {
   className?: string;
   children: React.ReactNode;
 };
-
-const PIXELS_PER_SECOND = 30;
-const MIN_DURATION_S = 8;
-const MAX_DURATION_S = 24;
 
 const useIsoLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
@@ -43,9 +40,7 @@ const MarqueeText: React.FC<MarqueeTextProps> = ({ active, className, children }
   }, [active, children]);
 
   const isScrolling = active && overflowPx > 0;
-  const durationS = isScrolling
-    ? Math.min(MAX_DURATION_S, Math.max(MIN_DURATION_S, overflowPx / PIXELS_PER_SECOND + 6))
-    : 0;
+  const durationS = isScrolling ? computeMarqueeDurationS(overflowPx) : 0;
 
   const innerStyle = isScrolling
     ? ({


### PR DESCRIPTION
## Summary

Long climb/boulder names were truncated on mobile with no way to read them in full — a regression of #1849, reported again via TestFlight in #3105 ("Boulders with long names should show the whole name imo"). We consulted an iOS-HIG perspective and a Material-3 perspective; both informed the approach, refined by on-device beta feedback:

- **Play-drawer header → single-line scrolling marquee.** A long name scrolls back and forth (matching the web climb header); a short name is centered. Crucially this keeps the header height **constant**, so the board renders identically for every climb (an earlier 2-line-wrap version shifted/shrank the board per climb). Under Reduce Motion it falls back to a **2-line wrap** (full name, no motion) rather than a truncation, so the whole name stays readable.
- **Now-playing bar → scrolling marquee.** The bottom bar scrolls a long name when it overflows, gated on Reduce Motion / "Remove animations" (falls back to tail-ellipsis). Covers all three bar surfaces: the iOS 26 native glass platter, the older-iOS floating capsule, and the Android docked Material bar.
- **Universal reveal:** ellipsis is the baseline on fixed-height chrome; the play-drawer header (reached by tapping any bar) shows the whole name.

The marquee pacing math (speed, duration clamp) is extracted to `@boardsesh/play-view` and imported by both the new RN `MarqueeText` and the existing web `marquee-text.tsx`, so both platforms scroll at the same speed.

**iOS 26 native platter:** animating inside that UIKit-snapshotted glass platter has a history of a "doubled text" artifact, so it's **being verified on-device** via the `pr-3255` OTA channel. If the glass artifact appears there, we fall back to ellipsis on that one surface (the header marquee + tap-to-open still cover the full name).

Deliberately left as tail-ellipsis:
- **"On the wall" status pill** — transient chip that remounts on every wall change; the full name is already reachable via tap → wall preview and the VoiceOver/TalkBack announce.

Closes #3105.

## Release Notes

- Long boulder names read in full again — the climb view and the play bar scroll a long name so nothing gets cut off.

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:shared`, `vp run typecheck:web` — pass.
- `vp run test:mobile` — full suite passes, incl. `MarqueeText` unit tests (static / scroll branch / overflow threshold / Reduce-Motion 2-line fallback) and updated `ClimbCapsule` / `NativeAccessoryClimbRow` / play-drawer tests.
- `vp test run --project web marquee-text` and the shared `marquee-timing` clamp test — pass.
- `vp check` (lint + format) — clean. `vp run check:mobile-bundle` — Android bundle OK.
- **On-device (pending):** load `pr-3255` and confirm: header scrolls a long name with constant height (board doesn't shift); iOS 26 glass bar + Android docked bar scroll; Reduce-Motion → header 2-line wrap + bars ellipsize; no glass "doubled text". Script in `.boardsesh/qa-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)