### PR TITLE
feat: let community admins and leaders edit saved boards and gyms

### DIFF
--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialBoardQueries, socialBoardMutations } from '../graphql/resolvers/social/boards';
+import { socialGymQueries, socialGymMutations } from '../graphql/resolvers/social/gyms';
+
+/**
+ * Real-DB coverage for the moderator board/gym editing authorization
+ * (issue: let community admins & leaders fix outdated catalog boards/gyms).
+ *
+ * The board/gym/role records that need fixing are owned by a system/import user,
+ * so the authorization under test is: owner OR community admin/leader scoped to
+ * the board type OR the linked gym's owner/admin may edit; a wrong-board-type
+ * leader and a plain user may not. enrichBoard/enrichGym must surface the same
+ * decision as `canEdit`.
+ *
+ * Mirrors session-feed-board-scope-integration.test.ts: inserts via raw SQL,
+ * calls the resolvers directly against the per-worker test DB.
+ */
+
+const SYS_OWNER = 'bg-auth-sys-owner';
+const GLOBAL_ADMIN = 'bg-auth-global-admin';
+const KILTER_LEADER = 'bg-auth-kilter-leader';
+const MOON_LEADER = 'bg-auth-moon-leader';
+const GLOBAL_LEADER = 'bg-auth-global-leader';
+const PLAIN_USER = 'bg-auth-plain-user';
+const GYM_ADMIN_MEMBER = 'bg-auth-gym-admin';
+const CLIMBER = 'bg-auth-climber';
+
+const ALL_USERS = [SYS_OWNER, GLOBAL_ADMIN, KILTER_LEADER, MOON_LEADER, GLOBAL_LEADER, PLAIN_USER, GYM_ADMIN_MEMBER];
+
+const authCtx = (userId: string): ConnectionContext =>
+  ({ connectionId: `conn-${userId}`, isAuthenticated: true, userId }) as ConnectionContext;
+
+const anonCtx = (): ConnectionContext => ({ connectionId: 'conn-anon', isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertRole = (userId: string, role: string, boardType: string | null) =>
+  db.execute(sql`
+    INSERT INTO community_roles (user_id, role, board_type, created_at)
+    VALUES (${userId}, ${role}, ${boardType}, now())
+  `);
+
+const insertGym = async (uuid: string, ownerId: string, name: string): Promise<number> => {
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, true, now(), now())
+    RETURNING id
+  `);
+  return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
+};
+
+const insertBoard = async (opts: {
+  uuid: string;
+  ownerId: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  gymId?: number | null;
+  boardType?: string;
+  name?: string;
+}): Promise<number> => {
+  const { uuid, ownerId, layoutId, sizeId, setIds, gymId = null, boardType = 'kilter', name = 'Board' } = opts;
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, gym_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${ownerId}, ${boardType}, ${layoutId}, ${sizeId}, ${setIds}, ${name}, ${gymId}, true, now(), now())
+    RETURNING id
+  `);
+  return Number(Array.from(result as Iterable<{ id: number }>)[0].id);
+};
+
+const insertTick = (uuid: string, boardId: number, status: 'send' | 'flash' | 'attempt') =>
+  db.execute(sql`
+    INSERT INTO boardsesh_ticks
+      (uuid, user_id, board_type, board_id, climb_uuid, angle, status, attempt_count, difficulty, climbed_at)
+    VALUES (${uuid}, ${CLIMBER}, 'kilter', ${boardId}, 'bg-auth-climb', 40, ${status}, 1, 20, now())
+  `);
+
+type TickRow = {
+  uuid: string;
+  board_id: number;
+  status: string;
+  climb_uuid: string;
+  angle: number;
+  difficulty: number | null;
+};
+
+const ticksForBoard = async (boardId: number): Promise<TickRow[]> => {
+  const result = await db.execute(sql`
+    SELECT uuid, board_id, status, climb_uuid, angle, difficulty
+    FROM boardsesh_ticks
+    WHERE board_id = ${boardId}
+    ORDER BY uuid
+  `);
+  return Array.from(result as Iterable<TickRow>).map((row) => ({
+    uuid: row.uuid,
+    board_id: Number(row.board_id),
+    status: row.status,
+    climb_uuid: row.climb_uuid,
+    angle: Number(row.angle),
+    difficulty: row.difficulty == null ? null : Number(row.difficulty),
+  }));
+};
+
+const boardConfig = async (uuid: string) => {
+  const result = await db.execute(sql`
+    SELECT layout_id, size_id, set_ids, name FROM user_boards WHERE uuid = ${uuid}
+  `);
+  const row = Array.from(result as Iterable<{ layout_id: number; size_id: number; set_ids: string; name: string }>)[0];
+  return { layoutId: Number(row.layout_id), sizeId: Number(row.size_id), setIds: row.set_ids, name: row.name };
+};
+
+let kilterGymUuid: string;
+let kilterGymId: number;
+let kilterBoardUuid: string;
+let kilterBoardId: number;
+
+beforeEach(async () => {
+  // Reset only the tables this suite owns; CASCADE clears their FK dependents.
+  // `users` is left intact and re-seeded idempotently to avoid a wide cascade.
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "board_follows",
+      "boardsesh_ticks", "user_boards", "gyms"
+    RESTART IDENTITY CASCADE
+  `);
+
+  await Promise.all(ALL_USERS.map(insertUser));
+
+  await Promise.all([
+    insertRole(GLOBAL_ADMIN, 'admin', null),
+    insertRole(KILTER_LEADER, 'community_leader', 'kilter'),
+    insertRole(MOON_LEADER, 'community_leader', 'moonboard'),
+    insertRole(GLOBAL_LEADER, 'community_leader', null),
+  ]);
+
+  kilterGymUuid = uuidv4();
+  kilterGymId = await insertGym(kilterGymUuid, SYS_OWNER, 'Bonsist');
+
+  kilterBoardUuid = uuidv4();
+  kilterBoardId = await insertBoard({
+    uuid: kilterBoardUuid,
+    ownerId: SYS_OWNER,
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    gymId: kilterGymId,
+    name: 'Bonsist Wall',
+  });
+
+  // A gym admin member (not the owner) — exercises the linked-gym edit path.
+  await db.execute(sql`
+    INSERT INTO gym_members (gym_id, user_id, role, created_at)
+    VALUES (${kilterGymId}, ${GYM_ADMIN_MEMBER}, 'admin', now())
+  `);
+});
+
+describe('updateBoard authorization for community moderators', () => {
+  it('lets a global community admin update a board they do not own', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, name: 'Bonsist 2019 Masters' } },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+    expect(result.name).toBe('Bonsist 2019 Masters');
+    expect(result.ownerId).toBe(SYS_OWNER);
+    expect((await boardConfig(kilterBoardUuid)).name).toBe('Bonsist 2019 Masters');
+  });
+
+  it('lets a board-type-scoped community_leader update a board they do not own', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, angle: 40 } },
+      authCtx(KILTER_LEADER),
+    );
+
+    expect(result.angle).toBe(40);
+    expect(result.ownerId).toBe(SYS_OWNER);
+  });
+
+  it('lets the linked gym owner/admin member update the gym board', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, name: 'Gym-admin edit' } },
+      authCtx(GYM_ADMIN_MEMBER),
+    );
+
+    expect(result.name).toBe('Gym-admin edit');
+  });
+
+  it('rejects a community_leader scoped to the WRONG board type', async () => {
+    await expect(
+      socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid: kilterBoardUuid, name: 'should fail' } },
+        authCtx(MOON_LEADER),
+      ),
+    ).rejects.toThrow(/Not authorized to update this board/);
+
+    // The board is untouched.
+    expect((await boardConfig(kilterBoardUuid)).name).toBe('Bonsist Wall');
+  });
+
+  it('allows a GLOBAL community_leader (boardType null) on a kilter board', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, name: 'Global leader edit' } },
+      authCtx(GLOBAL_LEADER),
+    );
+
+    expect(result.name).toBe('Global leader edit');
+  });
+
+  it('rejects a logged-in user with no role and no ownership', async () => {
+    await expect(
+      socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid: kilterBoardUuid, name: 'nope' } },
+        authCtx(PLAIN_USER),
+      ),
+    ).rejects.toThrow(/Not authorized to update this board/);
+
+    expect((await boardConfig(kilterBoardUuid)).name).toBe('Bonsist Wall');
+  });
+});
+
+describe('updateBoard config change with existing ticks', () => {
+  it('changes layout/size/set with ticks present and leaves the tick rows untouched', async () => {
+    await Promise.all([
+      insertTick('bg-auth-tick-1', kilterBoardId, 'send'),
+      insertTick('bg-auth-tick-2', kilterBoardId, 'flash'),
+      insertTick('bg-auth-tick-3', kilterBoardId, 'attempt'),
+    ]);
+
+    const before = await ticksForBoard(kilterBoardId);
+    expect(before).toHaveLength(3);
+
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, layoutId: 2, sizeId: 11, setIds: '3,4' } },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+    // Config reflects the physical reconfiguration.
+    expect(result.layoutId).toBe(2);
+    expect(result.sizeId).toBe(11);
+    expect(result.setIds).toBe('3,4');
+    expect(await boardConfig(kilterBoardUuid)).toMatchObject({ layoutId: 2, sizeId: 11, setIds: '3,4' });
+
+    // Old ticks are preserved verbatim — not deleted, moved, or re-pointed.
+    const after = await ticksForBoard(kilterBoardId);
+    expect(after).toHaveLength(3);
+    expect(after).toEqual(before);
+  });
+});
+
+describe('updateBoard duplicate-config uniqueness keys off the board owner', () => {
+  it('blocks a config change that collides with another board owned by the BOARD OWNER', async () => {
+    // The board's owner (SYS_OWNER) already has a second board with this config.
+    await insertBoard({
+      uuid: uuidv4(),
+      ownerId: SYS_OWNER,
+      layoutId: 2,
+      sizeId: 11,
+      setIds: '3,4',
+      name: 'Owner second board',
+    });
+
+    await expect(
+      socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid: kilterBoardUuid, layoutId: 2, sizeId: 11, setIds: '3,4' } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ).rejects.toThrow(/already have a board with this configuration/);
+  });
+
+  it('does NOT block when only the editing admin owns a board with the target config', async () => {
+    // The admin (caller) owns a board with the target config, but the board's
+    // owner (SYS_OWNER) does not. Keying the check off the owner means the edit
+    // must succeed — a caller-keyed check would have wrongly blocked it.
+    await insertBoard({
+      uuid: uuidv4(),
+      ownerId: GLOBAL_ADMIN,
+      layoutId: 9,
+      sizeId: 9,
+      setIds: '9,9',
+      name: "Admin's own board",
+    });
+
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, layoutId: 9, sizeId: 9, setIds: '9,9' } },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+    expect(result.layoutId).toBe(9);
+    expect(result.sizeId).toBe(9);
+    expect(result.setIds).toBe('9,9');
+  });
+});
+
+describe('updateGym authorization for community moderators', () => {
+  it('lets a global community admin update a gym they do not own', async () => {
+    const result = await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: kilterGymUuid, name: 'Bonsist (fixed)' } },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+    expect(result.name).toBe('Bonsist (fixed)');
+    expect(result.ownerId).toBe(SYS_OWNER);
+  });
+
+  it('lets a board-type-scoped community_leader update a gym whose boards match', async () => {
+    const result = await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: kilterGymUuid, description: 'All holds, no neutral screw-ons' } },
+      authCtx(KILTER_LEADER),
+    );
+
+    expect(result.description).toBe('All holds, no neutral screw-ons');
+  });
+
+  it('lets a GLOBAL community_leader (boardType null) update the gym', async () => {
+    const result = await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: kilterGymUuid, name: 'Global leader gym edit' } },
+      authCtx(GLOBAL_LEADER),
+    );
+
+    expect(result.name).toBe('Global leader gym edit');
+  });
+
+  it('rejects a community_leader scoped to a board type the gym does not have', async () => {
+    await expect(
+      socialGymMutations.updateGym(
+        null,
+        { input: { gymUuid: kilterGymUuid, name: 'should fail' } },
+        authCtx(MOON_LEADER),
+      ),
+    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+  });
+
+  it('rejects a logged-in user with no role and no ownership', async () => {
+    await expect(
+      socialGymMutations.updateGym(null, { input: { gymUuid: kilterGymUuid, name: 'nope' } }, authCtx(PLAIN_USER)),
+    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+  });
+});
+
+describe('enrichBoard canEdit', () => {
+  const canEditBoard = async (ctx: ConnectionContext): Promise<boolean> => {
+    const board = await socialBoardQueries.board(null, { boardUuid: kilterBoardUuid }, ctx);
+    expect(board).not.toBeNull();
+    return board!.canEdit;
+  };
+
+  it('is true for the owner', async () => {
+    expect(await canEditBoard(authCtx(SYS_OWNER))).toBe(true);
+  });
+
+  it('is true for a matching-board-type community_leader and a global admin', async () => {
+    expect(await canEditBoard(authCtx(KILTER_LEADER))).toBe(true);
+    expect(await canEditBoard(authCtx(GLOBAL_ADMIN))).toBe(true);
+  });
+
+  it('is true for the linked gym admin member', async () => {
+    expect(await canEditBoard(authCtx(GYM_ADMIN_MEMBER))).toBe(true);
+  });
+
+  it('is false for a wrong-board-type community_leader', async () => {
+    expect(await canEditBoard(authCtx(MOON_LEADER))).toBe(false);
+  });
+
+  it('is false for a plain logged-in user', async () => {
+    expect(await canEditBoard(authCtx(PLAIN_USER))).toBe(false);
+  });
+
+  it('is false for an anonymous viewer', async () => {
+    expect(await canEditBoard(anonCtx())).toBe(false);
+  });
+});
+
+describe('enrichGym canEdit', () => {
+  const canEditGym = async (ctx: ConnectionContext): Promise<boolean> => {
+    const gym = await socialGymQueries.gym(null, { gymUuid: kilterGymUuid }, ctx);
+    expect(gym).not.toBeNull();
+    return gym!.canEdit;
+  };
+
+  it('is true for the owner', async () => {
+    expect(await canEditGym(authCtx(SYS_OWNER))).toBe(true);
+  });
+
+  it('is true for a matching-board-type community_leader and a global admin', async () => {
+    expect(await canEditGym(authCtx(KILTER_LEADER))).toBe(true);
+    expect(await canEditGym(authCtx(GLOBAL_ADMIN))).toBe(true);
+  });
+
+  it('is true for a gym admin member', async () => {
+    expect(await canEditGym(authCtx(GYM_ADMIN_MEMBER))).toBe(true);
+  });
+
+  it('is false for a wrong-board-type community_leader', async () => {
+    expect(await canEditGym(authCtx(MOON_LEADER))).toBe(false);
+  });
+
+  it('is false for a plain logged-in user', async () => {
+    expect(await canEditGym(authCtx(PLAIN_USER))).toBe(false);
+  });
+
+  it('is false for an anonymous viewer', async () => {
+    expect(await canEditGym(anonCtx())).toBe(false);
+  });
+});

--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -349,13 +349,13 @@ describe('updateGym authorization for community moderators', () => {
         { input: { gymUuid: kilterGymUuid, name: 'should fail' } },
         authCtx(MOON_LEADER),
       ),
-    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+    ).rejects.toThrow(/Not authorized to edit this gym/);
   });
 
   it('rejects a logged-in user with no role and no ownership', async () => {
     await expect(
       socialGymMutations.updateGym(null, { input: { gymUuid: kilterGymUuid, name: 'nope' } }, authCtx(PLAIN_USER)),
-    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+    ).rejects.toThrow(/Not authorized to edit this gym/);
   });
 });
 
@@ -422,5 +422,86 @@ describe('enrichGym canEdit', () => {
 
   it('is false for an anonymous viewer', async () => {
     expect(await canEditGym(anonCtx())).toBe(false);
+  });
+});
+
+describe('updateGym for a gym admin member', () => {
+  it('lets a gym admin member (not owner, no community role) update the gym', async () => {
+    const result = await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: kilterGymUuid, name: 'Gym-admin gym edit' } },
+      authCtx(GYM_ADMIN_MEMBER),
+    );
+
+    expect(result.name).toBe('Gym-admin gym edit');
+  });
+});
+
+describe('gym membership management excludes community moderators (escalation guard)', () => {
+  // editing a gym's details (updateGym) is open to community moderators, but
+  // membership management (addGymMember/removeGymMember/linkBoardToGym) must NOT
+  // be — otherwise a board-type-scoped role could self-promote to a persistent
+  // gym admin that outlives the community role, or evict real gym admins.
+  const gymMemberRole = async (userId: string): Promise<string | null> => {
+    const result = await db.execute(sql`
+      SELECT role FROM gym_members WHERE gym_id = ${kilterGymId} AND user_id = ${userId} LIMIT 1
+    `);
+    const row = Array.from(result as Iterable<{ role: string }>)[0];
+    return row ? row.role : null;
+  };
+
+  it('rejects a community admin/leader adding a gym member (no self-promotion to gym admin)', async () => {
+    await expect(
+      socialGymMutations.addGymMember(
+        null,
+        { input: { gymUuid: kilterGymUuid, userId: GLOBAL_ADMIN, role: 'admin' } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+
+    await expect(
+      socialGymMutations.addGymMember(
+        null,
+        { input: { gymUuid: kilterGymUuid, userId: KILTER_LEADER, role: 'admin' } },
+        authCtx(KILTER_LEADER),
+      ),
+    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+
+    // Neither moderator gained a persistent gym_members row.
+    expect(await gymMemberRole(GLOBAL_ADMIN)).toBeNull();
+    expect(await gymMemberRole(KILTER_LEADER)).toBeNull();
+  });
+
+  it('rejects a community moderator removing an existing gym admin', async () => {
+    await expect(
+      socialGymMutations.removeGymMember(
+        null,
+        { input: { gymUuid: kilterGymUuid, userId: GYM_ADMIN_MEMBER } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
+
+    // The gym admin member is still there.
+    expect(await gymMemberRole(GYM_ADMIN_MEMBER)).toBe('admin');
+  });
+
+  it('still lets the gym owner and a gym admin member manage membership', async () => {
+    await expect(
+      socialGymMutations.addGymMember(
+        null,
+        { input: { gymUuid: kilterGymUuid, userId: PLAIN_USER, role: 'member' } },
+        authCtx(SYS_OWNER),
+      ),
+    ).resolves.toBe(true);
+    expect(await gymMemberRole(PLAIN_USER)).toBe('member');
+
+    await expect(
+      socialGymMutations.removeGymMember(
+        null,
+        { input: { gymUuid: kilterGymUuid, userId: PLAIN_USER } },
+        authCtx(GYM_ADMIN_MEMBER),
+      ),
+    ).resolves.toBe(true);
+    expect(await gymMemberRole(PLAIN_USER)).toBeNull();
   });
 });

--- a/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
+++ b/packages/backend/src/__tests__/board-gym-edit-authorization.test.ts
@@ -282,7 +282,7 @@ describe('updateBoard duplicate-config uniqueness keys off the board owner', () 
         { input: { boardUuid: kilterBoardUuid, layoutId: 2, sizeId: 11, setIds: '3,4' } },
         authCtx(GLOBAL_ADMIN),
       ),
-    ).rejects.toThrow(/already have a board with this configuration/);
+    ).rejects.toThrow(/already has a board with this configuration/);
   });
 
   it('does NOT block when only the editing admin owns a board with the target config', async () => {
@@ -503,5 +503,155 @@ describe('gym membership management excludes community moderators (escalation gu
       ),
     ).resolves.toBe(true);
     expect(await gymMemberRole(PLAIN_USER)).toBeNull();
+  });
+});
+
+describe('community roles reach public/catalog boards only, not private ones', () => {
+  let privateBoardUuid: string;
+
+  beforeEach(async () => {
+    // A stranger's PRIVATE kilter board (owner PLAIN_USER, no linked gym).
+    privateBoardUuid = uuidv4();
+    await db.execute(sql`
+      INSERT INTO user_boards
+        (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+      VALUES (${privateBoardUuid}, ${privateBoardUuid}, ${PLAIN_USER}, 'kilter', 5, 5, '5,6', 'Private wall', false, now(), now())
+    `);
+  });
+
+  it("rejects a community leader/admin editing a stranger's private board", async () => {
+    await expect(
+      socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid: privateBoardUuid, name: 'nope' } },
+        authCtx(KILTER_LEADER),
+      ),
+    ).rejects.toThrow(/Not authorized to update this board/);
+    await expect(
+      socialBoardMutations.updateBoard(
+        null,
+        { input: { boardUuid: privateBoardUuid, name: 'nope' } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ).rejects.toThrow(/Not authorized to update this board/);
+  });
+
+  it('reports canEdit=false for a community role on a private board', async () => {
+    const board = await socialBoardQueries.board(null, { boardUuid: privateBoardUuid }, authCtx(KILTER_LEADER));
+    expect(board?.canEdit).toBe(false);
+  });
+
+  it("still lets the private board's owner edit it", async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: privateBoardUuid, name: 'Owner rename' } },
+      authCtx(PLAIN_USER),
+    );
+    expect(result.name).toBe('Owner rename');
+  });
+});
+
+describe('updateBoard on soft-deleted boards', () => {
+  const boardDeletedAt = async (uuid: string): Promise<Date | null> => {
+    const result = await db.execute(sql`SELECT deleted_at FROM user_boards WHERE uuid = ${uuid}`);
+    const row = Array.from(result as Iterable<{ deleted_at: Date | null }>)[0];
+    return row?.deleted_at ?? null;
+  };
+
+  beforeEach(async () => {
+    await db.execute(sql`UPDATE user_boards SET deleted_at = now() WHERE uuid = ${kilterBoardUuid}`);
+  });
+
+  it('rejects moderators/gym admins resurrecting a board the owner removed', async () => {
+    for (const actor of [GLOBAL_ADMIN, KILTER_LEADER, GYM_ADMIN_MEMBER]) {
+      await expect(
+        socialBoardMutations.updateBoard(
+          null,
+          { input: { boardUuid: kilterBoardUuid, name: 'resurrect' } },
+          authCtx(actor),
+        ),
+      ).rejects.toThrow(/Board not found/);
+    }
+    expect(await boardDeletedAt(kilterBoardUuid)).not.toBeNull();
+  });
+
+  it('still lets the owner restore their board by editing it', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: kilterBoardUuid, name: 'Restored' } },
+      authCtx(SYS_OWNER),
+    );
+    expect(result.name).toBe('Restored');
+    expect(await boardDeletedAt(kilterBoardUuid)).toBeNull();
+  });
+});
+
+describe('system catalog boards are exempt from the owner-config uniqueness pre-check', () => {
+  // The DB's partial unique index excludes the zero-UUID system owner (many gyms
+  // legitimately share a config), so the resolver must skip its pre-check there —
+  // otherwise a moderator can't fix a catalog board to a config another catalog
+  // board already uses, which is the whole point of this feature.
+  const SYSTEM_OWNER = '00000000-0000-0000-0000-000000000000';
+  let sysBoardAUuid: string;
+
+  beforeEach(async () => {
+    await insertUser(SYSTEM_OWNER);
+    sysBoardAUuid = uuidv4();
+    const sysBoardBUuid = uuidv4();
+    await db.execute(sql`
+      INSERT INTO user_boards
+        (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+      VALUES
+        (${sysBoardAUuid}, ${sysBoardAUuid}, ${SYSTEM_OWNER}, 'kilter', 1, 10, '1,2', 'Catalog A', true, now(), now()),
+        (${sysBoardBUuid}, ${sysBoardBUuid}, ${SYSTEM_OWNER}, 'kilter', 2, 11, '3,4', 'Catalog B', true, now(), now())
+    `);
+  });
+
+  it('lets a moderator change a system board to a config another system board already has', async () => {
+    const result = await socialBoardMutations.updateBoard(
+      null,
+      { input: { boardUuid: sysBoardAUuid, layoutId: 2, sizeId: 11, setIds: '3,4' } },
+      authCtx(GLOBAL_ADMIN),
+    );
+    expect(result.layoutId).toBe(2);
+    expect(result.sizeId).toBe(11);
+    expect(result.setIds).toBe('3,4');
+  });
+});
+
+describe('community moderators cannot delete boards/gyms or link boards', () => {
+  const boardIsDeleted = async (uuid: string): Promise<boolean> => {
+    const result = await db.execute(sql`SELECT deleted_at FROM user_boards WHERE uuid = ${uuid}`);
+    const row = Array.from(result as Iterable<{ deleted_at: Date | null }>)[0];
+    return row?.deleted_at != null;
+  };
+
+  it('rejects a moderator deleting a board they do not own (delete stays owner-only)', async () => {
+    await expect(
+      socialBoardMutations.deleteBoard(null, { boardUuid: kilterBoardUuid }, authCtx(GLOBAL_ADMIN)),
+    ).rejects.toThrow();
+    expect(await boardIsDeleted(kilterBoardUuid)).toBe(false);
+  });
+
+  it('rejects a moderator deleting a gym they do not own', async () => {
+    await expect(
+      socialGymMutations.deleteGym(null, { gymUuid: kilterGymUuid }, authCtx(GLOBAL_ADMIN)),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a moderator linking their own board into a gym they do not own/admin', async () => {
+    const adminBoardUuid = uuidv4();
+    await db.execute(sql`
+      INSERT INTO user_boards
+        (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+      VALUES (${adminBoardUuid}, ${adminBoardUuid}, ${GLOBAL_ADMIN}, 'kilter', 3, 3, '7,8', 'Admin board', true, now(), now())
+    `);
+    await expect(
+      socialGymMutations.linkBoardToGym(
+        null,
+        { input: { boardUuid: adminBoardUuid, gymUuid: kilterGymUuid } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ).rejects.toThrow(/Not authorized: must be gym owner or admin/);
   });
 });

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -617,4 +617,51 @@ export const schemaSQL = `
   CREATE UNIQUE INDEX IF NOT EXISTS "board_beta_links_video_identity_unique" ON "board_beta_links" ("video_identity") WHERE "video_identity" IS NOT NULL;
   CREATE UNIQUE INDEX IF NOT EXISTS "board_beta_links_tick_uuid_unique" ON "board_beta_links" ("tick_uuid") WHERE "tick_uuid" IS NOT NULL;
   CREATE INDEX IF NOT EXISTS "board_beta_links_board_id_idx" ON "board_beta_links" ("board_id") WHERE "board_id" IS NOT NULL;
+
+  -- Community moderation roles (admin / community_leader / tester), global or
+  -- board-type-scoped. enrichBoard/enrichGym + requireBoardEditAccess /
+  -- requireGymOwnerOrAdmin read these to authorize moderators editing catalog
+  -- boards/gyms they don't own. role/board_type kept as plain text so the test
+  -- schema doesn't need the production enum types.
+  DROP TABLE IF EXISTS "community_roles" CASCADE;
+  CREATE TABLE IF NOT EXISTS "community_roles" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "role" text NOT NULL,
+    "board_type" text,
+    "granted_by" text REFERENCES "users"("id") ON DELETE SET NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS "community_roles_board_type_idx" ON "community_roles" ("board_type");
+
+  -- Gym membership (owner/admin can manage; admin members can edit the gym +
+  -- its boards). viewerCanAdminGym / requireGymOwnerOrAdmin read this.
+  DROP TABLE IF EXISTS "gym_members" CASCADE;
+  CREATE TABLE IF NOT EXISTS "gym_members" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "gym_id" bigint NOT NULL REFERENCES "gyms"("id") ON DELETE CASCADE,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "role" text NOT NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS "gym_members_unique_gym_user" ON "gym_members" ("gym_id", "user_id");
+
+  DROP TABLE IF EXISTS "gym_follows" CASCADE;
+  CREATE TABLE IF NOT EXISTS "gym_follows" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "gym_id" bigint NOT NULL REFERENCES "gyms"("id") ON DELETE CASCADE,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS "gym_follows_unique_gym_user" ON "gym_follows" ("gym_id", "user_id");
+
+  -- Board followers (enrichBoard counts these per board).
+  DROP TABLE IF EXISTS "board_follows" CASCADE;
+  CREATE TABLE IF NOT EXISTS "board_follows" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "board_uuid" text NOT NULL REFERENCES "user_boards"("uuid") ON DELETE CASCADE,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS "board_follows_unique_user_board" ON "board_follows" ("user_id", "board_uuid");
 `;

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../validation/schemas';
 import { generateUniqueGymSlug } from './gyms';
 import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
+import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
 import { logger } from '../../../utils/logger';
 import { redisClientManager } from '../../../redis/client';
 import { isUniqueViolation } from '../../../utils/postgres-errors';
@@ -142,9 +143,19 @@ async function viewerCanAdminGym(gymId: number, userId: string): Promise<boolean
 }
 
 /**
+ * A community admin/leader's edit reach covers public listings and the seeded
+ * system catalog — the boards this moderation exists to fix. A stranger's
+ * PRIVATE board stays owner-only (and gym-admin-only), so a role can't rewrite
+ * someone's private location/serial or flip their privacy flags.
+ */
+function boardIsRoleEditable(board: { isPublic: boolean; ownerId: string }): boolean {
+  return board.isPublic || board.ownerId === SYSTEM_BOARD_OWNER_ID;
+}
+
+/**
  * Authorize editing a board: the caller must be the board owner, a community
- * admin/leader for the board's type, or the owner/admin of the board's linked
- * gym. Throws when none apply.
+ * admin/leader for the board's type (public/catalog boards only), or the
+ * owner/admin of the board's linked gym. Throws when none apply.
  */
 async function requireBoardEditAccess(
   ctx: ConnectionContext,
@@ -153,7 +164,7 @@ async function requireBoardEditAccess(
   const userId = ctx.userId!;
 
   if (board.ownerId === userId) return;
-  if (await hasAdminOrLeader(userId, board.boardType)) return;
+  if (boardIsRoleEditable(board) && (await hasAdminOrLeader(userId, board.boardType))) return;
   if (board.gymId != null && (await viewerCanAdminGym(board.gymId, userId))) return;
 
   throw new Error('Not authorized to update this board');
@@ -254,7 +265,9 @@ async function enrichBoard(
   const commentStats = commentStatsResult[0];
   const isFollowedByMe = Number(followCheckResult[0]?.count || 0) > 0;
   const gymInfo = (gymInfoResult as Array<{ uuid: string; name: string }>)[0];
-  const canEdit = authenticatedUserId ? board.ownerId === authenticatedUserId || canEditByRole || canEditByGym : false;
+  const canEdit = authenticatedUserId
+    ? board.ownerId === authenticatedUserId || (canEditByRole && boardIsRoleEditable(board)) || canEditByGym
+    : false;
 
   return {
     uuid: board.uuid,
@@ -441,7 +454,7 @@ async function enrichBoards(
     const gym = board.gymId ? gymMap.get(board.gymId) : undefined;
     const canEdit = authenticatedUserId
       ? board.ownerId === authenticatedUserId ||
-        rolesGrantAdminOrLeader(viewerRoles, board.boardType) ||
+        (rolesGrantAdminOrLeader(viewerRoles, board.boardType) && boardIsRoleEditable(board)) ||
         (board.gymId != null && editableGymIds.has(board.gymId))
       : false;
 
@@ -1652,6 +1665,13 @@ export const socialBoardMutations = {
       throw new Error('Board not found');
     }
 
+    // A soft-deleted board is visible only to its owner (who can restore it by
+    // editing). Moderators/gym admins must not resurrect a board the owner
+    // deliberately removed — republishing its name, location, and serial.
+    if (board.deletedAt && board.ownerId !== userId) {
+      throw new Error('Board not found');
+    }
+
     // Owner, community admin/leader (for this board type), or the linked gym's
     // owner/admin may edit. Community moderators can fix outdated catalog boards.
     await requireBoardEditAccess(ctx, board);
@@ -1686,31 +1706,36 @@ export const socialBoardMutations = {
       validatedInput.setIds !== undefined;
 
     if (hasConfigChange) {
-      // Check unique constraint: no other active board with the same config for
-      // the board's OWNER (not the caller — an admin may be editing a board
-      // owned by a system/import user).
-      const newLayoutId = validatedInput.layoutId ?? board.layoutId;
-      const newSizeId = validatedInput.sizeId ?? board.sizeId;
-      const newSetIds = validatedInput.setIds ?? board.setIds;
+      // Check the unique constraint: no other active board with the same config
+      // for the board's OWNER (not the caller — a moderator may be editing a
+      // board owned by a system/import user). The DB's partial unique index
+      // exempts the system catalog owner (many gyms legitimately share a
+      // config), so skip the pre-check there or we'd block the very catalog
+      // fixes this feature exists for.
+      if (board.ownerId !== SYSTEM_BOARD_OWNER_ID) {
+        const newLayoutId = validatedInput.layoutId ?? board.layoutId;
+        const newSizeId = validatedInput.sizeId ?? board.sizeId;
+        const newSetIds = validatedInput.setIds ?? board.setIds;
 
-      const [configConflict] = await db
-        .select({ id: dbSchema.userBoards.id })
-        .from(dbSchema.userBoards)
-        .where(
-          and(
-            eq(dbSchema.userBoards.ownerId, board.ownerId),
-            eq(dbSchema.userBoards.boardType, board.boardType),
-            eq(dbSchema.userBoards.layoutId, newLayoutId),
-            eq(dbSchema.userBoards.sizeId, newSizeId),
-            eq(dbSchema.userBoards.setIds, newSetIds),
-            isNull(dbSchema.userBoards.deletedAt),
-            sql`${dbSchema.userBoards.id} != ${board.id}`,
-          ),
-        )
-        .limit(1);
+        const [configConflict] = await db
+          .select({ id: dbSchema.userBoards.id })
+          .from(dbSchema.userBoards)
+          .where(
+            and(
+              eq(dbSchema.userBoards.ownerId, board.ownerId),
+              eq(dbSchema.userBoards.boardType, board.boardType),
+              eq(dbSchema.userBoards.layoutId, newLayoutId),
+              eq(dbSchema.userBoards.sizeId, newSizeId),
+              eq(dbSchema.userBoards.setIds, newSetIds),
+              isNull(dbSchema.userBoards.deletedAt),
+              sql`${dbSchema.userBoards.id} != ${board.id}`,
+            ),
+          )
+          .limit(1);
 
-      if (configConflict) {
-        throw new Error('You already have a board with this configuration');
+        if (configConflict) {
+          throw new Error("The board's owner already has a board with this configuration");
+        }
       }
 
       if (validatedInput.layoutId !== undefined) updateValues.layoutId = validatedInput.layoutId;

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -21,6 +21,7 @@ import {
   UUIDSchema,
 } from '../../../validation/schemas';
 import { generateUniqueGymSlug } from './gyms';
+import { getUserCommunityRoles, hasAdminOrLeader, rolesGrantAdminOrLeader } from './roles';
 import { logger } from '../../../utils/logger';
 import { redisClientManager } from '../../../redis/client';
 import { isUniqueViolation } from '../../../utils/postgres-errors';
@@ -113,6 +114,52 @@ export async function resolveBoardFromPath(
 }
 
 /**
+ * Whether a user owns or is an admin member of a gym. Used to authorize editing
+ * a board through its linked gym (gym owners/admins may fix the gym's boards).
+ */
+async function viewerCanAdminGym(gymId: number, userId: string): Promise<boolean> {
+  const [ownedGym] = await db
+    .select({ id: dbSchema.gyms.id })
+    .from(dbSchema.gyms)
+    .where(and(eq(dbSchema.gyms.id, gymId), eq(dbSchema.gyms.ownerId, userId), isNull(dbSchema.gyms.deletedAt)))
+    .limit(1);
+
+  if (ownedGym) return true;
+
+  const [adminMembership] = await db
+    .select({ role: dbSchema.gymMembers.role })
+    .from(dbSchema.gymMembers)
+    .where(
+      and(
+        eq(dbSchema.gymMembers.gymId, gymId),
+        eq(dbSchema.gymMembers.userId, userId),
+        eq(dbSchema.gymMembers.role, 'admin'),
+      ),
+    )
+    .limit(1);
+
+  return !!adminMembership;
+}
+
+/**
+ * Authorize editing a board: the caller must be the board owner, a community
+ * admin/leader for the board's type, or the owner/admin of the board's linked
+ * gym. Throws when none apply.
+ */
+async function requireBoardEditAccess(
+  ctx: ConnectionContext,
+  board: typeof dbSchema.userBoards.$inferSelect,
+): Promise<void> {
+  const userId = ctx.userId!;
+
+  if (board.ownerId === userId) return;
+  if (await hasAdminOrLeader(userId, board.boardType)) return;
+  if (board.gymId != null && (await viewerCanAdminGym(board.gymId, userId))) return;
+
+  throw new Error('Not authorized to update this board');
+}
+
+/**
  * Enrich a board row with computed fields (counts, names, follow status).
  */
 async function enrichBoard(
@@ -121,72 +168,85 @@ async function enrichBoard(
   distanceMeters?: number | null,
 ) {
   // Run all independent queries in parallel to avoid N+1 per board
-  const [ownerResult, tickStatsResult, followerStatsResult, commentStatsResult, followCheckResult, gymInfoResult] =
-    await Promise.all([
-      // Get owner profile
-      db
-        .select({
-          name: dbSchema.users.name,
-          image: dbSchema.users.image,
-          displayName: dbSchema.userProfiles.displayName,
-          avatarUrl: dbSchema.userProfiles.avatarUrl,
-        })
-        .from(dbSchema.users)
-        .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
-        .where(eq(dbSchema.users.id, board.ownerId))
-        .limit(1),
+  const [
+    ownerResult,
+    tickStatsResult,
+    followerStatsResult,
+    commentStatsResult,
+    followCheckResult,
+    gymInfoResult,
+    canEditByRole,
+    canEditByGym,
+  ] = await Promise.all([
+    // Get owner profile
+    db
+      .select({
+        name: dbSchema.users.name,
+        image: dbSchema.users.image,
+        displayName: dbSchema.userProfiles.displayName,
+        avatarUrl: dbSchema.userProfiles.avatarUrl,
+      })
+      .from(dbSchema.users)
+      .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
+      .where(eq(dbSchema.users.id, board.ownerId))
+      .limit(1),
 
-      // Count total ascents and unique climbers
-      db
-        .select({
-          totalAscents: count(),
-          uniqueClimbers: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId})`,
-        })
-        .from(dbSchema.boardseshTicks)
-        .where(
-          and(
-            eq(dbSchema.boardseshTicks.boardId, board.id),
-            or(eq(dbSchema.boardseshTicks.status, 'flash'), eq(dbSchema.boardseshTicks.status, 'send')),
-          ),
+    // Count total ascents and unique climbers
+    db
+      .select({
+        totalAscents: count(),
+        uniqueClimbers: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId})`,
+      })
+      .from(dbSchema.boardseshTicks)
+      .where(
+        and(
+          eq(dbSchema.boardseshTicks.boardId, board.id),
+          or(eq(dbSchema.boardseshTicks.status, 'flash'), eq(dbSchema.boardseshTicks.status, 'send')),
         ),
+      ),
 
-      // Count followers
-      db.select({ count: count() }).from(dbSchema.boardFollows).where(eq(dbSchema.boardFollows.boardUuid, board.uuid)),
+    // Count followers
+    db.select({ count: count() }).from(dbSchema.boardFollows).where(eq(dbSchema.boardFollows.boardUuid, board.uuid)),
 
-      // Count comments
-      db
-        .select({ count: count() })
-        .from(dbSchema.comments)
-        .where(
-          and(
-            eq(dbSchema.comments.entityType, 'board'),
-            eq(dbSchema.comments.entityId, board.uuid),
-            isNull(dbSchema.comments.deletedAt),
-          ),
+    // Count comments
+    db
+      .select({ count: count() })
+      .from(dbSchema.comments)
+      .where(
+        and(
+          eq(dbSchema.comments.entityType, 'board'),
+          eq(dbSchema.comments.entityId, board.uuid),
+          isNull(dbSchema.comments.deletedAt),
         ),
+      ),
 
-      // Check if authenticated user follows this board
-      authenticatedUserId
-        ? db
-            .select({ count: count() })
-            .from(dbSchema.boardFollows)
-            .where(
-              and(
-                eq(dbSchema.boardFollows.userId, authenticatedUserId),
-                eq(dbSchema.boardFollows.boardUuid, board.uuid),
-              ),
-            )
-        : Promise.resolve([]),
+    // Check if authenticated user follows this board
+    authenticatedUserId
+      ? db
+          .select({ count: count() })
+          .from(dbSchema.boardFollows)
+          .where(
+            and(eq(dbSchema.boardFollows.userId, authenticatedUserId), eq(dbSchema.boardFollows.boardUuid, board.uuid)),
+          )
+      : Promise.resolve([]),
 
-      // Get gym info if board is linked to a gym
-      board.gymId
-        ? db
-            .select({ uuid: dbSchema.gyms.uuid, name: dbSchema.gyms.name })
-            .from(dbSchema.gyms)
-            .where(and(eq(dbSchema.gyms.id, board.gymId), isNull(dbSchema.gyms.deletedAt)))
-            .limit(1)
-        : Promise.resolve([]),
-    ]);
+    // Get gym info if board is linked to a gym
+    board.gymId
+      ? db
+          .select({ uuid: dbSchema.gyms.uuid, name: dbSchema.gyms.name })
+          .from(dbSchema.gyms)
+          .where(and(eq(dbSchema.gyms.id, board.gymId), isNull(dbSchema.gyms.deletedAt)))
+          .limit(1)
+      : Promise.resolve([]),
+
+    // Whether the viewer is a community admin/leader for this board type
+    authenticatedUserId ? hasAdminOrLeader(authenticatedUserId, board.boardType) : Promise.resolve(false),
+
+    // Whether the viewer owns/admins the board's linked gym
+    authenticatedUserId && board.gymId != null
+      ? viewerCanAdminGym(board.gymId, authenticatedUserId)
+      : Promise.resolve(false),
+  ]);
 
   const ownerInfo = ownerResult[0];
   const tickStats = tickStatsResult[0];
@@ -194,6 +254,7 @@ async function enrichBoard(
   const commentStats = commentStatsResult[0];
   const isFollowedByMe = Number(followCheckResult[0]?.count || 0) > 0;
   const gymInfo = (gymInfoResult as Array<{ uuid: string; name: string }>)[0];
+  const canEdit = authenticatedUserId ? board.ownerId === authenticatedUserId || canEditByRole || canEditByGym : false;
 
   return {
     uuid: board.uuid,
@@ -232,6 +293,7 @@ async function enrichBoard(
     gymName: gymInfo?.name ?? null,
     distanceMeters: distanceMeters ?? null,
     serialNumber: board.serialNumber ?? null,
+    canEdit,
   };
 }
 
@@ -250,83 +312,115 @@ async function enrichBoards(
   const ownerIds = [...new Set(boards.map((b) => b.board.ownerId))];
   const gymIds = [...new Set(boards.map((b) => b.board.gymId).filter((id): id is number => id != null))];
 
-  const [ownerRows, tickRows, followerRows, commentRows, followRows, gymRows] = await Promise.all([
-    // Batch owner profiles
-    db
-      .select({
-        userId: dbSchema.users.id,
-        name: dbSchema.users.name,
-        image: dbSchema.users.image,
-        displayName: dbSchema.userProfiles.displayName,
-        avatarUrl: dbSchema.userProfiles.avatarUrl,
-      })
-      .from(dbSchema.users)
-      .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
-      .where(inArray(dbSchema.users.id, ownerIds)),
+  const [ownerRows, tickRows, followerRows, commentRows, followRows, gymRows, viewerRoles, ownedGymRows, adminGymRows] =
+    await Promise.all([
+      // Batch owner profiles
+      db
+        .select({
+          userId: dbSchema.users.id,
+          name: dbSchema.users.name,
+          image: dbSchema.users.image,
+          displayName: dbSchema.userProfiles.displayName,
+          avatarUrl: dbSchema.userProfiles.avatarUrl,
+        })
+        .from(dbSchema.users)
+        .leftJoin(dbSchema.userProfiles, eq(dbSchema.users.id, dbSchema.userProfiles.userId))
+        .where(inArray(dbSchema.users.id, ownerIds)),
 
-    // Batch tick stats per board
-    db
-      .select({
-        boardId: dbSchema.boardseshTicks.boardId,
-        totalAscents: count(),
-        uniqueClimbers: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId})`,
-      })
-      .from(dbSchema.boardseshTicks)
-      .where(
-        and(
-          inArray(dbSchema.boardseshTicks.boardId, boardIds),
-          or(eq(dbSchema.boardseshTicks.status, 'flash'), eq(dbSchema.boardseshTicks.status, 'send')),
-        ),
-      )
-      .groupBy(dbSchema.boardseshTicks.boardId),
+      // Batch tick stats per board
+      db
+        .select({
+          boardId: dbSchema.boardseshTicks.boardId,
+          totalAscents: count(),
+          uniqueClimbers: sql<number>`COUNT(DISTINCT ${dbSchema.boardseshTicks.userId})`,
+        })
+        .from(dbSchema.boardseshTicks)
+        .where(
+          and(
+            inArray(dbSchema.boardseshTicks.boardId, boardIds),
+            or(eq(dbSchema.boardseshTicks.status, 'flash'), eq(dbSchema.boardseshTicks.status, 'send')),
+          ),
+        )
+        .groupBy(dbSchema.boardseshTicks.boardId),
 
-    // Batch follower counts per board
-    db
-      .select({
-        boardUuid: dbSchema.boardFollows.boardUuid,
-        count: count(),
-      })
-      .from(dbSchema.boardFollows)
-      .where(inArray(dbSchema.boardFollows.boardUuid, boardUuids))
-      .groupBy(dbSchema.boardFollows.boardUuid),
+      // Batch follower counts per board
+      db
+        .select({
+          boardUuid: dbSchema.boardFollows.boardUuid,
+          count: count(),
+        })
+        .from(dbSchema.boardFollows)
+        .where(inArray(dbSchema.boardFollows.boardUuid, boardUuids))
+        .groupBy(dbSchema.boardFollows.boardUuid),
 
-    // Batch comment counts per board
-    db
-      .select({
-        entityId: dbSchema.comments.entityId,
-        count: count(),
-      })
-      .from(dbSchema.comments)
-      .where(
-        and(
-          eq(dbSchema.comments.entityType, 'board'),
-          inArray(dbSchema.comments.entityId, boardUuids),
-          isNull(dbSchema.comments.deletedAt),
-        ),
-      )
-      .groupBy(dbSchema.comments.entityId),
+      // Batch comment counts per board
+      db
+        .select({
+          entityId: dbSchema.comments.entityId,
+          count: count(),
+        })
+        .from(dbSchema.comments)
+        .where(
+          and(
+            eq(dbSchema.comments.entityType, 'board'),
+            inArray(dbSchema.comments.entityId, boardUuids),
+            isNull(dbSchema.comments.deletedAt),
+          ),
+        )
+        .groupBy(dbSchema.comments.entityId),
 
-    // Batch follow status for authenticated user
-    authenticatedUserId
-      ? db
-          .select({ boardUuid: dbSchema.boardFollows.boardUuid })
-          .from(dbSchema.boardFollows)
-          .where(
-            and(
-              eq(dbSchema.boardFollows.userId, authenticatedUserId),
-              inArray(dbSchema.boardFollows.boardUuid, boardUuids),
-            ),
-          )
-      : Promise.resolve([]),
+      // Batch follow status for authenticated user
+      authenticatedUserId
+        ? db
+            .select({ boardUuid: dbSchema.boardFollows.boardUuid })
+            .from(dbSchema.boardFollows)
+            .where(
+              and(
+                eq(dbSchema.boardFollows.userId, authenticatedUserId),
+                inArray(dbSchema.boardFollows.boardUuid, boardUuids),
+              ),
+            )
+        : Promise.resolve([]),
 
-    // Batch gym info
-    gymIds.length > 0
-      ? db
-          .select({ id: dbSchema.gyms.id, uuid: dbSchema.gyms.uuid, name: dbSchema.gyms.name })
-          .from(dbSchema.gyms)
-          .where(and(inArray(dbSchema.gyms.id, gymIds), isNull(dbSchema.gyms.deletedAt)))
-      : Promise.resolve([]),
-  ]);
+      // Batch gym info
+      gymIds.length > 0
+        ? db
+            .select({ id: dbSchema.gyms.id, uuid: dbSchema.gyms.uuid, name: dbSchema.gyms.name })
+            .from(dbSchema.gyms)
+            .where(and(inArray(dbSchema.gyms.id, gymIds), isNull(dbSchema.gyms.deletedAt)))
+        : Promise.resolve([]),
+
+      // Viewer's community roles — fetched once, applied per board by board type
+      authenticatedUserId ? getUserCommunityRoles(authenticatedUserId) : Promise.resolve([]),
+
+      // Gyms (among the referenced ones) the viewer owns — grants edit on their boards
+      authenticatedUserId && gymIds.length > 0
+        ? db
+            .select({ id: dbSchema.gyms.id })
+            .from(dbSchema.gyms)
+            .where(
+              and(
+                inArray(dbSchema.gyms.id, gymIds),
+                eq(dbSchema.gyms.ownerId, authenticatedUserId),
+                isNull(dbSchema.gyms.deletedAt),
+              ),
+            )
+        : Promise.resolve([]),
+
+      // Gyms (among the referenced ones) the viewer is an admin member of
+      authenticatedUserId && gymIds.length > 0
+        ? db
+            .select({ gymId: dbSchema.gymMembers.gymId })
+            .from(dbSchema.gymMembers)
+            .where(
+              and(
+                inArray(dbSchema.gymMembers.gymId, gymIds),
+                eq(dbSchema.gymMembers.userId, authenticatedUserId),
+                eq(dbSchema.gymMembers.role, 'admin'),
+              ),
+            )
+        : Promise.resolve([]),
+    ]);
 
   // Index results for O(1) lookups
   const ownerMap = new Map(ownerRows.map((r) => [r.userId, r]));
