### PR TITLE
feat(mobile): browse OTA preview channels by PR title, open to everyone

### DIFF
--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -1,8 +1,8 @@
 name: Mobile OTA Preview (Per-PR Channel)
 
-# Publishes a PR's JS bundle to its own self-hosted OTA channel `pr-<number>` so a
-# tester on the store / TestFlight binary can load it via the in-app OTA Channel
-# Switcher (More → Development → type `pr-<number>`) — no per-tester build. Companion
+# Publishes a PR's JS bundle to its own self-hosted OTA channel `pr-<number>` so
+# anyone on the store / TestFlight binary can load it via the in-app switcher
+# (What's New → Try a preview → pick the PR) — no per-tester build. Companion
 # to mobile-ota-production.yml, which owns the `production` channel. The published
 # runtimeVersion matches the shipped binary because EXPO_UPDATES_CHANNEL stays
 # `production` (it feeds the hashed config); the `pr-<number>` value is only the eoas
@@ -330,8 +330,8 @@ jobs:
             let deployDesc;
             if (anyPublished) {
               headline =
-                `This PR is live on the OTA channel **\`${channel}\`**. Testers with the \`tester\` role on a ` +
-                `TestFlight / App Store build can load it without a new build:`;
+                `This PR is live on the OTA channel **\`${channel}\`**. Anyone on a TestFlight / App Store ` +
+                `build can load it without a new build:`;
               deployState = 'success';
               deployDesc = `OTA channel ${channel} ready`;
             } else if (nativeOnly) {
@@ -346,8 +346,8 @@ jobs:
               deployDesc = `OTA preview ${channel} failed`;
             }
             const howto = anyPublished
-              ? ['', '**More → Development → OTA Channel Switcher → type `' + channel + '`** → it downloads and ' +
-                 'reloads. Reset on the same screen (back to `production`).', '']
+              ? ['', '**What\'s New → Try a preview → pick this PR** → it downloads and reloads. Reset on the ' +
+                 'same screen (back to `production`).', '']
               : [''];
 
             const body = [

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -17,7 +17,7 @@ there's no MAU/bandwidth billing.
 | Channel source | `channel` in `eas.json`                  | `expo-channel-name` request header baked in by `expo prebuild`                                                                   |
 | Publish        | `vp run mobile:publish` (→ `eas update`) | auto on push to `main` (`mobile-ota-production.yml`); manual: `vp run mobile:publish -- --channel production` (→ `eoas publish`) |
 
-A third path rides the **same self-hosted server**: per-PR `pr-<number>` channels that let a tester
+A third path rides the **same self-hosted server**: per-PR `pr-<number>` channels that let any user
 validate a specific PR on a store/TestFlight build via the in-app switcher — see
 [Per-PR preview channels](#per-pr-preview-channels-self-hosted) below.
 
@@ -432,13 +432,21 @@ prebuild --platform ios --clean --no-install`, then confirm `ios/Boardsesh/Suppo
 4. Make a trivial JS change, push to `main` (or `vp run mobile:publish -- --channel production`),
    relaunch the TestFlight app, and confirm the OTA downloads and applies.
 
-## Tester channel switcher (in-app, production builds)
+## In-app channel switcher ("Try a preview", production builds)
 
-Users granted the **`tester`** community role (admin panel → Roles; admins implicitly count as
-testers) see an extra "OTA Channel Switcher" row under **More → Development** in the app. It lets a
-tester repoint a production/TestFlight build at a different channel (e.g. `preview-2`) at runtime to
-validate a specific PR's OTA, without a per-tester build.
+**Any** user on a production/TestFlight build can repoint it at a different channel at runtime to try a
+specific PR's OTA, without a per-tester build. The entry is a visible **"Try a preview"** button on the
+**What's New** screen (`app/changelog.tsx`), next to _Check for updates_ — shown only when
+`!__DEV__ && Updates.isEnabled`. It opens the switcher screen (`src/components/ChannelSwitcherScreen.tsx`),
+which lists the **live per-PR previews by pull-request title** (not raw `pr-<n>` strings) and a
+reset-to-production action. _(It used to be a tester-only "OTA Channel Switcher" row under
+More → Development; that row was removed.)_
 
+- **Live preview list:** the screen calls the **public** `otaPreviewChannels` GraphQL query
+  (`packages/backend/src/lib/ota-preview-channels.ts`), which derives the live channels from the GitHub
+  `pr-preview` Deployments this workflow writes, intersected with still-open PRs — two cached GitHub
+  calls, fail-soft to `[]`. Optional backend `GITHUB_TOKEN` raises the rate-limit ceiling (works
+  unauthenticated on the public repo).
 - **Mechanism:** `Updates.setUpdateRequestHeadersOverride({ 'expo-channel-name': <channel> })` —
   overrides only the channel header, keeping the build's `updates.url`, so the embedded code-signing
   cert still verifies every manifest. Then `checkForUpdateAsync` → `fetchUpdateAsync` → `reloadAsync`.
@@ -451,16 +459,16 @@ validate a specific PR's OTA, without a per-tester build.
   the switcher breaks (the override throws). Keep it baked in.
 - **Constraint:** the target channel must have an OTA published at the **same fingerprint
   runtimeVersion** as the running binary, or `checkForUpdateAsync` reports nothing available.
-- **Gating:** the row shows only when `isTester && !__DEV__ && Updates.isEnabled` (overrides are inert
-  in dev/Expo Go). Logic lives in `src/lib/channel-switch.ts` (unit-tested); UI in
-  `src/components/ChannelSwitcherScreen.tsx`. The `tester` role is global-only and grants nothing
-  beyond this flag (`UserProfile.isTester`).
+- **Tester-only extras:** the raw preset/custom-channel entry (`production`, `preview-1…4`, free-text)
+  and the Sentry crash-test tools on the same screen still require the **`tester`** role
+  (`UserProfile.isTester`; admin panel → Roles, admins implicitly count). Switch logic lives in
+  `src/lib/channel-switch.ts` (unit-tested). The `tester` role grants nothing beyond these extras.
 
 ## Per-PR preview channels (self-hosted)
 
 Every PR with React Native changes can publish its JS bundle to its own self-hosted channel
-`pr-<number>`, so a `tester` switches to it on a store/TestFlight build via the switcher above — no
-per-tester build. Workflow: `.github/workflows/mobile-ota-preview.yml` (sweep:
+`pr-<number>`, which any user can switch to on a store/TestFlight build via the "Try a preview" switcher
+above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.yml` (sweep:
 `mobile-ota-preview-sweep.yml`).
 
 - **Fingerprint parity.** The publish keeps `EXPO_UPDATES_CHANNEL=production` (so the runtimeVersion

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -54,6 +54,7 @@ import { integrationQueries } from './integrations/queries';
 import { integrationMutations } from './integrations/mutations';
 import { betaLinkQueries } from './beta-videos/queries';
 import { instagramBetaImportQueries } from './beta-videos/instagram-beta-import';
+import { otaQueries } from './ota/queries';
 import { isNoMatchClimb, isNoMatch } from './shared/helpers';
 
 export const resolvers = {
@@ -90,6 +91,7 @@ export const resolvers = {
     ...instagramBetaImportQueries,
     ...boardPresenceResolvers.Query,
     ...integrationQueries,
+    ...otaQueries,
   },
 
   Mutation: {

--- a/packages/backend/src/graphql/resolvers/ota/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ota/queries.ts
@@ -1,0 +1,20 @@
+import type { OtaPreviewChannel } from '@boardsesh/shared-schema';
+import { logger } from '../../../utils/logger';
+import { getLivePreviewChannels } from '../../../lib/ota-preview-channels';
+
+export const otaQueries = {
+  /**
+   * Live per-PR OTA preview channels for the in-app channel switcher. Public —
+   * no auth. Fail-soft: any GitHub error returns [] so the screen shows an empty
+   * state rather than erroring (the source is a best-effort convenience, not
+   * load-bearing data).
+   */
+  otaPreviewChannels: async (): Promise<OtaPreviewChannel[]> => {
+    try {
+      return await getLivePreviewChannels();
+    } catch (error) {
+      logger.warn(`[ota] otaPreviewChannels failed: ${String(error)}`);
+      return [];
+    }
+  },
+};

--- a/packages/backend/src/lib/__tests__/ota-preview-channels.test.ts
+++ b/packages/backend/src/lib/__tests__/ota-preview-channels.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLivePreviewChannels,
+  parsePreviewPrNumber,
+  type GitHubDeployment,
+  type GitHubOpenPullRequest,
+} from '../ota-preview-channels';
+
+describe('parsePreviewPrNumber', () => {
+  it('extracts the PR number from the workflow deployment description', () => {
+    expect(parsePreviewPrNumber('OTA preview pr-3253')).toBe(3253);
+  });
+
+  it('returns null for a description without a pr-<n> channel', () => {
+    expect(parsePreviewPrNumber('OTA preview production')).toBeNull();
+    expect(parsePreviewPrNumber(null)).toBeNull();
+    expect(parsePreviewPrNumber(undefined)).toBeNull();
+  });
+});
+
+describe('buildLivePreviewChannels', () => {
+  const openPr = (number: number, title: string): GitHubOpenPullRequest => ({
+    number,
+    title,
+    html_url: `https://github.com/boardsesh/boardsesh/pull/${number}`,
+  });
+  const deployment = (prNumber: number): GitHubDeployment => ({ description: `OTA preview pr-${prNumber}` });
+
+  it('returns only open PRs that have a published preview deployment, newest first', () => {
+    const deployments = [deployment(10), deployment(20), deployment(5)];
+    const openPullRequests = [openPr(20, 'Twenty'), openPr(10, 'Ten'), openPr(99, 'No preview yet')];
+
+    expect(buildLivePreviewChannels(deployments, openPullRequests)).toEqual([
+      { channel: 'pr-20', prNumber: 20, title: 'Twenty', url: 'https://github.com/boardsesh/boardsesh/pull/20' },
+      { channel: 'pr-10', prNumber: 10, title: 'Ten', url: 'https://github.com/boardsesh/boardsesh/pull/10' },
+    ]);
+  });
+
+  it('excludes channels whose PR is no longer open (channel torn down on close)', () => {
+    // PR 5 had a preview but is closed → not in the open list → excluded.
+    const result = buildLivePreviewChannels([deployment(5)], [openPr(10, 'Ten')]);
+    expect(result).toEqual([]);
+  });
+
+  it('ignores non-preview deployments and dedups repeated publishes', () => {
+    const deployments = [{ description: 'OTA preview production' }, deployment(10), deployment(10)];
+    const result = buildLivePreviewChannels(deployments, [openPr(10, 'Ten')]);
+    expect(result).toHaveLength(1);
+    expect(result[0].channel).toBe('pr-10');
+  });
+
+  it('returns an empty list when nothing has been deployed', () => {
+    expect(buildLivePreviewChannels([], [openPr(10, 'Ten')])).toEqual([]);
+  });
+});

