### PR TITLE
chore: stop formatting generated CHANGELOG + embedded firmware

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,13 @@
 # Local-only board-data exports (gitignored, see .gitignore). If an operator drops an
 # export here to run an importer, don't let `vp check` try to reformat the raw data.
 packages/db/data/
+# CHANGELOG.md is generated + owned by the mobile OTA pipeline (built from PR Release
+# Notes); hand-formatting it drifts vs the generator and the `changelog-owned` gate
+# rejects edits. It's in vite.config.ts fmt.ignore too, but the full-repo `vp check`
+# only honours .prettierignore for by-name files.
+CHANGELOG.md
+# Embedded ESP32 firmware is a self-contained PlatformIO sub-project with its own
+# .clang-format; its JS build scripts and Markdown aren't held to the web/mobile Prettier
+# config (the CI PR-lint already skips `embedded/`).
+embedded/
+docs/embedded-architecture.md


### PR DESCRIPTION
## Summary

The full-repo `vp check` (the push-to-main lint/format job) was failing on pre-existing format drift in three files it should never reformat. The CI **PR** lint only checks changed TS/JS and already excludes `embedded/` + generated dirs, so this only bites the **push-to-main** full-repo `vp check`.

Added to `.prettierignore`:

- **`CHANGELOG.md`** — generated and owned by the mobile OTA pipeline (built from PR Release Notes). Already in `vite.config.ts` `fmt.ignore`, but the full-repo `vp check` only honours `.prettierignore` for by-name files (per that file's own note), so it slipped through.
- **`embedded/`** — the ESP32 firmware is a self-contained PlatformIO sub-project with its own `.clang-format`; its JS build scripts and Markdown aren't held to the web/mobile Prettier config. The CI PR-lint already skips `embedded/`; this brings the full-repo check in line.
- **`docs/embedded-architecture.md`** — the embedded firmware doc, the only doc that drifts.

Lint coverage is unchanged — this only affects Prettier formatting. After the change, `vp check` exits clean (0 errors).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — before: failed with formatting issues in `CHANGELOG.md`, `docs/embedded-architecture.md`, `embedded/scripts/generate-board-data.mjs`. After: exits 0 (0 errors).