### PR TITLE
feat(mobile): move What's New into the user drawer

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useState } from 'react';
-import { router, useFocusEffect } from 'expo-router';
+import { router } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
@@ -25,8 +24,6 @@ import { useToast } from '../../../src/providers/toast-provider';
 import { useFeatureFlag } from '../../../src/providers/feature-flags-provider';
 import { replayOnboarding } from '../../../src/lib/onboarding/onboarding-storage';
 import { reportError } from '../../../src/lib/error-reporting';
-import { latestEntryDate } from '../../../src/lib/changelog';
-import { getLastSeenChangelogDate, hasUnseenChangelog } from '../../../src/lib/changelog-seen';
 
 // Translations live in the shared catalog at packages/shared/i18n/locales/<locale>/.
 // We deep-link to the active language's folder so a community member lands on the
@@ -69,24 +66,6 @@ export default function MoreScreen() {
   // (The OTA channel switcher moved to an everyone-facing "Try a preview" entry
   // on the changelog screen, so it's no longer listed here.)
   const showDevSection = (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showFeatureFlags);
-
-  // Whether the bundled changelog has an entry the user hasn't opened yet — drives
-  // the "New" pill on the What's New row. Re-read every time this screen regains
-  // focus: opening the changelog clears the flag, but a native-stack push leaves
-  // More mounted underneath, so a mount-only read would never see the cleared
-  // state when the user pops back.
-  const [changelogUnseen, setChangelogUnseen] = useState(false);
-  useFocusEffect(
-    useCallback(() => {
-      let active = true;
-      void getLastSeenChangelogDate().then((lastSeen) => {
-        if (active) setChangelogUnseen(hasUnseenChangelog(latestEntryDate, lastSeen));
-      });
-      return () => {
-        active = false;
-      };
-    }, []),
-  );
 
   // 'System' follows the device language; the rest are the supported locales,
   // labelled in their own script (English / Español / Français) from
@@ -352,23 +331,6 @@ export default function MoreScreen() {
         subtitle: t('mobile.onboarding.replaySubtitle'),
         icon: 'replay',
         onPress: navAction(handleReplayWalkthrough),
-      },
-    ],
-  });
-
-  // About / What's New — the "New" pill shows while there's an unseen entry.
-  sections.push({
-    key: 'about',
-    title: t('mobile.more.aboutSection'),
-    rows: [
-      {
-        kind: 'nav',
-        key: 'changelog',
-        label: t('mobile.more.changelogTitle'),
-        subtitle: t('mobile.more.changelogSubtitle'),
-        icon: 'changelog',
-        badge: changelogUnseen ? t('mobile.more.newPill') : undefined,
-        onPress: navAction(() => router.push('/changelog')),
       },
     ],
   });

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
 import Animated, { Easing, runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { router } from 'expo-router';
@@ -14,6 +14,8 @@ import { Text } from '../src/components/Text';
 import { Icon } from '../src/components/Icon';
 import { ListRow } from '../src/components/ListRow';
 import { useUserDrawer } from '../src/components/user-drawer/UserDrawerProvider';
+import { latestEntryDate } from '../src/lib/changelog';
+import { getLastSeenChangelogDate, hasUnseenChangelog } from '../src/lib/changelog-seen';
 
 const DRAWER_MAX_WIDTH = 320;
 const DRAWER_SCREEN_FRACTION = 0.86;
@@ -44,12 +46,28 @@ export default function UserDrawerScreen() {
   const windowDimensions = useWindowDimensions();
   const drawerWidth = Math.min(DRAWER_MAX_WIDTH, windowDimensions.width * DRAWER_SCREEN_FRACTION);
 
+  // Whether the bundled changelog has an entry the user hasn't opened yet — drives
+  // the "New" pill on the What's New row. The drawer is a fresh route push every
+  // time it opens, so a one-shot mount read is enough; opening the changelog clears
+  // the marker and the next drawer open re-reads it.
+  const [changelogUnseen, setChangelogUnseen] = useState(false);
+  useEffect(() => {
+    let active = true;
+    void getLastSeenChangelogDate().then((lastSeen) => {
+      if (active) setChangelogUnseen(hasUnseenChangelog(latestEntryDate, lastSeen));
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const {
     navigateToBoards,
     navigateToManageBoards,
     navigateToSettings,
     navigateToEditProfile,
     navigateToPlaylists,
+    navigateToChangelog,
     navigateToAbout,
     openDiscord,
     signOutAction,
@@ -218,6 +236,20 @@ export default function UserDrawerScreen() {
               onPress={() => close(() => navigateToPlaylists())}
             />
             <DrawerRow
+              icon="flash"
+              title={t('userDrawer.whatsNew')}
+              onPress={() => close(() => navigateToChangelog())}
+              trailing={
+                changelogUnseen ? (
+                  <View style={[styles.newPill, { backgroundColor: brandColors.primaryFill }]}>
+                    <Text variant="caption2" color={brandColors.onPrimary} style={styles.newPillLabel}>
+                      {t('userDrawer.newBadge')}
+                    </Text>
+                  </View>
+                ) : undefined
+              }
+            />
+            <DrawerRow
               icon="info"
               title={t('userDrawer.about')}
               onPress={() => close(() => navigateToAbout())}
@@ -285,15 +317,17 @@ type DrawerRowProps = {
   onPress: () => void;
   showSeparator?: boolean;
   tintColor?: string;
+  trailing?: ReactNode;
 };
 
-function DrawerRow({ icon, title, onPress, showSeparator = true, tintColor }: DrawerRowProps) {
+function DrawerRow({ icon, title, onPress, showSeparator = true, tintColor, trailing }: DrawerRowProps) {
   const { systemColors } = useTheme();
   const iconColor = tintColor ?? systemColors.label;
   return (
     <ListRow
       title={title}
       leading={<Icon name={icon} size={22} color={iconColor} />}
+      trailing={trailing}
       showChevron
       showSeparator={showSeparator}
       separatorInset={16}
@@ -343,5 +377,14 @@ const styles = StyleSheet.create({
   },
   drawerRow: {
     minHeight: 48,
+  },
+  newPill: {
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: borderRadius.full,
+  },
+  newPillLabel: {
+    fontWeight: '700',
+    textTransform: 'uppercase',
   },
 });

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -235,8 +235,11 @@ export default function UserDrawerScreen() {
               title={t('userDrawer.myPlaylists')}
               onPress={() => close(() => navigateToPlaylists())}
             />
+            {/* No subtitle: drawer rows are single-line menu entries (Settings,
+                About, …); the "Recent updates and fixes" line lives on the
+                changelog screen itself. The "New" pill carries the unseen cue. */}
             <DrawerRow
-              icon="flash"
+              icon="changelog"
               title={t('userDrawer.whatsNew')}
               onPress={() => close(() => navigateToChangelog())}
               trailing={

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -56,6 +56,9 @@ export const iconMap = {
   tag: { ios: 'tag', android: 'tag-outline' },
   'check.small': { ios: 'checkmark', android: 'check' },
   flash: { ios: 'bolt.fill', android: 'flash' },
+  // What's New / changelog. Mirrors the More tab's native changelog glyph
+  // (sparkles on iOS) so the same feature reads consistently across surfaces.
+  changelog: { ios: 'sparkles', android: 'star-four-points' },
   'open.external': { ios: 'arrow.up.right.square', android: 'open-in-new' },
 
   // Climb/Board

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -24,6 +24,7 @@ type UserDrawerContextValue = {
   navigateToSettings: () => void;
   navigateToEditProfile: () => void;
   navigateToPlaylists: () => void;
+  navigateToChangelog: () => void;
   navigateToAbout: () => void;
   openDiscord: () => void;
   signOutAction: () => void;
@@ -94,6 +95,10 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
     router.push('/(tabs)/discover/all');
   }, []);
 
+  const navigateToChangelog = useCallback(() => {
+    router.push('/changelog');
+  }, []);
+
   const navigateToAbout = useCallback(() => {
     router.push('/about');
   }, []);
@@ -119,6 +124,7 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
       navigateToSettings,
       navigateToEditProfile,
       navigateToPlaylists,
+      navigateToChangelog,
       navigateToAbout,
       openDiscord,
       signOutAction,
@@ -133,6 +139,7 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
       navigateToSettings,
       navigateToEditProfile,
       navigateToPlaylists,
+      navigateToChangelog,
       navigateToAbout,
       openDiscord,
       signOutAction,

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -66,13 +66,22 @@ vi.mock('react-i18next', () => ({
         'userDrawer.joinDiscord': 'Join Discord',
         'userDrawer.logout': 'Log out',
         'userDrawer.myPlaylists': 'My playlists',
+        'userDrawer.newBadge': 'New',
         'userDrawer.rateBoardsesh': 'Rate Boardsesh',
         'userDrawer.reportBug': 'Report a bug',
+        'userDrawer.whatsNew': "What's New",
       })[key] ?? key,
   }),
 }));
 
 vi.mock('../../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+// Mock the changelog data + seen-state so importing the screen never reaches the
+// real secure-store adapter; "nothing unseen" keeps the What's New pill hidden.
+vi.mock('../../../lib/changelog', () => ({ latestEntryDate: '2026-01-01T00:00:00.000Z' }));
+vi.mock('../../../lib/changelog-seen', () => ({
+  getLastSeenChangelogDate: vi.fn().mockResolvedValue('2026-01-01T00:00:00.000Z'),
+  hasUnseenChangelog: () => false,
+}));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));
@@ -218,6 +227,7 @@ describe('user-drawer route defers each action until the route unmounts', () => 
   it.each([
     ['Settings', '/(tabs)/profile/more'],
     ['My playlists', '/(tabs)/discover/all'],
+    ["What's New", '/changelog'],
     ['About', '/about'],
     ['My boards', '/boards/manage'],
   ])('%s closes the drawer, then pushes %s', (rowTitle, route) => {

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -76,12 +76,14 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../../lib/error-reporting', () => ({ reportError: vi.fn() }));
 // Mock the changelog data + seen-state so importing the screen never reaches the
-// real secure-store adapter; "nothing unseen" keeps the What's New pill hidden.
-vi.mock('../../../lib/changelog', () => ({ latestEntryDate: '2026-01-01T00:00:00.000Z' }));
-vi.mock('../../../lib/changelog-seen', () => ({
-  getLastSeenChangelogDate: vi.fn().mockResolvedValue('2026-01-01T00:00:00.000Z'),
-  hasUnseenChangelog: () => false,
+// real secure-store adapter. hasUnseenChangelog is a vi.fn so a test can flip it
+// to exercise the visible "New" pill path (default: nothing unseen → no pill).
+const changelogSeen = vi.hoisted(() => ({
+  getLastSeenChangelogDate: vi.fn(),
+  hasUnseenChangelog: vi.fn(() => false),
 }));
+vi.mock('../../../lib/changelog', () => ({ latestEntryDate: '2026-01-01T00:00:00.000Z' }));
+vi.mock('../../../lib/changelog-seen', () => changelogSeen);
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'user-1', displayName: 'Alex', email: 'alex@example.com', avatarUrl: null } }),
 }));
@@ -115,8 +117,17 @@ vi.mock('../../Icon', () => ({
   Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
 }));
 vi.mock('../../ListRow', () => ({
-  ListRow: ({ leading, onPress, title }: { leading?: ReactNode; onPress?: () => void; title: string }) =>
-    createElement('button', { 'data-row-title': title, onClick: onPress, type: 'button' }, leading, title),
+  ListRow: ({
+    leading,
+    onPress,
+    title,
+    trailing,
+  }: {
+    leading?: ReactNode;
+    onPress?: () => void;
+    title: string;
+    trailing?: ReactNode;
+  }) => createElement('button', { 'data-row-title': title, onClick: onPress, type: 'button' }, leading, title, trailing),
 }));
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
@@ -161,6 +172,8 @@ beforeEach(() => {
   feedbackPresent.mockClear();
   reanimated.closeCallbacks.length = 0;
   segmentsMock.current = [];
+  changelogSeen.getLastSeenChangelogDate.mockResolvedValue('2026-01-01T00:00:00.000Z');
+  changelogSeen.hasUnseenChangelog.mockReturnValue(false);
   // The route defers its post-close action one frame past unmount (so the route
   // VC dismissal flushes before a sheet presents). Run rAF synchronously so the
   // deferral resolves within the unmounting rerender the tests drive.
@@ -242,6 +255,15 @@ describe('user-drawer route defers each action until the route unmounts', () => 
 
     rerender(<Harness showScreen={false} />);
     expect(routerMock.push).toHaveBeenCalledWith(route);
+  });
+
+  it('shows the "New" pill on the What\'s New row when there is an unseen changelog entry', async () => {
+    changelogSeen.hasUnseenChangelog.mockReturnValue(true);
+    render(<Harness showScreen />);
+
+    // The pill (userDrawer.newBadge) renders only once the mount read of
+    // getLastSeenChangelogDate resolves and flips changelogUnseen to true.
+    expect(await screen.findByText('New')).toBeTruthy();
   });
 
   it('Change board closes the drawer, then pushes the /boards modal route with the returnTo', () => {

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -127,7 +127,8 @@ vi.mock('../../ListRow', () => ({
     onPress?: () => void;
     title: string;
     trailing?: ReactNode;
-  }) => createElement('button', { 'data-row-title': title, onClick: onPress, type: 'button' }, leading, title, trailing),
+  }) =>
+    createElement('button', { 'data-row-title': title, onClick: onPress, type: 'button' }, leading, title, trailing),
 }));
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -119,11 +119,7 @@
         "title": "Connected apps",
         "subtitle": "Board accounts, Apple Health",
         "subtitleWithStrava": "Board accounts, Apple Health, Strava"
-      },
-      "aboutSection": "About",
-      "changelogTitle": "What's New",
-      "changelogSubtitle": "Recent updates and fixes",
-      "newPill": "New"
+      }
     },
     "about": {
       "title": "About",
@@ -378,6 +374,8 @@
     "myPlaylists": "My playlists",
     "recentSessions": "Recent sessions",
     "about": "About",
+    "whatsNew": "What's New",
+    "newBadge": "New",
     "rateBoardsesh": "Rate Boardsesh",
     "reportBug": "Report a bug",
     "joinDiscord": "Join Discord",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -74,6 +74,8 @@
     "myPlaylists": "Mis listas",
     "recentSessions": "Sesiones recientes",
     "about": "Sobre",
+    "whatsNew": "Novedades",
+    "newBadge": "Nuevo",
     "rateBoardsesh": "Valorar Boardsesh",
     "reportBug": "Reportar un bug",
     "joinDiscord": "Únete a Discord",
@@ -317,11 +319,7 @@
         "title": "Aplicaciones conectadas",
         "subtitle": "Apple Health y Strava",
         "subtitleWithStrava": "Cuentas de plafón, Apple Health, Strava"
-      },
-      "aboutSection": "Acerca de",
-      "changelogTitle": "Novedades",
-      "changelogSubtitle": "Últimas mejoras y correcciones",
-      "newPill": "Nuevo"
+      }
     },
     "about": {
       "title": "Sobre Boardsesh",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -119,11 +119,7 @@
         "title": "Applications connectées",
         "subtitle": "Apple Health et Strava",
         "subtitleWithStrava": "Comptes de board, Apple Health, Strava"
-      },
-      "aboutSection": "À propos",
-      "changelogTitle": "Nouveautés",
-      "changelogSubtitle": "Dernières améliorations et corrections",
-      "newPill": "Nouveau"
+      }
     },
     "about": {
       "title": "À propos de Boardsesh",
@@ -378,6 +374,8 @@
     "myPlaylists": "Mes playlists",
     "recentSessions": "Sessions récentes",
     "about": "À propos",
+    "whatsNew": "Nouveautés",
+    "newBadge": "Nouveau",
     "rateBoardsesh": "Noter Boardsesh",
     "reportBug": "Signaler un bug",
     "joinDiscord": "Rejoindre Discord",


### PR DESCRIPTION
## Summary

On mobile, "What's New" (the changelog) lived in the More tab's About section. This moves it into the **user drawer** — the slide-in menu opened from the avatar in the top toolbar — so it sits alongside the rest of the account/app menu (Settings, My Playlists, About, Rate, Report a bug, Join Discord, Log out). The "New" unseen pill moves with it.

What changed:
- `UserDrawerProvider` gains a `navigateToChangelog` action; the drawer renders a "What's New" row just above "About". `DrawerRow` gained a `trailing` slot so the row can show the "New" pill, computed on open from the existing `getLastSeenChangelogDate()` / `hasUnseenChangelog()` helpers.
- The More tab drops the changelog row, its unseen-state effect, and the now-dead imports/styles. Its lone "About" section goes away with it.
- i18n: replaced the orphaned `mobile.more` changelog/about keys with `userDrawer.whatsNew` and `userDrawer.newBadge` across `en-US`, `es`, and `fr`.

This is mobile-only; the web app has no changelog feature.

## Release Notes

- Find What's New in the user menu now — tap your avatar to see the latest updates, with a badge when there's something fresh.

## Test plan

- `vp run typecheck:mobile` — passes
- `vp run test:mobile` — 2784 tests pass (includes the new What's New → `/changelog` navigation case in the user-drawer test and the i18n catalog completeness check)
- `vp run check:mobile-bundle` — Metro bundle OK
- `vp lint` — changed files clean (only pre-existing unrelated warnings/error)
- Manual: avatar → drawer → "What's New" (next to About) opens `/changelog`; the More tab no longer shows it; the "New" pill appears for unseen entries and clears after viewing; `es`/`fr` show translated labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018VKhhjK4v9r1FtPiwKzhVE)_