--- a/packages/backend/src/lib/__tests__/ota-preview-channels.test.ts
+++ b/packages/backend/src/lib/__tests__/ota-preview-channels.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildLivePreviewChannels,
   parsePreviewPrNumber,
+  getLivePreviewChannels,
+  resetLivePreviewChannelsCache,
   type GitHubDeployment,
   type GitHubOpenPullRequest,
 } from '../ota-preview-channels';
@@ -51,5 +53,60 @@ describe('buildLivePreviewChannels', () => {
 
   it('returns an empty list when nothing has been deployed', () => {
     expect(buildLivePreviewChannels([], [openPr(10, 'Ten')])).toEqual([]);
+  });
+});
+
+describe('getLivePreviewChannels (cache + network)', () => {
+  beforeEach(() => resetLivePreviewChannelsCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  // Returns deployments for the deployments URL, open PRs for the pulls URL.
+  const mockGitHubOk = (deployments: unknown, pulls: unknown) =>
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+      const body = url.includes('/deployments') ? deployments : pulls;
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+
+  const sample = {
+    deployments: [{ description: 'OTA preview pr-7' }],
+    pulls: [{ number: 7, title: 'Seven', html_url: 'https://github.com/boardsesh/boardsesh/pull/7' }],
+  };
+
+  it('fetches, builds, and serves from cache within the TTL (one refill)', async () => {
+    const fetchSpy = mockGitHubOk(sample.deployments, sample.pulls);
+
+    const first = await getLivePreviewChannels(0);
+    expect(first).toEqual([
+      { channel: 'pr-7', prNumber: 7, title: 'Seven', url: 'https://github.com/boardsesh/boardsesh/pull/7' },
+    ]);
+
+    // Within the TTL → served from cache, no new fetch.
+    const second = await getLivePreviewChannels(1_000);
+    expect(second).toBe(first);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // one refill = deployments + pulls
+  });
+
+  it('refetches once the cache TTL elapses', async () => {
+    const fetchSpy = mockGitHubOk(sample.deployments, sample.pulls);
+    await getLivePreviewChannels(0);
+    await getLivePreviewChannels(3 * 60 * 1000 + 1); // past CACHE_TTL_MS
+    expect(fetchSpy).toHaveBeenCalledTimes(4); // two refills
+  });
+
+  it('negative-caches [] on error so a burst does not re-hit GitHub', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('rate limited', { status: 403 }));
+
+    await expect(getLivePreviewChannels(0)).rejects.toThrow();
+    // Within the (shorter) error TTL → cached [], no further fetches.
+    await expect(getLivePreviewChannels(1_000)).resolves.toEqual([]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // only the first refill attempt
+  });
+
+  it('de-dupes concurrent refills onto a single fetch', async () => {
+    const fetchSpy = mockGitHubOk(sample.deployments, sample.pulls);
+    const [a, b] = await Promise.all([getLivePreviewChannels(0), getLivePreviewChannels(0)]);
+    expect(a).toEqual(b);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // one shared refill, not two
   });
 });

--- a/packages/backend/src/lib/ota-preview-channels.ts
+++ b/packages/backend/src/lib/ota-preview-channels.ts
@@ -13,12 +13,18 @@
 // under GitHub's rate limits with just two API calls per refill.
 
 import type { OtaPreviewChannel } from '@boardsesh/shared-schema';
+import { logger } from '../utils/logger';
 
 const GITHUB_API = 'https://api.github.com';
 // owner/repo to read previews from. Overridable for forks/self-hosting.
 const REPO = process.env.OTA_PREVIEW_REPO ?? 'boardsesh/boardsesh';
 const PREVIEW_ENVIRONMENT = 'pr-preview';
+const PAGE_SIZE = 100;
 const CACHE_TTL_MS = 3 * 60 * 1000;
+// Brief negative cache so a GitHub error (e.g. a 403 rate-limit) can't amplify
+// into a request storm — callers serve [] from cache until this elapses, then
+// one refill retries.
+const ERROR_CACHE_TTL_MS = 30 * 1000;
 
 // The deployment description the workflow sets is `OTA preview pr-<n>`; match
 // the channel anywhere in it so a wording tweak doesn't silently break parsing.
