### PR TITLE
fix(web): add missing i18n keys for user-drawer help and aurora import results

### DIFF
--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -373,6 +373,7 @@
     "classifyHolds": "Classify holds",
     "myPlaylists": "My playlists",
     "recentSessions": "Recent sessions",
+    "help": "Help",
     "about": "About",
     "whatsNew": "What's New",
     "newBadge": "New",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -269,6 +269,8 @@
         "unresolvedAttemptsTitle_other": "{{count}} attempts had no matching climb",
         "unresolvedCircuitsTitle_one": "{{count}} circuit climb couldn't be matched",
         "unresolvedCircuitsTitle_other": "{{count}} circuit climbs couldn't be matched",
+        "unresolvedTitle_one": "{{count}} climb couldn't be matched",
+        "unresolvedTitle_other": "{{count}} climbs couldn't be matched",
         "unresolvedMore": "...and {{count}} more",
         "partialTitle": "Import was interrupted",
         "partialBody": "Some data may not have been imported. Re-importing the same file is safe and will fill in the gaps."

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -73,6 +73,7 @@
     "classifyHolds": "Clasificar presas",
     "myPlaylists": "Mis listas",
     "recentSessions": "Sesiones recientes",
+    "help": "Ayuda",
     "about": "Sobre",
     "whatsNew": "Novedades",
     "newBadge": "Nuevo",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -292,6 +292,8 @@
         "unresolvedAttemptsTitle_other": "{{count}} intentos sin vía asociada",
         "unresolvedCircuitsTitle_one": "{{count}} vía del circuito no se pudo emparejar",
         "unresolvedCircuitsTitle_other": "{{count}} vías del circuito no se pudieron emparejar",
+        "unresolvedTitle_one": "{{count}} vía no se pudo emparejar",
+        "unresolvedTitle_other": "{{count}} vías no se pudieron emparejar",
         "unresolvedMore": "...y {{count}} más",
         "partialTitle": "La importación se interrumpió",
         "partialBody": "Es posible que algunos datos no se hayan importado. Volver a importar el mismo archivo es seguro y completará lo que falte."

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -373,6 +373,7 @@
     "classifyHolds": "Classer les prises",
     "myPlaylists": "Mes playlists",
     "recentSessions": "Sessions récentes",
+    "help": "Aide",
     "about": "À propos",
     "whatsNew": "Nouveautés",
     "newBadge": "Nouveau",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -292,6 +292,8 @@
         "unresolvedAttemptsTitle_other": "{{count}} essais sans bloc associé",
         "unresolvedCircuitsTitle_one": "{{count}} bloc du circuit n'a pas pu être associé",
         "unresolvedCircuitsTitle_other": "{{count}} blocs du circuit n'ont pas pu être associés",
+        "unresolvedTitle_one": "{{count}} bloc n'a pas pu être associé",
+        "unresolvedTitle_other": "{{count}} blocs n'ont pas pu être associés",
         "unresolvedMore": "...et {{count}} de plus",
         "partialTitle": "Importation interrompue",
         "partialBody": "Certaines données n'ont peut-être pas été importées. Réimporter le même fichier est sûr et complétera ce qui manque."


### PR DESCRIPTION
## Summary

Two string-literal `t()` calls referenced keys that were never added to the catalogs, so the missing-key reporter fired in production and users saw the raw key text instead of a label.

- **`common:userDrawer.help`** — the Help menu item in the user drawer (`user-drawer.tsx:489`, links to `/help`). **365 users / 530 events** — the single highest-volume unresolved Sentry issue ([BOARDSESH-7A](https://boardsesh.sentry.io/issues/BOARDSESH-7A)).
- **`settings:aurora.import.results.unresolvedTitle`** — the `AlertTitle` shown after an Aurora import leaves unmatched climbs (`aurora-credentials-section.tsx:949`). It's called with `{ count }`, so it needs `_one`/`_other` plural variants matching its `unresolvedAscentsTitle`/`unresolvedCircuitsTitle` siblings ([BOARDSESH-6S](https://boardsesh.sentry.io/issues/BOARDSESH-6S)).

Both keys added to **en-US, es, fr**. Spanish follows the glossary (`vía` for climb); French mirrors the existing circuit-title phrasing.

Both are live UI elements, so the keys are added rather than the `t()` calls removed.

### Why these slipped past `vp run check:i18n`
`check:i18n` flags hardcoded English under `app/`, and `check:i18n:orphans` flags catalog keys with no reference — neither verifies that every `t('literal')` *has* a catalog entry. That's the gap that let these reach prod. Out of scope here, but worth a follow-up lint.

Closes #3192

## Release Notes

- [x] No release note needed (internal / technical change)

<!-- Web-only i18n fix; the "What's New" screen is mobile-only and mobile has its own catalogs, so nothing ships there. -->

## Test plan

- `vp test run` on `catalog-completeness`, `check-orphaned-i18n-keys`, `plurals` — **61 passed**
- `vp run check:i18n` — OK (418 .tsx scanned, no hardcoded strings)
- `vp run check:i18n:orphans` — OK (3425 keys, every one has a live reference, including the 3 new keys)
- `vp check` on the 6 catalog files — formatting clean
- Confirmed both `t()` call sites in code resolve to the new keys (one drawer label, one pluralized alert title)