### PR TITLE
fix(mobile): tighten auth field a11y label + submit handling on Android

### DIFF
--- a/packages/mobile/src/components/AuthFieldset.ios.tsx
+++ b/packages/mobile/src/components/AuthFieldset.ios.tsx
@@ -95,6 +95,11 @@ function AuthField({ spec, index, isLast, registerFocus, onAdvance }: AuthFieldP
   // Parity with the old per-field RN error (accessibilityLiveRegion="polite"):
   // the error renders as SwiftUI Text, which can't be a VoiceOver live region, so
   // announce a newly-shown/changed error explicitly.
+  //
+  // Seeding the ref with spec.error means an error already present on first render
+  // is intentionally NOT announced on mount. That's correct for auth flows, where
+  // errors only surface after the user interacts (submit/validation) — never
+  // pre-seeded — so this avoids announcing stale validation as the screen appears.
   const previousErrorRef = useRef(spec.error);
   useEffect(() => {
     if (spec.error && spec.error !== previousErrorRef.current) {

--- a/packages/mobile/src/components/AuthTextInput.android.tsx
+++ b/packages/mobile/src/components/AuthTextInput.android.tsx
@@ -135,18 +135,18 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   // Memoized so the native Host isn't handed a fresh object every render.
   const keyboardActions = useMemo(() => {
     if (!onSubmitEditing) return undefined;
-    const submit = () => onSubmitEditing();
+    // The native handlers pass the field value; onSubmitEditing ignores it.
     switch (keyboardOptions.imeAction) {
       case 'next':
-        return { onNext: submit };
+        return { onNext: onSubmitEditing };
       case 'done':
-        return { onDone: submit };
+        return { onDone: onSubmitEditing };
       case 'go':
-        return { onGo: submit };
+        return { onGo: onSubmitEditing };
       case 'search':
-        return { onSearch: submit };
+        return { onSearch: onSubmitEditing };
       case 'send':
-        return { onSend: submit };
+        return { onSend: onSubmitEditing };
       default:
         return undefined;
     }

--- a/packages/mobile/src/components/AuthTextInput.android.tsx
+++ b/packages/mobile/src/components/AuthTextInput.android.tsx
@@ -64,12 +64,24 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
     autoComplete,
     returnKeyType,
     onSubmitEditing,
+    accessibilityLabel,
     testID,
     showLabel = 'Show password',
     hideLabel = 'Hide password',
   },
   ref,
 ) {
+  // accessibilityLabel is iOS-only: the Compose `semantics` modifier exposes
+  // `contentType` but not `contentDescription`, so Android derives the accessible
+  // name from the visible Material floating label. Warn if a caller passes a
+  // custom value that would silently be lost.
+  if (__DEV__ && accessibilityLabel && accessibilityLabel !== label) {
+    console.warn(
+      `[AuthTextInput] accessibilityLabel ("${accessibilityLabel}") is iOS-only; ` +
+        `Android derives the accessible name from the visible label ("${label}").`,
+    );
+  }
+
   const { brandColors } = useTheme();
   const textState = useNativeState(value);
   const lastEmittedRef = useRef(value);
@@ -114,12 +126,15 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
     returnKeyType,
     secureTextEntry,
   });
-  // Only the action matching keyboardOptions.imeAction fires, so wiring both is safe.
+  // Wire only the handler matching the field's imeAction so a single key press
+  // can't double-fire onSubmitEditing if the Compose bridge ever delivers both.
   // Memoized so the native Host isn't handed a fresh object every render.
-  const keyboardActions = useMemo(
-    () => (onSubmitEditing ? { onNext: () => onSubmitEditing(), onDone: () => onSubmitEditing() } : undefined),
-    [onSubmitEditing],
-  );
+  const keyboardActions = useMemo(() => {
+    if (!onSubmitEditing) return undefined;
+    return keyboardOptions.imeAction === 'next'
+      ? { onNext: () => onSubmitEditing() }
+      : { onDone: () => onSubmitEditing() };
+  }, [onSubmitEditing, keyboardOptions.imeAction]);
   const contentType = toAndroidContentType(autoComplete);
   const supportingText = error ?? hint;
 

--- a/packages/mobile/src/components/AuthTextInput.android.tsx
+++ b/packages/mobile/src/components/AuthTextInput.android.tsx
@@ -71,23 +71,25 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   },
   ref,
 ) {
-  // accessibilityLabel is iOS-only: the Compose `semantics` modifier exposes
-  // `contentType` but not `contentDescription`, so Android derives the accessible
-  // name from the visible Material floating label. Warn if a caller passes a
-  // custom value that would silently be lost.
-  if (__DEV__ && accessibilityLabel && accessibilityLabel !== label) {
-    console.warn(
-      `[AuthTextInput] accessibilityLabel ("${accessibilityLabel}") is iOS-only; ` +
-        `Android derives the accessible name from the visible label ("${label}").`,
-    );
-  }
-
   const { brandColors } = useTheme();
   const textState = useNativeState(value);
   const lastEmittedRef = useRef(value);
   const fieldRef = useRef<{ focus: () => Promise<void> }>(null);
   const [revealed, setRevealed] = useState(false);
   const masked = computeMasked(secureTextEntry, revealed);
+
+  // accessibilityLabel is iOS-only: the Compose `semantics` modifier exposes
+  // `contentType` but not `contentDescription`, so Android derives the accessible
+  // name from the visible Material floating label. Warn (once per label change,
+  // not per render) if a caller passes a custom value that would silently be lost.
+  useEffect(() => {
+    if (__DEV__ && accessibilityLabel && accessibilityLabel !== label) {
+      console.warn(
+        `[AuthTextInput] accessibilityLabel ("${accessibilityLabel}") is iOS-only; ` +
+          `Android derives the accessible name from the visible label ("${label}").`,
+      );
+    }
+  }, [accessibilityLabel, label]);
 
   // Push external value changes (e.g. EditProfile seeding the email once the
   // profile resolves) into the native observable. Our own edits already echo
@@ -126,14 +128,28 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
     returnKeyType,
     secureTextEntry,
   });