@@ -335,11 +429,21 @@ async function enrichBoards(
   const commentMap = new Map(commentRows.map((r) => [r.entityId, Number(r.count)]));
   const followedSet = new Set(followRows.map((r) => r.boardUuid));
   const gymMap = new Map(gymRows.map((r) => [r.id, r]));
+  // Gym ids the viewer can edit boards through (owns the gym OR is an admin member)
+  const editableGymIds = new Set<number>([
+    ...(ownedGymRows as Array<{ id: number }>).map((row) => row.id),
+    ...(adminGymRows as Array<{ gymId: number }>).map((row) => row.gymId),
+  ]);
 
   return boards.map(({ board, distanceMeters }) => {
     const owner = ownerMap.get(board.ownerId);
     const ticks = tickMap.get(board.id);
     const gym = board.gymId ? gymMap.get(board.gymId) : undefined;
+    const canEdit = authenticatedUserId
+      ? board.ownerId === authenticatedUserId ||
+        rolesGrantAdminOrLeader(viewerRoles, board.boardType) ||
+        (board.gymId != null && editableGymIds.has(board.gymId))
+      : false;
 
     return {
       uuid: board.uuid,
@@ -377,6 +481,7 @@ async function enrichBoards(
       gymName: gym?.name ?? null,
       distanceMeters: distanceMeters ?? null,
       serialNumber: board.serialNumber ?? null,
+      canEdit,
     };
   });
 }
@@ -722,6 +827,7 @@ export const socialBoardQueries = {
           gymName: null,
           distanceMeters: null,
           serialNumber: board.serialNumber ?? null,
+          canEdit: false,
         };
       });
     }
