### PR TITLE
feat(mobile): native M3 filter-chip row on Android (#3269)

### DIFF
--- a/docs/expo-ui-components.md
+++ b/docs/expo-ui-components.md
@@ -134,8 +134,11 @@ test/switch-row-stub.tsx              # passthrough stub (RN Pressable + Switch)
 - Both call `makeToggleHandler(onValueChange, disabled)` so the haptic + disabled
   behaviour can't drift between platforms.
 
-`FilterChipRow` is the second example — a SwiftUI-only control (its Android side is
-a placeholder), showing the same split with a richer iOS tree (menus, pickers).
+`FilterChipRow` is the second example — both sides are now built (SwiftUI menus on
+iOS, Jetpack Compose `FilterChip`s + `DropdownMenu`s on Android), showing the same
+split with a richer tree (menus, pickers / dropdowns) and the shared
+`FilterChipRow.logic` label helpers. On Android the chip row is the default climbs
+filtering surface (kill-switch flag `android-filter-chips`).
 
 ## Performance: memoize when a native control goes in a list
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -38,6 +38,7 @@ import { useDimensionLocks, useDimensionRepin } from '../../../src/lib/dimension
 import { hapticMedium } from '../../../src/lib/haptics';
 import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
+import { useFeatureFlag } from '../../../src/providers/feature-flags-provider';
 import { selectByVariant } from '../../../src/theme/variants';
 import { useActiveClimbUuid, useQueueActions } from '../../../src/providers/queue-provider';
 import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
@@ -200,12 +201,18 @@ function ClimbListInner() {
     listBottomSpacerHeight.value = withTiming(listPaddingBottom, { duration: timing.normal });
   }, [listBottomSpacerHeight, listPaddingBottom]);
   const listBottomSpacerStyle = useAnimatedStyle(() => ({ height: listBottomSpacerHeight.value }));
-  // Material keeps its filter button in the top-right toolbar
-  // (features.filtersInTopChrome). Liquid Glass shows the persistent native
-  // filter-chip row instead — the chips own filtering there, so the centre
-  // filter-summary is suppressed. (The Material chip row is a follow-up.)
+  // Liquid Glass shows the persistent native filter-chip row; Material historically
+  // kept its filters in the top toolbar (features.filtersInTopChrome). The native
+  // Material chip row now ships as the Android DEFAULT — `android-filter-chips` is a
+  // kill-switch (default ON): present-and-false reverts Material to the toolbar
+  // filters. We gate on the variant feature (not Platform.OS) and do NOT flip
+  // filtersInTopChrome, so Material's FAB-vs-toolbar + summary coupling stays put.
   const filterInTopChrome = features.filtersInTopChrome;
