### PR TITLE
fix(mobile): guard last-used-grade load against unmount

### DIFF
--- a/packages/mobile/src/hooks/use-last-used-grade.ts
+++ b/packages/mobile/src/hooks/use-last-used-grade.ts
@@ -11,9 +11,13 @@ export function useLastUsedGrade() {
   const [lastUsedGrade, setLastUsedGradeState] = useState<number | undefined>(undefined);
 
   useEffect(() => {
+    let active = true;
     void getLastUsedGradeId().then((value) => {
-      if (value !== undefined) setLastUsedGradeState(value);
+      if (active && value !== undefined) setLastUsedGradeState(value);
     });
+    return () => {
+      active = false;
+    };
   }, []);
 
   const rememberGrade = useCallback((difficultyId: number | undefined) => {


### PR DESCRIPTION
## Summary

Follow-up to #3256 (issue #3205). Addresses the one review nit that landed after that PR was merged: the `useLastUsedGrade` mount effect fires a SecureStore read with no cleanup, so if the hook unmounts before it resolves, `setState` runs on an unmounted component. React 18 doesn't throw, but the `active` guard is cleaner.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` on the changed file — clean
- Covered by the existing `useLastUsedGrade` usage in the climbs screen (mobile suite green on #3256)

🤖 Generated with [Claude Code](https://claude.com/claude-code)