### PR TITLE
feat(mobile): add MoonBoard account card to integrations

### DIFF
--- a/docs/ui/18-settings.md
+++ b/docs/ui/18-settings.md
@@ -163,6 +163,13 @@ credential to `pending` so the daemon picks it up again).
 
 - Route: `packages/mobile/app/(tabs)/profile/integrations.tsx`.
 - Board account cards render above platform/device integration cards.
+- A **MoonBoard** card renders first, above the Aurora-board cards (mobile only).
+  MoonBoard isn't in `AURORA_BOARDS`, so the card is self-contained — no
+  credential, status chip, or sync flow. It offers two actions: "Request your
+  data" opens a pre-filled mailto to `moonboardsupport@moonclimbing.com` (body
+  reads "MoonBoard app user"), and "Import data" opens an explanatory dialog
+  asking the user to send their MoonBoard export to Marco on Discord, since the
+  importer isn't built yet.
 - Uses backend REST endpoints instead of Next internal routes.
 - Kilter links via the username/password (ROPC) "Sign in to Kilter" card when the
   `kilter-oauth-linking` PostHog flag is on; otherwise only the "Kilter (Aurora)"

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -64,6 +64,12 @@ const IMPORT_RESULT_LIMIT = 8;
 const AURORA_CREDENTIALS_QUERY_KEY = ['auroraCredentials'] as const;
 const AURORA_UNSYNCED_QUERY_KEY = ['auroraCredentials', 'unsynced'] as const;
 
+// MoonBoard isn't an Aurora board, so it has no credential/sync flow — the card
+// just routes data requests to MoonBoard support and the (not-yet-built) importer
+// to Marco on Discord.
+const MOONBOARD_SUPPORT_EMAIL = 'moonboardsupport@moonclimbing.com';
+const MOONBOARD_DISCORD_URL = 'https://discord.gg/YXA8GsXfQK';
+
 function boardDisplayName(boardType: AuroraBoardName): string {
   return boardType.charAt(0).toUpperCase() + boardType.slice(1);
 }