@@ -76,27 +82,57 @@ async function githubGet<T>(path: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-let cache: { at: number; data: OtaPreviewChannel[] } | null = null;
+type ChannelCache = { at: number; data: OtaPreviewChannel[]; isError: boolean };
+let cache: ChannelCache | null = null;
+// De-dupes concurrent refills (cold start / just-expired) onto a single fetch so
+// a burst can't fan out into parallel GitHub calls.
+let inFlight: Promise<OtaPreviewChannel[]> | null = null;
 
 /**
- * Live preview channels, cached for {@link CACHE_TTL_MS}. Two GitHub calls per
- * refill regardless of how many channels exist. The caller is responsible for
- * fail-soft behaviour (the resolver returns [] on throw).
+ * Live preview channels, cached for {@link CACHE_TTL_MS} (or {@link
+ * ERROR_CACHE_TTL_MS} after a failure). Two GitHub calls per refill regardless
+ * of how many channels exist. The caller is responsible for fail-soft behaviour
+ * (the resolver returns [] on throw).
  */
 export async function getLivePreviewChannels(now: number = Date.now()): Promise<OtaPreviewChannel[]> {
-  if (cache && now - cache.at < CACHE_TTL_MS) return cache.data;
+  const ttl = cache?.isError ? ERROR_CACHE_TTL_MS : CACHE_TTL_MS;
+  if (cache && now - cache.at < ttl) return cache.data;
+  if (inFlight) return inFlight;
 
-  const [deployments, openPullRequests] = await Promise.all([
-    githubGet<GitHubDeployment[]>(`/repos/${REPO}/deployments?environment=${PREVIEW_ENVIRONMENT}&per_page=100`),
-    githubGet<GitHubOpenPullRequest[]>(`/repos/${REPO}/pulls?state=open&per_page=100`),
-  ]);
+  inFlight = (async () => {
+    try {
+      const [deployments, openPullRequests] = await Promise.all([
+        githubGet<GitHubDeployment[]>(
+          `/repos/${REPO}/deployments?environment=${PREVIEW_ENVIRONMENT}&per_page=${PAGE_SIZE}`,
+        ),
+        githubGet<GitHubOpenPullRequest[]>(`/repos/${REPO}/pulls?state=open&per_page=${PAGE_SIZE}`),
+      ]);
+      // Deployments accumulate over time (closed PRs are marked inactive, not
+      // deleted), so a single page can eventually overflow — surface it rather
+      // than silently dropping older-but-still-open previews.
+      if (deployments.length === PAGE_SIZE || openPullRequests.length === PAGE_SIZE) {
+        logger.warn(
+          `[ota] preview channel source hit the ${PAGE_SIZE}-item page cap; some live channels may be missing`,
+        );
+      }
+      const data = buildLivePreviewChannels(deployments, openPullRequests);
+      cache = { at: now, data, isError: false };
+      return data;
+    } catch (error) {
+      // Negative-cache [] briefly so repeated calls don't re-hit a rate-limited
+      // GitHub; recovers after ERROR_CACHE_TTL_MS. Rethrow so the resolver logs.
+      cache = { at: now, data: [], isError: true };
+      throw error;
+    } finally {
+      inFlight = null;
+    }
+  })();
 
-  const data = buildLivePreviewChannels(deployments, openPullRequests);
-  cache = { at: now, data };
-  return data;
+  return inFlight;
 }
 
 /** Test-only: reset the module cache between cases. */
 export function resetLivePreviewChannelsCache(): void {
   cache = null;
+  inFlight = null;
 }

--- a/packages/backend/src/lib/ota-preview-channels.ts
+++ b/packages/backend/src/lib/ota-preview-channels.ts
@@ -1,0 +1,102 @@
+// Lists the live per-PR OTA preview channels (`pr-<number>`) so the mobile app
+// can show them by PR title in the in-app channel switcher. See
+// docs/mobile-ota-updates.md.
+//
+// Source of truth = the GitHub "pr-preview" Deployments the
+// .github/workflows/mobile-ota-preview.yml workflow writes (one per publish,
+// described `OTA preview pr-<n>`). Intersecting those with the still-open PRs
+// gives the channels that are actually live: closing a PR tears its channel
+// down, so an open PR with a published preview is the precise "live" signal.
+//
+// The pure builder (buildLivePreviewChannels) is unit-tested; the fetch wrapper
+// caches the result so a single backend funnelling every client stays well
+// under GitHub's rate limits with just two API calls per refill.
+
+import type { OtaPreviewChannel } from '@boardsesh/shared-schema';
+
+const GITHUB_API = 'https://api.github.com';
+// owner/repo to read previews from. Overridable for forks/self-hosting.
+const REPO = process.env.OTA_PREVIEW_REPO ?? 'boardsesh/boardsesh';
+const PREVIEW_ENVIRONMENT = 'pr-preview';
+const CACHE_TTL_MS = 3 * 60 * 1000;
+
+// The deployment description the workflow sets is `OTA preview pr-<n>`; match
+// the channel anywhere in it so a wording tweak doesn't silently break parsing.
+const CHANNEL_PATTERN = /\bpr-(\d+)\b/;
+
+export type GitHubDeployment = { description: string | null };
+export type GitHubOpenPullRequest = { number: number; title: string; html_url: string };
+
+/** Extract the PR number from a `pr-preview` deployment description, or null. */
+export function parsePreviewPrNumber(description: string | null | undefined): number | null {
+  const match = description ? CHANNEL_PATTERN.exec(description) : null;
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * A channel is live when its PR is still open (closing tears the channel down)
+ * AND a `pr-preview` deployment was published for it. Newest PR first.
+ */
+export function buildLivePreviewChannels(
+  deployments: GitHubDeployment[],
+  openPullRequests: GitHubOpenPullRequest[],
+): OtaPreviewChannel[] {
+  const deployedPrNumbers = new Set<number>();
+  for (const deployment of deployments) {
+    const prNumber = parsePreviewPrNumber(deployment.description);
+    if (prNumber != null) deployedPrNumbers.add(prNumber);
+  }
+
+  return openPullRequests
+    .filter((pullRequest) => deployedPrNumbers.has(pullRequest.number))
+    .sort((first, second) => second.number - first.number)
+    .map((pullRequest) => ({
+      channel: `pr-${pullRequest.number}`,
+      prNumber: pullRequest.number,
+      title: pullRequest.title,
+      url: pullRequest.html_url,
+    }));
+}
+
+async function githubGet<T>(path: string): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'boardsesh-backend',
+  };
+  // Optional — unauthenticated works on the public repo (the two-call shape +
+  // cache keeps us under the 60/hr anon ceiling); a token raises it to 5000/hr.
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(`${GITHUB_API}${path}`, { headers });
+  if (!response.ok) {
+    throw new Error(`GitHub ${path} responded ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+let cache: { at: number; data: OtaPreviewChannel[] } | null = null;
+
+/**
+ * Live preview channels, cached for {@link CACHE_TTL_MS}. Two GitHub calls per
+ * refill regardless of how many channels exist. The caller is responsible for
+ * fail-soft behaviour (the resolver returns [] on throw).
+ */
+export async function getLivePreviewChannels(now: number = Date.now()): Promise<OtaPreviewChannel[]> {
+  if (cache && now - cache.at < CACHE_TTL_MS) return cache.data;
+
+  const [deployments, openPullRequests] = await Promise.all([
+    githubGet<GitHubDeployment[]>(`/repos/${REPO}/deployments?environment=${PREVIEW_ENVIRONMENT}&per_page=100`),
+    githubGet<GitHubOpenPullRequest[]>(`/repos/${REPO}/pulls?state=open&per_page=100`),
+  ]);
+
+  const data = buildLivePreviewChannels(deployments, openPullRequests);
+  cache = { at: now, data };
+  return data;
+}
+
+/** Test-only: reset the module cache between cases. */
+export function resetLivePreviewChannelsCache(): void {
+  cache = null;
+}

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -23,8 +23,7 @@ export default function ProfileLayout() {
       {/* i18n-ignore-next-line — preview-only screen */}
       <Stack.Screen name="branch-switcher" options={{ title: 'Branch Switcher' }} />
       <Stack.Screen name="dev-servers" options={{ title: t('mobile.more.metroServersTitle') }} />
-      {/* i18n-ignore-next-line — tester-only screen */}
-      <Stack.Screen name="channel-switcher" options={{ title: 'OTA Channel Switcher' }} />
+      <Stack.Screen name="channel-switcher" options={{ title: t('mobile.previewChannels.screenTitle') }} />
       {/* i18n-ignore-next-line — tester-only screen */}
       <Stack.Screen name="feature-flags" options={{ title: 'Feature Flags' }} />
       <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -23,7 +23,6 @@ export default function ProfileLayout() {
       {/* i18n-ignore-next-line — preview-only screen */}
       <Stack.Screen name="branch-switcher" options={{ title: 'Branch Switcher' }} />
       <Stack.Screen name="dev-servers" options={{ title: t('mobile.more.metroServersTitle') }} />
-      <Stack.Screen name="channel-switcher" options={{ title: t('mobile.previewChannels.screenTitle') }} />
       {/* i18n-ignore-next-line — tester-only screen */}
       <Stack.Screen name="feature-flags" options={{ title: 'Feature Flags' }} />
       <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />

--- a/packages/mobile/app/(tabs)/profile/channel-switcher.tsx
+++ b/packages/mobile/app/(tabs)/profile/channel-switcher.tsx
@@ -1,5 +1,0 @@
-import { ChannelSwitcherScreen } from '../../../src/components/ChannelSwitcherScreen';
-
-export default function ChannelSwitcherRoute() {
-  return <ChannelSwitcherScreen />;
-}

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useState } from 'react';
 import { router, useFocusEffect } from 'expo-router';
-import * as Updates from 'expo-updates';
 import { Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
@@ -51,11 +50,6 @@ export default function MoreScreen() {
   const { showToast } = useToast();
   const stravaEnabled = useFeatureFlag('strava-integration') === true;
 
-  // The OTA channel switcher relies on expo-updates runtime overrides, which only
-  // work on real (non-dev) builds where updates are enabled. Gated on the tester
-  // flag so only admin-marked testers see it.
-  const showChannelSwitcher = Boolean(profile?.isTester) && !__DEV__ && Updates.isEnabled;
-
   // Live Metro dev-server switching needs expo-dev-client's native launcher, which
   // is only linked into dev-client / Debug builds — never the App Store / TestFlight
   // binary (where it would throw "Dev launcher unavailable"). Show the row only where
@@ -67,10 +61,10 @@ export default function MoreScreen() {
   // wherever the dev section is allowed — for testers and in dev.
   const showFeatureFlags = __DEV__ || Boolean(profile?.isTester);
 
-  // Don't render an empty "Development" section header when no tool applies
-  // (e.g. a tester on a release build with updates disabled).
-  const showDevSection =
-    (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showChannelSwitcher || showFeatureFlags);
+  // Don't render an empty "Development" section header when no tool applies.
+  // (The OTA channel switcher moved to an everyone-facing "Try a preview" entry
+  // on the changelog screen, so it's no longer listed here.)
+  const showDevSection = (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showFeatureFlags);
 
   // Whether the bundled changelog has an entry the user hasn't opened yet — drives
   // the "New" pill on the What's New row. Re-read every time this screen regains
@@ -333,20 +327,8 @@ export default function MoreScreen() {
                 subtitle={t('mobile.more.metroServersSubtitle')}
                 leading={<Icon name="server" size={22} color={systemColors.secondaryLabel} />}
                 showChevron
-                showSeparator={showChannelSwitcher || showFeatureFlags}
-                onPress={() => router.push('/(tabs)/profile/dev-servers')}
-              />
-            ) : null}
-            {showChannelSwitcher ? (
-              <ListRow
-                // i18n-ignore-next-line — tester-only dev tooling
-                title="OTA Channel Switcher"
-                // i18n-ignore-next-line
-                subtitle="Switch Expo update channel"
-                leading={<Icon name="transfer" size={22} color={systemColors.secondaryLabel} />}
-                showChevron
                 showSeparator={showFeatureFlags}
-                onPress={() => router.push('/(tabs)/profile/channel-switcher')}
+                onPress={() => router.push('/(tabs)/profile/dev-servers')}
               />
             ) : null}
             {showFeatureFlags ? (

--- a/packages/mobile/app/changelog.tsx
+++ b/packages/mobile/app/changelog.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Stack } from 'expo-router';
+import { router, Stack } from 'expo-router';
 import { Alert, Platform, StyleSheet, View } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useTranslation } from 'react-i18next';
@@ -222,6 +222,25 @@ const CheckForUpdatesButton = memo(function CheckForUpdatesButton() {
   );
 });
 
+// Visible entry into the per-PR preview channel switcher — open to everyone, not
+// just testers. Shown only on real OTA builds where switching actually works
+// (overrides are inert in dev / Expo Go), the same gate as Check-for-updates, so
+// it never appears where it can't function.
+const TryPreviewButton = memo(function TryPreviewButton() {
+  const { t } = useTranslation('common');
+  if (__DEV__ || !Updates.isEnabled) return null;
+  return (
+    <Button
+      title={t('mobile.previewChannels.entryTitle')}
+      onPress={() => router.push('/(tabs)/profile/channel-switcher')}
+      variant="text"
+      size="small"
+      icon="branch"
+      style={styles.checkButton}
+    />
+  );
+});
+
 const keyExtractor = (item: TimelineItem) => (isNativeRelease(item) ? `native-${item.sha}` : `pr-${item.prNumber}`);
 
 export default function ChangelogScreen() {
@@ -263,6 +282,7 @@ export default function ChangelogScreen() {
           <View style={styles.emptyWrap}>
             <CurrentBuildChip />
             <CheckForUpdatesButton />
+            <TryPreviewButton />
             <Text variant="body" color={systemColors.secondaryLabel} style={styles.emptyText}>
               {t('mobile.changelog.empty')}
             </Text>
@@ -288,6 +308,7 @@ export default function ChangelogScreen() {
                 <View style={styles.headerMeta}>
                   <CurrentBuildChip />
                   <CheckForUpdatesButton />
+                  <TryPreviewButton />
                 </View>
               </View>
             }

--- a/packages/mobile/app/changelog.tsx
+++ b/packages/mobile/app/changelog.tsx
@@ -232,7 +232,7 @@ const TryPreviewButton = memo(function TryPreviewButton() {
   return (
     <Button
       title={t('mobile.previewChannels.entryTitle')}
-      onPress={() => router.push('/(tabs)/profile/channel-switcher')}
+      onPress={() => router.push('/channel-switcher')}
       variant="text"
       size="small"
       icon="branch"

--- a/packages/mobile/app/channel-switcher.tsx
+++ b/packages/mobile/app/channel-switcher.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { ChannelSwitcherScreen } from '../src/components/ChannelSwitcherScreen';
+import { useStackScreenOptions } from '../src/hooks/use-stack-screen-options';
+
+// Root-level route (sibling of changelog.tsx, where the "Try a preview" entry
+// lives) rather than a profile-tab screen, so pushing it from the changelog
+// stays in the same stack and gets a native header back button. Sets its own
+// header (the root Stack defaults to headerShown: false), mirroring changelog.
+export default function ChannelSwitcherRoute() {
+  const { t } = useTranslation('common');
+  const screenOptions = useStackScreenOptions();
+  return (
+    <>
+      <Stack.Screen options={{ ...screenOptions, title: t('mobile.previewChannels.screenTitle'), headerShown: true }} />
+      <ChannelSwitcherScreen />
+    </>
+  );
+}

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -304,24 +304,6 @@ export function ChannelSwitcherScreen() {
 
       {updatesUsable ? (
         <>
-          {/* Always offered (not gated on `override`) so a native override stranded
-              after an app-data clear — when the display mirror is gone — stays
-              clearable. Available to everyone so a user can always get back to the
-              shipped version. */}
-          <Pressable
-            onPress={() => void resetToBuildChannel()}
-            disabled={isSwitching}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.previewChannels.reset', { channel: buildChannel })}
-            accessibilityState={{ disabled: isSwitching }}
-            style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: isSwitching ? 0.5 : 1 }]}
-          >
-            <Icon name="refresh" size={16} color={systemColors.label} />
-            <Text variant="footnote" color={systemColors.label}>
-              {t('mobile.previewChannels.reset', { channel: buildChannel })}
-            </Text>
-          </Pressable>
-
           {isTester ? (
             <>
               {/* i18n-ignore-next-line — tester-only dev tooling */}
@@ -349,21 +331,34 @@ export function ChannelSwitcherScreen() {
                   );
                 })}
               </View>
+            </>
+          ) : null}
 
-              {/* i18n-ignore-next-line — tester-only dev tooling */}
-              <SectionHeader title="Custom Channel (tester)" />
+          {/* Manual channel entry: always for testers, and as a fallback for
+              everyone when the preview list fails to load — so a user is never
+              stranded without a way to switch. */}
+          {isTester || previewQuery.isError ? (
+            <>
+              <SectionHeader title={t('mobile.previewChannels.manualSection')} />
+              {previewQuery.isError ? (
+                <Text
+                  variant="footnote"
+                  color={systemColors.secondaryLabel}
+                  style={[styles.intro, { marginHorizontal: spacing[4] }]}
+                >
+                  {t('mobile.previewChannels.manualHint')}
+                </Text>
+              ) : null}
               <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
                 <TextInput
                   value={customChannel}
                   onChangeText={setCustomChannel}
-                  // i18n-ignore-next-line — tester-only screen
-                  placeholder="channel name"
+                  placeholder={t('mobile.previewChannels.manualPlaceholder')}
                   placeholderTextColor={systemColors.secondaryLabel}
                   autoCapitalize="none"
                   autoCorrect={false}
                   editable={!isSwitching}
-                  // i18n-ignore-next-line — tester-only screen
-                  accessibilityLabel="Custom OTA channel name"
+                  accessibilityLabel={t('mobile.previewChannels.manualInputA11y')}
                   style={[
                     styles.input,
                     {
@@ -380,8 +375,7 @@ export function ChannelSwitcherScreen() {
                   }}
                   disabled={isSwitching || customChannel.trim().length === 0}
                   accessibilityRole="button"
-                  // i18n-ignore-next-line — tester-only screen
-                  accessibilityLabel="Switch to the entered channel"
+                  accessibilityLabel={t('mobile.previewChannels.manualSwitchA11y')}
                   accessibilityState={{ disabled: isSwitching || customChannel.trim().length === 0 }}
                   style={[
                     styles.goButton,
@@ -394,13 +388,29 @@ export function ChannelSwitcherScreen() {
                 >
                   <Icon name="transfer" size={16} color={systemColors.label} />
                   <Text variant="footnote" color={systemColors.label}>
-                    {/* i18n-ignore-next-line — tester-only screen */}
-                    Switch
+                    {t('mobile.previewChannels.confirmSwitchConfirm')}
                   </Text>
                 </Pressable>
               </View>
             </>
           ) : null}
+
+          {/* Reset — available to everyone, kept last as the escape hatch back to
+              the shipped version. Not gated on `override` so a native override
+              stranded after an app-data clear stays clearable. */}
+          <Pressable
+            onPress={() => void resetToBuildChannel()}
+            disabled={isSwitching}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.previewChannels.reset', { channel: buildChannel })}
+            accessibilityState={{ disabled: isSwitching }}
+            style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: isSwitching ? 0.5 : 1 }]}
+          >
+            <Icon name="refresh" size={16} color={systemColors.label} />
+            <Text variant="footnote" color={systemColors.label}>
+              {t('mobile.previewChannels.reset', { channel: buildChannel })}
+            </Text>
+          </Pressable>
         </>
       ) : null}
 

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -1,8 +1,10 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { View, ScrollView, ActivityIndicator, Alert, Pressable, StyleSheet, TextInput } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import * as Updates from 'expo-updates';
 import { reportError, reportHandledError } from '../lib/error-reporting';
 import { isSentryEnabled, nativeSentryCrash } from '../lib/sentry';
+import { useOtaPreviewChannels, useProfile } from '../lib/graphql/hooks';
 import { Text } from './Text';
 import { SectionHeader } from './SectionHeader';
 import { ListRow } from './ListRow';
@@ -22,8 +24,19 @@ import {
 } from '../lib/channel-switch';
 
 export function ChannelSwitcherScreen() {
+  const { t } = useTranslation('common');
   const { systemColors, brandColors, spacing, borderRadius } = useTheme();
   const confirm = useConfirm();
+  const { data: profile } = useProfile();
+  // Live per-PR preview channels (with titles) from the backend. Public query —
+  // works for signed-out users too. Fail-soft: the backend returns [] on error,
+  // so isError is rare; we still handle it for completeness.
+  const previewQuery = useOtaPreviewChannels();
+  const previewChannels = previewQuery.data ?? [];
+  // The full developer tools (raw preset/custom channel entry, Sentry crash
+  // tests) stay tester-only; everyone else gets the friendly preview list.
+  const isTester = Boolean(profile?.isTester);
+
   const [override, setOverride] = useState<string | null>(null);
   const [customChannel, setCustomChannel] = useState('');
   const [switchingChannel, setSwitchingChannel] = useState<string | null>(null);
@@ -72,22 +85,20 @@ export function ChannelSwitcherScreen() {
     [],
   );
 
+  // `label` is the human-friendly name shown in the confirm/alert copy (a PR
+  // title for preview rows; the raw channel for the tester preset/custom rows).
   const switchToChannel = useCallback(
-    async (channel: string) => {
+    async (channel: string, label: string = channel) => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       const previousOverride = overrideRef.current;
       try {
         hapticLight();
         const confirmed = await confirm({
-          // i18n-ignore-next-line — tester-only screen
-          title: 'Switch OTA channel',
-          // i18n-ignore-next-line — tester-only screen
-          message: `Pull the latest update from "${channel}" and restart? It must have an update published for this build's fingerprint.`,
-          // i18n-ignore-next-line — tester-only screen
-          confirmLabel: 'Switch',
-          // i18n-ignore-next-line — tester-only screen
-          cancelLabel: 'Cancel',
+          title: t('mobile.previewChannels.confirmSwitchTitle'),
+          message: t('mobile.previewChannels.confirmSwitchMessage', { label }),
+          confirmLabel: t('mobile.previewChannels.confirmSwitchConfirm'),
+          cancelLabel: t('mobile.previewChannels.cancel'),
         });
         if (!confirmed) return;
 
@@ -96,18 +107,17 @@ export function ChannelSwitcherScreen() {
         if (result.status === 'reverted') {
           hapticError();
           Alert.alert(
-            // i18n-ignore-next-line — tester-only screen
-            'Switch failed',
-            result.error instanceof Error
-              ? result.error.message
-              : 'Could not switch channel. This build may not support channel overrides.',
+            t('mobile.previewChannels.switchFailedTitle'),
+            result.error instanceof Error ? result.error.message : t('mobile.previewChannels.switchFailedFallback'),
           );
         } else {
           // 'switched' (the app reloads) or 'pending-restart' — reflect the new channel.
           setOverride(channel);
           if (result.status === 'pending-restart') {
-            // i18n-ignore-next-line — tester-only screen
-            Alert.alert('Restart to finish', `Downloaded "${channel}". Restart the app to switch onto it.`);
+            Alert.alert(
+              t('mobile.previewChannels.restartTitle'),
+              t('mobile.previewChannels.restartSwitchMessage', { label }),
+            );
           }
         }
       } finally {
@@ -115,7 +125,7 @@ export function ChannelSwitcherScreen() {
         inFlightRef.current = false;
       }
     },
-    [confirm, runtimeVersion, makeDeps],
+    [confirm, runtimeVersion, makeDeps, t],
   );
 
   const resetToBuildChannel = useCallback(async () => {
@@ -125,14 +135,10 @@ export function ChannelSwitcherScreen() {
     try {
       hapticLight();
       const confirmed = await confirm({
-        // i18n-ignore-next-line — tester-only screen
-        title: 'Reset to build channel',
-        // i18n-ignore-next-line — tester-only screen
-        message: `Clear the override and return to "${buildChannel}"? The app will restart.`,
-        // i18n-ignore-next-line — tester-only screen
-        confirmLabel: 'Reset',
-        // i18n-ignore-next-line — tester-only screen
-        cancelLabel: 'Cancel',
+        title: t('mobile.previewChannels.confirmResetTitle', { channel: buildChannel }),
+        message: t('mobile.previewChannels.confirmResetMessage', { channel: buildChannel }),
+        confirmLabel: t('mobile.previewChannels.confirmResetConfirm'),
+        cancelLabel: t('mobile.previewChannels.cancel'),
       });
       if (!confirmed) return;
 
@@ -143,21 +149,26 @@ export function ChannelSwitcherScreen() {
         // The override was re-applied on the failed reset, so the build is still on the
         // previous channel (or the build channel if there was no override). Say so.
         const stayedOn = previousOverride ?? buildChannel;
-        const reason = result.error instanceof Error ? result.error.message : 'Could not reset channel.';
-        // i18n-ignore-next-line — tester-only screen
-        Alert.alert('Reset failed', `${reason} Stayed on "${stayedOn}".`);
+        const reason =
+          result.error instanceof Error ? result.error.message : t('mobile.previewChannels.resetFailedReason');
+        Alert.alert(
+          t('mobile.previewChannels.resetFailedTitle'),
+          t('mobile.previewChannels.resetFailedMessage', { reason, channel: stayedOn }),
+        );
       } else {
         setOverride(null);
         if (result.status === 'pending-restart') {
-          // i18n-ignore-next-line — tester-only screen
-          Alert.alert('Restart to finish', `Cleared the override. Restart the app to return to "${buildChannel}".`);
+          Alert.alert(
+            t('mobile.previewChannels.restartTitle'),
+            t('mobile.previewChannels.restartResetMessage', { channel: buildChannel }),
+          );
         }
       }
     } finally {
       setSwitchingChannel(null);
       inFlightRef.current = false;
     }
-  }, [confirm, buildChannel, makeDeps]);
+  }, [confirm, buildChannel, makeDeps, t]);
 
   // --- Sentry verification (tester-only) ---
   // Sentry never sends from a dev / Metro build (gated on !__DEV__), so the only
