### PR TITLE
fix(mobile): render MoonBoard previews in the session feed

### DIFF
--- a/packages/mobile/src/lib/playlists/__tests__/board-details-for-playlist.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/board-details-for-playlist.test.ts
@@ -61,6 +61,10 @@ describe('getBoardConfigForPlaylist', () => {
     expect(config?.layoutId).toBe(MOONBOARD_LAYOUTS['moonboard-2024'].id);
   });
 
+  it('returns null for an unknown moonboard layout id', () => {
+    expect(getBoardConfigForPlaylist('moonboard', 999999)).toBeNull();
+  });
+
   it('produces a moonboard config that feeds getBoardRenderData end-to-end', () => {
     const config = getBoardConfigForPlaylist('moonboard', MOONBOARD_LAYOUTS['moonboard-2016'].id);
     expect(config).not.toBeNull();

--- a/packages/mobile/src/lib/playlists/__tests__/board-details-for-playlist.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/board-details-for-playlist.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { getAllLayouts, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE } from '@boardsesh/board-config';
 import { getBoardConfigForPlaylist } from '../board-details-for-playlist';
+import { getBoardRenderData } from '../../board-details';
 
 function largestSizeId(layoutId: number): number {
   const sizes = getSizesForLayoutId('kilter', layoutId);
@@ -38,5 +40,40 @@ describe('getBoardConfigForPlaylist', () => {
 
   it('returns null for an unknown layout id', () => {
     expect(getBoardConfigForPlaylist('kilter', 999999)).toBeNull();
+  });
+
+  it('resolves a moonboard config (fixed size + all sets) for a real layout', () => {
+    const layoutId = MOONBOARD_LAYOUTS['moonboard-2016'].id;
+    const config = getBoardConfigForPlaylist('moonboard', layoutId);
+
+    expect(config).not.toBeNull();
+    expect(config?.boardName).toBe('moonboard');
+    expect(config?.layoutId).toBe(layoutId);
+    expect(config?.sizeId).toBe(MOONBOARD_SIZE.id);
+    expect(config?.setIds).toEqual(MOONBOARD_SETS['moonboard-2016'].map((set) => set.id));
+  });
+
+  it('falls back to the default moonboard layout when layoutId is null', () => {
+    const config = getBoardConfigForPlaylist('moonboard', null);
+
+    expect(config).not.toBeNull();
+    expect(config?.boardName).toBe('moonboard');
+    expect(config?.layoutId).toBe(MOONBOARD_LAYOUTS['moonboard-2024'].id);
+  });
+
+  it('produces a moonboard config that feeds getBoardRenderData end-to-end', () => {
+    const config = getBoardConfigForPlaylist('moonboard', MOONBOARD_LAYOUTS['moonboard-2016'].id);
+    expect(config).not.toBeNull();
+
+    const renderData = getBoardRenderData({
+      boardName: config!.boardName,
+      layoutId: config!.layoutId,
+      sizeId: config!.sizeId,
+      setIds: config!.setIds,
+    });
+
+    expect(renderData).not.toBeNull();
+    expect(renderData?.backgroundImageKeys.length).toBeGreaterThan(0);
+    expect(renderData?.holdsData.length).toBeGreaterThan(0);
   });
 });

--- a/packages/mobile/src/lib/playlists/board-details-for-playlist.ts
+++ b/packages/mobile/src/lib/playlists/board-details-for-playlist.ts
@@ -1,5 +1,6 @@
 import type { BoardName } from '@boardsesh/shared-schema';
 import { getSizesForLayoutId, getSetsForLayoutAndSize, getAllLayouts } from '@boardsesh/board-constants/product-sizes';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@boardsesh/board-config';
 
 export type PlaylistBoardConfig = {
   boardName: BoardName;
@@ -26,9 +27,10 @@ const boardConfigCache = new Map<string, PlaylistBoardConfig | null>();
  * Resolve a renderable board config (largest size + all its sets) for a
  * playlist that only carries `boardType` + `layoutId`. Mobile mirror of web's
  * `getBoardDetailsForPlaylist`, returning the minimal config the bundled
- * background cache needs. Returns null when the board/layout can't resolve
- * (e.g. moonboard, which the bundled-asset path doesn't cover) so the caller
- * falls back cleanly to the plain colour tile. Memoised by board key.
+ * background cache needs. Handles Aurora boards (kilter/tension) via the
+ * product-size tables and MoonBoard via its own layout/set config. Returns null
+ * when the board/layout can't resolve so the caller falls back cleanly to the
+ * plain colour tile. Memoised by board key.
  */
 export function getBoardConfigForPlaylist(
   boardType: string,
@@ -57,6 +59,13 @@ function computeBoardConfigForPlaylist(
   // return null (→ plain colour tile) rather than rendering a bad board, so the
   // cast is safe at runtime.
   const boardName = boardType as unknown as BoardName;
+
+  // MoonBoard isn't in the Aurora product-size tables — it has a single fixed
+  // size and its own layout/set config. Mirror web's `getMoonBoardDetailsForPlaylist`.
+  if (boardName === 'moonboard') {
+    return computeMoonBoardConfigForPlaylist(layoutId);
+  }
+
   const effectiveLayoutId = layoutId ?? getDefaultLayoutId(boardName);
   if (!effectiveLayoutId) return null;
 
@@ -77,6 +86,26 @@ function computeBoardConfigForPlaylist(
     boardName,
     layoutId: effectiveLayoutId,
     sizeId: largest.id,
+    setIds: sets.map((set) => set.id),
+  };
+}
+
+function computeMoonBoardConfigForPlaylist(layoutId: number | null | undefined): PlaylistBoardConfig | null {
+  // MoonBoard has one fixed size; default to the 2024 layout when the playlist
+  // carries no layout id (matches web's fallback).
+  const effectiveLayoutId = layoutId ?? MOONBOARD_LAYOUTS['moonboard-2024'].id;
+
+  const layoutEntry = Object.entries(MOONBOARD_LAYOUTS).find(([, layout]) => layout.id === effectiveLayoutId);
+  if (!layoutEntry) return null;
+
+  const [layoutKey] = layoutEntry;
+  const sets = MOONBOARD_SETS[layoutKey as MoonBoardLayoutKey] ?? [];
+  if (sets.length === 0) return null;
+
+  return {
+    boardName: 'moonboard',
+    layoutId: effectiveLayoutId,
+    sizeId: MOONBOARD_SIZE.id,
     setIds: sets.map((set) => set.id),
   };
 }


### PR DESCRIPTION
## Summary

In the mobile "From your crew" session feed, each card renders the climber's hardest send as a small board thumbnail (board art + lit holds). MoonBoard climbs showed a placeholder lightbulb icon instead, while kilter/tension rendered fine.

`HeroSend` (`packages/mobile/src/components/you/SessionFeedCard.tsx`) only renders the thumbnail when `getBoardConfigForPlaylist(...)` returns a config. That helper (`packages/mobile/src/lib/playlists/board-details-for-playlist.ts`) resolved board metadata solely through the Aurora product-size tables (`@boardsesh/board-constants/product-sizes`), which don't include MoonBoard — so it returned `null` and triggered the lightbulb fallback.

This adds a MoonBoard branch mirroring web's existing `getMoonBoardDetailsForPlaylist` (`packages/web/app/lib/board-config-for-playlist.ts`): resolve the layout via `MOONBOARD_LAYOUTS` (defaulting to 2024 when none is set), use the fixed `MOONBOARD_SIZE`, and include every set for the layout. The downstream render path already handles MoonBoard (`getBoardRenderData` in `packages/mobile/src/lib/board-details.ts`), so standard layouts (2010, 2016, 2024, Masters 2017/2019) now render board art plus lit holds.

Out of scope: Mini MoonBoard 2020/2025 board art isn't bundled yet (a known, separate gap) — those layouts will keep showing the existing gray missing-layer placeholder rather than the lightbulb.

## Release Notes

- MoonBoard sends now show the board preview in your crew's session feed, just like Kilter and Tension.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile board-details-for-playlist` — 7 passed (added MoonBoard cases: standard-layout config, null-layout default, end-to-end `getBoardRenderData`)
- `vp run check:mobile-bundle` — Metro bundle OK
- `vp check` — changed files clean (pre-existing format issues in unrelated files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5aS3QR2xVfKsfP37LYAcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5aS3QR2xVfKsfP37LYAcj)_