### PR TITLE
feat(mobile): native @expo/ui Forms for OTA channel + branch switchers (#3271)

### DIFF
--- a/docs/expo-ui-components.md
+++ b/docs/expo-ui-components.md
@@ -148,6 +148,27 @@ option a `Text` carrying a `tag` modifier; string-guard `onSelectionChange`); An
 declares a function (like `SegmentedControl`), not a `const`. Selection logic is shared via
 `makeRadioSelectHandler`.
 
+### Whole-screen forms: MoreForm / FeatureFlagsForm / SwitcherForm
+
+The settings screens consolidate an entire screen into ONE `Host` containing a single
+SwiftUI `Form` (iOS) / Compose `LazyColumn` of cards (Android), instead of one `Host`
+per control. The screen component owns the route guards, data hooks, `t()` calls,
+confirm/Alert/haptics, then builds a plain view-model that the native tree renders —
+`MoreForm.*`, `FeatureFlagsForm.*`, and `SwitcherForm.*` are the three. **Host sizing
+differs from a standalone control:** a Form/LazyColumn is a scrolling container, so the
+Host uses `style={{ flex: 1 }}` + (iOS) `useViewportSizeMeasurement` — NOT `matchContents`
+(which sizes to content and clips the scroll).
+
+`SwitcherForm` (`src/components/SwitcherForm.*`) backs **both** the OTA Channel and Branch
+switcher screens (`ChannelSwitcherScreen`, `BranchSwitcherScreen`) from one generic
+sections-of-typed-rows model (`info`/`status`/`target`/`field`/`action`), the same shape
+MoreForm uses — the two screens are the same OTA-target switcher, so they share one form
+rather than duplicating two near-identical native trees. Its inline text field is a bare
+native `TextField`/`OutlinedTextField` placed directly in the form (the standalone
+`AuthTextInput` renders its own `Host` and can't nest inside another), reusing
+`AuthTextInput.logic`'s pure prop→modifier mappers + `textFieldBrandColors`. Row state is
+derived once by `deriveSwitchRowState` (`SwitcherForm.logic.ts`) so iOS/Android can't drift.
+
 ## Buttons
 
 **A button _inside_ an existing native @expo/ui tree should be a native button,

--- a/packages/mobile/src/components/BranchSwitcherScreen.tsx
+++ b/packages/mobile/src/components/BranchSwitcherScreen.tsx
@@ -1,12 +1,6 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { View, ScrollView, ActivityIndicator, Alert, Pressable, StyleSheet, TextInput } from 'react-native';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { Alert } from 'react-native';
 import * as Updates from 'expo-updates';
-import { Text } from './Text';
-import { SectionHeader } from './SectionHeader';
-import { ListRow } from './ListRow';
-import { Icon } from './Icon';
-import { InfoRow } from './InfoRow';
-import { useTheme } from '../providers/theme-provider';
 import { useConfirm } from '../providers/dialog-provider';
 import { hapticLight, hapticError } from '../lib/haptics';
 import { reportHandledError } from '../lib/error-reporting';
@@ -20,6 +14,9 @@ import {
   type ChannelSwitchDeps,
 } from '../lib/channel-switch';
 import { isPreviewBuild } from '../lib/preview-build';
+import { SwitcherForm } from './SwitcherForm';
+import { deriveSwitchRowState, isSwitchRowPressable } from './SwitcherForm.logic';
+import type { SwitcherFormModel, SwitcherRow, SwitcherSection } from './SwitcherForm.types';
 
 // The branch baked into the running update's manifest metadata (set by the OTA
 // server). Read-only and tokenless — surfaced so a tester can see which branch
@@ -38,15 +35,14 @@ function getCurrentBranchName(): string | null {
   return null;
 }
 
-// Preview-build sibling of the tester OTA Channel Switcher. Both repoint the
-// running build at a different update target device-locally — overriding only the
-// `expo-channel-name` request header (no EAS API token, no project-wide channel
-// remap) — so they share the same override key and the same commit/revert state
-// machine in `channel-switch.ts`. This screen is framed around branches: a tester
-// picks a preview channel/branch (or types one) and the build pulls that branch's
-// OTA on restart.
+// Preview-build sibling of the tester OTA Channel Switcher, rendered as a single
+// native @expo/ui form via the shared <SwitcherForm />. Both repoint the running
+// build at a different update target device-locally — overriding only the
+// `expo-channel-name` request header — so they share the same override key and the
+// same commit/revert state machine in `channel-switch.ts`. This screen is framed
+// around branches: a tester picks a preview channel/branch (or types one) and the
+// build pulls that branch's OTA on restart. Tester-only, so copy is `i18n-ignore`d.
 export function BranchSwitcherScreen() {
-  const { systemColors, spacing, borderRadius } = useTheme();
   const confirm = useConfirm();
   const [override, setOverride] = useState<string | null>(null);
   const [customBranch, setCustomBranch] = useState('');
@@ -184,205 +180,146 @@ export function BranchSwitcherScreen() {
     }
   }, [confirm, buildChannel, makeDeps]);
 
+  // Build the native form's view-model. Memoized so the Host's children don't
+  // rebuild every render; `branches` is derived inside so the dep set stays stable.
+  const model = useMemo<SwitcherFormModel>(() => {
+    const sections: SwitcherSection[] = [];
+
+    // Current update info. Conditional rows mirror the original card.
+    const currentRows: SwitcherRow[] = [];
+    if (isEmbedded) {
+      // i18n-ignore-next-line
+      currentRows.push({ kind: 'info', key: 'status', label: 'Status', value: 'No OTA update applied' });
+    }
+    // i18n-ignore-next-line
+    currentRows.push({ kind: 'info', key: 'build', label: 'Build channel', value: buildChannel });
+    currentRows.push({
+      kind: 'info',
+      key: 'selected',
+      // i18n-ignore-next-line
+      label: 'Selected branch',
+      // i18n-ignore-next-line
+      value: override ?? `${buildChannel} (default)`,
+    });
+    if (currentBranch) {
+      // i18n-ignore-next-line
+      currentRows.push({ kind: 'info', key: 'running', label: 'Running branch', value: currentBranch });
+    }
+    if (currentUpdateId) {
+      // i18n-ignore-next-line
+      currentRows.push({ kind: 'info', key: 'update-id', label: 'Update ID', value: currentUpdateId.slice(0, 8) });
+    }
+    // i18n-ignore-next-line
+    currentRows.push({ kind: 'info', key: 'runtime', label: 'Runtime version', value: runtimeVersion });
+    sections.push({
+      key: 'current',
+      // i18n-ignore-next-line
+      title: 'Current Update',
+      footer: updatesUsable
+        ? undefined
+        : // i18n-ignore-next-line
+          'OTA updates are disabled in this build (development or updates not enabled), so branch switching is unavailable here.',
+      rows: currentRows,
+    });
+
+    if (updatesUsable) {
+      // Switch Branch — preview channels/branches, no chevron.
+      const branches = buildChannelList(override);
+      sections.push({
+        key: 'switch',
+        // i18n-ignore-next-line
+        title: 'Switch Branch',
+        rows: branches.map((branch) => {
+          const state = deriveSwitchRowState({
+            target: branch,
+            activeTarget,
+            switchingTarget: switchingTo,
+            updatesUsable,
+          });
+          return {
+            kind: 'target',
+            key: branch,
+            title: branch,
+            state,
+            showChevronWhenPressable: false,
+            onPress: isSwitchRowPressable(state) ? () => void switchToBranch(branch) : undefined,
+          };
+        }),
+      });
+
+      // Custom branch entry.
+      const trimmedCustomBranch = customBranch.trim();
+      const submitCustom = () => {
+        const value = customBranch.trim();
+        if (value) void switchToBranch(value);
+      };
+      sections.push({
+        key: 'custom',
+        // i18n-ignore-next-line
+        title: 'Custom Branch',
+        rows: [
+          {
+            kind: 'field',
+            key: 'custom-field',
+            // i18n-ignore-next-line
+            label: 'Custom branch name',
+            // i18n-ignore-next-line
+            placeholder: 'branch name',
+            value: customBranch,
+            onChangeText: setCustomBranch,
+            onSubmit: submitCustom,
+            editable: !isSwitching,
+          },
+          {
+            kind: 'action',
+            key: 'custom-switch',
+            // i18n-ignore-next-line
+            label: 'Switch',
+            icon: 'switch',
+            disabled: isSwitching || trimmedCustomBranch.length === 0,
+            onPress: submitCustom,
+          },
+        ],
+      });
+
+      // Reset — always offered (not gated on `override`) so a native override
+      // stranded after an app-data clear stays clearable.
+      sections.push({
+        key: 'reset',
+        rows: [
+          {
+            kind: 'action',
+            key: 'reset',
+            // i18n-ignore-next-line
+            label: `Reset to build branch (${buildChannel})`,
+            icon: 'reset',
+            disabled: isSwitching,
+            onPress: () => void resetToBuildBranch(),
+          },
+        ],
+      });
+    }
+
+    return { sections };
+  }, [
+    buildChannel,
+    override,
+    currentBranch,
+    currentUpdateId,
+    runtimeVersion,
+    isEmbedded,
+    updatesUsable,
+    activeTarget,
+    switchingTo,
+    isSwitching,
+    customBranch,
+    switchToBranch,
+    resetToBuildBranch,
+  ]);
+
   if (!preview) {
     return null;
   }
 
-  const branches = buildChannelList(override);
-  const trimmedCustomBranch = customBranch.trim();
-  const customBranchDisabled = isSwitching || trimmedCustomBranch.length === 0;
-
-  return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
-      {/* i18n-ignore-next-line */}
-      <SectionHeader title="Current Update" />
-      <View
-        style={[
-          styles.card,
-          {
-            backgroundColor: systemColors.secondaryBackground,
-            borderRadius: borderRadius.lg,
-            marginHorizontal: spacing[4],
-          },
-        ]}
-      >
-        {isEmbedded ? (
-          // i18n-ignore-next-line
-          <InfoRow label="Status" value="No OTA update applied" />
-        ) : null}
-        {/* i18n-ignore-next-line */}
-        <InfoRow label="Build channel" value={buildChannel} />
-        {/* i18n-ignore-next-line */}
-        <InfoRow label="Selected branch" value={override ?? `${buildChannel} (default)`} />
-        {currentBranch ? (
-          // i18n-ignore-next-line
-          <InfoRow label="Running branch" value={currentBranch} />
-        ) : null}
-        {currentUpdateId ? (
-          // i18n-ignore-next-line
-          <InfoRow label="Update ID" value={currentUpdateId.slice(0, 8)} />
-        ) : null}
-        {/* i18n-ignore-next-line */}
-        <InfoRow label="Runtime version" value={runtimeVersion} showSeparator={false} />
-      </View>
-
-      {!updatesUsable ? (
-        <View style={[styles.notice, { marginHorizontal: spacing[4] }]}>
-          <Text variant="footnote" color={systemColors.secondaryLabel}>
-            {/* i18n-ignore-next-line */}
-            OTA updates are disabled in this build (development or updates not enabled), so branch switching is
-            unavailable here.
-          </Text>
-        </View>
-      ) : (
-        <>
-          {/* i18n-ignore-next-line */}
-          <SectionHeader title="Switch Branch" />
-          <View
-            style={[
-              styles.card,
-              {
-                backgroundColor: systemColors.secondaryBackground,
-                borderRadius: borderRadius.lg,
-                marginHorizontal: spacing[4],
-              },
-            ]}
-          >
-            {branches.map((branch, index) => {
-              const isActive = branch === activeTarget;
-              const isThisSwitching = switchingTo === branch;
-              const isDisabled = isSwitching && !isThisSwitching;
-              const trailing = isThisSwitching ? (
-                <ActivityIndicator size="small" />
-              ) : isActive ? (
-                <Icon name="check.small" size={20} color={systemColors.label} />
-              ) : null;
-
-              return (
-                <ListRow
-                  key={branch}
-                  title={branch}
-                  trailing={trailing}
-                  onPress={isActive || isDisabled ? undefined : () => void switchToBranch(branch)}
-                  showSeparator={index < branches.length - 1}
-                  style={isDisabled ? styles.disabledRow : undefined}
-                />
-              );
-            })}
-          </View>
-
-          {/* i18n-ignore-next-line */}
-          <SectionHeader title="Custom Branch" />
-          <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
-            <TextInput
-              value={customBranch}
-              onChangeText={setCustomBranch}
-              // i18n-ignore-next-line
-              placeholder="branch name"
-              placeholderTextColor={systemColors.secondaryLabel}
-              autoCapitalize="none"
-              autoCorrect={false}
-              editable={!isSwitching}
-              // i18n-ignore-next-line
-              accessibilityLabel="Custom branch name"
-              style={[
-                styles.input,
-                {
-                  color: systemColors.label,
-                  backgroundColor: systemColors.secondaryBackground,
-                  borderRadius: borderRadius.md,
-                },
-              ]}
-            />
-            <Pressable
-              onPress={() => {
-                if (trimmedCustomBranch) void switchToBranch(trimmedCustomBranch);
-              }}
-              disabled={customBranchDisabled}
-              accessibilityRole="button"
-              // i18n-ignore-next-line
-              accessibilityLabel="Switch to the entered branch"
-              accessibilityState={{ disabled: customBranchDisabled }}
-              style={[
-                styles.goButton,
-                {
-                  backgroundColor: systemColors.tertiaryBackground,
-                  borderRadius: borderRadius.md,
-                  opacity: customBranchDisabled ? 0.5 : 1,
-                },
-              ]}
-            >
-              <Icon name="transfer" size={16} color={systemColors.label} />
-              <Text variant="footnote" color={systemColors.label}>
-                {/* i18n-ignore-next-line */}
-                Switch
-              </Text>
-            </Pressable>
-          </View>
-
-          {/* Always offered (not gated on `override`) so a native override stranded
-              after an app-data clear — when the display mirror is gone — stays
-              clearable. */}
-          <Pressable
-            onPress={() => void resetToBuildBranch()}
-            disabled={isSwitching}
-            accessibilityRole="button"
-            // i18n-ignore-next-line
-            accessibilityLabel="Reset to build branch"
-            accessibilityState={{ disabled: isSwitching }}
-            style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: isSwitching ? 0.5 : 1 }]}
-          >
-            <Icon name="refresh" size={16} color={systemColors.label} />
-            <Text variant="footnote" color={systemColors.label}>
-              {/* i18n-ignore-next-line */}
-              Reset to build branch ({buildChannel})
-            </Text>
-          </Pressable>
-        </>
-      )}
-
-      <View style={styles.bottomSpacer} />
-    </ScrollView>
-  );
+  return <SwitcherForm model={model} />;
 }