@@ -205,182 +216,225 @@ export function ChannelSwitcherScreen() {
     nativeSentryCrash();
   }, [confirm]);
 
-  const channels = buildChannelList(override);
+  const presetChannels = buildChannelList(override);
+
+  const cardStyle = [
+    styles.card,
+    {
+      backgroundColor: systemColors.secondaryBackground,
+      borderRadius: borderRadius.lg,
+      marginHorizontal: spacing[4],
+    },
+  ];
 
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
-      {/* i18n-ignore-next-line — tester-only screen */}
-      <SectionHeader title="Current Update" />
-      <View
-        style={[
-          styles.card,
-          {
-            backgroundColor: systemColors.secondaryBackground,
-            borderRadius: borderRadius.lg,
-            marginHorizontal: spacing[4],
-          },
-        ]}
-      >
-        {/* i18n-ignore-next-line — tester-only screen */}
-        <InfoRow label="Build channel" value={buildChannel} />
-        {/* i18n-ignore-next-line — tester-only screen */}
-        <InfoRow label="Selected channel" value={override ?? `${buildChannel} (default)`} />
-        {/* i18n-ignore-next-line — tester-only screen */}
-        <InfoRow label="Runtime version" value={runtimeVersion} showSeparator={false} />
+      <SectionHeader title={t('mobile.previewChannels.currentSection')} />
+      <View style={cardStyle}>
+        <InfoRow label={t('mobile.previewChannels.buildChannelLabel')} value={buildChannel} />
+        <InfoRow
+          label={t('mobile.previewChannels.selectedChannelLabel')}
+          value={override ?? t('mobile.previewChannels.defaultValue', { channel: buildChannel })}
+        />
+        <InfoRow label={t('mobile.previewChannels.runtimeVersionLabel')} value={runtimeVersion} showSeparator={false} />
       </View>
 
       {!updatesUsable ? (
         <View style={[styles.notice, { marginHorizontal: spacing[4] }]}>
           <Text variant="footnote" color={systemColors.secondaryLabel}>
-            {/* i18n-ignore-next-line — tester-only screen */}
-            OTA updates are disabled in this build (development or updates not enabled), so channel switching is
-            unavailable here. Use a TestFlight/store build.
+            {t('mobile.previewChannels.unavailableNotice')}
           </Text>
         </View>
-      ) : (
+      ) : null}
+
+      {/* Friendly per-PR preview list — shown to everyone. Rows are inert when
+          switching is unavailable (dev / Expo Go) but still render so the list
+          can be reviewed and screenshotted. */}
+      <SectionHeader title={t('mobile.previewChannels.listSection')} />
+      <Text
+        variant="footnote"
+        color={systemColors.secondaryLabel}
+        style={[styles.intro, { marginHorizontal: spacing[4] }]}
+      >
+        {t('mobile.previewChannels.intro')}
+      </Text>
+      <View style={cardStyle}>
+        {previewQuery.isLoading ? (
+          <View style={styles.statusRow}>
+            <ActivityIndicator size="small" />
+            <Text variant="footnote" color={systemColors.secondaryLabel}>
+              {t('mobile.previewChannels.loading')}
+            </Text>
+          </View>
+        ) : previewQuery.isError ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.statusText}>
+            {t('mobile.previewChannels.error')}
+          </Text>
+        ) : previewChannels.length === 0 ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.statusText}>
+            {t('mobile.previewChannels.empty')}
+          </Text>
+        ) : (
+          previewChannels.map((preview, index) => {
+            const isActive = preview.channel === activeChannel;
+            const isThisSwitching = switchingChannel === preview.channel;
+            const isDisabled = isSwitching && !isThisSwitching;
+            const trailing = isThisSwitching ? (
+              <ActivityIndicator size="small" />
+            ) : isActive ? (
+              <Icon name="check.small" size={20} color={systemColors.label} />
+            ) : updatesUsable ? (
+              <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+            ) : null;
+            const pressable = updatesUsable && !isActive && !isDisabled;
+            return (
+              <ListRow
+                key={preview.channel}
+                title={preview.title}
+                subtitle={preview.channel}
+                trailing={trailing}
+                onPress={pressable ? () => void switchToChannel(preview.channel, preview.title) : undefined}
+                showSeparator={index < previewChannels.length - 1}
+                style={isDisabled ? styles.disabledRow : undefined}
+              />
+            );
+          })
+        )}
+      </View>
+
+      {updatesUsable ? (
         <>
-          {/* i18n-ignore-next-line — tester-only screen */}
-          <SectionHeader title="Switch Channel" />
-          <View
-            style={[
-              styles.card,
-              {
-                backgroundColor: systemColors.secondaryBackground,
-                borderRadius: borderRadius.lg,
-                marginHorizontal: spacing[4],
-              },
-            ]}
-          >
-            {channels.map((channel, index) => {
-              const isActive = channel === activeChannel;
-              const isThisSwitching = switchingChannel === channel;
-              const isDisabled = isSwitching && !isThisSwitching;
-              const trailing = isThisSwitching ? (
-                <ActivityIndicator size="small" />
-              ) : isActive ? (
-                <Icon name="check.small" size={20} color={systemColors.label} />
-              ) : null;
-
-              return (
-                <ListRow
-                  key={channel}
-                  title={channel}
-                  trailing={trailing}
-                  onPress={isActive || isDisabled ? undefined : () => void switchToChannel(channel)}
-                  showSeparator={index < channels.length - 1}
-                  style={isDisabled ? styles.disabledRow : undefined}
-                />
-              );
-            })}
-          </View>
-
-          {/* i18n-ignore-next-line — tester-only screen */}
-          <SectionHeader title="Custom Channel" />
-          <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
-            <TextInput
-              value={customChannel}
-              onChangeText={setCustomChannel}
-              // i18n-ignore-next-line — tester-only screen
-              placeholder="channel name"
-              placeholderTextColor={systemColors.secondaryLabel}
-              autoCapitalize="none"
-              autoCorrect={false}
-              editable={!isSwitching}
-              // i18n-ignore-next-line — tester-only screen
-              accessibilityLabel="Custom OTA channel name"
-              style={[
-                styles.input,
-                {
-                  color: systemColors.label,
-                  backgroundColor: systemColors.secondaryBackground,
-                  borderRadius: borderRadius.md,
-                },
-              ]}
-            />
-            <Pressable
-              onPress={() => {
-                const trimmed = customChannel.trim();
-                if (trimmed) void switchToChannel(trimmed);
-              }}
-              disabled={isSwitching || customChannel.trim().length === 0}
-              accessibilityRole="button"
-              // i18n-ignore-next-line — tester-only screen
-              accessibilityLabel="Switch to the entered channel"
-              accessibilityState={{ disabled: isSwitching || customChannel.trim().length === 0 }}
-              style={[
-                styles.goButton,
-                {
-                  backgroundColor: systemColors.tertiaryBackground,
-                  borderRadius: borderRadius.md,
-                  opacity: isSwitching || customChannel.trim().length === 0 ? 0.5 : 1,
-                },
-              ]}
-            >
-              <Icon name="transfer" size={16} color={systemColors.label} />
-              <Text variant="footnote" color={systemColors.label}>
-                {/* i18n-ignore-next-line — tester-only screen */}
-                Switch
-              </Text>
-            </Pressable>
-          </View>
-
           {/* Always offered (not gated on `override`) so a native override stranded
               after an app-data clear — when the display mirror is gone — stays
-              clearable. */}
+              clearable. Available to everyone so a user can always get back to the
+              shipped version. */}
           <Pressable
             onPress={() => void resetToBuildChannel()}
             disabled={isSwitching}
             accessibilityRole="button"
-            // i18n-ignore-next-line — tester-only screen
-            accessibilityLabel="Reset to build channel"
+            accessibilityLabel={t('mobile.previewChannels.reset', { channel: buildChannel })}
             accessibilityState={{ disabled: isSwitching }}
             style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: isSwitching ? 0.5 : 1 }]}
           >
             <Icon name="refresh" size={16} color={systemColors.label} />
             <Text variant="footnote" color={systemColors.label}>
