### PR TITLE
feat(mobile): log which search filters get used (#3290)

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -12,9 +12,11 @@ import {
   mergeBoardFilters,
   countActiveFilters,
   hasActiveBoardFilters,
+  describeGradeFilter,
   DEFAULT_CLIMB_FILTER_STATE,
   DEFAULT_CLIMB_BOARD_FILTER_STATE,
   type ClimbBoardFilterState,
+  type GradeTapMeta,
 } from '@boardsesh/climb-filters';
 import {
   KILTER_HOMEWALL_LAYOUT_ID,
@@ -360,6 +362,12 @@ function ClimbListInner() {
   const gradesRef = useRef(gradesData);
   gradesRef.current = gradesData;
   const grades = useMemo(() => gradesData ?? [], [gradesData]);
+  // Ascending difficulty ids — feeds describeGradeFilter so the `Grade Filter
+  // Changed` event reports a range's size the same way web does.
+  const gradeIds = useMemo(
+    () => grades.map((grade) => grade.difficultyId).sort((first, second) => first - second),
+    [grades],
+  );
   const { formatGradeByDifficultyId } = useGradeFormat();
 
   const boardConfig = useMemo(
@@ -564,6 +572,19 @@ function ClimbListInner() {
       // active filter, so the analytics count and the UI never disagree (and a
       // grade-only search reports 1, not 0).
       activeFilterCount: countActiveFilters(filters, boardFilters),
+      // Individual filter dimensions (issue #3290): web sends these so the two
+      // platforms are comparable — "what share set a grade range / changed the
+      // sort?". `0` = unset to match web's sentinel (DEFAULT_SEARCH_PARAMS all
+      // default to 0; difficulty ids start at 10, so 0 is never a real grade),
+      // so a single PostHog query (`minGrade > 0`) works on both platforms.
+      // `setterCount` is the size of the setter filter (0 = none, like web).
+      minGrade: filters.minGrade ?? 0,
+      maxGrade: filters.maxGrade ?? 0,
+      sortBy: filters.sortBy,
+      sortOrder: filters.sortOrder,
+      setterCount: filters.setter?.length ?? 0,
+      minAscents: filters.minAscents ?? 0,
+      minRating: filters.minRating ?? 0,
     });
   }, [firstSearchPage, name, filters, boardFilters, boardName, layoutId, sizeId, setIds, angle]);
 
@@ -686,8 +707,41 @@ function ClimbListInner() {
     [addToQueue],
   );
 
+  // Mirror web's `Grade Filter Changed` payload (snake_case so both platforms
+  // land in one PostHog funnel — issue #3290) and add a mobile-only `source` so
+  // we can split the discoverable chrome rail from the buried filter sheet
+  // (the #3281 discoverability question).
+  const trackGradeFilterChanged = useCallback(
+    (previous: GradeBound, next: GradeBound, source: 'chrome_rail' | 'filter_sheet', meta?: GradeTapMeta) => {
+      const previousShape = describeGradeFilter(previous, gradeIds);
+      const nextShape = describeGradeFilter(next, gradeIds);
+      track(SHARED_EVENTS.GradeFilterChanged, {
+        filter_kind: nextShape.kind,
+        min_grade_id: next.minGradeId ?? null,
+        max_grade_id: next.maxGradeId ?? null,
+        range_size: nextShape.size,
+        previous_filter_kind: previousShape.kind,
+        previous_min_grade_id: previous.minGradeId ?? null,
+        previous_max_grade_id: previous.maxGradeId ?? null,
+        extended_range_within_window: meta?.extendedRangeWithinWindow ?? null,
+        board_name: boardName,
+        source,
+      });
+    },
+    [gradeIds, boardName],
+  );
+
   const handleApplyFilters = useCallback(
     (newFilters: ClimbFilters, newBoardFilters: ClimbBoardFilterState) => {
+      // Fire one grade event if the sheet's Apply actually changed the bound
+      // (the sheet is a draft batch-apply, so no per-tap meta to carry).
+      if (newFilters.minGrade !== filters.minGrade || newFilters.maxGrade !== filters.maxGrade) {
+        trackGradeFilterChanged(
+          { minGradeId: filters.minGrade, maxGradeId: filters.maxGrade },
+          { minGradeId: newFilters.minGrade, maxGradeId: newFilters.maxGrade },
+          'filter_sheet',
+        );
+      }
       setFilters(newFilters);
       setBoardFilters(newBoardFilters);
       setShowFilters(false);
@@ -703,7 +757,16 @@ function ClimbListInner() {
           .catch(() => {});
       }
     },
-    [t, isAuthenticated, name, setFilters, setBoardFilters],
+    [
+      t,
+      isAuthenticated,
+      name,
+      setFilters,
+      setBoardFilters,
+      trackGradeFilterChanged,
+      filters.minGrade,
+      filters.maxGrade,
+    ],
   );
 
   const handleApplyRecentFilter = useCallback(
@@ -741,10 +804,13 @@ function ClimbListInner() {
   }, [replaceSearch, name, filters.minGrade, filters.maxGrade]);
 
   const handleGradeChange = useCallback(
-    (next: GradeBound) => {
+    (next: GradeBound, meta?: GradeTapMeta) => {
+      // Capture the committed bound before setGrade() kicks off the re-render.
+      const previous: GradeBound = { minGradeId: filters.minGrade, maxGradeId: filters.maxGrade };
       setGrade(next);
+      trackGradeFilterChanged(previous, next, 'chrome_rail', meta);
     },
-    [setGrade],
+    [setGrade, trackGradeFilterChanged, filters.minGrade, filters.maxGrade],
   );
 
   // Remember the grade the climber filters by (from any path — the chip rail,

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -14,6 +14,7 @@ import {
   isRangeGrade,
   isSingleGrade,
   type GradeBound,
+  type GradeTapMeta,
 } from '@boardsesh/climb-filters';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { Text } from '../Text';
@@ -88,7 +89,9 @@ type GradeRangeRailProps = {
    * false so an unset rail opens at the easiest grade instead of mid-scrolled.
    */
   centerOnEmpty?: boolean;
-  onChange: (next: GradeBound) => void;
+  // `meta` carries the rule-3 tap context (extendedRangeWithinWindow) so the
+  // call site can feed it into the `Grade Filter Changed` analytics event.
+  onChange: (next: GradeBound, meta?: GradeTapMeta) => void;
   /**
    * Asked to dismiss itself (swipe the handle down, completed range, or cleared
    * selection). Only ever called when `dismissible` is true, so an inline,
@@ -252,7 +255,7 @@ export function GradeRangeRail({
       const withinWindow =
         lastSingleAtRef.current !== undefined && Date.now() - lastSingleAtRef.current < RANGE_EXTEND_WINDOW_MS;
       const result = computeGradeTap(bound, gradeIds, difficultyId, withinWindow);
-      onChange(result.next);
+      onChange(result.next, result.meta);
       lastSingleAtRef.current = isSingleGrade(result.next) ? Date.now() : undefined;
       // The rail auto-closes only when a tap *completes a range* — extending a
       // single grade into a two-ended range. Every other tap keeps it open:

--- a/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
@@ -199,14 +199,17 @@ describe('GradeRangeRail', () => {
     const onChange = vi.fn();
     const { getByText } = renderRail({ minGradeId: 12, maxGradeId: 12 }, onChange);
     fireEvent.click(getByText('V6'));
-    expect(onChange).toHaveBeenCalledWith({ minGradeId: 14, maxGradeId: 14 });
+    // Outside the extend window → switch single grade, with meta flagging that
+    // it was a switch (not an accidental range) so analytics can tell them apart.
+    expect(onChange).toHaveBeenCalledWith({ minGradeId: 14, maxGradeId: 14 }, { extendedRangeWithinWindow: false });
   });
 
   it('builds a range from a fresh single grade tap followed by a second tap', () => {
     const onChange = vi.fn();
     const { getByText, rerender } = renderRail({ minGradeId: undefined, maxGradeId: undefined }, onChange);
     fireEvent.click(getByText('V4'));
-    expect(onChange).toHaveBeenLastCalledWith({ minGradeId: 10, maxGradeId: 10 });
+    // First pick from "Any" is a plain single grade — rule 1 carries no meta.
+    expect(onChange).toHaveBeenLastCalledWith({ minGradeId: 10, maxGradeId: 10 }, undefined);
     rerender(
       <GradeRangeRail
         grades={grades}
@@ -216,7 +219,9 @@ describe('GradeRangeRail', () => {
       />,
     );
     fireEvent.click(getByText('V6'));
-    expect(onChange).toHaveBeenLastCalledWith({ minGradeId: 10, maxGradeId: 14 });
+    // Second tap inside the extend window builds a range — meta flags it so the
+    // `Grade Filter Changed` event can report `extended_range_within_window`.
+    expect(onChange).toHaveBeenLastCalledWith({ minGradeId: 10, maxGradeId: 14 }, { extendedRangeWithinWindow: true });
   });
 
   it('keeps the rail open after a first (single) grade tap', async () => {

--- a/packages/mobile/src/components/search/ClimbTopChrome.tsx
+++ b/packages/mobile/src/components/search/ClimbTopChrome.tsx
@@ -14,7 +14,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { Appbar, Chip } from 'react-native-paper';
 import type { Grade } from '@boardsesh/shared-schema';
-import type { GradeBound } from '@boardsesh/climb-filters';
+import type { GradeBound, GradeTapMeta } from '@boardsesh/climb-filters';
 import { useTheme } from '../../providers/theme-provider';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { selectByVariant } from '../../theme/variants';
@@ -70,7 +70,7 @@ type ClimbTopChromeProps = {
   gradeRailVisible?: boolean;
   gradeChip?: { label: string; active: boolean; onClear?: () => void };
   onOpenGrade?: () => void;
-  onGradeChange?: (grade: GradeBound) => void;
+  onGradeChange?: (grade: GradeBound, meta?: GradeTapMeta) => void;
   /** Persistent native filter-chip row + token row, rendered under the title on
    *  Liquid Glass, independent of search focus; null on the Material path. The
    *  caller composes it so every filter handler and the search-provider state

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -83,6 +83,10 @@ export const SHARED_EVENTS = {
   BleBoardConfigMismatchResolved: 'BLE Board Config Mismatch Resolved',
   // Search
   ClimbSearchPerformed: 'Climb Search Performed',
+  // Grade-range control changed (web's GradeRangePicker / mobile's GradeRangeRail).
+  // Shared so the native event lands in the same PostHog funnel as web's — the
+  // gap #3290 closed: web fired this 10,933× on the legacy webview, native 0×.
+  GradeFilterChanged: 'Grade Filter Changed',
   SearchHoldFilterChanged: 'Search Hold Filter Changed',
   SearchHoldFilterCleared: 'Search Hold Filter Cleared',
   SearchZoneEnabled: 'Search Zone Enabled',

--- a/packages/shared/climb-filters/src/__tests__/grade-range.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/grade-range.test.ts
@@ -8,6 +8,7 @@ import {
   isGradeInRange,
   isGradeEndpoint,
   computeGradeTap,
+  describeGradeFilter,
   type GradeBound,
 } from '../grade-range';
 
@@ -216,5 +217,37 @@ describe('computeGradeTap — rule 6: range outside collapse', () => {
     expect(computeGradeTap(range, gradeIds, 20, true)).toEqual({
       next: { minGradeId: 20, maxGradeId: 20 },
     });
+  });
+});
+
+describe('describeGradeFilter', () => {
+  it('classifies a cleared bound as "any" with null size', () => {
+    expect(describeGradeFilter(any, gradeIds)).toEqual({ kind: 'any', size: null });
+  });
+
+  it('classifies an equal bound as a single grade of size 1', () => {
+    expect(describeGradeFilter({ minGradeId: 14, maxGradeId: 14 }, gradeIds)).toEqual({ kind: 'single', size: 1 });
+  });
+
+  it('classifies a true range and counts the grades it spans inclusively', () => {
+    // 12..18 spans indices 1..4 → 4 grades.
+    expect(describeGradeFilter({ minGradeId: 12, maxGradeId: 18 }, gradeIds)).toEqual({ kind: 'range', size: 4 });
+    // Full span 10..20 → all 6 grades.
+    expect(describeGradeFilter({ minGradeId: 10, maxGradeId: 20 }, gradeIds)).toEqual({ kind: 'range', size: 6 });
+  });
+
+  it('treats a one-sided bound (legacy slider bookmark) as a range with null size', () => {
+    expect(describeGradeFilter({ minGradeId: 12, maxGradeId: undefined }, gradeIds)).toEqual({
+      kind: 'range',
+      size: null,
+    });
+    expect(describeGradeFilter({ minGradeId: undefined, maxGradeId: 18 }, gradeIds)).toEqual({
+      kind: 'range',
+      size: null,
+    });
+  });
+
+  it('returns a null size when a bound id is absent from the grade list', () => {
+    expect(describeGradeFilter({ minGradeId: 11, maxGradeId: 18 }, gradeIds)).toEqual({ kind: 'range', size: null });
   });
 });

--- a/packages/shared/climb-filters/src/grade-range.ts
+++ b/packages/shared/climb-filters/src/grade-range.ts
@@ -35,6 +35,31 @@ export type GradeTapMeta = {
 
 export type GradeTapResult = { next: GradeBound; meta?: GradeTapMeta };
 
+/** The shape of a grade bound, for analytics. */
+export type GradeFilterShape = { kind: 'any' | 'single' | 'range'; size: number | null };
+
+/**
+ * Classify a grade bound for analytics: "any" (cleared), "single" (one grade,
+ * size 1), or "range" (size = count of grades spanned, inclusive). `gradeIds`
+ * MUST be ascending difficulty_ids; ids absent from it (legacy one-sided
+ * bookmarks) fall through to a range with null size. Shared so web and mobile
+ * classify the `Grade Filter Changed` event identically.
+ */
+export function describeGradeFilter(bound: GradeBound, gradeIds: readonly number[]): GradeFilterShape {
+  const { minGradeId, maxGradeId } = bound;
+  if (minGradeId === undefined && maxGradeId === undefined) {
+    return { kind: 'any', size: null };
+  }
+  if (minGradeId !== undefined && maxGradeId !== undefined) {
+    if (minGradeId === maxGradeId) return { kind: 'single', size: 1 };
+    const minIdx = gradeIds.indexOf(minGradeId);
+    const maxIdx = gradeIds.indexOf(maxGradeId);
+    const size = minIdx >= 0 && maxIdx >= 0 ? maxIdx - minIdx + 1 : null;
+    return { kind: 'range', size };
+  }
+  return { kind: 'range', size: null };
+}
+
 /** Both bounds undefined = "Any" (filter cleared). */
 export function isAnyGrade(bound: GradeBound): boolean {
   return bound.minGradeId === undefined && bound.maxGradeId === undefined;

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -80,8 +80,10 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
   const maxGradeForPicker = uiSearchParams.maxGrade > 0 ? uiSearchParams.maxGrade : undefined;
 
   // Ascending difficulty ids — feeds the shared describeGradeFilter so web and
-  // mobile classify the `Grade Filter Changed` event identically.
-  const gradeIds = grades.map((g) => g.difficulty_id);
+  // mobile classify the `Grade Filter Changed` event identically. Sorted
+  // defensively (like mobile) so range_size stays correct even if the source
+  // list ever arrives out of order.
+  const gradeIds = grades.map((g) => g.difficulty_id).sort((first, second) => first - second);
 
   // The filter shape uses `0` as the "no grade" sentinel. `updateFilters` strips
   // `undefined` from updates, so we coerce both bounds to concrete numbers

--- a/packages/web/app/components/search-drawer/accordion-search-form.tsx
+++ b/packages/web/app/components/search-drawer/accordion-search-form.tsx
@@ -26,6 +26,8 @@ import ClimbSearchForm from './climb-search-form';
 import type { BoardDetails } from '@/app/lib/types';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { track } from '@/app/lib/analytics';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { describeGradeFilter } from '@boardsesh/climb-filters';
 import {
   getQualityPanelSummary,
   getStatusPanelSummary,
@@ -77,25 +79,9 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
   const minGradeForPicker = uiSearchParams.minGrade > 0 ? uiSearchParams.minGrade : undefined;
   const maxGradeForPicker = uiSearchParams.maxGrade > 0 ? uiSearchParams.maxGrade : undefined;
 
-  // Describe a (min, max) pair as a filter shape — used to populate both
-  // the current and previous state on the analytics event without duplicating
-  // the branching logic. The chip picker only ever emits both bounds defined
-  // together or both undefined, so only three kinds are produced. Legacy
-  // one-sided URL bookmarks (from the old slider) fall through to `range`
-  // with null size — rare and acceptable for analytics.
-  const describeFilter = (min: number | undefined, max: number | undefined) => {
-    if (min === undefined && max === undefined) {
-      return { kind: 'any' as const, size: null };
-    }
-    if (min !== undefined && max !== undefined) {
-      if (min === max) return { kind: 'single' as const, size: 1 };
-      const minIdx = grades.findIndex((g) => g.difficulty_id === min);
-      const maxIdx = grades.findIndex((g) => g.difficulty_id === max);
-      const size = minIdx >= 0 && maxIdx >= 0 ? maxIdx - minIdx + 1 : null;
-      return { kind: 'range' as const, size };
-    }
-    return { kind: 'range' as const, size: null };
-  };
+  // Ascending difficulty ids — feeds the shared describeGradeFilter so web and
+  // mobile classify the `Grade Filter Changed` event identically.
+  const gradeIds = grades.map((g) => g.difficulty_id);
 
   // The filter shape uses `0` as the "no grade" sentinel. `updateFilters` strips
   // `undefined` from updates, so we coerce both bounds to concrete numbers
@@ -108,12 +94,12 @@ const AccordionSearchForm: React.FC<AccordionSearchFormProps> = ({ boardDetails,
     // state here — updateFilters() below kicks off the re-render that will
     // refresh them. Capture them now so the analytics event carries the
     // before/after for funnel/rage-pattern analysis later.
-    const previous = describeFilter(minGradeForPicker, maxGradeForPicker);
-    const next = describeFilter(minGradeId, maxGradeId);
+    const previous = describeGradeFilter({ minGradeId: minGradeForPicker, maxGradeId: maxGradeForPicker }, gradeIds);
+    const next = describeGradeFilter({ minGradeId, maxGradeId }, gradeIds);
 
     updateFilters({ minGrade: minGradeId ?? 0, maxGrade: maxGradeId ?? 0 });
 
-    track('Grade Filter Changed', {
+    track(SHARED_EVENTS.GradeFilterChanged, {
       filter_kind: next.kind,
       min_grade_id: minGradeId ?? null,
       max_grade_id: maxGradeId ?? null,


### PR DESCRIPTION
## Summary

Closes #3290. Native search was an analytics blind spot — we could see *that* people searched, never *how* they filtered. This is pure instrumentation (no user-facing change) and the precondition for measuring #3281 (mobile grade-filter discoverability).

**1. Enrich the mobile `Climb Search Performed` event** (`packages/mobile/app/(tabs)/climbs/index.tsx`) with the individual filter dimensions: `minGrade`, `maxGrade`, `sortBy`, `sortOrder`, `setterCount`, `minAscents`, `minRating`. Field names + the `0`-means-unset sentinel match web's `Climb Search Performed` (`DEFAULT_SEARCH_PARAMS` all default to 0; difficulty ids start at 10, so 0 is never a real grade), so one PostHog query (`minGrade > 0`) compares both platforms. Previously `minGrade`/`maxGrade` were present on **0 of 6,747** native payloads.

**2. Fire a native `Grade Filter Changed` event** from *both* grade-commit surfaces — the chrome quick grade rail and the full filter sheet's Apply — tagged with a mobile-only `source: 'chrome_rail' | 'filter_sheet'` so we can split discoverable-affordance use from the buried sheet (the core #3281 question). The payload mirrors web's snake_case fields (`filter_kind`, `min_grade_id`, `max_grade_id`, `range_size`, `previous_*`, `extended_range_within_window`, `board_name`), so native lands in the **same** PostHog funnel as web's 10,933 legacy-webview events (native was 0).

**3. Shared plumbing.** Add `SHARED_EVENTS.GradeFilterChanged` and a reusable, tested `describeGradeFilter` helper in `@boardsesh/climb-filters`. Web now uses both (dropping its duplicate local `describeFilter`), guaranteeing the two platforms classify grade shape identically. The mobile grade rail (`GradeRail.tsx`) now threads the rule-3 tap `meta` through `onChange` so `extended_range_within_window` can be reported.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile`, `vp run typecheck:web`, `vp run typecheck:shared` — green.
- `vp check` on all changed files — green.
- `vp test run` — shared `grade-range` tests (incl. new `describeGradeFilter` cases) pass; mobile suite **2866 passed**; web `accordion-search-form-handlers` (22) pass.
- `vp run check:mobile-bundle` — OK.
- Manual (`__DEV__` analytics `onDebug` console): change grade via the chrome rail → `Grade Filter Changed` with `source: 'chrome_rail'`; via the filter sheet + Apply → `source: 'filter_sheet'`; run a filtered search → `Climb Search Performed` carries the new grade/sort/setter fields.
- Post-merge: sanity-check both events land in PostHog (project 412845) with non-null `min_grade_id` + `source` on native, per issue step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL4b6yHWrM4uUg9UMToYGp
