### PR TITLE
feat(mobile): emit CoreBluetooth disconnect reason from native BLE manager

### DIFF
--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -190,6 +190,33 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertTrue(url?.absoluteString.contains("include_background=1") ?? false)
     }
 
+    // The disconnect-reason dict feeds the JS `disconnected` event
+    // (NativeBleDisconnectEvent) and, through it, the `Bluetooth Disconnected`
+    // analytics event — key names and the nil-for-clean contract are load-bearing.
+    func testDisconnectReasonBodyIsNilForCleanDisconnect() {
+        XCTAssertNil(BoardBleEncoding.disconnectReasonBody(from: nil))
+    }
+
+    func testDisconnectReasonBodyCarriesCBErrorFields() {
+        let timeout = BoardBleEncoding.disconnectReasonBody(from: CBError(.connectionTimeout))
+        XCTAssertEqual(timeout?["errorCode"] as? Int, CBError.connectionTimeout.rawValue)
+        XCTAssertEqual(timeout?["errorDomain"] as? String, CBErrorDomain)
+        XCTAssertFalse((timeout?["errorDescription"] as? String ?? "").isEmpty)
+        // The takeover-vs-idle distinction rides on the code: peer-terminated
+        // (another central grabbing the last-connection-wins board) must stay
+        // distinguishable from the range/idle timeout above.
+        let peerDropped = BoardBleEncoding.disconnectReasonBody(from: CBError(.peripheralDisconnected))
+        XCTAssertNotEqual(peerDropped?["errorCode"] as? Int, timeout?["errorCode"] as? Int)
+    }
+
+    func testDisconnectReasonBodyWrapsArbitraryNSError() {
+        let error = NSError(domain: "com.example.test", code: 42, userInfo: [NSLocalizedDescriptionKey: "boom"])
+        let body = BoardBleEncoding.disconnectReasonBody(from: error)
+        XCTAssertEqual(body?["errorCode"] as? Int, 42)
+        XCTAssertEqual(body?["errorDomain"] as? String, "com.example.test")
+        XCTAssertEqual(body?["errorDescription"] as? String, "boom")
+    }
+
     // The write type is gated on board family. Aurora (Kilter/Tension) drove the
     // wall with write-without-response through the entire Capacitor era and the
     // first RN port, so it ALWAYS takes that path — even when iOS reports the

--- a/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleEncoding.swift
@@ -116,6 +116,23 @@ enum BoardBleEncoding {
         "soill": commonAuroraRoleMap(),
     ]
 