-  // Wire only the handler matching the field's imeAction so a single key press
-  // can't double-fire onSubmitEditing if the Compose bridge ever delivers both.
+  // Compose fires exactly the one keyboard action matching the field's imeAction,
+  // so wire only that handler — never several aliased to onSubmitEditing, which
+  // would double-fire if the bridge ever delivered more than one. imeActions with
+  // no submit semantics ('default'/'none'/'previous') wire nothing.
   // Memoized so the native Host isn't handed a fresh object every render.
   const keyboardActions = useMemo(() => {
     if (!onSubmitEditing) return undefined;
-    return keyboardOptions.imeAction === 'next'
-      ? { onNext: () => onSubmitEditing() }
-      : { onDone: () => onSubmitEditing() };
+    const submit = () => onSubmitEditing();
+    switch (keyboardOptions.imeAction) {
+      case 'next':
+        return { onNext: submit };
+      case 'done':
+        return { onDone: submit };
+      case 'go':
+        return { onGo: submit };
+      case 'search':
+        return { onSearch: submit };
+      case 'send':
+        return { onSend: submit };
+      default:
+        return undefined;
+    }
   }, [onSubmitEditing, keyboardOptions.imeAction]);
   const contentType = toAndroidContentType(autoComplete);
   const supportingText = error ?? hint;


### PR DESCRIPTION
## Summary

Addresses code-review feedback on the native `@expo/ui` auth fields (`AuthTextInput` / `AuthFieldset`):

- **`AuthTextInput.android.tsx` — `accessibilityLabel` no longer silently dropped.** The prop exists in the shared `AuthTextInputProps` but the Android component never destructured it. The Compose `semantics` modifier exposes only `contentType` (not `contentDescription`), so Android genuinely derives the accessible name from the visible Material floating label and the prop can't be applied. We now destructure it and `console.warn` in `__DEV__` when a caller passes a custom value that differs from the visible `label`, so a future TalkBack-label caller gets feedback instead of a silent no-op.
- **`AuthTextInput.android.tsx` — `onSubmitEditing` wired to a single keyboard action.** Previously both `onNext` and `onDone` were wired to the same callback, relying on the Compose bridge firing exactly the one matching `imeAction`. Now only the handler matching `keyboardOptions.imeAction` is wired, so a single key press can't double-fire if the bridge ever delivers both.
- **`AuthFieldset.ios.tsx` — comment only.** Documents that seeding `previousErrorRef` with `spec.error` intentionally skips announcing a pre-seeded error on mount, which is correct for auth flows (errors only surface after interaction).

Follow-up tracked against epic #3266: the platform-split components (`AuthTextInput.ios/android`, `AuthFieldset.ios/android`) still have no component-level render tests — only the pure mappers in `AuthTextInput.logic.test.ts` and node-env stubs are exercised, since Vitest can't mount native `@expo/ui` views. Adding native render coverage (error/hint rendering, reveal toggle, focus-chain wiring) is out of scope here.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 2852 tests pass (382 files)
- `vp run check:mobile-bundle` — Android bundle OK (12.7 MB)
- `vp check` — clean for the touched files (the 3 pre-existing format diffs are in `CHANGELOG.md` / docs / `embedded/scripts`, untouched here)
- Reasoned through behavior: omitting `accessibilityLabel` (every current call site) produces no warning and identical behavior; the submit handler fires exactly once for `next`/`done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRDMrGT7gWYQ3ZYxi8dfNX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRDMrGT7gWYQ3ZYxi8dfNX)_