### PR TITLE
feat(mobile): logbook sort as iOS Liquid Glass chips (#3257, scoped to sort)

### DIFF
--- a/packages/mobile/src/components/you/LogbookFilterSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookFilterSheet.tsx
@@ -54,6 +54,10 @@ type LogbookFilterSheetProps = {
   onApply: (filters: LogbookFilterState, sort: LogbookSortState) => void;
   /** Clear the toolbar's committed climb-name search (called by Reset). */
   onClearSearch?: () => void;
+  /** Show the in-sheet Sort (Latest/Hardest) block. Defaults true; the caller
+   *  passes false when the top-level sort chips own the sort, so it isn't shown
+   *  twice (Liquid Glass). The draft still tracks/commits sort either way. */
+  showSort?: boolean;
 };
 
 type StatusKey = 'sends' | 'attempts' | 'both';
@@ -140,6 +144,7 @@ export function LogbookFilterSheet({
   currentSort,
   onApply,
   onClearSearch,
+  showSort = true,
 }: LogbookFilterSheetProps) {
   const { t } = useTranslation('you');
   const theme = useTheme();
@@ -307,20 +312,24 @@ export function LogbookFilterSheet({
         showsVerticalScrollIndicator={false}
         contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + spacing[4] }]}
       >
-        {/* PRESET — the headline one-tap sort. Above Refine/Advanced. */}
-        <View style={styles.primary}>
-          <Text variant="footnote" style={styles.subsectionLabel}>
-            {t('mobile.logbook.sort')}
-          </Text>
-          <SegmentedControl
-            options={presetOptions}
-            selectedKey={presetKey}
-            onSelect={(key) => handlePreset(key)}
-            textVariant="footnote"
-            trackColor={trackColor}
-            accessibilityLabel={t('mobile.logbook.sort')}
-          />
-        </View>
+        {/* PRESET — the headline one-tap sort. Above Refine/Advanced. Suppressed
+            when the toolbar's top-level sort chips own it (Liquid Glass), so sort
+            isn't worded twice; the draft still tracks/commits it from chips. */}
+        {showSort ? (
+          <View style={styles.primary}>
+            <Text variant="footnote" style={styles.subsectionLabel}>
+              {t('mobile.logbook.sort')}
+            </Text>
+            <SegmentedControl
+              options={presetOptions}
+              selectedKey={presetKey}
+              onSelect={(key) => handlePreset(key)}
+              textVariant="footnote"
+              trackColor={trackColor}
+              accessibilityLabel={t('mobile.logbook.sort')}
+            />
+          </View>
+        ) : null}
 
         <View style={styles.sectionsContainer}>
           {/* REFINE — status / flash / grade / angle. */}

--- a/packages/mobile/src/components/you/LogbookSortChipRow.android.tsx
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.android.tsx
@@ -1,9 +1,5 @@
-// Android placeholder for the logbook sort-chip row. The native row is
-// SwiftUI-only (LogbookSortChipRow.ios.tsx); Android keeps the sort control
-// inside LogbookFilterSheet, so the chip row is a no-op here. The caller only
-// mounts it on Liquid Glass (iOS), so this never renders — but it keeps
-// @expo/ui/swift-ui (which resolves native views at module load) off the
-// Android bundle.
+// Android placeholder: importing the SwiftUI-only .ios row here would pull
+// @expo/ui/swift-ui onto the Android bundle. Android keeps the sheet's sort.
 
 import type { LogbookSortChipRowProps } from './LogbookSortChipRow.types';
 

--- a/packages/mobile/src/components/you/LogbookSortChipRow.android.tsx
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.android.tsx
@@ -1,0 +1,12 @@
+// Android placeholder for the logbook sort-chip row. The native row is
+// SwiftUI-only (LogbookSortChipRow.ios.tsx); Android keeps the sort control
+// inside LogbookFilterSheet, so the chip row is a no-op here. The caller only
+// mounts it on Liquid Glass (iOS), so this never renders — but it keeps
+// @expo/ui/swift-ui (which resolves native views at module load) off the
+// Android bundle.
+
+import type { LogbookSortChipRowProps } from './LogbookSortChipRow.types';
+
+export function LogbookSortChipRow(_props: LogbookSortChipRowProps): null {
+  return null;
+}

--- a/packages/mobile/src/components/you/LogbookSortChipRow.d.ts
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.d.ts
@@ -1,8 +1,5 @@
-// Ambient type for the platform-split LogbookSortChipRow so `tsc` resolves the
-// extensionless `./LogbookSortChipRow` import to this declaration, while Metro
-// picks the matching LogbookSortChipRow.ios.tsx / LogbookSortChipRow.android.tsx
-// at bundle time. Both implementations are still compiled and type-checked on
-// their own.
+// Ambient type so `tsc` resolves the extensionless `./LogbookSortChipRow` import
+// while Metro picks the .ios/.android implementation at bundle time.
 
 import type { FC } from 'react';
 import type { LogbookSortChipRowProps } from './LogbookSortChipRow.types';

--- a/packages/mobile/src/components/you/LogbookSortChipRow.d.ts
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.d.ts
@@ -1,0 +1,10 @@
+// Ambient type for the platform-split LogbookSortChipRow so `tsc` resolves the
+// extensionless `./LogbookSortChipRow` import to this declaration, while Metro
+// picks the matching LogbookSortChipRow.ios.tsx / LogbookSortChipRow.android.tsx
+// at bundle time. Both implementations are still compiled and type-checked on
+// their own.
+
+import type { FC } from 'react';
+import type { LogbookSortChipRowProps } from './LogbookSortChipRow.types';
+
+export declare const LogbookSortChipRow: FC<LogbookSortChipRowProps>;

--- a/packages/mobile/src/components/you/LogbookSortChipRow.ios.tsx
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.ios.tsx
@@ -1,19 +1,6 @@
-// Top-level sort chips for the logbook toolbar (the GitHub-PR-view idiom),
-// promoting the Latest/Hardest sort out of LogbookFilterSheet so the user can
-// switch sort without opening the sheet. Built from native @expo/ui SwiftUI
-// controls so the chips are real iOS 26 Liquid Glass capsules. iOS (Liquid
-// Glass) only — the Android counterpart is LogbookSortChipRow.android.tsx and
-// keeps the sheet's sort control. Mounted on Liquid Glass by the caller; when
-// shown, the sheet's own Sort block is suppressed so sort is never worded twice.
-//
-// Mirrors FilterChipRow.ios.tsx's <Host> / ScrollView / HStack / chipModifiers
-// structure, pared down to two mutually-exclusive chips:
-//   Latest  → preset 'recent'   (the resting default)
-//   Hardest → preset 'hardest'
-//
-// Each tap commits live through onSelectPreset (the tab's setPreset, which
-// persists). Labels reuse the filter sheet's i18n preset keys so a sort is
-// never worded two ways.
+// Latest/Hardest sort as native @expo/ui SwiftUI glass chips, mirroring the
+// climb list's FilterChipRow.ios.tsx. iOS-26 Liquid Glass only; the caller
+// suppresses the sheet's Sort block while these show.
 
 import { memo, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
@@ -28,11 +15,8 @@ function LogbookSortChipRowComponent({ preset, onSelectPreset }: LogbookSortChip
   const { t } = useTranslation('you');
   const { brandColors } = useTheme();
 
-  // Real iOS 26 Liquid Glass: the inactive chip is a neutral glass capsule
-  // (`buttonStyle('glass')`); the active sort is a brand-tinted prominent glass
-  // capsule (`buttonStyle('glassProminent')` + tint). @expo/ui guards both with
-  // `if #available(iOS 26)`, so they degrade gracefully on older iOS. (Matches
-  // FilterChipRow.ios.tsx's chipModifiers.)
+  // Active = brand-tinted prominent glass, inactive = neutral glass; @expo/ui
+  // guards both with `if #available(iOS 26)`. Matches FilterChipRow's chipModifiers.
   const chipModifiers = useCallback(
     (active: boolean) =>
       active
@@ -44,7 +28,7 @@ function LogbookSortChipRowComponent({ preset, onSelectPreset }: LogbookSortChip
   return (
     <Host matchContents={{ vertical: true }} style={styles.host}>
       <ScrollView axes="horizontal" showsIndicators={false}>
-        {/* Vertical slack lets a pressed chip's Liquid Glass lens expand without the host's fixed height clipping it. */}
+        {/* Vertical padding gives a pressed chip's glass lens room to expand. */}
         <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
           <Button
             label={t('mobile.logbook.preset.latest')}

--- a/packages/mobile/src/components/you/LogbookSortChipRow.ios.tsx
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.ios.tsx
@@ -1,0 +1,71 @@
+// Top-level sort chips for the logbook toolbar (the GitHub-PR-view idiom),
+// promoting the Latest/Hardest sort out of LogbookFilterSheet so the user can
+// switch sort without opening the sheet. Built from native @expo/ui SwiftUI
+// controls so the chips are real iOS 26 Liquid Glass capsules. iOS (Liquid
+// Glass) only — the Android counterpart is LogbookSortChipRow.android.tsx and
+// keeps the sheet's sort control. Mounted on Liquid Glass by the caller; when
+// shown, the sheet's own Sort block is suppressed so sort is never worded twice.
+//
+// Mirrors FilterChipRow.ios.tsx's <Host> / ScrollView / HStack / chipModifiers
+// structure, pared down to two mutually-exclusive chips:
+//   Latest  → preset 'recent'   (the resting default)
+//   Hardest → preset 'hardest'
+//
+// Each tap commits live through onSelectPreset (the tab's setPreset, which
+// persists). Labels reuse the filter sheet's i18n preset keys so a sort is
+// never worded two ways.
+
+import { memo, useCallback } from 'react';
+import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Host, HStack, ScrollView, Button } from '@expo/ui/swift-ui';
+import { buttonStyle, controlSize, tint, padding } from '@expo/ui/swift-ui/modifiers';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import type { LogbookSortChipRowProps } from './LogbookSortChipRow.types';
+
+function LogbookSortChipRowComponent({ preset, onSelectPreset }: LogbookSortChipRowProps) {
+  const { t } = useTranslation('you');
+  const { brandColors } = useTheme();
+
+  // Real iOS 26 Liquid Glass: the inactive chip is a neutral glass capsule
+  // (`buttonStyle('glass')`); the active sort is a brand-tinted prominent glass
+  // capsule (`buttonStyle('glassProminent')` + tint). @expo/ui guards both with
+  // `if #available(iOS 26)`, so they degrade gracefully on older iOS. (Matches
+  // FilterChipRow.ios.tsx's chipModifiers.)
+  const chipModifiers = useCallback(
+    (active: boolean) =>
+      active
+        ? [buttonStyle('glassProminent'), controlSize('small'), tint(brandColors.primary)]
+        : [buttonStyle('glass'), controlSize('small')],
+    [brandColors.primary],
+  );
+
+  return (
+    <Host matchContents={{ vertical: true }} style={styles.host}>
+      <ScrollView axes="horizontal" showsIndicators={false}>
+        {/* Vertical slack lets a pressed chip's Liquid Glass lens expand without the host's fixed height clipping it. */}
+        <HStack spacing={spacing[2]} modifiers={[padding({ horizontal: spacing[4], vertical: spacing[2] })]}>
+          <Button
+            label={t('mobile.logbook.preset.latest')}
+            onPress={() => onSelectPreset('recent')}
+            modifiers={chipModifiers(preset === 'recent')}
+          />
+          <Button
+            label={t('mobile.logbook.preset.hardest')}
+            onPress={() => onSelectPreset('hardest')}
+            modifiers={chipModifiers(preset === 'hardest')}
+          />
+        </HStack>
+      </ScrollView>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    width: '100%',
+  },
+});
+
+export const LogbookSortChipRow = memo(LogbookSortChipRowComponent);

--- a/packages/mobile/src/components/you/LogbookSortChipRow.types.ts
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.types.ts
@@ -1,0 +1,14 @@
+// Shared props for the logbook sort-chip row. The implementation is
+// platform-split: LogbookSortChipRow.ios.tsx renders native @expo/ui SwiftUI
+// glass chips, LogbookSortChipRow.android.tsx is a placeholder (Android keeps
+// the sheet's sort control). The split keeps @expo/ui/swift-ui — whose
+// components resolve native views at module load — off the Android bundle path.
+
+import type { LogbookSortPreset } from '@boardsesh/logbook';
+
+export type LogbookSortChipRowProps = {
+  /** The committed sort preset: Latest = 'recent', Hardest = 'hardest'. */
+  preset: LogbookSortPreset;
+  /** Live-commit a preset when its chip is tapped (persists via setPreset). */
+  onSelectPreset: (preset: LogbookSortPreset) => void;
+};

--- a/packages/mobile/src/components/you/LogbookSortChipRow.types.ts
+++ b/packages/mobile/src/components/you/LogbookSortChipRow.types.ts
@@ -1,14 +1,12 @@
-// Shared props for the logbook sort-chip row. The implementation is
-// platform-split: LogbookSortChipRow.ios.tsx renders native @expo/ui SwiftUI
-// glass chips, LogbookSortChipRow.android.tsx is a placeholder (Android keeps
-// the sheet's sort control). The split keeps @expo/ui/swift-ui — whose
-// components resolve native views at module load — off the Android bundle path.
+// Platform-split so @expo/ui/swift-ui (resolves native views at module load)
+// never reaches the Android bundle; Android keeps the sheet's sort control.
 
 import type { LogbookSortPreset } from '@boardsesh/logbook';
 
 export type LogbookSortChipRowProps = {
-  /** The committed sort preset: Latest = 'recent', Hardest = 'hardest'. */
-  preset: LogbookSortPreset;
+  /** Which preset to highlight (Latest = 'recent'); null lights no chip — a
+   *  non-preset sort is active. */
+  preset: LogbookSortPreset | null;
   /** Live-commit a preset when its chip is tapped (persists via setPreset). */
   onSelectPreset: (preset: LogbookSortPreset) => void;
 };

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, RefreshControl, Pressable, StyleSheet } from 'react-native';
+import { View, RefreshControl, Pressable, StyleSheet, Platform } from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import type { BottomSheet } from '@expo/ui/community/bottom-sheet';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations';
-import { toAscentFeedInput, DEFAULT_LOGBOOK_FILTERS, DEFAULT_LOGBOOK_SORT } from '@boardsesh/logbook';
+import {
+  toAscentFeedInput,
+  DEFAULT_LOGBOOK_FILTERS,
+  DEFAULT_LOGBOOK_SORT,
+  type LogbookSortPreset,
+} from '@boardsesh/logbook';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../lib/analytics';
 import { Text } from '../Text';
@@ -16,6 +21,7 @@ import { SearchHeader, type SearchHeaderHandle } from '../SearchHeader';
 import { LogbookRow } from './LogbookRow';
 import { LogbookEditSheet } from './LogbookEditSheet';
 import { LogbookFilterSheet } from './LogbookFilterSheet';
+import { LogbookSortChipRow } from './LogbookSortChipRow';
 import { useLogbookSearch, countActiveLogbookFilters } from './use-logbook-search';
 import { useUserAscentsFeed } from '../../lib/graphql/hooks';
 import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
@@ -50,9 +56,16 @@ type LogbookTabProps = {
 
 export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenTitle }: LogbookTabProps) {
   const { t } = useTranslation('you');
-  const { systemColors, brandColors } = useTheme();
+  const { systemColors, brandColors, variant } = useTheme();
   // Temporary kill switch while the search + filter UI is unfinished.
   const logbookFiltersEnabled = useFeatureFlag('logbook-filters') === true;
+  // Promote the Latest/Hardest sort to top-level Liquid Glass chips so it can be
+  // switched without opening the sheet. iOS 26 Liquid Glass only — the same
+  // capability the climbs screen gates its filter-chip row on (variant ===
+  // 'liquidGlass'); Android keeps the sheet's sort control. Already behind the
+  // logbook-filters flag (the whole toolbar is), so no new flag. When shown, the
+  // sheet's in-body Sort block is suppressed so sort isn't worded twice.
+  const showSortChips = logbookFiltersEnabled && Platform.OS === 'ios' && variant === 'liquidGlass';
   const router = useRouter();
   const { openPlayDrawer, openClimbActions } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
@@ -64,7 +77,9 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
   // Logbook search/filter/sort state. The committed name lives here; the visible
   // input value is debounced before it commits to the query.
   const logbookSearch = useLogbookSearch();
-  const { filters, sort, name, setName, apply, hydrated } = logbookSearch;
+  const { filters, sort, name, setName, setPreset, apply, hydrated } = logbookSearch;
+  // The committed preset feeds the top-level sort chips (Latest = 'recent').
+  const sortPreset: LogbookSortPreset = sort.mode === 'preset' ? sort.preset : 'recent';
   const activeFilterCount = useMemo(() => countActiveLogbookFilters(filters), [filters]);
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -232,6 +247,10 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
             </Pressable>
           </View>
         ) : null}
+        {/* Top-level Liquid Glass sort chips (Latest/Hardest) — switch sort
+            without opening the sheet. iOS Liquid Glass only; the sheet's own Sort
+            block is hidden (showSort={false}) so it isn't shown twice. */}
+        {showSortChips ? <LogbookSortChipRow preset={sortPreset} onSelectPreset={setPreset} /> : null}
       </View>
 
       {feed.isPending ? (
@@ -305,6 +324,9 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
           currentSort={sort}
           onApply={apply}
           onClearSearch={clearSearch}
+          // When the top-level sort chips are shown, drop the sheet's Sort block
+          // so sort isn't worded twice.
+          showSort={!showSortChips}
         />
       ) : null}
     </View>

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -35,6 +35,7 @@ import { hapticSelection } from '../../lib/haptics';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
@@ -59,13 +60,11 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
   const { systemColors, brandColors, variant } = useTheme();
   // Temporary kill switch while the search + filter UI is unfinished.
   const logbookFiltersEnabled = useFeatureFlag('logbook-filters') === true;
-  // Promote the Latest/Hardest sort to top-level Liquid Glass chips so it can be
-  // switched without opening the sheet. iOS 26 Liquid Glass only — the same
-  // capability the climbs screen gates its filter-chip row on (variant ===
-  // 'liquidGlass'); Android keeps the sheet's sort control. Already behind the
-  // logbook-filters flag (the whole toolbar is), so no new flag. When shown, the
-  // sheet's in-body Sort block is suppressed so sort isn't worded twice.
-  const showSortChips = logbookFiltersEnabled && Platform.OS === 'ios' && variant === 'liquidGlass';
+  // Latest/Hardest become top-level Liquid Glass chips (iOS 26 only) so sort is
+  // switchable without opening the sheet; the variant goes through selectByVariant
+  // per the mobile variant guard. When shown, the sheet's Sort block is suppressed.
+  const showSortChips =
+    logbookFiltersEnabled && Platform.OS === 'ios' && selectByVariant(variant, { liquidGlass: true, material: false });
   const router = useRouter();
   const { openPlayDrawer, openClimbActions } = useDrawerHost();
   const bottomChrome = useBottomChromeMetrics();
@@ -78,8 +77,9 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true, screenT
   // input value is debounced before it commits to the query.
   const logbookSearch = useLogbookSearch();
   const { filters, sort, name, setName, setPreset, apply, hydrated } = logbookSearch;
-  // The committed preset feeds the top-level sort chips (Latest = 'recent').
-  const sortPreset: LogbookSortPreset = sort.mode === 'preset' ? sort.preset : 'recent';
+  // Which preset the chips highlight; null (no chip lit) when a non-preset
+  // (custom) sort is in effect, rather than falsely lighting up Latest.
+  const sortPreset: LogbookSortPreset | null = sort.mode === 'preset' ? sort.preset : null;
   const activeFilterCount = useMemo(() => countActiveLogbookFilters(filters), [filters]);
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-sort-chips.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-sort-chips.test.tsx
@@ -2,7 +2,7 @@
 import { render, fireEvent, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LogbookSortPreset } from '@boardsesh/logbook';
+import { DEFAULT_LOGBOOK_FILTERS, DEFAULT_LOGBOOK_SORT, type LogbookSortPreset } from '@boardsesh/logbook';
 
 // Captures what LogbookTab hands the (mocked) sort chip row + filter sheet, so the
 // test can assert the Liquid-Glass gating and the showSort hand-off without native
@@ -123,6 +123,7 @@ vi.mock('../../../providers/feature-flags-provider', () => ({
 // use-logbook-search and @boardsesh/logbook run for real so setPreset commits the
 // preset into the feed through the real reducer.
 import { LogbookTab } from '../LogbookTab';
+import { loadLogbookPrefs } from '../../../lib/logbook-prefs-store';
 
 beforeEach(() => {
   captured.chipMounted = false;
@@ -183,5 +184,20 @@ describe('LogbookTab sort chips', () => {
     // Selecting Hardest commits via the real reducer; the chip re-renders with it.
     act(() => captured.onSelectPreset?.('hardest'));
     expect(captured.chipPreset).toBe('hardest');
+  });
+
+  it('lights no chip when a non-preset (custom) sort is active', async () => {
+    vi.mocked(loadLogbookPrefs).mockResolvedValueOnce({
+      filters: DEFAULT_LOGBOOK_FILTERS,
+      sort: { ...DEFAULT_LOGBOOK_SORT, mode: 'custom' },
+    });
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+    // Flush the persisted-prefs hydration so the custom sort lands in state.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(captured.chipMounted).toBe(true);
+    expect(captured.chipPreset).toBeNull();
   });
 });

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-sort-chips.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-sort-chips.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { render, fireEvent, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LogbookSortPreset } from '@boardsesh/logbook';
+
+// Captures what LogbookTab hands the (mocked) sort chip row + filter sheet, so the
+// test can assert the Liquid-Glass gating and the showSort hand-off without native
+// components. The chip row exposes its onSelectPreset + the committed preset; the
+// sheet exposes its showSort prop.
+const captured = vi.hoisted(() => ({
+  chipMounted: false,
+  chipPreset: undefined as LogbookSortPreset | undefined,
+  onSelectPreset: null as ((preset: LogbookSortPreset) => void) | null,
+  sheetMounted: false,
+  sheetShowSort: undefined as boolean | undefined,
+}));
+
+// The variant the (mocked) theme reports; flipped per test to drive the gate.
+const themeState = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
+const flagState = vi.hoisted(() => ({ logbookFilters: true }));
+// The platform the gate reads; flipped per test (the chip row is iOS-only).
+const platformState = vi.hoisted(() => ({ os: 'ios' as 'ios' | 'android' }));
+
+const feed = vi.hoisted(() => ({
+  data: { pages: [{ userAscentsFeed: { items: [] } }] },
+  isPending: false,
+  isError: false,
+  isRefetching: false,
+  isFetchingNextPage: false,
+  hasNextPage: false,
+  refetch: vi.fn(),
+  fetchNextPage: vi.fn(),
+}));
+
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  // The gate reads Platform.OS; a getter lets a test flip it per render.
+  Platform: {
+    get OS() {
+      return platformState.os;
+    },
+  },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  RefreshControl: () => null,
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('@shopify/flash-list', () => ({ FlashList: () => createElement('div', { 'data-testid': 'flash-list' }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../SearchHeader', () => ({ SearchHeader: () => createElement('div', { 'data-testid': 'search-header' }) }));
+
+vi.mock('../LogbookSortChipRow', () => ({
+  LogbookSortChipRow: ({
+    preset,
+    onSelectPreset,
+  }: {
+    preset: LogbookSortPreset;
+    onSelectPreset: (preset: LogbookSortPreset) => void;
+  }) => {
+    captured.chipMounted = true;
+    captured.chipPreset = preset;
+    captured.onSelectPreset = onSelectPreset;
+    return createElement('div', { 'data-testid': 'sort-chip-row' });
+  },
+}));
+
+vi.mock('../LogbookFilterSheet', () => ({
+  LogbookFilterSheet: ({ showSort }: { showSort?: boolean }) => {
+    captured.sheetMounted = true;
+    captured.sheetShowSort = showSort;
+    return createElement('div', { 'data-testid': 'filter-sheet' });
+  },
+}));
+
+vi.mock('../LogbookRow', () => ({ LogbookRow: () => createElement('div') }));
+vi.mock('../LogbookEditSheet', () => ({ LogbookEditSheet: () => null }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../ScreenTitle', () => ({
+  ScreenTitle: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+
+vi.mock('../../../lib/graphql/hooks', () => ({ useUserAscentsFeed: () => feed }));
+vi.mock('../../../lib/logbook-prefs-store', () => ({
+  loadLogbookPrefs: vi.fn(() => Promise.resolve(null)),
+  saveLogbookPrefs: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../../../hooks/use-bottom-chrome-metrics', () => ({
+  useBottomChromeMetrics: () => ({ scrollBottomPadding: 0 }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { black: '#000' } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {}, variant: themeState.variant }),
+}));
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('../../../lib/open-climb-in-play-drawer', () => ({ openClimbInPlayDrawer: vi.fn() }));
+vi.mock('../../../lib/tick-to-climb', () => ({ tickToClimb: vi.fn() }));
+vi.mock('../../../lib/playlists/board-details-for-playlist', () => ({ getBoardConfigForPlaylist: vi.fn() }));
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../providers/drawer-host-provider', () => ({
+  useDrawerHost: () => ({ openPlayDrawer: vi.fn(), openClimbActions: vi.fn() }),
+}));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useFeatureFlag: (key: string) => (key === 'logbook-filters' ? flagState.logbookFilters : undefined),
+}));
+
+// use-logbook-search and @boardsesh/logbook run for real so setPreset commits the
+// preset into the feed through the real reducer.
+import { LogbookTab } from '../LogbookTab';
+
+beforeEach(() => {
+  captured.chipMounted = false;
+  captured.chipPreset = undefined;
+  captured.onSelectPreset = null;
+  captured.sheetMounted = false;
+  captured.sheetShowSort = undefined;
+  themeState.variant = 'liquidGlass';
+  flagState.logbookFilters = true;
+  platformState.os = 'ios';
+});
+
+describe('LogbookTab sort chips', () => {
+  it('renders the sort chips and hides the sheet sort on iOS Liquid Glass', () => {
+    const { getByTestId, getByLabelText } = render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    expect(getByTestId('sort-chip-row')).toBeTruthy();
+    expect(captured.chipPreset).toBe('recent');
+
+    // Opening the sheet hands it showSort={false} so sort isn't worded twice.
+    fireEvent.click(getByLabelText('mobile.logbook.filter'));
+    expect(captured.sheetMounted).toBe(true);
+    expect(captured.sheetShowSort).toBe(false);
+  });
+
+  it('does not render the sort chips on Material and keeps the sheet sort', () => {
+    themeState.variant = 'material';
+    const { queryByTestId, getByLabelText } = render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    expect(queryByTestId('sort-chip-row')).toBeNull();
+
+    fireEvent.click(getByLabelText('mobile.logbook.filter'));
+    expect(captured.sheetShowSort).toBe(true);
+  });
+
+  it('does not render the sort chips on Android and keeps the sheet sort', () => {
+    platformState.os = 'android';
+    const { queryByTestId, getByLabelText } = render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    expect(queryByTestId('sort-chip-row')).toBeNull();
+
+    fireEvent.click(getByLabelText('mobile.logbook.filter'));
+    expect(captured.sheetShowSort).toBe(true);
+  });
+
+  it('hides the toolbar and chips when the logbook-filters flag is off', () => {
+    flagState.logbookFilters = false;
+    const { queryByTestId, queryByLabelText } = render(createElement(LogbookTab, { userId: 'user-1' }));
+
+    expect(queryByTestId('sort-chip-row')).toBeNull();
+    expect(queryByLabelText('mobile.logbook.filter')).toBeNull();
+  });
+
+  it('commits the selected preset live through setPreset', () => {
+    render(createElement(LogbookTab, { userId: 'user-1' }));
+    expect(captured.onSelectPreset).not.toBeNull();
+
+    // Selecting Hardest commits via the real reducer; the chip re-renders with it.
+    act(() => captured.onSelectPreset?.('hardest'));
+    expect(captured.chipPreset).toBe('hardest');
+  });
+});

--- a/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-tab-toolbar.test.tsx
@@ -33,6 +33,10 @@ const feed = vi.hoisted(() => ({
 vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
 
 vi.mock('react-native', () => ({
+  // The sort-chip gate reads Platform.OS; these toolbar tests don't assert chip
+  // behaviour (LogbookSortChipRow is stubbed via the vite alias), so a fixed OS
+  // is enough — the theme mock reports no `variant`, so the gate stays off.
+  Platform: { OS: 'ios' },
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   RefreshControl: () => null,
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },

--- a/packages/mobile/test/logbook-sort-chip-row-stub.tsx
+++ b/packages/mobile/test/logbook-sort-chip-row-stub.tsx
@@ -1,0 +1,10 @@
+// Test stub for the platform-split LogbookSortChipRow. Its iOS implementation
+// renders native @expo/ui SwiftUI views that can't mount under Vitest's node
+// env, and Vitest doesn't resolve `.ios`/`.android` platform extensions, so any
+// suite that transitively imports the logbook tab redirects here via a vite
+// alias. Component tests that assert chip behaviour register their own vi.mock,
+// which takes precedence over this alias.
+
+export function LogbookSortChipRow(): null {
+  return null;
+}

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -180,6 +180,16 @@ export default defineConfig({
         find: /^(.*\/)?MoreForm$/,
         replacement: fileURLToPath(new URL('./test/more-form-stub.tsx', import.meta.url)),
       },
+      // LogbookSortChipRow is platform-split the same way as FilterChipRow
+      // (LogbookSortChipRow.ios.tsx renders native @expo/ui SwiftUI glass chips;
+      // LogbookSortChipRow.android.tsx is a placeholder). Vitest doesn't resolve
+      // `.ios`/`.android` extensions and can't mount the SwiftUI host, so redirect
+      // the extensionless import to a null stub. Suites that assert chip behaviour
+      // register their own vi.mock (takes precedence).
+      {
+        find: /^(.*\/)?LogbookSortChipRow$/,
+        replacement: fileURLToPath(new URL('./test/logbook-sort-chip-row-stub.tsx', import.meta.url)),
+      },
     ],
     // .tsx test files can opt into a jsdom environment per file via the
     // `// @vitest-environment jsdom` pragma — needed to render React


### PR DESCRIPTION
Scoped implementation of #3257: bring the climb-list filter-chip idiom to the logbook — but, per product call, **only for the sort** (Latest/Hardest), which is the one facet that earns top-level quick access. Status/grade chips and the token "receipt" row from the full issue are **not** included.

## What changed
- **Latest/Hardest are now top-level iOS Liquid Glass chips** in the logbook toolbar, so you can switch sort without opening the filter sheet. Tapping a chip commits live (via the existing `setPreset`).
- Built from native `@expo/ui/swift-ui` controls (`buttonStyle('glass'|'glassProminent')` + tint), mirroring the climb list's `FilterChipRow` — active chip is a brand-tinted prominent glass capsule, inactive is neutral glass; both `if #available(iOS 26)`-guarded so they degrade.
- **iOS-26 Liquid Glass only.** Android (and Material) keep the sheet's sort control — `LogbookSortChipRow.android.tsx` is a `null` placeholder so `@expo/ui/swift-ui` never reaches the Android bundle.
- When the chips show, the sheet's in-body Sort block is suppressed (`showSort={false}`) so sort is never worded twice.
- Sits behind the existing **`logbook-filters`** flag (the toolbar already does — no new flag).

## Reuse / pattern
Platform-split `.ios`/`.android` + `.types.ts` + `.d.ts` + a Vitest stub/alias, exactly like `search/FilterChipRow.*`. Reuses the existing `mobile.logbook.preset.*` i18n keys (no new strings) and the existing `setPreset` action (no new reducer state).

## Testing
- `vp run typecheck:mobile`, lint, format — clean
- `vp test run --project mobile` — green (new `logbook-tab-sort-chips.test.tsx`: chips render + sheet `showSort=false` on iOS glass; hidden + sheet keeps sort on Material **and** Android; hidden + toolbar absent when the flag is off; live commit through the real reducer)
- `vp run check:mobile-bundle` — **both** iOS and Android bundles export (guards against `@expo/ui/swift-ui` leaking onto Android)
- Built by an implementation subagent, then independently QA-reviewed (no blocking/should-fix findings) — but the glass states need a real iOS-26 device/sim check, which is the one thing CI can't do.

## Release Notes
In the logbook, Latest and Hardest are now quick-tap chips at the top — switch how your ticks are sorted without opening the filter sheet. (iOS; the rest of the filters stay one tap away in the sheet.)