-
-const styles = StyleSheet.create({
-  card: {
-    padding: 12,
-    overflow: 'hidden',
-  },
-  notice: {
-    paddingVertical: 16,
-  },
-  customRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  input: {
-    flex: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-  },
-  goButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-  },
-  resetButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-    paddingVertical: 12,
-    marginTop: 16,
-  },
-  disabledRow: {
-    opacity: 0.5,
-  },
-  bottomSpacer: {
-    height: 40,
-  },
-});

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -21,6 +21,12 @@ import { SwitcherForm } from './SwitcherForm';
 import { deriveSwitchRowState, isSwitchRowPressable } from './SwitcherForm.logic';
 import type { SwitcherFormModel, SwitcherRow, SwitcherSection } from './SwitcherForm.types';
 
+// Stable empty fallback so `previewQuery.data ?? […]` doesn't hand the model
+// `useMemo` a fresh array reference on every render while the query is loading
+// (which would rebuild the whole form model each render). React-query returns a
+// stable `data` ref once resolved.
+const EMPTY_PREVIEW_CHANNELS: NonNullable<ReturnType<typeof useOtaPreviewChannels>['data']> = [];
+
 // The OTA preview-channel switcher, rendered as a single native @expo/ui form
 // (SwiftUI `Form` on iOS, Jetpack Compose `LazyColumn` on Android) via the shared
 // <SwitcherForm />. This component owns every hook, route data, `t()` call,
