### PR TITLE
feat(mobile): settings screens as native @expo/ui Forms

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { router, useFocusEffect } from 'expo-router';
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import type { ThemeOverride } from '@boardsesh/key-value-storage';
@@ -11,19 +11,16 @@ import { resolveLanguage, type LocaleOverride } from '../../../src/lib/i18n/loca
 import { openExternalUrl } from '../../../src/lib/open-url';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { useProfile } from '../../../src/lib/graphql/hooks';
-import { borderRadius, spacing } from '../../../src/theme/tokens';
+import { hapticLight, hapticSelection } from '../../../src/lib/haptics';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
-import { Icon } from '../../../src/components/Icon';
-import { Avatar } from '../../../src/components/Avatar';
-import { Text } from '../../../src/components/Text';
-import { ListRow } from '../../../src/components/ListRow';
-import { SectionHeader } from '../../../src/components/SectionHeader';
-import { SegmentedControl } from '../../../src/components/SegmentedControl';
-import { SessionRecordingSwitchRow } from '../../../src/components/settings/SessionRecordingSwitchRow';
-import { PlaylistTagsSwitchRow } from '../../../src/components/settings/PlaylistTagsSwitchRow';
+import { MoreForm } from '../../../src/components/MoreForm';
+import type { MoreButtonRow, MoreFormModel, MoreRow, MoreSection } from '../../../src/components/MoreForm.types';
 import { isPreviewBuild } from '../../../src/lib/preview-build';
 import { isDevLauncherAvailable } from '../../../src/lib/dev-launcher';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
+import { useSessionRecordingPreference } from '../../../src/lib/session-recording-preference';
+import { setSessionRecordingEnabled } from '../../../src/lib/analytics';
+import { useShowPlaylistTagsPreference } from '../../../src/lib/show-playlist-tags-preference';
 import { useToast } from '../../../src/providers/toast-provider';
 import { useFeatureFlag } from '../../../src/providers/feature-flags-provider';
 import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
@@ -36,8 +33,13 @@ import { getLastSeenChangelogDate, hasUnseenChangelog } from '../../../src/lib/c
 // exact files to edit.
 const GITHUB_LOCALES_TREE_URL = 'https://github.com/boardsesh/boardsesh/tree/main/packages/shared/i18n/locales';
 
+// The shared route screen for the "More" tab. It owns every hook, route guard, and
+// conditional (auth / tester / dev / preview-build), resolves all copy through the
+// i18n catalogs and all haptics, then builds a plain view-model and hands rendering
+// to the platform-split <MoreForm /> — a native SwiftUI Form on iOS, a Compose
+// LazyColumn on Android. The native tree renders strings + invokes handlers only.
 export default function MoreScreen() {
-  const { systemColors, brandColors, themeOverride, setThemeOverride } = useTheme();
+  const { themeOverride, setThemeOverride } = useTheme();
   const { t } = useTranslation('common');
   const { t: tProfile } = useTranslation('profile');
   const { t: tPlaylists } = useTranslation('playlists');
@@ -46,13 +48,16 @@ export default function MoreScreen() {
   const { data: profile } = useProfile();
   const { gradeFormat, setGradeFormat } = useGradeFormat();
   const { localePreference, setLocalePreference } = useLocalePreference();
+  const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
+    useSessionRecordingPreference();
+  const { enabled: showPlaylistTags, setEnabled: setShowPlaylistTags } = useShowPlaylistTagsPreference();
   const { showToast } = useToast();
   const stravaEnabled = useFeatureFlag('strava-integration') === true;
 
   // Live Metro dev-server switching needs expo-dev-client's native launcher, which
   // is only linked into dev-client / Debug builds — never the App Store / TestFlight
   // binary (where it would throw "Dev launcher unavailable"). Show the row only where
-  // it can actually work; testers on a release build get the OTA channel switcher.
+  // it can actually work.
   const showDevServerSwitcher = isDevLauncherAvailable();
 
   // Feature-flag overrides work in every build (dev forces them in place of the
@@ -129,320 +134,327 @@ export default function MoreScreen() {
     });
   };
 
+  // Wrap a navigation action with the light haptic the old ListRow fired on press.
+  const navAction = (action: () => void) => () => {
+    hapticLight();
+    action();
+  };
+
+  // Account action buttons (Sign Out / Delete Account) — destructive, no haptic,
+  // matching the old borderless red links. Shared between the signed-in and
+  // signed-out section layouts.
+  const accountActionRows: MoreButtonRow[] = [
+    {
+      kind: 'button',
+      key: 'signOut',
+      label: tProfile('mobile.signOut'),
+      role: 'destructive',
+      onPress: () => {
+        void signOut();
+      },
+    },
+    {
+      kind: 'button',
+      key: 'deleteAccount',
+      label: tSettings('deleteAccount.button'),
+      role: 'destructive',
+      onPress: () => router.push('/(tabs)/profile/delete-account'),
+    },
+  ];
+
+  const sections: MoreSection[] = [];
+
+  // Library — only when signed in (all-playlists is a profile feature).
+  if (profile?.id) {
+    sections.push({
+      key: 'library',
+      title: t('mobile.more.library'),
+      rows: [
+        {
+          kind: 'nav',
+          key: 'allPlaylists',
+          label: tPlaylists('library.allPlaylists.title'),
+          sfSymbol: 'music.note.list',
+          onPress: navAction(() => router.push('/(tabs)/discover/all')),
+        },
+      ],
+    });
+  }
+
+  // Integrations.
+  sections.push({
+    key: 'integrations',
+    title: t('mobile.more.integrations.title'),
+    rows: [
+      {
+        kind: 'nav',
+        key: 'integrations',
+        label: t('mobile.more.integrations.title'),
+        subtitle: t(
+          stravaEnabled ? 'mobile.more.integrations.subtitleWithStrava' : 'mobile.more.integrations.subtitle',
+        ),
+        sfSymbol: 'heart',
+        onPress: navAction(() => router.push('/(tabs)/profile/integrations')),
+      },
+    ],
+  });
+
+  // Appearance (segmented).
+  sections.push({
+    key: 'appearance',
+    title: t('mobile.more.appearance.title'),
+    rows: [
+      {
+        kind: 'segmented',
+        key: 'appearance',
+        label: t('mobile.more.appearance.title'),
+        options: appearanceOptions,
+        selectedKey: themeOverride,
+        onSelect: (key) => {
+          const next = appearanceOptions.find((option) => option.key === key);
+          if (next) {
+            hapticSelection();
+            void setThemeOverride(next.key);
+          }
+        },
+      },
+    ],
+  });
+
+  // Grade Format (segmented) — description as the section footer.
+  sections.push({
+    key: 'gradeFormat',
+    title: t('mobile.more.gradeFormat.title'),
+    footer: t('mobile.more.gradeFormat.description'),
+    rows: [
+      {
+        kind: 'segmented',
+        key: 'gradeFormat',
+        label: t('mobile.more.gradeFormat.title'),
+        options: gradeFormatOptions,
+        selectedKey: gradeFormat,
+        onSelect: (key) => {
+          const next = gradeFormatOptions.find((option) => option.key === key);
+          if (next) {
+            hapticSelection();
+            setGradeFormat(next.key);
+          }
+        },
+      },
+    ],
+  });
+
+  // Display options — show playlist tags toggle.
+  sections.push({
+    key: 'displayOptions',
+    title: t('mobile.more.displayOptions.title'),
+    rows: [
+      {
+        kind: 'toggle',
+        key: 'playlistTags',
+        label: t('mobile.more.displayOptions.playlistTags'),
+        subtitle: t('mobile.more.displayOptions.playlistTagsDescription'),
+        value: showPlaylistTags,
+        onValueChange: (next) => {
+          hapticSelection();
+          setShowPlaylistTags(next);
+        },
+      },
+    ],
+  });
+
+  // Accessibility (nav).
+  sections.push({
+    key: 'accessibility',
+    title: t('mobile.more.accessibility.title'),
+    rows: [
+      {
+        kind: 'nav',
+        key: 'accessibility',
+        label: t('mobile.more.accessibility.title'),
+        subtitle: t('mobile.more.accessibility.rowSubtitleShort'),
+        sfSymbol: 'accessibility',
+        onPress: navAction(() => router.push('/(tabs)/profile/accessibility')),
+      },
+    ],
+  });
+
+  // Language — a menu-style select; description as the section footer. The
+  // picker's own label carries the word "Language", so no section title.
+  sections.push({
+    key: 'language',
+    footer: t('mobile.more.language.description'),
+    rows: [
+      {
+        kind: 'select',
+        key: 'language',
+        label: t('mobile.more.language.title'),
+        options: languageOptions,
+        selectedKey: localePreference,
+        onSelect: (key) => {
+          const next = languageOptions.find((option) => option.key === key);
+          if (next) {
+            hapticSelection();
+            setLocalePreference(next.key);
+          }
+        },
+      },
+    ],
+  });
+
+  // Help translate — its own card under the language footnote.
+  sections.push({
+    key: 'languageContribute',
+    rows: [
+      {
+        kind: 'nav',
+        key: 'helpTranslate',
+        label: t('mobile.more.language.contributeTitle'),
+        subtitle: t('mobile.more.language.contributeSubtitle', { language: LOCALE_LABELS[activeLocale] }),
+        sfSymbol: 'character.bubble',
+        onPress: navAction(handleHelpTranslate),
+      },
+    ],
+  });
+
+  // Diagnostics — Session Recording toggle. Persist + apply live.
+  sections.push({
+    key: 'diagnostics',
+    title: t('mobile.more.diagnostics.title'),
+    rows: [
+      {
+        kind: 'toggle',
+        key: 'sessionRecording',
+        label: t('mobile.more.diagnostics.recording'),
+        subtitle: t('mobile.more.diagnostics.recordingDescription'),
+        value: sessionRecordingEnabled,
+        onValueChange: (next) => {
+          hapticSelection();
+          setSessionRecordingPreference(next);
+          setSessionRecordingEnabled(next);
+        },
+      },
+    ],
+  });
+
+  // Replay walkthrough (nav).
+  sections.push({
+    key: 'replay',
+    title: t('mobile.onboarding.replaySection'),
+    rows: [
+      {
+        kind: 'nav',
+        key: 'replay',
+        label: t('mobile.onboarding.replayTitle'),
+        subtitle: t('mobile.onboarding.replaySubtitle'),
+        sfSymbol: 'play.circle',
+        onPress: navAction(handleReplayWalkthrough),
+      },
+    ],
+  });
+
+  // About / What's New — the "New" pill shows while there's an unseen entry.
+  sections.push({
+    key: 'about',
+    title: t('mobile.more.aboutSection'),
+    rows: [
+      {
+        kind: 'nav',
+        key: 'changelog',
+        label: t('mobile.more.changelogTitle'),
+        subtitle: t('mobile.more.changelogSubtitle'),
+        sfSymbol: 'sparkles',
+        badge: changelogUnseen ? t('mobile.more.newPill') : undefined,
+        onPress: navAction(() => router.push('/changelog')),
+      },
+    ],
+  });
+
+  // Development — tester/dev-only tooling. Each row is independently gated.
+  if (showDevSection) {
+    const devRows: MoreRow[] = [];
+    if (showDevServerSwitcher) {
+      devRows.push({
+        kind: 'nav',
+        key: 'metroServers',
+        label: t('mobile.more.metroServersTitle'),
+        subtitle: t('mobile.more.metroServersSubtitle'),
+        sfSymbol: 'server.rack',
+        onPress: navAction(() => router.push('/(tabs)/profile/dev-servers')),
+      });
+    }
+    if (showFeatureFlags) {
+      devRows.push({
+        kind: 'nav',
+        key: 'featureFlags',
+        // i18n-ignore-next-line — tester-only dev tooling
+        label: 'Feature Flags',
+        // i18n-ignore-next-line
+        subtitle: 'Force feature flags on or off',
+        sfSymbol: 'flag',
+        onPress: navAction(() => router.push('/(tabs)/profile/feature-flags')),
+      });
+    }
+    sections.push({ key: 'development', title: t('mobile.more.development'), rows: devRows });
+  }
+
+  // Preview Build — branch switcher, only in EAS preview dev-client builds.
+  if (isPreviewBuild()) {
+    sections.push({
+      key: 'previewBuild',
+      // i18n-ignore-next-line — preview-only section
+      title: 'Preview Build',
+      rows: [
+        {
+          kind: 'nav',
+          key: 'branchSwitcher',
+          // i18n-ignore-next-line
+          label: 'Branch Switcher',
+          // i18n-ignore-next-line
+          subtitle: 'Switch EAS Update branch',
+          sfSymbol: 'arrow.triangle.branch',
+          onPress: navAction(() => router.push('/(tabs)/profile/branch-switcher')),
+        },
+      ],
+    });
+  }
+
+  // Account — Edit Profile (with the email as the section footer) plus the
+  // destructive Sign Out / Delete Account actions. When signed out, the actions
+  // carry the "Account" header themselves so it's never an empty section.
+  if (profile?.id) {
+    sections.push({
+      key: 'account',
+      title: tProfile('mobile.account'),
+      footer: profile.email ?? undefined,
+      rows: [
+        {
+          kind: 'nav',
+          key: 'editProfile',
+          label: tSettings('profile.editAction'),
+          sfSymbol: 'person.crop.circle',
+          onPress: navAction(() => router.push('/(tabs)/profile/edit')),
+        },
+      ],
+    });
+    sections.push({ key: 'accountActions', rows: accountActionRows });
+  } else {
+    sections.push({ key: 'accountActions', title: tProfile('mobile.account'), rows: accountActionRows });
+  }
+
+  const model: MoreFormModel = { sections };
+
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={styles.container}>
+    <View style={styles.root}>
+      {/* Dev-only QA panel (null in production); the Form fills the rest. */}
       <DevMetadataPanel />
