### PR TITLE
feat(mobile): show playlist tags on the climb list

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -50,6 +50,7 @@ import { useBottomChromeMetrics } from '../../../src/hooks/use-bottom-chrome-met
 import { useGrades } from '../../../src/lib/graphql/hooks';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useLastUsedGrade } from '../../../src/hooks/use-last-used-grade';
+import { useClimbListPlaylistMemberships } from '../../../src/hooks/use-climb-list-playlist-memberships';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
 import { SEARCH_CLIMBS, type SearchClimbsQueryResponse } from '../../../src/lib/graphql/operations';
 import { getHttpClient } from '../../../src/lib/graphql/client';
@@ -586,6 +587,12 @@ function ClimbListInner() {
     return () => handle.cancel();
   }, [visibleClimbs, getLogbook]);
 
+  // Feed the playlist-membership store for the visible climbs so the optional
+  // third-row playlist tags can render (gated inside the hook on the user
+  // setting + auth). Memoize the uuid list so the fetch effect's dep is stable.
+  const visibleClimbUuids = useMemo(() => visibleClimbs.map((climb) => climb.uuid), [visibleClimbs]);
+  useClimbListPlaylistMemberships({ boardName, layoutId, climbUuids: visibleClimbUuids });
+
   const handleRefresh = useCallback(() => {
     isLoadingMoreRef.current = false;
     void refetch();
@@ -1066,6 +1073,7 @@ function ClimbListInner() {
         onOpenActions={openClimbActions}
         onOpenPlaylist={openAddToPlaylist}
         onAddToQueue={handleAddToQueue}
+        showPlaylistChips
       />
     ),
     [

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -21,6 +21,7 @@ import { ListRow } from '../../../src/components/ListRow';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { SegmentedControl } from '../../../src/components/SegmentedControl';
 import { SessionRecordingSwitchRow } from '../../../src/components/settings/SessionRecordingSwitchRow';
+import { PlaylistTagsSwitchRow } from '../../../src/components/settings/PlaylistTagsSwitchRow';
 import { isPreviewBuild } from '../../../src/lib/preview-build';
 import { isDevLauncherAvailable } from '../../../src/lib/dev-launcher';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
@@ -227,6 +228,16 @@ export default function MoreScreen() {
           <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
             {t('mobile.more.gradeFormat.description')}
           </Text>
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <SectionHeader title={t('mobile.more.displayOptions.title')} />
+        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
+          <PlaylistTagsSwitchRow
+            label={t('mobile.more.displayOptions.playlistTags')}
+            description={t('mobile.more.displayOptions.playlistTagsDescription')}
+          />
         </View>
       </View>
 

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -11,6 +11,7 @@ import { useAscentStatus } from '../hooks/use-ascent-status';
 import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
+import { ClimbPlaylistChips } from './ClimbPlaylistChips';
 import type { IconName } from './icon-map';
 import type { AscentStatusValue } from '../lib/ascent-status-utils';
 
@@ -78,6 +79,14 @@ type ClimbListItemContentProps = {
    * their own). Marks it with the `people` glyph so it's clear it's the crowd's.
    */
   gradeIsConsensus?: boolean;
+  /**
+   * Render the third row of playlist-membership tags under the subtitle. Opt-in
+   * per surface (default off) so only the main filtered climb list shows them —
+   * the queue, session, and logbook rows that also reuse this visual stay clean.
+   * The chips additionally gate on the user's "Show playlist tags" setting and on
+   * fetched membership data, so passing `true` alone doesn't force them on.
+   */
+  showPlaylistChips?: boolean;
 };
 
 /**
@@ -138,6 +147,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   primarySubtitleOverride,
   consensusGrade,
   gradeIsConsensus = false,
+  showPlaylistChips = false,
 }: ClimbListItemContentProps) {
   const { t } = useTranslation('climbs');
   const { formatGrade } = useGradeFormat();
@@ -216,6 +226,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             {subtitleDetailText}
           </Text>
         ) : null}
+        {showPlaylistChips ? <ClimbPlaylistChips climbUuid={climb.uuid} /> : null}
       </View>
 
       {/* Right: ascent-status glyph + colorized grade — the two scan keys together */}

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -175,6 +175,12 @@ type ClimbListRowProps = {
   contentRowStyle?: StyleProp<ViewStyle>;
   separatorStyle?: StyleProp<ViewStyle>;
   showSeparator?: boolean;
+  /**
+   * Show the playlist-membership tag row in the default content layout. Only the
+   * main filtered climb list opts in; the chips still gate on the user setting +
+   * fetched data. Ignored when `renderContent` supplies a custom layout.
+   */
+  showPlaylistChips?: boolean;
 };
 
 const ClimbListRow = React.memo(function ClimbListRow({
@@ -195,6 +201,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   contentRowStyle,
   separatorStyle,
   showSeparator = true,
+  showPlaylistChips = false,
 }: ClimbListRowProps) {
   const { systemColors, brandColors: brand } = useTheme();
   // Active-row highlight colours, derived from the scheme-aware brand so the wash
@@ -367,6 +374,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
       sizeId={sizeId}
       setIds={setIds}
       angle={angle}
+      showPlaylistChips={showPlaylistChips}
     />
   );
 

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -1,0 +1,161 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
+import { Text } from './Text';
+import { useTheme } from '../providers/theme-provider';
+import { usePlaylistsContextOptional } from '../providers/playlists-provider';
+import { useClimbPlaylistMemberships } from '../hooks/use-climb-playlist-memberships';
+import { useShowPlaylistTagsPreference } from '../lib/show-playlist-tags-preference';
+import { isValidHexColor, PLAYLIST_COLORS } from './playlist/playlist-colors';
+import { resolvePlaylistEmojiIcon } from './playlist/playlist-icon';
+import { spacing, borderRadius } from '../theme/tokens';
+import { selectByVariant } from '../theme/variants';
+
+// A glanceable readout, not a control: show the first two playlists a climb is
+// in, then a "+N" token for the rest. The full list stays reachable through the
+// row's existing actions (swipe / long-press). No nested horizontal scroller —
+// it would fight the row's left/right swipe gestures and cost per-row on
+// FlashList recycle (HIG + M3 design review both rejected it).
+const MAX_VISIBLE_CHIPS = 2;
+// Lowest-priority line in the row, so cap its growth under accessibility text
+// sizes rather than letting it push the row taller than the board thumbnail.
+const CHIP_MAX_FONT_SCALE = 1.3;
+
+type ResolvedChip = { key: string; name: string; dotColor: string; emoji: string | null };
+
+/**
+ * Third row of a climb list item: small playlist-membership tags. Isolated and
+ * `React.memo`'d over the primitive `climbUuid` (mirrors `AscentStatusGlyph`) so
+ * a membership change re-renders only this strip — never the thumbnail, name, or
+ * grade. Subscribes to its own climb's membership via `useClimbPlaylistMemberships`
+ * and resolves names/colours from the playlists provider's `playlistsById` map.
+ *
+ * Renders nothing when: the user setting is off, no provider is mounted (e.g. a
+ * preview/test host), the climb is in no playlists, or memberships haven't loaded
+ * yet. Display-only — hidden from the accessibility tree and `pointerEvents="none"`
+ * so the whole row stays one clean target (membership management lives in the
+ * actions sheet).
+ */
+export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climbUuid }: { climbUuid: string }) {
+  const { enabled } = useShowPlaylistTagsPreference();
+  const membership = useClimbPlaylistMemberships(climbUuid);
+  const playlistsContext = usePlaylistsContextOptional();
+  const { variant, systemColors, m3 } = useTheme();
+
+  const playlistsById = playlistsContext?.playlistsById;
+
+  const chips = useMemo<ResolvedChip[]>(() => {
+    if (!playlistsById || membership.size === 0) return [];
+    const resolved: ResolvedChip[] = [];
+    let index = 0;
+    for (const playlistUuid of membership) {
+      const playlist = playlistsById.get(playlistUuid);
+      if (!playlist) continue;
+      const dotColor =
+        playlist.color && isValidHexColor(playlist.color)
+          ? playlist.color
+          : PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
+      resolved.push({
+        key: playlistUuid,
+        name: playlist.name,
+        dotColor,
+        emoji: resolvePlaylistEmojiIcon(playlist.icon),
+      });
+      index += 1;
+    }
+    return resolved;
+  }, [membership, playlistsById]);
+
+  if (!enabled || chips.length === 0) return null;
+
+  const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
+  const overflowCount = chips.length - visibleChips.length;
+
+  // Quiet neutral container + a small leading colour dot — the name carries the
+  // meaning, the dot is redundant colour identity (degrades gracefully when a
+  // playlist has no colour, and stays readable for colour-blind users). Liquid
+  // Glass uses a capsule on the system fill; Material uses an 8dp M3 chip on
+  // surfaceVariant, kept distinct from the app's capsule filter pills.
+  const containerColor = selectByVariant(variant, { liquidGlass: systemColors.fill, material: m3.surfaceVariant });
+  const labelColor = selectByVariant(variant, {
+    liquidGlass: systemColors.secondaryLabel,
+    material: m3.onSurfaceVariant,
+  });
+  const chipRadius = selectByVariant(variant, { liquidGlass: borderRadius.full, material: borderRadius.md });
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(150)}
+      style={styles.row}
+      pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      {visibleChips.map((chip) => (
+        <View key={chip.key} style={[styles.chip, { backgroundColor: containerColor, borderRadius: chipRadius }]}>
+          {chip.emoji ? (
+            <Text variant="caption1" maxFontSizeMultiplier={CHIP_MAX_FONT_SCALE} style={styles.emoji}>
+              {chip.emoji}
+            </Text>
+          ) : (
+            <View style={[styles.dot, { backgroundColor: chip.dotColor }]} />
+          )}
+          <Text
+            variant="caption1"
+            color={labelColor}
+            numberOfLines={1}
+            maxFontSizeMultiplier={CHIP_MAX_FONT_SCALE}
+            style={styles.label}
+          >
+            {chip.name}
+          </Text>
+        </View>
+      ))}
+      {overflowCount > 0 ? (
+        <View style={[styles.chip, styles.overflowChip, { backgroundColor: containerColor, borderRadius: chipRadius }]}>
+          <Text variant="caption1" color={labelColor} maxFontSizeMultiplier={CHIP_MAX_FONT_SCALE} style={styles.label}>
+            {`+${overflowCount}`}
+          </Text>
+        </View>
+      ) : null}
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    marginTop: spacing[1],
+    overflow: 'hidden',
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    minHeight: 20,
+    // Let a chip shrink so a long name ellipsizes rather than shoving the "+N"
+    // token off the row.
+    flexShrink: 1,
+  },
+  // The overflow counter never shrinks — it must always stay visible.
+  overflowChip: {
+    flexShrink: 0,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: borderRadius.full,
+    flexShrink: 0,
+  },
+  emoji: {
+    fontSize: 12,
+  },
+  label: {
+    fontWeight: '500',
+    flexShrink: 1,
+  },
+});

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
 import { Text } from './Text';
 import { useTheme } from '../providers/theme-provider';
 import { usePlaylistsContextOptional } from '../providers/playlists-provider';