@@ -35,7 +41,7 @@ export function ChannelSwitcherScreen() {
   // works for signed-out users too. Fail-soft: the backend returns [] on error,
   // so isError is rare; we still handle it for completeness.
   const previewQuery = useOtaPreviewChannels();
-  const previewChannels = previewQuery.data ?? [];
+  const previewChannels = previewQuery.data ?? EMPTY_PREVIEW_CHANNELS;
   // Channel switching (preview list, preset list, manual entry) is available to
   // everyone; only the Sentry crash-test tools stay tester-only.
   const isTester = Boolean(profile?.isTester);

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -1,16 +1,10 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { View, ScrollView, ActivityIndicator, Alert, Pressable, StyleSheet, TextInput } from 'react-native';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import * as Updates from 'expo-updates';
 import { reportError, reportHandledError } from '../lib/error-reporting';
 import { isSentryEnabled, nativeSentryCrash } from '../lib/sentry';
 import { useOtaPreviewChannels, useProfile } from '../lib/graphql/hooks';
-import { Text } from './Text';
-import { SectionHeader } from './SectionHeader';
-import { ListRow } from './ListRow';
-import { Icon } from './Icon';
-import { InfoRow } from './InfoRow';
-import { useTheme } from '../providers/theme-provider';
 import { useConfirm } from '../providers/dialog-provider';
 import { hapticLight, hapticError } from '../lib/haptics';
 import { getPreference, setPreference, removePreference } from '../lib/preference-store';
@@ -19,15 +13,22 @@ import {
   OTA_CHANNEL_OVERRIDE_KEY,
   buildChannelList,
   resolveBuildChannel,
-  deriveChannelRowState,
   performChannelSwitch,
   performChannelReset,
   type ChannelSwitchDeps,
 } from '../lib/channel-switch';
+import { SwitcherForm } from './SwitcherForm';
+import { deriveSwitchRowState, isSwitchRowPressable } from './SwitcherForm.logic';
+import type { SwitcherFormModel, SwitcherRow, SwitcherSection } from './SwitcherForm.types';
 
+// The OTA preview-channel switcher, rendered as a single native @expo/ui form
+// (SwiftUI `Form` on iOS, Jetpack Compose `LazyColumn` on Android) via the shared
+// <SwitcherForm />. This component owns every hook, route data, `t()` call,
+// confirm dialog, Alert, haptic, and the `channel-switch.ts` state machine, then
+// builds a plain view-model the native tree renders. Mirrors the
+// FeatureFlagsScreen → FeatureFlagsForm split.
 export function ChannelSwitcherScreen() {
   const { t } = useTranslation('common');
-  const { systemColors, brandColors, spacing, borderRadius } = useTheme();
   const confirm = useConfirm();
   const { data: profile } = useProfile();
   // Live per-PR preview channels (with titles) from the backend. Public query —
@@ -70,7 +71,7 @@ export function ChannelSwitcherScreen() {
   // Real builds always bake a channel (production for store/TestFlight), but
   // expo-updates can report it as null on device — notably Android — so resolve
   // to production there. In dev there's genuinely no channel, so stay honest with
-  // "unknown" rather than mislabel the debug InfoRow as production.
+  // "unknown" rather than mislabel the debug info row as production.
   const buildChannel = updatesUsable ? resolveBuildChannel(Updates.channel) : (Updates.channel ?? 'unknown');
   const isSwitching = switchingChannel !== null;
 
@@ -222,322 +223,236 @@ export function ChannelSwitcherScreen() {
     nativeSentryCrash();
   }, [confirm]);
 
-  // The tester preset list excludes the build channel (production on real
-  // builds) — it already has the dedicated production row below, so listing it
-  // again here would duplicate it.
-  const presetChannels = buildChannelList(override).filter((channel) => channel !== buildChannel);
+  // Build the native form's view-model. Memoized so the Host's children don't
+  // rebuild every render; derived lists (preset channels, the active channel) are
+  // computed inside so the dep set stays referentially stable.
+  const model = useMemo<SwitcherFormModel>(() => {
+    const sections: SwitcherSection[] = [];
 
-  // Production is the stable release. It's never in the backend preview list
-  // (that's only open PRs), so it's surfaced as a fixed first row everyone —
-  // tester or not — can tap to get back. Tapping runs the reset flow, which
-  // clears the override and returns to the baked-in production channel.
-  const productionRow = deriveChannelRowState({
-    channel: buildChannel,
-    activeChannel,
-    switchingChannel,
-    updatesUsable,
-  });
+    // Current channel info — the "updates unavailable" notice rides the footer.
+    sections.push({
+      key: 'current',
+      title: t('mobile.previewChannels.currentSection'),
+      footer: updatesUsable ? undefined : t('mobile.previewChannels.unavailableNotice'),
+      rows: [
+        { kind: 'info', key: 'build', label: t('mobile.previewChannels.buildChannelLabel'), value: buildChannel },
+        {
+          kind: 'info',
+          key: 'selected',
+          label: t('mobile.previewChannels.selectedChannelLabel'),
+          value: override ?? t('mobile.previewChannels.defaultValue', { channel: buildChannel }),
+        },
+        {
+          kind: 'info',
+          key: 'runtime',
+          label: t('mobile.previewChannels.runtimeVersionLabel'),
+          value: runtimeVersion,
+        },
+      ],
+    });
 
-  const cardStyle = [
-    styles.card,
-    {
-      backgroundColor: systemColors.secondaryBackground,
-      borderRadius: borderRadius.lg,
-      marginHorizontal: spacing[4],
-    },
-  ];
+    // Friendly per-PR preview list — shown to everyone. Rows stay inert (rendered
+    // but not tappable) when switching is unavailable so the list can be reviewed.
+    const previewRows: SwitcherRow[] = [];
 
-  return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
-      <SectionHeader title={t('mobile.previewChannels.currentSection')} />
-      <View style={cardStyle}>
-        <InfoRow label={t('mobile.previewChannels.buildChannelLabel')} value={buildChannel} />
-        <InfoRow
-          label={t('mobile.previewChannels.selectedChannelLabel')}
-          value={override ?? t('mobile.previewChannels.defaultValue', { channel: buildChannel })}
-        />
-        <InfoRow label={t('mobile.previewChannels.runtimeVersionLabel')} value={runtimeVersion} showSeparator={false} />
-      </View>
+    // Fixed production row first. Production is the stable release — never in the
+    // backend preview list (that's only open PRs) — so it's surfaced as a fixed row
+    // everyone can tap to get back. Tapping runs the reset flow, which clears the
+    // override and returns to the baked-in production channel.
+    const productionState = deriveSwitchRowState({
+      target: buildChannel,
+      activeTarget: activeChannel,
+      switchingTarget: switchingChannel,
+      updatesUsable,
+    });
+    previewRows.push({
+      kind: 'target',
+      key: 'production',
+      title: t('mobile.previewChannels.productionTitle'),
+      subtitle: t('mobile.previewChannels.productionSubtitle'),
+      state: productionState,
+      showChevronWhenPressable: true,
+      onPress: isSwitchRowPressable(productionState) ? () => void resetToBuildChannel() : undefined,
+    });
 
-      {!updatesUsable ? (
-        <View style={[styles.notice, { marginHorizontal: spacing[4] }]}>
-          <Text variant="footnote" color={systemColors.secondaryLabel}>
-            {t('mobile.previewChannels.unavailableNotice')}
-          </Text>
-        </View>
-      ) : null}
+    if (previewQuery.isLoading) {
+      previewRows.push({ kind: 'status', key: 'loading', label: t('mobile.previewChannels.loading'), busy: true });
+    } else if (previewQuery.isError) {
+      previewRows.push({ kind: 'status', key: 'error', label: t('mobile.previewChannels.error') });
+    } else if (previewChannels.length === 0) {
+      previewRows.push({ kind: 'status', key: 'empty', label: t('mobile.previewChannels.empty') });
+    } else {
+      for (const preview of previewChannels) {
+        const state = deriveSwitchRowState({
+          target: preview.channel,
+          activeTarget: activeChannel,
+          switchingTarget: switchingChannel,
+          updatesUsable,
+        });
+        previewRows.push({
+          kind: 'target',
+          key: preview.channel,
+          title: preview.title,
+          subtitle: preview.channel,
+          state,
+          showChevronWhenPressable: true,
+          onPress: isSwitchRowPressable(state) ? () => void switchToChannel(preview.channel, preview.title) : undefined,
+        });
+      }
+    }
+    sections.push({
+      key: 'preview',
+      title: t('mobile.previewChannels.listSection'),
+      intro: t('mobile.previewChannels.intro'),
+      rows: previewRows,
+    });
 
-      {/* Friendly per-PR preview list — shown to everyone. Rows are inert when
-          switching is unavailable (dev / Expo Go) but still render so the list
-          can be reviewed and screenshotted. */}
-      <SectionHeader title={t('mobile.previewChannels.listSection')} />
-      <Text
-        variant="footnote"
-        color={systemColors.secondaryLabel}
-        style={[styles.intro, { marginHorizontal: spacing[4] }]}
-      >
-        {t('mobile.previewChannels.intro')}
-      </Text>
-      <View style={cardStyle}>
-        {/* Fixed production row (see the productionRow derivation above). */}
-        <ListRow
-          title={t('mobile.previewChannels.productionTitle')}
-          subtitle={t('mobile.previewChannels.productionSubtitle')}
-          trailing={
-            productionRow.isSwitching ? (
-              <ActivityIndicator size="small" />
-            ) : productionRow.isActive ? (
-              <Icon name="check.small" size={20} color={systemColors.label} />
-            ) : updatesUsable ? (
-              <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
-            ) : null
-          }
-          onPress={productionRow.isPressable ? () => void resetToBuildChannel() : undefined}
-          // Divide into whatever follows (spinner, error text, or rows); only
-          // the bare empty-state notice reads better without a separator above it.
-          showSeparator={previewQuery.isLoading || previewQuery.isError || previewChannels.length > 0}
-          style={productionRow.isDisabled ? styles.disabledRow : undefined}
-        />
-        {previewQuery.isLoading ? (
-          <View style={styles.statusRow}>
-            <ActivityIndicator size="small" />
-            <Text variant="footnote" color={systemColors.secondaryLabel}>
-              {t('mobile.previewChannels.loading')}
-            </Text>
-          </View>
-        ) : previewQuery.isError ? (
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.statusText}>
-            {t('mobile.previewChannels.error')}
-          </Text>
-        ) : previewChannels.length === 0 ? (
-          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.statusText}>
-            {t('mobile.previewChannels.empty')}
-          </Text>
-        ) : (
-          previewChannels.map((preview, index) => {
-            const row = deriveChannelRowState({
-              channel: preview.channel,
-              activeChannel,
-              switchingChannel,
+    if (updatesUsable) {
+      // Preset channels (preview-1…4) — available to everyone, not just testers.
+      // The build channel (production) is filtered out since the fixed Production
+      // row above already covers it. Raw channel names, no chevron.
+      const presetChannels = buildChannelList(override).filter((channel) => channel !== buildChannel);
+      if (presetChannels.length > 0) {
+        sections.push({
+          key: 'preset',
+          title: t('mobile.previewChannels.presetSection'),
+          rows: presetChannels.map((channel) => {
+            const state = deriveSwitchRowState({
+              target: channel,
+              activeTarget: activeChannel,
+              switchingTarget: switchingChannel,
               updatesUsable,
             });
-            const trailing = row.isSwitching ? (
-              <ActivityIndicator size="small" />
-            ) : row.isActive ? (
-              <Icon name="check.small" size={20} color={systemColors.label} />
-            ) : updatesUsable ? (
-              <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
-            ) : null;
-            return (
-              <ListRow
-                key={preview.channel}
-                title={preview.title}
-                subtitle={preview.channel}
-                trailing={trailing}
-                onPress={row.isPressable ? () => void switchToChannel(preview.channel, preview.title) : undefined}
-                showSeparator={index < previewChannels.length - 1}
-                style={row.isDisabled ? styles.disabledRow : undefined}
-              />
-            );
-          })
-        )}
-      </View>
+            return {
+              kind: 'target',
+              key: channel,
+              title: channel,
+              state,
+              showChevronWhenPressable: false,
+              onPress: isSwitchRowPressable(state) ? () => void switchToChannel(channel) : undefined,
+            };
+          }),
+        });
+      }
 
-      {updatesUsable ? (
-        <>
-          {/* Preset channel list (preview-1…4) — available to everyone, not just
-              testers. The build channel is filtered out above since the fixed
-              Production row already covers it. */}
-          {presetChannels.length > 0 ? (
-            <>
-              <SectionHeader title={t('mobile.previewChannels.presetSection')} />
-              <View style={cardStyle}>
-                {presetChannels.map((channel, index) => {
-                  const row = deriveChannelRowState({ channel, activeChannel, switchingChannel, updatesUsable });
-                  const trailing = row.isSwitching ? (
-                    <ActivityIndicator size="small" />
-                  ) : row.isActive ? (
-                    <Icon name="check.small" size={20} color={systemColors.label} />
-                  ) : null;
+      // Free-text channel entry — available to everyone, so any user can switch to
+      // any channel (not just the previews/presets above). The hint only appears
+      // when the preview list failed to load.
+      {
+        const trimmed = customChannel.trim();
+        const submitManual = () => {
+          const value = customChannel.trim();
+          if (value) void switchToChannel(value);
+        };
+        sections.push({
+          key: 'manual',
+          title: t('mobile.previewChannels.manualSection'),
+          intro: previewQuery.isError ? t('mobile.previewChannels.manualHint') : undefined,
+          rows: [
+            {
+              kind: 'field',
+              key: 'manual-field',
+              label: t('mobile.previewChannels.manualInputA11y'),
+              placeholder: t('mobile.previewChannels.manualPlaceholder'),
+              value: customChannel,
+              onChangeText: setCustomChannel,
+              onSubmit: submitManual,
+              editable: !isSwitching,
+            },
+            {
+              kind: 'action',
+              key: 'manual-switch',
+              label: t('mobile.previewChannels.confirmSwitchConfirm'),
+              icon: 'switch',
+              disabled: isSwitching || trimmed.length === 0,
+              onPress: submitManual,
+            },
+          ],
+        });
+      }
 
-                  return (
-                    <ListRow
-                      key={channel}
-                      title={channel}
-                      trailing={trailing}
-                      onPress={row.isPressable ? () => void switchToChannel(channel) : undefined}
-                      showSeparator={index < presetChannels.length - 1}
-                      style={row.isDisabled ? styles.disabledRow : undefined}
-                    />
-                  );
-                })}
-              </View>
-            </>
-          ) : null}
+      // Reset — available to everyone, kept last as the escape hatch back to the
+      // shipped version. Not gated on `override` so a native override stranded
+      // after an app-data clear stays clearable.
+      sections.push({
+        key: 'reset',
+        rows: [
+          {
+            kind: 'action',
+            key: 'reset',
+            label: t('mobile.previewChannels.reset', { channel: buildChannel }),
+            icon: 'reset',
+            disabled: isSwitching,
+            onPress: () => void resetToBuildChannel(),
+          },
+        ],
+      });
+    }
 
-          {/* Free-text channel entry — available to everyone, so any user can
-              switch to any channel (not just the previews/presets above). The
-              hint only appears when the preview list failed to load. */}
-          <SectionHeader title={t('mobile.previewChannels.manualSection')} />
-          {previewQuery.isError ? (
-            <Text
-              variant="footnote"
-              color={systemColors.secondaryLabel}
-              style={[styles.intro, { marginHorizontal: spacing[4] }]}
-            >
-              {t('mobile.previewChannels.manualHint')}
-            </Text>
-          ) : null}
-          <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
-            <TextInput
-              value={customChannel}
-              onChangeText={setCustomChannel}
-              placeholder={t('mobile.previewChannels.manualPlaceholder')}
-              placeholderTextColor={systemColors.secondaryLabel}
-              autoCapitalize="none"
-              autoCorrect={false}
-              editable={!isSwitching}
-              accessibilityLabel={t('mobile.previewChannels.manualInputA11y')}
-              style={[
-                styles.input,
-                {
-                  color: systemColors.label,
-                  backgroundColor: systemColors.secondaryBackground,
-                  borderRadius: borderRadius.md,
-                },
-              ]}
-            />
-            <Pressable
-              onPress={() => {
-                const trimmed = customChannel.trim();
-                if (trimmed) void switchToChannel(trimmed);
-              }}
-              disabled={isSwitching || customChannel.trim().length === 0}
-              accessibilityRole="button"
-              accessibilityLabel={t('mobile.previewChannels.manualSwitchA11y')}
-              accessibilityState={{ disabled: isSwitching || customChannel.trim().length === 0 }}
-              style={[
-                styles.goButton,
-                {
-                  backgroundColor: systemColors.tertiaryBackground,
-                  borderRadius: borderRadius.md,
-                  opacity: isSwitching || customChannel.trim().length === 0 ? 0.5 : 1,
-                },
-              ]}
-            >
-              <Icon name="transfer" size={16} color={systemColors.label} />
-              <Text variant="footnote" color={systemColors.label}>
-                {t('mobile.previewChannels.confirmSwitchConfirm')}
-              </Text>
-            </Pressable>
-          </View>
+    // Sentry verification (tester-only).
+    if (isTester) {
+      sections.push({
+        key: 'sentry',
+        // i18n-ignore-next-line — tester-only screen
+        title: 'Test crash reporting (Sentry)',
+        rows: [
+          {
+            kind: 'info',
+            key: 'sentry-status',
+            // i18n-ignore-next-line — tester-only screen
+            label: 'Sentry',
+            // i18n-ignore-next-line — tester-only screen
+            value: isSentryEnabled ? 'Active' : 'Disabled in this build',
+          },
+          {
+            kind: 'action',
+            key: 'sentry-handled',
+            // i18n-ignore-next-line — tester-only screen
+            label: 'Send test event (handled)',
+            icon: 'send',
+            onPress: sendSentryTestEvent,
+          },
+          {
+            kind: 'action',
+            key: 'sentry-uncaught',
+            // i18n-ignore-next-line — tester-only screen
+            label: 'Throw JS exception (uncaught)',
+            icon: 'warning',
+            onPress: throwSentryUncaught,
+          },
+          {
+            kind: 'action',
+            key: 'sentry-native',
+            // i18n-ignore-next-line — tester-only screen
+            label: 'Native crash',
+            icon: 'flame',
+            onPress: () => void triggerSentryNativeCrash(),
+          },
+        ],
+      });
+    }
 
-          {/* Reset — available to everyone, kept last as the escape hatch back to
-              the shipped version. Not gated on `override` so a native override
-              stranded after an app-data clear stays clearable. */}
-          <Pressable
-            onPress={() => void resetToBuildChannel()}
-            disabled={isSwitching}
-            accessibilityRole="button"
-            accessibilityLabel={t('mobile.previewChannels.reset', { channel: buildChannel })}
-            accessibilityState={{ disabled: isSwitching }}
-            style={[styles.resetButton, { marginHorizontal: spacing[4], opacity: isSwitching ? 0.5 : 1 }]}
-          >
-            <Icon name="refresh" size={16} color={systemColors.label} />
-            <Text variant="footnote" color={systemColors.label}>
-              {t('mobile.previewChannels.reset', { channel: buildChannel })}
-            </Text>
-          </Pressable>
-        </>
-      ) : null}
+    return { sections };
+  }, [
+    t,
+    buildChannel,
+    override,
+    runtimeVersion,
+    updatesUsable,
+    activeChannel,
+    switchingChannel,
+    isSwitching,
+    isTester,
+    customChannel,
+    previewQuery.isLoading,
+    previewQuery.isError,
+    previewChannels,
+    switchToChannel,
+    resetToBuildChannel,
+    sendSentryTestEvent,
+    throwSentryUncaught,
+    triggerSentryNativeCrash,
+  ]);
 
-      {isTester ? (
-        <>
-          {/* i18n-ignore-next-line — tester-only screen */}
-          <SectionHeader title="Test crash reporting (Sentry)" />
-          <View style={cardStyle}>
-            {/* i18n-ignore-next-line — tester-only screen */}
-            <InfoRow label="Sentry" value={isSentryEnabled ? 'Active' : 'Disabled in this build'} />
-            <ListRow
-              // i18n-ignore-next-line — tester-only screen
-              title="Send test event (handled)"
-              trailing={<Icon name="send" size={18} color={systemColors.secondaryLabel} />}
-              onPress={sendSentryTestEvent}
-              showSeparator
-            />
-            <ListRow
-              // i18n-ignore-next-line — tester-only screen
-              title="Throw JS exception (uncaught)"
-              trailing={<Icon name="warning" size={18} color={brandColors.warning} />}
-              onPress={throwSentryUncaught}
-              showSeparator
-            />
-            <ListRow
-              // i18n-ignore-next-line — tester-only screen
-              title="Native crash"
-              trailing={<Icon name="flame" size={18} color={brandColors.error} />}
-              onPress={() => void triggerSentryNativeCrash()}
-              showSeparator={false}
-            />
-          </View>
-        </>
-      ) : null}
-
-      <View style={styles.bottomSpacer} />
-    </ScrollView>
-  );
+  return <SwitcherForm model={model} />;
 }