-              {/* i18n-ignore-next-line — tester-only screen */}
-              Reset to build channel ({buildChannel})
+              {t('mobile.previewChannels.reset', { channel: buildChannel })}
             </Text>
           </Pressable>
-        </>
-      )}
 
-      {/* i18n-ignore-next-line — tester-only screen */}
-      <SectionHeader title="Test crash reporting (Sentry)" />
-      <View
-        style={[
-          styles.card,
-          {
-            backgroundColor: systemColors.secondaryBackground,
-            borderRadius: borderRadius.lg,
-            marginHorizontal: spacing[4],
-          },
-        ]}
-      >
-        {/* i18n-ignore-next-line — tester-only screen */}
-        <InfoRow label="Sentry" value={isSentryEnabled ? 'Active' : 'Disabled in this build'} />
-        <ListRow
-          // i18n-ignore-next-line — tester-only screen
-          title="Send test event (handled)"
-          trailing={<Icon name="send" size={18} color={systemColors.secondaryLabel} />}
-          onPress={sendSentryTestEvent}
-          showSeparator
-        />
-        <ListRow
-          // i18n-ignore-next-line — tester-only screen
-          title="Throw JS exception (uncaught)"
-          trailing={<Icon name="warning" size={18} color={brandColors.warning} />}
-          onPress={throwSentryUncaught}
-          showSeparator
-        />
-        <ListRow
-          // i18n-ignore-next-line — tester-only screen
-          title="Native crash"
-          trailing={<Icon name="flame" size={18} color={brandColors.error} />}
-          onPress={() => void triggerSentryNativeCrash()}
-          showSeparator={false}
-        />
-      </View>
+          {isTester ? (
+            <>
+              {/* i18n-ignore-next-line — tester-only dev tooling */}
+              <SectionHeader title="Switch Channel (tester)" />
+              <View style={cardStyle}>
+                {presetChannels.map((channel, index) => {
+                  const isActive = channel === activeChannel;
+                  const isThisSwitching = switchingChannel === channel;
+                  const isDisabled = isSwitching && !isThisSwitching;
+                  const trailing = isThisSwitching ? (
+                    <ActivityIndicator size="small" />
+                  ) : isActive ? (
+                    <Icon name="check.small" size={20} color={systemColors.label} />
+                  ) : null;
+
+                  return (
+                    <ListRow
+                      key={channel}
+                      title={channel}
+                      trailing={trailing}
+                      onPress={isActive || isDisabled ? undefined : () => void switchToChannel(channel)}
+                      showSeparator={index < presetChannels.length - 1}
+                      style={isDisabled ? styles.disabledRow : undefined}
+                    />
+                  );
+                })}
+              </View>
+
+              {/* i18n-ignore-next-line — tester-only dev tooling */}
+              <SectionHeader title="Custom Channel (tester)" />
+              <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
+                <TextInput
+                  value={customChannel}
+                  onChangeText={setCustomChannel}
+                  // i18n-ignore-next-line — tester-only screen
+                  placeholder="channel name"
+                  placeholderTextColor={systemColors.secondaryLabel}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  editable={!isSwitching}
+                  // i18n-ignore-next-line — tester-only screen
+                  accessibilityLabel="Custom OTA channel name"
+                  style={[
+                    styles.input,
+                    {
+                      color: systemColors.label,
+                      backgroundColor: systemColors.secondaryBackground,
+                      borderRadius: borderRadius.md,
+                    },
+                  ]}
+                />
+                <Pressable
+                  onPress={() => {
+                    const trimmed = customChannel.trim();
+                    if (trimmed) void switchToChannel(trimmed);
+                  }}
+                  disabled={isSwitching || customChannel.trim().length === 0}
+                  accessibilityRole="button"
+                  // i18n-ignore-next-line — tester-only screen
+                  accessibilityLabel="Switch to the entered channel"
+                  accessibilityState={{ disabled: isSwitching || customChannel.trim().length === 0 }}
+                  style={[
+                    styles.goButton,
+                    {
+                      backgroundColor: systemColors.tertiaryBackground,
+                      borderRadius: borderRadius.md,
+                      opacity: isSwitching || customChannel.trim().length === 0 ? 0.5 : 1,
+                    },
+                  ]}
+                >
+                  <Icon name="transfer" size={16} color={systemColors.label} />
+                  <Text variant="footnote" color={systemColors.label}>
+                    {/* i18n-ignore-next-line — tester-only screen */}
+                    Switch
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          ) : null}
+        </>
+      ) : null}
+
+      {isTester ? (
+        <>
+          {/* i18n-ignore-next-line — tester-only screen */}
+          <SectionHeader title="Test crash reporting (Sentry)" />
+          <View style={cardStyle}>
+            {/* i18n-ignore-next-line — tester-only screen */}
+            <InfoRow label="Sentry" value={isSentryEnabled ? 'Active' : 'Disabled in this build'} />
+            <ListRow
+              // i18n-ignore-next-line — tester-only screen
+              title="Send test event (handled)"
+              trailing={<Icon name="send" size={18} color={systemColors.secondaryLabel} />}
+              onPress={sendSentryTestEvent}
+              showSeparator
+            />
+            <ListRow
+              // i18n-ignore-next-line — tester-only screen
+              title="Throw JS exception (uncaught)"
+              trailing={<Icon name="warning" size={18} color={brandColors.warning} />}
+              onPress={throwSentryUncaught}
+              showSeparator
+            />
+            <ListRow
+              // i18n-ignore-next-line — tester-only screen
+              title="Native crash"
+              trailing={<Icon name="flame" size={18} color={brandColors.error} />}
+              onPress={() => void triggerSentryNativeCrash()}
+              showSeparator={false}
+            />
+          </View>
+        </>
+      ) : null}
 
       <View style={styles.bottomSpacer} />
     </ScrollView>