+    /// Builds the JS-bound reason dict from a CoreBluetooth disconnect error.
+    /// Returns nil for a clean disconnect (no error) so the JS side reads a
+    /// missing reason as "iOS reported none" rather than a fabricated one. The
+    /// NSError `code` is the CBError.Code (e.g. 6 connectionTimeout, 7
+    /// peripheralDisconnected) that distinguishes a range/idle drop from a
+    /// peer-terminated link (another central taking the last-connection-wins board).
+    /// Keys must stay in sync with `NativeBleDisconnectEvent` in
+    /// `modules/live-activity/src/index.ts`.
+    static func disconnectReasonBody(from error: Error?) -> [String: Any]? {
+        guard let error = error as NSError? else { return nil }
+        return [
+            "errorCode": error.code,
+            "errorDomain": error.domain,
+            "errorDescription": error.localizedDescription,
+        ]
+    }
+
     static func parseApiLevel(deviceName: String?) -> Int {
         guard let deviceName else { return 2 }
         // Mirror the TS regex /@(\d+)/: the FIRST '@' immediately followed by one

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -174,7 +174,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private lazy var drainWaiters = WaiterPool(queue: bleQueue)
 
     private var onScanResult: ((BoardBleScanResult) -> Void)?
-    private var onDisconnect: ((String) -> Void)?
+    // Second arg carries the disconnect reason (CoreBluetooth NSError code/domain/
+    // description, or a write-stall `context` marker) so JS can tell a takeover
+    // apart from a range/idle timeout. nil when no reason is available.
+    private var onDisconnect: ((String, [String: Any]?) -> Void)?
     /// Fired whenever a connection becomes fully usable (write characteristic
     /// discovered) — JS-initiated connects, widget-intent reconnects and
     /// CoreBluetooth state restoration alike. The JS layer uses it to adopt
@@ -218,7 +221,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     func setEventHandlers(
         onScanResult: ((BoardBleScanResult) -> Void)?,
-        onDisconnect: ((String) -> Void)?,
+        onDisconnect: ((String, [String: Any]?) -> Void)?,
         onConnected: ((String, String?) -> Void)? = nil
     ) {
         runOnBleQueue { [weak self] in
@@ -853,6 +856,21 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         completePendingConnect(.failure(error ?? BoardBleError.notConnected))
     }
 
+    /// Builds the JS-bound reason dict from a CoreBluetooth disconnect error.
+    /// Returns nil for a clean disconnect (no error) so the JS side reads a
+    /// missing reason as "iOS reported none" rather than a fabricated one. The
+    /// NSError `code` is the CBError.Code (e.g. 6 connectionTimeout, 7
+    /// peripheralDisconnected) that distinguishes a range/idle drop from a
+    /// peer-terminated link (another central taking the last-connection-wins board).
+    private static func disconnectReasonBody(from error: Error?) -> [String: Any]? {
+        guard let error = error as NSError? else { return nil }
+        return [
+            "errorCode": error.code,
+            "errorDomain": error.domain,
+            "errorDescription": error.localizedDescription,
+        ]
+    }
+
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         let deviceId = peripheral.identifier.uuidString
         let wasCurrentPeripheral = connectedPeripheral?.identifier == peripheral.identifier
@@ -885,7 +903,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                         self.logger.error("BLE write-stall reconnect failed: \(error.localizedDescription, privacy: .public)")
                         self.writeStallRecoveringPeripheralId = nil
                         self.writeStallRecoveries = 0
-                        self.onDisconnect?(deviceId)
+                        self.onDisconnect?(deviceId, [
+                            "context": "write_stall_recovery_failed",
+                            "errorDescription": error.localizedDescription,
+                        ])
                     }
                 }
             }
@@ -900,7 +921,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectedPeripheral = nil
         writeCharacteristic = nil
         failQueuedWrites(error ?? BoardBleError.notConnected)
-        onDisconnect?(deviceId)
+        onDisconnect?(deviceId, Self.disconnectReasonBody(from: error))
 
         // No auto-reconnect. These boards are last-connection-wins, so silently
         // re-grabbing the link would steal the wall back from whoever took it — a
@@ -1352,7 +1373,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             writeStallRecoveries = 0
             writeStallRecoveringPeripheralId = nil
             cancelConnectionIntentionallyOnBleQueue(peripheral)
-            onDisconnect?(deviceId)
+            onDisconnect?(deviceId, ["context": "write_stall_budget_exhausted"])
             return
         }
 
@@ -1383,7 +1404,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             self.writeStallRecoveries = 0
             self.writeCharacteristic = nil
             self.connectedPeripheral = nil
-            self.onDisconnect?(recoveringId.uuidString)
+            self.onDisconnect?(recoveringId.uuidString, ["context": "write_stall_recovery_timeout"])
         }
         writeStallRecoveryWatchdog?.cancel()
         writeStallRecoveryWatchdog = recoveryWatchdog

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -748,6 +748,23 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // with a depleted budget (#3181).
             writeStallRecoveringPeripheralId = nil
             writeStallRecoveries = 0
+
+            // Below .poweredOn iOS invalidates every peripheral WITHOUT
+            // delivering didDisconnectPeripheral, so an active link vanishes
+            // silently — JS would keep showing "connected" until the next write
+            // failed. Surface it as an explicit disconnect with a context marker
+            // so analytics can tell bluetooth-off apart from a link loss.
+            if let peripheral = connectedPeripheral {
+                let deviceId = peripheral.identifier.uuidString
+                peripheralGenerations.removeValue(forKey: peripheral.identifier)
+                connectedPeripheral = nil
+                writeCharacteristic = nil
+                failQueuedWrites(BoardBleError.bluetoothUnavailable)
+                onDisconnect?(deviceId, [
+                    "context": "bluetooth_unavailable",
+                    "errorDescription": "central state \(central.state.rawValue)",
+                ])
+            }
         }
     }
 