-
-      {profile?.id ? (
-        <View style={styles.section}>
-          <SectionHeader title={t('mobile.more.library')} />
-          <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-            <ListRow
-              title={tPlaylists('library.allPlaylists.title')}
-              leading={<Icon name="playlist" size={22} color={systemColors.secondaryLabel} />}
-              showChevron
-              showSeparator={false}
-              onPress={() => router.push('/(tabs)/discover/all')}
-            />
-          </View>
-        </View>
-      ) : null}
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.integrations.title')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <ListRow
-            title={t('mobile.more.integrations.title')}
-            subtitle={t(
-              stravaEnabled ? 'mobile.more.integrations.subtitleWithStrava' : 'mobile.more.integrations.subtitle',
-            )}
-            leading={<Icon name="favorite" size={22} color={systemColors.secondaryLabel} />}
-            showChevron
-            showSeparator={false}
-            onPress={() => router.push('/(tabs)/profile/integrations')}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.appearance.title')} />
-        <View style={[styles.card, styles.cardPadded, { backgroundColor: systemColors.secondaryBackground }]}>
-          <SegmentedControl
-            options={appearanceOptions}
-            selectedKey={themeOverride}
-            onSelect={(key) => void setThemeOverride(key)}
-            trackColor={systemColors.fill}
-            accessibilityLabel={t('mobile.more.appearance.title')}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.gradeFormat.title')} />
-        <View style={[styles.card, styles.cardPadded, { backgroundColor: systemColors.secondaryBackground }]}>
-          <SegmentedControl
-            options={gradeFormatOptions}
-            selectedKey={gradeFormat}
-            onSelect={setGradeFormat}
-            trackColor={systemColors.fill}
-            accessibilityLabel={t('mobile.more.gradeFormat.title')}
-          />
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.settingHint}>
-            {t('mobile.more.gradeFormat.description')}
-          </Text>
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.displayOptions.title')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <PlaylistTagsSwitchRow
-            label={t('mobile.more.displayOptions.playlistTags')}
-            description={t('mobile.more.displayOptions.playlistTagsDescription')}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.accessibility.title')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <ListRow
-            title={t('mobile.more.accessibility.title')}
-            subtitle={t('mobile.more.accessibility.rowSubtitleShort')}
-            leading={<Icon name="visibility" size={22} color={systemColors.secondaryLabel} />}
-            showChevron
-            showSeparator={false}
-            onPress={() => router.push('/(tabs)/profile/accessibility')}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.language.title')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          {languageOptions.map((option, index) => (
-            <ListRow
-              key={option.key}
-              title={option.label}
-              trailing={
-                localePreference === option.key ? (
-                  <Icon name="check.small" size={20} color={systemColors.accent} />
-                ) : undefined
-              }
-              showSeparator={index < languageOptions.length - 1}
-              onPress={() => setLocalePreference(option.key)}
-            />
-          ))}
-        </View>
-        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.languageHint}>
-          {t('mobile.more.language.description')}
-        </Text>
-        <View style={[styles.card, styles.contributeCard, { backgroundColor: systemColors.secondaryBackground }]}>
-          <ListRow
-            title={t('mobile.more.language.contributeTitle')}
-            subtitle={t('mobile.more.language.contributeSubtitle', { language: LOCALE_LABELS[activeLocale] })}
-            leading={<Icon name="github" size={22} color={systemColors.secondaryLabel} />}
-            showChevron
-            showSeparator={false}
-            onPress={handleHelpTranslate}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.diagnostics.title')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <SessionRecordingSwitchRow
-            label={t('mobile.more.diagnostics.recording')}
-            description={t('mobile.more.diagnostics.recordingDescription')}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.onboarding.replaySection')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <ListRow
-            title={t('mobile.onboarding.replayTitle')}
-            subtitle={t('mobile.onboarding.replaySubtitle')}
-            leading={<Icon name="play.circle" size={22} color={systemColors.secondaryLabel} />}
-            showChevron
-            showSeparator={false}
-            onPress={handleReplayWalkthrough}
-          />
-        </View>
-      </View>
-
-      <View style={styles.section}>
-        <SectionHeader title={t('mobile.more.aboutSection')} />
-        <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-          <ListRow
-            title={t('mobile.more.changelogTitle')}
-            subtitle={t('mobile.more.changelogSubtitle')}
-            leading={<Icon name="flash" size={22} color={systemColors.secondaryLabel} />}
-            trailing={
-              changelogUnseen ? (
-                <View style={[styles.newPill, { backgroundColor: brandColors.primaryFill }]}>
-                  <Text variant="caption2" color={brandColors.onPrimary} style={styles.newPillLabel}>
-                    {t('mobile.more.newPill')}
-                  </Text>
-                </View>
-              ) : undefined
-            }
-            showChevron
-            showSeparator={false}
-            onPress={() => router.push('/changelog')}
-          />
-        </View>
-      </View>
-
-      {showDevSection ? (
-        <View style={styles.section}>
-          <SectionHeader title={t('mobile.more.development')} />
-          <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-            {showDevServerSwitcher ? (
-              <ListRow
-                title={t('mobile.more.metroServersTitle')}
-                subtitle={t('mobile.more.metroServersSubtitle')}
-                leading={<Icon name="server" size={22} color={systemColors.secondaryLabel} />}
-                showChevron
-                showSeparator={showFeatureFlags}
-                onPress={() => router.push('/(tabs)/profile/dev-servers')}
-              />
-            ) : null}
-            {showFeatureFlags ? (
-              <ListRow
-                // i18n-ignore-next-line — tester-only dev tooling
-                title="Feature Flags"
-                // i18n-ignore-next-line
-                subtitle="Force feature flags on or off"
-                leading={<Icon name="flag" size={22} color={systemColors.secondaryLabel} />}
-                showChevron
-                showSeparator={false}
-                onPress={() => router.push('/(tabs)/profile/feature-flags')}
-              />
-            ) : null}
-          </View>
-        </View>
-      ) : null}
-
-      {isPreviewBuild() ? (
-        <>
-          {/* i18n-ignore-next-line — preview-only section */}
-          <SectionHeader title="Preview Build" />
-          <ListRow
-            // i18n-ignore-next-line
-            title="Branch Switcher"
-            // i18n-ignore-next-line
-            subtitle="Switch EAS Update branch"
-            leading={<Icon name="branch" size={22} color={systemColors.label} />}
-            showChevron
-            showSeparator={false}
-            onPress={() => router.push('/(tabs)/profile/branch-switcher')}
-          />
-        </>
-      ) : null}
-
-      <View style={styles.section}>
-        <SectionHeader title={tProfile('mobile.account')} />
-        {profile?.id ? (
-          <View style={[styles.card, { backgroundColor: systemColors.secondaryBackground }]}>
-            <ListRow
-              title={tSettings('profile.editAction')}
-              leading={<Avatar uri={profile.avatarUrl} name={profile.displayName ?? profile.email ?? null} size={28} />}
-              showChevron
-              showSeparator={false}
-              onPress={() => router.push('/(tabs)/profile/edit')}
-            />
-          </View>
-        ) : null}
-        {profile?.email ? (
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.accountEmail}>
-            {profile.email}
-          </Text>
-        ) : null}
-        <Pressable
-          style={[styles.signOut, { borderColor: systemColors.separator }]}
-          onPress={() => {
-            void signOut();
-          }}
-          accessibilityRole="button"
-        >
-          <Text variant="body" color={brandColors.error}>
-            {tProfile('mobile.signOut')}
-          </Text>
-        </Pressable>
-        <Pressable
-          style={styles.deleteAccount}
-          onPress={() => router.push('/(tabs)/profile/delete-account')}
-          accessibilityRole="button"
-        >
-          <Text variant="body" color={brandColors.error}>
-            {tSettings('deleteAccount.button')}
-          </Text>
-        </Pressable>
-      </View>
-    </ScrollView>
+      <MoreForm model={model} />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    paddingTop: spacing[4],
-    paddingBottom: spacing[8],
-  },
-  section: {
-    width: '100%',
-    marginBottom: spacing[6],
-  },
-  card: {
-    overflow: 'hidden',
-    borderRadius: borderRadius.lg,
-    marginHorizontal: spacing[4],
-  },
-  cardPadded: {
-    padding: spacing[3],
-  },
-  settingHint: {
-    marginTop: spacing[2],
-  },
-  languageHint: {
-    marginTop: spacing[2],
-    paddingHorizontal: spacing[4],
-  },
-  contributeCard: {
-    marginTop: spacing[3],
-  },
-  newPill: {
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
-    borderRadius: borderRadius.full,
-  },
-  newPillLabel: {
-    fontWeight: '700',
-    textTransform: 'uppercase',
-  },
-  accountEmail: {
-    paddingHorizontal: spacing[4],
-    marginTop: spacing[3],
-    marginBottom: spacing[3],
-  },
-  signOut: {
-    alignItems: 'center',
-    paddingVertical: spacing[3],
-    marginHorizontal: spacing[4],
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-  // Deliberately subordinate to Sign Out: a borderless red text link, not the
-  // bordered button above. Sign Out is the routine action; account deletion is
-  // rare and irreversible, so it reads as a quieter, secondary affordance rather
-  // than competing for equal visual weight.
-  deleteAccount: {
-    alignItems: 'center',
-    paddingVertical: spacing[3],
-    marginHorizontal: spacing[4],
-    marginTop: spacing[2],
+  root: {
+    flex: 1,
   },
 });

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -140,15 +140,17 @@ export default function MoreScreen() {
     action();
   };
 
-  // Account action buttons (Sign Out / Delete Account) — destructive, no haptic,
-  // matching the old borderless red links. Shared between the signed-in and
-  // signed-out section layouts.
+  // Account action buttons — destructive, no haptic. Sign Out is the primary
+  // action (full-strength red); Delete Account is the quieter, secondary
+  // affordance (`emphasis: 'subtle'`) so the two don't read as equal heavy red
+  // blocks. Shared between the signed-in and signed-out section layouts.
   const accountActionRows: MoreButtonRow[] = [
     {
       kind: 'button',
       key: 'signOut',
       label: tProfile('mobile.signOut'),
       role: 'destructive',
+      emphasis: 'primary',
       onPress: () => {
         void signOut();
       },
@@ -158,6 +160,7 @@ export default function MoreScreen() {
       key: 'deleteAccount',
       label: tSettings('deleteAccount.button'),
       role: 'destructive',
+      emphasis: 'subtle',
       onPress: () => router.push('/(tabs)/profile/delete-account'),
     },
   ];
@@ -174,7 +177,7 @@ export default function MoreScreen() {
           kind: 'nav',
           key: 'allPlaylists',
           label: tPlaylists('library.allPlaylists.title'),
-          sfSymbol: 'music.note.list',
+          icon: 'playlists',
           onPress: navAction(() => router.push('/(tabs)/discover/all')),
         },
       ],
@@ -193,7 +196,7 @@ export default function MoreScreen() {
         subtitle: t(
           stravaEnabled ? 'mobile.more.integrations.subtitleWithStrava' : 'mobile.more.integrations.subtitle',
         ),
-        sfSymbol: 'heart',
+        icon: 'integrations',
         onPress: navAction(() => router.push('/(tabs)/profile/integrations')),
       },
     ],
@@ -273,7 +276,7 @@ export default function MoreScreen() {
         key: 'accessibility',
         label: t('mobile.more.accessibility.title'),
         subtitle: t('mobile.more.accessibility.rowSubtitleShort'),
-        sfSymbol: 'accessibility',
+        icon: 'accessibility',
         onPress: navAction(() => router.push('/(tabs)/profile/accessibility')),
       },
     ],
@@ -311,7 +314,7 @@ export default function MoreScreen() {
         key: 'helpTranslate',
         label: t('mobile.more.language.contributeTitle'),
         subtitle: t('mobile.more.language.contributeSubtitle', { language: LOCALE_LABELS[activeLocale] }),
-        sfSymbol: 'character.bubble',
+        icon: 'translate',
         onPress: navAction(handleHelpTranslate),
       },
     ],
@@ -347,7 +350,7 @@ export default function MoreScreen() {
         key: 'replay',
         label: t('mobile.onboarding.replayTitle'),
         subtitle: t('mobile.onboarding.replaySubtitle'),
-        sfSymbol: 'play.circle',
+        icon: 'replay',
         onPress: navAction(handleReplayWalkthrough),
       },
     ],
@@ -363,7 +366,7 @@ export default function MoreScreen() {
         key: 'changelog',
         label: t('mobile.more.changelogTitle'),
         subtitle: t('mobile.more.changelogSubtitle'),
-        sfSymbol: 'sparkles',
+        icon: 'changelog',
         badge: changelogUnseen ? t('mobile.more.newPill') : undefined,
         onPress: navAction(() => router.push('/changelog')),
       },
@@ -379,7 +382,7 @@ export default function MoreScreen() {
         key: 'metroServers',
         label: t('mobile.more.metroServersTitle'),
         subtitle: t('mobile.more.metroServersSubtitle'),
-        sfSymbol: 'server.rack',
+        icon: 'devServers',
         onPress: navAction(() => router.push('/(tabs)/profile/dev-servers')),
       });
     }
@@ -391,7 +394,7 @@ export default function MoreScreen() {
         label: 'Feature Flags',
         // i18n-ignore-next-line
         subtitle: 'Force feature flags on or off',
-        sfSymbol: 'flag',
+        icon: 'featureFlags',
         onPress: navAction(() => router.push('/(tabs)/profile/feature-flags')),
       });
     }
