### PR TITLE
feat(mobile): native Material 3 treatment for the on-the-board capsule

### DIFF
--- a/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
@@ -10,12 +10,19 @@
 // signal a lightbulb never carried. The avatar is INERT here (one Pressable opens
 // the read-only wall preview; the tap-sender-to-profile affordance lives in that
 // preview sheet, which has room for a full target). Fully-anonymous senders fall
-// back to an amber person glyph — never a lightbulb (a bistable leading slot
+// back to an amber person glyph — never a bare lightbulb (a bistable leading slot
 // breaks the visual scan + VoiceOver grammar) and never a literal "?".
 //
-// Deliberately a NON-glass pill (HIG: no glass-on-glass over the header's
-// progressive blur) with a warm "lit" tint — now the sole at-a-glance "live"
-// carrier. Compact by design — the name truncates, the grade stays.
+// Two platform-native skins behind one stateful body (see selectByVariant below):
+//   - Liquid Glass (iOS): a NON-glass pill (HIG: no glass-on-glass over the
+//     header's progressive blur) with a warm "lit" amber border + tint.
+//   - Material 3 (Android): an elevated assist chip — 8dp corner, level1
+//     elevation, surfaceContainer.high tonal fill, NO border. The "lit" warmth is
+//     carried the M3-native way through the tertiary colour role (a tonal wash, an
+//     amber avatar ring, and a filled-lightbulb badge), not a drawn border.
+// The data, grade derivation, tap handler and the debounced a11y announcement all
+// live in the single body so a variant flip never resets the announce dedupe.
+// Compact by design — the name truncates, the grade stays.
 
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { AccessibilityInfo, Pressable, StyleSheet, View } from 'react-native';
@@ -25,12 +32,14 @@ import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { useTheme } from '../../providers/theme-provider';
 import { useGradeFormat } from '../../hooks/use-grade-format';
-import { spacing } from '../../theme/tokens';
+import { spacing, borderRadius } from '../../theme/tokens';
 import { withAlpha } from '../../theme/colors';
+import { selectByVariant } from '../../theme/variants/select-by-variant';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { boardPresenceClimbToClimb } from '../../lib/board-presence/presence-climb';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { PressableSurface } from '../PressableSurface';
 import { BoardDriverAvatar } from '../board-presence/BoardDriverAvatar';
 import { useOpenWallPreview } from './use-open-wall-preview';
 
@@ -39,6 +48,16 @@ const CAPSULE_HEIGHT = 32;
 // truncating climb name in the tight centre slot (M3 would prefer 24; default to
 // 20). Fixed — does not scale with Dynamic Type.
 const AVATAR_SIZE = 20;
+// Material "lit" cue, carried by the tertiary role: a thin amber ring hugs the
+// avatar and a filled-lightbulb badge sits in its bottom-trailing corner.
+const AVATAR_RING_WIDTH = 1.5;
+const LIT_LEADING_SIZE = AVATAR_SIZE + AVATAR_RING_WIDTH * 2;
+const LIT_BADGE_SIZE = 14;
+const LIT_BADGE_GLYPH = 9;
+const ANON_GLYPH = 12;
+// 8pt all-round hit expansion lifts the 32pt visual chip to a >=48pt M3 touch
+// target without growing the chip itself.
+const MATERIAL_HIT_SLOP = spacing[2];
 // Debounce assistive-tech announcements so a fast party session (rapid wall
 // changes) doesn't spam the speech queue.
 const ANNOUNCE_DEBOUNCE_MS = 600;
@@ -53,7 +72,7 @@ type WallStatusCapsuleProps = {
 // stable BoardPresenceClimb from useWallClimbIfDistinct (changes only on a wall event).
 function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
   const { t } = useTranslation('session');
-  const { systemColors, brandColors } = useTheme();
+  const { variant, colorScheme, systemColors, brandColors, m3, m3SurfaceContainers, materialElevation } = useTheme();
   const { formatGrade } = useGradeFormat();
   const reduceMotion = useReducedMotion();
   const openWallPreview = useOpenWallPreview();
@@ -89,13 +108,112 @@ function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
     return () => clearTimeout(handle);
   }, [announceLabel]);
 