-  const showFilterChips = !filterInTopChrome;
+  const chipRowKilled = useFeatureFlag('android-filter-chips') === false;
+  // Material adopts the chip row by default; the kill-switch reverts it.
+  const materialChips = filterInTopChrome && !chipRowKilled;
+  // The chip row owns filtering on Liquid Glass (always) and on Material (by default).
+  const showFilterChips = !filterInTopChrome || materialChips;
 
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -1208,12 +1215,14 @@ function ClimbListInner() {
         onOpenGrade={handleOpenGrade}
         onGradeChange={handleGradeChange}
         filterChrome={filterChrome}
+        showPersistentChips={materialChips}
       />
 
       {/* On Liquid Glass the Grade chip opens a top-anchored range rail +
-          dismiss layer, just below the measured chrome. (Material renders its
-          own grade rail inside ClimbTopChrome.) */}
-      {showFilterChips && showGrade ? (
+          dismiss layer, just below the measured chrome. (Material — incl. the
+          Material chip-row default — renders its own grade rail inside
+          ClimbTopChrome, so this glass-only overlay is gated on !materialChips.) */}
+      {showFilterChips && !materialChips && showGrade ? (
         <>
           <Pressable
             style={styles.chipGradeDismiss}

--- a/packages/mobile/assets/material-icons/check.xml
+++ b/packages/mobile/assets/material-icons/check.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/history.xml
+++ b/packages/mobile/assets/material-icons/history.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/lock.xml
+++ b/packages/mobile/assets/material-icons/lock.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/lock_open.xml
+++ b/packages/mobile/assets/material-icons/lock_open.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"/>
+</vector>

--- a/packages/mobile/assets/material-icons/tune.xml
+++ b/packages/mobile/assets/material-icons/tune.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+  <path android:fillColor="#FFFFFFFF" android:pathData="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"/>
+</vector>

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -72,10 +72,18 @@ type ClimbTopChromeProps = {
   onOpenGrade?: () => void;
   onGradeChange?: (grade: GradeBound) => void;
   /** Persistent native filter-chip row + token row, rendered under the title on
-   *  Liquid Glass, independent of search focus; null on the Material path. The
-   *  caller composes it so every filter handler and the search-provider state
-   *  stay in the screen, not drilled through here. */
+   *  Liquid Glass, independent of search focus. On Material it renders in the search
+   *  stack instead when `showPersistentChips` is set. The caller composes it so every
+   *  filter handler and the search-provider state stay in the screen, not drilled
+   *  through here. */
   filterChrome?: ReactNode;
+  /** Android Material only: the native chip row (`filterChrome`) is the default
+   *  filtering surface. When set, the Material top-chrome filter affordances (grade
+   *  control, filter button, condensed summary) are suppressed and `filterChrome` is
+   *  rendered in the search stack instead; the app-bar search field, angle chip, and
+   *  the in-chrome grade rail stay. Always false on Liquid Glass (its own path renders
+   *  `filterChrome`). */
+  showPersistentChips?: boolean;
 };
 
 export function ClimbTopChrome({
@@ -104,6 +112,7 @@ export function ClimbTopChrome({
   onOpenGrade,
   onGradeChange,
   filterChrome,
+  showPersistentChips = false,
 }: ClimbTopChromeProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, variant } = useTheme();
@@ -147,10 +156,15 @@ export function ClimbTopChrome({
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   if (isMaterial) {
+    // When the persistent chip row is the default filtering surface, the Material
+    // top-chrome filter affordances (grade control, filter button, condensed summary)
+    // are suppressed — the chips own filtering. The app-bar search field, the angle
+    // chip, and the in-chrome grade rail (opened by the chip row's Grade chip) stay.
+    const showTopChromeFilters = !showPersistentChips;
     const hasGradeFilter = gradeChip?.active === true;
     const nonGradeFilterCount = Math.max(0, activeFilterCount - (hasGradeFilter ? 1 : 0));
     const hasNonGradeFilters = nonGradeFilterCount > 0;
-    const shouldShowFilterSummary = filterSummary != null && hasNonGradeFilters;
+    const shouldShowFilterSummary = showTopChromeFilters && filterSummary != null && hasNonGradeFilters;
     const visibleFilterSummary = shouldShowFilterSummary ? filterSummary : null;
     const visibleGradeLabel = gradeChip?.label ?? t('mobile.filter.grade');
 
@@ -216,26 +230,34 @@ export function ClimbTopChrome({
                   height={MATERIAL_SEARCH_HEIGHT}
                 />
               </View>
-              <GradeFilterControl
-                label={visibleGradeLabel}
-                active={hasGradeFilter}
-                expanded={gradeRailVisible}
-                height={MATERIAL_SEARCH_HEIGHT}
-                onPress={() => {
-                  if (gradeRailVisible) {
-                    onCloseGrade();
-                    return;
-                  }
-                  onOpenGrade?.();
-                }}
-                onClear={hasGradeFilter ? gradeChip?.onClear : undefined}
-                toggleAccessibilityLabel={t('mobile.search.gradeAction')}
-                clearAccessibilityLabel={t('mobile.gradeRail.clearFilterAria')}
-                openHint={t('mobile.search.gradeOpenHint')}
-                closeHint={t('mobile.search.gradeCloseHint')}
-              />
-              {onOpenFilters ? <FilterButton activeFilterCount={nonGradeFilterCount} onPress={onOpenFilters} /> : null}
+              {showTopChromeFilters ? (
+                <GradeFilterControl
+                  label={visibleGradeLabel}
+                  active={hasGradeFilter}
+                  expanded={gradeRailVisible}
+                  height={MATERIAL_SEARCH_HEIGHT}
+                  onPress={() => {
+                    if (gradeRailVisible) {
+                      onCloseGrade();
+                      return;
+                    }
+                    onOpenGrade?.();
+                  }}
+                  onClear={hasGradeFilter ? gradeChip?.onClear : undefined}
+                  toggleAccessibilityLabel={t('mobile.search.gradeAction')}
+                  clearAccessibilityLabel={t('mobile.gradeRail.clearFilterAria')}
+                  openHint={t('mobile.search.gradeOpenHint')}
+                  closeHint={t('mobile.search.gradeCloseHint')}
+                />
+              ) : null}
+              {showTopChromeFilters && onOpenFilters ? (
+                <FilterButton activeFilterCount={nonGradeFilterCount} onPress={onOpenFilters} />
+              ) : null}
             </View>
+
+            {/* The persistent native chip row owns filtering when the Material
+                default; it sits directly under the search field, like Liquid Glass. */}
+            {showPersistentChips ? filterChrome : null}
 
             {angleAdjustable || visibleFilterSummary ? (
               <View pointerEvents="box-none" style={styles.materialQuickRow}>

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -1,13 +1,394 @@
-// Android placeholder for the persistent filter-chip row. The native row is
-// SwiftUI-only (FilterChipRow.ios.tsx); the Material counterpart will be built
-// on @expo/ui jetpack-compose (Chip + DropdownMenu + Switch) in a follow-up.
-// Until then the chip row is a no-op on Android — the caller only mounts it on
-// Liquid Glass (showFilterChips), so this never renders, but it keeps
-// @expo/ui/swift-ui (which resolves native views at module load) off the Android
-// bundle.
+// FilterChipRow — Android implementation. Native Jetpack Compose Material 3
+// FilterChips + DropdownMenus via @expo/ui, mirroring the SwiftUI iOS reference
+// (FilterChipRow.ios.tsx) one-for-one: same chip set, order, labels, and
+// behaviour. The persistent, glanceable chip row is the Android (Material) default
+// filtering surface — the climbs screen suppresses the Material top-chrome filter
+// affordances while it's shown (gated by the `android-filter-chips` kill-switch).
+//
+// Compose specifics that differ from the SwiftUI tree:
+//   • DropdownMenu is CONTROLLED — each menu-bearing chip is its own small stateful
+//     sub-component owning `expanded` (cf. MoreForm.android.tsx's SelectRow). The
+//     chip's onClick opens it; an explicit close() in an item dismisses it.
+//   • The "Show" menu stays open while toggling simply by NOT closing the controlled
+//     menu on a toggle item's click — Compose has no menuActionDismissBehavior and
+//     doesn't auto-dismiss on click, so this is the natural equivalent.
+//   • Dimension chips reconstruct iOS's Menu+onPrimaryAction (tap toggles, long-press
+//     opens lock/unlock) from `combinedClickable`. The chip carries no `onClick`, so
+//     the modifier owns both gestures — avoiding the FilterChip-onClick-vs-
+//     combinedClickable conflict. A locked chip keeps firing onToggle on tap, but the
+//     shared `useDimensionRepin` in the climbs screen re-pins it, so the filter stays
+//     active (the same "locked ignores tap" outcome as iOS).
+//   • Single-choice (Popularity/Rating) skips the iOS string-tag Picker round-trip:
+//     each item's onClick closure carries the real `number | undefined` bucket.
+// Labels reuse FilterChipRow.logic so a filter is never worded two ways across
+// platforms; bucket sets come from the shared filter-chip-menus.
 
-import type { FilterChipRowProps } from './FilterChipRow.types';
+import { memo, useState, type ReactNode } from 'react';
+import { StyleSheet, type ImageSourcePropType } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Host } from '@expo/ui';
+import {
+  Row,
+  Text,
+  Icon,
+  FilterChip,
+  DropdownMenu,
+  DropdownMenuItem,
+  HorizontalDivider,
+} from '@expo/ui/jetpack-compose';
+import { combinedClickable, fillMaxWidth, horizontalScroll, padding } from '@expo/ui/jetpack-compose/modifiers';
+import { getFilterKey } from '../../lib/recent-filter-store';
+import { POPULARITY_BUCKETS, RATING_BUCKETS } from '../../lib/filter-chip-menus';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import { filterChipBrandColors } from '../../theme/expo-ui-modifiers';
+import { popularityChipLabel, ratingChipLabel } from './FilterChipRow.logic';
+import type { DimensionChip, FilterChipRowProps } from './FilterChipRow.types';
 
-export function FilterChipRow(_props: FilterChipRowProps): null {
-  return null;
+// Semantic icon → Material XML vector drawable. White-filled (#FFFFFFFF) so the
+// Compose `Icon` recolours them: inside a chip/menu slot the Icon inherits the
+// content colour (brand on-fill when the chip is selected, the menu text colour in
+// items), so no explicit tint is needed. Mirrors MORE_ICON_SOURCE in MoreForm.android.tsx.
+const ICON = {
+  tune: require('../../../assets/material-icons/tune.xml') as ImageSourcePropType,
+  history: require('../../../assets/material-icons/history.xml') as ImageSourcePropType,
+  check: require('../../../assets/material-icons/check.xml') as ImageSourcePropType,
+  lock: require('../../../assets/material-icons/lock.xml') as ImageSourcePropType,
+  lockOpen: require('../../../assets/material-icons/lock_open.xml') as ImageSourcePropType,
+};
+
+// M3 chip/menu leading-icon size.
+const ICON_SIZE = 18;
+
+type ChipColors = ReturnType<typeof filterChipBrandColors>;
+
+// An action chip with no menu (Filters · N, Grade): tap fires onPress.
+function ActionChip({
+  label,
+  selected,
+  colors,
+  iconSource,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  colors: ChipColors;
+  iconSource?: ImageSourcePropType;
+  onPress: () => void;
+}) {
+  return (
+    <FilterChip selected={selected} colors={colors} onClick={onPress}>
+      {iconSource ? (
+        <FilterChip.LeadingIcon>
+          <Icon source={iconSource} size={ICON_SIZE} />
+        </FilterChip.LeadingIcon>
+      ) : null}
+      <FilterChip.Label>
+        <Text>{label}</Text>
+      </FilterChip.Label>
+    </FilterChip>
+  );
 }
+
+// A chip that anchors a controlled DropdownMenu (Recent, Show, Popularity, Rating).
+// `renderItems` is given a `close` so single-choice/destructive items can dismiss
+// while keep-open toggle items simply don't call it.
+function MenuChip({
+  label,
+  selected,
+  colors,
+  iconSource,
+  renderItems,
+}: {
+  label: string;
+  selected: boolean;
+  colors: ChipColors;
+  iconSource?: ImageSourcePropType;
+  renderItems: (close: () => void) => ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
+      <DropdownMenu.Trigger>
+        <FilterChip selected={selected} colors={colors} onClick={() => setExpanded(true)}>
+          {iconSource ? (
+            <FilterChip.LeadingIcon>
+              <Icon source={iconSource} size={ICON_SIZE} />
+            </FilterChip.LeadingIcon>
+          ) : null}
+          <FilterChip.Label>
+            <Text>{label}</Text>
+          </FilterChip.Label>
+        </FilterChip>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Items>{renderItems(() => setExpanded(false))}</DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+// A single menu row: optional leading check, a text label, optional text colour
+// (for the destructive Clear).
+function MenuItem({
+  label,
+  checked,
+  onClick,
+  textColor,
+}: {
+  label: string;
+  checked: boolean;
+  onClick: () => void;
+  textColor?: string;
+}) {
+  return (
+    <DropdownMenuItem onClick={onClick} elementColors={textColor ? { textColor } : undefined}>
+      {checked ? (
+        <DropdownMenuItem.LeadingIcon>
+          <Icon source={ICON.check} size={ICON_SIZE} />
+        </DropdownMenuItem.LeadingIcon>
+      ) : null}
+      <DropdownMenuItem.Text>
+        <Text>{label}</Text>
+      </DropdownMenuItem.Text>
+    </DropdownMenuItem>
+  );
+}
+
+// Tall / Wide board-shape chip: tap toggles the filter, long-press opens a
+// lock/unlock menu. `combinedClickable` owns both gestures (no FilterChip.onClick),
+// avoiding the documented onClick-vs-combinedClickable conflict.
+function DimensionChipView({
+  dimension,
+  label,
+  colors,
+  lockLabel,
+  unlockLabel,
+}: {
+  dimension: DimensionChip;
+  label: string;
+  colors: ChipColors;
+  lockLabel: string;
+  unlockLabel: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
+      <DropdownMenu.Trigger>
+        <FilterChip
+          selected={dimension.active}
+          colors={colors}
+          modifiers={[combinedClickable({ onClick: dimension.onToggle, onLongClick: () => setExpanded(true) })]}
+        >
+          {dimension.locked ? (
+            <FilterChip.LeadingIcon>
+              <Icon source={ICON.lock} size={ICON_SIZE} />
+            </FilterChip.LeadingIcon>
+          ) : null}
+          <FilterChip.Label>
+            <Text>{label}</Text>
+          </FilterChip.Label>
+        </FilterChip>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Items>
+        <DropdownMenuItem
+          onClick={() => {
+            dimension.onToggleLock();
+            setExpanded(false);
+          }}
+        >
+          <DropdownMenuItem.LeadingIcon>
+            <Icon source={dimension.locked ? ICON.lockOpen : ICON.lock} size={ICON_SIZE} />
+          </DropdownMenuItem.LeadingIcon>
+          <DropdownMenuItem.Text>
+            <Text>{dimension.locked ? unlockLabel : lockLabel}</Text>
+          </DropdownMenuItem.Text>
+        </DropdownMenuItem>
+      </DropdownMenu.Items>
+    </DropdownMenu>
+  );
+}
+
+function FilterChipRowComponent({
+  activeFilterCount,
+  onOpenFilters,
+  recentFilters,
+  currentFilters,
+  currentSearchText,
+  onApplyRecent,
+  onClearRecent,
+  gradeLabel,
+  gradeActive,
+  onOpenGrade,
+  dimensionChips,
+  minAscents,
+  onChangePopularity,
+  minRating,
+  onChangeRating,
+  hideCompleted,
+  onToggleHideCompleted,
+  onlyBenchmarks,
+  onToggleBenchmarks,
+  canHideCompleted,
+}: FilterChipRowProps) {
+  const { t } = useTranslation('climbs');
+  const { brandColors, colorScheme } = useTheme();
+  const chipColors = filterChipBrandColors(brandColors);
+
+  const currentRecentKey = getFilterKey(currentFilters, currentSearchText);
+  const hasActivePopularity = minAscents != null;
+  const hasActiveRating = minRating != null;
+
+  const filtersLabel =
+    activeFilterCount > 0
+      ? t('mobile.search.chips.filtersWithCount', { count: activeFilterCount })
+      : t('mobile.filter.title');
+
+  return (
+    // `colorScheme` keeps the Compose MaterialTheme on our in-app Light/Dark toggle.
+    // `matchContents={{ vertical: true }}` (NOT the boolean form) fills the parent
+    // width so the Row's `fillMaxWidth()` has a bounded width to scroll within, while
+    // height tracks the chip content — mirrors SwitchRow/SegmentedControl.
+    <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
+      <Row
+        modifiers={[fillMaxWidth(), horizontalScroll(), padding(spacing[4], spacing[2], spacing[4], spacing[2])]}
+        verticalAlignment="center"
+        horizontalArrangement={{ spacedBy: spacing[2] }}
+      >
+        {/* Filters · N → the long-tail sheet. Action chip, no menu. */}
+        <ActionChip
+          label={filtersLabel}
+          selected={activeFilterCount > 0}
+          colors={chipColors}
+          iconSource={ICON.tune}
+          onPress={onOpenFilters}
+        />
+
+        {/* Recent ▾ — hidden when there are none. */}
+        {recentFilters.length > 0 ? (
+          <MenuChip
+            label={t('mobile.search.recentFilters')}
+            selected={false}
+            colors={chipColors}
+            iconSource={ICON.history}
+            renderItems={(close) => (
+              <>
+                {recentFilters.map((recent) => (
+                  <MenuItem
+                    key={recent.id}
+                    label={recent.label}
+                    checked={getFilterKey(recent.filters, recent.searchText) === currentRecentKey}
+                    onClick={() => {
+                      onApplyRecent(recent.filters, recent.searchText);
+                      close();
+                    }}
+                  />
+                ))}
+                <HorizontalDivider />
+                <MenuItem
+                  label={t('mobile.search.clearRecentSearches')}
+                  checked={false}
+                  textColor={brandColors.error}
+                  onClick={() => {
+                    onClearRecent();
+                    close();
+                  }}
+                />
+              </>
+            )}
+          />
+        ) : null}
+
+        {/* Grade → the range rail overlay. Action chip, no menu. */}
+        <ActionChip label={gradeLabel} selected={gradeActive} colors={chipColors} onPress={onOpenGrade} />
+
+        {/* Show ▾ — hide-sent (auth-gated) + benchmarks. The controlled menu stays
+            OPEN while toggling (these items don't call close()). */}
+        <MenuChip
+          label={t('mobile.search.chips.show')}
+          selected={hideCompleted || onlyBenchmarks}
+          colors={chipColors}
+          renderItems={() => (
+            <>
+              {canHideCompleted ? (
+                <MenuItem
+                  label={t('mobile.filter.hideSent')}
+                  checked={hideCompleted}
+                  onClick={() => onToggleHideCompleted(!hideCompleted)}
+                />
+              ) : null}
+              <MenuItem
+                label={t('mobile.filter.benchmark')}
+                checked={onlyBenchmarks}
+                onClick={() => onToggleBenchmarks(!onlyBenchmarks)}
+              />
+            </>
+          )}
+        />
+
+        {/* Tall / Wide — board-shape chips for the current Kilter homewall size
+            (empty otherwise). Tap toggles; long-press opens lock/unlock. */}
+        {dimensionChips.map((dimension) => (
+          <DimensionChipView
+            key={dimension.key}
+            dimension={dimension}
+            label={dimension.key === 'tall' ? t('mobile.search.chips.tall') : t('mobile.search.chips.wide')}
+            colors={chipColors}
+            lockLabel={t('mobile.search.chips.lock')}
+            unlockLabel={t('mobile.search.chips.unlock')}
+          />
+        ))}
+
+        {/* Popularity ▾ — single-choice min-ascents buckets. */}
+        <MenuChip
+          label={hasActivePopularity ? popularityChipLabel(minAscents, t) : t('mobile.filter.popularity')}
+          selected={hasActivePopularity}
+          colors={chipColors}
+          renderItems={(close) => (
+            <>
+              {POPULARITY_BUCKETS.map((bucket) => (
+                <MenuItem
+                  key={bucket ?? 'any'}
+                  label={popularityChipLabel(bucket, t)}
+                  checked={bucket === minAscents}
+                  onClick={() => {
+                    onChangePopularity(bucket);
+                    close();
+                  }}
+                />
+              ))}
+            </>
+          )}
+        />
+
+        {/* Min rating ▾ — single-choice star buckets. */}
+        <MenuChip
+          label={hasActiveRating ? ratingChipLabel(minRating, t) : t('mobile.filter.minRating')}
+          selected={hasActiveRating}
+          colors={chipColors}
+          renderItems={(close) => (
+            <>
+              {RATING_BUCKETS.map((bucket) => (
+                <MenuItem
+                  key={bucket ?? 'any'}
+                  label={ratingChipLabel(bucket, t)}
+                  checked={bucket === minRating}
+                  onClick={() => {
+                    onChangeRating(bucket);
+                    close();
+                  }}
+                />
+              ))}
+            </>
+          )}
+        />
+      </Row>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    width: '100%',
+  },
+});
+
+export const FilterChipRow = memo(FilterChipRowComponent);

--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -1,9 +1,8 @@
 // Persistent, glanceable filter chips under the climbs title (the GitHub-PR-view
 // idiom), built from native @expo/ui SwiftUI controls so the menus are real iOS
-// menus rather than RN re-creations. iOS (Liquid Glass) only — the Material
-// variant lives in ClimbTopChrome's Appbar path, and the Android counterpart is
-// FilterChipRow.android.tsx. Mounted on Liquid Glass by the caller; never on
-// search focus.
+// menus rather than RN re-creations. This is the iOS (Liquid Glass) tree; the
+// Android counterpart is FilterChipRow.android.tsx (native Jetpack Compose, the
+// Material default — see its header). Mounted by the caller; never on search focus.
 //
 // The always-visible facet chips follow the filter sheet's data-driven PRIMARY
 // importance order (the sheet's own comment: "the levers the analytics say carry
@@ -28,7 +27,6 @@ import { StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Host, HStack, ScrollView, Menu, Picker, Toggle, Button, Text, Divider } from '@expo/ui/swift-ui';
 import { buttonStyle, controlSize, tint, tag, padding, menuActionDismissBehavior } from '@expo/ui/swift-ui/modifiers';
-import { formatMinAscentsFilterCount } from '@boardsesh/climb-filters';
 import { getFilterKey } from '../../lib/recent-filter-store';
 import {
   POPULARITY_BUCKETS,
@@ -40,6 +38,7 @@ import {
 } from '../../lib/filter-chip-menus';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
+import { popularityChipLabel, ratingChipLabel } from './FilterChipRow.logic';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
 function FilterChipRowComponent({
@@ -67,22 +66,8 @@ function FilterChipRowComponent({
   const { t } = useTranslation('climbs');
   const { brandColors } = useTheme();
 
-  const popularityLabel = useCallback(
-    (bucket: number | undefined): string => {
-      if (bucket == null) return t('mobile.filter.anyAscents');
-      if (bucket === 2) return t('mobile.filter.established2plus');
-      return `${formatMinAscentsFilterCount(bucket)}+`;
-    },
-    [t],
-  );
-
-  // Picker option labels for the rating chip: "Any" / "N+ ⭐" (the exact wording
-  // the rating token uses, so chip, token, and sheet never diverge).
-  const ratingOptionLabel = useCallback(
-    (bucket: number | undefined): string =>
-      bucket == null ? t('mobile.filter.anyRating') : t('mobile.search.rating', { count: bucket }),
-    [t],
-  );
+  // Popularity / rating chip wording lives in FilterChipRow.logic (shared with the
+  // Android tree) so a filter is never worded two ways across platforms.
 
   // Real iOS 26 Liquid Glass: an inactive chip is a neutral glass capsule
   // (`buttonStyle('glass')`); an active facet is a brand-tinted prominent glass
@@ -182,7 +167,7 @@ function FilterChipRowComponent({
           {/* Popularity ▾ — min-ascents buckets; conflict-clear handled upstream.
               [PRIMARY #4] */}
           <Menu
-            label={hasActivePopularity ? popularityLabel(minAscents) : t('mobile.filter.popularity')}
+            label={hasActivePopularity ? popularityChipLabel(minAscents, t) : t('mobile.filter.popularity')}
             modifiers={chipModifiers(hasActivePopularity)}
           >
             <Picker
@@ -197,7 +182,7 @@ function FilterChipRowComponent({
             >
               {POPULARITY_BUCKETS.map((bucket) => (
                 <Text key={popularityTag(bucket)} modifiers={[tag(popularityTag(bucket))]}>
-                  {popularityLabel(bucket)}
+                  {popularityChipLabel(bucket, t)}
                 </Text>
               ))}
             </Picker>
@@ -218,7 +203,7 @@ function FilterChipRowComponent({
             >
               {RATING_BUCKETS.map((bucket) => (
                 <Text key={ratingTag(bucket)} modifiers={[tag(ratingTag(bucket))]}>
-                  {ratingOptionLabel(bucket)}
+                  {ratingChipLabel(bucket, t)}
                 </Text>
               ))}
             </Picker>

--- a/packages/mobile/src/components/search/FilterChipRow.logic.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.logic.ts
@@ -1,0 +1,33 @@
+// Pure label builders for the persistent filter-chip row, shared by both
+// implementations (FilterChipRow.ios.tsx SwiftUI menus, FilterChipRow.android.tsx
+// Jetpack Compose dropdowns). The chip wording is sourced once here so the two
+// platforms can't word the same filter differently, and so the popularity/rating
+// bucket → label mapping stays unit-testable without a native host (the
+// FilterChipRow vite alias swaps the COMPONENT for a null stub under Vitest, but
+// this `.logic` module is not aliased, so its functions run for real).
+//
+// The native JSX lives in the platform files; only the `t(...)`-bound wording lives
+// here. Keep using the shared POPULARITY_BUCKETS / RATING_BUCKETS from
+// `filter-chip-menus.ts` at the call sites so the chip and the sheet never diverge.
+
+import type { TFunction } from 'i18next';
+import { formatMinAscentsFilterCount } from '@boardsesh/climb-filters';
+
+/**
+ * Label for a popularity (min-ascents) bucket: "Any ascents" for the undefined
+ * bucket, "Established (2+)" for 2, otherwise "<count>+" (e.g. "10+", "1k+").
+ * Matches the filter sheet's wording so chip, token, and sheet never diverge.
+ */
+export function popularityChipLabel(bucket: number | undefined, t: TFunction<'climbs'>): string {
+  if (bucket == null) return t('mobile.filter.anyAscents');
+  if (bucket === 2) return t('mobile.filter.established2plus');
+  return `${formatMinAscentsFilterCount(bucket)}+`;
+}
+
+/**
+ * Label for a min-rating star bucket: "Any rating" for the undefined bucket,
+ * otherwise the localised "N+ ⭐" wording the rating token already uses.
+ */
+export function ratingChipLabel(bucket: number | undefined, t: TFunction<'climbs'>): string {
+  return bucket == null ? t('mobile.filter.anyRating') : t('mobile.search.rating', { count: bucket });
+}

--- a/packages/mobile/src/components/search/FilterChipRow.types.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.types.ts
@@ -1,8 +1,9 @@
 // Shared props for the persistent filter-chip row. The implementation is
 // platform-split: FilterChipRow.ios.tsx renders native @expo/ui SwiftUI menus,
-// FilterChipRow.android.tsx is a placeholder (the Material chip row lands with
-// the jetpack-compose follow-up). The split keeps @expo/ui/swift-ui — whose
-// components resolve native views at module load — off the Android bundle path.
+// FilterChipRow.android.tsx renders native @expo/ui Jetpack Compose FilterChips +
+// DropdownMenus. The split keeps each platform's @expo/ui import (swift-ui /
+// jetpack-compose) — whose components resolve native views at module load — off the
+// other platform's bundle path.
 
 import type { RecentFilter } from '../../lib/recent-filter-store';
 import type { ClimbFilters } from '../ClimbFilterSheet';

--- a/packages/mobile/src/components/search/__tests__/FilterChipRow.logic.test.ts
+++ b/packages/mobile/src/components/search/__tests__/FilterChipRow.logic.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { popularityChipLabel, ratingChipLabel } from '../FilterChipRow.logic';
+import { POPULARITY_BUCKETS, RATING_BUCKETS } from '../../../lib/filter-chip-menus';
+
+// Mirrors filter-labels.test.ts: the mock t returns the key (with interpolated
+// placeholders for readable assertions) for parametric keys, else the key itself.
+const text = (value: unknown) => (typeof value === 'string' || typeof value === 'number' ? String(value) : '');
+
+const mockT = ((key: string, opts?: Record<string, unknown>) => {
+  if (key === 'mobile.search.rating') return `${text(opts?.count)}+ ⭐`;
+  return key;
+}) as unknown as TFunction<'climbs'>;
+
+describe('popularityChipLabel', () => {
+  it('uses mobile.filter.anyAscents for the undefined bucket', () => {
+    expect(popularityChipLabel(undefined, mockT)).toBe('mobile.filter.anyAscents');
+  });
+
+  it('uses mobile.filter.established2plus for the 2 bucket (not "2+")', () => {
+    expect(popularityChipLabel(2, mockT)).toBe('mobile.filter.established2plus');
+  });
+
+  it('formats other buckets as "<count>+" via formatMinAscentsFilterCount', () => {
+    expect(popularityChipLabel(10, mockT)).toBe('10+');
+    expect(popularityChipLabel(100, mockT)).toBe('100+');
+    expect(popularityChipLabel(1000, mockT)).toBe('1k+');
+  });
+
+  it('produces a non-empty label for every shared POPULARITY_BUCKET', () => {
+    for (const bucket of POPULARITY_BUCKETS) {
+      expect(popularityChipLabel(bucket, mockT).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('ratingChipLabel', () => {
+  it('uses mobile.filter.anyRating for the undefined bucket', () => {
+    expect(ratingChipLabel(undefined, mockT)).toBe('mobile.filter.anyRating');
+  });
+
+  it('uses the localised star wording with count for a rating bucket', () => {
+    expect(ratingChipLabel(3, mockT)).toBe('3+ ⭐');
+  });
+
+  it('produces a non-empty label for every shared RATING_BUCKET', () => {
+    for (const bucket of RATING_BUCKETS) {
+      expect(ratingChipLabel(bucket, mockT).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -42,6 +42,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
     label: 'Kilter account linking',
     description: 'Show the Kilter username/password sign-in card in Integrations.',
   },
+  {
+    key: 'android-filter-chips',
+    label: 'Android filter chips',
+    description:
+      'Kill-switch (ON by default) for the persistent Material filter-chip row on the climbs screen. Turn OFF to revert to the top-toolbar filters (grade control + filter button + summary).',
+  },
 ] as const satisfies readonly FeatureFlagDefinition[];
 
 // The literal key union (e.g. `'strava-integration'`), preserved via the

--- a/packages/mobile/src/theme/expo-ui-modifiers.ts
+++ b/packages/mobile/src/theme/expo-ui-modifiers.ts
@@ -116,3 +116,27 @@ export function textFieldBrandColors(brandColors: BrandControlColors): {
     cursorColor: brandAccentColor(brandColors),
   };
 }
+
+/**
+ * Plain Compose `FilterChipColors` bridging the brand fill for a native Android
+ * Material 3 `FilterChip` — only the SELECTED (active facet) state is branded: the
+ * container takes the brand fill and the label + leading icon take the on-fill
+ * colour. Every unselected state reads the Compose Material theme. This is the
+ * Compose equivalent of the iOS chip's `glassProminent` + `tint(brandColors.primary)`
+ * active style. Returned as a minimal object — every `FilterChipColors` field is
+ * optional — so this shared file needs no `@expo/ui/jetpack-compose` import; the
+ * `.android.tsx` file passes it straight to each chip's `colors` prop. All branded
+ * fields read `brandAccentColor` / `onPrimary` so they can't drift from the other
+ * primitives.
+ */
+export function filterChipBrandColors(brandColors: BrandControlColors): {
+  selectedContainerColor: string;
+  selectedLabelColor: string;
+  selectedLeadingIconColor: string;
+} {
+  return {
+    selectedContainerColor: brandAccentColor(brandColors),
+    selectedLabelColor: brandColors.onPrimary,
+    selectedLeadingIconColor: brandColors.onPrimary,
+  };
+}


### PR DESCRIPTION
## Summary

Builds the native **Android** counterpart to the iOS filter-chip row and makes it the default Material filtering surface. `FilterChipRow.android.tsx` was a `return null` placeholder, so Android filters lived buried in the top app bar (filter button + condensed summary + grade control). This replaces it with real Jetpack Compose Material 3 `FilterChip`s + `DropdownMenu`s via `@expo/ui`, mirroring `FilterChipRow.ios.tsx` one-for-one (chip set, order, labels, behaviour): Filters · N, Recent, Grade, Show, Tall/Wide, Popularity, Min rating.

A horizontally-scrollable filter-chip row under the title is the canonical M3 pattern for frequent in-place list filtering (Play Store / Photos / Files), and climbs-screen usage is filter-heavy (~45%, grade-dominated) — so the chips are a better fit than a buried toolbar button.

**Gating:** the chip row is the Android default behind an `android-filter-chips` **kill-switch** feature flag (ON by default; flip it OFF in More → Feature Flags to revert to the toolbar filters). It gates on the **variant feature** (not `Platform.OS`) and deliberately does **not** flip `filtersInTopChrome`, so Material's FAB-vs-toolbar + summary coupling is untouched. When the chips are on, `ClimbTopChrome` suppresses the grade control + filter button + condensed summary; the app-bar search field, angle chip, and the in-chrome grade rail stay.

iOS is behaviourally unchanged — only the shared label helpers were extracted.

**Compose specifics (no SwiftUI equivalents):**
- Each menu chip is its own controlled-`DropdownMenu` sub-component (`expanded` state), following `MoreForm.android.tsx`'s `SelectRow`.
- The **Show** menu stays open while toggling by simply not closing the controlled menu (Compose has no `menuActionDismissBehavior`).
- **Tall/Wide** chips reconstruct iOS's tap-toggle + long-press-lock from `combinedClickable` (no `FilterChip.onClick`, to avoid the documented conflict); the shared `useDimensionRepin` keeps a locked filter pinned.
- Popularity/Rating single-choice menus skip the iOS string-tag round-trip — the item `onClick` carries the real `number | undefined` bucket.

Shared popularity/rating wording moved to `FilterChipRow.logic` (unit-tested, used by both platforms); brand fill via `filterChipBrandColors`; 5 white-fill Material XML drawables added (`tune`, `history`, `check`, `lock`, `lock_open`). **JS + asset only → OTA-deliverable, no native rebuild** (`@expo/ui` is already autolinked; XML drawables don't move the fingerprint).

Closes #3269.

## Release Notes

- Android: your climb filters now live in a tappable chip row right under the search bar — change grade, popularity, min rating, and what's shown in a single tap, no digging through a menu.
- Long-press the Tall or Wide chip to pin it so it sticks through clears.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2873 passed (incl. new `FilterChipRow.logic` unit tests)
- `vp run check:mobile-platform-imports` — pass (`@expo/ui/jetpack-compose` only in `*.android.tsx`)
- `vp run check:mobile-bundle` — both iOS + Android bundles export with the new component + 5 XML assets, no resolver errors
- `vp check` — pass (touched files)
- **Android on-device verification (in progress):** chip row renders below search; Filters/Grade open their surfaces; Recent hidden when empty + check on active; Show menu stays open while toggling; Tall/Wide tap-toggle + long-press lock; Popularity/Rating single-select + close; active chips brand-tinted; flag-OFF reverts to the Material toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNe7kMEivkixe11LTYJqkh
