### PR TITLE
feat(mobile): tag Sentry events with the OTA channel

### DIFF
--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -204,6 +204,12 @@ mounted once near the root beside `AnalyticsScreenTracker`:
   (`{ updateId, createdAtIso }`). It applies on the **next** launch, which the following
   `OTA Update Status` records — together they form the published → downloaded → applied funnel.
 
+The same launch reads also become **Sentry global tags** (`ota_channel`, `ota_update_id`,
+`ota_runtime_version`, `ota_is_embedded`) via `setOtaSentryTags`, so every crash / error event is
+attributable to a channel and bundle and lines up with the PostHog cohort above. A tester who switched
+channels in-app overrides `ota_channel` with their active channel (read from the AsyncStorage override
+mirror), matching the build-vs-override channel the switcher shows.
+
 Both no-op in dev / Expo Go (analytics disabled, `Updates.isEnabled` false); the `__DEV__` debug hook
 still logs `[analytics] OTA Update Status …` to Metro so you can confirm the tracker fires locally.
 In PostHog (project 412845), count distinct installs with `isEmbeddedLaunch = false` per `updateId` to

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -30,6 +30,20 @@ export function resetOtaStatusReportedForTests(): void {
   hasReportedStatus = false;
 }
 
+// Stamp the OTA cohort onto Sentry as global tags at module-eval time, NOT in an
+// effect: the root layout imports this tracker (and Sentry.init, which it imports
+// first) before the provider tree renders, so this runs before the auth gate
+// mounts. A native crash / app hang / startup reportError during splash or auth
+// then still carries ota_channel + the bundle identifiers — the window an
+// effect-based stamp would miss. expo-updates' constants are available
+// synchronously at import; setOtaSentryTags no-ops when Sentry is disabled.
+setOtaSentryTags({
+  channel: Updates.channel,
+  updateId: Updates.updateId,
+  runtimeVersion: Updates.runtimeVersion,
+  isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+});
+
 export function OtaUpdateTracker(): null {
   const { isUpdatePending, downloadedUpdate } = Updates.useUpdates();
   const reportedDownloadIdRef = useRef<string | null>(null);
@@ -57,15 +71,6 @@ export function OtaUpdateTracker(): null {
       ota_update_id: properties.updateId,
       ota_is_embedded: properties.isEmbeddedLaunch,
       ota_runtime_version: properties.runtimeVersion,
-    });
-    // Stamp the same OTA cohort onto Sentry as global tags so every later event
-    // (and native crash) is attributable to a channel / bundle, lining up with
-    // the PostHog super properties above.
-    setOtaSentryTags({
-      channel: Updates.channel,
-      updateId: Updates.updateId,
-      runtimeVersion: Updates.runtimeVersion,
-      isEmbeddedLaunch: Updates.isEmbeddedLaunch,
     });
   }, []);
 

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -30,19 +30,24 @@ export function resetOtaStatusReportedForTests(): void {
   hasReportedStatus = false;
 }
 
-// Stamp the OTA cohort onto Sentry as global tags at module-eval time, NOT in an
-// effect: the root layout imports this tracker (and Sentry.init, which it imports
-// first) before the provider tree renders, so this runs before the auth gate
-// mounts. A native crash / app hang / startup reportError during splash or auth
+// Stamp the OTA cohort onto Sentry as global tags. Exported so a test can assert
+// the Updates.* → tag-field wiring; CALLED at module-eval time below (not in an
+// effect) so it runs when the root layout imports this tracker — after
+// Sentry.init (imported first) but before the provider tree and the auth gate
+// render. A native crash / app hang / startup reportError during splash or auth
 // then still carries ota_channel + the bundle identifiers — the window an
 // effect-based stamp would miss. expo-updates' constants are available
 // synchronously at import; setOtaSentryTags no-ops when Sentry is disabled.