@@ -83,9 +82,12 @@ export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climb
   });
   const chipRadius = selectByVariant(variant, { liquidGlass: borderRadius.full, material: borderRadius.md });
 
+  // No mount animation: FlashList recycles cells, so a recycled row scrolling
+  // back into view would replay a fade for already-known membership (a visible
+  // flash). The row height is pinned by the thumbnail, so chips appearing causes
+  // no reflow — matches `AscentStatusGlyph`, which also just appears.
   return (
-    <Animated.View
-      entering={FadeIn.duration(150)}
+    <View
       style={styles.row}
       pointerEvents="none"
       accessibilityElementsHidden
@@ -118,7 +120,7 @@ export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climb
           </Text>
         </View>
       ) : null}
-    </Animated.View>
+    </View>
   );
 });
 

--- a/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+// Controls the hooks the chips read, set per-test before render.
+const ctrl = vi.hoisted(() => ({
+  enabled: true,
+  variant: 'liquidGlass' as 'material' | 'liquidGlass',
+  membership: new Set<string>(),
+  playlistsById: undefined as Map<string, Playlist> | undefined,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-strip': 'true' }, children),
+  },
+  FadeIn: { duration: () => ({}) },
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../theme/variants', () => ({
+  selectByVariant: (variant: 'material' | 'liquidGlass', byVariant: Record<string, unknown>) => byVariant[variant],
+}));
+
+// Avoid pulling the real tokens module (it transitively loads ios-colors →
+// PlatformColor, which isn't available under jsdom).
+vi.mock('../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8 },
+  borderRadius: { md: 8, full: 9999 },
+}));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: ctrl.variant,
+    systemColors: { fill: '#222', secondaryLabel: '#aaa' },
+    m3: { surfaceVariant: '#333', onSurfaceVariant: '#ccc' },
+  }),
+}));
+
+vi.mock('../../providers/playlists-provider', () => ({
+  usePlaylistsContextOptional: () => (ctrl.playlistsById ? { playlistsById: ctrl.playlistsById } : undefined),
+}));
+
+vi.mock('../../hooks/use-climb-playlist-memberships', () => ({
+  useClimbPlaylistMemberships: () => ctrl.membership,
+}));
+
+vi.mock('../../lib/show-playlist-tags-preference', () => ({
+  useShowPlaylistTagsPreference: () => ({ enabled: ctrl.enabled, loaded: true, setEnabled: vi.fn() }),
+}));
+
+import { ClimbPlaylistChips } from '../ClimbPlaylistChips';
+
+function playlist(uuid: string, name: string, color?: string): Playlist {
+  return {
+    id: uuid,
+    uuid,
+    boardType: 'kilter',
+    layoutId: 1,
+    name,
+    isPublic: false,
+    color,
+    createdAt: '',
+    updatedAt: '',
+    climbCount: 0,
+    followerCount: 0,
+    isFollowedByMe: false,
+    isPinnedByMe: false,
+  };
+}
+
+function setMemberships(entries: Array<[string, string]>, colors: Record<string, string | undefined> = {}) {
+  ctrl.membership = new Set(entries.map(([uuid]) => uuid));
+  ctrl.playlistsById = new Map(entries.map(([uuid, name]) => [uuid, playlist(uuid, name, colors[uuid])]));
+}
+
+describe('ClimbPlaylistChips', () => {
+  beforeEach(() => {
+    ctrl.enabled = true;
+    ctrl.variant = 'liquidGlass';
+    ctrl.membership = new Set();
+    ctrl.playlistsById = new Map();
+  });
+
+  it('renders nothing when the setting is off', () => {
+    ctrl.enabled = false;
+    setMemberships([['p1', 'Project@30']]);
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders nothing when the climb is in no playlists', () => {
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.querySelector('[data-strip]')).toBeNull();
+  });
+
+  it('renders nothing when no playlists provider is mounted', () => {
+    ctrl.membership = new Set(['p1']);
+    ctrl.playlistsById = undefined;
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.querySelector('[data-strip]')).toBeNull();
+  });
+
+  it('renders a chip per membership when there are two or fewer', () => {
+    setMemberships([
+      ['p1', 'Project@30'],
+      ['p2', 'Next@25'],
+    ]);
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.textContent).toContain('Project@30');
+    expect(container.textContent).toContain('Next@25');
+    expect(container.textContent).not.toContain('+');
+  });
+
+  it('shows the first two chips and a "+N" overflow token beyond two', () => {
+    setMemberships([
+      ['p1', 'Project@30'],
+      ['p2', 'Next@25'],
+      ['p3', 'Regression@30'],
+      ['p4', 'Warmups'],
+    ]);
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.textContent).toContain('Project@30');
+    expect(container.textContent).toContain('Next@25');
+    // The 3rd and 4th collapse into the overflow counter, not their own chips.
+    expect(container.textContent).not.toContain('Regression@30');
+    expect(container.textContent).not.toContain('Warmups');
+    expect(container.textContent).toContain('+2');
+  });
+
+  it('renders on the Material variant too', () => {
+    ctrl.variant = 'material';
+    setMemberships([['p1', 'Project@30']]);
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.textContent).toContain('Project@30');
+  });
+});