-
-const styles = StyleSheet.create({
-  card: {
-    padding: 12,
-    overflow: 'hidden',
-  },
-  notice: {
-    paddingVertical: 16,
-  },
-  intro: {
-    marginBottom: 8,
-    lineHeight: 18,
-  },
-  statusRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    paddingVertical: 8,
-  },
-  statusText: {
-    paddingVertical: 8,
-  },
-  customRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  input: {
-    flex: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-  },
-  goButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-  },
-  resetButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-    paddingVertical: 12,
-    marginTop: 16,
-  },
-  disabledRow: {
-    opacity: 0.5,
-  },
-  bottomSpacer: {
-    height: 40,
-  },
-});

--- a/packages/mobile/src/components/SwitcherForm.android.tsx
+++ b/packages/mobile/src/components/SwitcherForm.android.tsx
@@ -15,7 +15,7 @@
 // from the `expo-ui-modifiers` bridge; M3 surface/label colours come from the
 // Compose Material theme.
 
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { Host } from '@expo/ui';
 import {
   LazyColumn,
@@ -48,6 +48,17 @@ const ROW_PADDING = padding(spacing[4], spacing[3], spacing[4], spacing[3]);
 const CHEVRON = '›';
 const CHECK = '✓';
 
+// The manual channel / custom branch field is always a plain identifier input, so
+// its Compose keyboard options are fully static — hoisted so the native field
+// isn't handed a fresh object on every keystroke-driven re-render.
+const FIELD_KEYBOARD_OPTIONS = toAndroidKeyboardOptions({
+  keyboardType: undefined,
+  autoCapitalize: 'none',
+  autoCorrect: false,
+  returnKeyType: 'go',
+  secureTextEntry: false,
+});
+
 function TargetTrailing({ row }: { row: SwitcherTargetRow }) {
   if (row.state === 'switching') return <CircularProgressIndicator modifiers={[size(20, 20)]} strokeWidth={2} />;
   if (row.state === 'active') {
@@ -57,7 +68,9 @@ function TargetTrailing({ row }: { row: SwitcherTargetRow }) {
       </Text>
     );
   }
-  if (row.state === 'pressable' && row.showChevronWhenPressable) {
+  // A `disabled` row (another switch in flight) keeps the chevron — the whole Row
+  // is dimmed via alpha(0.5) — matching the original and the iOS side.
+  if ((row.state === 'pressable' || row.state === 'disabled') && row.showChevronWhenPressable) {
     return (
       <Text style={{ typography: 'titleMedium' }} modifiers={[alpha(0.4)]}>
         {CHEVRON}
@@ -96,6 +109,13 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
   const { brandColors } = useTheme();
   const textState = useNativeState(row.value);
   const lastEmittedRef = useRef(row.value);
+  // `row.onSubmit` is rebuilt each render (the screen makes it inline), so keep the
+  // latest in a ref and hand the native field a STABLE keyboardActions object —
+  // mirroring AuthTextInput.android's memoized keyboardActions.
+  const submitRef = useRef(row.onSubmit);
+  useEffect(() => {
+    submitRef.current = row.onSubmit;
+  }, [row.onSubmit]);
 
   useEffect(() => {
     if (shouldPushValueToNative(row.value, lastEmittedRef.current)) {
@@ -104,27 +124,27 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
     }
   }, [row.value, textState]);
 
-  const keyboardOptions = toAndroidKeyboardOptions({
-    keyboardType: undefined,
-    autoCapitalize: 'none',
-    autoCorrect: false,
-    returnKeyType: 'go',
-    secureTextEntry: false,
-  });
+  // `row.onChangeText` is the screen's stable setState setter, so this is stable.
+  const handleValueChange = useCallback(
+    (text: string) => {
+      lastEmittedRef.current = text;
+      row.onChangeText(text);
+    },
+    [row.onChangeText],
+  );
+  const keyboardActions = useMemo(() => ({ onGo: () => submitRef.current() }), []);
+  const colors = useMemo(() => textFieldBrandColors(brandColors), [brandColors]);
 
   return (
     <Column modifiers={[fillMaxWidth(), ROW_PADDING]}>
       <OutlinedTextField
         value={textState}
-        onValueChange={(text) => {
-          lastEmittedRef.current = text;
-          row.onChangeText(text);
-        }}
+        onValueChange={handleValueChange}
         readOnly={!row.editable}
         singleLine
-        keyboardOptions={keyboardOptions}
-        keyboardActions={{ onGo: () => row.onSubmit() }}
-        colors={textFieldBrandColors(brandColors)}
+        keyboardOptions={FIELD_KEYBOARD_OPTIONS}
+        keyboardActions={keyboardActions}
+        colors={colors}
         modifiers={[fillMaxWidth()]}
       >
         <OutlinedTextField.Label>

--- a/packages/mobile/src/components/SwitcherForm.android.tsx
+++ b/packages/mobile/src/components/SwitcherForm.android.tsx
@@ -158,6 +158,10 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
   );
 }
 
+// Label-only by design: unlike iOS (SF Symbols are free), an Android trailing icon
+// needs a bundled XML vector drawable per glyph. The action rows are the tester-only
+// Sentry rows + the Switch/Reset actions whose labels already carry the meaning, so
+// we skip the per-glyph drawable plumbing rather than ship a partial icon set.
 function ActionRow({ row, errorColor }: { row: SwitcherActionRow; errorColor: string }) {
   const rowModifiers = [
     fillMaxWidth(),

--- a/packages/mobile/src/components/SwitcherForm.android.tsx
+++ b/packages/mobile/src/components/SwitcherForm.android.tsx
@@ -1,0 +1,244 @@
+// SwitcherForm — Android implementation, a Jetpack Compose `LazyColumn` of
+// Material cards via @expo/ui/jetpack-compose.
+//
+// The whole OTA Channel / Branch switcher screen is ONE `Host` containing a single
+// `LazyColumn` — the Compose counterpart to the iOS `Form`. Same consolidation as
+// MoreForm / FeatureFlagsForm. A `LazyColumn` virtualizes its items, so the Host is
+// `style={{ flex: 1 }}` (NOT `matchContents`). `colorScheme` forces the Compose
+// MaterialTheme to follow the in-app Light/Dark toggle.
+//
+// Each section flattens to: an optional title `Text`, an optional intro `Text`, a
+// Material `Card` wrapping ALL its rows (info / status / target / field / action),
+// then an optional footer `Text`. Action rows render as clickable rows inside the
+// card (matching the RN `ListRow` look the screen had), not standalone filled
+// buttons — on iOS the parallel Form `Button` is already a row. Brand colours come
+// from the `expo-ui-modifiers` bridge; M3 surface/label colours come from the
+// Compose Material theme.
+
+import { useEffect, useRef, type ReactNode } from 'react';
+import { Host } from '@expo/ui';
+import {
+  LazyColumn,
+  Card,
+  Column,
+  Row,
+  Text,
+  Spacer,
+  OutlinedTextField,
+  CircularProgressIndicator,
+  useNativeState,
+} from '@expo/ui/jetpack-compose';
+import { fillMaxWidth, padding, alpha, weight, clickable, size } from '@expo/ui/jetpack-compose/modifiers';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { textFieldBrandColors } from '../theme/expo-ui-modifiers';
+import { spacing } from '../theme/tokens';
+import { shouldPushValueToNative, toAndroidKeyboardOptions } from './AuthTextInput.logic';
+import { assertNeverSwitcherRow } from './SwitcherForm.logic';
+import type {
+  SwitcherActionRow,
+  SwitcherFieldRow,
+  SwitcherFormProps,
+  SwitcherRow,
+  SwitcherSection,
+  SwitcherTargetRow,
+} from './SwitcherForm.types';
+
+const ROW_PADDING = padding(spacing[4], spacing[3], spacing[4], spacing[3]);
+const CHEVRON = '›';
+const CHECK = '✓';
+
+function TargetTrailing({ row }: { row: SwitcherTargetRow }) {
+  if (row.state === 'switching') return <CircularProgressIndicator modifiers={[size(20, 20)]} strokeWidth={2} />;
+  if (row.state === 'active') {
+    return (
+      <Text style={{ typography: 'titleMedium' }} modifiers={[alpha(0.7)]}>
+        {CHECK}
+      </Text>
+    );
+  }
+  if (row.state === 'pressable' && row.showChevronWhenPressable) {
+    return (
+      <Text style={{ typography: 'titleMedium' }} modifiers={[alpha(0.4)]}>
+        {CHEVRON}
+      </Text>
+    );
+  }
+  return null;
+}
+
+function TargetRow({ row }: { row: SwitcherTargetRow }) {
+  // `disabled` (another row switching) dims to 0.5, matching the RN opacity; every
+  // other non-pressable state renders at full opacity, tap unwired.
+  const rowModifiers = [
+    fillMaxWidth(),
+    ...(row.state === 'pressable' && row.onPress ? [clickable(row.onPress)] : []),
+    ROW_PADDING,
+    ...(row.state === 'disabled' ? [alpha(0.5)] : []),
+  ];
+  return (
+    <Row modifiers={rowModifiers} verticalAlignment="center">
+      <Column modifiers={[weight(1)]} verticalArrangement={{ spacedBy: spacing[1] }}>
+        <Text style={{ typography: 'bodyLarge' }}>{row.title}</Text>
+        {row.subtitle ? (
+          <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+            {row.subtitle}
+          </Text>
+        ) : null}
+      </Column>
+      <Spacer modifiers={[padding(spacing[2], 0, 0, 0)]} />
+      <TargetTrailing row={row} />
+    </Row>
+  );
+}
+
+function FieldRow({ row }: { row: SwitcherFieldRow }) {
+  const { brandColors } = useTheme();
+  const textState = useNativeState(row.value);
+  const lastEmittedRef = useRef(row.value);
+
+  useEffect(() => {
+    if (shouldPushValueToNative(row.value, lastEmittedRef.current)) {
+      lastEmittedRef.current = row.value;
+      textState.set(row.value);
+    }
+  }, [row.value, textState]);
+
+  const keyboardOptions = toAndroidKeyboardOptions({
+    keyboardType: undefined,
+    autoCapitalize: 'none',
+    autoCorrect: false,
+    returnKeyType: 'go',
+    secureTextEntry: false,
+  });
+
+  return (
+    <Column modifiers={[fillMaxWidth(), ROW_PADDING]}>
+      <OutlinedTextField
+        value={textState}
+        onValueChange={(text) => {
+          lastEmittedRef.current = text;
+          row.onChangeText(text);
+        }}
+        readOnly={!row.editable}
+        singleLine
+        keyboardOptions={keyboardOptions}
+        keyboardActions={{ onGo: () => row.onSubmit() }}
+        colors={textFieldBrandColors(brandColors)}
+        modifiers={[fillMaxWidth()]}
+      >
+        <OutlinedTextField.Label>
+          <Text>{row.label}</Text>
+        </OutlinedTextField.Label>
+        <OutlinedTextField.Placeholder>
+          <Text>{row.placeholder}</Text>
+        </OutlinedTextField.Placeholder>
+      </OutlinedTextField>
+    </Column>
+  );
+}
+
+function ActionRow({ row, errorColor }: { row: SwitcherActionRow; errorColor: string }) {
+  const rowModifiers = [
+    fillMaxWidth(),
+    ...(row.disabled ? [] : [clickable(row.onPress)]),
+    ROW_PADDING,
+    ...(row.disabled ? [alpha(0.5)] : []),
+  ];
+  return (
+    <Row modifiers={rowModifiers} verticalAlignment="center">
+      <Text style={{ typography: 'bodyLarge' }} color={row.destructive ? errorColor : undefined}>
+        {row.label}
+      </Text>
+    </Row>
+  );
+}
+
+function renderRow(row: SwitcherRow, errorColor: string): ReactNode {
+  switch (row.kind) {
+    case 'info':
+      return (
+        <Row key={row.key} modifiers={[fillMaxWidth(), ROW_PADDING]} verticalAlignment="center">
+          <Column modifiers={[weight(1)]}>
+            <Text style={{ typography: 'bodyLarge' }}>{row.label}</Text>
+          </Column>
+          <Text style={{ typography: 'bodyMedium' }} modifiers={[alpha(0.6)]}>
+            {row.value}
+          </Text>
+        </Row>
+      );
+    case 'status':
+      return (
+        <Row key={row.key} modifiers={[fillMaxWidth(), ROW_PADDING]} verticalAlignment="center">
+          {row.busy ? (
+            <CircularProgressIndicator modifiers={[size(20, 20), padding(0, 0, spacing[3], 0)]} strokeWidth={2} />
+          ) : null}
+          <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+            {row.label}
+          </Text>
+        </Row>
+      );
+    case 'target':
+      return <TargetRow key={row.key} row={row} />;
+    case 'field':
+      return <FieldRow key={row.key} row={row} />;
+    case 'action':
+      return <ActionRow key={row.key} row={row} errorColor={errorColor} />;
+    default:
+      return assertNeverSwitcherRow(row);
+  }
+}
+
+function flattenSection(section: SwitcherSection, errorColor: string): ReactNode[] {
+  const items: ReactNode[] = [];
+  if (section.title) {
+    items.push(
+      <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} modifiers={[alpha(0.6)]}>
+        {section.title}
+      </Text>,
+    );
+  }
+  if (section.intro) {
+    items.push(
+      <Text key={`${section.key}-intro`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+        {section.intro}
+      </Text>,
+    );
+  }
+  items.push(
+    <Card key={`${section.key}-card`} modifiers={[fillMaxWidth()]}>
+      <Column modifiers={[fillMaxWidth()]}>{section.rows.map((row) => renderRow(row, errorColor))}</Column>
+    </Card>,
+  );
+  if (section.footer) {
+    items.push(
+      <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+        {section.footer}
+      </Text>,
+    );
+  }
+  return items;
+}
+
+export function SwitcherForm({ model }: SwitcherFormProps) {
+  const { brandColors, colorScheme } = useTheme();
+  const items = model.sections.flatMap((section) => flattenSection(section, brandColors.error));
+
+  return (
+    <Host style={styles.host} colorScheme={colorScheme}>
+      <LazyColumn
+        contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
+        verticalArrangement={{ spacedBy: spacing[3] }}
+      >
+        {items}
+      </LazyColumn>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  // A LazyColumn virtualizes its rows and needs a bounded height to fill.
+  host: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/SwitcherForm.d.ts
+++ b/packages/mobile/src/components/SwitcherForm.d.ts
@@ -1,0 +1,10 @@
+// Ambient type for the platform-split SwitcherForm so `tsc` resolves the
+// extensionless `./SwitcherForm` import to this declaration, while Metro picks the
+// matching SwitcherForm.ios.tsx / SwitcherForm.android.tsx at bundle time. Both
+// implementations are still compiled and type-checked on their own. Mirrors the
+// MoreForm.d.ts / FeatureFlagsForm.d.ts mechanism.
+
+import type { FC } from 'react';
+import type { SwitcherFormProps } from './SwitcherForm.types';
+
+export declare const SwitcherForm: FC<SwitcherFormProps>;

--- a/packages/mobile/src/components/SwitcherForm.ios.tsx
+++ b/packages/mobile/src/components/SwitcherForm.ios.tsx
@@ -13,7 +13,7 @@
 // The screen precomputes every string + handler + row state; this tree renders the
 // model. Each row kind maps to the idiomatic SwiftUI control.
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Host } from '@expo/ui';
 import {
   Form,
@@ -107,6 +107,14 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
   const { brandColors } = useTheme();
   const textState = useNativeState(row.value);
   const lastEmittedRef = useRef(row.value);
+  // `row.onSubmit` is rebuilt each render (the screen makes it inline), so keep the
+  // latest in a ref and feed the modifier a STABLE closure — same stabilization as
+  // the Android FieldRow (and AuthTextInput) so keystroke re-renders don't churn
+  // the native handler registration.
+  const submitRef = useRef(row.onSubmit);
+  useEffect(() => {
+    submitRef.current = row.onSubmit;
+  }, [row.onSubmit]);
 
   useEffect(() => {
     if (shouldPushValueToNative(row.value, lastEmittedRef.current)) {
@@ -115,24 +123,30 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
     }
   }, [row.value, textState]);
 
+  // `row.onChangeText` is the screen's stable setState setter, so this is stable.
+  const handleTextChange = useCallback(
+    (text: string) => {
+      lastEmittedRef.current = text;
+      row.onChangeText(text);
+    },
+    [row.onChangeText],
+  );
+
+  const modifiers = useMemo(
+    () => [
+      tint(brandAccentColor(brandColors)),
+      accessibilityLabelModifier(row.label),
+      textInputAutocapitalization('never'),
+      autocorrectionDisabled(true),
+      submitLabelModifier('go'),
+      onSubmitModifier(() => submitRef.current()),
+      ...(row.editable ? [] : [disabledModifier(true)]),
+    ],
+    [brandColors, row.label, row.editable],
+  );
+
   return (
-    <TextField
-      text={textState}
-      placeholder={row.placeholder}
-      onTextChange={(text) => {
-        lastEmittedRef.current = text;
-        row.onChangeText(text);
-      }}
-      modifiers={[
-        tint(brandAccentColor(brandColors)),
-        accessibilityLabelModifier(row.label),
-        textInputAutocapitalization('never'),
-        autocorrectionDisabled(true),
-        submitLabelModifier('go'),
-        onSubmitModifier(() => row.onSubmit()),
-        ...(row.editable ? [] : [disabledModifier(true)]),
-      ]}
-    />
+    <TextField text={textState} placeholder={row.placeholder} onTextChange={handleTextChange} modifiers={modifiers} />
   );
 }
 

--- a/packages/mobile/src/components/SwitcherForm.ios.tsx
+++ b/packages/mobile/src/components/SwitcherForm.ios.tsx
@@ -1,0 +1,214 @@
+// SwitcherForm — iOS implementation, a real SwiftUI `Form` via @expo/ui/swift-ui.
+//
+// The whole OTA Channel / Branch switcher screen is ONE `Host` containing a single
+// SwiftUI `Form` (the grouped, inset-rounded iOS Settings look — section insets,
+// separators, and scrolling for free). Same consolidation as MoreForm /
+// FeatureFlagsForm: the entire form lives under one `Host`, not one per control.
+//
+// HOST SIZING: a `Form` is a scrolling container that fills its space, so the Host
+// uses `style={{ flex: 1 }}` + `useViewportSizeMeasurement` — NOT `matchContents`
+// (which would size to content and clip the scroll). `colorScheme` forces the
+// native appearance to follow the in-app Light/Dark toggle.
+//
+// The screen precomputes every string + handler + row state; this tree renders the
+// model. Each row kind maps to the idiomatic SwiftUI control.
+
+import { useEffect, useRef } from 'react';
+import { Host } from '@expo/ui';
+import {
+  Form,
+  Section,
+  Text,
+  Button,
+  Image,
+  HStack,
+  VStack,
+  Spacer,
+  ProgressView,
+  TextField,
+  useNativeState,
+} from '@expo/ui/swift-ui';
+import {
+  tint,
+  disabled as disabledModifier,
+  accessibilityLabel as accessibilityLabelModifier,
+  autocorrectionDisabled,
+  textInputAutocapitalization,
+  submitLabel as submitLabelModifier,
+  onSubmit as onSubmitModifier,
+  font,
+  foregroundStyle,
+} from '@expo/ui/swift-ui/modifiers';
+import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
+import { brandAccentColor } from '../theme/expo-ui-modifiers';
+import { spacing } from '../theme/tokens';
+import { shouldPushValueToNative } from './AuthTextInput.logic';
+import { assertNeverSwitcherRow } from './SwitcherForm.logic';
+import type { SwitcherActionRow, SwitcherFieldRow, SwitcherFormProps, SwitcherTargetRow } from './SwitcherForm.types';
+
+const PRIMARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'primary' });
+const SECONDARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'secondary' });
+const TERTIARY_LABEL = foregroundStyle({ type: 'hierarchical', style: 'tertiary' });
+const FOOTNOTE = font({ textStyle: 'footnote' });
+
+// Semantic action icon → SF Symbol. Cast at the call site (the SFSymbol union
+// isn't resolvable from the shared types module), matching MoreForm.ios.
+const ACTION_SF_SYMBOL = {
+  switch: 'arrow.left.arrow.right',
+  reset: 'arrow.counterclockwise',
+  send: 'paperplane',
+  warning: 'exclamationmark.triangle',
+  flame: 'flame',
+} as const;
+
+// A single switch-target row's trailing accessory, by precomputed state.
+function TargetTrailing({ row }: { row: SwitcherTargetRow }) {
+  if (row.state === 'switching') return <ProgressView />;
+  if (row.state === 'active') return <Image systemName="checkmark" modifiers={[SECONDARY_LABEL]} />;
+  if (row.state === 'pressable' && row.showChevronWhenPressable) {
+    return <Image systemName="chevron.right" modifiers={[FOOTNOTE, TERTIARY_LABEL]} />;
+  }
+  return null;
+}
+
+function TargetBody({ row }: { row: SwitcherTargetRow }) {
+  return (
+    <HStack spacing={spacing[3]}>
+      <VStack alignment="leading" spacing={spacing[1]}>
+        <Text modifiers={[PRIMARY_LABEL]}>{row.title}</Text>
+        {row.subtitle ? <Text modifiers={[FOOTNOTE, SECONDARY_LABEL]}>{row.subtitle}</Text> : null}
+      </VStack>
+      <Spacer />
+      <TargetTrailing row={row} />
+    </HStack>
+  );
+}
+
+function TargetRow({ row }: { row: SwitcherTargetRow }) {
+  // A pressable row is a Button; every other state renders as an inert HStack so a
+  // dimmed/active/switching row can't be tapped (the in-flight ref guarded this
+  // before; the structure enforces it now). `disabled`/`inert` read secondary.
+  if (row.state === 'pressable' && row.onPress) {
+    return <Button onPress={row.onPress}>{<TargetBody row={row} />}</Button>;
+  }
+  return <TargetBody row={row} />;
+}
+
+// The manual channel / custom branch field. Bridges the controlled `value` into a
+// native observable (reusing AuthTextInput's pure push-guard) and applies the same
+// identifier-field modifiers: no autocaps, no autocorrect, a "go" submit key.
+function FieldRow({ row }: { row: SwitcherFieldRow }) {
+  const { brandColors } = useTheme();
+  const textState = useNativeState(row.value);
+  const lastEmittedRef = useRef(row.value);
+
+  useEffect(() => {
+    if (shouldPushValueToNative(row.value, lastEmittedRef.current)) {
+      lastEmittedRef.current = row.value;
+      textState.set(row.value);
+    }
+  }, [row.value, textState]);
+
+  return (
+    <TextField
+      text={textState}
+      placeholder={row.placeholder}
+      onTextChange={(text) => {
+        lastEmittedRef.current = text;
+        row.onChangeText(text);
+      }}
+      modifiers={[
+        tint(brandAccentColor(brandColors)),
+        accessibilityLabelModifier(row.label),
+        textInputAutocapitalization('never'),
+        autocorrectionDisabled(true),
+        submitLabelModifier('go'),
+        onSubmitModifier(() => row.onSubmit()),
+        ...(row.editable ? [] : [disabledModifier(true)]),
+      ]}
+    />
+  );
+}
+
+function ActionRow({ row, accent }: { row: SwitcherActionRow; accent: string }) {
+  const modifiers = row.disabled ? [disabledModifier(true)] : [];
+  // A bare destructive/standalone action is an idiomatic Form button (centred,
+  // role-tinted); an action carrying a trailing icon (the Sentry rows) uses an
+  // HStack so the glyph sits at the trailing edge like the RN ListRow did.
+  if (!row.icon || row.icon === 'switch' || row.icon === 'reset') {
+    return (
+      <Button
+        role={row.destructive ? 'destructive' : undefined}
+        label={row.label}
+        onPress={row.onPress}
+        modifiers={modifiers}
+      />
+    );
+  }
+  return (
+    <Button role={row.destructive ? 'destructive' : undefined} onPress={row.onPress} modifiers={modifiers}>
+      <HStack spacing={spacing[3]}>
+        <Text modifiers={[PRIMARY_LABEL]}>{row.label}</Text>
+        <Spacer />
+        <Image systemName={ACTION_SF_SYMBOL[row.icon]} modifiers={[tint(accent)]} />
+      </HStack>
+    </Button>
+  );
+}
+
+export function SwitcherForm({ model }: SwitcherFormProps) {
+  const { brandColors, colorScheme } = useTheme();
+  const accent = brandAccentColor(brandColors);
+
+  return (
+    <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
+      <Form>
+        {model.sections.map((section) => (
+          <Section
+            key={section.key}
+            title={section.title}
+            footer={section.footer ? <Text>{section.footer}</Text> : undefined}
+          >
+            {section.intro ? <Text modifiers={[FOOTNOTE, SECONDARY_LABEL]}>{section.intro}</Text> : null}
+            {section.rows.map((row) => {
+              switch (row.kind) {
+                case 'info':
+                  return (
+                    <HStack key={row.key} spacing={spacing[3]}>
+                      <Text modifiers={[PRIMARY_LABEL]}>{row.label}</Text>
+                      <Spacer />
+                      <Text modifiers={[SECONDARY_LABEL]}>{row.value}</Text>
+                    </HStack>
+                  );
+                case 'status':
+                  return (
+                    <HStack key={row.key} spacing={spacing[2]}>
+                      {row.busy ? <ProgressView /> : null}
+                      <Text modifiers={[FOOTNOTE, SECONDARY_LABEL]}>{row.label}</Text>
+                    </HStack>
+                  );
+                case 'target':
+                  return <TargetRow key={row.key} row={row} />;
+                case 'field':
+                  return <FieldRow key={row.key} row={row} />;
+                case 'action':
+                  return <ActionRow key={row.key} row={row} accent={accent} />;
+                default:
+                  return assertNeverSwitcherRow(row);
+              }
+            })}
+          </Section>
+        ))}
+      </Form>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  // A Form fills the screen; flex + useViewportSizeMeasurement give SwiftUI the
+  // viewport as its proposed size so the Form scrolls within it.
+  host: {
+    flex: 1,
+  },
+});

--- a/packages/mobile/src/components/SwitcherForm.ios.tsx
+++ b/packages/mobile/src/components/SwitcherForm.ios.tsx
@@ -30,6 +30,7 @@ import {
 } from '@expo/ui/swift-ui';
 import {
   tint,
+  opacity,
   disabled as disabledModifier,
   accessibilityLabel as accessibilityLabelModifier,
   autocorrectionDisabled,
@@ -62,11 +63,13 @@ const ACTION_SF_SYMBOL = {
   flame: 'flame',
 } as const;
 
-// A single switch-target row's trailing accessory, by precomputed state.
+// A single switch-target row's trailing accessory, by precomputed state. A
+// `disabled` row (another switch in flight) keeps the chevron a pressable preview
+// row would show — the whole row is just dimmed — matching the original.
 function TargetTrailing({ row }: { row: SwitcherTargetRow }) {
   if (row.state === 'switching') return <ProgressView />;
   if (row.state === 'active') return <Image systemName="checkmark" modifiers={[SECONDARY_LABEL]} />;
-  if (row.state === 'pressable' && row.showChevronWhenPressable) {
+  if ((row.state === 'pressable' || row.state === 'disabled') && row.showChevronWhenPressable) {
     return <Image systemName="chevron.right" modifiers={[FOOTNOTE, TERTIARY_LABEL]} />;
   }
   return null;
@@ -74,7 +77,9 @@ function TargetTrailing({ row }: { row: SwitcherTargetRow }) {
 
 function TargetBody({ row }: { row: SwitcherTargetRow }) {
   return (
-    <HStack spacing={spacing[3]}>
+    // A `disabled` row dims to 0.5 (matching the Android `alpha(0.5)` and the
+    // original RN opacity), so the row that's actually switching stands out.
+    <HStack spacing={spacing[3]} modifiers={row.state === 'disabled' ? [opacity(0.5)] : undefined}>
       <VStack alignment="leading" spacing={spacing[1]}>
         <Text modifiers={[PRIMARY_LABEL]}>{row.title}</Text>
         {row.subtitle ? <Text modifiers={[FOOTNOTE, SECONDARY_LABEL]}>{row.subtitle}</Text> : null}
@@ -86,9 +91,9 @@ function TargetBody({ row }: { row: SwitcherTargetRow }) {
 }
 
 function TargetRow({ row }: { row: SwitcherTargetRow }) {
-  // A pressable row is a Button; every other state renders as an inert HStack so a
-  // dimmed/active/switching row can't be tapped (the in-flight ref guarded this
-  // before; the structure enforces it now). `disabled`/`inert` read secondary.
+  // A pressable row is a Button; every other state renders as an inert HStack so an
+  // active/switching/disabled row can't be tapped (the in-flight ref guarded this
+  // before; the structure enforces it now). A `disabled` row is dimmed in TargetBody.
   if (row.state === 'pressable' && row.onPress) {
     return <Button onPress={row.onPress}>{<TargetBody row={row} />}</Button>;
   }
@@ -131,7 +136,9 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
   );
 }
 
-function ActionRow({ row, accent }: { row: SwitcherActionRow; accent: string }) {
+type ActionIconColors = { accent: string; warning: string; error: string };
+
+function ActionRow({ row, iconColors }: { row: SwitcherActionRow; iconColors: ActionIconColors }) {
   const modifiers = row.disabled ? [disabledModifier(true)] : [];
   // A bare destructive/standalone action is an idiomatic Form button (centred,
   // role-tinted); an action carrying a trailing icon (the Sentry rows) uses an
@@ -146,12 +153,16 @@ function ActionRow({ row, accent }: { row: SwitcherActionRow; accent: string }) 
       />
     );
   }
+  // Semantic tint for the Sentry glyphs, matching the original RN icon colours:
+  // warning amber, flame red, everything else the brand accent.
+  const iconColor =
+    row.icon === 'warning' ? iconColors.warning : row.icon === 'flame' ? iconColors.error : iconColors.accent;
   return (
     <Button role={row.destructive ? 'destructive' : undefined} onPress={row.onPress} modifiers={modifiers}>
       <HStack spacing={spacing[3]}>
         <Text modifiers={[PRIMARY_LABEL]}>{row.label}</Text>
         <Spacer />
-        <Image systemName={ACTION_SF_SYMBOL[row.icon]} modifiers={[tint(accent)]} />
+        <Image systemName={ACTION_SF_SYMBOL[row.icon]} modifiers={[tint(iconColor)]} />
       </HStack>
     </Button>
   );
@@ -160,6 +171,7 @@ function ActionRow({ row, accent }: { row: SwitcherActionRow; accent: string }) 
 export function SwitcherForm({ model }: SwitcherFormProps) {
   const { brandColors, colorScheme } = useTheme();
   const accent = brandAccentColor(brandColors);
+  const iconColors: ActionIconColors = { accent, warning: brandColors.warning, error: brandColors.error };
 
   return (
     <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
@@ -193,7 +205,7 @@ export function SwitcherForm({ model }: SwitcherFormProps) {
                 case 'field':
                   return <FieldRow key={row.key} row={row} />;
                 case 'action':
-                  return <ActionRow key={row.key} row={row} accent={accent} />;
+                  return <ActionRow key={row.key} row={row} iconColors={iconColors} />;
                 default:
                   return assertNeverSwitcherRow(row);
               }

--- a/packages/mobile/src/components/SwitcherForm.logic.ts
+++ b/packages/mobile/src/components/SwitcherForm.logic.ts
@@ -1,0 +1,44 @@
+// Pure, node-testable helpers shared by both SwitcherForm platform files (and the
+// screens that build the model). No native imports, no rendering — so the
+// switch-target row state machine has one home and iOS/Android can't diverge.
+
+import type { SwitchRowState, SwitcherRow } from './SwitcherForm.types';
+
+/**
+ * Resolve the render/interaction state of one switch-target row, matching the
+ * behaviour ChannelSwitcherScreen and BranchSwitcherScreen hand-rolled inline:
+ *
+ * - the row currently switching → `switching` (spinner),
+ * - else the live target → `active` (checkmark),
+ * - else any switch in flight → `disabled` (another row is mid-switch; dimmed),
+ * - else, when OTA updates are usable → `pressable` (tappable to switch),
+ * - else → `inert` (dev / Expo Go: rendered so the list can be reviewed, not tappable).
+ *
+ * `switchingTarget` is the target identifier currently mid-switch, or null when
+ * idle. `activeTarget` is the live override (or build channel) the row compares
+ * against. The earlier inline code let a mid-switch row stay nominally pressable
+ * (guarded by an in-flight ref); folding it into `switching` here is equivalent —
+ * the ref already swallowed the tap — and reads clearer.
+ */
+export function deriveSwitchRowState(input: {
+  target: string;
+  activeTarget: string;
+  switchingTarget: string | null;
+  updatesUsable: boolean;
+}): SwitchRowState {
+  const { target, activeTarget, switchingTarget, updatesUsable } = input;
+  if (switchingTarget === target) return 'switching';
+  if (target === activeTarget) return 'active';
+  if (switchingTarget !== null) return 'disabled';
+  return updatesUsable ? 'pressable' : 'inert';
+}
+
+/** Only a `pressable` row wires an onPress; every other state is non-interactive. */
+export function isSwitchRowPressable(state: SwitchRowState): boolean {
+  return state === 'pressable';
+}
+
+/** Exhaustiveness guard for the row-kind switch in both platform renderers. */
+export function assertNeverSwitcherRow(row: never): never {
+  throw new Error(`Unhandled SwitcherRow kind: ${JSON.stringify(row as SwitcherRow)}`);
+}

--- a/packages/mobile/src/components/SwitcherForm.types.ts
+++ b/packages/mobile/src/components/SwitcherForm.types.ts
@@ -1,0 +1,110 @@
+// Shared view-model for the platform-split SwitcherForm — the native body of the
+// OTA Channel and Branch switcher screens. The implementation is split across
+// SwitcherForm.ios.tsx (a real SwiftUI `Form`) and SwitcherForm.android.tsx (a
+// Jetpack Compose `LazyColumn` of Material cards), each rendered as ONE `Host`
+// that fills the screen. The split keeps each platform's @expo/ui native tree —
+// which resolves native views at module load — off the other platform's bundle.
+//
+// Both ChannelSwitcherScreen and BranchSwitcherScreen own their route guards,
+// data hooks, confirm/Alert/haptics, and the `channel-switch.ts` state machine,
+// then build a plain `SwitcherFormModel` (sections of typed rows) and hand it to
+// <SwitcherForm />. The two screens are structurally the same OTA-target switcher
+// (info section → target list → custom-text field → reset), so they share ONE
+// generic form rather than duplicating two near-identical native trees — the same
+// sections-of-rows shape MoreForm uses. No native imports in this file.
+
+/**
+ * The render/interaction state of a single switch-target row (a preview channel,
+ * a tester preset channel, or a branch). Derived once by `deriveSwitchRowState`
+ * (SwitcherForm.logic.ts) so iOS and Android can't drift:
+ * - `active`     — the row is the live target; shows a checkmark, not pressable.
+ * - `switching`  — this row is mid-switch; shows a spinner, not pressable.
+ * - `disabled`   — another row is switching; dimmed, not pressable.
+ * - `pressable`  — tappable to switch (shows a chevron when `showChevronWhenPressable`).
+ * - `inert`      — OTA updates unusable (dev / Expo Go); rendered for review but not tappable.
+ */
+export type SwitchRowState = 'active' | 'switching' | 'disabled' | 'pressable' | 'inert';
+
+/** A read-only label/value pair (the "Current" section's build channel / runtime version). */
+export type SwitcherInfoRow = {
+  kind: 'info';
+  key: string;
+  label: string;
+  value: string;
+};
+
+/** A single status line: the preview list's loading (`busy`), error, or empty state. */
+export type SwitcherStatusRow = {
+  kind: 'status';
+  key: string;
+  label: string;
+  /** When true, a leading spinner accompanies the label (the loading state). */
+  busy?: boolean;
+};
+
+/** A selectable switch target. `state` is precomputed; the native side just renders it. */
+export type SwitcherTargetRow = {
+  kind: 'target';
+  key: string;
+  title: string;
+  /** Secondary line (the preview row's raw channel); omitted for preset/branch rows. */
+  subtitle?: string;
+  state: SwitchRowState;
+  /** Preview rows show a chevron when pressable; preset/branch rows don't. */
+  showChevronWhenPressable: boolean;
+  /** Wired by the screen only when the row is pressable. */
+  onPress?: () => void;
+};
+
+/** The manual channel / custom branch text field. Bridges to a native TextField. */
+export type SwitcherFieldRow = {
+  kind: 'field';
+  key: string;
+  /** Accessible name + (Android) the field's floating label. */
+  label: string;
+  placeholder: string;
+  value: string;
+  onChangeText: (text: string) => void;
+  /** Fires on the keyboard submit ("go") — the screen switches to the trimmed value. */
+  onSubmit: () => void;
+  editable: boolean;
+};
+
+/** A plain action button row: the manual "Switch", reset, and the tester Sentry rows. */
+export type SwitcherActionRow = {
+  kind: 'action';
+  key: string;
+  label: string;
+  /** Semantic trailing icon, mapped per-platform (SF Symbol / Material glyph). */
+  icon?: 'switch' | 'reset' | 'send' | 'warning' | 'flame';
+  /** Colours the row red + sets the native destructive role (the reset row). */
+  destructive?: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+};
+
+export type SwitcherRow =
+  | SwitcherInfoRow
+  | SwitcherStatusRow
+  | SwitcherTargetRow
+  | SwitcherFieldRow
+  | SwitcherActionRow;
+
+export type SwitcherSection = {
+  key: string;
+  /** Section header (iOS `Section` title / Android list title). */
+  title?: string;
+  /** A secondary footnote rendered above the section body (the preview list intro). */
+  intro?: string;
+  /** A footnote rendered below the section (the "updates unavailable" notice). */
+  footer?: string;
+  rows: SwitcherRow[];
+};
+
+export type SwitcherFormModel = {
+  sections: SwitcherSection[];
+};
+
+export type SwitcherFormProps = {
+  model: SwitcherFormModel;
+};

--- a/packages/mobile/src/components/__tests__/BranchSwitcherScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/BranchSwitcherScreen.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SwitcherFormModel } from '../SwitcherForm.types';
+
+// Branch switcher is preview-build (tester) only, so this locks the `isPreviewBuild()`
+// guard and the conditional "Current Update" rows. As with the Channel suite, the
+// mobile vitest `__DEV__: true` define forces `updatesUsable` false, so the
+// switch/custom/reset sections don't render here — that gating is covered by
+// `channel-switch.test.ts` + `switcher-form-logic.test.ts` + manual on-device QA.
+const captured = vi.hoisted(() => ({ model: null as SwitcherFormModel | null }));
+const buildState = vi.hoisted(() => ({ isPreview: true }));
+
+vi.mock('react-native', () => ({ Alert: { alert: vi.fn() } }));
+
+vi.mock('expo-updates', () => ({
+  channel: 'production',
+  runtimeVersion: '1.0.0',
+  isEnabled: true,
+  isEmbeddedLaunch: false,
+  manifest: { metadata: { branchName: 'feat/cool-thing' } },
+  updateId: 'abcdef1234567890',
+  checkForUpdateAsync: vi.fn(),
+  fetchUpdateAsync: vi.fn(),
+  reloadAsync: vi.fn(),
+}));
+
+vi.mock('../../lib/error-reporting', () => ({ reportHandledError: vi.fn() }));
+vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticError: vi.fn() }));
+vi.mock('../../lib/preference-store', () => ({
+  getPreference: vi.fn().mockResolvedValue(null),
+  setPreference: vi.fn(),
+  removePreference: vi.fn(),
+}));
+vi.mock('../../lib/apply-channel-override', () => ({ applyChannelOverride: vi.fn() }));
+vi.mock('../../lib/preview-build', () => ({ isPreviewBuild: () => buildState.isPreview }));
+vi.mock('../../providers/dialog-provider', () => ({ useConfirm: () => vi.fn().mockResolvedValue(false) }));
+
+vi.mock('../SwitcherForm', () => ({
+  SwitcherForm: ({ model }: { model: SwitcherFormModel }) => {
+    captured.model = model;
+    return null;
+  },
+}));
+
+import { BranchSwitcherScreen } from '../BranchSwitcherScreen';
+
+beforeEach(() => {
+  captured.model = null;
+  buildState.isPreview = true;
+});
+
+describe('BranchSwitcherScreen', () => {
+  it('renders nothing outside a preview build', () => {
+    buildState.isPreview = false;
+    render(createElement(BranchSwitcherScreen));
+    // The screen returns null before SwitcherForm, so no model is ever built.
+    expect(captured.model).toBeNull();
+  });
+
+  it('surfaces the current update info (build channel + running branch) in a preview build', () => {
+    render(createElement(BranchSwitcherScreen));
+
+    const current = captured.model?.sections.find((section) => section.key === 'current');
+    expect(current).toBeDefined();
+    expect(current?.rows).toContainEqual(
+      expect.objectContaining({ kind: 'info', label: 'Build channel', value: 'production' }),
+    );
+    expect(current?.rows).toContainEqual(
+      expect.objectContaining({ kind: 'info', label: 'Running branch', value: 'feat/cool-thing' }),
+    );
+    // Update ID is truncated to 8 chars, mirroring the original card.
+    expect(current?.rows).toContainEqual(
+      expect.objectContaining({ kind: 'info', label: 'Update ID', value: 'abcdef12' }),
+    );
+  });
+});

--- a/packages/mobile/src/components/__tests__/ChannelSwitcherScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/ChannelSwitcherScreen.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SwitcherFormModel, SwitcherTargetRow } from '../SwitcherForm.types';
+
+// Capture the view-model the screen hands to the native form, so we can assert the
+// refactor preserves the sections, the public-vs-tester gating, and the preview-row
+// mapping without mounting a native @expo/ui tree.
+//
+// NOTE: the mobile vitest config inlines `__DEV__: true` (a `define`, not a global),
+// so `updatesUsable = Updates.isEnabled && !__DEV__` is always false under test.
+// The OTA-switch-gated sections (preset / manual / reset) therefore can't render
+// here, and target rows resolve to the non-pressable `inert` state. That gating and
+// the switch flow itself are covered by `channel-switch.test.ts` +
+// `switcher-form-logic.test.ts` + manual on-device QA; this suite locks the
+// model-building, the signed-out preview list, and the tester gating.
+const captured = vi.hoisted(() => ({ model: null as SwitcherFormModel | null }));
+const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+const hooksState = vi.hoisted(() => ({
+  isTester: false,
+  previewChannels: [{ channel: 'pr-100', title: 'Fix the thing' }],
+  isLoading: false,
+  isError: false,
+}));
+
+vi.mock('react-native', () => ({
+  Alert: { alert: vi.fn() },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('expo-updates', () => ({
+  channel: 'production',
+  runtimeVersion: '1.0.0',
+  isEnabled: true,
+  isEmbeddedLaunch: false,
+  manifest: null,
+  updateId: null,
+  checkForUpdateAsync: vi.fn(),
+  fetchUpdateAsync: vi.fn(),
+  reloadAsync: vi.fn(),
+}));
+
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn(), reportHandledError: vi.fn() }));
+vi.mock('../../lib/sentry', () => ({ isSentryEnabled: false, nativeSentryCrash: vi.fn() }));
+vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn(), hapticError: vi.fn() }));
+vi.mock('../../lib/preference-store', () => ({
+  getPreference: vi.fn().mockResolvedValue(null),
+  setPreference: vi.fn(),
+  removePreference: vi.fn(),
+}));
+vi.mock('../../lib/apply-channel-override', () => ({ applyChannelOverride: vi.fn() }));
+
+vi.mock('../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { isTester: hooksState.isTester } }),
+  useOtaPreviewChannels: () => ({
+    data: hooksState.previewChannels,
+    isLoading: hooksState.isLoading,
+    isError: hooksState.isError,
+  }),
+}));
+
+vi.mock('../../providers/dialog-provider', () => ({ useConfirm: () => confirmMock }));
+
+vi.mock('../SwitcherForm', () => ({
+  SwitcherForm: ({ model }: { model: SwitcherFormModel }) => {
+    captured.model = model;
+    return null;
+  },
+}));
+
+import { ChannelSwitcherScreen } from '../ChannelSwitcherScreen';
+
+function sectionKeys(model: SwitcherFormModel): string[] {
+  return model.sections.map((section) => section.key);
+}
+
+function targetRow(model: SwitcherFormModel, sectionKey: string, rowKey: string): SwitcherTargetRow | undefined {
+  const row = model.sections
+    .find((section) => section.key === sectionKey)
+    ?.rows.find((candidate) => candidate.key === rowKey);
+  return row?.kind === 'target' ? row : undefined;
+}
+
+beforeEach(() => {
+  captured.model = null;
+  confirmMock.mockClear();
+  hooksState.isTester = false;
+  hooksState.previewChannels = [{ channel: 'pr-100', title: 'Fix the thing' }];
+  hooksState.isLoading = false;
+  hooksState.isError = false;
+});
+
+describe('ChannelSwitcherScreen', () => {
+  it('shows a signed-out, non-tester user the current + preview sections with the live PR row', () => {
+    render(createElement(ChannelSwitcherScreen));
+
+    const model = captured.model;
+    expect(model).not.toBeNull();
+    if (!model) return;
+
+    expect(sectionKeys(model)).toEqual(['current', 'preview']);
+    // No tester-only surfaces leak to a non-tester.
+    expect(sectionKeys(model)).not.toContain('preset');
+    expect(sectionKeys(model)).not.toContain('sentry');
+
+    // The build channel is surfaced, and the live PR preview row is rendered.
+    const current = model.sections.find((section) => section.key === 'current');
+    expect(current?.rows).toContainEqual(expect.objectContaining({ kind: 'info', value: 'production' }));
+    const previewRow = targetRow(model, 'preview', 'pr-100');
+    expect(previewRow?.title).toBe('Fix the thing');
+    expect(previewRow?.subtitle).toBe('pr-100');
+    expect(previewRow?.showChevronWhenPressable).toBe(true);
+
+    // The fixed Production row heads the preview list so everyone has a route home,
+    // even signed out. On the build channel (no override) it's the active row.
+    const productionRow = targetRow(model, 'preview', 'production');
+    expect(productionRow?.title).toBe('mobile.previewChannels.productionTitle');
+    expect(productionRow?.state).toBe('active');
+  });
+
+  it('renders the preview list when the backend query is empty', () => {
+    hooksState.previewChannels = [];
+    render(createElement(ChannelSwitcherScreen));
+
+    const preview = captured.model?.sections.find((section) => section.key === 'preview');
+    // The fixed Production row always leads; the empty-state status row follows.
+    expect(preview?.rows).toEqual([
+      expect.objectContaining({ kind: 'target', key: 'production' }),
+      expect.objectContaining({ kind: 'status', label: 'mobile.previewChannels.empty' }),
+    ]);
+  });
+
+  it('adds the Sentry section for a tester (gated on the profile, not OTA usability)', () => {
+    hooksState.isTester = true;
+    render(createElement(ChannelSwitcherScreen));
+
+    const model = captured.model;
+    expect(model).not.toBeNull();
+    if (!model) return;
+
+    expect(sectionKeys(model)).toContain('sentry');
+    expect(sectionKeys(model)).not.toContain('preset'); // OTA-gated; unavailable under test __DEV__
+  });
+});