@@ -394,6 +448,19 @@ const styles = StyleSheet.create({
   },
   notice: {
     paddingVertical: 16,
+  },
+  intro: {
+    marginBottom: 8,
+    lineHeight: 18,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  statusText: {
+    paddingVertical: 8,
   },
   customRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -65,9 +65,11 @@ import {
   GET_CLIMB,
   GET_SESSION_SUMMARY,
   GET_SESSION_HEALTH_EXPORT,
+  GET_OTA_PREVIEW_CHANNELS,
   END_SESSION,
   TOGGLE_FAVORITE,
   type GetProfileQueryResponse,
+  type GetOtaPreviewChannelsQueryResponse,
   type UpdateProfileMutationResponse,
   type GetMyBoardsQueryResponse,
   type GetBoardQueryResponse,
@@ -101,6 +103,26 @@ export function useProfile(options?: { enabled?: boolean }) {
     queryKey: ['profile'],
     queryFn: () => getHttpClient().request<GetProfileQueryResponse>(GET_PROFILE),
     select: (data) => data.profile,
+    enabled: options?.enabled ?? true,
+  });
+}
+
+// ============================================
+// OTA Preview Channels
+// ============================================
+
+/**
+ * Live per-PR OTA preview channels (`pr-<number>`) with their PR titles, for the
+ * in-app channel switcher. Public — no auth. The backend caches and fail-soft
+ * returns [] on any GitHub error, so this never throws on the data path; the
+ * screen renders an empty state instead.
+ */
+export function useOtaPreviewChannels(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ['otaPreviewChannels'],
+    queryFn: () => getHttpClient().request<GetOtaPreviewChannelsQueryResponse>(GET_OTA_PREVIEW_CHANNELS),
+    select: (data) => data.otaPreviewChannels,
+    staleTime: 60_000,
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -25,6 +25,7 @@ import type {
   SessionGradeDistributionItem,
   SessionHealthExport,
   UserSearchConnection,
+  OtaPreviewChannel,
 } from '@boardsesh/shared-schema';
 import type { SubscriptionQueueItem } from '../queue-conversion';
 
@@ -142,6 +143,21 @@ export const GET_PROFILE = gql`
 
 export type GetProfileQueryResponse = {
   profile: UserProfile | null;
+};
+
+export const GET_OTA_PREVIEW_CHANNELS = gql`
+  query GetOtaPreviewChannels {
+    otaPreviewChannels {
+      channel
+      prNumber
+      title
+      url
+    }
+  }
+`;
+
+export type GetOtaPreviewChannelsQueryResponse = {
+  otaPreviewChannels: OtaPreviewChannel[];
 };
 
 export const UPDATE_PROFILE = gql`

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3845,6 +3845,28 @@ type IntegrationExportResult {
   error: String
 }
 
+# ============================================
+# OTA Preview Channel Types
+# ============================================
+
+"""
+A live per-PR OTA preview channel. Switching a store/TestFlight build onto one
+loads that pull request's JS bundle before it ships, with no new build. The
+list is derived from the GitHub "pr-preview" deployments the
+mobile-ota-preview workflow publishes, so only channels that are actually live
+appear. See docs/mobile-ota-updates.md.
+"""
+type OtaPreviewChannel {
+  "The OTA channel name to switch onto, e.g. \"pr-3253\"."
+  channel: String!
+  "The pull request number."
+  prNumber: Int!
+  "The pull request title, for display."
+  title: String!
+  "The pull request web URL."
+  url: String!
+}
+
 """
 Root query type for all read operations.
 """
@@ -4512,6 +4534,19 @@ type Query {
   Requires authentication.
   """
   integrations: [IntegrationStatus!]!
+
+  # ============================================
+  # OTA Preview Channel Queries (public)
+  # ============================================
+
+  """
+  Live per-PR OTA preview channels a user can switch a store/TestFlight build
+  onto to try a pull request before it ships. Public — no authentication.
+  Derived from the GitHub "pr-preview" deployments the mobile-ota-preview
+  workflow publishes, filtered to still-open PRs, newest PR first. Returns an
+  empty list when the source is unavailable.
+  """
+  otaPreviewChannels: [OtaPreviewChannel!]!
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3182,6 +3182,25 @@ export type NotificationType =
   | 'vote_on_comment'
   | 'vote_on_tick';
 
+/**
+ * A live per-PR OTA preview channel. Switching a store/TestFlight build onto one
+ * loads that pull request's JS bundle before it ships, with no new build. The
+ * list is derived from the GitHub "pr-preview" deployments the
+ * mobile-ota-preview workflow publishes, so only channels that are actually live
+ * appear. See docs/mobile-ota-updates.md.
+ */
+export type OtaPreviewChannel = {
+  __typename?: 'OtaPreviewChannel';
+  /** The OTA channel name to switch onto, e.g. "pr-3253". */
+  channel: Scalars['String']['output'];
+  /** The pull request number. */
+  prNumber: Scalars['Int']['output'];
+  /** The pull request title, for display. */
+  title: Scalars['String']['output'];
+  /** The pull request web URL. */
+  url: Scalars['String']['output'];
+};
+
 /** Analysis of whether a climb's grade is an outlier compared to adjacent angles. */
 export type OutlierAnalysis = {
   __typename?: 'OutlierAnalysis';
@@ -3706,6 +3725,14 @@ export type Query = {
   newClimbFeed: NewClimbFeedResult;
   /** Get notifications for the current user. */
   notifications: NotificationConnection;
+  /**
+   * Live per-PR OTA preview channels a user can switch a store/TestFlight build
+   * onto to try a pull request before it ships. Public — no authentication.
+   * Derived from the GitHub "pr-preview" deployments the mobile-ota-preview
+   * workflow publishes, filtered to still-open PRs, newest PR first. Returns an
+   * empty list when the source is unavailable.
+   */
+  otaPreviewChannels: Array<OtaPreviewChannel>;
   /**
    * Get a specific playlist by ID.
    * Checks ownership/access permissions.
@@ -6330,6 +6357,7 @@ export type ResolversTypes = ResolversObject<{
   NotificationConnection: ResolverTypeWrapper<NotificationConnection>;
   NotificationEvent: ResolverTypeWrapper<NotificationEvent>;
   NotificationType: NotificationType;
+  OtaPreviewChannel: ResolverTypeWrapper<OtaPreviewChannel>;
   OutlierAnalysis: ResolverTypeWrapper<OutlierAnalysis>;
   PinPlaylistInput: PinPlaylistInput;
   PlaybackStateChanged: ResolverTypeWrapper<PlaybackStateChanged>;
@@ -6614,6 +6642,7 @@ export type ResolversParentTypes = ResolversObject<{
   Notification: Notification;
   NotificationConnection: NotificationConnection;
   NotificationEvent: NotificationEvent;
+  OtaPreviewChannel: OtaPreviewChannel;
   OutlierAnalysis: OutlierAnalysis;
   PinPlaylistInput: PinPlaylistInput;
   PlaybackStateChanged: PlaybackStateChanged;
@@ -8498,6 +8527,17 @@ export type NotificationEventResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type OtaPreviewChannelResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['OtaPreviewChannel'] = ResolversParentTypes['OtaPreviewChannel'],
+> = ResolversObject<{
+  channel?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  prNumber?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type OutlierAnalysisResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['OutlierAnalysis'] = ResolversParentTypes['OutlierAnalysis'],
@@ -8990,6 +9030,7 @@ export type QueryResolvers<
     ContextType,
     Partial<QueryNotificationsArgs>
   >;
+  otaPreviewChannels?: Resolver<Array<ResolversTypes['OtaPreviewChannel']>, ParentType, ContextType>;
   playlist?: Resolver<
     Maybe<ResolversTypes['Playlist']>,
     ParentType,
@@ -10217,6 +10258,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   Notification?: NotificationResolvers<ContextType>;
   NotificationConnection?: NotificationConnectionResolvers<ContextType>;
   NotificationEvent?: NotificationEventResolvers<ContextType>;
+  OtaPreviewChannel?: OtaPreviewChannelResolvers<ContextType>;
   OutlierAnalysis?: OutlierAnalysisResolvers<ContextType>;
   PlaybackStateChanged?: PlaybackStateChangedResolvers<ContextType>;
   Playlist?: PlaylistResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/index.ts
+++ b/packages/shared-schema/src/schema/index.ts
@@ -24,6 +24,7 @@ import { controllerTypeDefs } from './controller';
 import { feedbackTypeDefs } from './feedback';
 import { betaLinksTypeDefs } from './beta-links';
 import { integrationsTypeDefs } from './integrations';
+import { otaTypeDefs } from './ota';
 
 export const typeDefs = [
   scalarTypeDefs,
@@ -45,6 +46,7 @@ export const typeDefs = [
   newClimbFeedTypeDefs,
   betaLinksTypeDefs,
   integrationsTypeDefs,
+  otaTypeDefs,
   queriesTypeDefs,
   mutationsTypeDefs,
   subscriptionsTypeDefs,

--- a/packages/shared-schema/src/schema/ota.ts
+++ b/packages/shared-schema/src/schema/ota.ts
@@ -1,0 +1,23 @@
+export const otaTypeDefs = /* GraphQL */ `
+  # ============================================
+  # OTA Preview Channel Types
+  # ============================================
+
+  """
+  A live per-PR OTA preview channel. Switching a store/TestFlight build onto one
+  loads that pull request's JS bundle before it ships, with no new build. The
+  list is derived from the GitHub "pr-preview" deployments the
+  mobile-ota-preview workflow publishes, so only channels that are actually live
+  appear. See docs/mobile-ota-updates.md.
+  """
+  type OtaPreviewChannel {
+    "The OTA channel name to switch onto, e.g. \\"pr-3253\\"."
+    channel: String!
+    "The pull request number."
+    prNumber: Int!
+    "The pull request title, for display."
+    title: String!
+    "The pull request web URL."
+    url: String!
+  }
+`;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -666,5 +666,18 @@ export const queriesTypeDefs = /* GraphQL */ `
     Requires authentication.
     """
     integrations: [IntegrationStatus!]!
+
+    # ============================================
+    # OTA Preview Channel Queries (public)
+    # ============================================
+
+    """
+    Live per-PR OTA preview channels a user can switch a store/TestFlight build
+    onto to try a pull request before it ships. Public — no authentication.
+    Derived from the GitHub "pr-preview" deployments the mobile-ota-preview
+    workflow publishes, filtered to still-open PRs, newest PR first. Returns an
+    empty list when the source is unavailable.
+    """
+    otaPreviewChannels: [OtaPreviewChannel!]!
   }
 `;

--- a/packages/shared-schema/src/types/index.ts
+++ b/packages/shared-schema/src/types/index.ts
@@ -23,3 +23,4 @@ export * from './device-logging';
 export * from './feedback';
 export * from './integrations';
 export * from './instagram-beta-import';
+export * from './ota';

--- a/packages/shared-schema/src/types/ota.ts
+++ b/packages/shared-schema/src/types/ota.ts
@@ -1,0 +1,16 @@
+// Over-the-air (OTA) preview channel types. A per-PR `pr-<number>` channel lets
+// a user switch a store/TestFlight build onto a pull request's JS bundle before
+// it ships — see docs/mobile-ota-updates.md. The list is derived from the
+// GitHub `pr-preview` deployments the mobile-ota-preview workflow publishes, so
+// only channels that are actually live appear.
+
+export type OtaPreviewChannel = {
+  // The OTA channel name to switch onto, e.g. "pr-3253".
+  channel: string;
+  // The pull request number.
+  prNumber: number;
+  // The pull request title, for display.
+  title: string;
+  // The pull request web URL.
+  url: string;
+};

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3179,6 +3179,25 @@ export type NotificationType =
   | 'vote_on_comment'
   | 'vote_on_tick';
 
+/**
+ * A live per-PR OTA preview channel. Switching a store/TestFlight build onto one
+ * loads that pull request's JS bundle before it ships, with no new build. The
+ * list is derived from the GitHub "pr-preview" deployments the
+ * mobile-ota-preview workflow publishes, so only channels that are actually live
+ * appear. See docs/mobile-ota-updates.md.
+ */
+export type OtaPreviewChannel = {
+  __typename?: 'OtaPreviewChannel';
+  /** The OTA channel name to switch onto, e.g. "pr-3253". */
+  channel: Scalars['String']['output'];
+  /** The pull request number. */
+  prNumber: Scalars['Int']['output'];
+  /** The pull request title, for display. */
+  title: Scalars['String']['output'];
+  /** The pull request web URL. */
+  url: Scalars['String']['output'];
+};
+
 /** Analysis of whether a climb's grade is an outlier compared to adjacent angles. */
 export type OutlierAnalysis = {
   __typename?: 'OutlierAnalysis';
@@ -3703,6 +3722,14 @@ export type Query = {
   newClimbFeed: NewClimbFeedResult;
   /** Get notifications for the current user. */
   notifications: NotificationConnection;
+  /**
+   * Live per-PR OTA preview channels a user can switch a store/TestFlight build
+   * onto to try a pull request before it ships. Public — no authentication.
+   * Derived from the GitHub "pr-preview" deployments the mobile-ota-preview
+   * workflow publishes, filtered to still-open PRs, newest PR first. Returns an
+   * empty list when the source is unavailable.
+   */
+  otaPreviewChannels: Array<OtaPreviewChannel>;
   /**
    * Get a specific playlist by ID.
    * Checks ownership/access permissions.

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -269,7 +269,12 @@
       "restartResetMessage": "Cleared the preview. Restart the app to return to “{{channel}}”.",
       "resetFailedTitle": "Couldn't reset",
       "resetFailedReason": "Could not reset.",
-      "resetFailedMessage": "{{reason}} Stayed on “{{channel}}”."
+      "resetFailedMessage": "{{reason}} Stayed on “{{channel}}”.",
+      "manualSection": "Enter a channel manually",
+      "manualHint": "Couldn't load the preview list. Enter a channel name (like pr-1234) to switch manually.",
+      "manualPlaceholder": "channel name",
+      "manualInputA11y": "Channel name to switch to",
+      "manualSwitchA11y": "Switch to the entered channel"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -239,6 +239,37 @@
         "title": "Couldn't check for updates",
         "message": "Something went wrong getting the latest version. Try again in a bit."
       }
+    },
+    "previewChannels": {
+      "screenTitle": "App previews",
+      "entryTitle": "Try a preview",
+      "intro": "Load an upcoming pull request to try it before it ships. Switching restarts the app onto that version; reset to go back.",
+      "currentSection": "Current version",
+      "buildChannelLabel": "Build channel",
+      "selectedChannelLabel": "Selected channel",
+      "defaultValue": "{{channel}} (default)",
+      "runtimeVersionLabel": "Runtime version",
+      "unavailableNotice": "Previews need a TestFlight or App Store build, so switching is off here.",
+      "listSection": "Available previews",
+      "loading": "Loading previews…",
+      "empty": "No previews up for testing right now. Check back soon.",
+      "error": "Couldn't load previews. Try again in a bit.",
+      "reset": "Reset to {{channel}}",
+      "confirmSwitchTitle": "Switch to this preview?",
+      "confirmSwitchMessage": "Load “{{label}}” and restart? It needs a preview published for your app version.",
+      "confirmSwitchConfirm": "Switch",
+      "cancel": "Cancel",
+      "confirmResetTitle": "Back to {{channel}}?",
+      "confirmResetMessage": "Leave the preview and return to “{{channel}}”? The app will restart.",
+      "confirmResetConfirm": "Reset",
+      "switchFailedTitle": "Couldn't switch",
+      "switchFailedFallback": "Could not switch. This build may not support previews.",
+      "restartTitle": "Restart to finish",
+      "restartSwitchMessage": "Downloaded “{{label}}”. Restart the app to switch onto it.",
+      "restartResetMessage": "Cleared the preview. Restart the app to return to “{{channel}}”.",
+      "resetFailedTitle": "Couldn't reset",
+      "resetFailedReason": "Could not reset.",
+      "resetFailedMessage": "{{reason}} Stayed on “{{channel}}”."
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -467,7 +467,12 @@
       "restartResetMessage": "Se quitó la versión de prueba. Reinicia la app para volver a «{{channel}}».",
       "resetFailedTitle": "No se pudo restablecer",
       "resetFailedReason": "No se pudo restablecer.",
-      "resetFailedMessage": "{{reason}} Se quedó en «{{channel}}»."
+      "resetFailedMessage": "{{reason}} Se quedó en «{{channel}}».",
+      "manualSection": "Introduce un canal manualmente",
+      "manualHint": "No se pudo cargar la lista de versiones de prueba. Introduce un nombre de canal (como pr-1234) para cambiar manualmente.",
+      "manualPlaceholder": "nombre del canal",
+      "manualInputA11y": "Nombre del canal al que cambiar",
+      "manualSwitchA11y": "Cambiar al canal introducido"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -437,6 +437,37 @@
         "title": "No se pudo buscar actualizaciones",
         "message": "Algo salió mal al obtener la última versión. Inténtalo de nuevo en un rato."
       }
+    },
+    "previewChannels": {
+      "screenTitle": "Versiones de prueba",
+      "entryTitle": "Prueba una versión previa",
+      "intro": "Carga una propuesta de cambios para probarla antes de que se publique. Al cambiar, la app se reinicia en esa versión; restablece para volver.",
+      "currentSection": "Versión actual",
+      "buildChannelLabel": "Canal de compilación",
+      "selectedChannelLabel": "Canal seleccionado",
+      "defaultValue": "{{channel}} (predeterminado)",
+      "runtimeVersionLabel": "Versión de ejecución",
+      "unavailableNotice": "Las versiones de prueba requieren una compilación de TestFlight o de la App Store, así que aquí el cambio está desactivado.",
+      "listSection": "Versiones de prueba disponibles",
+      "loading": "Cargando versiones de prueba…",
+      "empty": "No hay versiones de prueba ahora mismo. Vuelve pronto.",
+      "error": "No se pudieron cargar las versiones de prueba. Inténtalo de nuevo en un rato.",
+      "reset": "Restablecer a {{channel}}",
+      "confirmSwitchTitle": "¿Cambiar a esta versión de prueba?",
+      "confirmSwitchMessage": "¿Cargar «{{label}}» y reiniciar? Necesita una versión de prueba publicada para tu versión de la app.",
+      "confirmSwitchConfirm": "Cambiar",
+      "cancel": "Cancelar",
+      "confirmResetTitle": "¿Volver a {{channel}}?",
+      "confirmResetMessage": "¿Salir de la versión de prueba y volver a «{{channel}}»? La app se reiniciará.",
+      "confirmResetConfirm": "Restablecer",
+      "switchFailedTitle": "No se pudo cambiar",
+      "switchFailedFallback": "No se pudo cambiar. Puede que esta compilación no admita versiones de prueba.",
+      "restartTitle": "Reinicia para terminar",
+      "restartSwitchMessage": "Se descargó «{{label}}». Reinicia la app para cambiar a ella.",
+      "restartResetMessage": "Se quitó la versión de prueba. Reinicia la app para volver a «{{channel}}».",
+      "resetFailedTitle": "No se pudo restablecer",
+      "resetFailedReason": "No se pudo restablecer.",
+      "resetFailedMessage": "{{reason}} Se quedó en «{{channel}}»."
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -239,6 +239,37 @@
         "title": "Impossible de rechercher des mises à jour",
         "message": "Une erreur s'est produite lors de la récupération de la dernière version. Réessayez dans un instant."
       }
+    },
+    "previewChannels": {
+      "screenTitle": "Versions d’essai",
+      "entryTitle": "Essayer une préversion",
+      "intro": "Chargez une demande de modifications pour l’essayer avant sa publication. Le changement redémarre l’app sur cette version ; réinitialisez pour revenir.",
+      "currentSection": "Version actuelle",
+      "buildChannelLabel": "Canal de build",
+      "selectedChannelLabel": "Canal sélectionné",
+      "defaultValue": "{{channel}} (par défaut)",
+      "runtimeVersionLabel": "Version d’exécution",
+      "unavailableNotice": "Les préversions nécessitent un build TestFlight ou App Store ; le changement est donc désactivé ici.",
+      "listSection": "Préversions disponibles",
+      "loading": "Chargement des préversions…",
+      "empty": "Aucune préversion à tester pour le moment. Revenez bientôt.",
+      "error": "Impossible de charger les préversions. Réessayez dans un instant.",
+      "reset": "Réinitialiser sur {{channel}}",
+      "confirmSwitchTitle": "Passer à cette préversion ?",
+      "confirmSwitchMessage": "Charger « {{label}} » et redémarrer ? Une préversion doit être publiée pour votre version de l’app.",
+      "confirmSwitchConfirm": "Changer",
+      "cancel": "Annuler",
+      "confirmResetTitle": "Revenir à {{channel}} ?",
+      "confirmResetMessage": "Quitter la préversion et revenir à « {{channel}} » ? L’app redémarrera.",
+      "confirmResetConfirm": "Réinitialiser",
+      "switchFailedTitle": "Échec du changement",
+      "switchFailedFallback": "Impossible de changer. Ce build ne prend peut-être pas en charge les préversions.",
+      "restartTitle": "Redémarrez pour terminer",
+      "restartSwitchMessage": "« {{label}} » téléchargée. Redémarrez l’app pour y basculer.",
+      "restartResetMessage": "Préversion retirée. Redémarrez l’app pour revenir à « {{channel}} ».",
+      "resetFailedTitle": "Échec de la réinitialisation",
+      "resetFailedReason": "Impossible de réinitialiser.",
+      "resetFailedMessage": "{{reason}} Resté sur « {{channel}} »."
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -269,7 +269,12 @@
       "restartResetMessage": "Préversion retirée. Redémarrez l’app pour revenir à « {{channel}} ».",
       "resetFailedTitle": "Échec de la réinitialisation",
       "resetFailedReason": "Impossible de réinitialiser.",
-      "resetFailedMessage": "{{reason}} Resté sur « {{channel}} »."
+      "resetFailedMessage": "{{reason}} Resté sur « {{channel}} ».",
+      "manualSection": "Saisir un canal manuellement",
+      "manualHint": "Impossible de charger la liste des préversions. Saisissez un nom de canal (comme pr-1234) pour changer manuellement.",
+      "manualPlaceholder": "nom du canal",
+      "manualInputA11y": "Nom du canal vers lequel basculer",
+      "manualSwitchA11y": "Basculer vers le canal saisi"
     }
   },
   "lightControl": {


### PR DESCRIPTION
## Summary

The in-app OTA channel switcher had two friction points: it showed raw channel strings (`pr-3253`) with no idea what they were, and it was locked to the `tester` role. This opens it up.

- **PR titles, not numbers.** The switcher now lists live per-PR preview channels by their pull-request **title**, sourced from a new public backend query.
- **Open to everyone.** Reachable from a visible **"Try a preview"** entry on the **What's New** screen (next to *Check for updates*), not buried under tester-only Development tooling.
- **Reset stays easy.** Anyone can jump back to the shipped version with one tap.

### How it works

- **Backend** (`packages/backend`, `packages/shared-schema`): new **public** `otaPreviewChannels` GraphQL query. It derives the live channels from the GitHub `pr-preview` deployments the `mobile-ota-preview` workflow already writes, intersected with still-open PRs (closing a PR tears its channel down). Two cached GitHub calls per refill, fail-soft to `[]` so the screen never errors. Optional `GITHUB_TOKEN` backend env raises the rate-limit ceiling (works unauthenticated on the public repo).
- **Mobile** (`packages/mobile`): `useOtaPreviewChannels` hook + reshaped `ChannelSwitcherScreen`. Everyone sees the preview list + reset; the raw preset/custom-channel entry and the Sentry crash-test tools stay **tester-only**. All now-user-facing strings are translated across en/es/fr. The tester-only More → Development row was removed.

### App Store note

- **2.5.2 (downloaded code):** not implicated — these are our own code-signed bundles of the same app (ordinary OTA).
- **2.3.1 (hidden features):** intentionally avoided a hidden long-press gesture in favour of a **visible, labeled** entry, so there's nothing undocumented to disclose in App Review notes.

## Release Notes

- Curious what's coming? Open What's New and tap **Try a preview** to load an upcoming change before it ships — then reset to jump back to the shipped version anytime.

## Test plan

- `vp run typecheck:backend`, `vp run typecheck:mobile` — green.
- `vp run test:mobile` (2773 passed), backend unit test for the new builder (`ota-preview-channels.test.ts`, 6 passed), i18n `catalog-completeness` (parity green).
- `vp run check:mobile-bundle` — OK (12.7 MB).
- `vp check` on changed files — 0 errors.
- **Manual (follow-up on a real build):** the live switch only works on a TestFlight/store build (`Updates.isEnabled`); the preview list + PR titles render and are screenshot-able in dev against a local backend (`EXPO_PUBLIC_BACKEND_URL`). End-to-end switch needs a live `pr-<n>` channel published at the build's fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011smTuU94FvESL3HmxCdHSb