@@ -412,7 +415,7 @@ export default function MoreScreen() {
           label: 'Branch Switcher',
           // i18n-ignore-next-line
           subtitle: 'Switch EAS Update branch',
-          sfSymbol: 'arrow.triangle.branch',
+          icon: 'branchSwitcher',
           onPress: navAction(() => router.push('/(tabs)/profile/branch-switcher')),
         },
       ],
@@ -432,7 +435,7 @@ export default function MoreScreen() {
           kind: 'nav',
           key: 'editProfile',
           label: tSettings('profile.editAction'),
-          sfSymbol: 'person.crop.circle',
+          icon: 'editProfile',
           onPress: navAction(() => router.push('/(tabs)/profile/edit')),
         },
       ],

--- a/packages/mobile/assets/material-icons/accessibility.xml
+++ b/packages/mobile/assets/material-icons/accessibility.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M20.5 6c-2.61.7-5.67 1-8.5 1s-5.89-.3-8.5-1L3 8c1.86.5 4 .83 6 1v13h2v-6h2v6h2V9c2-.17 4.14-.5 6-1l-.5-2zM12 6c1.1 0 2-.9 2-2s-.9-2-2-2s-2 .9-2 2s.9 2 2 2z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/branchSwitcher.xml
+++ b/packages/mobile/assets/material-icons/branchSwitcher.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/changelog.xml
+++ b/packages/mobile/assets/material-icons/changelog.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4L6.5 9.5L1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/devServers.xml
+++ b/packages/mobile/assets/material-icons/devServers.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M20 13H4c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h16c.55 0 1-.45 1-1v-6c0-.55-.45-1-1-1zM7 19c-1.1 0-2-.9-2-2s.9-2 2-2s2 .9 2 2s-.9 2-2 2zM20 3H4c-.55 0-1 .45-1 1v6c0 .55.45 1 1 1h16c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1zM7 9c-1.1 0-2-.9-2-2s.9-2 2-2s2 .9 2 2s-.9 2-2 2z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/editProfile.xml
+++ b/packages/mobile/assets/material-icons/editProfile.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10s10-4.48 10-10S17.52 2 12 2zm0 4c1.93 0 3.5 1.57 3.5 3.5S13.93 13 12 13s-3.5-1.57-3.5-3.5S10.07 6 12 6zm0 14c-2.03 0-4.43-.82-6.14-2.88a9.947 9.947 0 0 1 12.28 0C16.43 19.18 14.03 20 12 20z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/featureFlags.xml
+++ b/packages/mobile/assets/material-icons/featureFlags.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/integrations.xml
+++ b/packages/mobile/assets/material-icons/integrations.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/otaChannel.xml
+++ b/packages/mobile/assets/material-icons/otaChannel.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6c0 1.01-.25 1.97-.7 2.8l1.46 1.46A7.93 7.93 0 0 0 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6c0-1.01.25-1.97.7-2.8L5.24 7.74A7.93 7.93 0 0 0 4 12c0 4.42 3.58 8 8 8v3l4-4l-4-4v3z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/playlists.xml
+++ b/packages/mobile/assets/material-icons/playlists.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v-2H3v2zM17 6v8.18c-.31-.11-.65-.18-1-.18c-1.66 0-3 1.34-3 3s1.34 3 3 3s3-1.34 3-3V8h3V6h-5z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/replay.xml
+++ b/packages/mobile/assets/material-icons/replay.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10s10-4.48 10-10S17.52 2 12 2zM9.5 16.5v-9l7 4.5l-7 4.5z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/translate.xml
+++ b/packages/mobile/assets/material-icons/translate.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M12.87 15.07l-2.54-2.51l.03-.03A17.52 17.52 0 0 0 14.07 6H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35C8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5l3.11 3.11l.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"/>
+</vector>

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -47,6 +47,14 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
+// Bundle Android XML vector drawables (assets/material-icons/*.xml) as ASSETS so
+// @expo/ui's Compose `Icon` can load them via require() — the Material leading
+// icons on the MoreForm nav rows. The board renderer uses react-native-svg's
+// INLINE <Path> components (no .svg/.xml file imports, no svg/xml transformer, no
+// custom sourceExts), so nothing parses .xml through a transformer — moving `xml`
+// into assetExts is safe and doesn't affect react-native-svg.
+config.resolver.assetExts = [...(config.resolver.assetExts ?? []), 'xml'];
+
 // Force a single instance of the React-context singletons. bun's isolated
 // linker can materialise more than one physical copy of these (e.g. a shared
 // package like @boardsesh/board-react resolves its own peer-dep copy of

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -1,11 +1,5 @@
 import { useCallback, useMemo, useRef, useState, useEffect, type ComponentRef, type SetStateAction } from 'react';
 import { View, Pressable, StyleSheet, type ViewStyle } from 'react-native';