-setOtaSentryTags({
-  channel: Updates.channel,
-  updateId: Updates.updateId,
-  runtimeVersion: Updates.runtimeVersion,
-  isEmbeddedLaunch: Updates.isEmbeddedLaunch,
-});
+export function stampOtaLaunchSentryTags(): void {
+  setOtaSentryTags({
+    channel: Updates.channel,
+    updateId: Updates.updateId,
+    runtimeVersion: Updates.runtimeVersion,
+    isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+  });
+}
+
+stampOtaLaunchSentryTags();
 
 export function OtaUpdateTracker(): null {
   const { isUpdatePending, downloadedUpdate } = Updates.useUpdates();

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -6,6 +6,9 @@ import {
   OTA_UPDATE_STATUS_EVENT,
   buildOtaStatusProperties,
 } from '../../lib/ota-telemetry';
+import { setOtaChannelTag, setOtaSentryTags } from '../../lib/sentry';
+import { OTA_CHANNEL_OVERRIDE_KEY } from '../../lib/channel-switch';
+import { getPreference } from '../../lib/preference-store';
 
 // Emits OTA-adoption telemetry so a JS-only rollout is measurable (we previously
 // had no way to tell how many installs pulled an OTA — issue #3098). On mount it
@@ -55,6 +58,30 @@ export function OtaUpdateTracker(): null {
       ota_is_embedded: properties.isEmbeddedLaunch,
       ota_runtime_version: properties.runtimeVersion,
     });
+    // Stamp the same OTA cohort onto Sentry as global tags so every later event
+    // (and native crash) is attributable to a channel / bundle, lining up with
+    // the PostHog super properties above.
+    setOtaSentryTags({
+      channel: Updates.channel,
+      updateId: Updates.updateId,
+      runtimeVersion: Updates.runtimeVersion,
+      isEmbeddedLaunch: Updates.isEmbeddedLaunch,
+    });
+  }, []);
+
+  // A tester who switched channels in-app runs a bundle whose channel differs
+  // from the build-time Updates.channel; the active override lives only in the
+  // AsyncStorage mirror (no native read-back API). Read it async and overwrite
+  // just the ota_channel tag so their reports show the channel they're actually
+  // on — matching ChannelSwitcherScreen's `override ?? buildChannel`.
+  useEffect(() => {
+    let active = true;
+    void getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY).then((override) => {
+      if (active && override) setOtaChannelTag(override);
+    });
+    return () => {
+      active = false;
+    };
   }, []);
 
   // A newer bundle finished downloading this session; it applies on the next

