### PR TITLE
ci(mobile): stop auto-bumping iOS version on main; revert 2.1.1 to unblock OTA

### DIFF
--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -1,17 +1,20 @@
 name: Mobile Auto Version Bump
 
-# Polls App Store Connect hourly. When the current marketing version in
-# packages/mobile/app.config.ts has been accepted by Apple (PENDING_DEVELOPER_RELEASE,
+# Checks App Store Connect for the current marketing version in
+# packages/mobile/app.config.ts. When it has been accepted by Apple (PENDING_DEVELOPER_RELEASE,
 # PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, or READY_FOR_SALE), this workflow
 # bumps the patch version and pushes directly to main via the OTA push-back app token,
 # bypassing the PR requirement. The commit carries [skip ci] to prevent a spurious OTA
 # publish (the version change busts the fingerprint; no binary can pull such an OTA).
 #
 # Minor version bumps are intentionally excluded — those are a manual decision.
+#
+# The hourly schedule is intentionally disabled: an automatic bump on main rewrites the
+# native version, which busts the fingerprint and breaks fingerprint parity between the
+# native build and the OTA publish. Run this manually (workflow_dispatch) only when a
+# version bump is actually needed.
 
 on:
-  schedule:
-    - cron: '0 * * * *' # hourly; App Review approval is not time-critical
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/mobile-auto-version-bump.yml
+++ b/.github/workflows/mobile-auto-version-bump.yml
@@ -1,18 +1,18 @@
 name: Mobile Auto Version Bump
 
-# Checks App Store Connect for the current marketing version in
+# Manual-only (workflow_dispatch). The hourly schedule is intentionally disabled:
+# an automatic bump on main rewrites the native version, which busts the fingerprint
+# and breaks parity between the native build and the OTA publish. Run this only when a
+# version bump is actually needed.
+#
+# What it does when run: checks App Store Connect for the current marketing version in
 # packages/mobile/app.config.ts. When it has been accepted by Apple (PENDING_DEVELOPER_RELEASE,
-# PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, or READY_FOR_SALE), this workflow
-# bumps the patch version and pushes directly to main via the OTA push-back app token,
-# bypassing the PR requirement. The commit carries [skip ci] to prevent a spurious OTA
-# publish (the version change busts the fingerprint; no binary can pull such an OTA).
+# PENDING_APPLE_RELEASE, PROCESSING_FOR_APP_STORE, or READY_FOR_SALE), it bumps the patch
+# version and pushes directly to main via the OTA push-back app token, bypassing the PR
+# requirement. The commit carries [skip ci] to prevent a spurious OTA publish (the version
+# change busts the fingerprint; no binary can pull such an OTA).
 #
 # Minor version bumps are intentionally excluded — those are a manual decision.
-#
-# The hourly schedule is intentionally disabled: an automatic bump on main rewrites the
-# native version, which busts the fingerprint and breaks fingerprint parity between the
-# native build and the OTA publish. Run this manually (workflow_dispatch) only when a
-# version bump is actually needed.
 
 on:
   workflow_dispatch:

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -197,7 +197,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.1.1',
+    version: '2.1.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,


### PR DESCRIPTION
## Summary

The Mobile Auto Version Bump workflow polled App Store Connect hourly and pushed a patch version bump straight to `main` whenever the current version was accepted by Apple. That rewrites the native `version` in `packages/mobile/app.config.ts`, which busts the fingerprint and breaks parity between the native build and the production OTA publish — so OTAs stop landing on shipped binaries.

This PR:

- **Disables the hourly schedule** in `.github/workflows/mobile-auto-version-bump.yml`. The workflow now runs only via `workflow_dispatch`, so a version bump happens on demand when we actually need one rather than automatically. `dry_run` still defaults to `true`, so a manual run is safe by default.
- **Reverts the version `2.1.1 → 2.1.0`** in `app.config.ts`. The auto-bump to 2.1.1 (commit a4fe86b) was the change that busted the fingerprint; rolling back to 2.1.0 restores fingerprint parity so production OTAs match the shipped binary again.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- CI workflow lint / parity checks pass.
- `mobile-auto-version-bump.yml` no longer carries a `schedule:` trigger; `workflow_dispatch` is preserved.
- `app.config.ts` `version` is back to `2.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yD7NQPD8cqQwkez1TVisz)_