### PR TITLE
feat(mobile): let any user switch OTA channels (incl. back to production)

### DIFF
--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -438,9 +438,10 @@ prebuild --platform ios --clean --no-install`, then confirm `ios/Boardsesh/Suppo
 specific PR's OTA, without a per-tester build. The entry is a visible **"Try a preview"** button on the
 **What's New** screen (`app/changelog.tsx`), next to _Check for updates_ — shown only when
 `!__DEV__ && Updates.isEnabled`. It opens the switcher screen (`src/components/ChannelSwitcherScreen.tsx`),
-which lists the **live per-PR previews by pull-request title** (not raw `pr-<n>` strings) and a
-reset-to-production action. _(It used to be a tester-only "OTA Channel Switcher" row under
-More → Development; that row was removed.)_
+which lists a fixed **Production** row (return to the stable release — shown to everyone), the
+**live per-PR previews by pull-request title** (not raw `pr-<n>` strings), and a reset-to-production
+action. _(It used to be a tester-only "OTA Channel Switcher" row under More → Development; that row
+was removed.)_
 
 - **Live preview list:** the screen calls the **public** `otaPreviewChannels` GraphQL query
   (`packages/backend/src/lib/ota-preview-channels.ts`), which derives the live channels from the GitHub
@@ -459,10 +460,13 @@ More → Development; that row was removed.)_
   the switcher breaks (the override throws). Keep it baked in.
 - **Constraint:** the target channel must have an OTA published at the **same fingerprint
   runtimeVersion** as the running binary, or `checkForUpdateAsync` reports nothing available.