--- a/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
+++ b/packages/mobile/src/components/analytics/OtaUpdateTracker.tsx
@@ -76,9 +76,13 @@ export function OtaUpdateTracker(): null {
   // on — matching ChannelSwitcherScreen's `override ?? buildChannel`.
   useEffect(() => {
     let active = true;
-    void getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY).then((override) => {
-      if (active && override) setOtaChannelTag(override);
-    });
+    // Best-effort: a storage read failure just leaves the build channel tag from
+    // the launch stamp in place, so swallow rather than leak an unhandled rejection.
+    void getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY)
+      .then((override) => {
+        if (active && override) setOtaChannelTag(override);
+      })
+      .catch(() => {});
     return () => {
       active = false;
     };

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const analytics = vi.hoisted(() => ({ track: vi.fn(), registerSuperProperties: vi.fn() }));
+const sentry = vi.hoisted(() => ({ setOtaSentryTags: vi.fn(), setOtaChannelTag: vi.fn() }));
+const prefs = vi.hoisted(() => ({ getPreference: vi.fn() }));
 
 // Drives Updates.useUpdates() per test. The constants below mirror an OTA'd
 // production launch; `current` is swapped to exercise the downloaded-bundle
@@ -18,6 +20,19 @@ const updates = vi.hoisted(() => ({
 vi.mock('../../../lib/analytics', () => ({
   track: analytics.track,
   registerSuperProperties: analytics.registerSuperProperties,
+}));
+
+// Spy on the Sentry tag setters so the override effect's wiring is observable
+// without a real (disabled) Sentry. The module-scope setOtaSentryTags stamp also
+// routes through this mock at import.
+vi.mock('../../../lib/sentry', () => ({
+  setOtaSentryTags: sentry.setOtaSentryTags,
+  setOtaChannelTag: sentry.setOtaChannelTag,
+}));
+
+// Drives the AsyncStorage override mirror the channel-override effect reads.
+vi.mock('../../../lib/preference-store', () => ({
+  getPreference: prefs.getPreference,
 }));
 
 vi.mock('expo-updates', () => ({
@@ -42,6 +57,10 @@ function trackCallsFor(eventName: string) {
 beforeEach(() => {
   analytics.track.mockClear();
   analytics.registerSuperProperties.mockClear();
+  sentry.setOtaSentryTags.mockClear();
+  sentry.setOtaChannelTag.mockClear();
+  // Default: no tester override stored, so the override effect leaves the tag alone.
+  prefs.getPreference.mockReset().mockResolvedValue(null);
   updates.current = { isUpdatePending: false, downloadedUpdate: undefined };
   // The status guard is module-scoped (once per launch); reset it so each test
   // starts from a clean "nothing reported yet" state.
@@ -126,5 +145,33 @@ describe('OtaUpdateTracker', () => {
     updates.current = { isUpdatePending: true, downloadedUpdate: undefined };
     render(createElement(OtaUpdateTracker));
     expect(trackCallsFor('OTA Update Downloaded')).toHaveLength(0);
+  });
+});
+
+describe('OtaUpdateTracker channel-override Sentry tag', () => {
+  it('overrides ota_channel with a tester-stored override channel', async () => {
+    prefs.getPreference.mockResolvedValue('pr-3327');
+    render(createElement(OtaUpdateTracker));
+
+    await waitFor(() => expect(sentry.setOtaChannelTag).toHaveBeenCalledWith('pr-3327'));
+  });
+
+  it('leaves the build-channel tag in place when no override is stored', async () => {
+    prefs.getPreference.mockResolvedValue(null);
+    render(createElement(OtaUpdateTracker));
+
+    await waitFor(() => expect(prefs.getPreference).toHaveBeenCalled());
+    // Let the resolved promise's .then microtask flush before asserting the negative.
+    await Promise.resolve();
+    expect(sentry.setOtaChannelTag).not.toHaveBeenCalled();
+  });
+
+  it('swallows a storage read failure without overriding the tag or throwing', async () => {
+    prefs.getPreference.mockRejectedValue(new Error('secure store unavailable'));
+    render(createElement(OtaUpdateTracker));
+
+    await waitFor(() => expect(prefs.getPreference).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(sentry.setOtaChannelTag).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/ota-update-tracker.test.tsx
@@ -48,10 +48,17 @@ vi.mock('expo-updates', () => ({
 }));
 
 // Imported after the mocks (vi.mock is hoisted above imports).
-import { OtaUpdateTracker, resetOtaStatusReportedForTests } from '../OtaUpdateTracker';
+import { OtaUpdateTracker, resetOtaStatusReportedForTests, stampOtaLaunchSentryTags } from '../OtaUpdateTracker';
 
 function trackCallsFor(eventName: string) {
   return analytics.track.mock.calls.filter(([name]) => name === eventName);
+}
+
+// A macrotask boundary drains ALL pending microtasks — so the override effect's
+// getPreference().then().catch() chain has fully settled before a negative
+// assertion, avoiding the false-green of flushing only one microtask deep.
+function flushPendingPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 beforeEach(() => {
@@ -161,8 +168,7 @@ describe('OtaUpdateTracker channel-override Sentry tag', () => {
     render(createElement(OtaUpdateTracker));
 
     await waitFor(() => expect(prefs.getPreference).toHaveBeenCalled());
-    // Let the resolved promise's .then microtask flush before asserting the negative.
-    await Promise.resolve();
+    await flushPendingPromises();
     expect(sentry.setOtaChannelTag).not.toHaveBeenCalled();
   });
 
@@ -171,7 +177,20 @@ describe('OtaUpdateTracker channel-override Sentry tag', () => {
     render(createElement(OtaUpdateTracker));
 
     await waitFor(() => expect(prefs.getPreference).toHaveBeenCalled());
-    await Promise.resolve();
+    await flushPendingPromises();
     expect(sentry.setOtaChannelTag).not.toHaveBeenCalled();
+  });
+});
+
+describe('stampOtaLaunchSentryTags', () => {
+  it('stamps the launch OTA cohort onto Sentry from the Updates.* constants', () => {
+    sentry.setOtaSentryTags.mockClear();
+    stampOtaLaunchSentryTags();
+    expect(sentry.setOtaSentryTags).toHaveBeenCalledWith({
+      channel: 'production',
+      updateId: 'a1b2c3d4-0000-0000-0000-000000000000',
+      runtimeVersion: 'abcdef123456',
+      isEmbeddedLaunch: false,
+    });
   });
 });

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -12,6 +12,7 @@ vi.mock('@sentry/react-native', () => ({
   captureException: vi.fn(),
   flush: vi.fn(() => Promise.resolve(true)),
   wrap: vi.fn((component: unknown) => component),
+  setTag: vi.fn(),
 }));
 
 import * as Sentry from '@sentry/react-native';
@@ -21,6 +22,8 @@ import {
   applyOtaTagsToScope,
   captureToSentry,
   flushSentry,
+  setOtaChannelTag,
+  setOtaSentryTags,
   wrapWithSentry,
   isSentryEnabled,
   toSentryTag,
@@ -52,6 +55,18 @@ describe('flushSentry (disabled build)', () => {
   it('resolves true without flushing the SDK', async () => {
     await expect(flushSentry()).resolves.toBe(true);
     expect(Sentry.flush).not.toHaveBeenCalled();
+  });
+});
+
+describe('OTA tag setters (disabled build)', () => {
+  it('setOtaSentryTags is a no-op — never reaches Sentry.setTag', () => {
+    setOtaSentryTags({ channel: 'preview-2', updateId: 'abc', runtimeVersion: 'fp', isEmbeddedLaunch: false });
+    expect(Sentry.setTag).not.toHaveBeenCalled();
+  });
+
+  it('setOtaChannelTag is a no-op — never reaches Sentry.setTag', () => {
+    setOtaChannelTag('pr-123');
+    expect(Sentry.setTag).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -200,6 +200,8 @@ describe('applyOtaTagsToScope', () => {
     expect(scope.setTag).toHaveBeenCalledWith('ota_channel', undefined);
     expect(scope.setTag).toHaveBeenCalledWith('ota_update_id', undefined);
     expect(scope.setTag).toHaveBeenCalledWith('ota_runtime_version', 'fp-9f');
+    // isEmbeddedLaunch was omitted here too, so its tag clears alongside the others.
+    expect(scope.setTag).toHaveBeenCalledWith('ota_is_embedded', undefined);
   });
 
   it('distinguishes an omitted embedded flag (cleared) from an explicit false', () => {

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -204,6 +204,14 @@ describe('applyOtaTagsToScope', () => {
     expect(scope.setTag).toHaveBeenCalledWith('ota_is_embedded', undefined);
   });
 
+  it('treats an empty-string channel as absent (clears rather than writing a blank tag)', () => {
+    const scope = makeScope();
+    applyOtaTagsToScope(scope, { channel: '', updateId: '', runtimeVersion: 'fp-9f' });
+    expect(scope.setTag).toHaveBeenCalledWith('ota_channel', undefined);
+    expect(scope.setTag).toHaveBeenCalledWith('ota_update_id', undefined);
+    expect(scope.setTag).toHaveBeenCalledWith('ota_runtime_version', 'fp-9f');
+  });
+
   it('distinguishes an omitted embedded flag (cleared) from an explicit false', () => {
     const omitted = makeScope();
     applyOtaTagsToScope(omitted, {});

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -18,6 +18,7 @@ import * as Sentry from '@sentry/react-native';
 import {
   applyBleDiagnosticsToScope,
   applyErrorContextToScope,
+  applyOtaTagsToScope,
   captureToSentry,
   flushSentry,
   wrapWithSentry,
@@ -156,5 +157,43 @@ describe('applyBleDiagnosticsToScope', () => {
     ]) {
       expect(scope.setTag).toHaveBeenCalledWith(key, undefined);
     }
+  });
+});
+
+describe('applyOtaTagsToScope', () => {
+  function makeScope() {
+    return { setTag: vi.fn() };
+  }
+
+  it('sets each provided tag and stringifies the embedded boolean for filter-friendliness', () => {
+    const scope = makeScope();
+    applyOtaTagsToScope(scope, {
+      channel: 'preview-2',
+      updateId: 'abc-123',
+      runtimeVersion: 'fp-9f',
+      isEmbeddedLaunch: false,
+    });
+    expect(scope.setTag).toHaveBeenCalledWith('ota_channel', 'preview-2');
+    expect(scope.setTag).toHaveBeenCalledWith('ota_update_id', 'abc-123');
+    expect(scope.setTag).toHaveBeenCalledWith('ota_runtime_version', 'fp-9f');
+    expect(scope.setTag).toHaveBeenCalledWith('ota_is_embedded', 'false'); // string, not boolean
+  });
+
+  it('clears null / undefined fields (undefined) instead of writing the string "null"', () => {
+    const scope = makeScope();
+    applyOtaTagsToScope(scope, { channel: null, updateId: undefined, runtimeVersion: 'fp-9f' });
+    expect(scope.setTag).toHaveBeenCalledWith('ota_channel', undefined);
+    expect(scope.setTag).toHaveBeenCalledWith('ota_update_id', undefined);
+    expect(scope.setTag).toHaveBeenCalledWith('ota_runtime_version', 'fp-9f');
+  });
+
+  it('distinguishes an omitted embedded flag (cleared) from an explicit false', () => {
+    const omitted = makeScope();
+    applyOtaTagsToScope(omitted, {});
+    expect(omitted.setTag).toHaveBeenCalledWith('ota_is_embedded', undefined);
+
+    const explicit = makeScope();
+    applyOtaTagsToScope(explicit, { isEmbeddedLaunch: false });
+    expect(explicit.setTag).toHaveBeenCalledWith('ota_is_embedded', 'false');
   });
 });

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -200,17 +200,19 @@ export type OtaTagFields = {
 };
 
 /**
- * Pure mapping of OTA bundle fields onto a scope's tags. A null/undefined field
- * is cleared (setTag(key, undefined)) rather than written as the string "null",
- * matching applyBleDiagnosticsToScope: only real values become filterable tags,
- * so an embedded / dev-server launch (channel === null) leaves no noise. The
- * boolean is stringified so a Sentry filter reads `true`/`false`. Extracted (no
- * enablement gate, no SDK) so the coercion is directly unit-testable.
+ * Pure mapping of OTA bundle fields onto a scope's tags. A null/undefined/empty
+ * field is cleared (setTag(key, undefined)) rather than written as the string
+ * "null" or a blank value, matching applyBleDiagnosticsToScope: only real values
+ * become filterable tags, so an embedded / dev-server launch (channel === null)
+ * leaves no noise. The string fields use `|| undefined` so an empty string is
+ * treated as absent too. The boolean is stringified so a Sentry filter reads
+ * `true`/`false`. Extracted (no enablement gate, no SDK) so the coercion is
+ * directly unit-testable.
  */
 export function applyOtaTagsToScope(scope: TagScope, fields: OtaTagFields): void {
-  scope.setTag('ota_channel', fields.channel ?? undefined);
-  scope.setTag('ota_update_id', fields.updateId ?? undefined);
-  scope.setTag('ota_runtime_version', fields.runtimeVersion ?? undefined);
+  scope.setTag('ota_channel', fields.channel || undefined);
+  scope.setTag('ota_update_id', fields.updateId || undefined);
+  scope.setTag('ota_runtime_version', fields.runtimeVersion || undefined);
   scope.setTag('ota_is_embedded', fields.isEmbeddedLaunch === undefined ? undefined : String(fields.isEmbeddedLaunch));
 }
 

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -129,8 +129,9 @@ export type BleConnectionDiagnostics = {
 
 // A scope whose tags accept `undefined` (the clear value) — wider than
 // SentryScopeLike, which only models the set path. Structural so the mapping is
-// unit-testable with a plain fake, like applyErrorContextToScope.
-type BleTagScope = { setTag: (key: string, value: string | number | boolean | undefined) => void };
+// unit-testable with a plain fake, like applyErrorContextToScope. Shared by the
+// BLE-diagnostics and OTA tag mappers below.
+type TagScope = { setTag: (key: string, value: string | number | boolean | undefined) => void };
 
 /**
  * Pure mapping of BLE diagnostics onto a scope's tags. `null` diagnostics =
@@ -139,7 +140,7 @@ type BleTagScope = { setTag: (key: string, value: string | number | boolean | un
  * the supported clear). Extracted (no enablement gate, no SDK) so the set/clear
  * + boolean-stringify behaviour is directly unit-testable.
  */
-export function applyBleDiagnosticsToScope(scope: BleTagScope, diagnostics: BleConnectionDiagnostics | null): void {
+export function applyBleDiagnosticsToScope(scope: TagScope, diagnostics: BleConnectionDiagnostics | null): void {
   if (!diagnostics) {
     for (const key of BLE_DIAGNOSTIC_TAG_KEYS) scope.setTag(key, undefined);
     return;
@@ -161,9 +162,10 @@ export function applyBleDiagnosticsToScope(scope: BleTagScope, diagnostics: BleC
   }
 }
 
-// Adapts the top-level functional API to a BleTagScope. `Sentry.setTag` accepts
-// `undefined` (Primitive), so it carries the clear path too.
-const bleTagScope: BleTagScope = { setTag: (key, value) => Sentry.setTag(key, value) };
+// Adapts the top-level functional API to a TagScope. `Sentry.setTag` accepts
+// `undefined` (Primitive), so it carries the clear path too. Shared by the BLE
+// and OTA global-tag setters.
+const tagScope: TagScope = { setTag: (key, value) => Sentry.setTag(key, value) };
 
 /**
  * BLE write diagnostics captured at connect, kept as GLOBAL scope tags (not the
@@ -177,7 +179,7 @@ const bleTagScope: BleTagScope = { setTag: (key, value) => Sentry.setTag(key, va
  */
 export function setBleDiagnosticsTags(diagnostics: BleConnectionDiagnostics | null | undefined): void {
   if (!isSentryEnabled) return;
-  applyBleDiagnosticsToScope(bleTagScope, diagnostics ?? null);
+  applyBleDiagnosticsToScope(tagScope, diagnostics ?? null);
 }
 
 /**
@@ -186,7 +188,7 @@ export function setBleDiagnosticsTags(diagnostics: BleConnectionDiagnostics | nu
  */
 export function clearBleDiagnosticsTags(): void {
   if (!isSentryEnabled) return;
-  applyBleDiagnosticsToScope(bleTagScope, null);
+  applyBleDiagnosticsToScope(tagScope, null);
 }
 
 export type OtaTagFields = {
@@ -205,7 +207,7 @@ export type OtaTagFields = {
  * boolean is stringified so a Sentry filter reads `true`/`false`. Extracted (no
  * enablement gate, no SDK) so the coercion is directly unit-testable.
  */
-export function applyOtaTagsToScope(scope: BleTagScope, fields: OtaTagFields): void {
+export function applyOtaTagsToScope(scope: TagScope, fields: OtaTagFields): void {
   scope.setTag('ota_channel', fields.channel ?? undefined);
   scope.setTag('ota_update_id', fields.updateId ?? undefined);
   scope.setTag('ota_runtime_version', fields.runtimeVersion ?? undefined);
@@ -221,7 +223,7 @@ export function applyOtaTagsToScope(scope: BleTagScope, fields: OtaTagFields): v
  */
 export function setOtaSentryTags(fields: OtaTagFields): void {
   if (!isSentryEnabled) return;
-  applyOtaTagsToScope(bleTagScope, fields);
+  applyOtaTagsToScope(tagScope, fields);
 }
 
 /**

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -189,6 +189,53 @@ export function clearBleDiagnosticsTags(): void {
   applyBleDiagnosticsToScope(bleTagScope, null);
 }
 
+export type OtaTagFields = {
+  // Updates.channel is string | null (null on embedded / dev-server launches).
+  channel?: string | null;
+  updateId?: string | null;
+  runtimeVersion?: string | null;
+  isEmbeddedLaunch?: boolean;
+};
+
+/**
+ * Pure mapping of OTA bundle fields onto a scope's tags. A null/undefined field
+ * is cleared (setTag(key, undefined)) rather than written as the string "null",
+ * matching applyBleDiagnosticsToScope: only real values become filterable tags,
+ * so an embedded / dev-server launch (channel === null) leaves no noise. The
+ * boolean is stringified so a Sentry filter reads `true`/`false`. Extracted (no
+ * enablement gate, no SDK) so the coercion is directly unit-testable.
+ */
+export function applyOtaTagsToScope(scope: BleTagScope, fields: OtaTagFields): void {
+  scope.setTag('ota_channel', fields.channel ?? undefined);
+  scope.setTag('ota_update_id', fields.updateId ?? undefined);
+  scope.setTag('ota_runtime_version', fields.runtimeVersion ?? undefined);
+  scope.setTag('ota_is_embedded', fields.isEmbeddedLaunch === undefined ? undefined : String(fields.isEmbeddedLaunch));
+}
+
+/**
+ * Stamp the running OTA bundle's channel + identifiers as GLOBAL scope tags so
+ * they ride every later event, including native crashes. Called once per launch
+ * from OtaUpdateTracker. No-op when Sentry is disabled. Takes the fields IN so
+ * this module never imports expo-updates (which is unstubbed under vitest and
+ * would break the sentry suite).
+ */
+export function setOtaSentryTags(fields: OtaTagFields): void {
+  if (!isSentryEnabled) return;
+  applyOtaTagsToScope(bleTagScope, fields);
+}
+
+/**
+ * Overwrite only the `ota_channel` tag with a tester's active channel override.
+ * A dedicated single-key setter (not setOtaSentryTags) because the override path
+ * only knows the channel — passing the other fields as undefined would clear the
+ * ota_update_id / ota_runtime_version / ota_is_embedded tags the launch stamp
+ * just set. No-op when Sentry is disabled.
+ */
+export function setOtaChannelTag(channel: string): void {
+  if (!isSentryEnabled) return;
+  Sentry.setTag('ota_channel', channel);
+}
+
 /** Best-effort flush so a report survives a later hard crash. */
 export function flushSentry(): Promise<boolean> {
   return isSentryEnabled ? Sentry.flush() : Promise.resolve(true);


### PR DESCRIPTION
## Summary

Sentry events on mobile carried no signal about which JS bundle the user was running. We ship OTA updates across several channels (`production`, `preview-1..4`, per-PR `pr-<number>`), and testers can switch channels in-app — so a crash report couldn't be tied to a channel, and we couldn't tell whether a regression rode in on a specific OTA.

This stamps the running bundle's OTA cohort onto Sentry as **global tags**, so every later event (including native crashes and app hangs) carries it:

- `ota_channel` — the channel the user is on
- `ota_update_id`, `ota_runtime_version`, `ota_is_embedded`

These mirror the OTA super properties already sent to PostHog, so crash triage and analytics line up.

For testers who switched channels in-app, the active channel lives only in the AsyncStorage override mirror (no native read-back). A follow-up effect reads it and overwrites `ota_channel` with the channel they're actually on — matching `ChannelSwitcherScreen`'s `override ?? buildChannel`.

Implementation mirrors the existing BLE-diagnostics tag pattern in `sentry.ts`: a pure, unit-tested scope mapper (`applyOtaTagsToScope`) plus gated global-tag setters (`setOtaSentryTags`, `setOtaChannelTag`) that no-op when Sentry is disabled. `sentry.ts` stays free of `expo-updates` (unstubbed under vitest) by taking the fields in from `OtaUpdateTracker`, which already reads `Updates.*` for telemetry. Null/undefined fields clear the tag rather than writing the string `"null"`.

## Release Notes

- Crash reports now know which preview channel you're running, so beta bugs get sorted out faster.

## Test plan

- `vp run typecheck:mobile` — passes
- `vp test run --project mobile` — 2923 tests pass, including new `applyOtaTagsToScope` cases (set path, null/undefined clearing, boolean stringify, omitted-vs-false embedded flag)
- `vp run check:mobile-bundle` — Metro bundle builds (12.8 MB)
- `vp check` on the three changed files — clean lint + format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaFkMsafRBKQd78cMdaYwm)_