### PR TITLE
fix(mobile): shorten resting grade filter capsule label to "Grade"

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -814,7 +814,7 @@ function ClimbListInner() {
     if (gradeFilterToken) {
       return { label: gradeFilterToken.label, active: true, onClear: gradeFilterToken.clear };
     }
-    return { label: t('mobile.filter.gradeRange'), active: false };
+    return { label: t('mobile.filter.grade'), active: false };
   }, [gradeFilterToken, t]);
 
   // --- Persistent filter chips (Liquid Glass) ---

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -152,7 +152,7 @@ export function ClimbTopChrome({
     const hasNonGradeFilters = nonGradeFilterCount > 0;
     const shouldShowFilterSummary = filterSummary != null && hasNonGradeFilters;
     const visibleFilterSummary = shouldShowFilterSummary ? filterSummary : null;
-    const visibleGradeLabel = gradeChip?.label ?? t('mobile.filter.gradeRange');
+    const visibleGradeLabel = gradeChip?.label ?? t('mobile.filter.grade');
 
     return (
       <View

--- a/packages/mobile/src/components/search/FilterChipRow.types.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.types.ts
@@ -34,7 +34,7 @@ export type FilterChipRowProps = {
   onApplyRecent: (filters: ClimbFilters, searchText: string) => void;
   onClearRecent: () => void;
 
-  /** Localised grade-bound label ("V4–V6") or the "Grade range" placeholder. */
+  /** Localised grade-bound label ("V4–V6") or the resting "Grade" placeholder. */
   gradeLabel: string;
   gradeActive: boolean;
   onOpenGrade: () => void;

--- a/packages/mobile/src/components/search/GradeFilterControl.tsx
+++ b/packages/mobile/src/components/search/GradeFilterControl.tsx
@@ -1,7 +1,7 @@
 // The grade-range affordance in the climbs search row (Material variant). Shaped
 // as an M3 exposed-dropdown control — an outlined, field-height pill that reads as
-// a peer of the search field beside it: a label (the current selection, or "Grade
-// range") plus a trailing chevron that flips up while the inline grade rail is open.
+// a peer of the search field beside it: a label (the current selection, or the
+// resting "Grade") plus a trailing chevron that flips up while the inline grade rail is open.
 // When a range is active it swaps the chevron for a separate clear (X) button — a
 // sibling, not a nested target — so "tap body to edit" and "tap X to clear" stay
 // distinct (and independently labelled) for assistive tech.
@@ -13,7 +13,7 @@ import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
 
 type GradeFilterControlProps = {
-  /** Current selection text (e.g. "V4–V6"), or the resting "Grade range" label. */
+  /** Current selection text (e.g. "V4–V6"), or the resting "Grade" label. */
   label: string;
   /** A grade range is applied — switches to the filled/clearable state. */
   active: boolean;

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -615,7 +615,10 @@ describe('ClimbTopChrome', () => {
     expect(switcher?.getAttribute('data-hint')).toBe('mobile.search.boardSwitcherHint');
     expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     expect(container.querySelector('[data-search-field]')).not.toBeNull();
-    expect(container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent).toContain('Grade');
+    const gradeLabel = container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent;
+    expect(gradeLabel).toContain('Grade');
+    // The resting label is the bare "Grade", not the old "Grade range" placeholder.
+    expect(gradeLabel).not.toContain('range');
 
     fireEvent.click(capsule(container)!);
     expect(onOpenBoardDetail).toHaveBeenCalledTimes(1);

--- a/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/climb-top-chrome.test.tsx
@@ -598,7 +598,7 @@ describe('ClimbTopChrome', () => {
           onOpenBoardDetail,
           onOpenFilters: vi.fn(),
           activeFilterCount: 0,
-          gradeChip: { label: 'Grade range', active: false },
+          gradeChip: { label: 'Grade', active: false },
           gradeBound: { minGradeId: undefined, maxGradeId: undefined },
           onOpenGrade: vi.fn(),
           onGradeChange: vi.fn(),
@@ -615,9 +615,7 @@ describe('ClimbTopChrome', () => {
     expect(switcher?.getAttribute('data-hint')).toBe('mobile.search.boardSwitcherHint');
     expect(container.querySelector('[data-icon="chevron.down"]')).not.toBeNull();
     expect(container.querySelector('[data-search-field]')).not.toBeNull();
-    expect(container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent).toContain(
-      'Grade range',
-    );
+    expect(container.querySelector('[data-pressable="mobile.search.gradeAction"]')?.textContent).toContain('Grade');
 
     fireEvent.click(capsule(container)!);
     expect(onOpenBoardDetail).toHaveBeenCalledTimes(1);

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -576,6 +576,7 @@
       "both": "Both",
       "title": "Filters",
       "sortBy": "Sort by",
+      "grade": "Grade",
       "gradeRange": "Grade range",
       "anyAscents": "Any",
       "refineHint": "Climb type, setters, grade accuracy",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -576,6 +576,7 @@
       "both": "Ambos",
       "title": "Filtros",
       "sortBy": "Ordenar por",
+      "grade": "Grado",
       "gradeRange": "Rango de grado",
       "anyAscents": "Todos",
       "refineHint": "Tipo, equipadores, precisión de grado",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -576,6 +576,7 @@
       "both": "Les deux",
       "title": "Filtres",
       "sortBy": "Trier par",
+      "grade": "Cotation",
       "gradeRange": "Plage de cotation",
       "anyAscents": "Tous",
       "refineHint": "Type, ouvreurs, précision du niveau",


### PR DESCRIPTION
## Summary

The grade filter capsule in the mobile climb list read "Grade range" at rest — before any range is picked, the word "range" is noise. This shortens the resting label to just "Grade" while leaving the active selection label (e.g. "V4–V6") and the inline grade rail's own "Grade range" section title untouched.

- Add a new `mobile.filter.grade` key ("Grade" / "Grado" / "Cotation") across the `en-US`, `es`, and `fr` catalogs.
- Point the capsule's resting label (`climbs/index.tsx` grade chip + the `ClimbTopChrome` fallback) at the new key.
- Update stale doc comments and the `climb-top-chrome` test that referenced the old placeholder.

The inline grade rail keeps `mobile.filter.gradeRange` as its section header, since that view is the actual range picker.

## Release Notes

- The grade filter button on the climbs screen now just says "Grade" until you pick a range.

## Test plan

- `vp run typecheck:mobile` — passes.
- `vp test run --project mobile climb-top-chrome` — 27 passing.
- `vp test run i18n` — 92 passing (catalog parity intact).
- `vp check` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpLWg3eAnAejUekCNf6Pnb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpLWg3eAnAejUekCNf6Pnb)_