--- a/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
@@ -17,13 +17,6 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
 
-vi.mock('react-native-reanimated', () => ({
-  default: {
-    View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-strip': 'true' }, children),
-  },
-  FadeIn: { duration: () => ({}) },
-}));
-
 vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
@@ -101,14 +94,14 @@ describe('ClimbPlaylistChips', () => {
 
   it('renders nothing when the climb is in no playlists', () => {
     const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
-    expect(container.querySelector('[data-strip]')).toBeNull();
+    expect(container.textContent).toBe('');
   });
 
   it('renders nothing when no playlists provider is mounted', () => {
     ctrl.membership = new Set(['p1']);
     ctrl.playlistsById = undefined;
     const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
-    expect(container.querySelector('[data-strip]')).toBeNull();
+    expect(container.textContent).toBe('');
   });
 
   it('renders a chip per membership when there are two or fewer', () => {

--- a/packages/mobile/src/components/settings/PlaylistTagsSwitchRow.tsx
+++ b/packages/mobile/src/components/settings/PlaylistTagsSwitchRow.tsx
@@ -1,0 +1,13 @@
+import { SwitchRow } from '../SwitchRow';
+import { useShowPlaylistTagsPreference } from '../../lib/show-playlist-tags-preference';
+
+type PlaylistTagsSwitchRowProps = {
+  label: string;
+  description: string;
+};
+
+export function PlaylistTagsSwitchRow({ label, description }: PlaylistTagsSwitchRowProps) {
+  const { enabled, setEnabled } = useShowPlaylistTagsPreference();
+
+  return <SwitchRow label={label} description={description} value={enabled} onValueChange={setEnabled} />;
+}

--- a/packages/mobile/src/hooks/use-climb-list-playlist-memberships.ts
+++ b/packages/mobile/src/hooks/use-climb-list-playlist-memberships.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from 'react';
+import { InteractionManager } from 'react-native';
+import {
+  GET_PLAYLISTS_FOR_CLIMBS,
+  type GetPlaylistsForClimbsQueryResponse,
+} from '@boardsesh/graphql/operations/playlists';
+import { playlistMembershipStore } from '@boardsesh/climb-actions';
+import { getHttpClient } from '../lib/graphql/client';
+import { useAuth } from '../providers/auth-provider';
+import { useShowPlaylistTagsPreference } from '../lib/show-playlist-tags-preference';
+
+// The backend caps `climbUuids` per request; chunk longer visible sets.
+const CHUNK_SIZE = 500;
+
+type UseClimbListPlaylistMembershipsArgs = {
+  boardName: string;
+  layoutId: number;
+  // Must be a referentially-stable array (memoize at the call site) — the effect
+  // depends on it, so a fresh array every render would refetch every render.
+  climbUuids: readonly string[];
+};
+
+/**
+ * Feed the shared `playlistMembershipStore` with the playlist membership of the
+ * currently-visible climbs, so `ClimbPlaylistChips` rows can render tags. The
+ * mobile analog of web's incremental `GET_PLAYLISTS_FOR_CLIMBS` fetch, written
+ * to the established "fetch the visible UUIDs, write into the external store"
+ * pattern (see the favorites note in `use-mobile-climb-actions-data.ts`).
+ *
+ * No-op unless the user enabled the setting AND is signed in. Dedupes via a ref
+ * so each climb is requested once; resets the ref and clears the store whenever
+ * the board/layout/auth/enabled context flips, so a previous board's memberships
+ * can't paint the new board's rows. Deferred past the active fling via
+ * `runAfterInteractions`, mirroring the logbook fetch.
+ */
+export function useClimbListPlaylistMemberships({
+  boardName,
+  layoutId,
+  climbUuids,
+}: UseClimbListPlaylistMembershipsArgs): void {
+  const { enabled } = useShowPlaylistTagsPreference();
+  const { isAuthenticated } = useAuth();
+
+  const fetchedRef = useRef<Set<string>>(new Set());
+  const contextKey = `${boardName}:${layoutId}:${enabled ? 1 : 0}:${isAuthenticated ? 1 : 0}`;
+  const contextKeyRef = useRef(contextKey);
+
+  // Reset before any fetch when the context changes. Runs in the same render
+  // pass via the effect ordering below (this effect is declared first).
+  useEffect(() => {
+    if (contextKeyRef.current === contextKey) return;
+    contextKeyRef.current = contextKey;
+    fetchedRef.current = new Set();
+    playlistMembershipStore.reset();
+  }, [contextKey]);
+
+  useEffect(() => {
+    if (!enabled || !isAuthenticated || layoutId <= 0 || climbUuids.length === 0) return;
+    const toFetch = climbUuids.filter((uuid) => !fetchedRef.current.has(uuid));
+    if (toFetch.length === 0) return;
+
+    let cancelled = false;
+    const handle = InteractionManager.runAfterInteractions(async () => {
+      // Mark up-front so an overlapping effect run doesn't double-request the
+      // same uuids while this batch is in flight.
+      for (const uuid of toFetch) fetchedRef.current.add(uuid);
+      try {
+        for (let offset = 0; offset < toFetch.length; offset += CHUNK_SIZE) {
+          const chunk = toFetch.slice(offset, offset + CHUNK_SIZE);
+          const response = await getHttpClient().request<GetPlaylistsForClimbsQueryResponse>(GET_PLAYLISTS_FOR_CLIMBS, {
+            input: { boardType: boardName, layoutId, climbUuids: chunk },
+          });
+          if (cancelled) return;
+          // The backend returns only climbs that ARE in a playlist; the rest stay
+          // empty (no chips), which is what we want.
+          playlistMembershipStore.setMembershipsFor(response.playlistsForClimbs);
+        }
+      } catch {
+        // A failed batch must not wedge future fetches — drop these uuids so a
+        // later scroll or refresh retries them.
+        if (!cancelled) for (const uuid of toFetch) fetchedRef.current.delete(uuid);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
+  }, [enabled, isAuthenticated, boardName, layoutId, climbUuids]);
+}

--- a/packages/mobile/src/hooks/use-climb-playlist-memberships.ts
+++ b/packages/mobile/src/hooks/use-climb-playlist-memberships.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from 'react';
+import { playlistMembershipStore } from '@boardsesh/climb-actions';
+
+/**
+ * Subscribe to a single climb's playlist membership from the shared
+ * `playlistMembershipStore`. Per-UUID subscription: a row only re-renders when
+ * its OWN climb's membership changes, never when another row's does. The store
+ * returns a reference-stable `Set` (a shared empty set until the climb is
+ * fetched / when it's in no playlists), so `useSyncExternalStore`'s `Object.is`
+ * check holds and there's no render loop.
+ */
+export function useClimbPlaylistMemberships(climbUuid: string): ReadonlySet<string> {
+  return useSyncExternalStore(playlistMembershipStore.subscribe, () =>
+    playlistMembershipStore.getMembershipsForClimb(climbUuid),
+  );
+}

--- a/packages/mobile/src/hooks/use-climb-playlist-memberships.ts
+++ b/packages/mobile/src/hooks/use-climb-playlist-memberships.ts
@@ -1,6 +1,10 @@
 import { useSyncExternalStore } from 'react';
 import { playlistMembershipStore } from '@boardsesh/climb-actions';
 
+// Stable empty snapshot for the server path. Membership is never available
+// during SSR/hydration, so a shared frozen set keeps `Object.is` happy.
+const EMPTY_MEMBERSHIPS: ReadonlySet<string> = new Set();
+
 /**
  * Subscribe to a single climb's playlist membership from the shared
  * `playlistMembershipStore`. Per-UUID subscription: a row only re-renders when
@@ -10,7 +14,9 @@ import { playlistMembershipStore } from '@boardsesh/climb-actions';
  * check holds and there's no render loop.
  */
 export function useClimbPlaylistMemberships(climbUuid: string): ReadonlySet<string> {
-  return useSyncExternalStore(playlistMembershipStore.subscribe, () =>
-    playlistMembershipStore.getMembershipsForClimb(climbUuid),
+  return useSyncExternalStore(
+    playlistMembershipStore.subscribe,
+    () => playlistMembershipStore.getMembershipsForClimb(climbUuid),
+    () => EMPTY_MEMBERSHIPS,
   );
 }

--- a/packages/mobile/src/lib/show-playlist-tags-preference.ts
+++ b/packages/mobile/src/lib/show-playlist-tags-preference.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+// Whether to show playlist-membership tags on climb list rows. Opt-in: the
+// default is OFF, so rows look unchanged until a climber turns it on from
+// More → Display. When off, the main climb list also skips the
+// per-visible-climb membership fetch entirely.
+//
+// Structure mirrors `session-recording-preference.ts`: a module-level store read
+// via `useSyncExternalStore` with a referentially-stable cached snapshot (rebuilt
+// only inside `notify()`), plus a promise-singleton one-time load so any number
+// of mounted consumers trigger the AsyncStorage read exactly once.
+const STORAGE_KEY = 'showPlaylistTagsOnClimbList';
+const DEFAULT_SHOW_PLAYLIST_TAGS = false;
+
+type ShowPlaylistTagsSnapshot = { enabled: boolean; loaded: boolean };
+
+let current = DEFAULT_SHOW_PLAYLIST_TAGS;
+let hasLoaded = false;
+let snapshot: ShowPlaylistTagsSnapshot = { enabled: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: ShowPlaylistTagsSnapshot = { enabled: DEFAULT_SHOW_PLAYLIST_TAGS, loaded: false };
+
+function notify(): void {
+  snapshot = { enabled: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+export async function loadShowPlaylistTags(): Promise<boolean> {
+  if (hasLoaded) return current;
+  const stored = await getPreference<boolean>(STORAGE_KEY);
+  // A `setShowPlaylistTagsPreference` may have raced in while we awaited storage;
+  // honour the user's choice over the (now stale) persisted value.
+  if (hasLoaded) return current;
+  // An explicit stored choice (true/false) wins; an absent value falls back to
+  // OFF so the tags are opt-in only.
+  current = typeof stored === 'boolean' ? stored : DEFAULT_SHOW_PLAYLIST_TAGS;
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+export async function setShowPlaylistTagsPreference(enabled: boolean): Promise<void> {
+  current = enabled;
+  hasLoaded = true;
+  notify();
+  await setPreference(STORAGE_KEY, enabled);
+}
+
+let loadPromise: Promise<boolean> | null = null;
+function ensureShowPlaylistTagsLoaded(): Promise<boolean> {
+  if (!loadPromise) {
+    loadPromise = loadShowPlaylistTags().catch((error: unknown) => {
+      // A failed read must not leave a rejected promise cached — clear the
+      // singleton so the next mount retries instead of staying stuck at the
+      // default until the app restarts.
+      loadPromise = null;
+      throw error;
+    });
+  }
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): ShowPlaylistTagsSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): ShowPlaylistTagsSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+export function useShowPlaylistTagsPreference(): {
+  enabled: boolean;
+  loaded: boolean;
+  setEnabled: (enabled: boolean) => void;
+} {
+  const { enabled, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    // Swallow read failures here — the load already clears its cached promise so
+    // a later mount retries; nothing to do at this call site.
+    ensureShowPlaylistTagsLoaded().catch(() => {});
+  }, []);
+
+  const setEnabled = useCallback((next: boolean) => {
+    void setShowPlaylistTagsPreference(next);
+  }, []);
+
+  return { enabled, loaded, setEnabled };
+}

--- a/packages/mobile/src/providers/playlists-provider.tsx
+++ b/packages/mobile/src/providers/playlists-provider.tsx
@@ -20,6 +20,10 @@ export type PlaylistCreateBoard = {
 
 type PlaylistsContextValue = {
   playlists: Playlist[];
+  // Memoized `uuid → Playlist` lookup so per-row consumers (e.g. the climb-list
+  // playlist chips) resolve a climb's memberships in O(membership) rather than
+  // scanning the whole `playlists` array per row.
+  playlistsById: Map<string, Playlist>;
   getPlaylistsForClimb: (climbUuid: string) => Set<string>;
   addToPlaylist: (playlistId: string, climbUuid: string, angle: number) => Promise<void>;
   removeFromPlaylist: (playlistId: string, climbUuid: string) => Promise<void>;
@@ -93,6 +97,18 @@ export function PlaylistsProvider({
     [playlistMemberships],
   );
 
+  // Keyed by both uuid and id so a membership set sourced from either identifier
+  // resolves — the backend keys playlists by `uuid`, but some call sites carry
+  // `id`. Rebuilt only when the playlists array changes (5-min staleTime).
+  const playlistsById = useMemo(() => {
+    const byId = new Map<string, Playlist>();
+    for (const playlist of playlists) {
+      byId.set(playlist.uuid, playlist);
+      byId.set(playlist.id, playlist);
+    }
+    return byId;
+  }, [playlists]);
+
   const trackedCreatePlaylist = useCallback(
     async (
       name: string,
@@ -138,6 +154,7 @@ export function PlaylistsProvider({
   const value = useMemo<PlaylistsContextValue>(
     () => ({
       playlists,
+      playlistsById,
       getPlaylistsForClimb,
       addToPlaylist: trackedAddToPlaylist,
       removeFromPlaylist: trackedRemoveFromPlaylist,
@@ -148,6 +165,7 @@ export function PlaylistsProvider({
     }),
     [
       playlists,
+      playlistsById,
       getPlaylistsForClimb,
       trackedAddToPlaylist,
       trackedRemoveFromPlaylist,
@@ -165,4 +183,12 @@ export function usePlaylistsContext(): PlaylistsContextValue {
   const ctx = useContext(PlaylistsContext);
   if (!ctx) throw new Error('usePlaylistsContext must be used within a PlaylistsProvider');
   return ctx;
+}
+
+// Non-throwing variant for components that may render OUTSIDE the provider — e.g.
+// the shared `ClimbListItemContent` (reused by queue/session/logbook rows) and
+// its optional playlist chips. Returns `undefined` when no provider is mounted so
+// those consumers can degrade to "no chips" instead of crashing.
+export function usePlaylistsContextOptional(): PlaylistsContextValue | undefined {
+  return useContext(PlaylistsContext);
 }

--- a/packages/shared/climb-actions/src/__tests__/playlist-membership-store.test.ts
+++ b/packages/shared/climb-actions/src/__tests__/playlist-membership-store.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PlaylistMembershipStore } from '../playlist-membership-store';
+
+describe('PlaylistMembershipStore', () => {
+  it('returns a reference-stable set per climb so useSyncExternalStore can compare with Object.is', () => {
+    const store = new PlaylistMembershipStore();
+    store.setMembershipsFor([{ climbUuid: 'climb-1', playlistUuids: ['p1', 'p2'] }]);
+
+    const first = store.getMembershipsForClimb('climb-1');
+    const second = store.getMembershipsForClimb('climb-1');
+    expect(first).toBe(second);
+    expect([...first].sort()).toEqual(['p1', 'p2']);
+  });
+
+  it('returns the same shared empty set for unknown climbs', () => {
+    const store = new PlaylistMembershipStore();
+    const a = store.getMembershipsForClimb('missing-a');
+    const b = store.getMembershipsForClimb('missing-b');
+    expect(a.size).toBe(0);
+    expect(a).toBe(b);
+  });
+
+  it('notifies once per batch and only when contents actually change', () => {
+    const store = new PlaylistMembershipStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.setMembershipsFor([
+      { climbUuid: 'climb-1', playlistUuids: ['p1'] },
+      { climbUuid: 'climb-2', playlistUuids: ['p2'] },
+    ]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Same contents (different array) — no notification, same set reference kept.
+    const before = store.getMembershipsForClimb('climb-1');
+    store.setMembershipsFor([{ climbUuid: 'climb-1', playlistUuids: ['p1'] }]);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.getMembershipsForClimb('climb-1')).toBe(before);
+
+    // A real change to one climb fires exactly one notification and swaps its set.
+    store.setMembershipForClimb('climb-1', ['p1', 'p3']);
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(store.getMembershipsForClimb('climb-1')).not.toBe(before);
+    expect([...store.getMembershipsForClimb('climb-1')].sort()).toEqual(['p1', 'p3']);
+  });
+
+  it('reset clears all memberships and notifies once (no-op when already empty)', () => {
+    const store = new PlaylistMembershipStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.reset();
+    expect(listener).toHaveBeenCalledTimes(0);
+
+    store.setMembershipsFor([{ climbUuid: 'climb-1', playlistUuids: ['p1'] }]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.reset();
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(store.getMembershipsForClimb('climb-1').size).toBe(0);
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const store = new PlaylistMembershipStore();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.setMembershipsFor([{ climbUuid: 'climb-1', playlistUuids: ['p1'] }]);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.setMembershipForClimb('climb-1', ['p1', 'p2']);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/climb-actions/src/index.ts
+++ b/packages/shared/climb-actions/src/index.ts
@@ -3,4 +3,9 @@
 // deduplicating). No React, no DOM, no React Native.
 
 export { FavoritesStore, favoritesStore } from './favorites-store';
+export {
+  PlaylistMembershipStore,
+  playlistMembershipStore,
+  type ClimbPlaylistMembershipEntry,
+} from './playlist-membership-store';
 export { buildInstagramCaption, getBoardDisplayName, type InstagramCaptionInput } from './instagram-caption';

--- a/packages/shared/climb-actions/src/playlist-membership-store.ts
+++ b/packages/shared/climb-actions/src/playlist-membership-store.ts
@@ -1,0 +1,87 @@
+/**
+ * External store for per-climb playlist membership, enabling per-UUID
+ * subscriptions via `useSyncExternalStore`. Sibling to `favorites-store.ts`:
+ * each climb row subscribes to only its own membership, so a batch fetch (or a
+ * single add/remove) re-renders just the rows whose membership actually changed
+ * — not the whole list.
+ *
+ * Pure class with no React or DOM coupling. The `subscribe` signature matches
+ * `useSyncExternalStore` so web and mobile can point components straight at the
+ * singleton.
+ *
+ * Reference stability is load-bearing: `getMembershipsForClimb` returns the SAME
+ * `Set` instance until that climb's contents change (and a shared frozen empty
+ * set for misses), so `useSyncExternalStore`'s `Object.is` snapshot check holds
+ * across renders and never loops.
+ */
+const EMPTY_MEMBERSHIP: ReadonlySet<string> = new Set();
+
+export type ClimbPlaylistMembershipEntry = {
+  climbUuid: string;
+  playlistUuids: readonly string[];
+};
+
+export class PlaylistMembershipStore {
+  private membershipByClimb = new Map<string, ReadonlySet<string>>();
+  private listeners = new Set<() => void>();
+
+  /** Subscribe to store changes (signature expected by useSyncExternalStore). */
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  /**
+   * Read a climb's playlist membership. Returns a reference-stable `Set` (the
+   * same instance until the climb's contents change, or a shared empty set for
+   * climbs not yet fetched / in no playlists) so a per-UUID
+   * `useSyncExternalStore(store.subscribe, () => store.getMembershipsForClimb(uuid))`
+   * compares equal with `Object.is` and only re-renders on a real change.
+   */
+  getMembershipsForClimb = (climbUuid: string): ReadonlySet<string> => {
+    return this.membershipByClimb.get(climbUuid) ?? EMPTY_MEMBERSHIP;
+  };
+
+  /**
+   * Merge a batch of fetched memberships. A climb's `Set` is replaced (and a
+   * single notification fired) only when its contents differ from what's stored,
+   * so unchanged climbs keep their reference and don't re-render.
+   */
+  setMembershipsFor(entries: Iterable<ClimbPlaylistMembershipEntry>): void {
+    let changed = false;
+    for (const { climbUuid, playlistUuids } of entries) {
+      const existing = this.membershipByClimb.get(climbUuid);
+      const next = new Set(playlistUuids);
+      if (existing && existing.size === next.size && [...next].every((id) => existing.has(id))) continue;
+      this.membershipByClimb.set(climbUuid, next);
+      changed = true;
+    }
+    if (changed) this.notify();
+  }
+
+  /** Replace a single climb's membership (e.g. after an optimistic add/remove). */
+  setMembershipForClimb(climbUuid: string, playlistUuids: readonly string[]): void {
+    this.setMembershipsFor([{ climbUuid, playlistUuids }]);
+  }
+
+  /**
+   * Drop everything. Called when the board/layout changes so memberships from
+   * the previous board can't leak onto the new board's rows. No-op (and no
+   * notification) when already empty.
+   */
+  reset(): void {
+    if (this.membershipByClimb.size === 0) return;
+    this.membershipByClimb = new Map();
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const playlistMembershipStore = new PlaylistMembershipStore();

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -107,6 +107,11 @@
         "font": "French",
         "both": "Both"
       },
+      "displayOptions": {
+        "title": "Display",
+        "playlistTags": "Show playlist tags",
+        "playlistTagsDescription": "See which playlists each climb is in, right on the list."
+      },
       "language": {
         "title": "Language",
         "system": "System",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -305,6 +305,11 @@
         "font": "Francés",
         "both": "Ambos"
       },
+      "displayOptions": {
+        "title": "Visualización",
+        "playlistTags": "Mostrar etiquetas de playlist",
+        "playlistTagsDescription": "Mira en qué playlists está cada bloque, directamente en la lista."
+      },
       "language": {
         "title": "Idioma",
         "system": "Sistema",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -107,6 +107,11 @@
         "font": "Français",
         "both": "Les deux"
       },
+      "displayOptions": {
+        "title": "Affichage",
+        "playlistTags": "Afficher les étiquettes de playlist",
+        "playlistTagsDescription": "Voyez dans quelles playlists se trouve chaque bloc, directement dans la liste."
+      },
       "language": {
         "title": "Langue",
         "system": "Système",


### PR DESCRIPTION
Closes #2375.

Climbers organise climbs into playlists ("Project@30", "Next@25", "Regression@30") but, until now, could only see a climb's playlist membership by opening the three-dot actions menu. This adds an **opt-in third row of playlist tags** to each row of the **main filtered climb list** (mobile only).

## Release Notes

See which playlists a climb is in, right from the list. Turn on **Show playlist tags** under More → Display.

## What it looks like

Up to two chips — a small colour dot + the playlist name — sit under the "sends · rating · setter" line, with a **"+N"** token when a climb is in more than two playlists.

We ran the design past an Apple HIG and a Material 3 lens (the app already ships both as the Liquid Glass and Material variants). Both independently rejected the originally-sketched horizontally-scrollable chips — a nested horizontal scroller fights the row's existing left/right swipe gestures and costs per-row on FlashList — in favour of the fixed "2 + overflow" line. Chips are a quiet neutral container + a leading colour dot (the name carries the meaning, so it degrades gracefully with no colour and stays colour-blind safe), kept subordinate to the climb name and grade. Liquid Glass = capsule on the system fill; Material = 8dp M3 chip on `surfaceVariant`.

## How it's built

- **`playlistMembershipStore`** (`@boardsesh/climb-actions`, sibling to `favoritesStore`): a `useSyncExternalStore` module store, `Map<climbUuid, Set<playlistUuid>>`, returning reference-stable sets so each row re-renders only when its own climb's membership changes.
- **Batch fetch** (`useClimbListPlaylistMemberships`): the main list fetches `GET_PLAYLISTS_FOR_CLIMBS` for visible climbs (dedup ref, chunked, deferred past the fling like the logbook fetch) and writes into the store. Resets on board/layout/auth/setting change so stale memberships can't leak across boards. No-op unless the setting is on and the user is signed in.
- **`ClimbPlaylistChips`**: isolated `React.memo` strip (mirrors `AscentStatusGlyph`) that subscribes to its own climb and resolves names/colours from a new memoised `playlistsById` map on the provider. Display-only (`pointerEvents="none"`, hidden from the a11y tree).
- **Scope guard**: rendered only via a new `showPlaylistChips` prop that just the main list passes, so the shared `ClimbListItemContent` stays clean in the queue / session / logbook rows.
- **Setting**: `show-playlist-tags-preference` (default off) + a `PlaylistTagsSwitchRow` under a new More → Display section; strings in en-US/es/fr.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 372 files / 2788 tests pass, incl. new `climb-playlist-chips` render test (off / empty / no-provider / 2 chips / 2 + "+2" / Material).
- `vp test run climb-actions` — 282 pass, incl. new `playlist-membership-store` test (reference-stable sets, per-batch notify, reset).
- `vp test run catalog-completeness` — i18n parity across locales holds.
- `vp run check:mobile-bundle` — OK (12.7 MB). `vp run check:mobile-variants` — clean (`selectByVariant`, no raw compares). `vp check` — no lint/format/type findings on changed files.
- Manual device QA pending (see `.boardsesh/qa-notes.md`): both variants, board switch, zero-membership, signed-out, long names, VoiceOver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)