-  const tintStyle = useMemo(
+  const handlePress = useCallback(() => openWallPreview(boardPresenceClimbToClimb(climb)), [openWallPreview, climb]);
+
+  // Glass: a warm amber tint composited over the neutral surface = the "lit" carrier.
+  const glassTintStyle = useMemo(
     () => [StyleSheet.absoluteFill, { backgroundColor: withAlpha(brandColors.warning, 0.14) }],
     [brandColors.warning],
   );
+  // Material: a tertiary tonal wash = the M3-native "lit" accent (no border).
+  const materialWashStyle = useMemo(
+    () => [StyleSheet.absoluteFill, { backgroundColor: withAlpha(m3.tertiary, 0.1) }],
+    [m3.tertiary],
+  );
 
-  const handlePress = useCallback(() => openWallPreview(boardPresenceClimbToClimb(climb)), [openWallPreview, climb]);
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
 
+  if (isMaterial) {
+    return (
+      <Animated.View
+        key={climbUuid}
+        entering={reduceMotion ? undefined : FadeIn.duration(180)}
+        // Outer carries the tonal fill + the level1 elevation cast — NO
+        // overflow:'hidden' here, or Android would clip the shadow.
+        style={[styles.materialOuter, { backgroundColor: m3SurfaceContainers.high }, materialElevation.level1]}
+      >
+        <PressableSurface
+          onPress={handlePress}
+          // Android rides its native ripple; the iOS Material opt-in keeps it static.
+          feedback="none"
+          // Neutral M3 state layer — the warmth already lives in the fill + ring,
+          // so a tertiary-tinted ripple would over-warm the press.
+          rippleColor={m3.onSurfaceVariant}
+          hitSlop={MATERIAL_HIT_SLOP}
+          accessibilityRole="button"
+          accessibilityLabel={a11yLabel}
+          accessibilityHint={t('mobile.boardPresence.stripA11yHint')}
+          // borderRadius + overflow:'hidden' clips the ripple AND the wash to the
+          // 8dp corner; the cast still escapes via the un-clipped outer.
+          style={styles.materialPressable}
+        >
+          <View pointerEvents="none" style={materialWashStyle} />
+          <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants" style={styles.litLeading}>
+            {hasSenderIdentity ? (
+              <>
+                <View style={[styles.avatarRing, { borderColor: m3.tertiary }]}>
+                  <BoardDriverAvatar
+                    uri={climb.sentByAvatarUrl}
+                    name={senderName}
+                    userId={null}
+                    size={AVATAR_SIZE}
+                    status="none"
+                  />
+                </View>
+                <View
+                  style={[styles.litBadge, { backgroundColor: m3.tertiary, borderColor: m3SurfaceContainers.high }]}
+                >
+                  <Icon name="lightbulb.fill" size={LIT_BADGE_GLYPH} color={m3.onTertiary} />
+                </View>
+              </>
+            ) : (
+              <View style={[styles.anonLit, { backgroundColor: m3.tertiary }]}>
+                <Icon name="profile.fill" size={ANON_GLYPH} color={m3.onTertiary} />
+              </View>
+            )}
+          </View>
+          <Text
+            variant="subheadline"
+            color={m3.onSurface}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={styles.materialName}
+          >
+            {name}
+          </Text>
+          {formattedGrade ? (
+            // Light scheme: a neutral surfaceContainer.highest backdrop keeps the
+            // bright grade hues (e.g. V0 #FFD400) legible. Dark scheme: bare text
+            // already clears 4.5:1 on the dark tonal fill.
+            colorScheme === 'light' ? (
+              <View style={[styles.gradePill, { backgroundColor: m3SurfaceContainers.highest }]}>
+                <Text
+                  variant="subheadline"
+                  numberOfLines={1}
+                  maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+                  style={[styles.grade, { color: gradeColor }]}
+                >
+                  {formattedGrade}
+                </Text>
+              </View>
+            ) : (
+              <Text
+                variant="subheadline"
+                numberOfLines={1}
+                maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+                style={[styles.grade, { color: gradeColor }]}
+              >
+                {formattedGrade}
+              </Text>
+            )
+          ) : null}
+        </PressableSurface>
+      </Animated.View>
+    );
+  }
+
+  // Liquid Glass (iOS) — the original non-glass amber pill, unchanged.
   return (
     <Animated.View
       // Fades IN on mount and on each wall-climb change (keyed remount). Removal is
@@ -109,7 +227,7 @@ function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
         { backgroundColor: systemColors.secondaryBackground, borderColor: withAlpha(brandColors.warning, 0.35) },
       ]}
     >
-      <View pointerEvents="none" style={tintStyle} />
+      <View pointerEvents="none" style={glassTintStyle} />
       <Pressable
         onPress={handlePress}
         accessibilityRole="button"
