### PR TITLE
fix(mobile): make Android Tall/Wide filter chips work + toggle Grade

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1012,6 +1012,8 @@ function ClimbListInner() {
           gradeLabel={gradeChip.label}
           gradeActive={gradeChip.active}
           onOpenGrade={handleOpenGrade}
+          gradeRailOpen={showGrade}
+          onCloseGrade={handleDismissGrade}
           dimensionChips={dimensionChips}
           minAscents={filters.minAscents}
           onChangePopularity={handleChangePopularity}
@@ -1037,6 +1039,8 @@ function ClimbListInner() {
     handleClearRecentFilters,
     gradeChip,
     handleOpenGrade,
+    showGrade,
+    handleDismissGrade,
     dimensionChips,
     handleChangePopularity,
     handleChangeRating,

--- a/packages/mobile/src/components/grade/GradeRail.tsx
+++ b/packages/mobile/src/components/grade/GradeRail.tsx
@@ -93,11 +93,17 @@ type GradeRangeRailProps = {
   // call site can feed it into the `Grade Filter Changed` analytics event.
   onChange: (next: GradeBound, meta?: GradeTapMeta) => void;
   /**
-   * Asked to dismiss itself (swipe the handle down, completed range, or cleared
-   * selection). Only ever called when `dismissible` is true, so an inline,
-   * always-open rail (e.g. inside the filter sheet) can omit it.
+   * Asked to dismiss itself (swipe the handle, tap the handle, completed range, or
+   * cleared selection). Providing it also renders the grab handle + swipe-to-close
+   * gesture; an inline, always-open rail (e.g. inside the filter sheet) omits it.
    */
   onRequestClose?: () => void;
+  /**
+   * Auto-dismiss on completing a range / clearing the selection. Independent of the
+   * grab handle: the handle + swipe-to-close show whenever `onRequestClose` is set, so
+   * the chip-row rails (dismissible={false}) keep a manual close affordance without the
+   * rail vanishing mid-range-build.
+   */
   dismissible?: boolean;
   showTitle?: boolean;
   style?: StyleProp<ViewStyle>;
@@ -286,7 +292,7 @@ export function GradeRangeRail({
 
   return (
     <RailFrame style={style}>
-      {dismissible ? (
+      {onRequestClose ? (
         <GestureDetector gesture={handleGestureClose}>
           <PressableSurface
             onPress={handleRequestClose}

--- a/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
+++ b/packages/mobile/src/components/grade/__tests__/grade-range-rail.test.tsx
@@ -334,6 +334,38 @@ describe('GradeRangeRail', () => {
     expect(getByText('mobile.search.gradeClear')).toBeTruthy();
     expect(container.querySelector('[data-scroll="true"]')?.getAttribute('data-nested-scroll')).toBe('true');
   });
+
+  // The chip-row rails pass dismissible={false} (no auto-dismiss while building a
+  // range) but still need a manual close affordance — so the grab handle + swipe
+  // gesture are gated on onRequestClose, not dismissible.
+  it('renders the close handle when onRequestClose is set even with dismissible={false}', () => {
+    const onRequestClose = vi.fn();
+    const { container } = render(
+      <GradeRangeRail
+        grades={grades}
+        bound={{ minGradeId: undefined, maxGradeId: undefined }}
+        onChange={vi.fn()}
+        onRequestClose={onRequestClose}
+        dismissible={false}
+      />,
+    );
+    const handle = container.querySelector('[data-label="mobile.gradeRail.closeAria"]');
+    expect(handle).toBeTruthy();
+    fireEvent.click(handle as Element);
+    expect(onRequestClose).toHaveBeenCalled();
+  });
+
+  it('omits the close handle for an inline rail with no onRequestClose', () => {
+    const { container } = render(
+      <GradeRangeRail
+        grades={grades}
+        bound={{ minGradeId: undefined, maxGradeId: undefined }}
+        onChange={vi.fn()}
+        dismissible={false}
+      />,
+    );
+    expect(container.querySelector('[data-label="mobile.gradeRail.closeAria"]')).toBeNull();
+  });
 });
 
 describe('GradeSingleSelectRail', () => {

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -13,11 +13,17 @@
 //     menu on a toggle item's click — Compose has no menuActionDismissBehavior and
 //     doesn't auto-dismiss on click, so this is the natural equivalent.
 //   • Dimension chips reconstruct iOS's Menu+onPrimaryAction (tap toggles, long-press
-//     opens lock/unlock) from `combinedClickable`. The chip carries no `onClick`, so
-//     the modifier owns both gestures — avoiding the FilterChip-onClick-vs-
-//     combinedClickable conflict. A locked chip keeps firing onToggle on tap, but the
-//     shared `useDimensionRepin` in the climbs screen re-pins it, so the filter stays
-//     active (the same "locked ignores tap" outcome as iOS).
+//     opens lock/unlock). The FilterChip keeps its own `onClick` (tap → onToggle): the
+//     Compose FilterChip ALWAYS wires an internal onClick, so a `combinedClickable`
+//     placed on the chip's OWN modifier is dead (the chip's inner clickable consumes
+//     the gesture). The long-press lives instead on a wrapping `Row` carrying
+//     `combinedClickable({ onLongClick })` (no onClick → its native click event
+//     JS-no-ops, so no double-toggle) — the same plain-container pattern SelectRow uses
+//     in MoreForm.android.tsx. Long-press is best-effort on Compose; if a device doesn't
+//     propagate it to the parent the chip still toggles on tap (lock just unreachable).
+//     A locked chip keeps firing onToggle on tap, but `onToggle` early-returns when
+//     locked and the shared `useDimensionRepin` re-pins it, so the filter stays active
+//     (the same "locked ignores tap" outcome as iOS).
 //   • Single-choice (Popularity/Rating) skips the iOS string-tag Picker round-trip:
 //     each item's onClick closure carries the real `number | undefined` bucket.
 // Labels reuse FilterChipRow.logic so a filter is never worded two ways across
@@ -153,9 +159,12 @@ function MenuItem({
   );
 }
 
-// Tall / Wide board-shape chip: tap toggles the filter, long-press opens a
-// lock/unlock menu. `combinedClickable` owns both gestures (no FilterChip.onClick),
-// avoiding the documented onClick-vs-combinedClickable conflict.
+// Tall / Wide board-shape chip: tap toggles the filter (FilterChip.onClick),
+// long-press opens a lock/unlock menu. The long-press lives on the wrapping `Row`'s
+// `combinedClickable` rather than the chip — the chip's own internal onClick always
+// consumes the gesture, so a combinedClickable on the chip itself is dead (see the
+// file header). `indication: false` keeps the row from painting a second ripple over
+// the chip's own.
 function DimensionChipView({
   dimension,
   label,
@@ -173,20 +182,18 @@ function DimensionChipView({
   return (
     <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
       <DropdownMenu.Trigger>
-        <FilterChip
-          selected={dimension.active}
-          colors={colors}
-          modifiers={[combinedClickable({ onClick: dimension.onToggle, onLongClick: () => setExpanded(true) })]}
-        >
-          {dimension.locked ? (
-            <FilterChip.LeadingIcon>
-              <Icon source={ICON.lock} size={ICON_SIZE} />
-            </FilterChip.LeadingIcon>
-          ) : null}
-          <FilterChip.Label>
-            <Text>{label}</Text>
-          </FilterChip.Label>
-        </FilterChip>
+        <Row modifiers={[combinedClickable({ onLongClick: () => setExpanded(true) }, { indication: false })]}>
+          <FilterChip selected={dimension.active} colors={colors} onClick={dimension.onToggle}>
+            {dimension.locked ? (
+              <FilterChip.LeadingIcon>
+                <Icon source={ICON.lock} size={ICON_SIZE} />
+              </FilterChip.LeadingIcon>
+            ) : null}
+            <FilterChip.Label>
+              <Text>{label}</Text>
+            </FilterChip.Label>
+          </FilterChip>
+        </Row>
       </DropdownMenu.Trigger>
       <DropdownMenu.Items>
         <DropdownMenuItem
@@ -218,6 +225,8 @@ function FilterChipRowComponent({
   gradeLabel,
   gradeActive,
   onOpenGrade,
+  gradeRailOpen,
+  onCloseGrade,
   dimensionChips,
   minAscents,
   onChangePopularity,
@@ -297,8 +306,13 @@ function FilterChipRowComponent({
           />
         ) : null}
 
-        {/* Grade → the range rail overlay. Action chip, no menu. */}
-        <ActionChip label={gradeLabel} selected={gradeActive} colors={chipColors} onPress={onOpenGrade} />
+        {/* Grade → the range rail overlay. Action chip, no menu; tap toggles the rail. */}
+        <ActionChip
+          label={gradeLabel}
+          selected={gradeActive}
+          colors={chipColors}
+          onPress={gradeRailOpen ? onCloseGrade : onOpenGrade}
+        />
 
         {/* Show ▾ — hide-sent (auth-gated) + benchmarks. The controlled menu stays
             OPEN while toggling (these items don't call close()). */}

--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -52,6 +52,8 @@ function FilterChipRowComponent({
   gradeLabel,
   gradeActive,
   onOpenGrade,
+  gradeRailOpen,
+  onCloseGrade,
   dimensionChips,
   minAscents,
   onChangePopularity,
@@ -126,8 +128,13 @@ function FilterChipRowComponent({
             </Menu>
           ) : null}
 
-          {/* Grade → the range rail overlay. A button, not a menu. [PRIMARY #1] */}
-          <Button label={gradeLabel} onPress={onOpenGrade} modifiers={chipModifiers(gradeActive)} />
+          {/* Grade → the range rail overlay. A button, not a menu; tap toggles the
+              rail (close path beyond the tap-outside dismiss layer). [PRIMARY #1] */}
+          <Button
+            label={gradeLabel}
+            onPress={gradeRailOpen ? onCloseGrade : onOpenGrade}
+            modifiers={chipModifiers(gradeActive)}
+          />
 
           {/* Show ▾ — hide-sent + benchmarks; menuActionDismissBehavior keeps it
               open. [PRIMARY #2 + #3] — kept directly after Grade. */}

--- a/packages/mobile/src/components/search/FilterChipRow.types.ts
+++ b/packages/mobile/src/components/search/FilterChipRow.types.ts
@@ -39,6 +39,9 @@ export type FilterChipRowProps = {
   gradeLabel: string;
   gradeActive: boolean;
   onOpenGrade: () => void;
+  /** Whether the grade range rail is currently shown — the chip toggles it. */
+  gradeRailOpen: boolean;
+  onCloseGrade: () => void;
 
   /** Tall/Wide chips for the current Kilter homewall size (empty otherwise). */
   dimensionChips: DimensionChip[];


### PR DESCRIPTION
## Summary

Three interactions in the native Material 3 filter-chip row (#3310) were broken on Android. This fixes all three. JS-only, so it rides OTA — no new native build.

**Tall / Wide chips did nothing.** The Compose `FilterChip` always wires its own internal `onClick` (`ChipView.kt:208`), which sits inside the modifier chain and consumes the tap — so the `combinedClickable` placed on the chip's own `modifier` never fired (neither the toggle nor the lock long-press). Moved the tap to the `FilterChip`'s real `onClick`, and the long-press onto a wrapping `Row`'s `combinedClickable` (the plain-container pattern that already works in `MoreForm.android.tsx`'s `SelectRow`). Tap-toggle is now bulletproof; the long-press lock is best-effort on Compose and degrades to tap-only if a device drops it.

**The Grade chip couldn't be hidden.** It always *opened* the rail (no toggle), unlike the `GradeFilterControl` it replaced. The chip now toggles open/closed, via new shared `gradeRailOpen` / `onCloseGrade` props (applied on both platforms; harmless on iOS, which also keeps its tap-outside dismiss layer).

**The grade rail had no dismiss gesture on the chip-row paths.** `GradeRangeRail`'s grab handle + swipe-to-close were gated on `dismissible`, which the chip rows set `false` to avoid auto-closing while a range is being built. Gated the handle/swipe on `onRequestClose` instead, so the rails get a manual close (swipe up/down, or tap the handle) without the rail vanishing mid-build. Auto-dismiss-on-range-complete stays on `dismissible`.

## Release Notes

- The Tall and Wide filter chips now work — tap to filter to your homewall's shape, long-press to lock it on.
- Tap the Grade chip again (or swipe the grade picker away) to close it.

## Test plan

- `vp run typecheck:mobile` — clean.
- `vp run test:mobile` — 2898 passed; added two `GradeRangeRail` cases for the decoupled close handle.
- `vp run check:mobile-bundle` — Android bundle OK (12.8 MB).
- Android emulator verification — in progress; will post screenshots of the chip row + grade toggle. Long-press lock is best-effort on Compose and can't be confirmed via screenshots, so it's flagged for on-device QA.