### PR TITLE
fix(mobile): open the grade rail centred on the last-used grade (#3205)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -204,6 +204,12 @@ vi.mock('../../../../src/hooks/use-grade-format', () => ({
   useGradeFormat: () => ({ formatGradeByDifficultyId: (difficultyId: number) => String(difficultyId) }),
 }));
 
+// Stub the SecureStore-backed last-used-grade hook so the screen test doesn't
+// pull in expo-secure-store / expo-modules-core (matches the last-search mock).
+vi.mock('../../../../src/hooks/use-last-used-grade', () => ({
+  useLastUsedGrade: () => ({ lastUsedGrade: undefined, rememberGrade: vi.fn() }),
+}));
+
 vi.mock('../../../../src/lib/graphql/hooks/use-infinite-search-climbs', () => ({
   useInfiniteSearchClimbs: () => ({
     data: { pages: [{ climbs: [mocks.climb], hasMore: false }] },

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -49,6 +49,7 @@ import { useNativeAccessoryActive } from '../../../src/hooks/use-bottom-accessor
 import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-metrics';
 import { useGrades } from '../../../src/lib/graphql/hooks';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
+import { useLastUsedGrade } from '../../../src/hooks/use-last-used-grade';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { getHttpClient } from '../../../src/lib/graphql/client';
@@ -178,6 +179,7 @@ function ClimbListInner() {
     patchFilters,
     patchBoardFilters,
   } = useClimbSearch();
+  const { lastUsedGrade, rememberGrade } = useLastUsedGrade();
   const { getLogbook } = useBoardActions();
   const searchHeaderRef = useRef<SearchHeaderHandle>(null);
   const nativeSearchRef = useRef<NativeSearchBarRef>(null);
@@ -738,6 +740,15 @@ function ClimbListInner() {
     [setGrade],
   );
 
+  // Remember the grade the climber filters by (from any path — the chip rail,
+  // the filter sheet's Apply, tokens, recent pills, per-board restore) so the
+  // rail can open centred on it later. Skips clears (undefined) so clearing
+  // keeps the last real grade in memory rather than forgetting it.
+  useEffect(() => {
+    const focusGrade = filters.minGrade ?? filters.maxGrade;
+    if (focusGrade != null) rememberGrade(focusGrade);
+  }, [filters.minGrade, filters.maxGrade, rememberGrade]);
+
   const handleCreateClimb = useCallback(() => {
     router.push({
       pathname: '/(tabs)/climbs/create',
@@ -1183,6 +1194,7 @@ function ClimbListInner() {
         }
         gradeBound={gradeBound}
         grades={grades}
+        lastUsedGradeId={lastUsedGrade}
         gradeRailVisible={showGrade}
         gradeChip={gradeChip}
         onOpenGrade={handleOpenGrade}
@@ -1205,6 +1217,7 @@ function ClimbListInner() {
             <GradeRangeRail
               grades={grades}
               bound={gradeBound}
+              lastUsedGradeId={lastUsedGrade}
               onChange={handleGradeChange}
               onRequestClose={handleDismissGrade}
               dismissible={false}
@@ -1220,6 +1233,7 @@ function ClimbListInner() {
           currentFilters={filters}
           currentBoardFilters={boardFilters}
           searchName={name}
+          lastUsedGradeId={lastUsedGrade}
           onApply={handleApplyFilters}
         />
       ) : null}

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -71,6 +71,8 @@ type ClimbFilterSheetProps = {
   currentBoardFilters: ClimbBoardFilterState;
   /** Current committed name term, so the live "Show N" count matches Apply. */
   searchName?: string;
+  /** Last-used grade id; centres the grade rail on a familiar grade when unset. */
+  lastUsedGradeId?: number;
   onApply: (filters: ClimbFilters, boardFilters: ClimbBoardFilterState) => void;
 };
 
@@ -133,6 +135,7 @@ export function ClimbFilterSheet({
   currentFilters,
   currentBoardFilters,
   searchName,
+  lastUsedGradeId,
   onApply,
 }: ClimbFilterSheetProps) {
   const { t } = useTranslation('climbs');
@@ -617,6 +620,7 @@ export function ClimbFilterSheet({
             <GradeRangeRail
               grades={grades ?? []}
               bound={{ minGradeId: localFilters.minGrade, maxGradeId: localFilters.maxGrade }}
+              lastUsedGradeId={lastUsedGradeId}
               onChange={handleGradeChange}
               dismissible={false}
               showTitle

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -28,6 +28,9 @@ import { spacing } from '../../theme/tokens';
 import { GradeChip } from './GradeChip';
 
 const CLEAR_DISMISS_MS = 300;
+// How many frames to re-assert the centring scroll. One scrollTo can be dropped
+// while the host sheet is still presenting; a few frames of re-assert lands it.
+const CENTER_ASSERT_FRAMES = 4;
 
 type ChipLayout = { x: number; width: number };
 
@@ -74,6 +77,12 @@ type GradeRangeRailProps = {
   bound: GradeBound;
   sendDifficultyIds?: readonly number[];
   /**
+   * The climber's last-used grade. When nothing is selected (and centerOnEmpty
+   * is on), the rail opens centred on this instead of the generic band default,
+   * so reopening the filter lands on the grade they actually climb.
+   */
+  lastUsedGradeId?: number;
+  /**
    * Auto-center the rail on mount when there is no grade selection. True (the
    * default) surfaces the climber's typical grades; the logbook filter passes
    * false so an unset rail opens at the easiest grade instead of mid-scrolled.
@@ -95,6 +104,7 @@ export function GradeRangeRail({
   grades: unsortedGrades,
   bound,
   sendDifficultyIds = [],
+  lastUsedGradeId,
   centerOnEmpty = true,
   onChange,
   onRequestClose,
@@ -115,6 +125,13 @@ export function GradeRangeRail({
   const onRequestCloseRef = useRef(onRequestClose);
   const [railWidth, setRailWidth] = useState(0);
   const didCenterRef = useRef(false);
+  const centeringRef = useRef(false);
+  const centerAssertsRef = useRef(0);
+  const centerRafRef = useRef<number | null>(null);
+  // Set once the climber taps/drags the rail. After that we never re-centre, so
+  // the row can't yank out from under their finger; before that we re-centre as
+  // the focus settles (e.g. lastUsedGrade resolving from storage after mount).
+  const userInteractedRef = useRef(false);
 
   const grades = useMemo(() => sortedGrades(unsortedGrades), [unsortedGrades]);
   const gradeIds = useMemo(() => grades.map((grade) => grade.difficultyId), [grades]);
@@ -122,8 +139,8 @@ export function GradeRangeRail({
     // With centering-on-empty off (the logbook filter), only auto-center when a
     // grade is actually selected; otherwise open at the start, not mid-scrolled.
     if (!centerOnEmpty && bound.minGradeId == null && bound.maxGradeId == null) return undefined;
-    return gradeRailCenter(bound, grades, sendDifficultyIds);
-  }, [centerOnEmpty, bound, grades, sendDifficultyIds]);
+    return gradeRailCenter(bound, grades, sendDifficultyIds, lastUsedGradeId);
+  }, [centerOnEmpty, bound, grades, sendDifficultyIds, lastUsedGradeId]);
 
   const clearDismissTimer = useCallback(() => {
     if (dismissTimerRef.current) {
@@ -165,19 +182,73 @@ export function GradeRangeRail({
     [handleRequestClose],
   );
 
-  const maybeCenter = useCallback(() => {
-    if (didCenterRef.current || railWidth === 0 || centerId == null) return;
-    const chipLayout = chipLayoutsRef.current[centerId];
-    if (!chipLayout) return;
-    didCenterRef.current = true;
-    const offset = Math.max(0, chipLayout.x + chipLayout.width / 2 - railWidth / 2);
-    scrollRef.current?.scrollTo({ x: offset, animated: false });
+  const clearCenterRaf = useCallback(() => {
+    if (centerRafRef.current != null) {
+      cancelAnimationFrame(centerRafRef.current);
+      centerRafRef.current = null;
+    }
+  }, []);
+
+  // Scroll the focus grade into the centre once both the rail width and the
+  // focus chip's position are known. A single scrollTo issued while the host
+  // sheet is still presenting can be swallowed (the rail stays pinned at the
+  // start), so re-assert the offset across a few frames before latching.
+  const startCentering = useCallback(() => {
+    if (didCenterRef.current || centeringRef.current) return;
+    if (railWidth === 0 || centerId == null) return;
+    if (chipLayoutsRef.current[centerId] == null) return;
+    centeringRef.current = true;
+    centerAssertsRef.current = 0;
+    const assertCenter = () => {
+      const chipLayout = chipLayoutsRef.current[centerId];
+      if (chipLayout) {
+        const offset = Math.max(0, chipLayout.x + chipLayout.width / 2 - railWidth / 2);
+        scrollRef.current?.scrollTo({ x: offset, animated: false });
+      }
+      centerAssertsRef.current += 1;
+      if (centerAssertsRef.current >= CENTER_ASSERT_FRAMES) {
+        didCenterRef.current = true;
+        centeringRef.current = false;
+        centerRafRef.current = null;
+        return;
+      }
+      centerRafRef.current = requestAnimationFrame(assertCenter);
+    };
+    assertCenter();
   }, [centerId, railWidth]);
+
+  // Re-centre whenever the focus or measured width settles — covers the case
+  // where lastUsedGrade resolves from storage a tick after mount (no layout
+  // event of its own) and would otherwise leave the rail latched on the default
+  // band centre. Skipped once the climber has interacted, so a tap never yanks
+  // the row. `startCentering` changes identity only when centerId/railWidth do.
+  useEffect(() => {
+    if (userInteractedRef.current) return;
+    clearCenterRaf();
+    didCenterRef.current = false;
+    centeringRef.current = false;
+    startCentering();
+  }, [startCentering, clearCenterRaf]);
+
+  // Cancel any in-flight re-assert loop on unmount.
+  useEffect(() => clearCenterRaf, [clearCenterRaf]);
+
+  // The user dragging the rail latches centring for good so it never fights
+  // their finger, and stops the dismiss timer.
+  const handleScrollBeginDrag = useCallback(() => {
+    clearDismissTimer();
+    clearCenterRaf();
+    userInteractedRef.current = true;
+    centeringRef.current = false;
+    didCenterRef.current = true;
+  }, [clearDismissTimer, clearCenterRaf]);
 
   const handleTapGrade = useCallback(
     (difficultyId: number) => {
       hapticSelection();
       clearDismissTimer();
+      userInteractedRef.current = true;
+      didCenterRef.current = true;
       const withinWindow =
         lastSingleAtRef.current !== undefined && Date.now() - lastSingleAtRef.current < RANGE_EXTEND_WINDOW_MS;
       const result = computeGradeTap(bound, gradeIds, difficultyId, withinWindow);
@@ -201,6 +272,8 @@ export function GradeRangeRail({
   const handleClear = useCallback(() => {
     hapticSelection();
     clearDismissTimer();
+    userInteractedRef.current = true;
+    didCenterRef.current = true;
     lastSingleAtRef.current = undefined;
     onChange(clearGradeBound());
     if (dismissible) scheduleDismiss(CLEAR_DISMISS_MS);
@@ -239,10 +312,11 @@ export function GradeRangeRail({
         keyboardShouldPersistTaps="handled"
         style={styles.railScroll}
         contentContainerStyle={styles.railContent}
-        onScrollBeginDrag={clearDismissTimer}
+        onScrollBeginDrag={handleScrollBeginDrag}
+        onContentSizeChange={startCentering}
         onLayout={(event) => {
           setRailWidth(event.nativeEvent.layout.width);
-          maybeCenter();
+          startCentering();
         }}
       >
         <GradeChip
@@ -277,7 +351,7 @@ export function GradeRangeRail({
               accessibilityState={{ selected: endpoint }}
               onLayout={({ nativeEvent }) => {
                 chipLayoutsRef.current[grade.difficultyId] = nativeEvent.layout;
-                maybeCenter();
+                startCentering();
               }}
             />
           );

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -65,6 +65,8 @@ type ClimbTopChromeProps = {
   filterSummary?: { text: string; onClear: () => void };
   gradeBound?: GradeBound;
   grades?: readonly Grade[];
+  /** Last-used grade id; centres an unselected rail on a familiar grade. */
+  lastUsedGradeId?: number;
   gradeRailVisible?: boolean;
   gradeChip?: { label: string; active: boolean; onClear?: () => void };
   onOpenGrade?: () => void;
@@ -96,6 +98,7 @@ export function ClimbTopChrome({
   filterSummary,
   gradeBound,
   grades = [],
+  lastUsedGradeId,
   gradeRailVisible = false,
   gradeChip,
   onOpenGrade,
@@ -259,6 +262,7 @@ export function ClimbTopChrome({
               <GradeRangeRail
                 grades={grades}
                 bound={gradeBound}
+                lastUsedGradeId={lastUsedGradeId}
                 onChange={onGradeChange}
                 onRequestClose={onCloseGrade}
                 dismissible={false}

--- a/packages/mobile/src/hooks/use-last-used-grade.ts
+++ b/packages/mobile/src/hooks/use-last-used-grade.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getLastUsedGradeId, setLastUsedGradeId } from '../lib/last-grade-store';
+
+/**
+ * Reads the last grade the climber filtered by from secure storage on mount and
+ * exposes a `rememberGrade` callback that persists subsequent picks. The grade
+ * rail uses `lastUsedGrade` to open centred on a familiar grade when no range is
+ * currently selected. Port of web's `useLastUsedGrade`.
+ */
+export function useLastUsedGrade() {
+  const [lastUsedGrade, setLastUsedGradeState] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    void getLastUsedGradeId().then((value) => {
+      if (value !== undefined) setLastUsedGradeState(value);
+    });
+  }, []);
+
+  const rememberGrade = useCallback((difficultyId: number | undefined) => {
+    if (difficultyId === undefined) return;
+    setLastUsedGradeState(difficultyId);
+    void setLastUsedGradeId(difficultyId);
+  }, []);
+
+  return { lastUsedGrade, rememberGrade };
+}

--- a/packages/mobile/src/lib/__tests__/grade-seed.test.ts
+++ b/packages/mobile/src/lib/__tests__/grade-seed.test.ts
@@ -49,4 +49,22 @@ describe('gradeRailCenter', () => {
   it('falls back to the default band center with no selection and no sends', () => {
     expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [])).toBe(16);
   });
+
+  it('uses the last-used grade when nothing is selected', () => {
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [], 13)).toBe(13);
+  });
+
+  it('prefers the last-used grade over the modal send grade', () => {
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [14, 14, 17], 13)).toBe(13);
+  });
+
+  it('keeps the current selection ahead of the last-used grade', () => {
+    expect(gradeRailCenter({ minGradeId: 18, maxGradeId: 20 }, GRADES, [], 13)).toBe(18);
+  });
+
+  it('ignores a last-used grade that is not on the current board', () => {
+    // id 99 is from another board family; fall through to the send/default tiers.
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [14, 14], 99)).toBe(14);
+    expect(gradeRailCenter({ minGradeId: undefined, maxGradeId: undefined }, GRADES, [], 99)).toBe(16);
+  });
 });

--- a/packages/mobile/src/lib/__tests__/last-grade-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/last-grade-store.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('expo-secure-store', () => {
+  let storage: Record<string, string> = {};
+  let failNext = false;
+  return {
+    getItemAsync: vi.fn(async (key: string) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('boom');
+      }
+      return storage[key] ?? null;
+    }),
+    setItemAsync: vi.fn(async (key: string, value: string) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('boom');
+      }
+      storage[key] = value;
+    }),
+    __reset: () => {
+      storage = {};
+    },
+    __failNext: () => {
+      failNext = true;
+    },
+    __raw: () => storage,
+  };
+});
+
+const STORE_KEY = 'boardsesh_last_used_grade';
+
+async function secureStore() {
+  return (await import('expo-secure-store')) as unknown as {
+    __reset: () => void;
+    __failNext: () => void;
+    __raw: () => Record<string, string>;
+    setItemAsync: (key: string, value: string) => Promise<void>;
+  };
+}
+
+beforeEach(async () => {
+  (await secureStore()).__reset();
+});
+
+describe('last-grade-store', () => {
+  it('returns undefined when nothing is stored', async () => {
+    const { getLastUsedGradeId } = await import('../last-grade-store');
+    expect(await getLastUsedGradeId()).toBeUndefined();
+  });
+
+  it('round-trips a difficulty id', async () => {
+    const { getLastUsedGradeId, setLastUsedGradeId } = await import('../last-grade-store');
+    await setLastUsedGradeId(22);
+    expect((await secureStore()).__raw()[STORE_KEY]).toBe('22');
+    expect(await getLastUsedGradeId()).toBe(22);
+  });
+
+  it('returns undefined for a non-numeric stored value', async () => {
+    const store = await secureStore();
+    await store.setItemAsync(STORE_KEY, 'not-a-number');
+    const { getLastUsedGradeId } = await import('../last-grade-store');
+    expect(await getLastUsedGradeId()).toBeUndefined();
+  });
+
+  it('swallows read errors and returns undefined', async () => {
+    const store = await secureStore();
+    store.__failNext();
+    const { getLastUsedGradeId } = await import('../last-grade-store');
+    await expect(getLastUsedGradeId()).resolves.toBeUndefined();
+  });
+
+  it('swallows write errors', async () => {
+    const store = await secureStore();
+    store.__failNext();
+    const { setLastUsedGradeId } = await import('../last-grade-store');
+    await expect(setLastUsedGradeId(15)).resolves.toBeUndefined();
+  });
+});

--- a/packages/mobile/src/lib/grade-seed.ts
+++ b/packages/mobile/src/lib/grade-seed.ts
@@ -40,15 +40,23 @@ export function defaultGradeCenter(grades: readonly Grade[]): number | undefined
 
 /**
  * The difficulty id the grade rail should scroll to / highlight: the current
- * selection if any, else the climber's modal send grade, else the default band
- * center.
+ * selection if any, else the climber's last-used grade, else their modal send
+ * grade, else the default band center.
+ *
+ * `lastUsedGradeId` is only honoured when it actually exists on the current
+ * board — difficulty scales differ across board families, so a value remembered
+ * on one board falls through to the send/default heuristics on another.
  */
 export function gradeRailCenter(
   selected: GradeSelection,
   grades: readonly Grade[],
   sendDifficultyIds: readonly number[] = [],
+  lastUsedGradeId?: number,
 ): number | undefined {
   if (selected.minGradeId != null) return selected.minGradeId;
   if (selected.maxGradeId != null) return selected.maxGradeId;
+  if (lastUsedGradeId != null && grades.some((grade) => grade.difficultyId === lastUsedGradeId)) {
+    return lastUsedGradeId;
+  }
   return selectModalSendGrade(sendDifficultyIds) ?? defaultGradeCenter(grades);
 }

--- a/packages/mobile/src/lib/last-grade-store.ts
+++ b/packages/mobile/src/lib/last-grade-store.ts
@@ -1,0 +1,29 @@
+import * as SecureStore from 'expo-secure-store';
+
+// Remembers the last grade the climber actually filtered by, so the grade rail
+// can open centred on it even after the filter is cleared. Deliberately a
+// SINGLE global value (not per-board): the rail validates membership against
+// the current board's grade band before centring, so a value from another board
+// family with a different difficulty scale just falls through to the band
+// default. Mirrors web's `lastUsedGrade` (user-preferences-db.ts) in spirit.
+const LAST_GRADE_KEY = 'boardsesh_last_used_grade';
+
+/** The last-used difficulty id, or `undefined` if none was ever stored. */
+export async function getLastUsedGradeId(): Promise<number | undefined> {
+  try {
+    const value = await SecureStore.getItemAsync(LAST_GRADE_KEY);
+    if (!value) return undefined;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function setLastUsedGradeId(difficultyId: number): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(LAST_GRADE_KEY, String(difficultyId));
+  } catch {
+    // Storage failure is non-critical.
+  }
+}


### PR DESCRIPTION
## Summary

Closes #3205. The climb grade rail always opened scrolled to the easiest grade. That's a fine first-run default, but it's annoying when you already have a range set and just want to nudge it (bump a warm-up up). It now opens with a useful grade in view:

- **A range is selected** → centre on it. This already half-existed, but the single `scrollTo` could be swallowed while the filter sheet was still presenting, leaving the rail pinned at the start. Centring now re-asserts across a few frames (and on `onContentSizeChange`) until it lands, then latches once you drag/tap so it never yanks under your finger.
- **Nothing selected** → centre on the **last grade you filtered by**, persisted in SecureStore (`boardsesh_last_used_grade`) and validated against the current board's grade band, so a remembered id from a board with a different scale falls through to the band default.

Wired through all three rail surfaces: the Liquid-Glass grade overlay, the Material grade rail, and the Filters sheet. The single-select logbook grade rail (You tab) is untouched — it still opens at the easiest grade.

## Release Notes

- The grade filter now opens where you left off — on your recent grades instead of scrolled all the way back to the easy end.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2782 pass (added `grade-seed` last-used cases + a `last-grade-store` suite)
- `vp run check:mobile-bundle` — OK
- `vp check` on all touched files — clean
- Manual (iOS sim + flows in `.boardsesh/qa-notes.md`): set a mid/high range → Apply → reopen the Filters sheet and the Grade overlay → rail centred on the selection, not V0; clear → reopen → centred on the last-used grade; tap to adjust → no recentre under finger; cross-board scale → no crash, band-default fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)