@@ -165,6 +283,7 @@ function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
 export const WallStatusCapsule = memo(WallStatusCapsuleImpl);
 
 const styles = StyleSheet.create({
+  // --- Liquid Glass (iOS) ---
   capsule: {
     flexShrink: 1,
     maxWidth: '100%',
@@ -190,5 +309,65 @@ const styles = StyleSheet.create({
   grade: {
     fontVariant: ['tabular-nums'],
     fontWeight: '700',
+  },
+  // --- Material 3 (Android) ---
+  materialOuter: {
+    flexShrink: 1,
+    maxWidth: '100%',
+    borderRadius: borderRadius.md,
+  },
+  materialPressable: {
+    flexShrink: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: CAPSULE_HEIGHT,
+    borderRadius: borderRadius.md,
+    overflow: 'hidden',
+    paddingLeft: spacing[2],
+    paddingRight: spacing[3],
+    gap: spacing[2],
+  },
+  materialName: {
+    flexShrink: 1,
+    minWidth: 0,
+    fontWeight: '500',
+  },
+  gradePill: {
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[1],
+    justifyContent: 'center',
+  },
+  litLeading: {
+    position: 'relative',
+    width: LIT_LEADING_SIZE,
+    height: LIT_LEADING_SIZE,
+  },
+  avatarRing: {
+    width: LIT_LEADING_SIZE,
+    height: LIT_LEADING_SIZE,
+    borderRadius: LIT_LEADING_SIZE / 2,
+    borderWidth: AVATAR_RING_WIDTH,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  litBadge: {
+    position: 'absolute',
+    right: -2,
+    bottom: -2,
+    width: LIT_BADGE_SIZE,
+    height: LIT_BADGE_SIZE,
+    borderRadius: LIT_BADGE_SIZE / 2,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  anonLit: {
+    width: LIT_LEADING_SIZE,
+    height: LIT_LEADING_SIZE,
+    borderRadius: LIT_LEADING_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
@@ -1,25 +1,21 @@
-// The "On the wall" status capsule — a compact pill that surfaces the climb
-// currently LIT on the physical board (when it differs from the user's own queue
-// head, e.g. a teammate is driving the wall in a party session). It sits in the
-// centre of the top-header islands row (iOS) / a slim row under the app bar
-// (Android) — the home for "what's lit right now" that the bottom queue accessory
-// used to overload.
+// The "On the wall" status capsule — surfaces the climb currently LIT on the
+// physical board (when it differs from the user's own queue head, e.g. a teammate
+// is driving the wall in a party session). It sits in the centre of the
+// top-header islands row (iOS) / a slim band under the app bar (Android).
 //
-// Leads with the SENDER's avatar (whoever sent the climb to the board), so the
-// capsule answers "who lit it + what's lit" at a glance — the core party-session
-// signal a lightbulb never carried. The avatar is INERT here (one Pressable opens
-// the read-only wall preview; the tap-sender-to-profile affordance lives in that
-// preview sheet, which has room for a full target). Fully-anonymous senders fall
-// back to an amber person glyph — never a bare lightbulb (a bistable leading slot
-// breaks the visual scan + VoiceOver grammar) and never a literal "?".
+// Leads with the SENDER's avatar (whoever sent the climb to the board), so it
+// answers "who lit it + what's lit" at a glance — the core party-session signal a
+// lightbulb never carried. The avatar is INERT here (one Pressable opens the
+// read-only wall preview; the tap-sender-to-profile affordance lives in that
+// preview sheet). Fully-anonymous senders fall back to a neutral person glyph.
 //
 // Two platform-native skins behind one stateful body (see selectByVariant below):
 //   - Liquid Glass (iOS): a NON-glass pill (HIG: no glass-on-glass over the
 //     header's progressive blur) with a warm "lit" amber border + tint.
-//   - Material 3 (Android): an elevated assist chip — 8dp corner, level1
-//     elevation, surfaceContainer.high tonal fill, NO border. The "lit" warmth is
-//     carried the M3-native way through the tertiary colour role (a tonal wash, an
-//     amber avatar ring, and a filled-lightbulb badge), not a drawn border.
+//   - Material 3 (Android): a full-bleed titled status band — a tertiary accent
+//     rail + an "On the wall" overline (the lit semantic stated in words and
+//     carried by the tertiary colour role) + a bottom divider. No floating pill,
+//     no border, no lightbulb (the bottom queue bar already owns that glyph).
 // The data, grade derivation, tap handler and the debounced a11y announcement all
 // live in the single body so a variant flip never resets the announce dedupe.
 // Compact by design — the name truncates, the grade stays.
@@ -45,19 +41,13 @@ import { useOpenWallPreview } from './use-open-wall-preview';
 
 const CAPSULE_HEIGHT = 32;
 // 20pt reads unambiguously as a face above M3's ~18dp floor while protecting the
-// truncating climb name in the tight centre slot (M3 would prefer 24; default to
-// 20). Fixed — does not scale with Dynamic Type.
+// truncating climb name in the tight slot. Fixed — does not scale with Dynamic Type.
 const AVATAR_SIZE = 20;
-// Material "lit" cue, carried by the tertiary role: a thin amber ring hugs the
-// avatar and a filled-lightbulb badge sits in its bottom-trailing corner.
-const AVATAR_RING_WIDTH = 1.5;
-const LIT_LEADING_SIZE = AVATAR_SIZE + AVATAR_RING_WIDTH * 2;
-const LIT_BADGE_SIZE = 14;
-const LIT_BADGE_GLYPH = 9;
 const ANON_GLYPH = 12;
-// 8pt all-round hit expansion lifts the 32pt visual chip to a >=48pt M3 touch
-// target without growing the chip itself.
-const MATERIAL_HIT_SLOP = spacing[2];
+// Material status band: a 4dp tertiary accent rail down the leading edge and a
+// 56dp two-line body (overline + climb line) — already past the 48dp touch floor.
+const BAND_RAIL_WIDTH = 4;
+const BAND_MIN_HEIGHT = 56;
 // Debounce assistive-tech announcements so a fast party session (rapid wall
 // changes) doesn't spam the speech queue.
 const ANNOUNCE_DEBOUNCE_MS = 600;
@@ -72,7 +62,7 @@ type WallStatusCapsuleProps = {
 // stable BoardPresenceClimb from useWallClimbIfDistinct (changes only on a wall event).
 function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
   const { t } = useTranslation('session');
-  const { variant, colorScheme, systemColors, brandColors, m3, m3SurfaceContainers, materialElevation } = useTheme();
+  const { variant, colorScheme, systemColors, brandColors, m3, m3SurfaceContainers } = useTheme();
   const { formatGrade } = useGradeFormat();
   const reduceMotion = useReducedMotion();
   const openWallPreview = useOpenWallPreview();
@@ -115,43 +105,72 @@ function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
     () => [StyleSheet.absoluteFill, { backgroundColor: withAlpha(brandColors.warning, 0.14) }],
     [brandColors.warning],
   );
-  // Material: a tertiary tonal wash = the M3-native "lit" accent (no border).
-  const materialWashStyle = useMemo(
-    () => [StyleSheet.absoluteFill, { backgroundColor: withAlpha(m3.tertiary, 0.1) }],
-    [m3.tertiary],
-  );
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
 
   if (isMaterial) {
+    // The grade sits on the app-bar surface (the band body is transparent). In the
+    // light scheme that surface is near-white, where bright hues (e.g. V0 #FFD400)
+    // fail 4.5:1 — so wrap the grade in a neutral tonal pill there. Dark scheme keeps
+    // bare text (already legible on the dark surface).
+    const gradeNode = formattedGrade ? (
+      colorScheme === 'light' ? (
+        <View style={[styles.gradePill, { backgroundColor: m3SurfaceContainers.highest }]}>
+          <Text
+            variant="subheadline"
+            numberOfLines={1}
+            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+            style={[styles.grade, { color: gradeColor }]}
+          >
+            {formattedGrade}
+          </Text>
+        </View>
+      ) : (
+        <Text
+          variant="subheadline"
+          numberOfLines={1}
+          maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+          style={[styles.grade, { color: gradeColor }]}
+        >
+          {formattedGrade}
+        </Text>
+      )
+    ) : null;
+
     return (
       <Animated.View
         key={climbUuid}
         entering={reduceMotion ? undefined : FadeIn.duration(180)}
-        // Outer carries the tonal fill + the level1 elevation cast — NO
-        // overflow:'hidden' here, or Android would clip the shadow.
-        style={[styles.materialOuter, { backgroundColor: m3SurfaceContainers.high }, materialElevation.level1]}
+        style={[styles.bandOuter, { borderBottomColor: m3.outlineVariant }]}
       >
         <PressableSurface
           onPress={handlePress}
           // Android rides its native ripple; the iOS Material opt-in keeps it static.
           feedback="none"
-          // Neutral M3 state layer — the warmth already lives in the fill + ring,
-          // so a tertiary-tinted ripple would over-warm the press.
+          // Neutral M3 state layer — the warmth lives in the rail + overline.
           rippleColor={m3.onSurfaceVariant}
-          hitSlop={MATERIAL_HIT_SLOP}
           accessibilityRole="button"
           accessibilityLabel={a11yLabel}
           accessibilityHint={t('mobile.boardPresence.stripA11yHint')}
-          // borderRadius + overflow:'hidden' clips the ripple AND the wash to the
-          // 8dp corner; the cast still escapes via the un-clipped outer.
-          style={styles.materialPressable}
+          style={styles.bandPressable}
         >
-          <View pointerEvents="none" style={materialWashStyle} />
-          <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants" style={styles.litLeading}>
-            {hasSenderIdentity ? (
-              <>
-                <View style={[styles.avatarRing, { borderColor: m3.tertiary }]}>
+          {/* The "lit" accent: a tertiary rail down the leading edge. */}
+          <View pointerEvents="none" style={[styles.bandRail, { backgroundColor: m3.tertiary }]} />
+          <View style={styles.bandContent}>
+            <Text
+              variant="caption1"
+              numberOfLines={1}
+              maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+              style={[styles.bandOverline, { color: m3.tertiary }]}
+            >
+              {t('mobile.boardPresence.stripOverline')}
+            </Text>
+            <View style={styles.bandMainRow}>
+              {/* Inert + a11y-hidden so the band reads as one node (the profile tap
+                  lives in the wall-preview sheet). `userId={null}` only suppresses the
+                  avatar's own profile-link tap; the face still resolves from `uri`. */}
+              <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+                {hasSenderIdentity ? (
                   <BoardDriverAvatar
                     uri={climb.sentByAvatarUrl}
                     name={senderName}
@@ -159,55 +178,25 @@ function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
                     size={AVATAR_SIZE}
                     status="none"
                   />
-                </View>
-                <View
-                  style={[styles.litBadge, { backgroundColor: m3.tertiary, borderColor: m3SurfaceContainers.high }]}
-                >
-                  <Icon name="lightbulb.fill" size={LIT_BADGE_GLYPH} color={m3.onTertiary} />
-                </View>
-              </>
-            ) : (
-              <View style={[styles.anonLit, { backgroundColor: m3.tertiary }]}>
-                <Icon name="profile.fill" size={ANON_GLYPH} color={m3.onTertiary} />
+                ) : (
+                  <View style={[styles.bandAnon, { backgroundColor: m3SurfaceContainers.highest }]}>
+                    <Icon name="profile.fill" size={ANON_GLYPH} color={m3.onSurfaceVariant} />
+                  </View>
+                )}
               </View>
-            )}
-          </View>
-          <Text
-            variant="subheadline"
-            color={m3.onSurface}
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-            style={styles.materialName}
-          >
-            {name}
-          </Text>
-          {formattedGrade ? (
-            // Light scheme: a neutral surfaceContainer.highest backdrop keeps the
-            // bright grade hues (e.g. V0 #FFD400) legible. Dark scheme: bare text
-            // already clears 4.5:1 on the dark tonal fill.
-            colorScheme === 'light' ? (
-              <View style={[styles.gradePill, { backgroundColor: m3SurfaceContainers.highest }]}>
-                <Text
-                  variant="subheadline"
-                  numberOfLines={1}
-                  maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-                  style={[styles.grade, { color: gradeColor }]}
-                >
-                  {formattedGrade}
-                </Text>
-              </View>
-            ) : (
               <Text
                 variant="subheadline"
+                color={m3.onSurface}
                 numberOfLines={1}
+                ellipsizeMode="tail"
                 maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-                style={[styles.grade, { color: gradeColor }]}
+                style={styles.bandName}
               >
-                {formattedGrade}
+                {name}
               </Text>
-            )
-          ) : null}
+              {gradeNode}
+            </View>
+          </View>
         </PressableSurface>
       </Animated.View>
     );
@@ -310,64 +299,52 @@ const styles = StyleSheet.create({
     fontVariant: ['tabular-nums'],
     fontWeight: '700',
   },
-  // --- Material 3 (Android) ---
-  materialOuter: {
-    flexShrink: 1,
-    maxWidth: '100%',
-    borderRadius: borderRadius.md,
+  // --- Material 3 status band (Android) ---
+  bandOuter: {
+    width: '100%',
+    borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  materialPressable: {
-    flexShrink: 1,
-    minWidth: 0,
+  bandPressable: {
+    minHeight: BAND_MIN_HEIGHT,
+    justifyContent: 'center',
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[4],
+  },
+  bandRail: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: BAND_RAIL_WIDTH,
+  },
+  bandContent: {
+    gap: 2,
+  },
+  bandOverline: {
+    fontWeight: '600',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+  },
+  bandMainRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    height: CAPSULE_HEIGHT,
-    borderRadius: borderRadius.md,
-    overflow: 'hidden',
-    paddingLeft: spacing[2],
-    paddingRight: spacing[3],
     gap: spacing[2],
   },
-  materialName: {
-    flexShrink: 1,
+  bandName: {
+    flex: 1,
     minWidth: 0,
     fontWeight: '500',
+  },
+  bandAnon: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: AVATAR_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   gradePill: {
     borderRadius: borderRadius.md,
     paddingHorizontal: spacing[1],
-    justifyContent: 'center',
-  },
-  litLeading: {
-    position: 'relative',
-    width: LIT_LEADING_SIZE,
-    height: LIT_LEADING_SIZE,
-  },
-  avatarRing: {
-    width: LIT_LEADING_SIZE,
-    height: LIT_LEADING_SIZE,
-    borderRadius: LIT_LEADING_SIZE / 2,
-    borderWidth: AVATAR_RING_WIDTH,
-    alignItems: 'center',
-    justifyContent: 'center',
-    overflow: 'hidden',
-  },
-  litBadge: {
-    position: 'absolute',
-    right: -2,
-    bottom: -2,
-    width: LIT_BADGE_SIZE,
-    height: LIT_BADGE_SIZE,
-    borderRadius: LIT_BADGE_SIZE / 2,
-    borderWidth: 1.5,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  anonLit: {
-    width: LIT_LEADING_SIZE,
-    height: LIT_LEADING_SIZE,
-    borderRadius: LIT_LEADING_SIZE / 2,
-    alignItems: 'center',
     justifyContent: 'center',
   },
 });

--- a/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
+++ b/packages/mobile/src/components/queue-control/WallStatusCapsule.tsx
@@ -160,10 +160,14 @@ function WallStatusCapsuleImpl({ climb }: WallStatusCapsuleProps) {
             <Text
               variant="caption1"
               numberOfLines={1}
+              // Truncate the trailing sender, never the protected "On the wall" prefix.
+              ellipsizeMode="tail"
               maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
               style={[styles.bandOverline, { color: m3.tertiary }]}
             >
-              {t('mobile.boardPresence.stripOverline')}
+              {senderName
+                ? t('mobile.boardPresence.stripOverlineWithSender', { sender: senderName })
+                : t('mobile.boardPresence.stripOverline')}
             </Text>
             <View style={styles.bandMainRow}>
               {/* Inert + a11y-hidden so the band reads as one node (the profile tap

--- a/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
@@ -256,19 +256,21 @@ describe('WallStatusCapsule', () => {
       expect(getByText('V5 6C')).not.toBeNull();
     });
 
-    it('states the lit semantic in words via the "On the wall" overline (no lightbulb)', () => {
+    it('names the sender in the "On the wall" overline (no lightbulb)', () => {
       const { container, getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
       expect(container.querySelector('[data-driver-avatar]')).not.toBeNull();
-      // The overline carries the "lit" meaning; the bottom queue bar owns the bulb.
-      expect(getByText('mobile.boardPresence.stripOverline')).not.toBeNull();
+      // The overline carries "lit + who" in words; the bottom queue bar owns the bulb.
+      expect(getByText('mobile.boardPresence.stripOverlineWithSender:Casey')).not.toBeNull();
       expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();
       // The person glyph belongs to the anonymous fallback, not a known sender.
       expect(container.querySelector('[data-icon="profile.fill"]')).toBeNull();
     });
 
-    it('falls back to a neutral person glyph (no lightbulb) for an anonymous sender', () => {
+    it('falls back to the bare overline + a neutral person glyph for an anonymous sender', () => {
       const climb = makeClimb({ sentByDisplayName: null, sentByAvatarUrl: null, sentByUserId: null });
-      const { container } = render(<WallStatusCapsule climb={climb} />);
+      const { container, getByText } = render(<WallStatusCapsule climb={climb} />);
+      // No sender to name — the overline drops the "· {sender}" suffix gracefully.
+      expect(getByText('mobile.boardPresence.stripOverline')).not.toBeNull();
       expect(container.querySelector('[data-driver-avatar]')).toBeNull();
       expect(container.querySelector('[data-icon="profile.fill"]')).not.toBeNull();
       expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();

--- a/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
@@ -4,7 +4,13 @@ import { fireEvent, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 
-const spies = vi.hoisted(() => ({ openWallPreview: vi.fn(), announce: vi.fn(), reduceMotion: false }));
+const spies = vi.hoisted(() => ({
+  openWallPreview: vi.fn(),
+  announce: vi.fn(),
+  reduceMotion: false,
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  colorScheme: 'dark' as 'dark' | 'light',
+}));
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -65,8 +71,13 @@ vi.mock('../../board-presence/BoardDriverAvatar', () => ({
 }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
+    variant: spies.variant,
+    colorScheme: spies.colorScheme,
     systemColors: { label: '#111', secondaryBackground: '#222' },
     brandColors: { warning: '#FBBF24' },
+    m3: { tertiary: '#FF8A3D', onTertiary: '#3A1D00', onSurface: '#F5F2FB', onSurfaceVariant: '#A9A2B6' },
+    m3SurfaceContainers: { high: '#2A2142', highest: '#322748' },
+    materialElevation: { level1: { elevation: 1 } },
   }),
 }));
 vi.mock('../../../hooks/use-grade-format', () => ({
@@ -78,7 +89,37 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-text': 'true' }, children),
 }));
 vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }) }));
-vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    onPress,
+    accessibilityRole,
+    accessibilityLabel,
+    accessibilityHint,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityRole?: string;
+    accessibilityLabel?: string;
+    accessibilityHint?: string;
+  }) =>
+    createElement(
+      'button',
+      {
+        'data-pressable': 'true',
+        'data-pressable-surface': 'true',
+        'data-role': accessibilityRole,
+        'data-label': accessibilityLabel,
+        'data-hint': accessibilityHint,
+        onClick: onPress,
+      },
+      children,
+    ),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { none: 0, sm: 4, md: 8, lg: 12, xl: 16, full: 9999 },
+}));
 vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string) => color }));
 vi.mock('../../../theme/typography', () => ({ CHROME_LABEL_MAX_FONT_SCALE: 1.2 }));
 
@@ -106,6 +147,8 @@ describe('WallStatusCapsule', () => {
     spies.openWallPreview.mockClear();
     spies.announce.mockClear();
     spies.reduceMotion = false;
+    spies.variant = 'liquidGlass';
+    spies.colorScheme = 'dark';
   });
 
   it('renders without the entering animation when Reduce Motion is on', () => {
@@ -186,5 +229,62 @@ describe('WallStatusCapsule', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('renders the Liquid Glass Pressable pill (not the Material surface) on iOS', () => {
+    const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+    expect(container.querySelector('[data-pressable]')).not.toBeNull();
+    expect(container.querySelector('[data-pressable-surface]')).toBeNull();
+    // No lightbulb badge in the glass skin — the warm "lit" cue is the amber pill.
+    expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();
+  });
+
+  describe('Material variant (Android)', () => {
+    beforeEach(() => {
+      spies.variant = 'material';
+    });
+
+    it('renders a Material assist chip via PressableSurface (native ripple), not the glass Pressable', () => {
+      const { container, getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
+      expect(container.querySelector('[data-pressable-surface]')).not.toBeNull();
+      expect(getByText('Wax On')).not.toBeNull();
+      expect(getByText('V5 6C')).not.toBeNull();
+    });
+
+    it('lights the sender avatar with a filled-lightbulb badge (tertiary "lit" cue)', () => {
+      const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+      expect(container.querySelector('[data-driver-avatar]')).not.toBeNull();
+      expect(container.querySelector('[data-icon="lightbulb.fill"]')).not.toBeNull();
+      // The amber person glyph belongs to the anonymous fallback, not a known sender.
+      expect(container.querySelector('[data-icon="profile.fill"]')).toBeNull();
+    });
+
+    it('falls back to a tertiary-filled person glyph (no lightbulb) for an anonymous sender', () => {
+      const climb = makeClimb({ sentByDisplayName: null, sentByAvatarUrl: null, sentByUserId: null });
+      const { container } = render(<WallStatusCapsule climb={climb} />);
+      expect(container.querySelector('[data-driver-avatar]')).toBeNull();
+      expect(container.querySelector('[data-icon="profile.fill"]')).not.toBeNull();
+      expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();
+    });
+
+    it('opens the read-only wall preview on tap', () => {
+      const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+      fireEvent.click(container.querySelector('[data-pressable-surface]') as Element);
+      expect(spies.openWallPreview).toHaveBeenCalledWith({ uuid: 'wall-1', _converted: true });
+    });
+
+    it('keeps the grade legible in the light scheme (still renders the grade text)', () => {
+      spies.colorScheme = 'light';
+      const { getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
+      expect(getByText('V5 6C')).not.toBeNull();
+    });
+
+    it('exposes the same button role + sender-naming label as the glass skin', () => {
+      const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+      const pressable = container.querySelector('[data-pressable-surface]');
+      expect(pressable?.getAttribute('data-role')).toBe('button');
+      expect(pressable?.getAttribute('data-label')).toContain('Wax On');
+      expect(pressable?.getAttribute('data-label')).toContain('Casey');
+    });
   });
 });

--- a/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/wall-status-capsule.test.tsx
@@ -75,9 +75,14 @@ vi.mock('../../../providers/theme-provider', () => ({
     colorScheme: spies.colorScheme,
     systemColors: { label: '#111', secondaryBackground: '#222' },
     brandColors: { warning: '#FBBF24' },
-    m3: { tertiary: '#FF8A3D', onTertiary: '#3A1D00', onSurface: '#F5F2FB', onSurfaceVariant: '#A9A2B6' },
+    m3: {
+      tertiary: '#FF8A3D',
+      onTertiary: '#3A1D00',
+      onSurface: '#F5F2FB',
+      onSurfaceVariant: '#A9A2B6',
+      outlineVariant: '#4A4458',
+    },
     m3SurfaceContainers: { high: '#2A2142', highest: '#322748' },
-    materialElevation: { level1: { elevation: 1 } },
   }),
 }));
 vi.mock('../../../hooks/use-grade-format', () => ({
@@ -231,12 +236,12 @@ describe('WallStatusCapsule', () => {
     }
   });
 
-  it('renders the Liquid Glass Pressable pill (not the Material surface) on iOS', () => {
-    const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+  it('renders the Liquid Glass Pressable pill (not the Material band) on iOS', () => {
+    const { container, queryByText } = render(<WallStatusCapsule climb={makeClimb()} />);
     expect(container.querySelector('[data-pressable]')).not.toBeNull();
     expect(container.querySelector('[data-pressable-surface]')).toBeNull();
-    // No lightbulb badge in the glass skin — the warm "lit" cue is the amber pill.
-    expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();
+    // The glass pill carries the "lit" cue as the amber tint — no visible overline.
+    expect(queryByText('mobile.boardPresence.stripOverline')).toBeNull();
   });
 
   describe('Material variant (Android)', () => {
@@ -244,22 +249,24 @@ describe('WallStatusCapsule', () => {
       spies.variant = 'material';
     });
 
-    it('renders a Material assist chip via PressableSurface (native ripple), not the glass Pressable', () => {
+    it('renders a Material status band via PressableSurface (native ripple), not the glass Pressable', () => {
       const { container, getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
       expect(container.querySelector('[data-pressable-surface]')).not.toBeNull();
       expect(getByText('Wax On')).not.toBeNull();
       expect(getByText('V5 6C')).not.toBeNull();
     });
 
-    it('lights the sender avatar with a filled-lightbulb badge (tertiary "lit" cue)', () => {
-      const { container } = render(<WallStatusCapsule climb={makeClimb()} />);
+    it('states the lit semantic in words via the "On the wall" overline (no lightbulb)', () => {
+      const { container, getByText } = render(<WallStatusCapsule climb={makeClimb()} />);
       expect(container.querySelector('[data-driver-avatar]')).not.toBeNull();
-      expect(container.querySelector('[data-icon="lightbulb.fill"]')).not.toBeNull();
-      // The amber person glyph belongs to the anonymous fallback, not a known sender.
+      // The overline carries the "lit" meaning; the bottom queue bar owns the bulb.
+      expect(getByText('mobile.boardPresence.stripOverline')).not.toBeNull();
+      expect(container.querySelector('[data-icon="lightbulb.fill"]')).toBeNull();
+      // The person glyph belongs to the anonymous fallback, not a known sender.
       expect(container.querySelector('[data-icon="profile.fill"]')).toBeNull();
     });
 
-    it('falls back to a tertiary-filled person glyph (no lightbulb) for an anonymous sender', () => {
+    it('falls back to a neutral person glyph (no lightbulb) for an anonymous sender', () => {
       const climb = makeClimb({ sentByDisplayName: null, sentByAvatarUrl: null, sentByUserId: null });
       const { container } = render(<WallStatusCapsule climb={climb} />);
       expect(container.querySelector('[data-driver-avatar]')).toBeNull();

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -356,14 +356,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0,
   },
   materialWallStatusRow: {
-    flexDirection: 'row',
-    // Leading-aligned so the chip's left edge lines up with the search field and
-    // filter pills below it as one Material chip stack (a centred free-float is an
-    // iOS top-island convention).
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-    paddingHorizontal: spacing[4],
-    paddingBottom: spacing[2],
+    // Full-bleed "On the wall" status band — it owns its own padding, accent rail
+    // and bottom divider, so the wrapper adds no inset.
+    width: '100%',
   },
   materialSearchStack: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -357,7 +357,10 @@ const styles = StyleSheet.create({
   },
   materialWallStatusRow: {
     flexDirection: 'row',
-    justifyContent: 'center',
+    // Leading-aligned so the chip's left edge lines up with the search field and
+    // filter pills below it as one Material chip stack (a centred free-float is an
+    // iOS top-island convention).
+    justifyContent: 'flex-start',
     alignItems: 'center',
     paddingHorizontal: spacing[4],
     paddingBottom: spacing[2],

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -390,6 +390,7 @@
       "stripA11yLabel": "On the wall: {{name}}, {{grade}}",
       "stripA11yLabelWithSender": "On the wall: {{name}}, {{grade}}, lit by {{sender}}",
       "stripA11yHint": "Opens the wall climb",
+      "stripOverline": "On the wall",
       "stripAnnounce": "Now on the wall: {{name}}, {{grade}}",
       "stripAnnounceWithSender": "Now on the wall: {{name}}, {{grade}}, lit by {{sender}}",
       "switchBoard": "Switch board",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -391,6 +391,7 @@
       "stripA11yLabelWithSender": "On the wall: {{name}}, {{grade}}, lit by {{sender}}",
       "stripA11yHint": "Opens the wall climb",
       "stripOverline": "On the wall",
+      "stripOverlineWithSender": "On the wall · {{sender}}",
       "stripAnnounce": "Now on the wall: {{name}}, {{grade}}",
       "stripAnnounceWithSender": "Now on the wall: {{name}}, {{grade}}, lit by {{sender}}",
       "switchBoard": "Switch board",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -391,6 +391,7 @@
       "stripA11yLabelWithSender": "En el muro: {{name}}, {{grade}}, encendido por {{sender}}",
       "stripA11yHint": "Abre el bloque del muro",
       "stripOverline": "En el muro",
+      "stripOverlineWithSender": "En el muro · {{sender}}",
       "stripAnnounce": "Ahora en el muro: {{name}}, {{grade}}",
       "stripAnnounceWithSender": "Ahora en el muro: {{name}}, {{grade}}, encendido por {{sender}}",
       "switchBoard": "Cambiar de muro",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -390,6 +390,7 @@
       "stripA11yLabel": "En el muro: {{name}}, {{grade}}",
       "stripA11yLabelWithSender": "En el muro: {{name}}, {{grade}}, encendido por {{sender}}",
       "stripA11yHint": "Abre el bloque del muro",
+      "stripOverline": "En el muro",
       "stripAnnounce": "Ahora en el muro: {{name}}, {{grade}}",
       "stripAnnounceWithSender": "Ahora en el muro: {{name}}, {{grade}}, encendido por {{sender}}",
       "switchBoard": "Cambiar de muro",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -391,6 +391,7 @@
       "stripA11yLabelWithSender": "Sur le mur : {{name}}, {{grade}}, allumé par {{sender}}",
       "stripA11yHint": "Ouvre le bloc du mur",
       "stripOverline": "Sur le mur",
+      "stripOverlineWithSender": "Sur le mur · {{sender}}",
       "stripAnnounce": "Sur le mur maintenant : {{name}}, {{grade}}",
       "stripAnnounceWithSender": "Sur le mur maintenant : {{name}}, {{grade}}, allumé par {{sender}}",
       "switchBoard": "Changer de mur",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -390,6 +390,7 @@
       "stripA11yLabel": "Sur le mur : {{name}}, {{grade}}",
       "stripA11yLabelWithSender": "Sur le mur : {{name}}, {{grade}}, allumé par {{sender}}",
       "stripA11yHint": "Ouvre le bloc du mur",
+      "stripOverline": "Sur le mur",
       "stripAnnounce": "Sur le mur maintenant : {{name}}, {{grade}}",
       "stripAnnounceWithSender": "Sur le mur maintenant : {{name}}, {{grade}}, allumé par {{sender}}",
       "switchBoard": "Changer de mur",


### PR DESCRIPTION
## Summary

The "on the board" capsule (`WallStatusCapsule`) — the tag under the Climbs header that shows which climb is currently lit on the wall (a teammate's send in a party session) — shipped a single iOS treatment on both platforms: a fully-rounded, hairline-bordered amber pill. On Android, beside the Paper app bar / search bar / outlined filter chips, it read as misplaced iOS UI.

This adds a Material 3 branch via `selectByVariant` **inside the one stateful body**, so the debounced accessibility-announce logic (`lastAnnouncedRef` + the announce effect) is never duplicated across a variant flip. iOS Liquid Glass is unchanged.

Android now renders a **full-bleed "On the wall" status band**:
- A **4dp tertiary accent rail** down the leading edge + an uppercase **"On the wall" overline** (the lit semantic stated in words and carried by the tertiary colour role) + the sender avatar, climb name and color-coded grade + a bottom `outlineVariant` divider.
- **Transparent body** so it reads as a labelled extension of the app bar rather than a contrasting block. Whole-row native Material ripple via `PressableSurface` (neutral `onSurfaceVariant` state layer); 56dp tall, past the 48dp touch floor.
- **No lightbulb, no border, no floating pill.** The bottom queue bar already owns the lightbulb glyph; the rail + overline carry the "lit" warmth.
- Light-scheme grade pill keeps bright hues (e.g. V0 `#FFD400`) legible on the near-white surface.
- New `stripOverline` string: "On the wall" / "En el muro" / "Sur le mur".

Design came from an M3 design-team pass (four proposals → three-judge panel → synthesis). The first cut shipped the compact "assist chip"; after on-device feedback that it still felt disjointed (orphan row, warm-colour outlier, duplicate bulb) it was reworked into the titled status band the panel had ranked as runner-up.

## Release Notes

- On Android, the tag showing whose climb is on the wall is now a clean "On the wall" status band that fits the app instead of an iOS-style pill.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 2844 passed (incl. Material-band assertions in `wall-status-capsule.test.tsx`; iOS branch stays covered).
- `vp test run catalog-completeness` — 28 passed (the new `stripOverline` key has en/es/fr parity).
- `vp run check:mobile-bundle` — Android bundle OK.
- `vp check` — format + lint clean.
- ⚠️ **On-device visual QA pending.** The band only renders during a live party/board-presence session (a peer lighting a climb different from your own queue head), which the solo screenshot harness can't reproduce. Needs an eyeball in a real party session: tertiary rail, "On the wall" overline, avatar/name/grade, bottom divider, ripple on press, and grade legibility in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EREwG3qNWA5ZPgXdaSjB2A