### PR TITLE
feat(mobile): capture BLE disconnect reason for analytics (JS path)

### DIFF
--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -17,6 +17,15 @@ export type NativeBleScanEvent = {
 
 export type NativeBleDisconnectEvent = {
   deviceId: string;
+  // CoreBluetooth disconnect reason, present when iOS supplied an NSError on
+  // didDisconnectPeripheral. Absent on a clean/expected drop, or when the drop
+  // came from an app-driven write-stall recovery (which sets `context` instead).
+  errorCode?: number;
+  errorDomain?: string;
+  errorDescription?: string;
+  // App-side classification for drops the native layer caused itself (write-stall
+  // budget exhausted, recovery reconnect failed/timed out).
+  context?: string;
 };
 
 export type NativeBleConnectedEvent = {

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -950,6 +950,67 @@ describe('RNBleAdapter', () => {
 
       expect(typeof unsubscribe2).toBe('function');
     });
+
+    it('forwards a ble-plx disconnect error as BleDisconnectInfo', async () => {
+      const adapter = setupConnectableAdapter(
+        'aurora',
+        'dev-disc',
+        vi.fn().mockResolvedValue([
+          {
+            uuid: 'uart-write-uuid',
+            isWritableWithoutResponse: true,
+            writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+          },
+        ]),
+      );
+      await adapter.requestAndConnect();
+
+      const callback = vi.fn();
+      adapter.onDisconnect(callback);
+
+      // Fire the handler react-native-ble-plx was handed, shaped like an iOS
+      // peer-terminated drop (CBError code 7) — what a takeover looks like.
+      const handler = mockBleManager.onDeviceDisconnected.mock.calls.at(-1)?.[1] as
+        | ((error: unknown, device: unknown) => void)
+        | undefined;
+      handler?.(
+        { errorCode: 201, iosErrorCode: 7, androidErrorCode: null, reason: 'Peripheral disconnected', message: 'msg' },
+        null,
+      );
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'ble-plx',
+          bleErrorCode: 201,
+          iosErrorCode: 7,
+          description: 'Peripheral disconnected',
+        }),
+      );
+    });
+
+    it('forwards a clean (null-error) ble-plx drop as a source-only BleDisconnectInfo', async () => {
+      const adapter = setupConnectableAdapter(
+        'aurora',
+        'dev-disc-clean',
+        vi.fn().mockResolvedValue([
+          {
+            uuid: 'uart-write-uuid',
+            isWritableWithoutResponse: true,
+            writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+          },
+        ]),
+      );
+      await adapter.requestAndConnect();
+
+      const callback = vi.fn();
+      adapter.onDisconnect(callback);
+      const handler = mockBleManager.onDeviceDisconnected.mock.calls.at(-1)?.[1] as
+        | ((error: unknown, device: unknown) => void)
+        | undefined;
+      handler?.(null, null);
+
+      expect(callback).toHaveBeenCalledWith({ source: 'ble-plx' });
+    });
   });
 
   describe('requestAndConnect — original MoonBoard (RedBearLab) fallback', () => {

--- a/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/native-ios-adapter.test.ts
@@ -17,7 +17,13 @@ type ScanListener = (payload: {
   rssi: number;
   serviceUuids?: string[];
 }) => void;
-type DisconnectListener = (payload: { deviceId: string }) => void;
+type DisconnectListener = (payload: {
+  deviceId: string;
+  errorCode?: number;
+  errorDomain?: string;
+  errorDescription?: string;
+  context?: string;
+}) => void;
 const harness = vi.hoisted(() => {
   const scanListeners: ScanListener[] = [];
   const disconnectListeners: DisconnectListener[] = [];
@@ -366,6 +372,45 @@ describe('NativeIosBleAdapter connect flow', () => {
     adapter.onDisconnect(onDisconnect);
     disconnectListeners[0]?.({ deviceId: 'adopted-dev' });
     expect(onDisconnect).toHaveBeenCalled();
+  });
+
+  it('forwards the native disconnect reason fields as BleDisconnectInfo', () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+
+    adapter.adoptConnection('adopted-dev');
+    const onDisconnect = vi.fn();
+    adapter.onDisconnect(onDisconnect);
+    // Shaped like an iOS peer-terminated drop (CBError code 7) — what a takeover
+    // of the last-connection-wins board looks like once the Swift layer attaches
+    // the NSError.
+    disconnectListeners[0]?.({
+      deviceId: 'adopted-dev',
+      errorCode: 7,
+      errorDomain: 'CBErrorDomain',
+      errorDescription: 'The specified device has disconnected from us.',
+    });
+
+    expect(onDisconnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'native-ios',
+        iosErrorCode: 7,
+        errorDomain: 'CBErrorDomain',
+        description: 'The specified device has disconnected from us.',
+      }),
+    );
+  });
+
+  it('forwards a write-stall context marker when the native layer caused the drop', () => {
+    const adapter = new NativeIosBleAdapter(() => Promise.reject(new Error('picker should not open')));
+
+    adapter.adoptConnection('adopted-dev');
+    const onDisconnect = vi.fn();
+    adapter.onDisconnect(onDisconnect);
+    disconnectListeners[0]?.({ deviceId: 'adopted-dev', context: 'write_stall_budget_exhausted' });
+
+    expect(onDisconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'native-ios', context: 'write_stall_budget_exhausted' }),
+    );
   });
 });
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -1,4 +1,4 @@
-import { type Device, type Characteristic } from 'react-native-ble-plx';
+import { type Device, type Characteristic, type BleError } from 'react-native-ble-plx';
 import {
   AURORA_ADVERTISED_SERVICE_UUID,
   UART_SERVICE_UUID,
@@ -13,7 +13,14 @@ import { bleManager } from './ble-manager';
 import { waitForBlePoweredOn } from './availability';
 import { isLikelyBoardDevice } from './board-device-filter';
 import { upsertDiscoveredDevice } from './scan-device-cache';
-import type { BluetoothAdapter, BleConnection, BoardScanFamily, DevicePickerFn, DiscoveredDevice } from './types';
+import type {
+  BluetoothAdapter,
+  BleConnection,
+  BleDisconnectInfo,
+  BoardScanFamily,
+  DevicePickerFn,
+  DiscoveredDevice,
+} from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
 const CONNECTION_TIMEOUT_MS = 12_000;
@@ -43,7 +50,7 @@ async function findWriteCharacteristic(
 export class RNBleAdapter implements BluetoothAdapter {
   private connectedDevice: Device | null = null;
   private writeCharacteristic: Characteristic | null = null;
-  private disconnectCallback: (() => void) | null = null;
+  private disconnectCallback: ((info?: BleDisconnectInfo) => void) | null = null;
   private disconnectSubscription: { remove: () => void } | null = null;
 
   constructor(
@@ -234,12 +241,12 @@ export class RNBleAdapter implements BluetoothAdapter {
     this.connectedDevice = deviceWithServices;
     this.writeCharacteristic = writeCharacteristic;
 
-    this.disconnectSubscription = bleManager.onDeviceDisconnected(selectedDeviceId, (_error, _device) => {
+    this.disconnectSubscription = bleManager.onDeviceDisconnected(selectedDeviceId, (error, _device) => {
       this.connectedDevice = null;
       this.writeCharacteristic = null;
       this.disconnectSubscription?.remove();
       this.disconnectSubscription = null;
-      this.disconnectCallback?.();
+      this.disconnectCallback?.(bleErrorToDisconnectInfo(error));
     });
 
     return {
@@ -328,12 +335,27 @@ export class RNBleAdapter implements BluetoothAdapter {
     }
   }
 
-  onDisconnect(callback: () => void): () => void {
+  onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void {
     this.disconnectCallback = callback;
     return () => {
       this.disconnectCallback = null;
     };
   }
+}
+
+// Normalise a react-native-ble-plx disconnect error into the cross-adapter
+// shape. `onDeviceDisconnected` passes null on a clean drop; an unexpected drop
+// (RF loss, another central grabbing the board) carries a BleError whose
+// iosErrorCode/androidErrorCode is the platform's real reason code.
+function bleErrorToDisconnectInfo(error: BleError | null): BleDisconnectInfo {
+  if (!error) return { source: 'ble-plx' };
+  return {
+    source: 'ble-plx',
+    bleErrorCode: error.errorCode,
+    iosErrorCode: error.iosErrorCode ?? undefined,
+    androidErrorCode: error.androidErrorCode ?? undefined,
+    description: error.reason ?? error.message ?? undefined,
+  };
 }
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {

--- a/packages/mobile/src/lib/ble/native-ios-adapter.ts
+++ b/packages/mobile/src/lib/ble/native-ios-adapter.ts
@@ -7,9 +7,17 @@ import {
 import {
   boardBleNative,
   type NativeBleConfigureBoardOptions,
+  type NativeBleDisconnectEvent,
   type NativeBleScanEvent,
 } from '../../../modules/live-activity/src/index';
-import type { BluetoothAdapter, BleConnection, BoardScanFamily, DevicePickerFn, DiscoveredDevice } from './types';
+import type {
+  BluetoothAdapter,
+  BleConnection,
+  BleDisconnectInfo,
+  BoardScanFamily,
+  DevicePickerFn,
+  DiscoveredDevice,
+} from './types';
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 import { isLikelyBoardDevice } from './board-device-filter';
 import { upsertDiscoveredDevice } from './scan-device-cache';
@@ -33,6 +41,21 @@ function uint8ArrayToHex(bytes: Uint8Array): string {
   return hex;
 }
 
+// Normalise the native `disconnected` event into the cross-adapter shape. The
+// Swift layer attaches the CoreBluetooth NSError (code/domain/description) for a
+// real link drop, or a `context` marker for a drop it caused itself during
+// write-stall recovery. Older binaries emit deviceId only, leaving every field
+// undefined — read as "platform didn't report a reason".
+function nativeDisconnectInfo(payload: NativeBleDisconnectEvent): BleDisconnectInfo {
+  return {
+    source: 'native-ios',
+    iosErrorCode: payload.errorCode,
+    errorDomain: payload.errorDomain,
+    description: payload.errorDescription,
+    context: payload.context,
+  };
+}
+
 // Adapter that drives the BoardBleManager Swift singleton via the
 // `@boardsesh/live-activity-module` Expo Module. iOS-only — guarded at the
 // factory level. Keeps the encoding-in-JS pattern the existing
@@ -42,7 +65,7 @@ function uint8ArrayToHex(bytes: Uint8Array): string {
 // has the board metadata it needs to encode without going through JS.
 export class NativeIosBleAdapter implements BluetoothAdapter {
   private connectedDeviceId: string | null = null;
-  private disconnectCallback: (() => void) | null = null;
+  private disconnectCallback: ((info?: BleDisconnectInfo) => void) | null = null;
   private disconnectSubscription: { remove: () => void } | null = null;
 
   constructor(
@@ -228,7 +251,7 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
       this.connectedDeviceId = null;
       this.disconnectSubscription?.remove();
       this.disconnectSubscription = null;
-      this.disconnectCallback?.();
+      this.disconnectCallback?.(nativeDisconnectInfo(payload));
     });
   }
 
@@ -283,7 +306,7 @@ export class NativeIosBleAdapter implements BluetoothAdapter {
     }
   }
 
-  onDisconnect(callback: () => void): () => void {
+  onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void {
     this.disconnectCallback = callback;
     return () => {
       this.disconnectCallback = null;

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -11,6 +11,28 @@ export type DiscoveredDevice = {
 
 export type BoardScanFamily = 'aurora' | 'moonboard';
 
+// Best-effort reason for an unsolicited BLE drop, surfaced to analytics so we
+// can tell a takeover (another phone grabbing the last-connection-wins board)
+// apart from a range/idle timeout or an app-driven write-stall recovery. Fields
+// are sparse — each adapter fills only what its platform exposes. `source` names
+// which adapter observed the drop so a missing code reads as "platform didn't
+// report one" rather than "we forgot to capture it".
+export type BleDisconnectInfo = {
+  source: 'native-ios' | 'ble-plx' | 'write-failure';
+  // CoreBluetooth CBError code (native-ios: NSError.code; ble-plx: iosErrorCode).
+  iosErrorCode?: number;
+  // Android GATT status (ble-plx androidErrorCode).
+  androidErrorCode?: number;
+  // react-native-ble-plx BleErrorCode enum value.
+  bleErrorCode?: number;
+  // NSError domain (native-ios) — distinguishes CBErrorDomain from CBATTErrorDomain.
+  errorDomain?: string;
+  // App-side classification for drops we caused (write-stall recovery paths).
+  context?: string;
+  // Human-readable description (localizedDescription / ble-plx reason or message).
+  description?: string;
+};
+
 // The picker subscribes for live device updates and, optionally, a one-shot
 // signal that the scan has stopped (timeout) so it can drop its "scanning"
 // spinner instead of implying a scan that's no longer running.
@@ -23,5 +45,5 @@ export type BluetoothAdapter = {
   requestAndConnect(targetSerial?: string): Promise<BleConnection>;
   disconnect(): Promise<void>;
   write(data: Uint8Array, signal?: AbortSignal): Promise<void>;
-  onDisconnect(callback: () => void): () => void;
+  onDisconnect(callback: (info?: BleDisconnectInfo) => void): () => void;
 };

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -29,7 +29,7 @@ import {
   subscribeNativeBleConnected,
 } from './adapter-factory';
 import { requestBleRuntimePermissions } from './use-ble-permissions';
-import type { BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
+import type { BleDisconnectInfo, BluetoothAdapter, DevicePickerFn, DiscoveredDevice } from './types';
 import type { HoldPlacement } from '../../components/board-renderer/types';
 import { track } from '../analytics';
 import { reportHandledError } from '../error-reporting';
@@ -396,9 +396,20 @@ export function useBoardBluetooth({
     void adapter?.disconnect().catch(() => {});
   }, [onConnectionChange]);
 
-  const handleDisconnection = useCallback(() => {
-    clearConnectionAfterDrop();
-  }, [clearConnectionAfterDrop]);
+  // Stash the most recent drop's reason so the provider's isConnected-transition
+  // effect — which actually fires the `Bluetooth Disconnected` analytics event —
+  // can attach it. Set synchronously here, before clearConnectionAfterDrop flips
+  // isConnected, so it's current when that effect reads it. Reset on a fresh
+  // connect so a later clean transition can't inherit a stale reason.
+  const lastDisconnectInfoRef = useRef<BleDisconnectInfo | null>(null);
+
+  const handleDisconnection = useCallback(
+    (info?: BleDisconnectInfo) => {
+      lastDisconnectInfoRef.current = info ?? null;
+      clearConnectionAfterDrop();
+    },
+    [clearConnectionAfterDrop],
+  );
 
   const sendFramesToBoard = useCallback(
     async (frames: string, mirrored: boolean = false, signal?: AbortSignal, sendContext?: BleSendContext) => {
@@ -567,7 +578,7 @@ export function useBoardBluetooth({
             // failed on a dead link. On a shared board this is usually another
             // device having grabbed it. Recorded so the two-climber case is visible.
             track(SHARED_EVENTS.BluetoothConnectionStolen, { boardName, layoutId, sizeId });
-            handleDisconnection();
+            handleDisconnection({ source: 'write-failure' });
           }
           return false;
         } finally {
@@ -732,6 +743,7 @@ export function useBoardBluetooth({
 
         connectedConfigKeyRef.current =
           layoutId !== undefined && sizeId !== undefined ? boardConfigKey(boardName, layoutId, sizeId) : null;
+        lastDisconnectInfoRef.current = null;
         setIsConnected(true);
         onConnectionChange?.(true);
         onConnectSuccess?.(parsedSerial);
@@ -970,6 +982,7 @@ export function useBoardBluetooth({
         setLastConnectedBoard({ serial, configKey: currentConfigKey });
       }
       connectedConfigKeyRef.current = currentConfigKey;
+      lastDisconnectInfoRef.current = null;
       setIsConnected(true);
       onConnectionChange?.(true);
       onConnectSuccess?.(serial);
@@ -1078,5 +1091,6 @@ export function useBoardBluetooth({
     pickerState,
     reconnectSerialForCurrentBoard,
     connectInitialSendRef,
+    lastDisconnectInfoRef,
   };
 }

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -7,6 +7,7 @@ import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { BoardPresenceClimb, UserBoard } from '@boardsesh/shared-schema';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { PickerState } from '../../lib/ble/use-board-bluetooth';
+import type { BleDisconnectInfo } from '../../lib/ble/types';
 
 type BluetoothHookOptions = {
   onConnectSuccess?: (serial: string | null) => void;
@@ -46,6 +47,7 @@ const bluetooth = vi.hoisted(() => {
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
       connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },
+      lastDisconnectInfoRef: { current: null as BleDisconnectInfo | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -7,6 +7,7 @@ import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import type { BoardSerialConfig } from '@boardsesh/graphql/operations';
 import type { ResolvedBoardEntry } from '../../lib/ble/resolve-serials';
 import type { PickerState } from '../../lib/ble/use-board-bluetooth';
+import type { BleDisconnectInfo } from '../../lib/ble/types';
 import { setHoldColorOverridesPreference } from '../../lib/hold-color-overrides';
 
 type TestResolvedBoard = { boardId: number };
@@ -56,6 +57,7 @@ const bluetooth = vi.hoisted(() => {
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
       connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },
+      lastDisconnectInfoRef: { current: null as BleDisconnectInfo | null },
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -689,6 +689,48 @@ describe('BluetoothProvider wall-confirm integration', () => {
       expect(presence.showUndoWallChangeSnackbar).not.toHaveBeenCalled();
     });
 
+    it('attaches the captured disconnect reason to the unexpected-drop analytics event', async () => {
+      // Start connected so the next transition reads as a real drop, not the
+      // initial mount.
+      bluetooth.state.isConnected = true;
+      bluetooth.state.lastDisconnectInfoRef.current = null;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      analytics.track.mockClear();
+
+      // The hook stashes a native-iOS peer-terminated drop (CBError 7 — what a
+      // takeover looks like) just before the link goes down.
+      bluetooth.state.lastDisconnectInfoRef.current = {
+        source: 'native-ios',
+        iosErrorCode: 7,
+        errorDomain: 'CBErrorDomain',
+        description: 'The specified device has disconnected from us.',
+      };
+      bluetooth.state.isConnected = false;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(analytics.track).toHaveBeenCalledWith(
+          'Bluetooth Disconnected',
+          expect.objectContaining({
+            reason: 'unexpected',
+            disconnectSource: 'native-ios',
+            disconnectIosCode: 7,
+            disconnectErrorDomain: 'CBErrorDomain',
+            disconnectReason: 'The specified device has disconnected from us.',
+          }),
+        );
+      });
+    });
+
     it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {
       presence.enabled = true;
       presence.boardId = 99;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -731,6 +731,66 @@ describe('BluetoothProvider wall-confirm integration', () => {
       });
     });
 
+    it('tags a write-failure drop with disconnectSource write-failure', async () => {
+      bluetooth.state.isConnected = true;
+      bluetooth.state.lastDisconnectInfoRef.current = null;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      analytics.track.mockClear();
+
+      // The write-failure path (use-board-bluetooth) stashes this shape before
+      // flipping the link down — no platform codes, just the source.
+      bluetooth.state.lastDisconnectInfoRef.current = { source: 'write-failure' };
+      bluetooth.state.isConnected = false;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(analytics.track).toHaveBeenCalledWith(
+          'Bluetooth Disconnected',
+          expect.objectContaining({ reason: 'unexpected', disconnectSource: 'write-failure' }),
+        );
+      });
+    });
+
+    it('omits reason fields when no disconnect info was captured', async () => {
+      bluetooth.state.isConnected = true;
+      bluetooth.state.lastDisconnectInfoRef.current = null;
+
+      const { rerender } = renderProvider(createElement(BluetoothProbe));
+      analytics.track.mockClear();
+
+      // Ref stays null (a drop the adapters didn't classify) — the event still
+      // fires, just without any disconnect* reason fields.
+      bluetooth.state.isConnected = false;
+      rerender(
+        createElement(BluetoothProvider, {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 10,
+          setIds: '1,20',
+          children: createElement(BluetoothProbe),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(analytics.track).toHaveBeenCalledWith(
+          'Bluetooth Disconnected',
+          expect.objectContaining({ reason: 'unexpected' }),
+        );
+      });
+      const disconnectCall = analytics.track.mock.calls.find(([event]) => event === 'Bluetooth Disconnected');
+      expect(disconnectCall?.[1].disconnectSource).toBeUndefined();
+      expect(disconnectCall?.[1].disconnectIosCode).toBeUndefined();
+    });
+
     it('shows the Undo snackbar once after an armed control gain reports a wall change', async () => {
       presence.enabled = true;
       presence.boardId = 99;

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -1167,7 +1167,9 @@ export function BluetoothProvider({
       });
     }
     wasConnectedRef.current = isConnected;
-  }, [clearPendingWallReportAndUndoToastArm, releaseBoardHolder, isConnected, boardName, lastDisconnectInfoRef]);
+    // lastDisconnectInfoRef is a stable ref (read via .current), so it's
+    // intentionally not a dependency — the isConnected transition is the trigger.
+  }, [clearPendingWallReportAndUndoToastArm, releaseBoardHolder, isConnected, boardName]);
 
   const value = useMemo<BluetoothContextValue>(
     () => ({

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -743,6 +743,7 @@ export function BluetoothProvider({
     pickerState,
     reconnectSerialForCurrentBoard,
     connectInitialSendRef,
+    lastDisconnectInfoRef,
   } = useBoardBluetooth({
     boardName,
     layoutId,
@@ -1147,14 +1148,26 @@ export function BluetoothProvider({
       // longer writing the wall). Compare-and-delete server-side, so if another
       // phone already took over this is a no-op.
       releaseBoardHolder();
+      // The hook stashed the drop's platform reason (CoreBluetooth / ble-plx
+      // code, or a write-stall context) on this ref before flipping isConnected.
+      // Flattened onto the event so analytics can tell a takeover apart from a
+      // range/idle timeout — the gap that left `disconnectReason` null before.
+      const disconnectInfo = lastDisconnectInfoRef.current;
       track(SHARED_EVENTS.BluetoothDisconnected, {
         boardName,
         reason: 'unexpected',
         inSession: sessionIdRef.current != null,
+        disconnectSource: disconnectInfo?.source,
+        disconnectReason: disconnectInfo?.description,
+        disconnectContext: disconnectInfo?.context,
+        disconnectIosCode: disconnectInfo?.iosErrorCode,
+        disconnectAndroidCode: disconnectInfo?.androidErrorCode,
+        disconnectBleCode: disconnectInfo?.bleErrorCode,
+        disconnectErrorDomain: disconnectInfo?.errorDomain,
       });
     }
     wasConnectedRef.current = isConnected;
-  }, [clearPendingWallReportAndUndoToastArm, releaseBoardHolder, isConnected, boardName]);
+  }, [clearPendingWallReportAndUndoToastArm, releaseBoardHolder, isConnected, boardName, lastDisconnectInfoRef]);
 
   const value = useMemo<BluetoothContextValue>(
     () => ({


### PR DESCRIPTION
## Summary

The mobile `Bluetooth Disconnected` event always sent `disconnectReason: null`, so in telemetry we can't tell **why** the board dropped. With shared gym boards the most common cause is another phone grabbing the connection (last-connection-wins — intended behaviour), but that's indistinguishable from a range/idle timeout or an app-driven write-stall recovery. ~4 in 10 board connections end in an `unexpected` disconnect across 230+ users, and we've been flying blind on the cause.

This PR captures the platform disconnect reason and flattens it onto the event. It threads the reason from each `BluetoothAdapter.onDisconnect` callback (previously arg-less) through `useBoardBluetooth` to the provider's `track()` call:

- **react-native-ble-plx** (`RNBleAdapter`) surfaces a `BleError` (`errorCode` / `iosErrorCode` / `androidErrorCode` / `reason`) on `onDeviceDisconnected` that we were discarding — now mapped to `BleDisconnectInfo`.
- **native iOS** (`NativeIosBleAdapter`) reads optional reason fields off the `disconnected` event. They stay `undefined` until the matching native build ships, so this degrades to a `source`-only reason rather than crashing.
- the provider adds `disconnectSource`, `disconnectReason`, `disconnectIosCode`, `disconnectAndroidCode`, `disconnectBleCode`, `disconnectErrorDomain`, `disconnectContext` to the event.

JS-only, so it rides OTA. The Swift side that emits the CoreBluetooth NSError is in a **separate native PR** (#3289) so it doesn't bump the Expo fingerprint and block OTA on main.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — green
- `vp test run --project mobile` — 2841 passed (added ble-plx + native-iOS reason-mapping tests; updated provider hook mocks)
- `vp check` on changed files — no warnings/lint/type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
