### PR TITLE
fix(mobile): wrap board-setup chips so labels stop clipping

### DIFF
--- a/packages/mobile/src/components/board-discovery/BoardConfigChips.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardConfigChips.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { ScrollView, Pressable, StyleSheet } from 'react-native';
+import { View, Pressable, StyleSheet } from 'react-native';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { brandColors } from '../../theme/colors';
@@ -23,15 +23,21 @@ type BoardConfigChipsProps<T> = {
 };
 
 /**
- * A horizontal row of selectable chips for one board-config dimension (board
+ * A wrapping row of selectable chips for one board-config dimension (board
  * type / layout / size / angle / sets). Carries selection to assistive tech via
  * `accessibilityState.selected` (not colour alone), and `hitSlop` keeps the
  * touch target ≥44pt even though the chip is visually compact.
+ *
+ * Flex-wrap, not a horizontal ScrollView: a horizontal ScrollView nested in the
+ * form's vertical ScrollView collapses its cross-axis height on iOS and clips
+ * the chip labels (top or bottom, worse as Dynamic Type grows). Wrapping lets
+ * each chip size to its content and the row grow with the outer scroll — same
+ * fix the climb filter sheet's chip rows use.
  */
 function BoardConfigChipsInner<T>({ groupLabel, options, onSelect, disabled = false }: BoardConfigChipsProps<T>) {
   const { systemColors, brandColors: themeBrandColors } = useTheme();
   return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.row}>
+    <View style={styles.row}>
       {options.map((option) => (
         <Pressable
           key={option.key}
@@ -57,7 +63,7 @@ function BoardConfigChipsInner<T>({ groupLabel, options, onSelect, disabled = fa
           </Text>
         </Pressable>
       ))}
-    </ScrollView>
+    </View>
   );
 }
 
@@ -68,6 +74,8 @@ export const BoardConfigChips = memo(BoardConfigChipsInner) as typeof BoardConfi
 
 const styles = StyleSheet.create({
   row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: spacing[2],
     paddingVertical: spacing[1],
   },
@@ -76,6 +84,8 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[2],
     borderRadius: borderRadius.full,
     borderWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   chipDisabled: {
     opacity: 0.4,


### PR DESCRIPTION
## Summary

The board / layout / size chips on the mobile **Set up your board** screen were clipping their labels — tops or bottoms cut off, looking compressed and hard to read.

Root cause: each chip row was a **horizontal `ScrollView` nested inside the form's vertical `ScrollView`**. On iOS that inner ScrollView collapses its cross-axis height and clips the chips — top or bottom depending on the font baseline, and worse as Dynamic Type grows. (Same failure mode the climb filter sheet hit and fixed by wrapping.)

The fix renders the chips with **flex-wrap** instead of a horizontal ScrollView: each chip sizes to its content, the row grows with the outer scroll, and nothing clips at any text size. As a bonus, every board type is visible at once instead of hidden behind a horizontal scroll.

> Note: an earlier push tried dropping the `Text` line height globally; that fixed the simulator but regressed on-device (descenders clipped). Reverted — the real cause was the nested ScrollView, so this change is scoped to `BoardConfigChips` only.

## Release Notes

- The board, layout, and size buttons on board setup no longer cut off their labels — they wrap to fit and every option is visible.

## Test plan

- Reproduced the clip on iPhone 16 Pro Max simulator and confirmed it worsens with larger Dynamic Type (matches the on-device report).
- After the fix, verified **Set up your board** renders full, un-clipped chip labels at default, XXXL, and accessibility-large text sizes (4× zoom).
- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — 381 files / 2837 tests passed.
- `vp check` on the changed file — lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