@@ -86,6 +92,14 @@ function buildKilterDataRequestMailto(t: TFunction<'settings'>): string {
   const subject = t('aurora.kilterEmail.subject');
   const body = t('aurora.kilterEmail.body', { name, email });
   return `mailto:peter@auroraclimbing.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
+function buildMoonBoardDataRequestMailto(t: TFunction<'settings'>): string {
+  const name = t('aurora.moonboard.email.namePlaceholder');
+  const email = t('aurora.moonboard.email.emailPlaceholder');
+  const subject = t('aurora.moonboard.email.subject');
+  const body = t('aurora.moonboard.email.body', { name, email });
+  return `mailto:${MOONBOARD_SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 }
 
 function totalImported(result: ImportResult): number {
@@ -375,6 +389,7 @@ export function BoardAccountsSection() {
   return (
     <View style={styles.section}>
       <SectionHeader title={t('aurora.title')} />
+      <MoonBoardAccountCard />
       {isLoading ? (
         AURORA_BOARDS.map((boardType, boardIndex) => (
           <BoardAccountSkeletonCard
@@ -486,6 +501,93 @@ export function BoardAccountsSection() {
         onCancel={resetImport}
         onConfirm={handleImportConfirm}
       />
+    </View>
+  );
+}
+
+function MoonBoardAccountCard() {
+  const { t } = useTranslation('settings');
+  const { t: tCommon } = useTranslation('common');
+  const { systemColors } = useTheme();
+  const { showToast } = useToast();
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+
+  const handleRequestData = useCallback(() => {
+    void Linking.openURL(buildMoonBoardDataRequestMailto(t)).catch(() => {
+      showToast(t('aurora.mobile.requestDataFailed'), 'error');
+    });
+  }, [showToast, t]);
+
+  const handleOpenDiscord = useCallback(() => {
+    void Linking.openURL(MOONBOARD_DISCORD_URL).catch(() => {
+      showToast(t('aurora.mobile.requestDataFailed'), 'error');
+    });
+  }, [showToast, t]);
+
+  return (
+    <View
+      style={[
+        styles.card,
+        styles.accountCard,
+        styles.accountCardSpacing,
+        { backgroundColor: systemColors.secondaryBackground },
+      ]}
+    >
+      <View style={styles.accountHeader}>
+        <View>
+          <Text variant="headline">{t('aurora.moonboard.title')}</Text>
+        </View>
+      </View>
+      <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.accountCopy}>
+        {t('aurora.moonboard.copy')}
+      </Text>
+      <View style={styles.actionRow}>
+        <Button
+          title={t('aurora.moonboard.import')}
+          icon="upload"
+          variant="outlined"
+          size="small"
+          onPress={() => setImportDialogOpen(true)}
+        />
+        <Button
+          title={t('aurora.moonboard.requestData')}
+          icon="open.external"
+          variant="text"
+          size="small"
+          onPress={handleRequestData}
+        />
+      </View>
+
+      <Modal
+        visible={importDialogOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setImportDialogOpen(false)}
+      >
+        <View style={styles.modalBackdrop}>
+          <View style={[styles.modalCard, { backgroundColor: systemColors.secondaryBackground }]}>
+            <Text variant="headline" style={styles.modalTitle}>
+              {t('aurora.moonboard.importDialog.title')}
+            </Text>
+            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.modalCopy}>
+              {t('aurora.moonboard.importDialog.body')}
+            </Text>
+            <View style={styles.modalActions}>
+              <Button
+                title={tCommon('actions.close')}
+                variant="text"
+                role="cancel"
+                onPress={() => setImportDialogOpen(false)}
+              />
+              <Button
+                title={t('aurora.moonboard.importDialog.discordCta')}
+                icon="open.external"
+                onPress={handleOpenDiscord}
+              />
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -84,12 +84,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+// The i18n keys must stay literal in each builder (the linter hard-fails on
+// `t(variable)`), so only the mailto string assembly is shared here.
+function dataRequestMailto(recipient: string, subject: string, body: string): string {
+  return `mailto:${recipient}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
 function buildKilterDataRequestMailto(t: TFunction<'settings'>): string {
   const name = t('aurora.kilterEmail.namePlaceholder');
   const email = t('aurora.kilterEmail.emailPlaceholder');
   const subject = t('aurora.kilterEmail.subject');
   const body = t('aurora.kilterEmail.body', { name, email });
-  return `mailto:peter@auroraclimbing.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  return dataRequestMailto('peter@auroraclimbing.com', subject, body);
 }
 
 function buildMoonBoardDataRequestMailto(t: TFunction<'settings'>): string {
@@ -97,7 +103,7 @@ function buildMoonBoardDataRequestMailto(t: TFunction<'settings'>): string {
   const email = t('aurora.moonboard.email.emailPlaceholder');
   const subject = t('aurora.moonboard.email.subject');
   const body = t('aurora.moonboard.email.body', { name, email });
-  return `mailto:${MOONBOARD_SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  return dataRequestMailto(MOONBOARD_SUPPORT_EMAIL, subject, body);
 }
 
 function totalImported(result: ImportResult): number {

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -64,9 +64,7 @@ const IMPORT_RESULT_LIMIT = 8;
 const AURORA_CREDENTIALS_QUERY_KEY = ['auroraCredentials'] as const;
 const AURORA_UNSYNCED_QUERY_KEY = ['auroraCredentials', 'unsynced'] as const;
 
-// MoonBoard isn't an Aurora board, so it has no credential/sync flow — the card
-// just routes data requests to MoonBoard support and the (not-yet-built) importer
-// to Marco on Discord.
+// MoonBoard isn't an Aurora board, so it has no credential/sync flow.
 const MOONBOARD_SUPPORT_EMAIL = 'moonboardsupport@moonclimbing.com';
 const MOONBOARD_DISCORD_URL = 'https://discord.gg/YXA8GsXfQK';
 

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -512,6 +512,9 @@ function MoonBoardAccountCard() {
   const { showToast } = useToast();
   const [importDialogOpen, setImportDialogOpen] = useState(false);
 
+  const openImportDialog = useCallback(() => setImportDialogOpen(true), []);
+  const closeImportDialog = useCallback(() => setImportDialogOpen(false), []);
+
   const handleRequestData = useCallback(() => {
     void Linking.openURL(buildMoonBoardDataRequestMailto(t)).catch(() => {
       showToast(t('aurora.mobile.requestDataFailed'), 'error');
@@ -520,7 +523,7 @@ function MoonBoardAccountCard() {
 
   const handleOpenDiscord = useCallback(() => {
     void Linking.openURL(MOONBOARD_DISCORD_URL).catch(() => {
-      showToast(t('aurora.mobile.requestDataFailed'), 'error');
+      showToast(t('aurora.moonboard.importDialog.openFailed'), 'error');
     });
   }, [showToast, t]);
 
@@ -547,7 +550,7 @@ function MoonBoardAccountCard() {
           icon="upload"
           variant="outlined"
           size="small"
-          onPress={() => setImportDialogOpen(true)}
+          onPress={openImportDialog}
         />
         <Button
           title={t('aurora.moonboard.requestData')}
@@ -558,12 +561,7 @@ function MoonBoardAccountCard() {
         />
       </View>
 
-      <Modal
-        visible={importDialogOpen}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setImportDialogOpen(false)}
-      >
+      <Modal visible={importDialogOpen} transparent animationType="fade" onRequestClose={closeImportDialog}>
         <View style={styles.modalBackdrop}>
           <View style={[styles.modalCard, { backgroundColor: systemColors.secondaryBackground }]}>
             <Text variant="headline" style={styles.modalTitle}>
@@ -573,12 +571,7 @@ function MoonBoardAccountCard() {
               {t('aurora.moonboard.importDialog.body')}
             </Text>
             <View style={styles.modalActions}>
-              <Button
-                title={tCommon('actions.close')}
-                variant="text"
-                role="cancel"
-                onPress={() => setImportDialogOpen(false)}
-              />
+              <Button title={tCommon('actions.close')} variant="text" role="cancel" onPress={closeImportDialog} />
               <Button
                 title={t('aurora.moonboard.importDialog.discordCta')}
                 icon="open.external"

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -503,7 +503,9 @@ export function BoardAccountsSection() {
   );
 }
 
-function MoonBoardAccountCard() {
+// Standalone (no props), so memo skips re-renders when the query/import-state
+// heavy BoardAccountsSection parent re-renders.
+const MoonBoardAccountCard = memo(function MoonBoardAccountCard() {
   const { t } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
   const { systemColors } = useTheme();
@@ -581,7 +583,7 @@ function MoonBoardAccountCard() {
       </Modal>
     </View>
   );
-}
+});
 
 type BoardAccountSkeletonCardProps = {
   isLast: boolean;

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -241,4 +241,32 @@ describe('BoardAccountsSection — MoonBoard card', () => {
     fireEvent.click(discordButton!);
     expect(mocks.openURL).toHaveBeenCalledWith('https://discord.gg/YXA8GsXfQK');
   });
+
+  it('shows an error toast when the support email fails to open', async () => {
+    mocks.openURL.mockReset().mockRejectedValueOnce(new Error('no mail handler'));
+    const { container } = render(<BoardAccountsSection />);
+    fireEvent.click(button(container, 'aurora.moonboard.requestData')!);
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith('aurora.mobile.requestDataFailed', 'error');
+    });
+  });
+
+  it('shows a Discord-specific error toast when the Discord link fails to open', async () => {
+    mocks.openURL.mockReset().mockRejectedValueOnce(new Error('no discord handler'));
+    const { container } = render(<BoardAccountsSection />);
+    fireEvent.click(button(container, 'aurora.moonboard.import')!);
+    fireEvent.click(button(container, 'aurora.moonboard.importDialog.discordCta')!);
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith('aurora.moonboard.importDialog.openFailed', 'error');
+    });
+  });
+
+  it('closes the import dialog via the Close button', () => {
+    const { container } = render(<BoardAccountsSection />);
+    fireEvent.click(button(container, 'aurora.moonboard.import')!);
+    expect(button(container, 'aurora.moonboard.importDialog.discordCta')).not.toBeNull();
+
+    fireEvent.click(button(container, 'actions.close')!);
+    expect(button(container, 'aurora.moonboard.importDialog.discordCta')).toBeNull();
+  });
 });

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   deleteAurora: vi.fn(),
   streamImport: vi.fn(),
   showToast: vi.fn(),
+  openURL: vi.fn((_url: string) => Promise.resolve()),
   confirm: vi.fn(() => Promise.resolve(true)),
   invalidate: vi.fn(() => Promise.resolve()),
   refetch: vi.fn(() => Promise.resolve()),
@@ -81,7 +82,7 @@ vi.mock('react-native', () => ({
     }),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
   Platform: { OS: 'ios' },
-  Linking: { openURL: () => Promise.resolve() },
+  Linking: { openURL: mocks.openURL },
 }));
 
 vi.mock('expo-file-system', () => ({ File: class File {} }));
@@ -204,5 +205,40 @@ describe('BoardAccountsSection — Kilter password card', () => {
       expect(mocks.saveKilterViaPassword).toHaveBeenCalledWith({ username: 'climber', password: 'secret' });
     });
     expect(mocks.saveAurora).not.toHaveBeenCalled();
+  });
+});
+
+describe('BoardAccountsSection — MoonBoard card', () => {
+  beforeEach(() => {
+    mocks.showToast.mockReset();
+    mocks.openURL.mockReset().mockResolvedValue(undefined);
+    mocks.flags = {};
+    mocks.credentials = [];
+  });
+
+  it('renders the MoonBoard card with import and request-data actions', () => {
+    const { container } = render(<BoardAccountsSection />);
+    expect(button(container, 'aurora.moonboard.import')).not.toBeNull();
+    expect(button(container, 'aurora.moonboard.requestData')).not.toBeNull();
+  });
+
+  it('opens a MoonBoard support email when "Request your data" is pressed', () => {
+    const { container } = render(<BoardAccountsSection />);
+    fireEvent.click(button(container, 'aurora.moonboard.requestData')!);
+    expect(mocks.openURL).toHaveBeenCalledTimes(1);
+    expect(mocks.openURL.mock.calls[0]?.[0]).toContain('mailto:moonboardsupport@moonclimbing.com');
+  });
+
+  it('opens the Discord hand-off dialog from "Import data" and links to Discord', () => {
+    const { container } = render(<BoardAccountsSection />);
+    // Dialog starts closed, so the Discord CTA is not rendered yet.
+    expect(button(container, 'aurora.moonboard.importDialog.discordCta')).toBeNull();
+
+    fireEvent.click(button(container, 'aurora.moonboard.import')!);
+    const discordButton = button(container, 'aurora.moonboard.importDialog.discordCta');
+    expect(discordButton).not.toBeNull();
+
+    fireEvent.click(discordButton!);
+    expect(mocks.openURL).toHaveBeenCalledWith('https://discord.gg/YXA8GsXfQK');
   });
 });

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -296,7 +296,8 @@
       "importDialog": {
         "title": "MoonBoard import is on the way",
         "body": "We're still building the MoonBoard importer. Export your data from the MoonBoard app and send it to Marco on Discord — he'll use it to build the import.",
-        "discordCta": "Open Discord"
+        "discordCta": "Open Discord",
+        "openFailed": "Couldn't open Discord. Try again."
       }
     },
     "mobile": {

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -282,6 +282,23 @@
       "emailPlaceholder": "[YOUR EMAIL]",
       "body": "Hey there!\n\nEx-app user here. I was wondering if I could get a copy of my data so I can save my logbooks and other data for personal tracking records.\n\nMy username is {{name}}, and this should be under this email ({{email}}).\n\nThanks!\n\n{{name}}"
     },
+    "moonboard": {
+      "title": "MoonBoard",
+      "copy": "Logged climbs in the MoonBoard app? Email MoonBoard to request your data, then send it over so we can pull it into Boardsesh.",
+      "import": "Import data",
+      "requestData": "Request your data",
+      "email": {
+        "subject": "MoonBoard data",
+        "namePlaceholder": "[YOUR NAME]",
+        "emailPlaceholder": "[YOUR EMAIL]",
+        "body": "Hey there!\n\nMoonBoard app user here. I was wondering if I could get a copy of my data so I can save my logbooks and other data for personal tracking records.\n\nMy username is {{name}}, and this should be under this email ({{email}}).\n\nThanks!\n\n{{name}}"
+      },
+      "importDialog": {
+        "title": "MoonBoard import is on the way",
+        "body": "We're still building the MoonBoard importer. Export your data from the MoonBoard app and send it to Marco on Discord — he'll use it to build the import.",
+        "discordCta": "Open Discord"
+      }
+    },
     "mobile": {
       "connectedAs": "Connected as {{name}}",
       "connected": "Connected",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -304,6 +304,23 @@
       "namePlaceholder": "[TU NOMBRE]",
       "emailPlaceholder": "[TU CORREO]",
       "body": "¡Hola!\n\nSoy un ex usuario de la app. Me preguntaba si podríais enviarme una copia de mis datos para guardar mis logbooks y otra información para mi seguimiento personal.\n\nMi usuario es {{name}} y debería estar bajo este correo ({{email}}).\n\n¡Gracias!\n\n{{name}}"
+    },
+    "moonboard": {
+      "title": "MoonBoard",
+      "copy": "¿Registraste vías en la app de MoonBoard? Escribe a MoonBoard para pedir tus datos y luego envíanoslos para incorporarlos a Boardsesh.",
+      "import": "Importar datos",
+      "requestData": "Pedir tus datos",
+      "email": {
+        "subject": "Datos de MoonBoard",
+        "namePlaceholder": "[TU NOMBRE]",
+        "emailPlaceholder": "[TU CORREO]",
+        "body": "¡Hola!\n\nSoy usuario de la app de MoonBoard. Me preguntaba si podríais enviarme una copia de mis datos para guardar mis logbooks y otra información para mi seguimiento personal.\n\nMi usuario es {{name}} y debería estar bajo este correo ({{email}}).\n\n¡Gracias!\n\n{{name}}"
+      },
+      "importDialog": {
+        "title": "La importación de MoonBoard está en camino",
+        "body": "Todavía estamos creando el importador de MoonBoard. Exporta tus datos desde la app de MoonBoard y envíaselos a Marco por Discord — los usará para crear la importación.",
+        "discordCta": "Abrir Discord"
+      }
     }
   },
   "healthkit": {

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -307,7 +307,7 @@
     },
     "moonboard": {
       "title": "MoonBoard",
-      "copy": "¿Registraste vías en la app de MoonBoard? Escribe a MoonBoard para pedir tus datos y luego envíanoslos para incorporarlos a Boardsesh.",
+      "copy": "¿Registraste bloques en la app de MoonBoard? Escribe a MoonBoard para pedir tus datos y luego envíanoslos para incorporarlos a Boardsesh.",
       "import": "Importar datos",
       "requestData": "Pedir tus datos",
       "email": {
@@ -319,7 +319,8 @@
       "importDialog": {
         "title": "La importación de MoonBoard está en camino",
         "body": "Todavía estamos creando el importador de MoonBoard. Exporta tus datos desde la app de MoonBoard y envíaselos a Marco por Discord — los usará para crear la importación.",
-        "discordCta": "Abrir Discord"
+        "discordCta": "Abrir Discord",
+        "openFailed": "No se pudo abrir Discord. Inténtalo de nuevo."
       }
     }
   },

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -304,6 +304,23 @@
       "namePlaceholder": "[VOTRE NOM]",
       "emailPlaceholder": "[VOTRE E-MAIL]",
       "body": "Bonjour !\n\nAncien utilisateur de l'app. Serait-il possible d'obtenir une copie de mes données pour garder mes carnets et le reste pour mon suivi perso ?\n\nMon nom d'utilisateur est {{name}}, rattaché à cet e-mail ({{email}}).\n\nMerci !\n\n{{name}}"
+    },
+    "moonboard": {
+      "title": "MoonBoard",
+      "copy": "Vous avez enregistré des blocs dans l'app MoonBoard ? Écrivez à MoonBoard pour demander vos données, puis envoyez-les-nous pour les intégrer à Boardsesh.",
+      "import": "Importer les données",
+      "requestData": "Demander vos données",
+      "email": {
+        "subject": "Données MoonBoard",
+        "namePlaceholder": "[VOTRE NOM]",
+        "emailPlaceholder": "[VOTRE E-MAIL]",
+        "body": "Bonjour !\n\nUtilisateur de l'app MoonBoard. Serait-il possible d'obtenir une copie de mes données pour garder mes carnets et le reste pour mon suivi perso ?\n\nMon nom d'utilisateur est {{name}}, rattaché à cet e-mail ({{email}}).\n\nMerci !\n\n{{name}}"
+      },
+      "importDialog": {
+        "title": "L'import MoonBoard arrive bientôt",
+        "body": "Nous construisons encore l'importateur MoonBoard. Exportez vos données depuis l'app MoonBoard et envoyez-les à Marco sur Discord — il s'en servira pour créer l'import.",
+        "discordCta": "Ouvrir Discord"
+      }
     }
   },
   "healthkit": {

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -319,7 +319,8 @@
       "importDialog": {
         "title": "L'import MoonBoard arrive bientôt",
         "body": "Nous construisons encore l'importateur MoonBoard. Exportez vos données depuis l'app MoonBoard et envoyez-les à Marco sur Discord — il s'en servira pour créer l'import.",
-        "discordCta": "Ouvrir Discord"
+        "discordCta": "Ouvrir Discord",
+        "openFailed": "Impossible d'ouvrir Discord. Réessayez."
       }
     }
   },


### PR DESCRIPTION
## Summary

Adds a MoonBoard card at the top of the mobile **Board Accounts** section (Profile → Integrations). It mirrors the legacy "Kilter (Aurora)" data-import card, but MoonBoard isn't an Aurora board, so the card is fully self-contained — no credential or sync flow.

- **Request your data** opens a pre-filled email to `moonboardsupport@moonclimbing.com`. The body says "MoonBoard app user" (instead of the Kilter card's "Ex-app user").
- **Import data** opens an explanatory modal: the importer isn't built yet, so export your MoonBoard data and send it to Marco on Discord (existing `discord.gg` invite) so he can build it.
- New `aurora.moonboard.*` strings added to all three locale catalogs (en-US, es, fr); catalog-completeness test passes.

Implemented entirely in `BoardAccountsSection.tsx` plus the locale catalogs — reuses the existing card layout, mailto helper pattern, RN `Modal` + shared styles, and theme/Button/Text primitives.

## Release Notes

- MoonBoard climbers can now request their data and kick off getting it into Boardsesh

## Test plan

- `vp run typecheck:mobile` — passes
- `vp run test:mobile` + `catalog-completeness.test.ts` (28 tests) — pass
- `vp fmt --check` on changed files — clean
- `vp run check:mobile-bundle` — OK (12.8 MB)
- Manual: card renders first in Board Accounts; "Request your data" opens email to `moonboardsupport@moonclimbing.com` with a "MoonBoard app user" body; "Import data" opens the Discord modal with a working "Open Discord" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtXsTY1EqTS5AwsDLqQkTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtXsTY1EqTS5AwsDLqQkTD)_