### PR TITLE
fix(mobile): stop NetInfo offline signal from stranding data screens

### DIFF
--- a/packages/mobile/src/providers/__tests__/query-provider-connectivity.test.ts
+++ b/packages/mobile/src/providers/__tests__/query-provider-connectivity.test.ts
@@ -18,6 +18,10 @@ vi.mock('@react-native-community/netinfo', () => ({
       captured.netInfoListener = listener;
       return () => {};
     },
+    // The provider seeds the initial state via fetch() before registering the
+    // live listener; resolve to connected so the seed leaves onlineManager
+    // online (the default the tests below then drive away from).
+    fetch: () => Promise.resolve({ isConnected: true }),
   },
 }));
 

--- a/packages/mobile/src/providers/__tests__/query-provider-network-mode.test.ts
+++ b/packages/mobile/src/providers/__tests__/query-provider-network-mode.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// query-provider imports AppState/Platform from react-native, which can't load
+// under vitest's node env — mock it. NetInfo resolves via the netinfo-stub alias
+// (vite.config.ts), which reports connected, so the module-load seed leaves
+// onlineManager online; each test drives it offline explicitly below.
+vi.mock('react-native', () => ({
+  AppState: {
+    addEventListener: (_event: string, _handler: (status: string) => void) => ({ remove: () => {} }),
+  },
+  Platform: { OS: 'ios' },
+}));
+
+vi.mock('../../lib/error-reporting', () => ({ reportHandledError: vi.fn() }));
+
+import { onlineManager } from '@tanstack/react-query';
+import { createQueryClient } from '../query-provider';
+
+describe('createQueryClient network mode', () => {
+  afterEach(() => {
+    // onlineManager is a process-global singleton; restore it so this offline
+    // state doesn't bleed into other assertions.
+    onlineManager.setOnline(true);
+  });
+
+  it('fetches queries while offline (offlineFirst) instead of pausing them', async () => {
+    onlineManager.setOnline(false);
+    const queryClient = createQueryClient();
+    const queryFn = vi.fn().mockResolvedValue('payload');
+
+    // With the default networkMode 'online', an offline query pauses and this
+    // promise would never settle (the test would time out). 'offlineFirst' runs
+    // the fetch once regardless, so it resolves — proving data screens can't be
+    // stranded by a wrong/late NetInfo offline signal.
+    await expect(queryClient.fetchQuery({ queryKey: ['offline-first-probe'], queryFn })).resolves.toBe('payload');
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    queryClient.clear();
+  });
+});

--- a/packages/mobile/src/providers/query-provider.tsx
+++ b/packages/mobile/src/providers/query-provider.tsx
@@ -19,18 +19,32 @@ import { reportHandledError } from '../lib/error-reporting';
 // (the canonical Expo offline-support pattern). A single root QueryProvider
 // lives for the whole app, so there's nothing to tear down.
 //