@@ -1536,7 +1642,6 @@ export const socialBoardMutations = {
     const validatedInput = validateInput(UpdateBoardInputSchema, input, 'input');
     const userId = ctx.userId!;
 
-    // Verify ownership
     const [board] = await db
       .select()
       .from(dbSchema.userBoards)
@@ -1547,9 +1652,9 @@ export const socialBoardMutations = {
       throw new Error('Board not found');
     }
 
-    if (board.ownerId !== userId) {
-      throw new Error('Not authorized to update this board');
-    }
+    // Owner, community admin/leader (for this board type), or the linked gym's
+    // owner/admin may edit. Community moderators can fix outdated catalog boards.
+    await requireBoardEditAccess(ctx, board);
 
     // Build update values (only provided fields)
     const updateValues: Record<string, unknown> = {
@@ -1570,25 +1675,20 @@ export const socialBoardMutations = {
       updateValues.isAngleAdjustable = validatedInput.isAngleAdjustable;
     if (validatedInput.serialNumber !== undefined) updateValues.serialNumber = validatedInput.serialNumber;
 
-    // Handle config field changes (layoutId, sizeId, setIds) — only allowed on boards with zero ticks
+    // Config field changes (layoutId, sizeId, setIds). Authorized editors may
+    // change these even when the board has logged climbs — a config change
+    // reflects a real physical reconfiguration. Old boardsesh_ticks rows are
+    // left untouched: they keep referencing the climbs/config they were logged
+    // against. We do not delete, move, or modify any tick rows here.
     const hasConfigChange =
       validatedInput.layoutId !== undefined ||
       validatedInput.sizeId !== undefined ||
       validatedInput.setIds !== undefined;
 
     if (hasConfigChange) {
-      const [tickCount] = await db
-        .select({ total: count() })
-        .from(dbSchema.boardseshTicks)
-        .where(eq(dbSchema.boardseshTicks.boardId, board.id));
-
-      if (Number(tickCount?.total || 0) > 0) {
-        throw new Error(
-          'Cannot change board configuration because this board has logged climbs. Delete the board and create a new one instead.',
-        );
-      }
-
-      // Check unique constraint: no other active board with same config for this user
+      // Check unique constraint: no other active board with the same config for
+      // the board's OWNER (not the caller — an admin may be editing a board
+      // owned by a system/import user).
       const newLayoutId = validatedInput.layoutId ?? board.layoutId;
       const newSizeId = validatedInput.sizeId ?? board.sizeId;
       const newSetIds = validatedInput.setIds ?? board.setIds;
@@ -1598,7 +1698,7 @@ export const socialBoardMutations = {
         .from(dbSchema.userBoards)
         .where(
           and(
-            eq(dbSchema.userBoards.ownerId, userId),
+            eq(dbSchema.userBoards.ownerId, board.ownerId),
             eq(dbSchema.userBoards.boardType, board.boardType),
             eq(dbSchema.userBoards.layoutId, newLayoutId),
             eq(dbSchema.userBoards.sizeId, newSizeId),

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -5,6 +5,7 @@ import { rowsFromResult } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
+import { getUserCommunityRoles, rolesGrantAdminOrLeader } from './roles';
 import {
   CreateGymInputSchema,
   UpdateGymInputSchema,
@@ -103,6 +104,7 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
     commentCountResult,
     followCheckResult,
     memberCheckResult,
+    viewerRolesResult,
   ] = await Promise.all([
     // Get owner profile
     db
@@ -163,6 +165,10 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
           .where(and(eq(dbSchema.gymMembers.userId, authenticatedUserId), eq(dbSchema.gymMembers.gymId, gym.id)))
           .limit(1)
       : Promise.resolve([]),
+
+    // Viewer's community roles (for canEdit: a community admin/leader scoped to
+    // one of the gym's board types, or global, may edit the gym)
+    authenticatedUserId ? getUserCommunityRoles(authenticatedUserId) : Promise.resolve([]),
   ]);
 
   const ownerInfo = ownerResult[0];
@@ -178,6 +184,15 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
   const memberRow = (memberCheckResult as Array<{ role: string }>)[0];
   const isMember = isOwner || !!memberRow;
   const myRole = isOwner ? 'admin' : ((memberRow?.role as 'admin' | 'member' | undefined) ?? null);
+
+  // Editable by gym owner/admin, or a community admin/leader whose role is
+  // global or scoped to one of the gym's board types.
+  const viewerRoles = viewerRolesResult as Array<{ role: string; boardType: string | null }>;
+  const canEdit =
+    isOwner ||
+    memberRow?.role === 'admin' ||
+    rolesGrantAdminOrLeader(viewerRoles, null) ||
+    boardTypes.some((boardType) => rolesGrantAdminOrLeader(viewerRoles, boardType));
 
   return {
     uuid: gym.uuid,
@@ -203,6 +218,7 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
     isFollowedByMe,
     isMember,
     myRole,
+    canEdit,
   };
 }
 
@@ -224,7 +240,7 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
     return gym;
   }
 
-  // Check if user is admin
+  // Check if user is a gym admin member
   const [member] = await db
     .select({ role: dbSchema.gymMembers.role })
     .from(dbSchema.gymMembers)
@@ -237,11 +253,30 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
     )
     .limit(1);
 
-  if (!member) {
-    throw new Error('Not authorized: must be gym owner or admin');
+  if (member) {
+    return gym;
   }
 
-  return gym;
+  // A community admin/leader may also edit. A gym spans multiple board types, so
+  // allow a global role (boardType null) or any role matching one of the gym's
+  // board types (same set enrichGym computes).
+  const [roles, gymBoardTypeRows] = await Promise.all([
+    getUserCommunityRoles(userId),
+    db
+      .selectDistinct({ boardType: dbSchema.userBoards.boardType })
+      .from(dbSchema.userBoards)
+      .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt))),
+  ]);
+  const gymBoardTypes = gymBoardTypeRows.map((row) => row.boardType);
+  const hasCommunityAccess =
+    rolesGrantAdminOrLeader(roles, null) ||
+    gymBoardTypes.some((boardType) => rolesGrantAdminOrLeader(roles, boardType));
+
+  if (hasCommunityAccess) {
+    return gym;
+  }
+
+  throw new Error('Not authorized: must be gym owner or admin');
 }
 
 // ============================================

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -223,9 +223,13 @@ async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenticatedUs
 }
 
 /**
- * Verify user is gym owner or admin, return the gym row.
+ * Load a gym and report whether the user is its owner or an admin member. Shared
+ * building block for the two gym gates below.
  */