@@ -856,21 +873,6 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         completePendingConnect(.failure(error ?? BoardBleError.notConnected))
     }
 
-    /// Builds the JS-bound reason dict from a CoreBluetooth disconnect error.
-    /// Returns nil for a clean disconnect (no error) so the JS side reads a
-    /// missing reason as "iOS reported none" rather than a fabricated one. The
-    /// NSError `code` is the CBError.Code (e.g. 6 connectionTimeout, 7
-    /// peripheralDisconnected) that distinguishes a range/idle drop from a
-    /// peer-terminated link (another central taking the last-connection-wins board).
-    private static func disconnectReasonBody(from error: Error?) -> [String: Any]? {
-        guard let error = error as NSError? else { return nil }
-        return [
-            "errorCode": error.code,
-            "errorDomain": error.domain,
-            "errorDescription": error.localizedDescription,
-        ]
-    }
-
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         let deviceId = peripheral.identifier.uuidString
         let wasCurrentPeripheral = connectedPeripheral?.identifier == peripheral.identifier
@@ -921,7 +923,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectedPeripheral = nil
         writeCharacteristic = nil
         failQueuedWrites(error ?? BoardBleError.notConnected)
-        onDisconnect?(deviceId, Self.disconnectReasonBody(from: error))
+        onDisconnect?(deviceId, BoardBleEncoding.disconnectReasonBody(from: error))
 
         // No auto-reconnect. These boards are last-connection-wins, so silently
         // re-grabbing the link would steal the wall back from whoever took it — a

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -43,8 +43,12 @@ public class BoardBleModule: Module {
                         "serviceUuids": result.serviceUuids
                     ])
                 },
-                onDisconnect: { [weak self] deviceId in
-                    self?.emitOrBuffer(name: "disconnected", body: ["deviceId": deviceId])
+                onDisconnect: { [weak self] deviceId, reason in
+                    var body: [String: Any] = ["deviceId": deviceId]
+                    if let reason {
+                        body.merge(reason) { _, new in new }
+                    }
+                    self?.emitOrBuffer(name: "disconnected", body: body)
                 },
                 onConnected: { [weak self] deviceId, deviceName in
                     self?.emitOrBuffer(name: "connected", body: [

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -46,7 +46,9 @@ public class BoardBleModule: Module {
                 onDisconnect: { [weak self] deviceId, reason in
                     var body: [String: Any] = ["deviceId": deviceId]
                     if let reason {
-                        body.merge(reason) { _, new in new }
+                        // deviceId is authoritative — a reason dict must never
+                        // overwrite keys the event body already carries.
+                        body.merge(reason) { current, _ in current }
                     }
                     self?.emitOrBuffer(name: "disconnected", body: body)
                 },


### PR DESCRIPTION
## Summary

Native counterpart to #3288 (which ships the JS reader on OTA). `BoardBleManager` dropped the `error: Error?` from `didDisconnectPeripheral`, so the `disconnected` event carried only a `deviceId` and JS reported `disconnectReason: null`.

This threads the reason through `onDisconnect((String, [String: Any]?))`:

- `didDisconnectPeripheral` attaches the CoreBluetooth `NSError` (`code` / `domain` / `localizedDescription`). The CBError code is what distinguishes a peer-terminated link (another central grabbing the last-connection-wins board) from a range/idle timeout.
- the three write-stall recovery paths attach a `context` marker instead, so an app-driven drop isn't mistaken for a link loss.
- `BoardBleModule` merges the reason dict into the emitted event body.

> [!WARNING]
> **Native change — do not merge to `main` until a native build is being cut.** It bumps the Expo fingerprint, so a production OTA published from `main` with this change would no longer match any shipped store binary. Hold this PR until the next build cycle. The JS PR (#3288) is fingerprint-neutral and degrades to a `source`-only reason until this lands in a build, so it can merge first.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- JS reader + adapter mapping covered by #3288's test suite. Swift compiles with the next native iOS build; no JS test exercises the Swift path directly.
- Manual native verification deferred to the build that ships this (capture a real Kilter takeover vs walk-away and confirm the CBError codes differ in PostHog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