--- a/packages/mobile/src/components/__tests__/ChannelSwitcherScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/ChannelSwitcherScreen.test.tsx
@@ -134,6 +134,21 @@ describe('ChannelSwitcherScreen', () => {
     ]);
   });
 
+  it('surfaces the error status when the backend query fails', () => {
+    // The error branch is also the non-tester fallback that adds a `manual` section,
+    // but that section is `updatesUsable`-gated (false under test __DEV__), so only
+    // the preview error-status row is observable here.
+    hooksState.isError = true;
+    render(createElement(ChannelSwitcherScreen));
+
+    const preview = captured.model?.sections.find((section) => section.key === 'preview');
+    // The fixed Production row always leads; the error-status row follows.
+    expect(preview?.rows).toEqual([
+      expect.objectContaining({ kind: 'target', key: 'production' }),
+      expect.objectContaining({ kind: 'status', label: 'mobile.previewChannels.error' }),
+    ]);
+  });
+
   it('adds the Sentry section for a tester (gated on the profile, not OTA usability)', () => {
     hooksState.isTester = true;
     render(createElement(ChannelSwitcherScreen));

--- a/packages/mobile/src/components/__tests__/switcher-form-logic.test.ts
+++ b/packages/mobile/src/components/__tests__/switcher-form-logic.test.ts
@@ -18,6 +18,12 @@ describe('deriveSwitchRowState', () => {
     expect(deriveSwitchRowState({ ...base, target: 'pr-100', switchingTarget: 'pr-3271' })).toBe('disabled');
   });
 
+  it('keeps the active row active while a different row is switching', () => {
+    // `active` is checked before the `switchingTarget !== null` disable, so the
+    // live target keeps its checkmark while another row is mid-switch.
+    expect(deriveSwitchRowState({ ...base, target: 'production', switchingTarget: 'pr-3271' })).toBe('active');
+  });
+
   it('is pressable when idle, usable, and not the active row', () => {
     expect(deriveSwitchRowState({ ...base, target: 'pr-3271' })).toBe('pressable');
   });

--- a/packages/mobile/src/components/__tests__/switcher-form-logic.test.ts
+++ b/packages/mobile/src/components/__tests__/switcher-form-logic.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSwitchRowState, isSwitchRowPressable } from '../SwitcherForm.logic';
+
+describe('deriveSwitchRowState', () => {
+  const base = { activeTarget: 'production', switchingTarget: null, updatesUsable: true };
+
+  it('marks the live target active', () => {
+    expect(deriveSwitchRowState({ ...base, target: 'production' })).toBe('active');
+  });
+
+  it('marks the in-flight target switching, even when it is also the active one', () => {
+    expect(deriveSwitchRowState({ ...base, target: 'pr-3271', switchingTarget: 'pr-3271' })).toBe('switching');
+    // `switching` wins over `active` so a re-switch to the current target still spins.
+    expect(deriveSwitchRowState({ ...base, target: 'production', switchingTarget: 'production' })).toBe('switching');
+  });
+
+  it('disables every other row while one is switching', () => {
+    expect(deriveSwitchRowState({ ...base, target: 'pr-100', switchingTarget: 'pr-3271' })).toBe('disabled');
+  });
+
+  it('is pressable when idle, usable, and not the active row', () => {
+    expect(deriveSwitchRowState({ ...base, target: 'pr-3271' })).toBe('pressable');
+  });
+
+  it('is inert when OTA updates are unusable (dev / Expo Go) and not the active row', () => {
+    expect(deriveSwitchRowState({ ...base, target: 'pr-3271', updatesUsable: false })).toBe('inert');
+    // The active row still reads as active even when switching is unavailable.
+    expect(deriveSwitchRowState({ ...base, target: 'production', updatesUsable: false })).toBe('active');
+  });
+});
+
+describe('isSwitchRowPressable', () => {
+  it('is true only for the pressable state', () => {
+    expect(isSwitchRowPressable('pressable')).toBe(true);
+    for (const state of ['active', 'switching', 'disabled', 'inert'] as const) {
+      expect(isSwitchRowPressable(state)).toBe(false);
+    }
+  });
+});

--- a/packages/mobile/test/switcher-form-stub.tsx
+++ b/packages/mobile/test/switcher-form-stub.tsx
@@ -1,0 +1,83 @@
+// Test stub for the platform-split SwitcherForm. Its iOS / Android implementations
+// render native @expo/ui trees (a SwiftUI `Form` / Compose `LazyColumn` of cards)
+// that can't mount under Vitest's node env, and Vitest doesn't resolve
+// `.ios`/`.android` platform extensions, so any suite that transitively renders the
+// Channel / Branch switcher screens redirects here via a vite alias (see
+// vite.config.ts).
+//
+// This is a FAITHFUL PASSTHROUGH (not a null stub): it preserves the public API and
+// the button accessibility semantics with plain React Native primitives, so screen
+// tests' label / role assertions keep passing. Component tests that assert the
+// switcher screens' model register their own vi.mock, which takes precedence over
+// this alias.
+
+import { Pressable, Text, TextInput, View } from 'react-native';
+import type { SwitcherFormProps } from '../src/components/SwitcherForm.types';
+
+export function SwitcherForm({ model }: SwitcherFormProps) {
+  return (
+    <View>
+      {model.sections.map((section) => (
+        <View key={section.key}>
+          {section.title ? <Text>{section.title}</Text> : null}
+          {section.intro ? <Text>{section.intro}</Text> : null}
+          {section.rows.map((row) => {
+            switch (row.kind) {
+              case 'info':
+                return (
+                  <View key={row.key}>
+                    <Text>{row.label}</Text>
+                    <Text>{row.value}</Text>
+                  </View>
+                );
+              case 'status':
+                return <Text key={row.key}>{row.label}</Text>;
+              case 'target':
+                return (
+                  <Pressable
+                    key={row.key}
+                    onPress={row.onPress}
+                    disabled={!row.onPress}
+                    accessibilityRole="button"
+                    accessibilityLabel={row.title}
+                    accessibilityState={{ selected: row.state === 'active', disabled: !row.onPress }}
+                  >
+                    <Text>{row.title}</Text>
+                    {row.subtitle ? <Text>{row.subtitle}</Text> : null}
+                  </Pressable>
+                );
+              case 'field':
+                return (
+                  <TextInput
+                    key={row.key}
+                    aria-label={row.label}
+                    placeholder={row.placeholder}
+                    value={row.value}
+                    editable={row.editable}
+                    onChangeText={row.onChangeText}
+                    onSubmitEditing={() => row.onSubmit()}
+                  />
+                );
+              case 'action':
+                return (
+                  <Pressable
+                    key={row.key}
+                    onPress={row.onPress}
+                    disabled={row.disabled}
+                    accessibilityRole="button"
+                    accessibilityLabel={row.label}
+                    accessibilityState={{ disabled: Boolean(row.disabled) }}
+                  >
+                    <Text>{row.label}</Text>
+                  </Pressable>
+                );
+              default:
+                return null;
+            }
+          })}
+          {section.footer ? <Text>{section.footer}</Text> : null}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/packages/mobile/test/switcher-form-stub.tsx
+++ b/packages/mobile/test/switcher-form-stub.tsx
@@ -12,6 +12,7 @@
 // this alias.
 
 import { Pressable, Text, TextInput, View } from 'react-native';
+import { assertNeverSwitcherRow } from '../src/components/SwitcherForm.logic';
 import type { SwitcherFormProps } from '../src/components/SwitcherForm.types';
 
 export function SwitcherForm({ model }: SwitcherFormProps) {
@@ -72,7 +73,10 @@ export function SwitcherForm({ model }: SwitcherFormProps) {
                   </Pressable>
                 );
               default:
-                return null;
+                // Mirror the real renderers: a new SwitcherRow kind must fail
+                // (compile-time via `never`, runtime if it slips through) rather
+                // than silently render nothing in tests.
+                return assertNeverSwitcherRow(row);
             }
           })}
           {section.footer ? <Text>{section.footer}</Text> : null}

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -202,6 +202,18 @@ export default defineConfig({
         find: /^(.*\/)?FeatureFlagsForm$/,
         replacement: fileURLToPath(new URL('./test/feature-flags-form-stub.tsx', import.meta.url)),
       },
+      // SwitcherForm is platform-split (SwitcherForm.ios.tsx renders a native
+      // @expo/ui SwiftUI `Form`; SwitcherForm.android.tsx a native Compose
+      // `LazyColumn` of cards) and backs both the OTA Channel + Branch switcher
+      // screens. Vitest doesn't resolve `.ios`/`.android` extensions and can't mount
+      // either native tree, so redirect the extensionless import to a faithful
+      // passthrough stub that keeps the public API + button/field accessibility
+      // roles. Suites that assert the switcher screens' model register their own
+      // vi.mock (takes precedence).
+      {
+        find: /^(.*\/)?SwitcherForm$/,
+        replacement: fileURLToPath(new URL('./test/switcher-form-stub.tsx', import.meta.url)),
+      },
       // MoreForm is platform-split (MoreForm.ios.tsx renders a native @expo/ui
       // SwiftUI `Form`; MoreForm.android.tsx a native Compose `LazyColumn`).
       // Vitest doesn't resolve `.ios`/`.android` extensions and can't mount either

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -268,8 +268,7 @@
       "manualSection": "Enter a channel manually",
       "manualHint": "Couldn't load the preview list. Enter a channel name (like pr-1234) to switch manually.",
       "manualPlaceholder": "channel name",
-      "manualInputA11y": "Channel name to switch to",
-      "manualSwitchA11y": "Switch to the entered channel"
+      "manualInputA11y": "Channel name to switch to"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -469,8 +469,7 @@
       "manualSection": "Introduce un canal manualmente",
       "manualHint": "No se pudo cargar la lista de versiones de prueba. Introduce un nombre de canal (como pr-1234) para cambiar manualmente.",
       "manualPlaceholder": "nombre del canal",
-      "manualInputA11y": "Nombre del canal al que cambiar",
-      "manualSwitchA11y": "Cambiar al canal introducido"
+      "manualInputA11y": "Nombre del canal al que cambiar"
     }
   },
   "lightControl": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -268,8 +268,7 @@
       "manualSection": "Saisir un canal manuellement",
       "manualHint": "Impossible de charger la liste des préversions. Saisissez un nom de canal (comme pr-1234) pour changer manuellement.",
       "manualPlaceholder": "nom du canal",
-      "manualInputA11y": "Nom du canal vers lequel basculer",
-      "manualSwitchA11y": "Basculer vers le canal saisi"
+      "manualInputA11y": "Nom du canal vers lequel basculer"
     }
   },
   "lightControl": {


### PR DESCRIPTION
## Summary

Closes #3271 (part of the @expo/ui native-UI epic #3275).

Migrates the OTA **Channel** and **Branch** switcher screens from hand-rolled RN (`ScrollView` + card/`ListRow`/`InfoRow` + bare `TextInput`) to a single-`Host` native form — a SwiftUI `Form` on iOS, a Jetpack Compose `LazyColumn` of Material cards on Android — the same whole-screen consolidation as `MoreForm` / `FeatureFlagsForm`. Each screen keeps every hook, route guard, `t()`/confirm/`Alert`/haptic, and the `channel-switch.ts` state machine, and now builds a plain view-model the native tree renders. `DevServerSwitcherScreen` stays RN (the issue rules it out).

**One shared form, not two.** The two screens are the same OTA-target switcher (info → target list → custom-text field → reset), so they share **one generic `SwitcherForm`** (sections of typed rows: `info`/`status`/`target`/`field`/`action`) — the same sections-of-rows shape `MoreForm` uses — rather than duplicating two near-identical native trees. This is a deliberate divergence from the issue's literal `ChannelSwitcherForm`/`BranchSwitcherForm` naming, in service of the "extract, don't duplicate" rule. The screens (`ChannelSwitcherScreen`/`BranchSwitcherScreen`) remain the view-model owners, as the issue requires.

**Text field.** The blocking dependency (native text inputs, #3266 / PR #3284) merged on the 29th. Its `AuthTextInput` renders its own `Host` and so can't nest inside another `Host`'s native tree, so the inline manual-channel / custom-branch field is a bare native `TextField` / `OutlinedTextField` placed directly in the form, reusing `AuthTextInput.logic`'s pure prop→modifier mappers + `textFieldBrandColors`. Row state is derived once by `deriveSwitchRowState` so iOS/Android can't drift.

JS-only / OTA-deliverable (`@expo/ui` 56.0.18 already autolinked) — no native build. Drops the now-orphaned `previewChannels.manualSwitchA11y` key (the native action button's accessible name is its visible "Switch" label).

## Release Notes

- [x] No release note needed (internal / technical change)

Dev/tester OTA-tooling screens; RN → native rendering with no behaviour change.

## Test plan

- `vp run typecheck:mobile` — green
- `vp run test:mobile` — green (adds `switcher-form-logic` + `ChannelSwitcherScreen` + `BranchSwitcherScreen` view-model tests; full suite 2905+ passing)
- `vp run check:mobile-platform-imports` — green (swift-ui only in `.ios`, jetpack-compose only in `.android`)
- `vp run check:mobile-bundle` — iOS + Android bundles OK
- `vp check` — format + lint clean

**On-device verification** of the native rendering is the remaining step. Note dev/Metro builds force `updatesUsable` false (`!__DEV__`), so the switch/preset/reset sections only appear in a real build — verify via the `pr-<N>` OTA channel (More → Development → OTA Channel Switcher) once this PR's preview publishes. Flows to exercise: manual field accepts input with autocorrect off; switch a preview channel → confirm → restart Alert; reset → confirm → returns to build channel; tester preset + Sentry rows; Branch switch/reset; light/dark via the in-app toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)