-async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<typeof dbSchema.gyms.$inferSelect> {
+async function loadGymWithOwnerOrAdmin(
+  gymUuid: string,
+  userId: string,
+): Promise<{ gym: typeof dbSchema.gyms.$inferSelect; isOwnerOrGymAdmin: boolean }> {
   const [gym] = await db
     .select()
     .from(dbSchema.gyms)
@@ -237,7 +241,7 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
   }
 
   if (gym.ownerId === userId) {
-    return gym;
+    return { gym, isOwnerOrGymAdmin: true };
   }
 
   // Check if user is a gym admin member
@@ -253,7 +257,32 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
     )
     .limit(1);
 
-  if (member) {
+  return { gym, isOwnerOrGymAdmin: !!member };
+}
+
+/**
+ * Gate for gym MANAGEMENT (add/remove members, link boards): owner or gym admin
+ * member only. Community moderators are intentionally excluded here — otherwise
+ * a board-type-scoped role could self-promote to a persistent gym admin (a
+ * gym_members row that outlives the community role) or evict other admins.
+ */
+async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<typeof dbSchema.gyms.$inferSelect> {
+  const { gym, isOwnerOrGymAdmin } = await loadGymWithOwnerOrAdmin(gymUuid, userId);
+  if (!isOwnerOrGymAdmin) {
+    throw new Error('Not authorized: must be gym owner or admin');
+  }
+  return gym;
+}
+
+/**
+ * Gate for EDITING a gym's own details (updateGym): owner, gym admin member, or
+ * a community admin/leader whose role is global or scoped to one of the gym's
+ * board types. Mirrors the `canEdit` computation in enrichGym so the edit UI and
+ * the mutation agree. Editing details only — never membership (see above).
+ */
+async function requireGymEditAccess(gymUuid: string, userId: string): Promise<typeof dbSchema.gyms.$inferSelect> {
+  const { gym, isOwnerOrGymAdmin } = await loadGymWithOwnerOrAdmin(gymUuid, userId);
+  if (isOwnerOrGymAdmin) {
     return gym;
   }
 
@@ -276,7 +305,7 @@ async function requireGymOwnerOrAdmin(gymUuid: string, userId: string): Promise<
     return gym;
   }
 
-  throw new Error('Not authorized: must be gym owner or admin');
+  throw new Error('Not authorized to edit this gym');
 }
 
 // ============================================
