### PR TITLE
feat(mobile): climb card — logbook grade, sticky sections, copy name

### DIFF
--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -4,6 +4,7 @@ import Animated, { FadeIn, FadeOut, useAnimatedStyle, useSharedValue, withTiming
 import { Text } from './Text';
 import { Icon } from './Icon';
 import { hapticSelection } from '../lib/haptics';
+import { getSectionExpandedSync, setSectionExpanded, useSectionExpanded } from '../lib/section-expand-store';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing, borderRadius } from '../theme/tokens';
 import { timing } from '../theme/animations';
@@ -28,6 +29,11 @@ type CollapsibleSectionProps = {
   /** Fires when the section expands/collapses (and once on mount). Lets a caller
    *  gate expensive content (e.g. a query) on the section being open. */
   onExpandedChange?: (expanded: boolean) => void;
+  /** When set, the section's expand state persists under this key (across climbs
+   *  and app restarts) instead of resetting to `defaultExpanded` each mount.
+   *  `defaultExpanded` is then only the first-ever state before the user touches
+   *  the section. Omit to keep the section's state ephemeral. */
+  persistKey?: string;
   children: ReactNode;
 };
 
@@ -40,6 +46,7 @@ export function CollapsibleSection({
   headerAction,
   onHeaderLayout,
   onExpandedChange,
+  persistKey,
   children,
 }: CollapsibleSectionProps) {
   const handleHeaderLayout = useCallback(
@@ -72,6 +79,7 @@ export function CollapsibleSection({
       headerAction={headerAction}
       onHeaderLayoutEvent={onHeaderLayout ? handleHeaderLayout : undefined}
       onExpandedChange={onExpandedChange}
+      persistKey={persistKey}
     >
       {children}
     </CollapsibleSectionInternal>
@@ -86,6 +94,7 @@ function CollapsibleSectionInternal({
   headerAction,
   onHeaderLayoutEvent,
   onExpandedChange,
+  persistKey,
   children,
 }: {
   title: string;
@@ -98,10 +107,26 @@ function CollapsibleSectionInternal({
   // never get conflated in callers or refactors.
   onHeaderLayoutEvent?: (event: LayoutChangeEvent) => void;
   onExpandedChange?: (expanded: boolean) => void;
+  persistKey?: string;
   children: ReactNode;
 }) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
-  const chevronRotation = useSharedValue(defaultExpanded ? 1 : 0);
+  // Seed from the persisted store synchronously when warm (no flash on the next
+  // climb); fall back to `defaultExpanded` for a cold store or no persistKey.
+  const initialExpanded = persistKey ? (getSectionExpandedSync(persistKey) ?? defaultExpanded) : defaultExpanded;
+  const [expanded, setExpanded] = useState(initialExpanded);
+  const chevronRotation = useSharedValue(initialExpanded ? 1 : 0);
+
+  // Subscribe to the persisted value so a cold-launch async load (or an external
+  // change to the same key) reconciles into local state.
+  const { expanded: persistedExpanded } = useSectionExpanded(persistKey);
+  useEffect(() => {
+    if (!persistKey || persistedExpanded === undefined) return;
+    setExpanded((prev) => {
+      if (prev === persistedExpanded) return prev;
+      chevronRotation.value = withTiming(persistedExpanded ? 1 : 0, { duration: timing.normal });
+      return persistedExpanded;
+    });
+  }, [persistKey, persistedExpanded, chevronRotation]);
 
   const isFirstReset = useRef(true);
   useEffect(() => {
@@ -109,6 +134,9 @@ function CollapsibleSectionInternal({
       isFirstReset.current = false;
       return;
     }
+    // A persisted section ignores resetKey — its remembered state outranks the
+    // per-mount default that resetKey would otherwise restore.
+    if (persistKey) return;
     setExpanded(defaultExpanded);
     chevronRotation.value = withTiming(defaultExpanded ? 1 : 0, { duration: timing.normal });
   }, [resetKey]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -124,9 +152,10 @@ function CollapsibleSectionInternal({
     setExpanded((prev) => {
       const next = !prev;
       chevronRotation.value = withTiming(next ? 1 : 0, { duration: timing.normal });
+      if (persistKey) setSectionExpanded(persistKey, next);
       return next;
     });
-  }, [chevronRotation]);
+  }, [chevronRotation, persistKey]);
 
   const chevronStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${chevronRotation.value * 180}deg` }],

--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -120,13 +120,12 @@ function CollapsibleSectionInternal({
   // change to the same key) reconciles into local state.
   const { expanded: persistedExpanded } = useSectionExpanded(persistKey);
   useEffect(() => {
-    if (!persistKey || persistedExpanded === undefined) return;
-    setExpanded((prev) => {
-      if (prev === persistedExpanded) return prev;
-      chevronRotation.value = withTiming(persistedExpanded ? 1 : 0, { duration: timing.normal });
-      return persistedExpanded;
-    });
-  }, [persistKey, persistedExpanded, chevronRotation]);
+    // Keep the Reanimated side-effect out of the setState updater: StrictMode
+    // double-invokes updaters in dev, which would fire withTiming twice.
+    if (!persistKey || persistedExpanded === undefined || persistedExpanded === expanded) return;
+    chevronRotation.value = withTiming(persistedExpanded ? 1 : 0, { duration: timing.normal });
+    setExpanded(persistedExpanded);
+  }, [persistKey, persistedExpanded, expanded, chevronRotation]);
 
   const isFirstReset = useRef(true);
   useEffect(() => {
@@ -148,14 +147,15 @@ function CollapsibleSectionInternal({
   }, [expanded, onExpandedChange]);
 
   const toggleExpanded = useCallback(() => {
+    // Side-effects (haptic, animation, persist) stay outside setExpanded so a
+    // StrictMode double-invoke of the updater can't fire them twice. `expanded`
+    // is in deps, so this closure is never stale.
+    const next = !expanded;
     hapticSelection();
-    setExpanded((prev) => {
-      const next = !prev;
-      chevronRotation.value = withTiming(next ? 1 : 0, { duration: timing.normal });
-      if (persistKey) setSectionExpanded(persistKey, next);
-      return next;
-    });
-  }, [chevronRotation, persistKey]);
+    chevronRotation.value = withTiming(next ? 1 : 0, { duration: timing.normal });
+    if (persistKey) setSectionExpanded(persistKey, next);
+    setExpanded(next);
+  }, [expanded, chevronRotation, persistKey]);
 
   const chevronStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${chevronRotation.value * 180}deg` }],

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
+import { loadSectionExpandState, resetSectionExpandStoreForTests } from '../../lib/section-expand-store';
 
 // AsyncStorage holds the persisted expand map. Seed it before rendering to drive
 // the cold-load path (store unloaded at first mount, value arrives async).
 vi.mock('@react-native-async-storage/async-storage', () => {
-  const storage: Record<string, string> = {};
+  let storage: Record<string, string> = {};
   return {
     default: {
       getItem: vi.fn(async (key: string) => storage[key] ?? null),
@@ -16,6 +17,9 @@ vi.mock('@react-native-async-storage/async-storage', () => {
       removeItem: vi.fn(async (key: string) => {
         delete storage[key];
       }),
+      __reset: () => {
+        storage = {};
+      },
       __setRaw: (key: string, value: string) => {
         storage[key] = value;
       },
@@ -45,20 +49,30 @@ vi.mock('../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
 
 const BODY = 'SECTION_BODY';
 
-async function seedStorage(key: string, value: boolean) {
-  const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+async function getMockStorage() {
+  return (await import('@react-native-async-storage/async-storage')).default as unknown as {
+    __reset: () => void;
     __setRaw: (key: string, value: string) => void;
   };
-  asyncStorage.__setRaw('climbCardSectionExpanded', JSON.stringify({ [key]: value }));
+}
+
+async function seedStorage(key: string, value: boolean) {
+  (await getMockStorage()).__setRaw('climbCardSectionExpanded', JSON.stringify({ [key]: value }));
 }
 
 import { CollapsibleSection } from '../CollapsibleSection';
 
 describe('CollapsibleSection persistence', () => {
+  // Each test owns its store + storage state — no inherited side-effects, so the
+  // file is order-independent and passes in isolation.
+  beforeEach(async () => {
+    resetSectionExpandStoreForTests();
+    (await getMockStorage()).__reset();
+  });
+
   it('reconciles to the persisted expanded state once the cold store loads', async () => {
-    // Store starts unloaded (first test in the file): seed AsyncStorage, then
-    // render collapsed. The async load should flip the section open via the
-    // persisted-sync effect.
+    // Cold store: seed AsyncStorage, render collapsed, then the async load should
+    // flip the section open via the persisted-sync effect.
     await seedStorage('logbook', true);
     const { queryByText, getByText } = render(
       createElement(CollapsibleSection, {
@@ -75,9 +89,12 @@ describe('CollapsibleSection persistence', () => {
     await waitFor(() => expect(getByText(BODY)).toBeTruthy());
   });
 
-  it('seeds the initial state synchronously when the store is already warm', () => {
-    // The previous test loaded the store (hasLoaded=true, logbook=true), so a
-    // fresh mount reads the value synchronously and opens with no async wait.
+  it('seeds the initial state synchronously when the store is already warm', async () => {
+    // Warm the store before rendering: the mount then reads the value
+    // synchronously and opens with no async wait.
+    await seedStorage('logbook', true);
+    await loadSectionExpandState();
+
     const { getByText } = render(
       createElement(CollapsibleSection, {
         title: 'Logbook',

--- a/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-persist.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// AsyncStorage holds the persisted expand map. Seed it before rendering to drive
+// the cold-load path (store unloaded at first mount, value arrives async).
+vi.mock('@react-native-async-storage/async-storage', () => {
+  const storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+    },
+  };
+});
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: () => onPress?.() }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  FadeIn: { duration: () => ({}) },
+  FadeOut: { duration: () => ({}) },
+  useSharedValue: (value: number) => ({ value }),
+  useAnimatedStyle: (factory: () => Record<string, unknown>) => factory(),
+  withTiming: (value: number) => value,
+}));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+const BODY = 'SECTION_BODY';
+
+async function seedStorage(key: string, value: boolean) {
+  const asyncStorage = (await import('@react-native-async-storage/async-storage')).default as unknown as {
+    __setRaw: (key: string, value: string) => void;
+  };
+  asyncStorage.__setRaw('climbCardSectionExpanded', JSON.stringify({ [key]: value }));
+}
+
+import { CollapsibleSection } from '../CollapsibleSection';
+
+describe('CollapsibleSection persistence', () => {
+  it('reconciles to the persisted expanded state once the cold store loads', async () => {
+    // Store starts unloaded (first test in the file): seed AsyncStorage, then
+    // render collapsed. The async load should flip the section open via the
+    // persisted-sync effect.
+    await seedStorage('logbook', true);
+    const { queryByText, getByText } = render(
+      createElement(CollapsibleSection, {
+        title: 'Logbook',
+        persistKey: 'logbook',
+        defaultExpanded: false,
+        children: createElement('span', null, BODY),
+      }),
+    );
+
+    // Cold store → seeded from default (collapsed) → body not rendered yet.
+    expect(queryByText(BODY)).toBeNull();
+    // After the async load resolves, the effect expands the section.
+    await waitFor(() => expect(getByText(BODY)).toBeTruthy());
+  });
+
+  it('seeds the initial state synchronously when the store is already warm', () => {
+    // The previous test loaded the store (hasLoaded=true, logbook=true), so a
+    // fresh mount reads the value synchronously and opens with no async wait.
+    const { getByText } = render(
+      createElement(CollapsibleSection, {
+        title: 'Logbook',
+        persistKey: 'logbook',
+        defaultExpanded: false,
+        children: createElement('span', null, BODY),
+      }),
+    );
+    expect(getByText(BODY)).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -110,7 +110,7 @@ export const DeferredSections = memo(function DeferredSections({
 
       {readyToRender && (
         <>
-          <CollapsibleSection title={t('mobile.logbook.title')} summary={logbookSummary}>
+          <CollapsibleSection title={t('mobile.logbook.title')} summary={logbookSummary} persistKey="logbook">
             <LogbookSection
               climbUuid={climb.uuid}
               boardName={boardName}
@@ -119,7 +119,7 @@ export const DeferredSections = memo(function DeferredSections({
             />
           </CollapsibleSection>
 
-          <CollapsibleSection title={t('mobile.community.title')} defaultExpanded>
+          <CollapsibleSection title={t('mobile.community.title')} defaultExpanded persistKey="community">
             <CommunitySection
               climbUuid={climb.uuid}
               boardName={boardName}
@@ -128,7 +128,7 @@ export const DeferredSections = memo(function DeferredSections({
             />
           </CollapsibleSection>
 
-          <CollapsibleSection title={t('mobile.similarClimbs.title')}>
+          <CollapsibleSection title={t('mobile.similarClimbs.title')} persistKey="similarClimbs">
             <SimilarClimbsSection
               climbUuid={climb.uuid}
               boardName={boardName}

--- a/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
@@ -47,7 +47,12 @@ export const LogbookEntryRow = memo(function LogbookEntryRow({ entry, showMirror
     () => formatGradeByDifficultyId(entry.difficulty),
     [formatGradeByDifficultyId, entry.difficulty],
   );
-  const gradeColor = useMemo(() => getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR, [gradeLabel]);
+  // Only resolve a color when there's a chip to paint — skips the lookup on the
+  // common no-grade rows (most attempts).
+  const gradeColor = useMemo(
+    () => (gradeLabel ? (getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR),
+    [gradeLabel],
+  );
 
   const stars = useMemo(() => {
     if (!isSuccess || entry.quality == null || entry.quality <= 0) return null;

--- a/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
@@ -2,9 +2,11 @@ import { memo, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { LogbookEntry } from '@boardsesh/board-react';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '../../lib/ascent-status-utils';
+import { useGradeFormat } from '../../hooks/use-grade-format';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
@@ -33,10 +35,19 @@ const STATUS_ICON: Record<AscentStatusValue, { name: 'flash' | 'tick' | 'close';
 
 export const LogbookEntryRow = memo(function LogbookEntryRow({ entry, showMirrorTag }: LogbookEntryRowProps) {
   const { t } = useTranslation('session');
+  const { formatGradeByDifficultyId } = useGradeFormat();
 
   const status = normalizeAscentStatus({ status: entry.status, isAscent: entry.is_ascent, tries: entry.tries });
   const statusIcon = STATUS_ICON[status];
   const isSuccess = status !== 'attempt';
+
+  // The grade the climber gave this ascent. Null when they logged no personal
+  // grade (typical for attempts), in which case the chip is hidden.
+  const gradeLabel = useMemo(
+    () => formatGradeByDifficultyId(entry.difficulty),
+    [formatGradeByDifficultyId, entry.difficulty],
+  );
+  const gradeColor = useMemo(() => getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR, [gradeLabel]);
 
   const stars = useMemo(() => {
     if (!isSuccess || entry.quality == null || entry.quality <= 0) return null;
@@ -62,6 +73,13 @@ export const LogbookEntryRow = memo(function LogbookEntryRow({ entry, showMirror
             {`${entry.angle}°`}
           </Text>
         </View>
+        {gradeLabel ? (
+          <View style={styles.gradeChip}>
+            <Text variant="caption2" color={gradeColor} style={styles.gradeText}>
+              {gradeLabel}
+            </Text>
+          </View>
+        ) : null}
         {showMirrorTag && entry.is_mirror ? (
           <View style={styles.mirrorChip}>
             <Text variant="caption2" color={iosSystemColors.systemGray}>
@@ -103,6 +121,16 @@ const styles = StyleSheet.create({
     paddingVertical: 1,
     borderRadius: borderRadius.full,
     backgroundColor: iosSystemColors.systemBlue,
+  },
+  gradeChip: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: 1,
+    borderRadius: borderRadius.full,
+    backgroundColor: `${iosSystemColors.systemGray}1F`,
+  },
+  gradeText: {
+    fontVariant: ['tabular-nums'],
+    fontWeight: '700',
   },
   mirrorChip: {
     paddingHorizontal: spacing[2],

--- a/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookEntryRow.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { LogbookEntry } from '@boardsesh/board-react';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { BOULDER_GRADES } from '@boardsesh/board-constants/boulder-grade-mapping';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { normalizeAscentStatus, type AscentStatusValue } from '../../lib/ascent-status-utils';
@@ -27,6 +28,12 @@ function formatClimbedAt(iso: string): string {
   }).format(date);
 }
 
+// Canonical difficulty_id → "6a/V3" name, which always carries both scales so
+// the grade color resolves regardless of the user's display-format preference.
+const GRADE_NAME_BY_DIFFICULTY_ID = new Map<number, string>(
+  BOULDER_GRADES.map((grade) => [grade.difficulty_id, grade.difficulty_name]),
+);
+
 const STATUS_ICON: Record<AscentStatusValue, { name: 'flash' | 'tick' | 'close'; color: string }> = {
   flash: { name: 'flash', color: iosSystemColors.systemYellow },
   send: { name: 'tick', color: iosSystemColors.systemGreen },
@@ -47,12 +54,14 @@ export const LogbookEntryRow = memo(function LogbookEntryRow({ entry, showMirror
     () => formatGradeByDifficultyId(entry.difficulty),
     [formatGradeByDifficultyId, entry.difficulty],
   );
-  // Only resolve a color when there's a chip to paint — skips the lookup on the
-  // common no-grade rows (most attempts).
-  const gradeColor = useMemo(
-    () => (gradeLabel ? (getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR),
-    [gradeLabel],
-  );
+  // Color keys off the raw difficulty id (via its canonical name), not the
+  // display-formatted label — so a "V6 / 7a" combined-format label still paints
+  // the right color. Falls back for no-grade rows / unknown ids.
+  const gradeColor = useMemo(() => {
+    if (entry.difficulty == null) return DEFAULT_GRADE_COLOR;
+    const difficultyName = GRADE_NAME_BY_DIFFICULTY_ID.get(entry.difficulty);
+    return (difficultyName ? getGradeColor(difficultyName) : undefined) ?? DEFAULT_GRADE_COLOR;
+  }, [entry.difficulty]);
 
   const stars = useMemo(() => {
     if (!isSuccess || entry.quality == null || entry.quality <= 0) return null;

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -21,6 +21,7 @@ import {
 import { ScrollView, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useAnimatedReaction, useSharedValue, runOnJS } from 'react-native-reanimated';
 import { router } from 'expo-router';
+import * as Clipboard from 'expo-clipboard';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -169,6 +170,9 @@ export function PlayDrawer({
   openTarget,
 }: PlayDrawerProps) {
   const { t } = useTranslation('session');
+  // The copy/share affordance strings live in the `climbs` namespace alongside
+  // the climb-actions sheet's "Link copied" toast.
+  const { t: tClimbs } = useTranslation('climbs');
   const insets = useSafeAreaInsets();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   // The route is mounted only while the player is open, so the player is "open"
@@ -422,6 +426,16 @@ export function PlayDrawer({
       showToast(t('playView.shareError'), 'error');
     });
   }, [shareClimb, showToast, t]);
+
+  // Long-press the climb name to copy it — handy for pasting into a chat when
+  // sharing beta. The success toast carries its own confirmation haptic.
+  const handleCopyName = useCallback(() => {
+    const climbName = displayedClimb?.name;
+    if (!climbName) return;
+    void Clipboard.setStringAsync(climbName);
+    track(SHARED_EVENTS.ClimbShared, { method: 'copy_name', climbUuid: displayedClimb.uuid, boardName, layoutId });
+    showToast(tClimbs('mobile.climbActions.nameCopied'), 'success');
+  }, [displayedClimb, boardName, layoutId, showToast, tClimbs]);
 
   const openDrawer = useCallback(
     (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
@@ -723,6 +737,7 @@ export function PlayDrawer({
                         // read-only "on the wall" status rides in the header's leading slot
                         // (left of the name, opposite the grade) rather than as a banner.
                         leading={isPreview && drawerPreviewIsWallClimb ? <PlayDrawerOnWallBanner /> : undefined}
+                        onLongPressName={handleCopyName}
                       />
                     }
                     peek={

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -431,7 +431,7 @@ export function PlayDrawer({
   // sharing beta. Delegates to the unit-tested copyClimbName helper; haptic for
   // tactile confirmation, info toast matching the "Link copied" affordance.
   const handleCopyName = useCallback(() => {
-    copyClimbName(
+    void copyClimbName(
       displayedClimb,
       { boardName, layoutId },
       {

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -428,13 +428,15 @@ export function PlayDrawer({
   }, [shareClimb, showToast, t]);
 
   // Long-press the climb name to copy it — handy for pasting into a chat when
-  // sharing beta. The success toast carries its own confirmation haptic.
+  // sharing beta. Fire a haptic for tactile confirmation of the long-press, then
+  // an info toast (matching the "Link copied" affordance in ClimbActionsSheet).
   const handleCopyName = useCallback(() => {
     const climbName = displayedClimb?.name;
     if (!climbName) return;
     void Clipboard.setStringAsync(climbName);
+    hapticSuccess();
     track(SHARED_EVENTS.ClimbShared, { method: 'copy_name', climbUuid: displayedClimb.uuid, boardName, layoutId });
-    showToast(tClimbs('mobile.climbActions.nameCopied'), 'success');
+    showToast(tClimbs('mobile.climbActions.nameCopied'), 'info');
   }, [displayedClimb, boardName, layoutId, showToast, tClimbs]);
 
   const openDrawer = useCallback(

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -21,7 +21,6 @@ import {
 import { ScrollView, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useAnimatedReaction, useSharedValue, runOnJS } from 'react-native-reanimated';
 import { router } from 'expo-router';
-import * as Clipboard from 'expo-clipboard';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -36,6 +35,7 @@ import { BoardRenderUnavailable } from './BoardRenderUnavailable';
 import { PlaybackControls } from './PlaybackControls';
 import { useMobilePlayback } from './use-mobile-playback';
 import { PlayDrawerHeader } from './PlayDrawerHeader';
+import { copyClimbName } from './copy-climb-name';
 import { SwipeableHeader } from './SwipeableHeader';
 import { PlayDrawerPreviewBanner } from './PlayDrawerPreviewBanner';
 import { PlayDrawerOnWallBanner } from './PlayDrawerOnWallBanner';
@@ -428,15 +428,19 @@ export function PlayDrawer({
   }, [shareClimb, showToast, t]);
 
   // Long-press the climb name to copy it — handy for pasting into a chat when
-  // sharing beta. Fire a haptic for tactile confirmation of the long-press, then
-  // an info toast (matching the "Link copied" affordance in ClimbActionsSheet).
+  // sharing beta. Delegates to the unit-tested copyClimbName helper; haptic for
+  // tactile confirmation, info toast matching the "Link copied" affordance.
   const handleCopyName = useCallback(() => {
-    const climbName = displayedClimb?.name;
-    if (!climbName) return;
-    void Clipboard.setStringAsync(climbName);
-    hapticSuccess();
-    track(SHARED_EVENTS.ClimbShared, { method: 'copy_name', climbUuid: displayedClimb.uuid, boardName, layoutId });
-    showToast(tClimbs('mobile.climbActions.nameCopied'), 'info');
+    copyClimbName(
+      displayedClimb,
+      { boardName, layoutId },
+      {
+        haptic: hapticSuccess,
+        track,
+        showToast: (message) => showToast(message, 'info'),
+        toastMessage: tClimbs('mobile.climbActions.nameCopied'),
+      },
+    );
   }, [displayedClimb, boardName, layoutId, showToast, tClimbs]);
 
   const openDrawer = useCallback(

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -437,8 +437,9 @@ export function PlayDrawer({
       {
         haptic: hapticSuccess,
         track,
-        showToast: (message) => showToast(message, 'info'),
+        showToast: (message, variant) => showToast(message, variant ?? 'info'),
         toastMessage: tClimbs('mobile.climbActions.nameCopied'),
+        errorToastMessage: tClimbs('mobile.climbActions.copyNameError'),
       },
     );
   }, [displayedClimb, boardName, layoutId, showToast, tClimbs]);

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, type ReactNode } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { formatSends, formatQuality } from '../../lib/format-climb-stats';
@@ -25,6 +25,9 @@ type PlayDrawerHeaderProps = {
   /** Left-aligned element on the name's row (e.g. the on-wall status). The header
    *  balances both flanks so the name stays centered. */
   leading?: ReactNode;
+  /** Long-press handler on the name (copies it to the clipboard). When omitted the
+   *  name is a plain, non-interactive label — used for the swipe "peek" header. */
+  onLongPressName?: () => void;
 };
 
 export const PlayDrawerHeader = memo(function PlayDrawerHeader({
@@ -37,6 +40,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   benchmarkDifficulty,
   characteristics,
   leading,
+  onLongPressName,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
   const gradeColor = useMemo(
@@ -56,9 +60,18 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
       center={
         <>
           <View style={styles.nameRow}>
-            <Text variant="body" style={styles.nameText} numberOfLines={1}>
-              {name}
-            </Text>
+            <Pressable
+              onLongPress={onLongPressName}
+              disabled={!onLongPressName}
+              delayLongPress={350}
+              accessibilityRole={onLongPressName ? 'button' : undefined}
+              accessibilityHint={onLongPressName ? t('mobile.climbActions.copyNameHint') : undefined}
+              style={styles.namePressable}
+            >
+              <Text variant="body" style={styles.nameText} numberOfLines={1}>
+                {name}
+              </Text>
+            </Pressable>
             <ClimbAttributeIcons benchmarkDifficulty={benchmarkDifficulty} characteristics={characteristics} />
           </View>
           <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
@@ -85,6 +98,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    minWidth: 0,
+  },
+  // Shrinks with the name so a long title still truncates while the attribute
+  // glyphs stay visible; the long-press target is the name text itself.
+  namePressable: {
+    flexShrink: 1,
     minWidth: 0,
   },
   nameText: {

--- a/packages/mobile/src/components/play-drawer/__tests__/copy-climb-name.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/copy-climb-name.test.ts
@@ -12,6 +12,7 @@ function makeDeps() {
     track: vi.fn(),
     showToast: vi.fn(),
     toastMessage: 'Name copied',
+    errorToastMessage: "Couldn't copy name",
   };
 }
 
@@ -54,7 +55,7 @@ describe('copyClimbName', () => {
     expect(result).toBe(false);
     expect(deps.haptic).not.toHaveBeenCalled();
     expect(deps.track).not.toHaveBeenCalled();
-    expect(deps.showToast).not.toHaveBeenCalled();
+    expect(deps.showToast).toHaveBeenCalledWith("Couldn't copy name", 'error');
   });
 
   it('no-ops when there is no climb', async () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/copy-climb-name.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/copy-climb-name.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const clipboard = vi.hoisted(() => ({ setStringAsync: vi.fn(async (_text: string) => {}) }));
+vi.mock('expo-clipboard', () => ({ setStringAsync: clipboard.setStringAsync }));
+vi.mock('@boardsesh/analytics', () => ({ SHARED_EVENTS: { ClimbShared: 'Climb Shared' } }));
+
+import { copyClimbName } from '../copy-climb-name';
+
+function makeDeps() {
+  return {
+    haptic: vi.fn(),
+    track: vi.fn(),
+    showToast: vi.fn(),
+    toastMessage: 'Name copied',
+  };
+}
+
+describe('copyClimbName', () => {
+  beforeEach(() => {
+    clipboard.setStringAsync.mockClear();
+  });
+
+  it('copies the name and fires haptic, analytics, and toast', () => {
+    const deps = makeDeps();
+    const result = copyClimbName(
+      { name: 'Hueco Madness', uuid: 'climb-1' },
+      { boardName: 'kilter', layoutId: 8 },
+      deps,
+    );
+
+    expect(result).toBe(true);
+    expect(clipboard.setStringAsync).toHaveBeenCalledTimes(1);
+    expect(clipboard.setStringAsync).toHaveBeenCalledWith('Hueco Madness');
+    expect(deps.haptic).toHaveBeenCalledTimes(1);
+    expect(deps.track).toHaveBeenCalledWith('Climb Shared', {
+      method: 'copy_name',
+      climbUuid: 'climb-1',
+      boardName: 'kilter',
+      layoutId: 8,
+    });
+    expect(deps.showToast).toHaveBeenCalledWith('Name copied');
+  });
+
+  it('no-ops when there is no climb', () => {
+    const deps = makeDeps();
+    const result = copyClimbName(null, { boardName: 'kilter', layoutId: 8 }, deps);
+
+    expect(result).toBe(false);
+    expect(clipboard.setStringAsync).not.toHaveBeenCalled();
+    expect(deps.haptic).not.toHaveBeenCalled();
+    expect(deps.track).not.toHaveBeenCalled();
+    expect(deps.showToast).not.toHaveBeenCalled();
+  });
+
+  it('no-ops on an empty name', () => {
+    const deps = makeDeps();
+    const result = copyClimbName({ name: '', uuid: 'climb-1' }, { boardName: 'tension', layoutId: 1 }, deps);
+
+    expect(result).toBe(false);
+    expect(clipboard.setStringAsync).not.toHaveBeenCalled();
+    expect(deps.showToast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/copy-climb-name.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/copy-climb-name.test.ts
@@ -20,9 +20,9 @@ describe('copyClimbName', () => {
     clipboard.setStringAsync.mockClear();
   });
 
-  it('copies the name and fires haptic, analytics, and toast', () => {
+  it('copies the name and fires haptic, analytics, and toast', async () => {
     const deps = makeDeps();
-    const result = copyClimbName(
+    const result = await copyClimbName(
       { name: 'Hueco Madness', uuid: 'climb-1' },
       { boardName: 'kilter', layoutId: 8 },
       deps,
@@ -41,9 +41,25 @@ describe('copyClimbName', () => {
     expect(deps.showToast).toHaveBeenCalledWith('Name copied');
   });
 
-  it('no-ops when there is no climb', () => {
+  it('does not claim success when the clipboard write fails', async () => {
     const deps = makeDeps();
-    const result = copyClimbName(null, { boardName: 'kilter', layoutId: 8 }, deps);
+    clipboard.setStringAsync.mockRejectedValueOnce(new Error('clipboard unavailable'));
+
+    const result = await copyClimbName(
+      { name: 'Hueco Madness', uuid: 'climb-1' },
+      { boardName: 'kilter', layoutId: 8 },
+      deps,
+    );
+
+    expect(result).toBe(false);
+    expect(deps.haptic).not.toHaveBeenCalled();
+    expect(deps.track).not.toHaveBeenCalled();
+    expect(deps.showToast).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when there is no climb', async () => {
+    const deps = makeDeps();
+    const result = await copyClimbName(null, { boardName: 'kilter', layoutId: 8 }, deps);
 
     expect(result).toBe(false);
     expect(clipboard.setStringAsync).not.toHaveBeenCalled();
@@ -52,9 +68,9 @@ describe('copyClimbName', () => {
     expect(deps.showToast).not.toHaveBeenCalled();
   });
 
-  it('no-ops on an empty name', () => {
+  it('no-ops on an empty name', async () => {
     const deps = makeDeps();
-    const result = copyClimbName({ name: '', uuid: 'climb-1' }, { boardName: 'tension', layoutId: 1 }, deps);
+    const result = await copyClimbName({ name: '', uuid: 'climb-1' }, { boardName: 'tension', layoutId: 1 }, deps);
 
     expect(result).toBe(false);
     expect(clipboard.setStringAsync).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/play-drawer/__tests__/logbook-entry-row-grade.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/logbook-entry-row-grade.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { LogbookEntry } from '@boardsesh/board-react';
+
+// react-native isn't satisfiable under jsdom; stub the surface the row touches.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../lib/ascent-status-utils', () => ({
+  // Echo the status so the row's success/attempt branch follows the fixture.
+  normalizeAscentStatus: ({ status }: { status?: string }) => status ?? 'send',
+}));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../hooks/use-grade-format', () => ({
+  // Mirrors the real formatter: null id → null (chip hidden), else "V<id>".
+  useGradeFormat: () => ({
+    formatGradeByDifficultyId: (id: number | null | undefined) => (id == null ? null : `V${id}`),
+  }),
+}));
+
+import { LogbookEntryRow } from '../LogbookEntryRow';
+
+function makeEntry(overrides: Partial<LogbookEntry>): LogbookEntry {
+  return {
+    uuid: 'tick-1',
+    climb_uuid: 'climb-1',
+    angle: 40,
+    is_mirror: false,
+    tries: 1,
+    quality: null,
+    difficulty: null,
+    comment: '',
+    climbed_at: '2026-01-01T12:00:00.000Z',
+    is_ascent: true,
+    status: 'send',
+    upvotes: 0,
+    downvotes: 0,
+    commentCount: 0,
+    ...overrides,
+  };
+}
+
+describe('LogbookEntryRow grade chip', () => {
+  it('renders the grade the climber gave when difficulty is set', () => {
+    const { getByText } = render(
+      createElement(LogbookEntryRow, { entry: makeEntry({ difficulty: 5 }), showMirrorTag: false }),
+    );
+    expect(getByText('V5')).toBeTruthy();
+  });
+
+  it('hides the grade chip when no personal grade was logged', () => {
+    const { queryByText } = render(
+      createElement(LogbookEntryRow, { entry: makeEntry({ difficulty: null }), showMirrorTag: false }),
+    );
+    // The only V-grade-shaped text would be the chip; its absence means hidden.
+    expect(queryByText(/^V\d+$/)).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// react-native isn't satisfiable under jsdom; stub the surface the header touches.
+// Pressable becomes a <button> whose click fires onLongPress (so we can drive the
+// long-press path) and honours `disabled` (the peek header passes no handler).
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  Pressable: ({
+    children,
+    onLongPress,
+    disabled,
+    accessibilityHint,
+  }: {
+    children?: ReactNode;
+    onLongPress?: () => void;
+    disabled?: boolean;
+    accessibilityHint?: string;
+  }) =>
+    createElement(
+      'button',
+      { onClick: () => onLongPress?.(), disabled, 'aria-label': 'name-pressable', title: accessibilityHint ?? '' },
+      children,
+    ),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../lib/format-climb-stats', () => ({
+  formatSends: (count: number) => `${count} sends`,
+  formatQuality: (value: string) => value,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../DrawerHeader', () => ({
+  // Render the center column so the name Pressable is in the tree.
+  DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
+}));
+vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => createElement('i', null) }));
+
+import { PlayDrawerHeader } from '../PlayDrawerHeader';
+
+const baseProps = {
+  name: 'Hueco Madness',
+  difficulty: 'V6',
+  qualityAverage: '0',
+  ascensionistCount: 0,
+  setterUsername: '',
+};
+
+describe('PlayDrawerHeader long-press copy', () => {
+  it('fires onLongPressName when the name is long-pressed', () => {
+    const onLongPressName = vi.fn();
+    const { getByLabelText, getByText } = render(createElement(PlayDrawerHeader, { ...baseProps, onLongPressName }));
+    expect(getByText('Hueco Madness')).toBeTruthy();
+    fireEvent.click(getByLabelText('name-pressable'));
+    expect(onLongPressName).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the name without an interactive press target on the peek header (no handler)', () => {
+    const { getByLabelText, getByText } = render(createElement(PlayDrawerHeader, baseProps));
+    expect(getByText('Hueco Madness')).toBeTruthy();
+    // The Pressable is disabled when no handler is supplied (swipe "peek" header).
+    expect((getByLabelText('name-pressable') as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/copy-climb-name.ts
+++ b/packages/mobile/src/components/play-drawer/copy-climb-name.ts
@@ -21,16 +21,23 @@ export type CopyClimbNameDeps = {
  * the clipboard, which is mocked at the module boundary in tests) so the
  * behaviour is unit-testable without mounting the play drawer.
  *
- * Returns `false` (no-op) when there's no name to copy.
+ * Awaits the clipboard write so the "Name copied" confirmation never fires when
+ * nothing actually landed on the clipboard. Resolves `false` when there's no
+ * name to copy or the write fails.
  */
-export function copyClimbName(
+export async function copyClimbName(
   climb: CopyClimbNameTarget | null | undefined,
   context: { boardName: string; layoutId: number },
   deps: CopyClimbNameDeps,
-): boolean {
+): Promise<boolean> {
   const name = climb?.name;
   if (!name) return false;
-  void Clipboard.setStringAsync(name);
+  try {
+    await Clipboard.setStringAsync(name);
+  } catch {
+    // Nothing reached the clipboard — don't claim success.
+    return false;
+  }
   deps.haptic();
   deps.track(SHARED_EVENTS.ClimbShared, {
     method: 'copy_name',

--- a/packages/mobile/src/components/play-drawer/copy-climb-name.ts
+++ b/packages/mobile/src/components/play-drawer/copy-climb-name.ts
@@ -9,10 +9,12 @@ export type CopyClimbNameDeps = {
   /** Analytics sink (forwards a ClimbShared event with method=copy_name). Matches
    *  the `track` signature from @boardsesh/analytics. */
   track: (event: string, properties?: AnalyticsEventProperties) => void;
-  /** Shows the "Name copied" confirmation. */
-  showToast: (message: string) => void;
-  /** Already-localized toast string. */
+  /** Shows a toast (info on success, error on a failed write). */
+  showToast: (message: string, variant?: 'info' | 'error') => void;
+  /** Already-localized success string. */
   toastMessage: string;
+  /** Already-localized failure string, shown when the clipboard write rejects. */
+  errorToastMessage: string;
 };
 
 /**
@@ -35,7 +37,9 @@ export async function copyClimbName(
   try {
     await Clipboard.setStringAsync(name);
   } catch {
-    // Nothing reached the clipboard — don't claim success.
+    // Nothing reached the clipboard — surface a failure rather than a silent
+    // no-op, so the long-press doesn't just feel broken.
+    deps.showToast(deps.errorToastMessage, 'error');
     return false;
   }
   deps.haptic();

--- a/packages/mobile/src/components/play-drawer/copy-climb-name.ts
+++ b/packages/mobile/src/components/play-drawer/copy-climb-name.ts
@@ -1,0 +1,43 @@
+import * as Clipboard from 'expo-clipboard';
+import { SHARED_EVENTS, type AnalyticsEventProperties } from '@boardsesh/analytics';
+
+export type CopyClimbNameTarget = { name?: string | null; uuid: string };
+
+export type CopyClimbNameDeps = {
+  /** Tactile confirmation of the long-press. */
+  haptic: () => void;
+  /** Analytics sink (forwards a ClimbShared event with method=copy_name). Matches
+   *  the `track` signature from @boardsesh/analytics. */
+  track: (event: string, properties?: AnalyticsEventProperties) => void;
+  /** Shows the "Name copied" confirmation. */
+  showToast: (message: string) => void;
+  /** Already-localized toast string. */
+  toastMessage: string;
+};
+
+/**
+ * Copy a climb's name to the clipboard with haptic + toast confirmation and a
+ * share-analytics event. Pure orchestration with all platform I/O injected (bar
+ * the clipboard, which is mocked at the module boundary in tests) so the
+ * behaviour is unit-testable without mounting the play drawer.
+ *
+ * Returns `false` (no-op) when there's no name to copy.
+ */
+export function copyClimbName(
+  climb: CopyClimbNameTarget | null | undefined,
+  context: { boardName: string; layoutId: number },
+  deps: CopyClimbNameDeps,
+): boolean {
+  const name = climb?.name;
+  if (!name) return false;
+  void Clipboard.setStringAsync(name);
+  deps.haptic();
+  deps.track(SHARED_EVENTS.ClimbShared, {
+    method: 'copy_name',
+    climbUuid: climb.uuid,
+    boardName: context.boardName,
+    layoutId: context.layoutId,
+  });
+  deps.showToast(deps.toastMessage);
+  return true;
+}

--- a/packages/mobile/src/lib/__tests__/section-expand-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/section-expand-store.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Import the key from source so a rename can't leave these tests checking a
+// stale slot. Safe alongside the per-test dynamic imports: it's a constant
+// literal, identical across the module instances vi.resetModules() creates.
+import { STORAGE_KEY } from '../section-expand-store';
 
 vi.mock('@react-native-async-storage/async-storage', () => {
   let storage: Record<string, string> = {};
+  let throwOnRead = false;
   return {
     default: {
-      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      getItem: vi.fn(async (key: string) => {
+        if (throwOnRead) throw new Error('AsyncStorage read failed');
+        return storage[key] ?? null;
+      }),
       setItem: vi.fn(async (key: string, value: string) => {
         storage[key] = value;
       }),
@@ -13,22 +21,25 @@ vi.mock('@react-native-async-storage/async-storage', () => {
       }),
       __reset: () => {
         storage = {};
+        throwOnRead = false;
       },
       __setRaw: (key: string, value: string) => {
         storage[key] = value;
       },
       __getRaw: (key: string) => storage[key] ?? null,
+      __setThrowOnRead: (value: boolean) => {
+        throwOnRead = value;
+      },
     },
   };
 });
-
-const STORAGE_KEY = 'climbCardSectionExpanded';
 
 async function getMockStorage() {
   return (await import('@react-native-async-storage/async-storage')).default as unknown as {
     __reset: () => void;
     __setRaw: (key: string, value: string) => void;
     __getRaw: (key: string) => string | null;
+    __setThrowOnRead: (value: boolean) => void;
   };
 }
 
@@ -52,6 +63,14 @@ describe('section-expand-store', () => {
     expect(getSectionExpandedSync('logbook')).toBe(true);
     expect(getSectionExpandedSync('community')).toBe(false);
     expect(getSectionExpandedSync('similarClimbs')).toBeUndefined();
+  });
+
+  it('resolves to an empty map (no throw) when the AsyncStorage read rejects', async () => {
+    (await getMockStorage()).__setThrowOnRead(true);
+    const { loadSectionExpandState, getSectionExpandedSync } = await import('../section-expand-store');
+    // Must not reject — a rejected load would permanently poison the singleton.
+    await expect(loadSectionExpandState()).resolves.toEqual({});
+    expect(getSectionExpandedSync('logbook')).toBeUndefined();
   });
 
   it('falls back to an empty map for a malformed stored payload', async () => {

--- a/packages/mobile/src/lib/__tests__/section-expand-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/section-expand-store.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+      __getRaw: (key: string) => storage[key] ?? null,
+    },
+  };
+});
+
+const STORAGE_KEY = 'climbCardSectionExpanded';
+
+async function getMockStorage() {
+  return (await import('@react-native-async-storage/async-storage')).default as unknown as {
+    __reset: () => void;
+    __setRaw: (key: string, value: string) => void;
+    __getRaw: (key: string) => string | null;
+  };
+}
+
+describe('section-expand-store', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (await getMockStorage()).__reset();
+  });
+
+  it('reads undefined for an unset key before and after an empty load', async () => {
+    const { getSectionExpandedSync, loadSectionExpandState } = await import('../section-expand-store');
+    expect(getSectionExpandedSync('logbook')).toBeUndefined();
+    await loadSectionExpandState();
+    expect(getSectionExpandedSync('logbook')).toBeUndefined();
+  });
+
+  it('loads a stored expand map', async () => {
+    (await getMockStorage()).__setRaw(STORAGE_KEY, JSON.stringify({ logbook: true, community: false }));
+    const { loadSectionExpandState, getSectionExpandedSync } = await import('../section-expand-store');
+    await loadSectionExpandState();
+    expect(getSectionExpandedSync('logbook')).toBe(true);
+    expect(getSectionExpandedSync('community')).toBe(false);
+    expect(getSectionExpandedSync('similarClimbs')).toBeUndefined();
+  });
+
+  it('falls back to an empty map for a malformed stored payload', async () => {
+    // Non-boolean values are rejected wholesale rather than partially trusted.
+    (await getMockStorage()).__setRaw(STORAGE_KEY, JSON.stringify({ logbook: 'yes' }));
+    const { loadSectionExpandState, getSectionExpandedSync } = await import('../section-expand-store');
+    await loadSectionExpandState();
+    expect(getSectionExpandedSync('logbook')).toBeUndefined();
+  });
+
+  it('updates the in-memory value synchronously and persists it', async () => {
+    const { setSectionExpanded, getSectionExpandedSync } = await import('../section-expand-store');
+    setSectionExpanded('logbook', true);
+    expect(getSectionExpandedSync('logbook')).toBe(true);
+
+    // The write is best-effort/async; flush microtasks then assert it reached storage.
+    await Promise.resolve();
+    const raw = (await getMockStorage()).__getRaw(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual({ logbook: true });
+  });
+
+  it('a set before load wins over the persisted value (no clobber on race)', async () => {
+    (await getMockStorage()).__setRaw(STORAGE_KEY, JSON.stringify({ logbook: false }));
+    const { setSectionExpanded, loadSectionExpandState, getSectionExpandedSync } =
+      await import('../section-expand-store');
+    setSectionExpanded('logbook', true);
+    await loadSectionExpandState();
+    expect(getSectionExpandedSync('logbook')).toBe(true);
+  });
+
+  it('merges a new section without dropping existing ones', async () => {
+    const { setSectionExpanded, getSectionExpandedSync } = await import('../section-expand-store');
+    setSectionExpanded('logbook', true);
+    setSectionExpanded('community', false);
+    expect(getSectionExpandedSync('logbook')).toBe(true);
+    expect(getSectionExpandedSync('community')).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/section-expand-store.ts
+++ b/packages/mobile/src/lib/section-expand-store.ts
@@ -80,6 +80,15 @@ export function setSectionExpanded(key: string, expanded: boolean): void {
   });
 }
 
+/** Test-only: clear the in-memory singleton so each test starts from a cold
+ *  store (mirrors the `resetDimensionLocksForTests` convention). */
+export function resetSectionExpandStoreForTests(): void {
+  current = {};
+  hasLoaded = false;
+  snapshot = { map: current, loaded: hasLoaded };
+  loadPromise = null;
+}
+
 /** Synchronous read of the cached map — `undefined` when this key has no stored
  *  preference yet (or storage hasn't loaded). Lets a section pick its initial
  *  state without a flash when the store is already warm from a prior climb. */

--- a/packages/mobile/src/lib/section-expand-store.ts
+++ b/packages/mobile/src/lib/section-expand-store.ts
@@ -59,6 +59,10 @@ export async function loadSectionExpandState(): Promise<ExpandedMap> {
 // effect).
 let loadPromise: Promise<ExpandedMap> | null = null;
 function ensureSectionExpandLoaded(): Promise<ExpandedMap> {
+  // Already established by an earlier read or a `setSectionExpanded` — skip the
+  // read entirely so the "load once" intent holds even when a write beats the
+  // first section's mount.
+  if (hasLoaded) return Promise.resolve(current);
   if (!loadPromise) loadPromise = loadSectionExpandState();
   return loadPromise;
 }

--- a/packages/mobile/src/lib/section-expand-store.ts
+++ b/packages/mobile/src/lib/section-expand-store.ts
@@ -8,7 +8,10 @@
 import { useEffect, useSyncExternalStore } from 'react';
 import { getPreference, setPreference } from './preference-store';
 
-const STORAGE_KEY = 'climbCardSectionExpanded';
+// Exported so tests assert against the source of truth rather than duplicating
+// the literal (a rename would otherwise leave tests silently checking the wrong
+// slot).
+export const STORAGE_KEY = 'climbCardSectionExpanded';
 
 type ExpandedMap = Record<string, boolean>;
 type ExpandedSnapshot = { map: ExpandedMap; loaded: boolean };
@@ -38,7 +41,10 @@ function notify(): void {
 
 export async function loadSectionExpandState(): Promise<ExpandedMap> {
   if (hasLoaded) return current;
-  const stored = await getPreference<ExpandedMap>(STORAGE_KEY);
+  // Guard the read like the write in `setSectionExpanded`: a rejected
+  // AsyncStorage.getItem would otherwise leave `loadPromise` permanently
+  // rejected with no retry, silently pinning every section to its default.
+  const stored = await getPreference<ExpandedMap>(STORAGE_KEY).catch(() => null);
   // A `setSectionExpanded` may have raced in while we awaited storage; honour
   // the user's choice rather than clobbering it with the (now stale) value.
   if (hasLoaded) return current;

--- a/packages/mobile/src/lib/section-expand-store.ts
+++ b/packages/mobile/src/lib/section-expand-store.ts
@@ -1,0 +1,107 @@
+// Persists the expand/collapse state of the climb-card collapsible sections
+// (logbook, community, similar climbs) so a section the user opened stays open
+// on the next climb and across app restarts. Backed by AsyncStorage via the
+// shared preference store; mirrors the singleton/useSyncExternalStore pattern in
+// `grade-format-preference.ts` so every mounted section shares one load + one
+// subscription.
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+
+const STORAGE_KEY = 'climbCardSectionExpanded';
+
+type ExpandedMap = Record<string, boolean>;
+type ExpandedSnapshot = { map: ExpandedMap; loaded: boolean };
+
+// `current`/`hasLoaded` are the canonical state; `snapshot` is the cached
+// compound value every consumer reads via `getSnapshot`. It is rebuilt ONLY in
+// `notify()` (only when state actually changes) so `getSnapshot` returns a
+// referentially-stable object across renders — required by useSyncExternalStore
+// to avoid an infinite render loop.
+let current: ExpandedMap = {};
+let hasLoaded = false;
+let snapshot: ExpandedSnapshot = { map: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+// Stable server snapshot so it never trips the snapshot-changed loop.
+const SERVER_SNAPSHOT: ExpandedSnapshot = { map: {}, loaded: false };
+
+function isExpandedMap(value: unknown): value is ExpandedMap {
+  if (value == null || typeof value !== 'object') return false;
+  return Object.values(value as Record<string, unknown>).every((entry) => typeof entry === 'boolean');
+}
+
+function notify(): void {
+  snapshot = { map: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+export async function loadSectionExpandState(): Promise<ExpandedMap> {
+  if (hasLoaded) return current;
+  const stored = await getPreference<ExpandedMap>(STORAGE_KEY);
+  // A `setSectionExpanded` may have raced in while we awaited storage; honour
+  // the user's choice rather than clobbering it with the (now stale) value.
+  if (hasLoaded) return current;
+  current = isExpandedMap(stored) ? stored : {};
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+// One-time load, memoized as a promise singleton so it fires exactly once no
+// matter how many sections mount (or how many times StrictMode re-invokes the
+// effect).
+let loadPromise: Promise<ExpandedMap> | null = null;
+function ensureSectionExpandLoaded(): Promise<ExpandedMap> {
+  if (!loadPromise) loadPromise = loadSectionExpandState();
+  return loadPromise;
+}
+
+/** Persist a section's expand state. Best-effort write — a failed persist still
+ *  updates the in-memory store so the UI stays responsive this session. */
+export function setSectionExpanded(key: string, expanded: boolean): void {
+  current = { ...current, [key]: expanded };
+  hasLoaded = true;
+  notify();
+  void setPreference(STORAGE_KEY, current).catch(() => {
+    // Storage write failed (full disk, first-install permission race).
+    // Persisting a UI preference is best-effort; swallow rather than leak an
+    // unhandled rejection.
+  });
+}
+
+/** Synchronous read of the cached map — `undefined` when this key has no stored
+ *  preference yet (or storage hasn't loaded). Lets a section pick its initial
+ *  state without a flash when the store is already warm from a prior climb. */
+export function getSectionExpandedSync(key: string): boolean | undefined {
+  return current[key];
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): ExpandedSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): ExpandedSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+/** Subscribe to a section's persisted expand state. Returns `undefined` for
+ *  `expanded` when the key has no stored value (caller should fall back to its
+ *  own default). Pass `undefined` as the key to opt out of persistence. */
+export function useSectionExpanded(key: string | undefined): { expanded: boolean | undefined; loaded: boolean } {
+  const { map, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  // Kick the one-time AsyncStorage load from an effect (not render/subscribe).
+  useEffect(() => {
+    if (key) void ensureSectionExpandLoaded();
+  }, [key]);
+
+  return { expanded: key ? map[key] : undefined, loaded };
+}

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -715,6 +715,8 @@
       "preview": "Preview",
       "copyLink": "Copy link",
       "linkCopied": "Link copied",
+      "nameCopied": "Name copied",
+      "copyNameHint": "Press and hold to copy the name",
       "tick": "Log a tick",
       "addBetaVideo": "Add beta video",
       "openInApp": "Open in Aurora app",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -716,6 +716,7 @@
       "copyLink": "Copy link",
       "linkCopied": "Link copied",
       "nameCopied": "Name copied",
+      "copyNameError": "Couldn't copy name",
       "copyNameHint": "Press and hold to copy the name",
       "tick": "Log a tick",
       "addBetaVideo": "Add beta video",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -716,6 +716,7 @@
       "copyLink": "Copiar enlace",
       "linkCopied": "Enlace copiado",
       "nameCopied": "Nombre copiado",
+      "copyNameError": "No se pudo copiar el nombre",
       "copyNameHint": "Mantén pulsado para copiar el nombre",
       "tick": "Registrar un envío",
       "addBetaVideo": "Añadir vídeo de beta",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -715,6 +715,8 @@
       "preview": "Vista previa",
       "copyLink": "Copiar enlace",
       "linkCopied": "Enlace copiado",
+      "nameCopied": "Nombre copiado",
+      "copyNameHint": "Mantén pulsado para copiar el nombre",
       "tick": "Registrar un envío",
       "addBetaVideo": "Añadir vídeo de beta",
       "openInApp": "Abrir en la app Aurora",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -716,6 +716,7 @@
       "copyLink": "Copier le lien",
       "linkCopied": "Lien copié",
       "nameCopied": "Nom copié",
+      "copyNameError": "Impossible de copier le nom",
       "copyNameHint": "Appuie longuement pour copier le nom",
       "tick": "Enregistrer une croix",
       "addBetaVideo": "Ajouter une vidéo beta",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -715,6 +715,8 @@
       "preview": "Aperçu",
       "copyLink": "Copier le lien",
       "linkCopied": "Lien copié",
+      "nameCopied": "Nom copié",
+      "copyNameHint": "Appuie longuement pour copier le nom",
       "tick": "Enregistrer une croix",
       "addBetaVideo": "Ajouter une vidéo beta",
       "openInApp": "Ouvrir dans l'app Aurora",


### PR DESCRIPTION
## Summary

Three small quality-of-life improvements to the mobile climb card (the play drawer).

**1. Logbook rows show the grade you gave.** Each logbook entry already carried your personal grade (`Tick.difficulty`) but never displayed it. Adds a grade-colored chip next to the angle, formatted to your grade-display preference (V / Font / both). Hidden when no personal grade was logged (e.g. most attempts). No backend or query change — the field was already fetched.

**2. Section expand/collapse state sticks.** The logbook, community, and similar-climbs sections used to reset to their default open/closed state on every climb. Now whatever you leave them at persists across climbs and app restarts. Implemented as a `persistKey` on `CollapsibleSection` backed by a new AsyncStorage-backed `section-expand-store` (`useSyncExternalStore` singleton, same pattern as `grade-format-preference`). State is per-device (not synced to the server profile).

**3. Long-press the climb name to copy it.** The name was a plain label. Long-pressing it now copies the climb name to the clipboard with a haptic + toast — handy for pasting into a chat when sharing beta. Only the active header is interactive; the swipe "peek" header stays a plain label.

## Release Notes

- See the grade you gave each climb right in its logbook
- Logbook, community, and similar-climbs sections now stay open if you leave them open
- Long-press a climb's name to copy it

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2789 passing, plus new tests:
  - `section-expand-store.test.ts` (load / set / malformed-payload fallback / no-clobber race / merge)
  - `logbook-entry-row-grade.test.tsx` (chip shown with a grade, hidden without)
- `vp lint` on changed files — 0 warnings / 0 errors
- `vp run check:mobile-bundle` — iOS + Android bundles OK
- i18n parity (`catalog-completeness.test.ts`) — `nameCopied` / `copyNameHint` present in en-US, es, fr

Not yet exercised on a simulator/device — happy to add screenshots if useful.