-// NetInfo is a native module, so this JS reaches devices only via the next
-// native build — the fingerprint runtimeVersion policy gates the OTA so old
-// binaries never receive code importing a missing native module.
-onlineManager.setEventListener((setOnline) =>
-  NetInfo.addEventListener((state) => {
+// NetInfo is a native module; the fingerprint runtimeVersion policy gates the
+// OTA so a binary running this JS has the matching native module compiled in.
+onlineManager.setEventListener((setOnline) => {
+  // Seed the current state up front: onlineManager defaults to online and would
+  // otherwise stay there until the first NetInfo change event arrives. Combined
+  // with `networkMode: 'offlineFirst'` below, a wrong/late offline signal can
+  // no longer strand the initial fetch.
+  void NetInfo.fetch()
+    .then((state) => setOnline(state.isConnected ?? true))
+    .catch(() => {
+      // A failed seed leaves the default (online); the live listener below
+      // still delivers real state, so there's nothing actionable to report.
+    });
+  return NetInfo.addEventListener((state) => {
     setOnline(state.isConnected ?? true);
-  }),
-);
+  });
+});
 
 if (Platform.OS !== 'web') {
-  AppState.addEventListener('change', (status) => {
-    focusManager.setFocused(status === 'active');
+  // Mirror onlineManager's setEventListener wiring so focusManager owns the
+  // AppState subscription and tears it down on re-wire.
+  focusManager.setEventListener((handleFocus) => {
+    const subscription = AppState.addEventListener('change', (status) => {
+      handleFocus(status === 'active');
+    });
+    return () => subscription.remove();
   });
 }
 
@@ -77,9 +91,17 @@ export function createQueryClient(): QueryClient {
     }),
     defaultOptions: {
       queries: {
+        // `offlineFirst` runs the fetch once regardless of onlineManager status
+        // (only retries pause while offline), so a wrong/late NetInfo offline
+        // signal can't leave data screens stuck in `fetchStatus: 'paused'`.
+        // refetchOnReconnect still fires when connectivity returns.
+        networkMode: 'offlineFirst',
         staleTime: 5 * 60 * 1000,
         gcTime: 30 * 60 * 1000,
         retry: 2,
+      },
+      mutations: {
+        networkMode: 'offlineFirst',
       },
     },
   });


### PR DESCRIPTION
## Summary

PR #3242 bridged NetInfo into React Query's `onlineManager` so `refetchOnReconnect` works on RN. But `networkMode` was left at its default `'online'`, which means whenever `onlineManager.isOnline()` is `false`, **every query goes to `fetchStatus: 'paused'` and never fetches**. On a device where NetInfo reports/initialises as offline (no initial-state seed, flagged in #3242's own review), the bridge strands the whole app — **data screens stuck loading forever**. This is the "cannot connect" reported on a TestFlight `pr-<n>` build. Before #3242, RN was treated as permanently online, so data always loaded — the bridge introduced the regression.

The app boots fine for the reporter (shell renders), so the netinfo native module is present — this is the pause-on-offline path, not an import crash.

### Changes
- **`networkMode: 'offlineFirst'`** for queries *and* mutations in `createQueryClient`. The fetch runs once regardless of `onlineManager` status; only *retries* pause while offline. A wrong/late `isConnected: false` can no longer strand the initial load, while `refetchOnReconnect` and offline-retry-pausing still work. **This is the core cure.**
- **Seed initial connectivity** via `NetInfo.fetch()` in the `onlineManager.setEventListener` setup, so it starts from the device's real state instead of waiting for the first change event.
- **`focusManager` symmetry** — wire `AppState` through `focusManager.setEventListener` (owns + tears down the subscription) instead of a bare discarded `AppState.addEventListener` (review nit).

### Scope note
The approved plan also included crash-proofing the netinfo *import* via a guarded `require()` (for binaries that lack the native module). I dropped that here: this vitest/rolldown setup's `require()` doesn't honour `vi.mock`/the vite alias (it resolves netinfo's TS source and throws `SyntaxError`), so the success path isn't unit-testable and a module-load `require` makes every provider-importing suite hit a caught error. It's also not the reported bug (the binary boots — module present) and the fingerprint-gated OTA already prevents JS/native divergence for shipped builds. Worth a follow-up behind a testability refactor.

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- This fixes a regression from #3242 that has not shipped in a released build (native change, no new store build cut), so released users never saw the bug. -->

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2783 tests pass (372 files), incl. new `query-provider-network-mode.test.ts` (proves an offline query reaches `fetchStatus`/resolves instead of pausing) and updated `query-provider-connectivity.test.ts` (seed `fetch` + `focusManager.setEventListener`)
- `vp run check:mobile-bundle` — OK, netinfo resolves (12.7 MB)
- `vp check` (changed files) — pass
- **Device:** publish this branch's `pr-<n>` OTA, switch the TestFlight build to it (More → Development → OTA Channel Switcher), confirm Search / logbook / profile load. JS-only change → OTA reaches the existing netinfo-capable binary, no new native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T85c8PYxnoVykTooqQU5qK