### PR TITLE
perf(mobile): keep Android tab trees resident on switch (#3153)

### DIFF
--- a/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
+++ b/packages/mobile/app/(tabs)/__tests__/tab-layout.test.tsx
@@ -82,7 +82,25 @@ vi.mock('../../../src/hooks/use-bottom-accessory', () => ({
 // Stub the Material-variant path so it doesn't pull in native modules.
 vi.mock('expo-router', () => {
   const Tabs = Object.assign(
-    ({ children }: { children?: ReactNode }) => createElement('nav', { 'data-tabs-material': 'true' }, children),
+    ({
+      children,
+      screenOptions,
+      detachInactiveScreens,
+    }: {
+      children?: ReactNode;
+      screenOptions?: { freezeOnBlur?: boolean };
+      detachInactiveScreens?: boolean;
+    }) =>
+      createElement(
+        'nav',
+        {
+          'data-tabs-material': 'true',
+          'data-freeze-on-blur': String(screenOptions?.freezeOnBlur),
+          // false (Android, keep resident) vs undefined (default elsewhere).
+          'data-detach-inactive': String(detachInactiveScreens),
+        },
+        children,
+      ),
     {
       Screen: ({ name, options }: { name: string; options?: { lazy?: boolean } }) => {
         const screen = { name, options };
@@ -291,6 +309,36 @@ describe('TabLayout', () => {
     render(<TabLayout />);
 
     expect(cfg.materialScreens.find((screen) => screen.name === 'record')?.options).toMatchObject({ lazy: false });
+  });
+
+  it('freezes blurred JS tabs so resident-but-inactive trees stop processing', () => {
+    cfg.variant = 'material';
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs-material="true"]')?.getAttribute('data-freeze-on-blur')).toBe('true');
+  });
+
+  it('keeps inactive tab native trees resident on Android (re-attach, not rebuild)', () => {
+    // Android detaches a blurred tab's native subtree by default, so a switch
+    // rebuilds every node. detachInactiveScreens=false makes it a cheap re-attach.
+    cfg.variant = 'material';
+    cfg.platformOS = 'android';
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs-material="true"]')?.getAttribute('data-detach-inactive')).toBe('false');
+  });
+
+  it('leaves detachInactiveScreens at the RN default off Android', () => {
+    cfg.variant = 'material';
+    cfg.platformOS = 'ios';
+
+    const { container } = render(<TabLayout />);
+
+    expect(container.querySelector('[data-tabs-material="true"]')?.getAttribute('data-detach-inactive')).toBe(
+      'undefined',
+    );
   });
 
   it('renders the Record badge when a session is active', () => {

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -73,10 +73,21 @@ export default function TabLayout() {
   const onAccessorySurface = useOnAccessorySurface();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
+  // Android detaches (destroys) a blurred tab's native (Fabric) view tree by
+  // default, so re-focusing a tab rebuilds every node (`createNode`/`completeRoot`
+  // burst — worst on Profile's SVG charts). Keep inactive tabs resident there so a
+  // switch is a cheap re-attach; `freezeOnBlur` below stops the resident-but-blurred
+  // trees from burning CPU. Scoped to Android (the profiled platform); `undefined`
+  // keeps the RN default elsewhere.
+  const keepInactiveTabsResident = Platform.OS === 'android';
 
   if (!nativeTabBar) {
     return (
-      <Tabs tabBar={(props) => <MaterialTabBar {...props} />} screenOptions={{ headerShown: false }}>
+      <Tabs
+        tabBar={(props) => <MaterialTabBar {...props} />}
+        detachInactiveScreens={keepInactiveTabsResident ? false : undefined}
+        screenOptions={{ headerShown: false, freezeOnBlur: true }}
+      >
         <Tabs.Screen
           name="home"
           options={{ title: t('mobile.nav.home'), tabBarIcon: materialTabIcon('home', 'home-outline') }}

--- a/packages/mobile/app/(tabs)/_layout.tsx
+++ b/packages/mobile/app/(tabs)/_layout.tsx
@@ -73,12 +73,9 @@ export default function TabLayout() {
   const onAccessorySurface = useOnAccessorySurface();
   const showRecordBadge = isBluetoothConnected || sessionId !== null;
   const eagerMountRecord = Platform.OS === 'android';
-  // Android detaches (destroys) a blurred tab's native (Fabric) view tree by
-  // default, so re-focusing a tab rebuilds every node (`createNode`/`completeRoot`
-  // burst — worst on Profile's SVG charts). Keep inactive tabs resident there so a
-  // switch is a cheap re-attach; `freezeOnBlur` below stops the resident-but-blurred
-  // trees from burning CPU. Scoped to Android (the profiled platform); `undefined`
-  // keeps the RN default elsewhere.
+  // Android destroys a blurred tab's native view tree by default, rebuilding every
+  // node on re-focus (worst on Profile's charts). Keep inactive tabs resident so a
+  // switch re-attaches instead; `freezeOnBlur` below idles the resident trees.
   const keepInactiveTabsResident = Platform.OS === 'android';
 
   if (!nativeTabBar) {


### PR DESCRIPTION
## Summary

Closes #3153.

On Android, switching bottom tabs **destroys and rebuilds each tab's native (Fabric) view tree** on every switch — a `createNode` / `completeRoot` / `appendChild` burst, worst on the Profile tab (its ~5 SVG charts get re-instantiated each time). Profiling on a physical Pixel 8 (Hermes CPU sampling) showed the tab-nav flow spending ~61% of wall time on the JS thread, dominated by that Fabric node work.

**Root cause:** the JS `Tabs` navigator (expo-router's vendored `@react-navigation/bottom-tabs`) defaults `detachInactiveScreens` to `true` on Android, so a blurred tab's native subtree is detached/destroyed and rebuilt on return. `freezeOnBlur` is also unset, so resident inactive tabs aren't frozen.

**Fix** (`packages/mobile/app/(tabs)/_layout.tsx`, JS Tabs branch only):
- `detachInactiveScreens={false}` as a **navigator prop**, Android-gated via the existing `Platform.OS === 'android'` idiom (sibling to `eagerMountRecord`). Keeps inactive tabs resident → a switch becomes a cheap re-attach instead of a full rebuild.
- `freezeOnBlur: true` in `screenOptions` so resident-but-blurred trees stop processing while inactive (verified to compose with `enabled={false}` in the vendored `ScreenFallback`/`MaybeScreen`).

The iOS-26 `NativeTabs` branch is UIKit-managed and untouched. Memory trade-off (Profile's charts stay resident) is scoped to Android and offset by `freezeOnBlur`.

> Note: `detachInactiveScreens` is a navigator prop, **not** a screen option — the issue text said `screenOptions` for both, but only `freezeOnBlur` is read from screen options.

## Release Notes

- Snappier tab switching on Android — hopping between Home, Climbs, and your profile no longer rebuilds each screen from scratch.

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 2899 passed (incl. 3 new tab-layout cases: `freezeOnBlur` set, Android `detachInactiveScreens=false`, default off Android)
- `vp run check:mobile-bundle` — Android bundle OK (12.8 MB)
- `vp check` — changed files clean

**Still needs on-device QA (can't be automated in CI):**
- freezeOnBlur + Record/live session: start a live session, switch away from Record and back — confirm session UI, timer, and board/BLE state stay live and intact.
- Memory on a mid/low-end Android device (Profile's resident SVG charts). Escape hatch if it regresses: change is already Android-gated; can narrow or drop `detachInactiveScreens={false}` while keeping `freezeOnBlur`.
- Absolute frame wins want a **release-build** Hermes re-profile (the issue flags dev-build timings as inflated).