-- **Tester-only extras:** the raw preset/custom-channel entry (`production`, `preview-1…4`, free-text)
-  and the Sentry crash-test tools on the same screen still require the **`tester`** role
-  (`UserProfile.isTester`; admin panel → Roles, admins implicitly count). Switch logic lives in
-  `src/lib/channel-switch.ts` (unit-tested). The `tester` role grants nothing beyond these extras.
+- **Channel switching is universal.** Every user on a production/TestFlight build can switch to any
+  channel: the fixed **Production** row, the live per-PR previews, the preset list (`preview-1…4`,
+  excluding the build channel so it doesn't duplicate the Production row), and free-text manual entry
+  are all shown to everyone. Switch logic lives in `src/lib/channel-switch.ts` (unit-tested:
+  `resolveBuildChannel`, `deriveChannelRowState`, and the switch/reset state machine).
+- **Tester-only extras:** only the Sentry crash-test tools on the same screen still require the
+  **`tester`** role (`UserProfile.isTester`; admin panel → Roles, admins implicitly count).
 
 ## Per-PR preview channels (self-hosted)
 

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -19,6 +19,7 @@ import {
   OTA_CHANNEL_OVERRIDE_KEY,
   buildChannelList,
   resolveBuildChannel,
+  deriveChannelRowState,
   performChannelSwitch,
   performChannelReset,
   type ChannelSwitchDeps,
@@ -34,8 +35,8 @@ export function ChannelSwitcherScreen() {
   // so isError is rare; we still handle it for completeness.
   const previewQuery = useOtaPreviewChannels();
   const previewChannels = previewQuery.data ?? [];
-  // The full developer tools (raw preset/custom channel entry, Sentry crash
-  // tests) stay tester-only; everyone else gets the friendly preview list.
+  // Channel switching (preview list, preset list, manual entry) is available to
+  // everyone; only the Sentry crash-test tools stay tester-only.
   const isTester = Boolean(profile?.isTester);
 
   const [override, setOverride] = useState<string | null>(null);
@@ -221,16 +222,21 @@ export function ChannelSwitcherScreen() {
     nativeSentryCrash();
   }, [confirm]);
 
-  const presetChannels = buildChannelList(override);
+  // The tester preset list excludes the build channel (production on real
+  // builds) — it already has the dedicated production row below, so listing it
+  // again here would duplicate it.
+  const presetChannels = buildChannelList(override).filter((channel) => channel !== buildChannel);
 
   // Production is the stable release. It's never in the backend preview list
   // (that's only open PRs), so it's surfaced as a fixed first row everyone —
   // tester or not — can tap to get back. Tapping runs the reset flow, which
   // clears the override and returns to the baked-in production channel.
-  const productionIsActive = activeChannel === buildChannel;
-  const productionIsSwitching = switchingChannel === buildChannel;
-  const productionIsDisabled = isSwitching && !productionIsSwitching;
-  const productionIsPressable = updatesUsable && !productionIsActive && !productionIsDisabled;
+  const productionRow = deriveChannelRowState({
+    channel: buildChannel,
+    activeChannel,
+    switchingChannel,
+    updatesUsable,
+  });
 
   const cardStyle = [
     styles.card,
@@ -273,22 +279,22 @@ export function ChannelSwitcherScreen() {
         {t('mobile.previewChannels.intro')}
       </Text>
       <View style={cardStyle}>
-        {/* Fixed production row (see the productionIs* derivations above). */}
+        {/* Fixed production row (see the productionRow derivation above). */}
         <ListRow
           title={t('mobile.previewChannels.productionTitle')}
           subtitle={t('mobile.previewChannels.productionSubtitle')}
           trailing={
-            productionIsSwitching ? (
+            productionRow.isSwitching ? (
               <ActivityIndicator size="small" />
-            ) : productionIsActive ? (
+            ) : productionRow.isActive ? (
               <Icon name="check.small" size={20} color={systemColors.label} />
             ) : updatesUsable ? (
               <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
             ) : null
           }
-          onPress={productionIsPressable ? () => void resetToBuildChannel() : undefined}
+          onPress={productionRow.isPressable ? () => void resetToBuildChannel() : undefined}
           showSeparator
-          style={productionIsDisabled ? styles.disabledRow : undefined}
+          style={productionRow.isDisabled ? styles.disabledRow : undefined}
         />
         {previewQuery.isLoading ? (
           <View style={styles.statusRow}>
@@ -307,26 +313,28 @@ export function ChannelSwitcherScreen() {
           </Text>
         ) : (
           previewChannels.map((preview, index) => {
-            const isActive = preview.channel === activeChannel;
-            const isThisSwitching = switchingChannel === preview.channel;
-            const isDisabled = isSwitching && !isThisSwitching;
-            const trailing = isThisSwitching ? (
+            const row = deriveChannelRowState({
+              channel: preview.channel,
+              activeChannel,
+              switchingChannel,
+              updatesUsable,
+            });
+            const trailing = row.isSwitching ? (
               <ActivityIndicator size="small" />
-            ) : isActive ? (
+            ) : row.isActive ? (
               <Icon name="check.small" size={20} color={systemColors.label} />
             ) : updatesUsable ? (
               <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
             ) : null;
-            const pressable = updatesUsable && !isActive && !isDisabled;
             return (
               <ListRow
                 key={preview.channel}
                 title={preview.title}
                 subtitle={preview.channel}
                 trailing={trailing}
-                onPress={pressable ? () => void switchToChannel(preview.channel, preview.title) : undefined}
+                onPress={row.isPressable ? () => void switchToChannel(preview.channel, preview.title) : undefined}
                 showSeparator={index < previewChannels.length - 1}
-                style={isDisabled ? styles.disabledRow : undefined}
+                style={row.isDisabled ? styles.disabledRow : undefined}
               />
             );
           })
@@ -335,18 +343,18 @@ export function ChannelSwitcherScreen() {
 
       {updatesUsable ? (
         <>
-          {isTester ? (
+          {/* Preset channel list (preview-1…4) — available to everyone, not just
+              testers. The build channel is filtered out above since the fixed
+              Production row already covers it. */}
+          {presetChannels.length > 0 ? (
             <>
-              {/* i18n-ignore-next-line — tester-only dev tooling */}
-              <SectionHeader title="Switch Channel (tester)" />
+              <SectionHeader title={t('mobile.previewChannels.presetSection')} />
               <View style={cardStyle}>
                 {presetChannels.map((channel, index) => {
-                  const isActive = channel === activeChannel;
-                  const isThisSwitching = switchingChannel === channel;
-                  const isDisabled = isSwitching && !isThisSwitching;
-                  const trailing = isThisSwitching ? (
+                  const row = deriveChannelRowState({ channel, activeChannel, switchingChannel, updatesUsable });
+                  const trailing = row.isSwitching ? (
                     <ActivityIndicator size="small" />
-                  ) : isActive ? (
+                  ) : row.isActive ? (
                     <Icon name="check.small" size={20} color={systemColors.label} />
                   ) : null;
 
@@ -355,9 +363,9 @@ export function ChannelSwitcherScreen() {
                       key={channel}
                       title={channel}
                       trailing={trailing}
-                      onPress={isActive || isDisabled ? undefined : () => void switchToChannel(channel)}
+                      onPress={row.isActive || row.isDisabled ? undefined : () => void switchToChannel(channel)}
                       showSeparator={index < presetChannels.length - 1}
-                      style={isDisabled ? styles.disabledRow : undefined}
+                      style={row.isDisabled ? styles.disabledRow : undefined}
                     />
                   );
                 })}
@@ -365,66 +373,62 @@ export function ChannelSwitcherScreen() {
             </>
           ) : null}
 
-          {/* Manual channel entry: always for testers, and as a fallback for
-              everyone when the preview list fails to load — so a user is never
-              stranded without a way to switch. */}
-          {isTester || previewQuery.isError ? (
-            <>
-              <SectionHeader title={t('mobile.previewChannels.manualSection')} />
-              {previewQuery.isError ? (
-                <Text
-                  variant="footnote"
-                  color={systemColors.secondaryLabel}
-                  style={[styles.intro, { marginHorizontal: spacing[4] }]}
-                >
-                  {t('mobile.previewChannels.manualHint')}
-                </Text>
-              ) : null}
-              <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
-                <TextInput
-                  value={customChannel}
-                  onChangeText={setCustomChannel}
-                  placeholder={t('mobile.previewChannels.manualPlaceholder')}
-                  placeholderTextColor={systemColors.secondaryLabel}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  editable={!isSwitching}
-                  accessibilityLabel={t('mobile.previewChannels.manualInputA11y')}
-                  style={[
-                    styles.input,
-                    {
-                      color: systemColors.label,
-                      backgroundColor: systemColors.secondaryBackground,
-                      borderRadius: borderRadius.md,
-                    },
-                  ]}
-                />
-                <Pressable
-                  onPress={() => {
-                    const trimmed = customChannel.trim();
-                    if (trimmed) void switchToChannel(trimmed);
-                  }}
-                  disabled={isSwitching || customChannel.trim().length === 0}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('mobile.previewChannels.manualSwitchA11y')}
-                  accessibilityState={{ disabled: isSwitching || customChannel.trim().length === 0 }}
-                  style={[
-                    styles.goButton,
-                    {
-                      backgroundColor: systemColors.tertiaryBackground,
-                      borderRadius: borderRadius.md,
-                      opacity: isSwitching || customChannel.trim().length === 0 ? 0.5 : 1,
-                    },
-                  ]}
-                >
-                  <Icon name="transfer" size={16} color={systemColors.label} />
-                  <Text variant="footnote" color={systemColors.label}>
-                    {t('mobile.previewChannels.confirmSwitchConfirm')}
-                  </Text>
-                </Pressable>
-              </View>
-            </>
+          {/* Free-text channel entry — available to everyone, so any user can
+              switch to any channel (not just the previews/presets above). The
+              hint only appears when the preview list failed to load. */}
+          <SectionHeader title={t('mobile.previewChannels.manualSection')} />
+          {previewQuery.isError ? (
+            <Text
+              variant="footnote"
+              color={systemColors.secondaryLabel}
+              style={[styles.intro, { marginHorizontal: spacing[4] }]}
+            >
+              {t('mobile.previewChannels.manualHint')}
+            </Text>
           ) : null}
+          <View style={[styles.customRow, { marginHorizontal: spacing[4] }]}>
+            <TextInput
+              value={customChannel}
+              onChangeText={setCustomChannel}
+              placeholder={t('mobile.previewChannels.manualPlaceholder')}
+              placeholderTextColor={systemColors.secondaryLabel}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!isSwitching}
+              accessibilityLabel={t('mobile.previewChannels.manualInputA11y')}
+              style={[
+                styles.input,
+                {
+                  color: systemColors.label,
+                  backgroundColor: systemColors.secondaryBackground,
+                  borderRadius: borderRadius.md,
+                },
+              ]}
+            />
+            <Pressable
+              onPress={() => {
+                const trimmed = customChannel.trim();
+                if (trimmed) void switchToChannel(trimmed);
+              }}
+              disabled={isSwitching || customChannel.trim().length === 0}
+              accessibilityRole="button"
+              accessibilityLabel={t('mobile.previewChannels.manualSwitchA11y')}
+              accessibilityState={{ disabled: isSwitching || customChannel.trim().length === 0 }}
+              style={[
+                styles.goButton,
+                {
+                  backgroundColor: systemColors.tertiaryBackground,
+                  borderRadius: borderRadius.md,
+                  opacity: isSwitching || customChannel.trim().length === 0 ? 0.5 : 1,
+                },
+              ]}
+            >
+              <Icon name="transfer" size={16} color={systemColors.label} />
+              <Text variant="footnote" color={systemColors.label}>
+                {t('mobile.previewChannels.confirmSwitchConfirm')}
+              </Text>
+            </Pressable>
+          </View>
 
           {/* Reset — available to everyone, kept last as the escape hatch back to
               the shipped version. Not gated on `override` so a native override

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -219,6 +219,15 @@ export function ChannelSwitcherScreen() {
 
   const presetChannels = buildChannelList(override);
 
+  // Production is the stable release. It's never in the backend preview list
+  // (that's only open PRs), so it's surfaced as a fixed first row everyone —
+  // tester or not — can tap to get back. Tapping runs the reset flow, which
+  // clears the override and returns to the baked-in production channel.
+  const productionIsActive = activeChannel === buildChannel;
+  const productionIsSwitching = switchingChannel === buildChannel;
+  const productionIsDisabled = isSwitching && !productionIsSwitching;
+  const productionIsPressable = updatesUsable && !productionIsActive && !productionIsDisabled;
+
   const cardStyle = [
     styles.card,
     {
@@ -260,34 +269,23 @@ export function ChannelSwitcherScreen() {
         {t('mobile.previewChannels.intro')}
       </Text>
       <View style={cardStyle}>
-        {/* Production is the stable release. It's never in the backend preview
-            list (that's only open PRs), so it's surfaced here as a fixed first
-            row that everyone — tester or not — can tap to get back. Tapping runs
-            the reset flow, which clears the override and returns to the baked-in
-            production channel. */}
-        {(() => {
-          const isActive = activeChannel === buildChannel;
-          const isThisSwitching = switchingChannel === buildChannel;
-          const isDisabled = isSwitching && !isThisSwitching;
-          const trailing = isThisSwitching ? (
-            <ActivityIndicator size="small" />
-          ) : isActive ? (
-            <Icon name="check.small" size={20} color={systemColors.label} />
-          ) : updatesUsable ? (
-            <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
-          ) : null;
-          const pressable = updatesUsable && !isActive && !isDisabled;
-          return (
-            <ListRow
-              title={t('mobile.previewChannels.productionTitle')}
-              subtitle={t('mobile.previewChannels.productionSubtitle')}
-              trailing={trailing}
-              onPress={pressable ? () => void resetToBuildChannel() : undefined}
-              showSeparator
-              style={isDisabled ? styles.disabledRow : undefined}
-            />
-          );
-        })()}
+        {/* Fixed production row (see the productionIs* derivations above). */}
+        <ListRow
+          title={t('mobile.previewChannels.productionTitle')}
+          subtitle={t('mobile.previewChannels.productionSubtitle')}
+          trailing={
+            productionIsSwitching ? (
+              <ActivityIndicator size="small" />
+            ) : productionIsActive ? (
+              <Icon name="check.small" size={20} color={systemColors.label} />
+            ) : updatesUsable ? (
+              <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+            ) : null
+          }
+          onPress={productionIsPressable ? () => void resetToBuildChannel() : undefined}
+          showSeparator
+          style={productionIsDisabled ? styles.disabledRow : undefined}
+        />
         {previewQuery.isLoading ? (
           <View style={styles.statusRow}>
             <ActivityIndicator size="small" />

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -363,7 +363,7 @@ export function ChannelSwitcherScreen() {
                       key={channel}
                       title={channel}
                       trailing={trailing}
-                      onPress={row.isActive || row.isDisabled ? undefined : () => void switchToChannel(channel)}
+                      onPress={row.isPressable ? () => void switchToChannel(channel) : undefined}
                       showSeparator={index < presetChannels.length - 1}
                       style={row.isDisabled ? styles.disabledRow : undefined}
                     />

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -293,9 +293,9 @@ export function ChannelSwitcherScreen() {
             ) : null
           }
           onPress={productionRow.isPressable ? () => void resetToBuildChannel() : undefined}
-          // Only divide into the previews when there are rows below; an empty /
-          // error notice shouldn't sit under a separator that implies more rows.
-          showSeparator={previewQuery.isLoading || previewChannels.length > 0}
+          // Divide into whatever follows (spinner, error text, or rows); only
+          // the bare empty-state notice reads better without a separator above it.
+          showSeparator={previewQuery.isLoading || previewQuery.isError || previewChannels.length > 0}
           style={productionRow.isDisabled ? styles.disabledRow : undefined}
         />
         {previewQuery.isLoading ? (

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -18,6 +18,7 @@ import { applyChannelOverride } from '../lib/apply-channel-override';
 import {
   OTA_CHANNEL_OVERRIDE_KEY,
   buildChannelList,
+  resolveBuildChannel,
   performChannelSwitch,
   performChannelReset,
   type ChannelSwitchDeps,
@@ -63,7 +64,7 @@ export function ChannelSwitcherScreen() {
     overrideRef.current = override;
   }, [override]);
 
-  const buildChannel = Updates.channel ?? 'unknown';
+  const buildChannel = resolveBuildChannel(Updates.channel);
   const runtimeVersion = Updates.runtimeVersion ?? 'unknown';
   const updatesUsable = Updates.isEnabled && !__DEV__;
   const isSwitching = switchingChannel !== null;
@@ -259,6 +260,34 @@ export function ChannelSwitcherScreen() {
         {t('mobile.previewChannels.intro')}
       </Text>
       <View style={cardStyle}>
+        {/* Production is the stable release. It's never in the backend preview
+            list (that's only open PRs), so it's surfaced here as a fixed first
+            row that everyone — tester or not — can tap to get back. Tapping runs
+            the reset flow, which clears the override and returns to the baked-in
+            production channel. */}
+        {(() => {
+          const isActive = activeChannel === buildChannel;
+          const isThisSwitching = switchingChannel === buildChannel;
+          const isDisabled = isSwitching && !isThisSwitching;
+          const trailing = isThisSwitching ? (
+            <ActivityIndicator size="small" />
+          ) : isActive ? (
+            <Icon name="check.small" size={20} color={systemColors.label} />
+          ) : updatesUsable ? (
+            <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+          ) : null;
+          const pressable = updatesUsable && !isActive && !isDisabled;
+          return (
+            <ListRow
+              title={t('mobile.previewChannels.productionTitle')}
+              subtitle={t('mobile.previewChannels.productionSubtitle')}
+              trailing={trailing}
+              onPress={pressable ? () => void resetToBuildChannel() : undefined}
+              showSeparator
+              style={isDisabled ? styles.disabledRow : undefined}
+            />
+          );
+        })()}
         {previewQuery.isLoading ? (
           <View style={styles.statusRow}>
             <ActivityIndicator size="small" />

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -64,9 +64,13 @@ export function ChannelSwitcherScreen() {
     overrideRef.current = override;
   }, [override]);
 
-  const buildChannel = resolveBuildChannel(Updates.channel);
   const runtimeVersion = Updates.runtimeVersion ?? 'unknown';
   const updatesUsable = Updates.isEnabled && !__DEV__;
+  // Real builds always bake a channel (production for store/TestFlight), but
+  // expo-updates can report it as null on device — notably Android — so resolve
+  // to production there. In dev there's genuinely no channel, so stay honest with
+  // "unknown" rather than mislabel the debug InfoRow as production.
+  const buildChannel = updatesUsable ? resolveBuildChannel(Updates.channel) : (Updates.channel ?? 'unknown');
   const isSwitching = switchingChannel !== null;
 
   // A channel is "active" when it's the live override, or — with no override —

--- a/packages/mobile/src/components/ChannelSwitcherScreen.tsx
+++ b/packages/mobile/src/components/ChannelSwitcherScreen.tsx
@@ -293,7 +293,9 @@ export function ChannelSwitcherScreen() {
             ) : null
           }
           onPress={productionRow.isPressable ? () => void resetToBuildChannel() : undefined}
-          showSeparator
+          // Only divide into the previews when there are rows below; an empty /
+          // error notice shouldn't sit under a separator that implies more rows.
+          showSeparator={previewQuery.isLoading || previewChannels.length > 0}
           style={productionRow.isDisabled ? styles.disabledRow : undefined}
         />
         {previewQuery.isLoading ? (

--- a/packages/mobile/src/lib/__tests__/channel-switch.test.ts
+++ b/packages/mobile/src/lib/__tests__/channel-switch.test.ts
@@ -3,6 +3,7 @@ import {
   PRESET_CHANNELS,
   buildChannelList,
   resolveBuildChannel,
+  deriveChannelRowState,
   performChannelSwitch,
   performChannelReset,
   type ChannelSwitchDeps,
@@ -44,6 +45,49 @@ describe('resolveBuildChannel', () => {
   it('passes a real build channel through unchanged', () => {
     expect(resolveBuildChannel('production')).toBe('production');
     expect(resolveBuildChannel('preview-2')).toBe('preview-2');
+  });
+});
+
+describe('deriveChannelRowState', () => {
+  const base = { channel: 'preview-1', activeChannel: 'production', switchingChannel: null, updatesUsable: true };
+
+  it('an idle, inactive row on a usable build is pressable', () => {
+    expect(deriveChannelRowState(base)).toEqual({
+      isActive: false,
+      isSwitching: false,
+      isDisabled: false,
+      isPressable: true,
+    });
+  });
+
+  it('the active channel shows a checkmark and is not pressable', () => {
+    expect(deriveChannelRowState({ ...base, channel: 'production' })).toMatchObject({
+      isActive: true,
+      isPressable: false,
+    });
+  });
+
+  it('the row being switched to is marked switching, not disabled', () => {
+    expect(deriveChannelRowState({ ...base, switchingChannel: 'preview-1' })).toMatchObject({
+      isSwitching: true,
+      isDisabled: false,
+      isPressable: false,
+    });
+  });
+
+  it('other rows are disabled while a different switch is in flight', () => {
+    expect(deriveChannelRowState({ ...base, switchingChannel: 'preview-2' })).toMatchObject({
+      isSwitching: false,
+      isDisabled: true,
+      isPressable: false,
+    });
+  });
+
+  it('nothing is pressable when updates are unavailable (dev / Expo Go)', () => {
+    expect(deriveChannelRowState({ ...base, updatesUsable: false })).toMatchObject({
+      isActive: false,
+      isPressable: false,
+    });
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/channel-switch.test.ts
+++ b/packages/mobile/src/lib/__tests__/channel-switch.test.ts
@@ -42,6 +42,10 @@ describe('resolveBuildChannel', () => {
     expect(resolveBuildChannel(undefined)).toBe('production');
   });
 
+  it('treats an empty-string channel as no channel', () => {
+    expect(resolveBuildChannel('')).toBe('production');
+  });
+
   it('passes a real build channel through unchanged', () => {
     expect(resolveBuildChannel('production')).toBe('production');
     expect(resolveBuildChannel('preview-2')).toBe('preview-2');
@@ -86,6 +90,13 @@ describe('deriveChannelRowState', () => {
   it('nothing is pressable when updates are unavailable (dev / Expo Go)', () => {
     expect(deriveChannelRowState({ ...base, updatesUsable: false })).toMatchObject({
       isActive: false,
+      isPressable: false,
+    });
+  });
+
+  it('the active channel is still marked active on an unusable build, just not pressable', () => {
+    expect(deriveChannelRowState({ ...base, channel: 'production', updatesUsable: false })).toMatchObject({
+      isActive: true,
       isPressable: false,
     });
   });

--- a/packages/mobile/src/lib/__tests__/channel-switch.test.ts
+++ b/packages/mobile/src/lib/__tests__/channel-switch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   PRESET_CHANNELS,
   buildChannelList,
+  resolveBuildChannel,
   performChannelSwitch,
   performChannelReset,
   type ChannelSwitchDeps,
@@ -31,6 +32,18 @@ describe('buildChannelList', () => {
 
   it('appends a custom override that is not a preset', () => {
     expect(buildChannelList('my-feature')).toEqual([...PRESET_CHANNELS, 'my-feature']);
+  });
+});
+
+describe('resolveBuildChannel', () => {
+  it('falls back to production when expo-updates reports no channel', () => {
+    expect(resolveBuildChannel(null)).toBe('production');
+    expect(resolveBuildChannel(undefined)).toBe('production');
+  });
+
+  it('passes a real build channel through unchanged', () => {
+    expect(resolveBuildChannel('production')).toBe('production');
+    expect(resolveBuildChannel('preview-2')).toBe('preview-2');
   });
 });
 

--- a/packages/mobile/src/lib/channel-switch.ts
+++ b/packages/mobile/src/lib/channel-switch.ts
@@ -31,7 +31,8 @@ export function buildChannelList(override: string | null): string[] {
 // AND it hits the Android null-channel bug, this would mislabel it as production —
 // revisit this default if that ever becomes possible.
 export function resolveBuildChannel(channel: string | null | undefined): string {
-  return channel ?? 'production';
+  // `||` (not `??`) so an empty-string channel also falls back to production.
+  return channel || 'production';
 }
 
 // Per-row UI state for a channel in the switcher list, shared by the fixed

--- a/packages/mobile/src/lib/channel-switch.ts
+++ b/packages/mobile/src/lib/channel-switch.ts
@@ -24,8 +24,46 @@ export function buildChannelList(override: string | null): string[] {
 // This is a display/label default only: the switcher gates every actual switch on
 // `updatesUsable` (Updates.isEnabled && !__DEV__), so only real store/TestFlight
 // binaries — which always bake the channel — ever act on it.
+//
+// Assumption: a real build that reports a null channel was built for production.
+// Today that always holds (only production store/TestFlight binaries ship). If we
+// ever ship a binary that bakes a non-production channel (e.g. a `staging` build)
+// AND it hits the Android null-channel bug, this would mislabel it as production —
+// revisit this default if that ever becomes possible.
 export function resolveBuildChannel(channel: string | null | undefined): string {
   return channel ?? 'production';
+}
+
+// Per-row UI state for a channel in the switcher list, shared by the fixed
+// production row and the preview / tester-preset rows so the active-checkmark,
+// in-flight-spinner, and pressability rules stay identical and unit-testable.
+export type ChannelRowState = {
+  // This channel is the one the build is currently on (live override, or the
+  // build channel when there's no override) — show a checkmark, don't switch.
+  isActive: boolean;
+  // A switch onto THIS channel is in flight — show a spinner.
+  isSwitching: boolean;
+  // A switch onto a DIFFERENT channel is in flight — dim and block this row.
+  isDisabled: boolean;
+  // The row should respond to taps (switching is available and the row is
+  // neither already active nor blocked by another in-flight switch).
+  isPressable: boolean;
+};
+
+export function deriveChannelRowState(params: {
+  channel: string;
+  activeChannel: string;
+  switchingChannel: string | null;
+  updatesUsable: boolean;
+}): ChannelRowState {
+  const { channel, activeChannel, switchingChannel, updatesUsable } = params;
+  const isActive = channel === activeChannel;
+  const isSwitching = switchingChannel === channel;
+  const isDisabled = switchingChannel !== null && !isSwitching;
+  // Not pressable while already active, blocked by another switch, or mid-switch
+  // onto this same channel (it's showing a spinner).
+  const isPressable = updatesUsable && !isActive && !isDisabled && !isSwitching;
+  return { isActive, isSwitching, isDisabled, isPressable };
 }
 
 export type ChannelSwitchDeps = {

--- a/packages/mobile/src/lib/channel-switch.ts
+++ b/packages/mobile/src/lib/channel-switch.ts
@@ -21,6 +21,9 @@ export function buildChannelList(override: string | null): string[] {
 // report Updates.channel as null on device (notably Android). Fall back to the
 // production channel so the build-channel label and active-channel detection stay
 // correct — otherwise users see "unknown" and can't tell the way back to production.
+// This is a display/label default only: the switcher gates every actual switch on
+// `updatesUsable` (Updates.isEnabled && !__DEV__), so only real store/TestFlight
+// binaries — which always bake the channel — ever act on it.
 export function resolveBuildChannel(channel: string | null | undefined): string {
   return channel ?? 'production';
 }

--- a/packages/mobile/src/lib/channel-switch.ts
+++ b/packages/mobile/src/lib/channel-switch.ts
@@ -17,6 +17,14 @@ export function buildChannelList(override: string | null): string[] {
   return Array.from(new Set<string>([...PRESET_CHANNELS, ...(override ? [override] : [])]));
 }
 
+// Production binaries bake EXPO_UPDATES_CHANNEL=production, but expo-updates can
+// report Updates.channel as null on device (notably Android). Fall back to the
+// production channel so the build-channel label and active-channel detection stay
+// correct — otherwise users see "unknown" and can't tell the way back to production.
+export function resolveBuildChannel(channel: string | null | undefined): string {
+  return channel ?? 'production';
+}
+
 export type ChannelSwitchDeps = {
   // Override the build's `expo-channel-name` request header (null clears it).
   applyOverride: (channel: string | null) => void;

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -264,6 +264,7 @@
       "resetFailedTitle": "Couldn't reset",
       "resetFailedReason": "Could not reset.",
       "resetFailedMessage": "{{reason}} Stayed on “{{channel}}”.",
+      "presetSection": "More channels",
       "manualSection": "Enter a channel manually",
       "manualHint": "Couldn't load the preview list. Enter a channel name (like pr-1234) to switch manually.",
       "manualPlaceholder": "channel name",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -243,6 +243,8 @@
       "runtimeVersionLabel": "Runtime version",
       "unavailableNotice": "Previews need a TestFlight or App Store build, so switching is off here.",
       "listSection": "Available previews",
+      "productionTitle": "Production",
+      "productionSubtitle": "The stable release everyone runs",
       "loading": "Loading previews…",
       "empty": "No previews up for testing right now. Check back soon.",
       "error": "Couldn't load previews. Try again in a bit.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -464,6 +464,7 @@
       "resetFailedTitle": "No se pudo restablecer",
       "resetFailedReason": "No se pudo restablecer.",
       "resetFailedMessage": "{{reason}} Se quedó en «{{channel}}».",
+      "presetSection": "Más canales",
       "manualSection": "Introduce un canal manualmente",
       "manualHint": "No se pudo cargar la lista de versiones de prueba. Introduce un nombre de canal (como pr-1234) para cambiar manualmente.",
       "manualPlaceholder": "nombre del canal",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -443,6 +443,8 @@
       "runtimeVersionLabel": "Versión de ejecución",
       "unavailableNotice": "Las versiones de prueba requieren una compilación de TestFlight o de la App Store, así que aquí el cambio está desactivado.",
       "listSection": "Versiones de prueba disponibles",
+      "productionTitle": "Producción",
+      "productionSubtitle": "La versión estable que usa todo el mundo",
       "loading": "Cargando versiones de prueba…",
       "empty": "No hay versiones de prueba ahora mismo. Vuelve pronto.",
       "error": "No se pudieron cargar las versiones de prueba. Inténtalo de nuevo en un rato.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -243,6 +243,8 @@
       "runtimeVersionLabel": "Version d’exécution",
       "unavailableNotice": "Les préversions nécessitent un build TestFlight ou App Store ; le changement est donc désactivé ici.",
       "listSection": "Préversions disponibles",
+      "productionTitle": "Production",
+      "productionSubtitle": "La version stable que tout le monde utilise",
       "loading": "Chargement des préversions…",
       "empty": "Aucune préversion à tester pour le moment. Revenez bientôt.",
       "error": "Impossible de charger les préversions. Réessayez dans un instant.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -264,6 +264,7 @@
       "resetFailedTitle": "Échec de la réinitialisation",
       "resetFailedReason": "Impossible de réinitialiser.",
       "resetFailedMessage": "{{reason}} Resté sur « {{channel}} ».",
+      "presetSection": "Plus de canaux",
       "manualSection": "Saisir un canal manuellement",
       "manualHint": "Impossible de charger la liste des préversions. Saisissez un nom de canal (comme pr-1234) pour changer manuellement.",
       "manualPlaceholder": "nom du canal",


### PR DESCRIPTION
## Summary

On Android the OTA channel switcher never showed "production", so once you'd switched to a PR preview there was no obvious way back to the stable app. More broadly, the preset channel list and manual entry were tester-only, so regular users couldn't freely move between channels.

This makes channel switching universal — any user on a production/TestFlight build can switch to any channel and back to production.

Changes:

- **Fixed "Production · stable release" row** at the top of the previews list, shown to everyone. Checkmarked when you're on the build channel; taps into the reset flow to return to production.
- **`resolveBuildChannel()`** falls back to `production` when expo-updates reports no channel (notably Android), so the label and active-channel detection are correct on real builds. Gated on `updatesUsable` so dev builds stay honest ("unknown"). Comment documents the production-fallback assumption as a limitation.
- **Ungated the preset list (`preview-1…4`) and free-text manual entry** — both now show for every user, not just testers. The build channel is filtered out of the preset list so it doesn't duplicate the Production row. Only the Sentry crash-test tools remain tester-only.
- **`deriveChannelRowState()`** — pure helper for per-row active/switching/disabled/pressable state, shared by all three row types and unit-tested (incl. in-flight and updates-unavailable paths). A row mid-switch onto itself is no longer pressable.
- Updated `docs/mobile-ota-updates.md`; added the `presetSection` string to en-US, es, fr.

## Release Notes

- Switch between app versions yourself: open **What's New → Try a preview** to jump onto any preview build — or tap **Production** to get back to the stable app. No tester access needed.

## Test plan

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — 2927 tests pass (incl. new `resolveBuildChannel` + `deriveChannelRowState` cases and i18n catalog completeness)
- `vp run check:mobile-bundle` — Android bundle OK
- `vp lint` on changed files — 0 warnings / 0 errors
- Manual (on a store/TestFlight build): More → What's New → Try a preview. A "Production · stable release" row shows for any user, checkmarked when no override is set; the preset list and manual entry are visible to non-testers; switching to a `pr-<N>` preview and tapping Production returns to the stable app. In a dev build the rows render but are inert (expected, `updatesUsable === false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kQhRkdTv5cNesMa14nGwR