@@ -613,7 +642,7 @@ export const socialGymMutations = {
     const validatedInput = validateInput(UpdateGymInputSchema, input, 'input');
     const userId = ctx.userId!;
 
-    const gym = await requireGymOwnerOrAdmin(validatedInput.gymUuid, userId);
+    const gym = await requireGymEditAccess(validatedInput.gymUuid, userId);
 
     const updateValues: Record<string, unknown> = {
       updatedAt: new Date(),

--- a/packages/backend/src/graphql/resolvers/social/roles.ts
+++ b/packages/backend/src/graphql/resolvers/social/roles.ts
@@ -25,20 +25,53 @@ export async function requireAdmin(ctx: ConnectionContext, boardType?: string | 
 }
 
 /**
+ * A community role row reduced to what authorization checks need: the role name
+ * and its board-type scope (null = global, applies to every board type).
+ */
+export type CommunityRoleScope = { role: string; boardType: string | null };
+
+/**
+ * Fetch a user's community role rows ({ role, boardType }). Batch callers fetch
+ * once and compute admin/leader access for many board types in-memory via
+ * `rolesGrantAdminOrLeader`, avoiding a per-row query.
+ */
+export async function getUserCommunityRoles(userId: string): Promise<CommunityRoleScope[]> {
+  return db
+    .select({ role: dbSchema.communityRoles.role, boardType: dbSchema.communityRoles.boardType })
+    .from(dbSchema.communityRoles)
+    .where(eq(dbSchema.communityRoles.userId, userId));
+}
+
+/**
+ * Pure predicate: do the given role rows grant admin/community_leader access for
+ * a board type? A role qualifies when it is admin or community_leader AND its
+ * scope is global (null) or matches the requested board type.
+ */
+export function rolesGrantAdminOrLeader(roles: CommunityRoleScope[], boardType?: string | null): boolean {
+  return roles.some(
+    (entry) =>
+      (entry.role === 'admin' || entry.role === 'community_leader') &&
+      (entry.boardType === null || entry.boardType === boardType),
+  );
+}
+
+/**
+ * Non-throwing check: does the user hold an admin or community_leader role that
+ * is global or scoped to the given board type? Mirrors `requireAdminOrLeader`'s
+ * logic for callers (like `canEdit` computation) that need a boolean, not a throw.
+ */
+export async function hasAdminOrLeader(userId: string, boardType?: string | null): Promise<boolean> {
+  const roles = await getUserCommunityRoles(userId);
+  return rolesGrantAdminOrLeader(roles, boardType);
+}
+
+/**
  * Check if a user has admin or community_leader role.
  */
 export async function requireAdminOrLeader(ctx: ConnectionContext, boardType?: string | null): Promise<void> {
   requireAuthenticated(ctx);
-  const userId = ctx.userId!;
 
-  const roles = await db
-    .select({ role: dbSchema.communityRoles.role, boardType: dbSchema.communityRoles.boardType })
-    .from(dbSchema.communityRoles)
-    .where(eq(dbSchema.communityRoles.userId, userId));
-
-  const hasRole = roles.some(
-    (r) => (r.role === 'admin' || r.role === 'community_leader') && (r.boardType === null || r.boardType === boardType),
-  );
+  const hasRole = await hasAdminOrLeader(ctx.userId!, boardType);
 
   if (!hasRole) {
     throw new Error('Admin or community leader role required for this operation');

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -72,9 +72,12 @@ function EditBoardForm({ board }: { board: UserBoard }) {
   const setActiveBoard = useSetActiveBoard();
   const updateBoard = useUpdateBoard();
 
-  // Config edits are server-rejected once a board has ticks; lock the chips and
-  // omit the config from the update so we don't trip that guard.
-  const lockedConfig = board.totalAscents > 0;
+  // Authorized editors (owner, or a community admin/leader for this board type —
+  // the server reports this as `canEdit`) may change the config even when the
+  // board has ticks: a config change reflects a real physical reconfiguration and
+  // the old ticks are preserved server-side. Anyone without edit access keeps the
+  // config chips locked.
+  const lockedConfig = !board.canEdit;
 
   const seed = useMemo<BoardBuilderSeed>(() => {
     const seedBoardName = toBoardName(board.boardType)!;

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import type { Gym, UpdateGymInput } from '@boardsesh/shared-schema';
+import { useGym, useUpdateGym } from '../../src/lib/graphql/hooks';
+import { useToast } from '../../src/providers/toast-provider';
+import { useTheme } from '../../src/providers/theme-provider';
+import { useStackScreenOptions } from '../../src/hooks/use-stack-screen-options';
+import { hapticSelection } from '../../src/lib/haptics';
+import { GymForm, type GymFormSeed, type GymFormSubmitValues } from '../../src/components/gym-directory/GymForm';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { ActivityIndicator } from '../../src/components/ActivityIndicator';
+import { iosSystemColors } from '../../src/theme/ios-colors';
+import { spacing } from '../../src/theme/tokens';
+
+/**
+ * Edit a gym the viewer can edit — the native counterpart of the web gym editor.
+ * Reached from the wall finder's edit affordance (shown only when `gym.canEdit`).
+ * Loads any gym by uuid, then hands a remounted-per-gym form to {@link EditGymForm}.
+ * The root Stack hides headers, so this opts into one (back button + title).
+ */
+export default function EditGym() {
+  const router = useRouter();
+  const { gymUuid } = useLocalSearchParams<{ gymUuid?: string }>();
+  const { t } = useTranslation('boards');
+  const { systemColors } = useTheme();
+  const screenOptions = useStackScreenOptions();
+
+  const { data: gym, isLoading } = useGym(gymUuid ?? null);
+
+  const header = (
+    <Stack.Screen options={{ ...screenOptions, title: t('mobile.gymEdit.screenTitle'), headerShown: true }} />
+  );
+
+  if (isLoading) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        {header}
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  // Missing (deleted elsewhere / stale link): nothing to edit, so offer a way back
+  // rather than a broken form.
+  if (!gym) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        {header}
+        <Icon name="error" size={40} color={iosSystemColors.systemGray} />
+        <Text variant="headline" style={styles.stateTitle}>
+          {t('mobile.gymEdit.notFound')}
+        </Text>
+        <Button
+          title={t('mobile.gymEdit.back')}
+          variant="outlined"
+          onPress={() => router.back()}
+          style={styles.stateButton}
+        />
+      </View>
+    );
+  }
+
+  // Remount the form per gym so its once-only field seeds come from a fully-loaded
+  // gym (mirrors the board-edit screen).
+  return (
+    <>
+      {header}
+      <EditGymForm key={gym.uuid} gym={gym} />
+    </>
+  );
+}
+
+function EditGymForm({ gym }: { gym: Gym }) {
+  const router = useRouter();
+  const { t } = useTranslation('boards');
+  const { showToast } = useToast();
+  const updateGym = useUpdateGym();
+
+  const seed = useMemo<GymFormSeed>(
+    () => ({
+      name: gym.name,
+      description: gym.description ?? '',
+      address: gym.address ?? '',
+      contactEmail: gym.contactEmail ?? '',
+      contactPhone: gym.contactPhone ?? '',
+      latitude: gym.latitude ?? null,
+      longitude: gym.longitude ?? null,
+      isPublic: gym.isPublic,
+    }),
+    [gym],
+  );
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (values: GymFormSubmitValues) => {
+      if (submitting) return;
+      // `UpdateGymInput`'s optional string/number fields can't be nulled, so a
+      // blanked field is sent as `undefined` (no change) — matching the web editor.
+      const input: UpdateGymInput = {
+        gymUuid: gym.uuid,
+        name: values.name,
+        description: values.description ?? undefined,
+        address: values.address ?? undefined,
+        contactEmail: values.contactEmail ?? undefined,
+        contactPhone: values.contactPhone ?? undefined,
+        latitude: values.latitude ?? undefined,
+        longitude: values.longitude ?? undefined,
+        isPublic: values.isPublic,
+      };
+      setSubmitting(true);
+      hapticSelection();
+      try {
+        await updateGym.mutateAsync(input);
+        showToast(t('mobile.gymEdit.updateSuccess'), 'success');
+        router.back();
+        // Navigated away on success — leave `submitting` set (unmounting).
+      } catch {
+        // The server enforces edit access authoritatively; surface a retry on any
+        // rejection.
+        showToast(t('mobile.gymEdit.updateError'), 'error');
+        setSubmitting(false);
+      }
+    },
+    [submitting, gym.uuid, updateGym, showToast, t, router],
+  );
+
+  return (
+    <GymForm
+      seed={seed}
+      submitting={submitting}
+      onSubmit={(values) => void handleSubmit(values)}
+      submitLabel={t('mobile.gymEdit.save')}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[8],
+  },
+  stateTitle: {
+    marginTop: spacing[3],
+    textAlign: 'center',
+  },
+  stateButton: {
+    marginTop: spacing[4],
+  },
+});

--- a/packages/mobile/app/gyms/edit.tsx
+++ b/packages/mobile/app/gyms/edit.tsx
@@ -99,17 +99,19 @@ function EditGymForm({ gym }: { gym: Gym }) {
   const handleSubmit = useCallback(
     async (values: GymFormSubmitValues) => {
       if (submitting) return;
-      // `UpdateGymInput`'s optional string/number fields can't be nulled, so a
-      // blanked field is sent as `undefined` (no change) — matching the web editor.
+      // Fields are sent as-is. The form yields `null` for a blanked field, which
+      // tells the server to clear it (coordinates also clear the PostGIS
+      // location); `undefined` would mean "leave unchanged". `name`/`isPublic`
+      // are never null.
       const input: UpdateGymInput = {
         gymUuid: gym.uuid,
         name: values.name,
-        description: values.description ?? undefined,
-        address: values.address ?? undefined,
-        contactEmail: values.contactEmail ?? undefined,
-        contactPhone: values.contactPhone ?? undefined,
-        latitude: values.latitude ?? undefined,
-        longitude: values.longitude ?? undefined,
+        description: values.description,
+        address: values.address,
+        contactEmail: values.contactEmail,
+        contactPhone: values.contactPhone,
+        latitude: values.latitude,
+        longitude: values.longitude,
         isPublic: values.isPublic,
       };
       setSubmitting(true);

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -255,6 +255,25 @@ export default function GymDiscovery() {
     [setActiveBoard, router, boardReturnTo, showToast, t],
   );
 
+  // Edit a board / gym the viewer can edit (the row only renders the pencil when
+  // `canEdit`). The board editor already loads any board by uuid and unlocks its
+  // config for moderators; the gym editor is the new gyms/edit screen.
+  const onEditBoard = useCallback(
+    (board: UserBoard) => {
+      hapticSelection();
+      router.push({ pathname: '/boards/edit', params: { boardUuid: board.uuid } });
+    },
+    [router],
+  );
+
+  const onEditGym = useCallback(
+    (gym: Gym) => {
+      hapticSelection();
+      router.push({ pathname: '/gyms/edit', params: { gymUuid: gym.uuid } });
+    },
+    [router],
+  );
+
   // Tap/expand a gym row: toggle its boards, select it, and recenter the map on it
   // (no-op when the map is blank — the row just expands).
   const onPressGym = useCallback(
@@ -487,6 +506,8 @@ export default function GymDiscovery() {
         mapAvailable={mapAvailable}
         onPressGym={onPressGym}
         onActivateBoard={activate}
+        onEditGym={onEditGym}
+        onEditBoard={onEditBoard}
         noBoardsLabel={t('mobile.gyms.noBoards')}
         searchSlot={searchField}
         placeCaption={placeCaption}

--- a/packages/mobile/src/components/ble/__tests__/DeviceCard.test.tsx
+++ b/packages/mobile/src/components/ble/__tests__/DeviceCard.test.tsx
@@ -110,6 +110,7 @@ function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
     serialNumber: 'SN-1',
     ...overrides,
   };

--- a/packages/mobile/src/components/gym-directory/GymForm.tsx
+++ b/packages/mobile/src/components/gym-directory/GymForm.tsx
@@ -8,6 +8,8 @@ import { SwitchRow } from '../SwitchRow';
 import { Text } from '../Text';
 import { Button } from '../Button';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { parseCoordinate, LATITUDE_RANGE, LONGITUDE_RANGE } from './gym-coordinate';
 
 /** The gym's current values, used to seed the form once on mount. */
 export type GymFormSeed = {
@@ -45,13 +47,6 @@ function coordToText(value: number | null): string {
   return value == null ? '' : String(value);
 }
 
-function parseCoord(text: string): number | null {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) return null;
-  const parsed = Number(trimmed);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
 /**
  * The gym editor form — name, description, address, contact email/phone,
  * coordinates, and a public toggle, with a pinned primary action. The native
@@ -76,18 +71,22 @@ export function GymForm({ seed, submitting, onSubmit, submitLabel }: GymFormProp
   const [isPublic, setIsPublic] = useState(seed.isPublic);
 
   const trimmedName = name.trim();
-  const canSubmit = trimmedName.length > 0 && !submitting;
+  const latitude = parseCoordinate(latitudeText, LATITUDE_RANGE.min, LATITUDE_RANGE.max);
+  const longitude = parseCoordinate(longitudeText, LONGITUDE_RANGE.min, LONGITUDE_RANGE.max);
+  const canSubmit = trimmedName.length > 0 && !submitting && !latitude.error && !longitude.error;
 
   const handleSubmit = useCallback(() => {
-    if (trimmedName.length === 0 || submitting) return;
+    const lat = parseCoordinate(latitudeText, LATITUDE_RANGE.min, LATITUDE_RANGE.max);
+    const lon = parseCoordinate(longitudeText, LONGITUDE_RANGE.min, LONGITUDE_RANGE.max);
+    if (trimmedName.length === 0 || submitting || lat.error || lon.error) return;
     onSubmit({
       name: trimmedName,
       description: description.trim() || null,
       address: address.trim() || null,
       contactEmail: contactEmail.trim() || null,
       contactPhone: contactPhone.trim() || null,
-      latitude: parseCoord(latitudeText),
-      longitude: parseCoord(longitudeText),
+      latitude: lat.value,
+      longitude: lon.value,
       isPublic,
     });
   }, [
@@ -117,7 +116,7 @@ export function GymForm({ seed, submitting, onSubmit, submitLabel }: GymFormProp
           onChangeText={setName}
           placeholder={t('mobile.gymEdit.namePlaceholder')}
           accessibilityLabel={t('mobile.gymEdit.name')}
-          maxLength={120}
+          maxLength={100}
           returnKeyType="next"
         />
 
@@ -160,7 +159,7 @@ export function GymForm({ seed, submitting, onSubmit, submitLabel }: GymFormProp
           placeholder={t('mobile.gymEdit.contactPhonePlaceholder')}
           accessibilityLabel={t('mobile.gymEdit.contactPhone')}
           keyboardType="phone-pad"
-          maxLength={40}
+          maxLength={30}
         />
 
         <View style={styles.coordRow}>
@@ -175,6 +174,11 @@ export function GymForm({ seed, submitting, onSubmit, submitLabel }: GymFormProp
               autoCorrect={false}
               maxLength={20}
             />
+            {latitude.error && (
+              <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.coordError}>
+                {t('mobile.gymEdit.invalidCoordinate')}
+              </Text>
+            )}
           </View>
           <View style={styles.coordField}>
             <SectionLabel>{t('mobile.gymEdit.longitude')}</SectionLabel>
@@ -187,6 +191,11 @@ export function GymForm({ seed, submitting, onSubmit, submitLabel }: GymFormProp
               autoCorrect={false}
               maxLength={20}
             />
+            {longitude.error && (
+              <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.coordError}>
+                {t('mobile.gymEdit.invalidCoordinate')}
+              </Text>
+            )}
           </View>
         </View>
 
@@ -283,6 +292,9 @@ const styles = StyleSheet.create({
   },
   coordField: {
     flex: 1,
+  },
+  coordError: {
+    marginTop: spacing[1],
   },
   switchBlock: {
     marginTop: spacing[4],

--- a/packages/mobile/src/components/gym-directory/GymForm.tsx
+++ b/packages/mobile/src/components/gym-directory/GymForm.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useState, type ComponentProps } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '../../providers/theme-provider';
+import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
+import { SwitchRow } from '../SwitchRow';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+/** The gym's current values, used to seed the form once on mount. */
+export type GymFormSeed = {
+  name: string;
+  description: string;
+  address: string;
+  contactEmail: string;
+  contactPhone: string;
+  latitude: number | null;
+  longitude: number | null;
+  isPublic: boolean;
+};
+
+/** The normalized values handed back on submit. Text fields collapse to `null`
+ *  when blank; coordinates parse to a finite number or `null`. */
+export type GymFormSubmitValues = {
+  name: string;
+  description: string | null;
+  address: string | null;
+  contactEmail: string | null;
+  contactPhone: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  isPublic: boolean;
+};
+
+type GymFormProps = {
+  seed: GymFormSeed;
+  submitting: boolean;
+  onSubmit: (values: GymFormSubmitValues) => void;
+  submitLabel: string;
+};
+
+function coordToText(value: number | null): string {
+  return value == null ? '' : String(value);
+}
+
+function parseCoord(text: string): number | null {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * The gym editor form — name, description, address, contact email/phone,
+ * coordinates, and a public toggle, with a pinned primary action. The native
+ * (StyleSheet + theme) counterpart of the web gym form; the gym-edit screen owns
+ * the mutation, success toast, and navigation. Seeds its fields once via the
+ * `useState` initializers, so re-renders never clobber in-progress edits (the
+ * screen remounts it per gym).
+ */
+export function GymForm({ seed, submitting, onSubmit, submitLabel }: GymFormProps) {
+  const { t } = useTranslation('boards');
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const bottomChrome = useBottomChromeMetrics();
+
+  const [name, setName] = useState(seed.name);
+  const [description, setDescription] = useState(seed.description);
+  const [address, setAddress] = useState(seed.address);
+  const [contactEmail, setContactEmail] = useState(seed.contactEmail);
+  const [contactPhone, setContactPhone] = useState(seed.contactPhone);
+  const [latitudeText, setLatitudeText] = useState(coordToText(seed.latitude));
+  const [longitudeText, setLongitudeText] = useState(coordToText(seed.longitude));
+  const [isPublic, setIsPublic] = useState(seed.isPublic);
+
+  const trimmedName = name.trim();
+  const canSubmit = trimmedName.length > 0 && !submitting;
+
+  const handleSubmit = useCallback(() => {
+    if (trimmedName.length === 0 || submitting) return;
+    onSubmit({
+      name: trimmedName,
+      description: description.trim() || null,
+      address: address.trim() || null,
+      contactEmail: contactEmail.trim() || null,
+      contactPhone: contactPhone.trim() || null,
+      latitude: parseCoord(latitudeText),
+      longitude: parseCoord(longitudeText),
+      isPublic,
+    });
+  }, [
+    trimmedName,
+    submitting,
+    onSubmit,
+    description,
+    address,
+    contactEmail,
+    contactPhone,
+    latitudeText,
+    longitudeText,
+    isPublic,
+  ]);
+
+  return (
+    <KeyboardAvoidingView style={styles.flex} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[styles.content, { paddingBottom: bottomChrome.scrollBottomPadding + spacing[16] }]}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <SectionLabel>{t('mobile.gymEdit.name')}</SectionLabel>
+        <GymTextInput
+          value={name}
+          onChangeText={setName}
+          placeholder={t('mobile.gymEdit.namePlaceholder')}
+          accessibilityLabel={t('mobile.gymEdit.name')}
+          maxLength={120}
+          returnKeyType="next"
+        />
+
+        <SectionLabel>{t('mobile.gymEdit.description')}</SectionLabel>
+        <GymTextInput
+          value={description}
+          onChangeText={setDescription}
+          placeholder={t('mobile.gymEdit.descriptionPlaceholder')}
+          accessibilityLabel={t('mobile.gymEdit.description')}
+          maxLength={500}
+          multiline
+          style={styles.multiline}
+        />
+
+        <SectionLabel>{t('mobile.gymEdit.address')}</SectionLabel>
+        <GymTextInput
+          value={address}
+          onChangeText={setAddress}
+          placeholder={t('mobile.gymEdit.addressPlaceholder')}
+          accessibilityLabel={t('mobile.gymEdit.address')}
+          maxLength={200}
+        />
+
+        <SectionLabel>{t('mobile.gymEdit.contactEmail')}</SectionLabel>
+        <GymTextInput
+          value={contactEmail}
+          onChangeText={setContactEmail}
+          placeholder={t('mobile.gymEdit.contactEmailPlaceholder')}
+          accessibilityLabel={t('mobile.gymEdit.contactEmail')}
+          keyboardType="email-address"
+          autoCapitalize="none"
+          autoCorrect={false}
+          maxLength={200}
+        />
+
+        <SectionLabel>{t('mobile.gymEdit.contactPhone')}</SectionLabel>
+        <GymTextInput
+          value={contactPhone}
+          onChangeText={setContactPhone}
+          placeholder={t('mobile.gymEdit.contactPhonePlaceholder')}
+          accessibilityLabel={t('mobile.gymEdit.contactPhone')}
+          keyboardType="phone-pad"
+          maxLength={40}
+        />
+
+        <View style={styles.coordRow}>
+          <View style={styles.coordField}>
+            <SectionLabel>{t('mobile.gymEdit.latitude')}</SectionLabel>
+            <GymTextInput
+              value={latitudeText}
+              onChangeText={setLatitudeText}
+              placeholder={t('mobile.gymEdit.coordinatePlaceholder')}
+              accessibilityLabel={t('mobile.gymEdit.latitude')}
+              keyboardType="numbers-and-punctuation"
+              autoCorrect={false}
+              maxLength={20}
+            />
+          </View>
+          <View style={styles.coordField}>
+            <SectionLabel>{t('mobile.gymEdit.longitude')}</SectionLabel>
+            <GymTextInput
+              value={longitudeText}
+              onChangeText={setLongitudeText}
+              placeholder={t('mobile.gymEdit.coordinatePlaceholder')}
+              accessibilityLabel={t('mobile.gymEdit.longitude')}
+              keyboardType="numbers-and-punctuation"
+              autoCorrect={false}
+              maxLength={20}
+            />
+          </View>
+        </View>
+
+        <View style={styles.switchBlock}>
+          <SwitchRow
+            label={t('mobile.gymEdit.public')}
+            description={t('mobile.gymEdit.publicHint')}
+            value={isPublic}
+            onValueChange={setIsPublic}
+          />
+        </View>
+      </ScrollView>
+
+      {/* Pinned, safe-area-aware primary action — mirrors the board form footer. */}
+      <View
+        style={[
+          styles.footer,
+          {
+            backgroundColor: systemColors.secondaryBackground,
+            borderTopColor: systemColors.separator,
+            paddingBottom: insets.bottom + spacing[3],
+          },
+        ]}
+      >
+        <Button
+          title={submitLabel}
+          onPress={handleSubmit}
+          variant="filled"
+          size="large"
+          disabled={!canSubmit}
+          loading={submitting}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  const { systemColors } = useTheme();
+  return (
+    <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.sectionLabel}>
+      {children}
+    </Text>
+  );
+}
+
+/** Themed text input for the gym form fields. Mirrors the board form's input. */
+function GymTextInput({ style, ...props }: ComponentProps<typeof TextInput>) {
+  const { systemColors } = useTheme();
+  return (
+    <TextInput
+      placeholderTextColor={systemColors.tertiaryLabel}
+      {...props}
+      style={[
+        styles.input,
+        {
+          color: systemColors.label,
+          borderColor: systemColors.separator,
+          backgroundColor: systemColors.secondaryBackground,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing[4],
+    gap: spacing[2],
+  },
+  sectionLabel: {
+    marginTop: spacing[3],
+    marginBottom: spacing[1],
+    textTransform: 'uppercase',
+  },
+  input: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    fontSize: 17,
+  },
+  multiline: {
+    minHeight: 88,
+    textAlignVertical: 'top',
+  },
+  coordRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+  coordField: {
+    flex: 1,
+  },
+  switchBlock: {
+    marginTop: spacing[4],
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/packages/mobile/src/components/gym-directory/GymListPanel.tsx
+++ b/packages/mobile/src/components/gym-directory/GymListPanel.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, memo, useCallback, useImperativeHandle, useMemo, useRef, type ReactNode } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import Animated from 'react-native-reanimated';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
@@ -33,6 +34,10 @@ type GymListPanelProps = {
   onPressGym: (gym: Gym) => void;
   /** Tap a board (under a gym, or a standalone) — makes it active. */
   onActivateBoard: (board: UserBoard) => void;
+  /** Edit a gym the viewer can edit — only shown on rows whose `gym.canEdit` is true. */
+  onEditGym: (gym: Gym) => void;
+  /** Edit a board the viewer can edit — only shown on rows whose `board.canEdit` is true. */
+  onEditBoard: (board: UserBoard) => void;
   /** Caption shown under an expanded gym that has no boards yet. */
   noBoardsLabel: string;
   /** The pinned search field (lives in the panel header so it survives a blank map). */
@@ -62,6 +67,8 @@ export const GymListPanel = forwardRef<GymListPanelHandle, GymListPanelProps>(fu
     mapAvailable,
     onPressGym,
     onActivateBoard,
+    onEditGym,
+    onEditBoard,
     noBoardsLabel,
     searchSlot,
     placeCaption,
@@ -122,6 +129,8 @@ export const GymListPanel = forwardRef<GymListPanelHandle, GymListPanelProps>(fu
               noBoardsLabel={noBoardsLabel}
               onPressGym={onPressGym}
               onActivateBoard={onActivateBoard}
+              onEditGym={onEditGym}
+              onEditBoard={onEditBoard}
             />
           );
         case 'standalone':
@@ -131,11 +140,12 @@ export const GymListPanel = forwardRef<GymListPanelHandle, GymListPanelProps>(fu
               subtitle={item.subtitle}
               selected={item.selected}
               onActivateBoard={onActivateBoard}
+              onEditBoard={onEditBoard}
             />
           );
       }
     },
-    [noBoardsLabel, onPressGym, onActivateBoard],
+    [noBoardsLabel, onPressGym, onActivateBoard, onEditGym, onEditBoard],
   );
 
   const listContentStyle = useMemo(
@@ -220,6 +230,8 @@ type GymRowProps = {
   noBoardsLabel: string;
   onPressGym: (gym: Gym) => void;
   onActivateBoard: (board: UserBoard) => void;
+  onEditGym: (gym: Gym) => void;
+  onEditBoard: (board: UserBoard) => void;
 };
 
 const GymRow = memo(function GymRow({
@@ -231,9 +243,13 @@ const GymRow = memo(function GymRow({
   noBoardsLabel,
   onPressGym,
   onActivateBoard,
+  onEditGym,
+  onEditBoard,
 }: GymRowProps) {
   const { systemColors, brandColors } = useTheme();
+  const { t } = useTranslation('boards');
   const handlePress = useCallback(() => onPressGym(gym), [onPressGym, gym]);
+  const handleEdit = useCallback(() => onEditGym(gym), [onEditGym, gym]);
   return (
     <View style={[styles.gymBlock, { borderColor: selected ? brandColors.primary : systemColors.separator }]}>
       {selected ? <View style={[styles.selectedAccent, { backgroundColor: brandColors.primary }]} /> : null}
@@ -255,12 +271,15 @@ const GymRow = memo(function GymRow({
             </Text>
           ) : null}
         </View>
+        {gym.canEdit ? <EditButton onPress={handleEdit} label={t('mobile.gyms.editGym')} /> : null}
         <Icon name={expanded ? 'minus' : 'add'} size={20} color={systemColors.tertiaryLabel} />
       </PressableSurface>
 
       {expanded ? (
         boards.length > 0 ? (
-          boards.map((board) => <BoardRow key={board.uuid} board={board} onActivateBoard={onActivateBoard} />)
+          boards.map((board) => (
+            <BoardRow key={board.uuid} board={board} onActivateBoard={onActivateBoard} onEditBoard={onEditBoard} />
+          ))
         ) : (
           <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.noBoards}>
             {noBoardsLabel}
@@ -274,12 +293,16 @@ const GymRow = memo(function GymRow({
 const BoardRow = memo(function BoardRow({
   board,
   onActivateBoard,
+  onEditBoard,
 }: {
   board: UserBoard;
   onActivateBoard: (board: UserBoard) => void;
+  onEditBoard: (board: UserBoard) => void;
 }) {
   const { systemColors, brandColors } = useTheme();
+  const { t } = useTranslation('boards');
   const handlePress = useCallback(() => onActivateBoard(board), [onActivateBoard, board]);
+  const handleEdit = useCallback(() => onEditBoard(board), [onEditBoard, board]);
   return (
     <PressableSurface
       onPress={handlePress}
@@ -293,6 +316,7 @@ const BoardRow = memo(function BoardRow({
           {board.boardType}
         </Text>
       </View>
+      {board.canEdit ? <EditButton onPress={handleEdit} label={t('mobile.gyms.editBoard')} /> : null}
     </PressableSurface>
   );
 });
@@ -302,14 +326,18 @@ const StandaloneRow = memo(function StandaloneRow({
   subtitle,
   selected,
   onActivateBoard,
+  onEditBoard,
 }: {
   board: UserBoard;
   subtitle: string;
   selected: boolean;
   onActivateBoard: (board: UserBoard) => void;
+  onEditBoard: (board: UserBoard) => void;
 }) {
   const { systemColors, brandColors } = useTheme();
+  const { t } = useTranslation('boards');
   const handlePress = useCallback(() => onActivateBoard(board), [onActivateBoard, board]);
+  const handleEdit = useCallback(() => onEditBoard(board), [onEditBoard, board]);
   return (
     <View style={[styles.gymBlock, { borderColor: selected ? brandColors.primary : systemColors.separator }]}>
       {selected ? <View style={[styles.selectedAccent, { backgroundColor: brandColors.primary }]} /> : null}
@@ -321,9 +349,30 @@ const StandaloneRow = memo(function StandaloneRow({
             {subtitle}
           </Text>
         </View>
+        {board.canEdit ? <EditButton onPress={handleEdit} label={t('mobile.gyms.editBoard')} /> : null}
         <Icon name="chevron.right" size={18} color={systemColors.tertiaryLabel} />
       </PressableSurface>
     </View>
+  );
+});
+
+/**
+ * The pencil affordance shown on a row the viewer can edit. Reads its own colour
+ * so the parent rows' `renderItem` deps stay free of theme values; the label is
+ * resolved by the caller (a literal `t(...)`) so the i18n key stays static.
+ */
+const EditButton = memo(function EditButton({ onPress, label }: { onPress: () => void; label: string }) {
+  const { systemColors } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={10}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={styles.editButton}
+    >
+      <Icon name="edit" size={18} color={systemColors.secondaryLabel} />
+    </Pressable>
   );
 });
 
@@ -414,5 +463,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing[3],
     padding: spacing[3],
+  },
+  editButton: {
+    padding: spacing[1],
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-coordinate.test.ts
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-coordinate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { parseCoordinate, LATITUDE_RANGE, LONGITUDE_RANGE } from '../gym-coordinate';
+
+describe('parseCoordinate', () => {
+  const lat = (text: string) => parseCoordinate(text, LATITUDE_RANGE.min, LATITUDE_RANGE.max);
+  const lon = (text: string) => parseCoordinate(text, LONGITUDE_RANGE.min, LONGITUDE_RANGE.max);
+
+  it('treats a blank field as a deliberate clear (null, no error)', () => {
+    expect(lat('')).toEqual({ value: null, error: false });
+    expect(lat('   ')).toEqual({ value: null, error: false });
+  });
+
+  it('parses a plain decimal', () => {
+    expect(lat('48.8584')).toEqual({ value: 48.8584, error: false });
+    expect(lon('-12.3')).toEqual({ value: -12.3, error: false });
+  });
+
+  it('normalizes a decimal comma (es/fr keyboards) instead of wiping the location', () => {
+    expect(lat('48,8584')).toEqual({ value: 48.8584, error: false });
+    expect(lon('-1,5')).toEqual({ value: -1.5, error: false });
+  });
+
+  it('flags non-empty unparseable text as an error, not a silent clear', () => {
+    expect(lat('abc')).toEqual({ value: null, error: true });
+    expect(lat('4.5.6')).toEqual({ value: null, error: true });
+  });
+
+  it('flags out-of-range values and accepts the boundaries', () => {
+    expect(lat('91')).toEqual({ value: null, error: true });
+    expect(lat('-90.1')).toEqual({ value: null, error: true });
+    expect(lat('90')).toEqual({ value: 90, error: false });
+    expect(lon('181')).toEqual({ value: null, error: true });
+    expect(lon('180')).toEqual({ value: 180, error: false });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(lat('  -12.3  ')).toEqual({ value: -12.3, error: false });
+  });
+});

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-list-panel.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-list-panel.test.tsx
@@ -137,6 +137,8 @@ describe('GymListPanel', () => {
         mapAvailable
         onPressGym={vi.fn()}
         onActivateBoard={vi.fn()}
+        onEditGym={vi.fn()}
+        onEditBoard={vi.fn()}
         noBoardsLabel="No boards yet"
         searchSlot={<div data-testid="search">search</div>}
       />,
@@ -156,6 +158,8 @@ describe('GymListPanel', () => {
         mapAvailable
         onPressGym={onPressGym}
         onActivateBoard={vi.fn()}
+        onEditGym={vi.fn()}
+        onEditBoard={vi.fn()}
         noBoardsLabel="No boards yet"
         searchSlot={<div>search</div>}
       />,
@@ -172,6 +176,8 @@ describe('GymListPanel', () => {
         mapAvailable
         onPressGym={vi.fn()}
         onActivateBoard={vi.fn()}
+        onEditGym={vi.fn()}
+        onEditBoard={vi.fn()}
         noBoardsLabel="No boards yet"
         searchSlot={<div>search</div>}
         locationPrompt={<div data-testid="loc-prompt">grant location</div>}

--- a/packages/mobile/src/components/gym-directory/gym-coordinate.ts
+++ b/packages/mobile/src/components/gym-directory/gym-coordinate.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure coordinate-field parsing for the gym editor, kept out of the component so
+ * it's unit-testable without loading React Native.
+ */
+
+export const LATITUDE_RANGE = { min: -90, max: 90 } as const;
+export const LONGITUDE_RANGE = { min: -180, max: 180 } as const;
+
+/**
+ * Parse a coordinate text field. A blank field is a deliberate clear (`null`, no
+ * error). Otherwise the text must be a finite number within [min, max]; a
+ * decimal comma — common on es/fr keyboards, where `Number('48,85')` is `NaN` —
+ * is normalized to a dot first. Any non-empty, unparseable, or out-of-range text
+ * is an error so the form can block submit; otherwise a typo would send `null`
+ * and silently wipe the gym's saved location.
+ */
+export function parseCoordinate(text: string, min: number, max: number): { value: number | null; error: boolean } {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return { value: null, error: false };
+  const parsed = Number(trimmed.replace(',', '.'));
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) return { value: null, error: true };
+  return { value: parsed, error: false };
+}

--- a/packages/mobile/src/lib/ble/__tests__/board-config-match.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/board-config-match.test.ts
@@ -43,6 +43,7 @@ function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
     serialNumber: 'SN-1',
     ...overrides,
   };

--- a/packages/mobile/src/lib/ble/__tests__/resolve-serials-hook.test.tsx
+++ b/packages/mobile/src/lib/ble/__tests__/resolve-serials-hook.test.tsx
@@ -51,6 +51,7 @@ function makeBoard(serialNumber: string, overrides: Partial<UserBoard> = {}): Us
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
     serialNumber,
     ...overrides,
   };

--- a/packages/mobile/src/lib/ble/__tests__/resolve-serials.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/resolve-serials.test.ts
@@ -47,6 +47,7 @@ function makeBoard(serialNumber: string, overrides: Partial<UserBoard> = {}): Us
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
     serialNumber,
     ...overrides,
   };

--- a/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
+++ b/packages/mobile/src/lib/feedback/__tests__/use-submit-app-feedback.test.ts
@@ -24,6 +24,7 @@ const activeBoard: UserBoard = {
   followerCount: 0,
   commentCount: 0,
   isFollowedByMe: false,
+  canEdit: false,
 };
 
 const currentClimbQueueItem: ClimbQueueItem = {

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -412,6 +412,7 @@ export function useUpdateBoard() {
  * for one of its board types — the server enforces the access check). Invalidate
  * the single-gym cache plus the nearby-gym search results so the wall finder's
  * list/pins reflect the rename or visibility change without a manual reload.
+ * Also refresh the board lists, whose rows render the gym's name (`gymName`).
  */
 export function useUpdateGym() {
   const queryClient = useQueryClient();
@@ -423,6 +424,8 @@ export function useUpdateGym() {
     onSuccess: (updated) => {
       void queryClient.invalidateQueries({ queryKey: ['gym', updated.uuid] });
       void queryClient.invalidateQueries({ queryKey: ['nearbyGyms'] });
+      void queryClient.invalidateQueries({ queryKey: ['nearbyBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -18,6 +18,7 @@ import type {
   UpdateProfileInput,
   SessionSummary,
   SessionHealthExport,
+  UpdateGymInput,
 } from '@boardsesh/shared-schema';
 import {
   SIMILAR_CLIMBS_QUERY,
@@ -36,7 +37,14 @@ import {
   type DeleteDraftClimbMutationVariables,
   type DeleteDraftClimbMutationResponse,
 } from '@boardsesh/graphql/operations/new-climb-feed';
-import { SEARCH_GYMS, type SearchGymsQueryResponse } from '@boardsesh/graphql/operations/gyms';
+import {
+  SEARCH_GYMS,
+  GET_GYM,
+  UPDATE_GYM,
+  type SearchGymsQueryResponse,
+  type GetGymQueryResponse,
+  type UpdateGymMutationResponse,
+} from '@boardsesh/graphql/operations/gyms';
 import {
   UPDATE_BOARD,
   DELETE_BOARD,
@@ -177,6 +185,20 @@ export function useBoard(boardUuid: string | null) {
     queryFn: () => getHttpClient().request<GetBoardQueryResponse>(GET_BOARD, { boardUuid }),
     select: (data) => data.board,
     enabled: !!boardUuid,
+  });
+}
+
+/**
+ * A single gym by uuid, including the viewer's `canEdit` flag. Backs the
+ * gym-edit screen (moderators reach it from the wall finder's edit affordance).
+ * Disabled until a uuid resolves so the edit screen can pass `null` while routing.
+ */
+export function useGym(gymUuid: string | null) {
+  return useQuery({
+    queryKey: ['gym', gymUuid],
+    queryFn: () => getHttpClient().request<GetGymQueryResponse>(GET_GYM, { gymUuid }),
+    select: (data) => data.gym,
+    enabled: !!gymUuid,
   });
 }
 
@@ -376,6 +398,26 @@ export function useUpdateBoard() {
     onSuccess: (updated) => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
       void queryClient.invalidateQueries({ queryKey: ['board', updated.uuid] });
+    },
+  });
+}
+
+/**
+ * Edit a gym the viewer can edit (owner, gym admin, or community admin/leader
+ * for one of its board types — the server enforces the access check). Invalidate
+ * the single-gym cache plus the nearby-gym search results so the wall finder's
+ * list/pins reflect the rename or visibility change without a manual reload.
+ */
+export function useUpdateGym() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpdateGymInput) => {
+      const response = await getHttpClient().request<UpdateGymMutationResponse>(UPDATE_GYM, { input });
+      return response.updateGym;
+    },
+    onSuccess: (updated) => {
+      void queryClient.invalidateQueries({ queryKey: ['gym', updated.uuid] });
+      void queryClient.invalidateQueries({ queryKey: ['nearbyGyms'] });
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -382,11 +382,14 @@ export function useCreateBoard() {
 }
 
 /**
- * Edit a board the user owns (name, visibility, angle, location, serial — and
- * layout/size/sets only when the board has zero ticks; the server enforces the
- * latter). Invalidate-only: `myBoards` carries enriched fields (counts, sizeName)
- * that can't be rebuilt client-side. Re-syncing the active board's denormalised
- * AsyncStorage copy is the edit screen's job — see `useSetActiveBoard`.
+ * Edit a board the caller is authorised to edit (owner, or a community
+ * admin/leader for the board type — the server enforces access via `canEdit`).
+ * Config (layout/size/sets) can change too; existing ticks are preserved
+ * server-side. Invalidate-only: `myBoards` carries enriched fields (counts,
+ * sizeName) that can't be rebuilt client-side; also refresh the wall-finder
+ * lists/pins so a moderator's edit from gym discovery shows without a reload.
+ * Re-syncing the active board's denormalised AsyncStorage copy is the edit
+ * screen's job — see `useSetActiveBoard`.
  */
 export function useUpdateBoard() {
   const queryClient = useQueryClient();
@@ -398,6 +401,8 @@ export function useUpdateBoard() {
     onSuccess: (updated) => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
       void queryClient.invalidateQueries({ queryKey: ['board', updated.uuid] });
+      void queryClient.invalidateQueries({ queryKey: ['nearbyBoards'] });
+      void queryClient.invalidateQueries({ queryKey: ['searchBoards'] });
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -69,6 +69,7 @@ const BOARD_FIELDS = `
   gymName
   distanceMeters
   serialNumber
+  canEdit
 `;
 
 const CLIMB_SEARCH_FIELDS = `

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -255,6 +255,7 @@ function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
     serialNumber: 'SN-2',
     ...overrides,
   };

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -75,6 +75,7 @@ const activeBoard = vi.hoisted(() => {
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
   } satisfies UserBoard;
   return {
     defaultStored,

--- a/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-leave-session.test.tsx
@@ -41,6 +41,7 @@ const activeBoard = vi.hoisted(() => ({
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
   } satisfies UserBoard,
   getStoredActiveBoard: vi.fn(),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-local-queue.test.tsx
@@ -42,6 +42,7 @@ const activeBoard = vi.hoisted(() => ({
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
   } satisfies UserBoard,
   getStoredActiveBoard: vi.fn(),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-regrade.test.tsx
@@ -40,6 +40,7 @@ const activeBoard = vi.hoisted(() => ({
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
   } satisfies UserBoard,
   getStoredActiveBoard: vi.fn(),
 }));

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -81,6 +81,7 @@ const activeBoard = vi.hoisted(() => ({
     followerCount: 0,
     commentCount: 0,
     isFollowedByMe: false,
+    canEdit: false,
   } satisfies UserBoard,
   getStoredActiveBoard: vi.fn(),
   setActiveBoard: vi.fn(async () => {}),
@@ -370,6 +371,7 @@ describe('QueueProvider session update subscription', () => {
       followerCount: 0,
       commentCount: 0,
       isFollowedByMe: false,
+      canEdit: false,
     };
     activeBoard.getStoredActiveBoard.mockReset();
     activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2128,6 +2128,8 @@ type UserBoard {
   distanceMeters: Float
   "Controller box serial number"
   serialNumber: String
+  "Whether the current viewer may edit this board (owner, community admin/leader for its board type, or owner/admin of its linked gym)"
+  canEdit: Boolean!
 }
 
 """
@@ -2278,11 +2280,11 @@ input UpdateBoardInput {
   angle: Int
   "New angle adjustable flag"
   isAngleAdjustable: Boolean
-  "New layout ID (only allowed when board has zero ticks)"
+  "New layout ID (authorized editors only; existing ticks are preserved untouched)"
   layoutId: Int
-  "New size ID (only allowed when board has zero ticks)"
+  "New size ID (authorized editors only; existing ticks are preserved untouched)"
   sizeId: Int
-  "New set IDs (only allowed when board has zero ticks)"
+  "New set IDs (authorized editors only; existing ticks are preserved untouched)"
   setIds: String
   "Controller box serial number"
   serialNumber: String
@@ -2485,6 +2487,8 @@ type Gym {
   isMember: Boolean!
   "Current user's role (null if not a member/owner)"
   myRole: GymMemberRole
+  "Whether the current viewer may edit this gym (owner, gym admin, or community admin/leader for one of its board types)"
+  canEdit: Boolean!
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1866,6 +1866,8 @@ export type Gym = {
   boardCount: Scalars['Int']['output'];
   /** Distinct board types at this gym (kilter, tension, ...) — for filtering and badges */
   boardTypes: Array<Scalars['String']['output']>;
+  /** Whether the current viewer may edit this gym (owner, gym admin, or community admin/leader for one of its board types) */
+  canEdit: Scalars['Boolean']['output'];
   /** Number of comments */
   commentCount: Scalars['Int']['output'];
   /** Contact email */
@@ -5734,7 +5736,7 @@ export type UpdateBoardInput = {
   isUnlisted?: InputMaybe<Scalars['Boolean']['input']>;
   /** New GPS latitude */
   latitude?: InputMaybe<Scalars['Float']['input']>;
-  /** New layout ID (only allowed when board has zero ticks) */
+  /** New layout ID (authorized editors only; existing ticks are preserved untouched) */
   layoutId?: InputMaybe<Scalars['Int']['input']>;
   /** New location name */
   locationName?: InputMaybe<Scalars['String']['input']>;
@@ -5744,9 +5746,9 @@ export type UpdateBoardInput = {
   name?: InputMaybe<Scalars['String']['input']>;
   /** Controller box serial number */
   serialNumber?: InputMaybe<Scalars['String']['input']>;
-  /** New set IDs (only allowed when board has zero ticks) */
+  /** New set IDs (authorized editors only; existing ticks are preserved untouched) */
   setIds?: InputMaybe<Scalars['String']['input']>;
-  /** New size ID (only allowed when board has zero ticks) */
+  /** New size ID (authorized editors only; existing ticks are preserved untouched) */
   sizeId?: InputMaybe<Scalars['Int']['input']>;
   /** New slug */
   slug?: InputMaybe<Scalars['String']['input']>;
@@ -5864,6 +5866,8 @@ export type UserBoard = {
   angle: Scalars['Int']['output'];
   /** Board type (kilter, tension, moonboard) */
   boardType: Scalars['String']['output'];
+  /** Whether the current viewer may edit this board (owner, community admin/leader for its board type, or owner/admin of its linked gym) */
+  canEdit: Scalars['Boolean']['output'];
   /** Number of comments */
   commentCount: Scalars['Int']['output'];
   /** When created */
@@ -7685,6 +7689,7 @@ export type GymResolvers<
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   boardCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   boardTypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  canEdit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   commentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   contactEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   contactPhone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10047,6 +10052,7 @@ export type UserBoardResolvers<
 > = ResolversObject<{
   angle?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  canEdit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   commentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -77,6 +77,8 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     distanceMeters: Float
     "Controller box serial number"
     serialNumber: String
+    "Whether the current viewer may edit this board (owner, community admin/leader for its board type, or owner/admin of its linked gym)"
+    canEdit: Boolean!
   }
 
   """
@@ -227,11 +229,11 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     angle: Int
     "New angle adjustable flag"
     isAngleAdjustable: Boolean
-    "New layout ID (only allowed when board has zero ticks)"
+    "New layout ID (authorized editors only; existing ticks are preserved untouched)"
     layoutId: Int
-    "New size ID (only allowed when board has zero ticks)"
+    "New size ID (authorized editors only; existing ticks are preserved untouched)"
     sizeId: Int
-    "New set IDs (only allowed when board has zero ticks)"
+    "New set IDs (authorized editors only; existing ticks are preserved untouched)"
     setIds: String
     "Controller box serial number"
     serialNumber: String

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -58,6 +58,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     isMember: Boolean!
     "Current user's role (null if not a member/owner)"
     myRole: GymMemberRole
+    "Whether the current viewer may edit this gym (owner, gym admin, or community admin/leader for one of its board types)"
+    canEdit: Boolean!
   }
 
   """

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -36,6 +36,8 @@ export type UserBoard = {
   gymName?: string | null;
   distanceMeters?: number | null;
   serialNumber?: string | null;
+  /** Whether the current viewer may edit this board (owner, community admin/leader for its board type, or owner/admin of its linked gym). */
+  canEdit?: boolean;
 };
 
 export type UserBoardConnection = {

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -26,6 +26,8 @@ export type Gym = {
   isFollowedByMe: boolean;
   isMember: boolean;
   myRole?: GymMemberRole | null;
+  /** Whether the current viewer may edit this gym (owner, gym admin, or community admin/leader for one of its board types). */
+  canEdit?: boolean;
 };
 
 export type GymConnection = {

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -67,12 +67,12 @@ export type UpdateGymInput = {
   gymUuid: string;
   name?: string;
   slug?: string;
-  description?: string;
-  address?: string;
-  contactEmail?: string;
-  contactPhone?: string;
-  latitude?: number;
-  longitude?: number;
+  description?: string | null;
+  address?: string | null;
+  contactEmail?: string | null;
+  contactPhone?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
   isPublic?: boolean;
   imageUrl?: string;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1863,6 +1863,8 @@ export type Gym = {
   boardCount: Scalars['Int']['output'];
   /** Distinct board types at this gym (kilter, tension, ...) — for filtering and badges */
   boardTypes: Array<Scalars['String']['output']>;
+  /** Whether the current viewer may edit this gym (owner, gym admin, or community admin/leader for one of its board types) */
+  canEdit: Scalars['Boolean']['output'];
   /** Number of comments */
   commentCount: Scalars['Int']['output'];
   /** Contact email */
@@ -5731,7 +5733,7 @@ export type UpdateBoardInput = {
   isUnlisted?: InputMaybe<Scalars['Boolean']['input']>;
   /** New GPS latitude */
   latitude?: InputMaybe<Scalars['Float']['input']>;
-  /** New layout ID (only allowed when board has zero ticks) */
+  /** New layout ID (authorized editors only; existing ticks are preserved untouched) */
   layoutId?: InputMaybe<Scalars['Int']['input']>;
   /** New location name */
   locationName?: InputMaybe<Scalars['String']['input']>;
@@ -5741,9 +5743,9 @@ export type UpdateBoardInput = {
   name?: InputMaybe<Scalars['String']['input']>;
   /** Controller box serial number */
   serialNumber?: InputMaybe<Scalars['String']['input']>;
-  /** New set IDs (only allowed when board has zero ticks) */
+  /** New set IDs (authorized editors only; existing ticks are preserved untouched) */
   setIds?: InputMaybe<Scalars['String']['input']>;
-  /** New size ID (only allowed when board has zero ticks) */
+  /** New size ID (authorized editors only; existing ticks are preserved untouched) */
   sizeId?: InputMaybe<Scalars['Int']['input']>;
   /** New slug */
   slug?: InputMaybe<Scalars['String']['input']>;
@@ -5861,6 +5863,8 @@ export type UserBoard = {
   angle: Scalars['Int']['output'];
   /** Board type (kilter, tension, moonboard) */
   boardType: Scalars['String']['output'];
+  /** Whether the current viewer may edit this board (owner, community admin/leader for its board type, or owner/admin of its linked gym) */
+  canEdit: Scalars['Boolean']['output'];
   /** Number of comments */
   commentCount: Scalars['Int']['output'];
   /** When created */

--- a/packages/shared/graphql/src/operations/boards.ts
+++ b/packages/shared/graphql/src/operations/boards.ts
@@ -53,6 +53,7 @@ const BOARD_FIELDS = `
   gymName
   distanceMeters
   serialNumber
+  canEdit
 `;
 
 export const GET_BOARD = gql`

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -42,6 +42,7 @@ const GYM_FIELDS = `
   isFollowedByMe
   isMember
   myRole
+  canEdit
 `;
 
 export const GET_GYM = gql`

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -58,6 +58,7 @@
       "latitude": "Latitude",
       "longitude": "Longitude",
       "coordinatePlaceholder": "Decimal degrees",
+      "invalidCoordinate": "Enter a valid coordinate",
       "public": "Public gym",
       "publicHint": "Show it on the map so climbers can find it"
     },

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -38,6 +38,29 @@
       "back": "Go back",
       "configLockedHint": "This board has logged climbs, so its layout, size, and sets are locked."
     },
+    "gymEdit": {
+      "screenTitle": "Edit gym",
+      "save": "Save changes",
+      "updateError": "Couldn't save your changes. Try again.",
+      "updateSuccess": "Gym updated",
+      "notFound": "We couldn't find that gym",
+      "back": "Go back",
+      "name": "Name",
+      "namePlaceholder": "Gym name",
+      "description": "Description",
+      "descriptionPlaceholder": "Tell climbers what's on the wall",
+      "address": "Address",
+      "addressPlaceholder": "Street, city",
+      "contactEmail": "Contact email",
+      "contactEmailPlaceholder": "hello@gym.com",
+      "contactPhone": "Contact phone",
+      "contactPhonePlaceholder": "Phone number",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "coordinatePlaceholder": "Decimal degrees",
+      "public": "Public gym",
+      "publicHint": "Show it on the map so climbers can find it"
+    },
     "manage": {
       "ownedHeader": "Your boards",
       "followingHeader": "Following",
@@ -142,7 +165,9 @@
       "clearSearch": "Clear search",
       "closeMap": "Close",
       "otherBoardsTitle": "Boards nearby",
-      "multiBoardChip": "2+ board types"
+      "multiBoardChip": "2+ board types",
+      "editGym": "Edit gym",
+      "editBoard": "Edit board"
     }
   },
   "boardEntity": {
@@ -223,7 +248,7 @@
       "hideLocation": "Hidden from nearby board searches unless you follow the searcher"
     },
     "alerts": {
-      "configEditable": "You can change the board layout because no climbs have been logged yet."
+      "configEditable": "You can change the layout, size, and hold sets. Climbs already logged stay put."
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -38,6 +38,29 @@
       "back": "Volver",
       "configLockedHint": "Este plafón tiene ascensos registrados, así que su layout, tamaño y sets están bloqueados."
     },
+    "gymEdit": {
+      "screenTitle": "Editar gimnasio",
+      "save": "Guardar cambios",
+      "updateError": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
+      "updateSuccess": "Gimnasio actualizado",
+      "notFound": "No encontramos ese gimnasio",
+      "back": "Volver",
+      "name": "Nombre",
+      "namePlaceholder": "Nombre del gimnasio",
+      "description": "Descripción",
+      "descriptionPlaceholder": "Cuéntales a los escaladores qué hay en el muro",
+      "address": "Dirección",
+      "addressPlaceholder": "Calle, ciudad",
+      "contactEmail": "Correo de contacto",
+      "contactEmailPlaceholder": "hola@gimnasio.com",
+      "contactPhone": "Teléfono de contacto",
+      "contactPhonePlaceholder": "Número de teléfono",
+      "latitude": "Latitud",
+      "longitude": "Longitud",
+      "coordinatePlaceholder": "Grados decimales",
+      "public": "Gimnasio público",
+      "publicHint": "Muéstralo en el mapa para que los escaladores lo encuentren"
+    },
     "manage": {
       "ownedHeader": "Tus plafones",
       "followingHeader": "Siguiendo",
@@ -142,7 +165,9 @@
       "clearSearch": "Borrar búsqueda",
       "closeMap": "Cerrar",
       "otherBoardsTitle": "Plafones cercanos",
-      "multiBoardChip": "2+ tipos de plafón"
+      "multiBoardChip": "2+ tipos de plafón",
+      "editGym": "Editar gimnasio",
+      "editBoard": "Editar plafón"
     }
   },
   "boardEntity": {
@@ -223,7 +248,7 @@
       "hideLocation": "Oculto de las búsquedas de plafones cercanos a menos que sigas al buscador"
     },
     "alerts": {
-      "configEditable": "Puedes cambiar la disposición del plafón porque aún no se han registrado bloques."
+      "configEditable": "Puedes cambiar la disposición, el tamaño y los conjuntos de presas. Los bloques ya registrados se mantienen igual."
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -58,6 +58,7 @@
       "latitude": "Latitud",
       "longitude": "Longitud",
       "coordinatePlaceholder": "Grados decimales",
+      "invalidCoordinate": "Introduce una coordenada válida",
       "public": "Gimnasio público",
       "publicHint": "Muéstralo en el mapa para que los escaladores lo encuentren"
     },

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -38,6 +38,29 @@
       "back": "Retour",
       "configLockedHint": "Ce board a des voies enregistrées : son layout, sa taille et ses sets sont verrouillés."
     },
+    "gymEdit": {
+      "screenTitle": "Modifier la salle",
+      "save": "Enregistrer",
+      "updateError": "Impossible d'enregistrer les modifications. Réessaie.",
+      "updateSuccess": "Salle mise à jour",
+      "notFound": "Salle introuvable",
+      "back": "Retour",
+      "name": "Nom",
+      "namePlaceholder": "Nom de la salle",
+      "description": "Description",
+      "descriptionPlaceholder": "Dis aux grimpeurs ce qu'il y a sur le mur",
+      "address": "Adresse",
+      "addressPlaceholder": "Rue, ville",
+      "contactEmail": "E-mail de contact",
+      "contactEmailPlaceholder": "bonjour@salle.com",
+      "contactPhone": "Téléphone de contact",
+      "contactPhonePlaceholder": "Numéro de téléphone",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "coordinatePlaceholder": "Degrés décimaux",
+      "public": "Salle publique",
+      "publicHint": "Affiche-la sur la carte pour que les grimpeurs la trouvent"
+    },
     "manage": {
       "ownedHeader": "Tes boards",
       "followingHeader": "Abonnements",
@@ -142,7 +165,9 @@
       "clearSearch": "Effacer la recherche",
       "closeMap": "Fermer",
       "otherBoardsTitle": "Murs à proximité",
-      "multiBoardChip": "2+ types de mur"
+      "multiBoardChip": "2+ types de mur",
+      "editGym": "Modifier la salle",
+      "editBoard": "Modifier le board"
     }
   },
   "boardEntity": {
@@ -223,7 +248,7 @@
       "hideLocation": "Masqué des recherches de boards à proximité, sauf pour les personnes que vous suivez"
     },
     "alerts": {
-      "configEditable": "Vous pouvez modifier le layout du board tant qu'aucun bloc n'a été enregistré."
+      "configEditable": "Vous pouvez modifier le layout, la taille et les jeux de prises. Les blocs déjà enregistrés restent intacts."
     }
   },
   "editBoard": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -58,6 +58,7 @@
       "latitude": "Latitude",
       "longitude": "Longitude",
       "coordinatePlaceholder": "Degrés décimaux",
+      "invalidCoordinate": "Saisissez une coordonnée valide",
       "public": "Salle publique",
       "publicHint": "Affiche-la sur la carte pour que les grimpeurs la trouvent"
     },

--- a/packages/web/app/components/board-entity/board-detail.tsx
+++ b/packages/web/app/components/board-entity/board-detail.tsx
@@ -192,12 +192,7 @@ export function BoardDetailContent({
   if (isEditing) {
     return (
       <Box sx={{ px: 2, pb: 2, overflow: 'auto', flex: 1 }}>
-        <EditBoardForm
-          board={board}
-          totalAscents={board.totalAscents}
-          onSuccess={handleEditSuccess}
-          onCancel={() => setIsEditing(false)}
-        />
+        <EditBoardForm board={board} onSuccess={handleEditSuccess} onCancel={() => setIsEditing(false)} />
       </Box>
     );
   }
@@ -330,29 +325,29 @@ export function BoardDetailContent({
               onFollowChange={handleFollowChange}
             />
           )}
+          {board.canEdit && (
+            <MuiButton
+              variant="outlined"
+              size="small"
+              startIcon={<EditOutlined />}
+              onClick={() => setIsEditing(true)}
+              sx={{ textTransform: 'none' }}
+            >
+              {t('boardEntity.actions.edit')}
+            </MuiButton>
+          )}
           {isOwner && (
-            <>
-              <MuiButton
-                variant="outlined"
-                size="small"
-                startIcon={<EditOutlined />}
-                onClick={() => setIsEditing(true)}
-                sx={{ textTransform: 'none' }}
-              >
-                {t('boardEntity.actions.edit')}
-              </MuiButton>
-              <MuiButton
-                variant="outlined"
-                size="small"
-                color="error"
-                startIcon={<DeleteOutlined />}
-                onClick={() => setShowDeleteDialog(true)}
-                disabled={isDeleting}
-                sx={{ textTransform: 'none' }}
-              >
-                {isDeleting ? <CircularProgress size={16} /> : t('boardEntity.actions.delete')}
-              </MuiButton>
-            </>
+            <MuiButton
+              variant="outlined"
+              size="small"
+              color="error"
+              startIcon={<DeleteOutlined />}
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={isDeleting}
+              sx={{ textTransform: 'none' }}
+            >
+              {isDeleting ? <CircularProgress size={16} /> : t('boardEntity.actions.delete')}
+            </MuiButton>
           )}
         </Box>
       </Box>

--- a/packages/web/app/components/board-entity/edit-board-form.tsx
+++ b/packages/web/app/components/board-entity/edit-board-form.tsx
@@ -17,12 +17,11 @@ import BoardForm from './board-form';
 
 type EditBoardFormProps = {
   board: UserBoard;
-  totalAscents?: number;
   onSuccess?: (board: UserBoard) => void;
   onCancel?: () => void;
 };
 
-export default function EditBoardForm({ board, totalAscents, onSuccess, onCancel }: EditBoardFormProps) {
+export default function EditBoardForm({ board, onSuccess, onCancel }: EditBoardFormProps) {
   const { t } = useTranslation('boards');
   const { showMessage } = useSnackbar();
 
@@ -34,13 +33,13 @@ export default function EditBoardForm({ board, totalAscents, onSuccess, onCancel
   });
 
   const configEditable = useMemo(() => {
-    if (totalAscents !== 0) return undefined;
+    if (!board.canEdit) return undefined;
     const options = getBoardSelectorOptions();
     const boardType = board.boardType as BoardName;
     const layouts = options.layouts[boardType] ?? [];
     if (layouts.length === 0) return undefined;
     return { boardType, layouts, sizes: options.sizes, sets: options.sets };
-  }, [totalAscents, board.boardType]);
+  }, [board.canEdit, board.boardType]);
 
   const handleSubmit = useCallback(
     async (values: {

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -218,29 +218,29 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                 onFollowChange={() => fetchGym()}
               />
             )}
+            {gym.canEdit && (
+              <MuiButton
+                variant="outlined"
+                size="small"
+                startIcon={<EditOutlined />}
+                onClick={() => setIsEditing(true)}
+                sx={{ textTransform: 'none' }}
+              >
+                {t('gymEntity.actions.edit')}
+              </MuiButton>
+            )}
             {isOwner && (
-              <>
-                <MuiButton
-                  variant="outlined"
-                  size="small"
-                  startIcon={<EditOutlined />}
-                  onClick={() => setIsEditing(true)}
-                  sx={{ textTransform: 'none' }}
-                >
-                  {t('gymEntity.actions.edit')}
-                </MuiButton>
-                <MuiButton
-                  variant="outlined"
-                  size="small"
-                  color="error"
-                  startIcon={<DeleteOutlined />}
-                  onClick={() => setShowDeleteDialog(true)}
-                  disabled={isDeleting}
-                  sx={{ textTransform: 'none' }}
-                >
-                  {isDeleting ? <CircularProgress size={16} /> : t('gymEntity.actions.delete')}
-                </MuiButton>
-              </>
+              <MuiButton
+                variant="outlined"
+                size="small"
+                color="error"
+                startIcon={<DeleteOutlined />}
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={isDeleting}
+                sx={{ textTransform: 'none' }}
+              >
+                {isDeleting ? <CircularProgress size={16} /> : t('gymEntity.actions.delete')}
+              </MuiButton>
             )}
           </Box>
         </Box>


### PR DESCRIPTION
## Summary

A user reported that the board setup listed under the **Bonsist** gym in Sofia, Bulgaria is outdated (the wall is now a 40° 2019 MoonBoard Masters setup, all holds, no neutral screw-ons). These public/catalog gym + board records are owned by a system import user, so until now **nobody but the owner could fix them**.

This wires the existing `community_roles` system (`admin`, `community_leader`; global or board-type-scoped — the same roles already used for grading proposals) into board and gym editing.

**Backend**
- `updateBoard` / `updateGym` now authorize the **owner**, a **community admin/leader for the board type** (or global), or the **linked gym's owner/admin** — via `requireBoardEditAccess` / an extended `requireGymOwnerOrAdmin`.
- Dropped the *"board has logged climbs → blocked"* config guard. Authorized editors may change layout/size/hold-sets after a real physical reconfiguration; **existing ticks are left untouched** — they keep referencing the climbs/config they were logged against (per the decision that old ticks stay on the old config).
- Fixed a latent bug: the duplicate-config uniqueness check now keys off the **board's owner**, not the caller (an admin editing a system-owned board was checking the wrong owner's boards).
- New computed `canEdit: Boolean!` on `UserBoard` and `Gym` — single source of truth that drives every client's edit UI. `enrichBoards` computes it O(1) per row (roles + editable gym ids fetched once).

**Web** — Edit button + config chips gate on `canEdit` (Delete stays owner-only).

**Mobile** — `useGym` / `useUpdateGym` hooks, config unlock in `boards/edit`, a new `gyms/edit` screen + `GymForm`, and edit affordances in gym discovery.

### Permission scoping
A MoonBoard `community_leader` can edit MoonBoard boards/gyms; a global admin/leader edits anything; an unrelated logged-in user is still rejected.

### Known limitation
`UpdateBoardInput` can't change `boardType` (the Bonsist record is already a MoonBoard, so angle + layout + hold-sets cover it). A listing with the *wrong board type entirely* still needs delete + recreate. A board-type-scoped leader also can't edit a gym that has zero linked boards (no board type to match) — global admins can.

## Release Notes

- Outdated board and gym listings can now be fixed by the community — the setups you browse stay accurate as walls get reconfigured.

## Test plan

- New `packages/backend/src/__tests__/board-gym-edit-authorization.test.ts` (26 real-DB cases): community admin/leader edits a board & gym they don't own; board-type scoping rejects the wrong type; config change with existing ticks succeeds **and leaves tick rows byte-identical**; the uniqueness check keys off the board's owner; a plain user is rejected; `canEdit` correct for owner / matching-role / wrong-type / anonymous viewers.
- Full backend suite: 141 files / 1849 tests pass. Web: 4832 pass. Mobile: 2866 pass.
- `vp run codegen` (no drift), `vp run typecheck` (web/backend/shared/mobile), `vp check`, `vp run check:i18n` + catalog-completeness (en/es/fr parity), `vp run check:mobile-bundle` — all green.
- Manual QA pending (web: edit Bonsist as a community leader; mobile: gym discovery → edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqifitS6fqvEGHJSSwyatT