-// react-native-gesture-handler's ScrollView (not the bare RN one) for the
-// horizontal sort-by chip rail: nested inside the sheet's vertical
-// BottomSheetScrollView, a plain RN ScrollView won't scroll on Android because
-// the parent scroll/pan gestures capture the touch. The gesture-handler
-// scrollable coordinates nested scrolling correctly.
-import { ScrollView } from 'react-native-gesture-handler';
 import { BottomSheetModal, BottomSheetScrollView } from '@expo/ui/community/bottom-sheet';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -843,11 +837,11 @@ export function ClimbFilterSheet({
               <Text variant="footnote" style={styles.subsectionLabel}>
                 {t('mobile.filter.sortBy')}
               </Text>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.horizontalChipRow}
-              >
+              {/* Flex-wrap (matching the popularity/rating chip rows above), not a
+                  horizontal ScrollView: a gesture-handler ScrollView nested in the
+                  native bottom sheet collapsed the chip row's height on iOS and
+                  clipped the labels. SORT_OPTIONS is short, so wrapping is fine. */}
+              <View style={styles.chipRow}>
                 {SORT_OPTIONS.map((option) => (
                   <Chip
                     key={option}
@@ -856,7 +850,7 @@ export function ClimbFilterSheet({
                     onPress={() => handleSortByChange(option)}
                   />
                 ))}
-              </ScrollView>
+              </View>
               <View style={styles.subsectionGap} />
               <Text variant="footnote" style={styles.subsectionLabel}>
                 {t('mobile.filter.sortOrderLabel')}
@@ -926,10 +920,6 @@ const styles = StyleSheet.create({
   chipRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: spacing[2],
-  },
-  horizontalChipRow: {
-    flexDirection: 'row',
     gap: spacing[2],
   },
   chipText: {

--- a/packages/mobile/src/components/FeatureFlagsForm.android.tsx
+++ b/packages/mobile/src/components/FeatureFlagsForm.android.tsx
@@ -34,11 +34,14 @@ import { FEATURE_FLAG_CHOICES } from './FeatureFlagsForm.logic';
 import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
 
 export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
-  const { brandColors } = useTheme();
+  const { brandColors, colorScheme } = useTheme();
   const segmentColors = segmentedBrandColors(brandColors);
 
   return (
-    <Host style={styles.host}>
+    // `colorScheme` forces the Compose MaterialTheme to follow the in-app
+    // Light/Dark toggle (`themeOverride`) instead of the OS scheme — without it the
+    // cards stay dark when the user picks "Light" in-app.
+    <Host style={styles.host} colorScheme={colorScheme}>
       <LazyColumn
         contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
         verticalArrangement={{ spacedBy: spacing[3] }}

--- a/packages/mobile/src/components/FeatureFlagsForm.android.tsx
+++ b/packages/mobile/src/components/FeatureFlagsForm.android.tsx
@@ -1,0 +1,102 @@
+// FeatureFlagsForm — Android implementation, a Jetpack Compose `LazyColumn` of
+// Material cards via @expo/ui/jetpack-compose.
+//
+// The whole tester-only Feature Flags screen is ONE `Host` containing a single
+// `LazyColumn` — the Compose counterpart to the iOS `Form`. This is the PR-2
+// consolidation: instead of one `Host` per control, the entire list lives under
+// one `Host`. A `LazyColumn` virtualizes its items, so it must be given a bounded
+// height — hence `style={{ flex: 1 }}` on the Host (NOT `matchContents`, which the
+// per-row controls use to report intrinsic height back to RN).
+//
+// Each direct child of the LazyColumn is a list item: the title, the notice, one
+// Material `Card` per flag, then the reset button. Brand colours come from the
+// `expo-ui-modifiers` bridge; M3 surface/label colours come from the Compose
+// Material theme the Host sets up.
+//
+// All copy is hardcoded English with `i18n-ignore` — tester-only.
+
+import { Host } from '@expo/ui';
+import {
+  LazyColumn,
+  Card,
+  Column,
+  Text,
+  Button,
+  SingleChoiceSegmentedButtonRow,
+  SegmentedButton,
+} from '@expo/ui/jetpack-compose';
+import { fillMaxWidth, padding, alpha } from '@expo/ui/jetpack-compose/modifiers';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { segmentedBrandColors } from '../theme/expo-ui-modifiers';
+import { spacing } from '../theme/tokens';
+import { FEATURE_FLAG_CHOICES } from './FeatureFlagsForm.logic';
+import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
+
+export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
+  const { brandColors } = useTheme();
+  const segmentColors = segmentedBrandColors(brandColors);
+
+  return (
+    <Host style={styles.host}>
+      <LazyColumn
+        contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
+        verticalArrangement={{ spacedBy: spacing[3] }}
+      >
+        {/* i18n-ignore-next-line — tester-only screen */}
+        <Text style={{ typography: 'titleLarge' }}>{title}</Text>
+        <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+          {noticeText}
+        </Text>
+
+        {rows.map((row) => (
+          <Card key={row.key} modifiers={[fillMaxWidth()]}>
+            <Column
+              modifiers={[padding(spacing[4], spacing[3], spacing[4], spacing[3])]}
+              verticalArrangement={{ spacedBy: spacing[2] }}
+            >
+              <Text style={{ typography: 'bodyLarge' }}>{row.label}</Text>
+              <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+                {row.description}
+              </Text>
+              <SingleChoiceSegmentedButtonRow modifiers={[fillMaxWidth()]}>
+                {FEATURE_FLAG_CHOICES.map((choice) => (
+                  <SegmentedButton
+                    key={choice.key}
+                    selected={choice.key === row.choice}
+                    onClick={() => onSelect(row.key, choice.key)}
+                    colors={segmentColors}
+                  >
+                    {/* The label slot is a native composable SLOT — its child must be
+                        a Compose `Text`, not a raw string, or it doesn't render and
+                        isn't exposed to the a11y tree. */}
+                    <SegmentedButton.Label>
+                      <Text>{choice.label}</Text>
+                    </SegmentedButton.Label>
+                  </SegmentedButton>
+                ))}
+              </SingleChoiceSegmentedButtonRow>
+              <Text style={{ typography: 'labelSmall' }} modifiers={[alpha(0.6)]}>
+                {row.effectiveLabel}
+              </Text>
+            </Column>
+          </Card>
+        ))}
+
+        {/* `enabled={canReset}` greys the button and blocks the tap when there's
+            nothing to reset. The label is a Text child (Button content is a slot). */}
+        <Button onClick={onReset} enabled={canReset} modifiers={[fillMaxWidth()]}>
+          {/* i18n-ignore-next-line — tester-only screen */}
+          <Text>Reset all overrides</Text>
+        </Button>
+      </LazyColumn>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  // A LazyColumn virtualizes its rows and needs a bounded height to fill.
+  host: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/FeatureFlagsForm.d.ts
+++ b/packages/mobile/src/components/FeatureFlagsForm.d.ts
@@ -1,0 +1,10 @@
+// Ambient type for the platform-split FeatureFlagsForm so `tsc` resolves the
+// extensionless `./FeatureFlagsForm` import to this declaration, while Metro picks
+// the matching FeatureFlagsForm.ios.tsx / FeatureFlagsForm.android.tsx at bundle
+// time. Both implementations are still compiled and type-checked on their own.
+// Mirrors the SwitchRow.d.ts mechanism.
+
+import type { FC } from 'react';
+import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
+
+export declare const FeatureFlagsForm: FC<FeatureFlagsFormProps>;

--- a/packages/mobile/src/components/FeatureFlagsForm.ios.tsx
+++ b/packages/mobile/src/components/FeatureFlagsForm.ios.tsx
@@ -38,11 +38,13 @@ import { FEATURE_FLAG_CHOICES, isFeatureFlagChoice } from './FeatureFlagsForm.lo
 import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
 
 export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
-  const { brandColors } = useTheme();
+  const { brandColors, colorScheme } = useTheme();
   const accent = brandAccentColor(brandColors);
 
   return (
-    <Host style={styles.host} useViewportSizeMeasurement>
+    // `colorScheme` forces the native appearance to follow the in-app Light/Dark
+    // toggle (`themeOverride`) instead of the OS scheme.
+    <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
       <Form>
         {/* `title` is the section header; `footer` carries the notice. A footer is a
             view slot, so it's a `<Text>` child, not a raw string. */}

--- a/packages/mobile/src/components/FeatureFlagsForm.ios.tsx
+++ b/packages/mobile/src/components/FeatureFlagsForm.ios.tsx
@@ -1,0 +1,115 @@
+// FeatureFlagsForm — iOS implementation, a real SwiftUI `Form` via @expo/ui/swift-ui.
+//
+// The whole tester-only Feature Flags screen is ONE `Host` containing a single
+// SwiftUI `Form` (the grouped, inset-rounded settings look you get in iOS
+// Settings — for free, including the scrolling, section insets, and separators).
+// This is the PR-2 consolidation the PR-1 primitives anticipated: instead of one
+// `Host` per control, the entire form lives under one `Host`.
+//
+// HOST SIZING IS DIFFERENT FROM A STANDALONE CONTROL. A `Form` is a scrolling
+// container that wants to fill its space, not size to its content. So this Host
+// uses `style={{ flex: 1 }}` + `useViewportSizeMeasurement` (HostProps: "the host
+// will use the viewport size as the proposed size for SwiftUI layout … useful for
+// SwiftUI views that need to fill their available space, such as `Form`"). The
+// per-row controls (SwitchRow/SegmentedControl) use `matchContents` because they
+// must report their intrinsic height back to RN's layout; a Form is the opposite
+// case — it takes all the height it's given.
+//
+// All copy is hardcoded English with `i18n-ignore` — tester-only, matching the
+// rest of the screen. The screen precomputes every derived string; this tree only
+// renders props.
+
+import { Host } from '@expo/ui';
+import { Form, Section, Picker, Text, Button, VStack } from '@expo/ui/swift-ui';
+import {
+  pickerStyle,
+  tint,
+  tag,
+  font,
+  foregroundStyle,
+  disabled as disabledModifier,
+  accessibilityLabel,
+} from '@expo/ui/swift-ui/modifiers';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { brandAccentColor } from '../theme/expo-ui-modifiers';
+import { spacing } from '../theme/tokens';
+import { FEATURE_FLAG_CHOICES, isFeatureFlagChoice } from './FeatureFlagsForm.logic';
+import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
+
+export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
+  const { brandColors } = useTheme();
+  const accent = brandAccentColor(brandColors);
+
+  return (
+    <Host style={styles.host} useViewportSizeMeasurement>
+      <Form>
+        {/* `title` is the section header; `footer` carries the notice. A footer is a
+            view slot, so it's a `<Text>` child, not a raw string. */}
+        <Section title={title} footer={<Text>{noticeText}</Text>}>
+          {rows.map((row) => (
+            <VStack key={row.key} alignment="leading" spacing={spacing[1]}>
+              <Text>{row.label}</Text>
+              <Text
+                modifiers={[
+                  font({ textStyle: 'footnote' }),
+                  foregroundStyle({ type: 'hierarchical', style: 'secondary' }),
+                ]}
+              >
+                {row.description}
+              </Text>
+              {/* Native iOS segmented control; brand-tinted selected fill. The tag
+                  on each option maps SwiftUI's selection to the choice key. */}
+              <Picker
+                selection={row.choice}
+                onSelectionChange={(value) => {
+                  // @expo/ui types the selection as the untyped Picker tag; narrow
+                  // it to a FeatureFlagChoice before forwarding (drops anything
+                  // unexpected rather than blind-casting).
+                  if (isFeatureFlagChoice(value)) onSelect(row.key, value);
+                }}
+                // Name the segmented group for VoiceOver (the visible label sits
+                // above; this gives the control itself an accessible name).
+                modifiers={[pickerStyle('segmented'), tint(accent), accessibilityLabel(row.label)]}
+              >
+                {FEATURE_FLAG_CHOICES.map((choice) => (
+                  <Text key={choice.key} modifiers={[tag(choice.key)]}>
+                    {choice.label}
+                  </Text>
+                ))}
+              </Picker>
+              <Text
+                modifiers={[
+                  font({ textStyle: 'caption' }),
+                  foregroundStyle({ type: 'hierarchical', style: 'secondary' }),
+                ]}
+              >
+                {row.effectiveLabel}
+              </Text>
+            </VStack>
+          ))}
+        </Section>
+        {/* Reset lives in its own section so it reads as a standalone destructive
+            row (the standard iOS Settings idiom). `destructive` colours it red;
+            `disabled` greys it out and blocks the tap when there's nothing to reset. */}
+        <Section>
+          {/* i18n-ignore-next-line — tester-only screen */}
+          <Button
+            role="destructive"
+            label="Reset all overrides"
+            onPress={onReset}
+            modifiers={[disabledModifier(!canReset)]}
+          />
+        </Section>
+      </Form>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  // A Form fills the screen; flex + useViewportSizeMeasurement give SwiftUI the
+  // viewport as its proposed size so the Form scrolls within it.
+  host: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/FeatureFlagsForm.logic.ts
+++ b/packages/mobile/src/components/FeatureFlagsForm.logic.ts
@@ -1,0 +1,32 @@
+// Pure, node-testable helpers shared by both platform FeatureFlagsForm files
+// (and the test stub). Keeping the segment catalog + the selection guard here
+// means iOS and Android render the same three options in the same order and can't
+// drift, and it's testable without mounting a native @expo/ui tree. No native
+// imports, no rendering.
+
+import type { FeatureFlagChoice } from './FeatureFlagsForm.types';
+
+/**
+ * The three segments every flag row renders, in display order. Labels are
+ * tester-facing English only (this screen never reaches a non-tester surface).
+ * Shared by the iOS segmented `Picker`, the Android `SegmentedButton` row, and
+ * the test stub so the options can't diverge across platforms.
+ */
+export const FEATURE_FLAG_CHOICES: readonly { key: FeatureFlagChoice; label: string }[] = [
+  // i18n-ignore-next-line — tester-only screen
+  { key: 'default', label: 'Default' },
+  // i18n-ignore-next-line — tester-only screen
+  { key: 'on', label: 'On' },
+  // i18n-ignore-next-line — tester-only screen
+  { key: 'off', label: 'Off' },
+];
+
+/**
+ * Narrows the iOS segmented `Picker`'s untyped selection (`string | number |
+ * null`) to a `FeatureFlagChoice` before it's handed to `onSelect`. The Picker's
+ * tags are always our three choice keys, so a non-matching value is dropped
+ * rather than blind-cast — mirrors SegmentedControl.ios's string guard.
+ */
+export function isFeatureFlagChoice(value: unknown): value is FeatureFlagChoice {
+  return value === 'default' || value === 'on' || value === 'off';
+}

--- a/packages/mobile/src/components/FeatureFlagsForm.types.ts
+++ b/packages/mobile/src/components/FeatureFlagsForm.types.ts
@@ -1,0 +1,42 @@
+// Shared props for the platform-split FeatureFlagsForm — the native body of the
+// tester-only Feature Flags screen. The implementation is split across
+// FeatureFlagsForm.ios.tsx (a real SwiftUI `Form`) and FeatureFlagsForm.android.tsx
+// (a Jetpack Compose `LazyColumn` of Material cards), each rendered as ONE `Host`
+// that fills the screen. The split keeps each platform's @expo/ui native tree —
+// which resolves native views at module load — off the other platform's bundle.
+//
+// The screen (FeatureFlagsScreen.tsx) keeps the route guards + data hooks and
+// builds a plain view-model array, so the native tree just renders strings: every
+// piece of derived copy (the "Live default… Effective…" caption) is precomputed
+// here as `effectiveLabel`. No native imports.
+
+/** The three override states a tester can force a flag into. */
+export type FeatureFlagChoice = 'default' | 'on' | 'off';
+
+/**
+ * One flag's fully-resolved view model. `choice` is the current segmented
+ * selection; `effectiveLabel` is the precomputed "Live default: X · Effective: Y"
+ * caption (built in the screen so the native tree stays dumb).
+ */
+export type FeatureFlagRow = {
+  key: string;
+  label: string;
+  description: string;
+  choice: FeatureFlagChoice;
+  effectiveLabel: string;
+};
+
+export type FeatureFlagsFormProps = {
+  /** One entry per catalog flag, in display order. */
+  rows: FeatureFlagRow[];
+  /** Fired when a row's segment changes. The screen maps it to set/clear override. */
+  onSelect: (key: string, choice: FeatureFlagChoice) => void;
+  /** Fired by the "Reset all overrides" button. */
+  onReset: () => void;
+  /** Enables the reset button — false greys it out when there are no overrides. */
+  canReset: boolean;
+  /** The footnote explaining what overrides do (rendered as the section footer on iOS). */
+  noticeText: string;
+  /** The section/list title ("Feature Flags"). */
+  title: string;
+};

--- a/packages/mobile/src/components/FeatureFlagsScreen.tsx
+++ b/packages/mobile/src/components/FeatureFlagsScreen.tsx
@@ -1,53 +1,88 @@
-import { useMemo } from 'react';
-import { ScrollView, View, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
+import { useCallback, useMemo } from 'react';
+import { View, StyleSheet, ActivityIndicator } from 'react-native';
 import { Redirect } from 'expo-router';
-import { Text } from './Text';
-import { SectionHeader } from './SectionHeader';
-import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
-import { SegmentedControl } from './SegmentedControl';
-import { hapticLight } from '../lib/haptics';
+import { hapticLight, hapticSelection } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { FEATURE_FLAG_DEFINITIONS, FEATURE_FLAG_KEYS } from '../providers/feature-flags-provider';
 import { useFeatureFlagOverrides } from '../lib/feature-flag-overrides';
 import { readPosthogFeatureFlags } from '../lib/analytics';
 import { useProfile } from '../lib/graphql/hooks';
+import { FeatureFlagsForm } from './FeatureFlagsForm';
+import type { FeatureFlagChoice, FeatureFlagRow } from './FeatureFlagsForm.types';
 
 // Tester-only screen — all copy is hardcoded English with `i18n-ignore`, matching
 // ChannelSwitcherScreen. It lets a tester force any catalog flag On/Off (or back
 // to Default) on-device; the choice is the highest-precedence layer in the
 // FeatureFlagsProvider merge and persists across restarts.
+//
+// This is the SHARED route component: it owns the route guards + data hooks and
+// builds a plain view-model array, then hands rendering to the platform-split
+// <FeatureFlagsForm /> (a native SwiftUI Form on iOS, a Compose card list on
+// Android). The native tree renders strings only — every derived caption is
+// precomputed here.
 
-type OverrideChoice = 'default' | 'on' | 'off';
-
-const CHOICE_OPTIONS: { key: OverrideChoice; label: string }[] = [
-  // i18n-ignore-next-line — tester-only screen
-  { key: 'default', label: 'Default' },
-  // i18n-ignore-next-line — tester-only screen
-  { key: 'on', label: 'On' },
-  // i18n-ignore-next-line — tester-only screen
-  { key: 'off', label: 'Off' },
-];
+// i18n-ignore-next-line — tester-only screen
+const SCREEN_TITLE = 'Feature Flags';
+// i18n-ignore-next-line — tester-only screen
+const NOTICE_TEXT =
+  'Force a flag On or Off on this device. Overrides win over PostHog and build-time settings and persist across restarts. Default falls back to the live (PostHog) value.';
 
 export function FeatureFlagsScreen() {
-  const { systemColors, borderRadius } = useTheme();
+  const { systemColors } = useTheme();
   const { overrides, loaded: overridesLoaded, setOverride, clearOverride, clearAll } = useFeatureFlagOverrides();
   const { data: profile, isLoading: profileLoading } = useProfile();
 
-  // Resolved base values (PostHog) so the footnote can show what a flag falls
-  // back to when its override is cleared. No-op / empty in dev or unkeyed builds.
-  // Read once on mount: PostHog values rarely move while this tester screen is
-  // open, and live override changes already re-render via the store hook.
+  // Resolved base values (PostHog) so the caption can show what a flag falls back
+  // to when its override is cleared. No-op / empty in dev or unkeyed builds. Read
+  // once on mount: PostHog values rarely move while this tester screen is open,
+  // and live override changes already re-render via the store hook.
   const baseFlags = useMemo(() => readPosthogFeatureFlags(FEATURE_FLAG_KEYS), []);
   const hasOverrides = Object.keys(overrides).length > 0;
 
-  const handleSelect = (key: string, choice: OverrideChoice) => {
-    if (choice === 'default') {
-      clearOverride(key);
-    } else {
-      setOverride(key, choice === 'on');
-    }
-  };
+  // The native form's view model. Memoized so the Host's children don't rebuild
+  // every render (the form is a single native tree). Each row carries the
+  // precomputed "Live default… Effective…" caption so the native side renders a
+  // plain string.
+  const rows = useMemo<FeatureFlagRow[]>(
+    () =>
+      FEATURE_FLAG_DEFINITIONS.map((definition) => {
+        const override = overrides[definition.key];
+        const choice: FeatureFlagChoice = override === undefined ? 'default' : override ? 'on' : 'off';
+        const base = baseFlags[definition.key];
+        // i18n-ignore-next-line — tester-only screen
+        const baseLabel = base === undefined ? 'not set' : base ? 'on' : 'off';
+        const effective = override ?? base ?? false;
+        return {
+          key: definition.key,
+          label: definition.label,
+          description: definition.description,
+          choice,
+          // i18n-ignore-next-line — tester-only screen
+          effectiveLabel: `Live default: ${baseLabel} · Effective: ${effective ? 'on' : 'off'}`,
+        };
+      }),
+    [overrides, baseFlags],
+  );
+
+  const handleSelect = useCallback(
+    (key: string, choice: FeatureFlagChoice) => {
+      // The native segmented controls don't fire a selection haptic on their own,
+      // so keep the tactile feedback the old SegmentedControl provided.
+      hapticSelection();
+      if (choice === 'default') {
+        clearOverride(key);
+      } else {
+        setOverride(key, choice === 'on');
+      }
+    },
+    [clearOverride, setOverride],
+  );
+
+  const handleReset = useCallback(() => {
+    hapticLight();
+    clearAll();
+  }, [clearAll]);
 
   // Route guard. Hiding the More-tab row for non-testers is not a guard — a deep
   // link or manual navigation reaches this route directly, and the overrides it
@@ -58,7 +93,7 @@ export function FeatureFlagsScreen() {
   if (!__DEV__) {
     if (profileLoading) {
       return (
-        <View style={styles.loading}>
+        <View style={[styles.loading, { backgroundColor: systemColors.groupedBackground }]}>
           <ActivityIndicator />
         </View>
       );
@@ -73,125 +108,25 @@ export function FeatureFlagsScreen() {
   // snap to the tester's saved choices.
   if (!overridesLoaded) {
     return (
-      <View style={styles.loading}>
+      <View style={[styles.loading, { backgroundColor: systemColors.groupedBackground }]}>
         <ActivityIndicator />
       </View>
     );
   }
 
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
-      {/* i18n-ignore-next-line — tester-only screen */}
-      <SectionHeader title="Feature Flags" />
-      <View style={[styles.notice, { marginHorizontal: spacing[4] }]}>
-        <Text variant="footnote" color={systemColors.secondaryLabel}>
-          {/* i18n-ignore-next-line — tester-only screen */}
-          Force a flag On or Off on this device. Overrides win over PostHog and build-time settings and persist across
-          restarts. Default falls back to the live (PostHog) value.
-        </Text>
-      </View>
-
-      <View
-        style={[
-          styles.card,
-          {
-            backgroundColor: systemColors.secondaryBackground,
-            borderRadius: borderRadius.lg,
-            marginHorizontal: spacing[4],
-          },
-        ]}
-      >
-        {FEATURE_FLAG_DEFINITIONS.map((definition, index) => {
-          const override = overrides[definition.key];
-          const choice: OverrideChoice = override === undefined ? 'default' : override ? 'on' : 'off';
-          const base = baseFlags[definition.key];
-          // i18n-ignore-next-line — tester-only screen
-          const baseLabel = base === undefined ? 'not set' : base ? 'on' : 'off';
-          const effective = override ?? base ?? false;
-
-          return (
-            <View
-              key={definition.key}
-              style={[
-                styles.flagRow,
-                { paddingVertical: spacing[3], paddingHorizontal: spacing[4] },
-                index < FEATURE_FLAG_DEFINITIONS.length - 1 && {
-                  borderBottomWidth: StyleSheet.hairlineWidth,
-                  borderBottomColor: systemColors.separator,
-                },
-              ]}
-            >
-              <Text variant="body">{definition.label}</Text>
-              <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.flagDescription}>
-                {definition.description}
-              </Text>
-              <View style={{ marginTop: spacing[2] }}>
-                <SegmentedControl
-                  options={CHOICE_OPTIONS}
-                  selectedKey={choice}
-                  onSelect={(next) => handleSelect(definition.key, next)}
-                  trackColor={systemColors.fill}
-                  textVariant="footnote"
-                  accessibilityLabel={definition.label}
-                />
-              </View>
-              <Text variant="caption1" color={systemColors.secondaryLabel} style={{ marginTop: spacing[2] }}>
-                {/* i18n-ignore-next-line — tester-only screen */}
-                {`Live default: ${baseLabel} · Effective: ${effective ? 'on' : 'off'}`}
-              </Text>
-            </View>
-          );
-        })}
-      </View>
-
-      <Pressable
-        onPress={() => {
-          hapticLight();
-          clearAll();
-        }}
-        disabled={!hasOverrides}
-        accessibilityRole="button"
-        // i18n-ignore-next-line — tester-only screen
-        accessibilityLabel="Reset all overrides"
-        accessibilityState={{ disabled: !hasOverrides }}
-        style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: hasOverrides ? 1 : 0.5 }]}
-      >
-        <Icon name="refresh" size={16} color={systemColors.label} />
-        <Text variant="footnote" color={systemColors.label}>
-          {/* i18n-ignore-next-line — tester-only screen */}
-          Reset all overrides
-        </Text>
-      </Pressable>
-
-      <View style={styles.bottomSpacer} />
-    </ScrollView>
+    <FeatureFlagsForm
+      rows={rows}
+      onSelect={handleSelect}
+      onReset={handleReset}
+      canReset={hasOverrides}
+      noticeText={NOTICE_TEXT}
+      title={SCREEN_TITLE}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    overflow: 'hidden',
-  },
-  notice: {
-    paddingVertical: spacing[4],
-  },
-  flagRow: {
-    width: '100%',
-  },
-  flagDescription: {
-    marginTop: 2,
-  },
-  resetButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: spacing[2],
-    paddingVertical: spacing[3],
-    marginTop: spacing[4],
-  },
-  bottomSpacer: {
-    height: spacing[10],
-  },
   loading: {
     flex: 1,
     alignItems: 'center',

--- a/packages/mobile/src/components/MoreForm.android.tsx
+++ b/packages/mobile/src/components/MoreForm.android.tsx
@@ -1,0 +1,227 @@
+// MoreForm — Android implementation, a Jetpack Compose `LazyColumn` via
+// @expo/ui/jetpack-compose.
+//
+// The entire "More" settings screen is ONE `Host` containing a single
+// `LazyColumn` — the Compose counterpart to the iOS `Form`. Like the
+// FeatureFlagsForm pilot, the whole list lives under one `Host`. A `LazyColumn`
+// virtualizes its items, so the Host is `style={{ flex: 1 }}` (NOT `matchContents`,
+// which per-row controls use to report intrinsic height back to RN).
+//
+// Each section becomes: an optional title `Text`, then either a Material `Card`
+// wrapping its rows (nav / toggle / segmented / select) OR standalone `Button`s
+// (an all-button section like the account actions), then an optional footer
+// `Text`. Brand colours come from the `expo-ui-modifiers` bridge; M3
+// surface/label colours come from the Compose Material theme the Host sets up.
+//
+// The screen (more.tsx) precomputes every string + handler (incl. haptics); this
+// tree renders props and invokes handlers.
+
+import { useState, type ReactNode } from 'react';
+import { Host } from '@expo/ui';
+import {
+  LazyColumn,
+  Card,
+  Column,
+  Row,
+  Text,
+  Switch,
+  Button,
+  Badge,
+  Spacer,
+  SingleChoiceSegmentedButtonRow,
+  SegmentedButton,
+  DropdownMenu,
+  DropdownMenuItem,
+} from '@expo/ui/jetpack-compose';
+import { fillMaxWidth, padding, alpha, weight, clickable } from '@expo/ui/jetpack-compose/modifiers';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { segmentedBrandColors, switchBrandColors, type BrandControlColors } from '../theme/expo-ui-modifiers';
+import { spacing } from '../theme/tokens';
+import { assertNeverRow, selectedOptionLabel } from './MoreForm.logic';
+import type { MoreFormProps, MoreRow, MoreSelectRow } from './MoreForm.types';
+
+// Trailing disclosure chevron. The Compose `Icon` needs a vector-drawable source,
+// so a muted `›` glyph stands in for the disclosure indicator on these nav rows.
+const CHEVRON = '›';
+const ROW_PADDING = padding(spacing[4], spacing[3], spacing[4], spacing[3]);
+
+type RowColors = {
+  brandColors: BrandControlColors & { error: string };
+  switchColors: ReturnType<typeof switchBrandColors>;
+  segmentColors: ReturnType<typeof segmentedBrandColors>;
+};
+
+function SelectRow({ row }: { row: MoreSelectRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const currentLabel = selectedOptionLabel(row.options, row.selectedKey);
+  return (
+    <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
+      <DropdownMenu.Trigger>
+        <Row modifiers={[fillMaxWidth(), clickable(() => setExpanded(true)), ROW_PADDING]} verticalAlignment="center">
+          <Column modifiers={[weight(1)]}>
+            <Text style={{ typography: 'bodyLarge' }}>{row.label}</Text>
+          </Column>
+          <Text style={{ typography: 'bodyMedium' }} modifiers={[alpha(0.6)]}>
+            {currentLabel}
+          </Text>
+          <Text style={{ typography: 'titleMedium' }} modifiers={[alpha(0.4)]}>
+            {CHEVRON}
+          </Text>
+        </Row>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Items>
+        {row.options.map((option) => (
+          <DropdownMenuItem
+            key={option.key}
+            onClick={() => {
+              row.onSelect(option.key);
+              setExpanded(false);
+            }}
+          >
+            <DropdownMenuItem.Text>
+              <Text>{option.label}</Text>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+function renderRow(row: MoreRow, colors: RowColors): ReactNode {
+  switch (row.kind) {
+    case 'nav':
+      return (
+        <Row key={row.key} modifiers={[fillMaxWidth(), clickable(row.onPress), ROW_PADDING]} verticalAlignment="center">
+          <Column modifiers={[weight(1)]} verticalArrangement={{ spacedBy: spacing[1] }}>
+            <Text style={{ typography: 'bodyLarge' }}>{row.label}</Text>
+            {row.subtitle ? (
+              <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+                {row.subtitle}
+              </Text>
+            ) : null}
+          </Column>
+          {row.badge ? (
+            <Badge containerColor={colors.brandColors.primaryFill} contentColor={colors.brandColors.onPrimary}>
+              <Text style={{ typography: 'labelSmall' }}>{row.badge}</Text>
+            </Badge>
+          ) : null}
+          <Spacer modifiers={[padding(spacing[2], 0, 0, 0)]} />
+          <Text style={{ typography: 'titleMedium' }} modifiers={[alpha(0.4)]}>
+            {CHEVRON}
+          </Text>
+        </Row>
+      );
+    case 'toggle':
+      return (
+        <Row key={row.key} modifiers={[fillMaxWidth(), ROW_PADDING]} verticalAlignment="center">
+          <Column modifiers={[weight(1)]} verticalArrangement={{ spacedBy: spacing[1] }}>
+            <Text style={{ typography: 'bodyLarge' }}>{row.label}</Text>
+            {row.subtitle ? (
+              <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+                {row.subtitle}
+              </Text>
+            ) : null}
+          </Column>
+          <Switch value={row.value} onCheckedChange={row.onValueChange} colors={colors.switchColors} />
+        </Row>
+      );
+    case 'segmented':
+      return (
+        <Column key={row.key} modifiers={[fillMaxWidth(), ROW_PADDING]}>
+          <SingleChoiceSegmentedButtonRow modifiers={[fillMaxWidth()]}>
+            {row.options.map((option) => (
+              <SegmentedButton
+                key={option.key}
+                selected={option.key === row.selectedKey}
+                onClick={() => row.onSelect(option.key)}
+                colors={colors.segmentColors}
+              >
+                <SegmentedButton.Label>
+                  <Text>{option.label}</Text>
+                </SegmentedButton.Label>
+              </SegmentedButton>
+            ))}
+          </SingleChoiceSegmentedButtonRow>
+        </Column>
+      );
+    case 'select':
+      return <SelectRow key={row.key} row={row} />;
+    case 'button':
+      return (
+        <Button
+          key={row.key}
+          onClick={row.onPress}
+          modifiers={[fillMaxWidth()]}
+          colors={
+            row.role === 'destructive'
+              ? { containerColor: colors.brandColors.error, contentColor: colors.brandColors.onPrimary }
+              : undefined
+          }
+        >
+          <Text>{row.label}</Text>
+        </Button>
+      );
+    default:
+      return assertNeverRow(row);
+  }
+}
+
+export function MoreForm({ model }: MoreFormProps) {
+  const { brandColors } = useTheme();
+  const colors: RowColors = {
+    brandColors,
+    switchColors: switchBrandColors(brandColors),
+    segmentColors: segmentedBrandColors(brandColors),
+  };
+
+  // Flatten sections into LazyColumn items: title Text, the rows (carded unless
+  // the section is all buttons), then footer Text.
+  const items: ReactNode[] = [];
+  for (const section of model.sections) {
+    if (section.title) {
+      items.push(
+        <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} modifiers={[alpha(0.6)]}>
+          {section.title}
+        </Text>,
+      );
+    }
+    const allButtons = section.rows.every((row) => row.kind === 'button');
+    if (allButtons) {
+      // Standalone full-width buttons (e.g. Sign Out / Delete Account), no card.
+      for (const row of section.rows) items.push(renderRow(row, colors));
+    } else {
+      items.push(
+        <Card key={`${section.key}-card`} modifiers={[fillMaxWidth()]}>
+          <Column modifiers={[fillMaxWidth()]}>{section.rows.map((row) => renderRow(row, colors))}</Column>
+        </Card>,
+      );
+    }
+    if (section.footer) {
+      items.push(
+        <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+          {section.footer}
+        </Text>,
+      );
+    }
+  }
+
+  return (
+    <Host style={styles.host}>
+      <LazyColumn
+        contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
+        verticalArrangement={{ spacedBy: spacing[3] }}
+      >
+        {items}
+      </LazyColumn>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  // A LazyColumn virtualizes its rows and needs a bounded height to fill.
+  host: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/MoreForm.android.tsx
+++ b/packages/mobile/src/components/MoreForm.android.tsx
@@ -26,7 +26,9 @@ import {
   Text,
   Switch,
   Button,
+  TextButton,
   Badge,
+  Icon,
   Spacer,
   SingleChoiceSegmentedButtonRow,
   SegmentedButton,
@@ -34,12 +36,30 @@ import {
   DropdownMenuItem,
 } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth, padding, alpha, weight, clickable } from '@expo/ui/jetpack-compose/modifiers';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, type ColorValue, type ImageSourcePropType } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
 import { segmentedBrandColors, switchBrandColors, type BrandControlColors } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { assertNeverRow, selectedOptionLabel } from './MoreForm.logic';
-import type { MoreFormProps, MoreRow, MoreSelectRow } from './MoreForm.types';
+import type { MoreFormProps, MoreIconName, MoreRow, MoreSelectRow } from './MoreForm.types';
+
+// Semantic icon → Material XML vector drawable. The `.xml` files are bundled as
+// ASSETS (metro.config.js adds `xml` to resolver.assetExts), so `require()` gives
+// the Compose `Icon` a vector-drawable source it tints itself. White-filled
+// (#FFFFFFFF) so the `tint` recolours them; a missing `icon` renders no leading slot.
+const MORE_ICON_SOURCE: Record<MoreIconName, ImageSourcePropType> = {
+  playlists: require('../../assets/material-icons/playlists.xml'),
+  integrations: require('../../assets/material-icons/integrations.xml'),
+  accessibility: require('../../assets/material-icons/accessibility.xml'),
+  translate: require('../../assets/material-icons/translate.xml'),
+  replay: require('../../assets/material-icons/replay.xml'),
+  changelog: require('../../assets/material-icons/changelog.xml'),
+  devServers: require('../../assets/material-icons/devServers.xml'),
+  otaChannel: require('../../assets/material-icons/otaChannel.xml'),
+  featureFlags: require('../../assets/material-icons/featureFlags.xml'),
+  branchSwitcher: require('../../assets/material-icons/branchSwitcher.xml'),
+  editProfile: require('../../assets/material-icons/editProfile.xml'),
+};
 
 // Trailing disclosure chevron. The Compose `Icon` needs a vector-drawable source,
 // so a muted `›` glyph stands in for the disclosure indicator on these nav rows.
@@ -50,6 +70,8 @@ type RowColors = {
   brandColors: BrandControlColors & { error: string };
   switchColors: ReturnType<typeof switchBrandColors>;
   segmentColors: ReturnType<typeof segmentedBrandColors>;
+  /** Tint for a nav row's leading Material icon — the secondary-label colour. */
+  iconTint: ColorValue;
 };
 
 function SelectRow({ row }: { row: MoreSelectRow }) {
@@ -94,6 +116,18 @@ function renderRow(row: MoreRow, colors: RowColors): ReactNode {
     case 'nav':
       return (
         <Row key={row.key} modifiers={[fillMaxWidth(), clickable(row.onPress), ROW_PADDING]} verticalAlignment="center">
+          {/* Leading Material icon (a bundled XML vector drawable), tinted to the
+              secondary-label colour with a trailing gap before the label column —
+              the normal Material list-row layout. Omitted when the row has no icon. */}
+          {row.icon ? (
+            <Icon
+              source={MORE_ICON_SOURCE[row.icon]}
+              size={22}
+              tint={colors.iconTint}
+              contentDescription={undefined}
+              modifiers={[padding(0, 0, spacing[3], 0)]}
+            />
+          ) : null}
           <Column modifiers={[weight(1)]} verticalArrangement={{ spacedBy: spacing[1] }}>
             <Text style={{ typography: 'bodyLarge' }}>{row.label}</Text>
             {row.subtitle ? (
@@ -149,6 +183,22 @@ function renderRow(row: MoreRow, colors: RowColors): ReactNode {
     case 'select':
       return <SelectRow key={row.key} row={row} />;
     case 'button':
+      // A `subtle` destructive action (Delete Account) renders as a TEXT button
+      // whose label is the error colour — a quieter, secondary affordance — so it
+      // doesn't read as a second heavy filled-red block next to the primary
+      // destructive action (Sign Out). Both stay red; only the weight differs.
+      if (row.role === 'destructive' && row.emphasis === 'subtle') {
+        return (
+          <TextButton
+            key={row.key}
+            onClick={row.onPress}
+            modifiers={[fillMaxWidth()]}
+            colors={{ contentColor: colors.brandColors.error }}
+          >
+            <Text>{row.label}</Text>
+          </TextButton>
+        );
+      }
       return (
         <Button
           key={row.key}
@@ -169,11 +219,12 @@ function renderRow(row: MoreRow, colors: RowColors): ReactNode {
 }
 
 export function MoreForm({ model }: MoreFormProps) {
-  const { brandColors } = useTheme();
+  const { brandColors, systemColors, colorScheme } = useTheme();
   const colors: RowColors = {
     brandColors,
     switchColors: switchBrandColors(brandColors),
     segmentColors: segmentedBrandColors(brandColors),
+    iconTint: systemColors.secondaryLabel,
   };
 
   // Flatten sections into LazyColumn items: title Text, the rows (carded unless
@@ -208,7 +259,10 @@ export function MoreForm({ model }: MoreFormProps) {
   }
 
   return (
-    <Host style={styles.host}>
+    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
+    // Light/Dark toggle (`themeOverride`) instead of the OS scheme — without it the
+    // cards stay dark when the user picks "Light" in-app.
+    <Host style={styles.host} colorScheme={colorScheme}>
       <LazyColumn
         contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
         verticalArrangement={{ spacedBy: spacing[3] }}

--- a/packages/mobile/src/components/MoreForm.d.ts
+++ b/packages/mobile/src/components/MoreForm.d.ts
@@ -1,0 +1,9 @@
+// Ambient type for the platform-split MoreForm so `tsc` resolves the extensionless
+// `./MoreForm` import to this declaration, while Metro picks the matching
+// MoreForm.ios.tsx / MoreForm.android.tsx at bundle time. Both implementations are
+// still compiled and type-checked on their own. Mirrors FeatureFlagsForm.d.ts.
+
+import type { FC } from 'react';
+import type { MoreFormProps } from './MoreForm.types';
+
+export declare const MoreForm: FC<MoreFormProps>;

--- a/packages/mobile/src/components/MoreForm.ios.tsx
+++ b/packages/mobile/src/components/MoreForm.ios.tsx
@@ -33,7 +33,7 @@ import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { assertNeverRow } from './MoreForm.logic';
-import type { MoreFormProps, MoreNavRow, MoreRow } from './MoreForm.types';
+import type { MoreFormProps, MoreIconName, MoreNavRow, MoreRow } from './MoreForm.types';
 
 // Hierarchical foreground styles for the system label colours SwiftUI uses in a
 // Settings list. Reused across rows so the palette can't drift.
@@ -42,10 +42,27 @@ const SECONDARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'secondar
 const TERTIARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'tertiary' });
 const FOOTNOTE = font({ textStyle: 'footnote' });
 
-// The SFSymbol union the Image `systemName` prop accepts. The model carries
-// `sfSymbol` as a plain string (the union isn't resolvable from the shared types
-// module), so narrow it here at the single call site.
+// The SFSymbol union the Image `systemName` prop accepts. The model carries a
+// semantic `MoreIconName`; map it to the SF Symbol here (the symbol union isn't
+// resolvable from the shared types module), then narrow at the single call site.
 type SystemImageName = NonNullable<ComponentProps<typeof Image>['systemName']>;
+
+// Semantic icon → SF Symbol. Kept as plain strings + cast at the call site (the
+// prior `sfSymbol` field was a string too) so an SF Symbol name that isn't in the
+// `sf-symbols-typescript` union doesn't fail the type-check.
+const IOS_SF_SYMBOL: Record<MoreIconName, string> = {
+  playlists: 'music.note.list',
+  integrations: 'heart',
+  accessibility: 'accessibility',
+  translate: 'character.bubble',
+  replay: 'play.circle',
+  changelog: 'sparkles',
+  devServers: 'server.rack',
+  otaChannel: 'arrow.triangle.2.circlepath',
+  featureFlags: 'flag',
+  branchSwitcher: 'arrow.triangle.branch',
+  editProfile: 'person.crop.circle',
+};
 
 function NavRow({ row }: { row: MoreNavRow }) {
   return (
@@ -55,7 +72,9 @@ function NavRow({ row }: { row: MoreNavRow }) {
     // pill); the manual chevron is the disclosure indicator.
     <Button onPress={row.onPress} modifiers={row.badge ? [badgeModifier(row.badge)] : []}>
       <HStack spacing={spacing[3]}>
-        {row.sfSymbol ? <Image systemName={row.sfSymbol as SystemImageName} modifiers={[SECONDARY_LABEL]} /> : null}
+        {row.icon ? (
+          <Image systemName={IOS_SF_SYMBOL[row.icon] as SystemImageName} modifiers={[SECONDARY_LABEL]} />
+        ) : null}
         <VStack alignment="leading" spacing={spacing[1]}>
           <Text modifiers={[PRIMARY_LABEL]}>{row.label}</Text>
           {row.subtitle ? <Text modifiers={[FOOTNOTE, SECONDARY_LABEL]}>{row.subtitle}</Text> : null}
@@ -125,13 +144,17 @@ function renderRow(row: MoreRow, accent: string) {
         </Picker>
       );
     case 'button':
-      // `destructive` colours the label red; the action lives in the screen.
+      // `destructive` colours the label red; the action lives in the screen. A
+      // `subtle` button keeps the red but drops to footnote size so a secondary
+      // destructive action (Delete Account) reads quieter than the primary one
+      // (Sign Out) stacked above it, instead of two equal-weight red rows.
       return (
         <Button
           key={row.key}
           role={row.role === 'destructive' ? 'destructive' : undefined}
           label={row.label}
           onPress={row.onPress}
+          modifiers={row.emphasis === 'subtle' ? [FOOTNOTE] : []}
         />
       );
     default:
@@ -140,11 +163,14 @@ function renderRow(row: MoreRow, accent: string) {
 }
 
 export function MoreForm({ model }: MoreFormProps) {
-  const { brandColors } = useTheme();
+  const { brandColors, colorScheme } = useTheme();
   const accent = brandAccentColor(brandColors);
 
   return (
-    <Host style={styles.host} useViewportSizeMeasurement>
+    // `colorScheme` forces the native appearance to follow our in-app Light/Dark
+    // toggle (`themeOverride`) instead of the OS scheme — harmless on iOS but the
+    // way the SwiftUI tree honours a non-system choice.
+    <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
       <Form>
         {model.sections.map((section) => (
           <Section

--- a/packages/mobile/src/components/MoreForm.ios.tsx
+++ b/packages/mobile/src/components/MoreForm.ios.tsx
@@ -1,0 +1,169 @@
+// MoreForm — iOS implementation, a real SwiftUI `Form` via @expo/ui/swift-ui.
+//
+// The entire "More" settings screen is ONE `Host` containing a single SwiftUI
+// `Form` (the grouped, inset-rounded iOS Settings look — section insets,
+// separators, and scrolling all for free). This mirrors the FeatureFlagsForm
+// pilot: instead of one `Host` per control, the whole form lives under one `Host`.
+//
+// HOST SIZING: a `Form` is a scrolling container that fills its space, so the Host
+// uses `style={{ flex: 1 }}` + `useViewportSizeMeasurement` (gives SwiftUI the
+// viewport as its proposed size). Per-row controls elsewhere use `matchContents`;
+// a Form is the opposite case — it takes all the height it's given.
+//
+// The screen (more.tsx) precomputes every string + handler (incl. haptics), so
+// this tree only renders props. Each row kind maps to the idiomatic SwiftUI
+// control: nav → a Button row with a leading symbol, title/subtitle, optional
+// badge, and a trailing chevron; toggle → Toggle; segmented → segmented Picker;
+// select → menu-style Picker; button → Button (destructive colours it red).
+
+import type { ComponentProps } from 'react';
+import { Host } from '@expo/ui';
+import { Form, Section, Picker, Toggle, Text, Button, Image, HStack, VStack, Spacer } from '@expo/ui/swift-ui';
+import {
+  pickerStyle,
+  tint,
+  tag,
+  font,
+  foregroundStyle,
+  badge as badgeModifier,
+  accessibilityLabel as accessibilityLabelModifier,
+} from '@expo/ui/swift-ui/modifiers';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { brandAccentColor } from '../theme/expo-ui-modifiers';
+import { spacing } from '../theme/tokens';
+import { assertNeverRow } from './MoreForm.logic';
+import type { MoreFormProps, MoreNavRow, MoreRow } from './MoreForm.types';
+
+// Hierarchical foreground styles for the system label colours SwiftUI uses in a
+// Settings list. Reused across rows so the palette can't drift.
+const PRIMARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'primary' });
+const SECONDARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'secondary' });
+const TERTIARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'tertiary' });
+const FOOTNOTE = font({ textStyle: 'footnote' });
+
+// The SFSymbol union the Image `systemName` prop accepts. The model carries
+// `sfSymbol` as a plain string (the union isn't resolvable from the shared types
+// module), so narrow it here at the single call site.
+type SystemImageName = NonNullable<ComponentProps<typeof Image>['systemName']>;
+
+function NavRow({ row }: { row: MoreNavRow }) {
+  return (
+    // A row Button. Every child sets an explicit foregroundStyle so the row reads
+    // as a Settings row (label/secondary/tertiary), not the default accent-tinted
+    // button content. `badge(...)` adds the standard trailing badge (the "New"
+    // pill); the manual chevron is the disclosure indicator.
+    <Button onPress={row.onPress} modifiers={row.badge ? [badgeModifier(row.badge)] : []}>
+      <HStack spacing={spacing[3]}>
+        {row.sfSymbol ? <Image systemName={row.sfSymbol as SystemImageName} modifiers={[SECONDARY_LABEL]} /> : null}
+        <VStack alignment="leading" spacing={spacing[1]}>
+          <Text modifiers={[PRIMARY_LABEL]}>{row.label}</Text>
+          {row.subtitle ? <Text modifiers={[FOOTNOTE, SECONDARY_LABEL]}>{row.subtitle}</Text> : null}
+        </VStack>
+        <Spacer />
+        <Image systemName="chevron.right" modifiers={[FOOTNOTE, TERTIARY_LABEL]} />
+      </HStack>
+    </Button>
+  );
+}
+
+function renderRow(row: MoreRow, accent: string) {
+  switch (row.kind) {
+    case 'nav':
+      return <NavRow key={row.key} row={row} />;
+    case 'toggle':
+      // Two Text children → title + subtitle (SwiftUI styles the second secondary
+      // and folds both into the VoiceOver label). Brand on-track tint.
+      return (
+        <Toggle key={row.key} isOn={row.value} onIsOnChange={row.onValueChange} modifiers={[tint(accent)]}>
+          <Text>{row.label}</Text>
+          {row.subtitle ? <Text>{row.subtitle}</Text> : null}
+        </Toggle>
+      );
+    case 'segmented':
+      // Native iOS segmented control; each option's `tag` maps selection to its
+      // key. The section header is the visible label, so this only carries an
+      // accessibility label for VoiceOver.
+      return (
+        <Picker
+          key={row.key}
+          selection={row.selectedKey}
+          onSelectionChange={(value) => {
+            if (typeof value === 'string') row.onSelect(value);
+          }}
+          modifiers={[
+            pickerStyle('segmented'),
+            tint(accent),
+            ...(row.label ? [accessibilityLabelModifier(row.label)] : []),
+          ]}
+        >
+          {row.options.map((option) => (
+            <Text key={option.key} modifiers={[tag(option.key)]}>
+              {option.label}
+            </Text>
+          ))}
+        </Picker>
+      );
+    case 'select':
+      // Menu-style Picker: a labelled row showing the current value + chevron that
+      // pops a menu on tap — the idiomatic iOS Settings language picker.
+      return (
+        <Picker
+          key={row.key}
+          label={row.label}
+          selection={row.selectedKey}
+          onSelectionChange={(value) => {
+            if (typeof value === 'string') row.onSelect(value);
+          }}
+          modifiers={[pickerStyle('menu'), tint(accent)]}
+        >
+          {row.options.map((option) => (
+            <Text key={option.key} modifiers={[tag(option.key)]}>
+              {option.label}
+            </Text>
+          ))}
+        </Picker>
+      );
+    case 'button':
+      // `destructive` colours the label red; the action lives in the screen.
+      return (
+        <Button
+          key={row.key}
+          role={row.role === 'destructive' ? 'destructive' : undefined}
+          label={row.label}
+          onPress={row.onPress}
+        />
+      );
+    default:
+      return assertNeverRow(row);
+  }
+}
+
+export function MoreForm({ model }: MoreFormProps) {
+  const { brandColors } = useTheme();
+  const accent = brandAccentColor(brandColors);
+
+  return (
+    <Host style={styles.host} useViewportSizeMeasurement>
+      <Form>
+        {model.sections.map((section) => (
+          <Section
+            key={section.key}
+            title={section.title}
+            footer={section.footer ? <Text>{section.footer}</Text> : undefined}
+          >
+            {section.rows.map((row) => renderRow(row, accent))}
+          </Section>
+        ))}
+      </Form>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  // A Form fills the screen; flex + useViewportSizeMeasurement give SwiftUI the
+  // viewport as its proposed size so the Form scrolls within it.
+  host: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/MoreForm.logic.ts
+++ b/packages/mobile/src/components/MoreForm.logic.ts
@@ -1,0 +1,25 @@
+// Pure, node-testable helpers shared by both platform MoreForm files and the test
+// stub. No native imports, no rendering — so the row-kind exhaustiveness guard and
+// the select-label lookup can't drift across platforms and are unit-testable
+// without mounting a native @expo/ui tree.
+
+import type { MoreOption } from './MoreForm.types';
+
+/**
+ * Exhaustiveness guard for the `MoreRow` discriminated union. Each platform's
+ * row-kind switch ends with `default: return assertNeverRow(row)`, so adding a new
+ * `MoreRow` kind without handling it is a compile error (the arg won't be `never`)
+ * rather than a row that silently renders nothing.
+ */
+export function assertNeverRow(row: never): never {
+  throw new Error(`Unhandled MoreRow kind: ${JSON.stringify(row)}`);
+}
+
+/**
+ * The label of the currently-selected option, for a `select` row's trailing value
+ * (the Android dropdown trigger shows it; iOS's native menu Picker derives it from
+ * the selected tag). Falls back to an empty string if the key isn't found.
+ */
+export function selectedOptionLabel(options: MoreOption[], selectedKey: string): string {
+  return options.find((option) => option.key === selectedKey)?.label ?? '';
+}

--- a/packages/mobile/src/components/MoreForm.types.ts
+++ b/packages/mobile/src/components/MoreForm.types.ts
@@ -1,0 +1,98 @@
+// Shared view-model for the platform-split MoreForm — the native body of the main
+// "More" settings screen. The implementation is split across MoreForm.ios.tsx (a
+// real SwiftUI `Form`) and MoreForm.android.tsx (a Jetpack Compose `LazyColumn` of
+// Material cards), each rendered as ONE `Host` that fills the screen. The split
+// keeps each platform's @expo/ui native tree — which resolves native views at
+// module load — off the other platform's bundle.
+//
+// The route screen (app/(tabs)/profile/more.tsx) keeps every hook, route guard,
+// conditional (auth / tester / dev / preview-build) and i18n `t()` call, then
+// builds this plain view-model and hands it to <MoreForm />. The native tree
+// renders strings + invokes the row handlers only — all derived copy and haptics
+// live in the screen.
+//
+// `sfSymbol` is a plain string here (the `sf-symbols-typescript` SFSymbol union
+// isn't resolvable from this shared module); the iOS tree narrows it to the
+// Image `systemName` type at the call site.
+
+/** A choice in a segmented control or select menu. */
+export type MoreOption = {
+  key: string;
+  label: string;
+};
+
+/**
+ * A tappable row that navigates somewhere. Renders a trailing chevron; an
+ * optional leading SF Symbol (iOS) and an optional trailing badge ("New" pill).
+ */
+export type MoreNavRow = {
+  kind: 'nav';
+  key: string;
+  label: string;
+  subtitle?: string;
+  /** Leading SF Symbol name on iOS (e.g. `person.crop.circle` for Edit Profile). */
+  sfSymbol?: string;
+  /** Trailing badge text, e.g. the "New" pill on the changelog row. */
+  badge?: string;
+  onPress: () => void;
+};
+
+/** A switch row (Session Recording). */
+export type MoreToggleRow = {
+  kind: 'toggle';
+  key: string;
+  label: string;
+  subtitle?: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+};
+
+/** An inline segmented control (Appearance, Grade Format). */
+export type MoreSegmentedRow = {
+  kind: 'segmented';
+  key: string;
+  /** Accessibility label for the segmented group (not rendered as visible text). */
+  label?: string;
+  options: MoreOption[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+};
+
+/** A menu-style picker that shows the current value and opens a menu (Language). */
+export type MoreSelectRow = {
+  kind: 'select';
+  key: string;
+  label: string;
+  options: MoreOption[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+};
+
+/** A standalone action button (Sign Out, Delete Account). */
+export type MoreButtonRow = {
+  kind: 'button';
+  key: string;
+  label: string;
+  role?: 'destructive';
+  onPress: () => void;
+};
+
+/** Discriminated union of every row kind the More screen needs. */
+export type MoreRow = MoreNavRow | MoreToggleRow | MoreSegmentedRow | MoreSelectRow | MoreButtonRow;
+
+/** One grouped section: an optional header title, optional footer note, and its rows. */
+export type MoreSection = {
+  key: string;
+  title?: string;
+  footer?: string;
+  rows: MoreRow[];
+};
+
+/** The whole screen as plain data: an ordered list of sections. */
+export type MoreFormModel = {
+  sections: MoreSection[];
+};
+
+export type MoreFormProps = {
+  model: MoreFormModel;
+};

--- a/packages/mobile/src/components/MoreForm.types.ts
+++ b/packages/mobile/src/components/MoreForm.types.ts
@@ -11,9 +11,30 @@
 // renders strings + invokes the row handlers only — all derived copy and haptics
 // live in the screen.
 //
-// `sfSymbol` is a plain string here (the `sf-symbols-typescript` SFSymbol union
-// isn't resolvable from this shared module); the iOS tree narrows it to the
-// Image `systemName` type at the call site.
+// Leading icons are SEMANTIC (`MoreIconName`), not a platform glyph string. Each
+// platform maps the name to its own native icon: iOS → an SF Symbol
+// (MoreForm.ios.tsx), Android → a Material XML vector drawable under
+// assets/material-icons/ (MoreForm.android.tsx). Keeping the model platform-neutral
+// lets both sides render real native icons from one source of truth.
+
+/**
+ * Semantic leading-icon name for a nav row, one per place the More screen links
+ * to. The platform files own the name → glyph mapping (SF Symbol on iOS, Material
+ * vector drawable on Android), so this union is the single contract between the
+ * screen and both renderers.
+ */
+export type MoreIconName =
+  | 'playlists'
+  | 'integrations'
+  | 'accessibility'
+  | 'translate'
+  | 'replay'
+  | 'changelog'
+  | 'devServers'
+  | 'otaChannel'
+  | 'featureFlags'
+  | 'branchSwitcher'
+  | 'editProfile';
 
 /** A choice in a segmented control or select menu. */
 export type MoreOption = {
@@ -23,15 +44,16 @@ export type MoreOption = {
 
 /**
  * A tappable row that navigates somewhere. Renders a trailing chevron; an
- * optional leading SF Symbol (iOS) and an optional trailing badge ("New" pill).
+ * optional leading semantic icon (an SF Symbol on iOS, a Material vector drawable
+ * on Android) and an optional trailing badge ("New" pill).
  */
 export type MoreNavRow = {
   kind: 'nav';
   key: string;
   label: string;
   subtitle?: string;
-  /** Leading SF Symbol name on iOS (e.g. `person.crop.circle` for Edit Profile). */
-  sfSymbol?: string;
+  /** Semantic leading icon; each platform maps it to its own native glyph. */
+  icon?: MoreIconName;
   /** Trailing badge text, e.g. the "New" pill on the changelog row. */
   badge?: string;
   onPress: () => void;
@@ -74,6 +96,14 @@ export type MoreButtonRow = {
   key: string;
   label: string;
   role?: 'destructive';
+  /**
+   * Visual weight. `'primary'` (default) is the full-strength affordance — a
+   * filled red block on Android, a body-size destructive row on iOS. `'subtle'`
+   * is a quieter, secondary destructive affordance (a text-only button on
+   * Android, a footnote-size row on iOS) so two destructive actions stacked
+   * together (Sign Out + Delete Account) don't read as equal heavy red blocks.
+   */
+  emphasis?: 'primary' | 'subtle';
   onPress: () => void;
 };
 

--- a/packages/mobile/src/components/SegmentedControl.ios.tsx
+++ b/packages/mobile/src/components/SegmentedControl.ios.tsx
@@ -35,11 +35,13 @@ export function SegmentedControl<K extends string = string>({
   const handleSelect = makeSelectHandler(onSelect, disabledKeys);
 
   return (
-    // minHeight floors the row in RN's layout: the native iOS Host (matchContents
-    // vertical) under-reports the segmented Picker's height to React Native, so
-    // without a floor the control collapses and the content below it (e.g. the
-    // sort buttons under "Order") rides up over it.
-    <Host matchContents={{ vertical: true }} style={[styles.host, styles.minRow]}>
+    // Explicit height, NOT matchContents: the native iOS Host under-reported the
+    // segmented Picker's height to RN (~26pt for a ~35pt control) AND the style
+    // minHeight floor wasn't applied, so the control was squished and a parent
+    // with `overflow: 'hidden'` (the profile chrome's rounded glass track) clipped
+    // the bottom of the selected pill. A fixed frame sizes the control
+    // deterministically across every container.
+    <Host style={styles.host}>
       <Picker
         selection={selectedKey}
         onSelectionChange={(value) => {
@@ -71,9 +73,8 @@ export function SegmentedControl<K extends string = string>({
 const styles = StyleSheet.create({
   host: {
     width: '100%',
-  },
-  // iOS segmented control sits ~32pt; 44 gives a comfortable, non-collapsing row.
-  minRow: {
-    minHeight: 44,
+    // The native segmented control sits ~35pt; 40 contains it with minimal slack.
+    // (matchContents under-reported it to ~26pt, clipping the pill.)
+    height: 40,
   },
 });

--- a/packages/mobile/src/components/__tests__/more-form-logic.test.ts
+++ b/packages/mobile/src/components/__tests__/more-form-logic.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { assertNeverRow, selectedOptionLabel } from '../MoreForm.logic';
+import type { MoreOption } from '../MoreForm.types';
+
+const options: MoreOption[] = [
+  { key: 'system', label: 'System' },
+  { key: 'en-US', label: 'English' },
+  { key: 'es', label: 'Español' },
+];
+
+describe('selectedOptionLabel', () => {
+  it('returns the label for the selected key', () => {
+    expect(selectedOptionLabel(options, 'es')).toBe('Español');
+  });
+
+  it('returns an empty string when the key is not present', () => {
+    expect(selectedOptionLabel(options, 'fr')).toBe('');
+    expect(selectedOptionLabel([], 'system')).toBe('');
+  });
+});
+
+describe('assertNeverRow', () => {
+  it('throws when reached with an unexpected row kind', () => {
+    // Cast through unknown: at runtime an unhandled kind would arrive here, and the
+    // guard must throw rather than silently return.
+    const rogue = { kind: 'mystery', key: 'x' } as unknown as never;
+    expect(() => assertNeverRow(rogue)).toThrow(/Unhandled MoreRow kind/);
+  });
+});

--- a/packages/mobile/src/components/you/ProfileTopChrome.tsx
+++ b/packages/mobile/src/components/you/ProfileTopChrome.tsx
@@ -18,21 +18,13 @@ import { Appbar } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../providers/theme-provider';
 import { createVariantComponent } from '../../theme/variants';
-import { useNativeGlass } from '../../hooks/use-native-glass';
-import { spacing, shadows } from '../../theme/tokens';
+import { spacing } from '../../theme/tokens';
 import { Icon } from '../Icon';
 import { iconMap } from '../icon-map';
-import { GlassSurface } from '../GlassSurface';
 import { SegmentedControl } from '../SegmentedControl';
 import { MaterialTabs } from '../navigation/MaterialTabs';
 import { CollapsingLargeTitleHeader, GlassActionToolbar, GlassToolbarAction } from '../chrome';
 import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction';
-
-// The segmented control floats over the chrome's faded scrim with scrolling
-// content behind it, so it needs its own glass track to stay legible and to give
-// the opaque selected thumb something to pop against (matching the Climbs search
-// capsule's treatment). 10 leaves a hair of glass around the thumb's radius-7 tile.
-const SEGMENT_TRACK_RADIUS = 10;
 
 export type ProfileTabKey = 'progress' | 'sessions' | 'logbook' | 'social';
 
@@ -141,7 +133,6 @@ function ProfileTopChromeGlass({
 }: ProfileTopChromeProps) {
   const { t } = useTranslation('you');
   const { systemColors, brandColors } = useTheme();
-  const nativeGlass = useNativeGlass();
 
   const dashboardTitle = t('metadata.dashboard.title');
   const segmentOptions = useSegmentOptions();
@@ -165,30 +156,18 @@ function ProfileTopChromeGlass({
 
   return (
     <CollapsingLargeTitleHeader onHeightChange={onHeightChange} leftActions={leftActions} rightActions={rightActions}>
+      {/* The native iOS segmented control brings its own track/background, so it
+          renders directly — wrapping it in the old GlassSurface track doubled the
+          border. The padded segmentStack positions it under the large title. */}
       <View pointerEvents="box-none" style={styles.segmentStack}>
-        <View
-          style={[
-            styles.segmentTrack,
-            !nativeGlass && shadows.sm,
-            !nativeGlass && { borderWidth: StyleSheet.hairlineWidth, borderColor: systemColors.separator },
-          ]}
-        >
-          <GlassSurface
-            glassEffectStyle="regular"
-            fallbackColor={systemColors.fill}
-            borderRadius={SEGMENT_TRACK_RADIUS}
-            style={StyleSheet.absoluteFill}
-            pointerEvents="none"
-          />
-          <SegmentedControl
-            options={segmentOptions}
-            selectedKey={activeTab}
-            onSelect={onSelectTab}
-            trackColor="transparent"
-            textVariant="footnote"
-            accessibilityLabel={dashboardTitle}
-          />
-        </View>
+        <SegmentedControl
+          options={segmentOptions}
+          selectedKey={activeTab}
+          onSelect={onSelectTab}
+          trackColor="transparent"
+          textVariant="footnote"
+          accessibilityLabel={dashboardTitle}
+        />
       </View>
     </CollapsingLargeTitleHeader>
   );
@@ -198,11 +177,6 @@ const styles = StyleSheet.create({
   segmentStack: {
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[2],
-  },
-  segmentTrack: {
-    borderRadius: SEGMENT_TRACK_RADIUS,
-    // Clip the absolutely-filled GlassSurface to the rounded corners on Android.
-    overflow: 'hidden',
   },
   materialContainer: {
     position: 'absolute',

--- a/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/profile-top-chrome.test.tsx
@@ -217,10 +217,11 @@ describe('ProfileTopChrome', () => {
       expect(onSelectTab).toHaveBeenCalledWith('logbook');
     });
 
-    it('wraps the segmented control in a glass track', () => {
+    it('renders the native segmented control without a glass-track wrapper', () => {
       const { container } = render(<ProfileTopChrome {...makeProps()} />);
-      // The glass branch mounts a GlassSurface track and a transparent track colour.
-      expect(container.querySelector('[data-slot="children"] [data-glass="true"]')).not.toBeNull();
+      // The native segmented control brings its own track, so it renders directly —
+      // wrapping it in a GlassSurface doubled the border, so the wrapper was dropped.
+      expect(container.querySelector('[data-glass="true"]')).toBeNull();
       expect(segments.entries.at(-1)!.trackColor).toBe('transparent');
     });
 

--- a/packages/mobile/test/feature-flags-form-stub.tsx
+++ b/packages/mobile/test/feature-flags-form-stub.tsx
@@ -1,0 +1,56 @@
+// Test stub for the platform-split FeatureFlagsForm. Its iOS / Android
+// implementations render native @expo/ui trees (a SwiftUI `Form` / Compose
+// `LazyColumn` of cards) that can't mount under Vitest's node env, and Vitest
+// doesn't resolve `.ios`/`.android` platform extensions, so any suite that
+// transitively renders the Feature Flags screen redirects here via a vite alias
+// (see vite.config.ts).
+//
+// This is a FAITHFUL PASSTHROUGH (not a null stub): it preserves the public API
+// and the radio/radiogroup + button accessibility semantics with plain React
+// Native primitives, so screen tests' label / role assertions keep passing.
+// Component tests that assert FeatureFlagsForm internals register their own
+// vi.mock, which takes precedence over this alias.
+
+import { Pressable, Text, View } from 'react-native';
+import { FEATURE_FLAG_CHOICES } from '../src/components/FeatureFlagsForm.logic';
+// The shared props type has no native imports, so it's safe to pull into the
+// node-env stub — keeps the stub's contract from drifting from the real component.
+import type { FeatureFlagsFormProps } from '../src/components/FeatureFlagsForm.types';
+
+export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
+  return (
+    <View>
+      <Text>{title}</Text>
+      <Text>{noticeText}</Text>
+      {rows.map((row) => (
+        <View key={row.key}>
+          <Text>{row.label}</Text>
+          <Text>{row.description}</Text>
+          <View accessibilityRole="radiogroup" accessibilityLabel={row.label}>
+            {FEATURE_FLAG_CHOICES.map((choice) => (
+              <Pressable
+                key={choice.key}
+                onPress={() => onSelect(row.key, choice.key)}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: choice.key === row.choice }}
+                accessibilityLabel={choice.label}
+              >
+                <Text>{choice.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+          <Text>{row.effectiveLabel}</Text>
+        </View>
+      ))}
+      <Pressable
+        onPress={onReset}
+        disabled={!canReset}
+        accessibilityRole="button"
+        accessibilityLabel="Reset all overrides"
+        accessibilityState={{ disabled: !canReset }}
+      >
+        <Text>Reset all overrides</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/packages/mobile/test/more-form-stub.tsx
+++ b/packages/mobile/test/more-form-stub.tsx
@@ -1,0 +1,79 @@
+// Test stub for the platform-split MoreForm. Its iOS / Android implementations
+// render native @expo/ui trees (a SwiftUI `Form` / Compose `LazyColumn`) that
+// can't mount under Vitest's node env, and Vitest doesn't resolve `.ios`/`.android`
+// platform extensions, so any suite that transitively renders the More screen
+// redirects here via a vite alias (see vite.config.ts).
+//
+// This is a FAITHFUL PASSTHROUGH (not a null stub): it renders every row's visible
+// label and wires its handler to a plain React Native primitive with a sensible
+// accessibility role (nav/button → button, toggle → switch, segmented/select →
+// radiogroup of radios), so screen tests' label / role assertions and handler
+// invocations keep working. Component tests that assert MoreForm internals can
+// register their own vi.mock, which takes precedence over this alias.
+
+import { Pressable, Switch, Text, View } from 'react-native';
+import { selectedOptionLabel } from '../src/components/MoreForm.logic';
+// The shared props type has no native imports, so it's safe in the node-env stub —
+// keeps the stub's contract from drifting from the real component.
+import type { MoreFormProps, MoreRow } from '../src/components/MoreForm.types';
+
+function StubRow({ row }: { row: MoreRow }) {
+  switch (row.kind) {
+    case 'nav':
+      return (
+        <Pressable onPress={row.onPress} accessibilityRole="button" accessibilityLabel={row.label}>
+          <Text>{row.label}</Text>
+          {row.subtitle ? <Text>{row.subtitle}</Text> : null}
+          {row.badge ? <Text>{row.badge}</Text> : null}
+        </Pressable>
+      );
+    case 'toggle':
+      return (
+        <View>
+          <Text>{row.label}</Text>
+          {row.subtitle ? <Text>{row.subtitle}</Text> : null}
+          <Switch value={row.value} onValueChange={row.onValueChange} accessibilityLabel={row.label} />
+        </View>
+      );
+    case 'segmented':
+    case 'select':
+      return (
+        <View accessibilityRole="radiogroup" accessibilityLabel={row.label}>
+          {row.kind === 'select' ? <Text>{selectedOptionLabel(row.options, row.selectedKey)}</Text> : null}
+          {row.options.map((option) => (
+            <Pressable
+              key={option.key}
+              onPress={() => row.onSelect(option.key)}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: option.key === row.selectedKey }}
+              accessibilityLabel={option.label}
+            >
+              <Text>{option.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      );
+    case 'button':
+      return (
+        <Pressable onPress={row.onPress} accessibilityRole="button" accessibilityLabel={row.label}>
+          <Text>{row.label}</Text>
+        </Pressable>
+      );
+  }
+}
+
+export function MoreForm({ model }: MoreFormProps) {
+  return (
+    <View>
+      {model.sections.map((section) => (
+        <View key={section.key}>
+          {section.title ? <Text>{section.title}</Text> : null}
+          {section.rows.map((row) => (
+            <StubRow key={row.key} row={row} />
+          ))}
+          {section.footer ? <Text>{section.footer}</Text> : null}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/packages/mobile/test/more-form-stub.tsx
+++ b/packages/mobile/test/more-form-stub.tsx
@@ -12,7 +12,7 @@
 // register their own vi.mock, which takes precedence over this alias.
 
 import { Pressable, Switch, Text, View } from 'react-native';
-import { selectedOptionLabel } from '../src/components/MoreForm.logic';
+import { assertNeverRow, selectedOptionLabel } from '../src/components/MoreForm.logic';
 // The shared props type has no native imports, so it's safe in the node-env stub —
 // keeps the stub's contract from drifting from the real component.
 import type { MoreFormProps, MoreRow } from '../src/components/MoreForm.types';
@@ -59,6 +59,10 @@ function StubRow({ row }: { row: MoreRow }) {
           <Text>{row.label}</Text>
         </Pressable>
       );
+    // Match the real platform files: a future MoreRow kind that isn't handled is a
+    // compile error here, not a row that silently renders nothing.
+    default:
+      return assertNeverRow(row);
   }
 }
 

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -169,6 +169,17 @@ export default defineConfig({
         find: /^(.*\/)?FeatureFlagsForm$/,
         replacement: fileURLToPath(new URL('./test/feature-flags-form-stub.tsx', import.meta.url)),
       },
+      // MoreForm is platform-split (MoreForm.ios.tsx renders a native @expo/ui
+      // SwiftUI `Form`; MoreForm.android.tsx a native Compose `LazyColumn`).
+      // Vitest doesn't resolve `.ios`/`.android` extensions and can't mount either
+      // native tree, so redirect the extensionless import to a faithful
+      // passthrough stub that keeps the public API + nav/button/switch/radio
+      // accessibility roles. Suites that assert MoreForm internals register their
+      // own vi.mock (takes precedence).
+      {
+        find: /^(.*\/)?MoreForm$/,
+        replacement: fileURLToPath(new URL('./test/more-form-stub.tsx', import.meta.url)),
+      },
     ],
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -158,6 +158,17 @@ export default defineConfig({
         find: /^(.*\/)?AngleSlider$/,
         replacement: fileURLToPath(new URL('./test/angle-slider-stub.tsx', import.meta.url)),
       },
+      // FeatureFlagsForm is platform-split (FeatureFlagsForm.ios.tsx renders a
+      // native @expo/ui SwiftUI `Form`; FeatureFlagsForm.android.tsx a native
+      // Compose `LazyColumn` of cards). Vitest doesn't resolve `.ios`/`.android`
+      // extensions and can't mount either native tree, so redirect the
+      // extensionless import to a faithful passthrough stub that keeps the public
+      // API + radio/radiogroup + button accessibility roles. Suites that assert
+      // FeatureFlagsForm internals register their own vi.mock (takes precedence).
+      {
+        find: /^(.*\/)?FeatureFlagsForm$/,
+        replacement: fileURLToPath(new URL('./test/feature-flags-form-stub.tsx', import.meta.url)),
+      },
     ],
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React


### PR DESCRIPTION
## Summary

**Stacked on #3254 (PR-1).** Migrates the settings screens to native `@expo/ui` `Form`/`Section` (iOS SwiftUI) and a Compose list (Android), one **Host per screen**.

- **Feature Flags** (tester-only) — the pilot establishing the pattern.
- **More** (the main settings screen) — nav rows, Appearance/Grade-Format segmented, Language menu picker, Session-recording toggle, changelog "New" badge, and Sign Out / Delete actions, all native. `more.tsx` stays the shared route screen (keeps every guard/conditional/handler/i18n); a typed view-model is rendered by `MoreForm.ios`/`.android`.

The one-Host-per-Form structure also sidesteps the per-row Host-height issue from PR-1, since the native Form/list owns its row layout.

**Known follow-ups** (tracked, not blockers): the More account row uses an SF Symbol stand-in for the avatar image; Android nav-row leading icons are pending (Material XML drawables) — see review thread. **Not** converted (need the deferred native `TextField` or are bespoke): channel/branch switcher, dev-servers, and the Accessibility editor.

## Release Notes

- Your settings now use your phone's own native controls and layout — the More screen looks and moves like the rest of iOS and Android.

## Test plan

- `vp run typecheck:mobile` ✓ · `vp run test:mobile` ✓ (372 files / 2789 tests) · `vp run check:mobile-platform-imports` ✓ · `vp run check:mobile-bundle` ✓ (iOS + Android)
- **Android emulator:** Feature Flags Form verified ✓; More screen verification in progress
- **iOS:** on-device verification by the author (Form insets, row kinds, badge, menu Language picker, destructive buttons, SF-symbol avatar row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01637bTyb8XqTvo8Vz65NE36