### PR TITLE
fix(mobile): open create-climb over the player on remix/edit, carry board id on new climbs

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -225,12 +225,14 @@ if (isPlayerRoute(segments)) router.dismiss();
 router.push({ pathname: '/(tabs)/climbs/create', params });
 ```
 
-The precedent is `handleSwitchBoardFromDrawer` in `drawer-host-provider.tsx`, which does the
-same `router.dismiss()` → `router.push('/boards')` when the play drawer's board-mismatch
-overlay routes to the board picker. `useCreateClimbNavigation`
-(`src/components/create-climb/use-create-climb-navigation.ts`) is the shared version for
-remix/edit, and both entry points (the reaction menu's `useClimbActions`, the in-player
-`ClimbActionsSheet`) go through it.
+`handleSwitchBoardFromDrawer` in `drawer-host-provider.tsx` does the same
+`router.dismiss()` → `router.push('/boards')` when the play drawer's board-mismatch overlay
+routes to the board picker — but copy the shape, not the code: it is **ungated**, so on an
+iPad pane (where there is no `/play` route) it pops whatever is focused instead. The gated
+version is `useCreateClimbNavigation`
+(`src/components/create-climb/use-create-climb-navigation.ts`), and both remix/edit entry
+points (the reaction menu's `useClimbActions`, the in-player `ClimbActionsSheet`) go through
+it.
 
 Two things that are easy to get wrong:
 

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -206,6 +206,47 @@ Is it a secondary surface OVER the current screen, or its own full surface?
    e.g. the board sheet / queue list) owns this itself: add `insets.bottom + spacing[N]`. Apply on
    both platforms — `insets.bottom` is 0 when there's nothing to clear, so there's no double-inset.
 
+## Pushing a route from INSIDE a modal route (the cross-navigator trap)
+
+The in-tree-opener rule above is about sheets. Routes have their own version of it, and it
+bites the other way round.
+
+`/play` is a `transparentModal` in the **root** stack. `/(tabs)/climbs/create` is also a
+`transparentModal`, but it lives in the **climbs-tab** stack — a different navigator, mounted
+_beneath_ the root modal. So a `router.push('/(tabs)/climbs/create')` fired from inside the
+player pushes create into a navigator that is already covered: create stacks **under** the
+still-live player (two drawers visible at once), and `CreateDrawer`'s root-window
+`BottomSheet` strands a scrim over the search list once you navigate away.
+
+**The fix: dismiss the modal route first, then push.**
+
+```ts
+if (isPlayerRoute(segments)) router.dismiss();
+router.push({ pathname: '/(tabs)/climbs/create', params });
+```
+
+The precedent is `handleSwitchBoardFromDrawer` in `drawer-host-provider.tsx`, which does the
+same `router.dismiss()` → `router.push('/boards')` when the play drawer's board-mismatch
+overlay routes to the board picker. `useCreateClimbNavigation`
+(`src/components/create-climb/use-create-climb-navigation.ts`) is the shared version for
+remix/edit, and both entry points (the reaction menu's `useClimbActions`, the in-player
+`ClimbActionsSheet`) go through it.
+
+Two things that are easy to get wrong:
+
+- **Gate the dismiss.** The same menu opens from the climbs list and the board sheet, where
+  there is no modal to close — and on an **iPad regular-width layout the player renders in the
+  detail pane, not the `/play` route** at all. An ungated `router.dismiss()` pops the wrong
+  screen. Gate on `isPlayerRoute(segments)` (`src/lib/route-segments.ts`).
+- **Read the segments from a ref, not a dep.** `useSegments()` hands back a fresh array on
+  every navigation, so listing it in a `useCallback` dep array churns the callback identity and
+  rebuilds any memoised list built on top of it (here, `useClimbActions`' action list). Mirror
+  it with the repo's latest-ref idiom (`segmentsRef.current = segments`) and read it inside the
+  handler.
+
+The rule of thumb: **before pushing a route, ask which navigator it lands in.** Same navigator
+is fine. A navigator _below_ the modal you're standing in needs the dismiss first.
+
 ## A latency footgun (any route)
 
 A modal route's present animation can't START until React commits the route's first frame. If

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -9,6 +8,7 @@ import { buildReadableClimbViewPath } from '@boardsesh/play-view/readable-url-ut
 import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { ModalSheet } from './ModalSheet';
+import { useCreateClimbNavigation } from './create-climb/use-create-climb-navigation';
 import { ClimbPreviewCard } from './ClimbPreviewCard';
 import { ListRow } from './ListRow';
 import { Icon } from './Icon';
@@ -66,9 +66,9 @@ function ClimbActionsSheet({
   onClose,
 }: ClimbActionsSheetProps) {
   const { t } = useTranslation('climbs');
+  const { openRemix, openEdit } = useCreateClimbNavigation();
   const { showToast } = useToast();
   const theme = useTheme();
-  const router = useRouter();
 
   const handleAddToQueue = useCallback(() => {
     onAddToQueue?.();
@@ -138,39 +138,21 @@ function ClimbActionsSheet({
     }
   }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose, showToast, t]);
 
+  // Close this sub-sheet, then navigate. This sheet only ever renders inside the play
+  // drawer, so `openRemix`/`openEdit` dismiss the player route first (when it IS a
+  // route — on an iPad detail pane there's nothing to dismiss) and create opens as the
+  // sole top surface instead of stacking underneath.
   const handleFork = useCallback(() => {
     if (!climb) return;
     onClose();
-    router.push({
-      pathname: '/(tabs)/climbs/create',
-      params: {
-        forkFrames: climb.frames,
-        forkName: climb.name,
-        forkDescription: climb.description ?? '',
-        boardName,
-        layoutId: String(layoutId),
-        sizeId: String(sizeId),
-        setIds,
-        angle: String(angle),
-      },
-    });
-  }, [climb, boardName, layoutId, sizeId, setIds, angle, router, onClose]);
+    openRemix(climb, { boardName, layoutId, sizeId, setIds, angle });
+  }, [climb, boardName, layoutId, sizeId, setIds, angle, openRemix, onClose]);
 
   const handleEdit = useCallback(() => {
     if (!climb) return;
     onClose();
-    router.push({
-      pathname: '/(tabs)/climbs/create',
-      params: {
-        editClimbUuid: climb.uuid,
-        boardName,
-        layoutId: String(layoutId),
-        sizeId: String(sizeId),
-        setIds,
-        angle: String(angle),
-      },
-    });
-  }, [climb, boardName, layoutId, sizeId, setIds, angle, router, onClose]);
+    openEdit(climb, { boardName, layoutId, sizeId, setIds, angle });
+  }, [climb, boardName, layoutId, sizeId, setIds, angle, openEdit, onClose]);
 
   // Edit is owner-only, and only while the climb is still a draft OR within
   // 24h of first publish (the backend enforces the same window). `userId`

--- a/packages/mobile/src/components/ClimbActionsSheet.tsx
+++ b/packages/mobile/src/components/ClimbActionsSheet.tsx
@@ -138,10 +138,10 @@ function ClimbActionsSheet({
     }
   }, [climb, boardName, layoutId, sizeId, setIds, angle, onClose, showToast, t]);
 
-  // Close this sub-sheet, then navigate. This sheet only ever renders inside the play
-  // drawer, so `openRemix`/`openEdit` dismiss the player route first (when it IS a
-  // route — on an iPad detail pane there's nothing to dismiss) and create opens as the
-  // sole top surface instead of stacking underneath.
+  // Close this sub-sheet, then navigate. `openRemix`/`openEdit` decide for themselves
+  // whether a player route needs dismissing first (it does from `/play`; it doesn't from
+  // an iPad detail pane, or anywhere else this sheet might later be reused), so create
+  // opens as the sole top surface instead of stacking underneath.
   const handleFork = useCallback(() => {
     if (!climb) return;
     onClose();

--- a/packages/mobile/src/components/ClimbPreviewCard.tsx
+++ b/packages/mobile/src/components/ClimbPreviewCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { View } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { ClimbListItemContent, type ClimbListItemClimb } from './ClimbListItemContent';
@@ -22,8 +23,13 @@ type ClimbPreviewCardProps = {
  * `ClimbListRow`, not here. The row sits transparent on the sheet's glass so it
  * stays cohesive with the action rows below; a hairline separator divides it from
  * them.
+ *
+ * Memoized: its host sheets subscribe to route info (`ClimbActionsSheet` reaches
+ * `useSegments` through `useCreateClimbNavigation`), so the sheet re-renders on every
+ * navigation in the app. Props here are the climb plus primitives, so a shallow compare
+ * keeps the board thumbnail out of that churn.
  */
-export function ClimbPreviewCard({ climb, boardName, layoutId, sizeId, setIds, angle }: ClimbPreviewCardProps) {
+function ClimbPreviewCardComponent({ climb, boardName, layoutId, sizeId, setIds, angle }: ClimbPreviewCardProps) {
   const { systemColors } = useTheme();
   return (
     <View>
@@ -41,3 +47,5 @@ export function ClimbPreviewCard({ climb, boardName, layoutId, sizeId, setIds, a
     </View>
   );
 }
+
+export const ClimbPreviewCard = memo(ClimbPreviewCardComponent);

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -9,7 +9,14 @@ import type { Climb } from '@boardsesh/shared-schema';
 // The mock captures the latest `visible` it was handed.
 const sheet = vi.hoisted(() => ({ visible: undefined as boolean | undefined }));
 const preview = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
-const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material', canUpdate: false }));
+// `segments` drives the real `useCreateClimbNavigation` (deliberately NOT mocked, so the
+// Remix/Edit rows are covered end-to-end through the hook that owns the player dismiss).
+const ctrl = vi.hoisted(() => ({
+  variant: 'liquidGlass' as 'liquidGlass' | 'material',
+  canUpdate: false,
+  segments: ['play'] as readonly string[],
+}));
+const nav = vi.hoisted(() => ({ push: vi.fn(), dismiss: vi.fn() }));
 const clipboard = vi.hoisted(() => ({ setStringAsync: vi.fn() }));
 const urlBuilder = vi.hoisted(() => ({ buildReadableClimbViewPath: vi.fn(() => '/readable/view/x') }));
 
@@ -43,7 +50,10 @@ vi.mock('../Icon', () => ({
     createElement('span', { 'data-icon': name, 'data-color': typeof color === 'string' ? color : '' }),
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ push: nav.push, dismiss: nav.dismiss }),
+  useSegments: () => ctrl.segments,
+}));
 vi.mock('expo-clipboard', () => ({ setStringAsync: clipboard.setStringAsync }));
 vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn() }));
 vi.mock('@boardsesh/play-view/readable-url-utils', () => ({
@@ -105,6 +115,10 @@ beforeEach(() => {
   preview.props = null;
   ctrl.variant = 'liquidGlass';
   ctrl.canUpdate = false;
+  // This sheet only ever renders inside the play drawer, so /play is the realistic default.
+  ctrl.segments = ['play'];
+  nav.push.mockClear();
+  nav.dismiss.mockClear();
 });
 
 describe('ClimbActionsSheet controlled visible (always-mounted toggle)', () => {
@@ -252,5 +266,66 @@ describe('ClimbActionsSheet controlled visible (always-mounted toggle)', () => {
 
     expect(onEditEntry).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ClimbActionsSheet create-climb navigation (Remix / Edit)', () => {
+  // Both /play and /(tabs)/climbs/create are transparentModals, but in different
+  // navigators — create lives under the player, so it must not be pushed while the
+  // player is still up.
+  it('closes the sheet, dismisses the player, then pushes create with the fork params', () => {
+    const onClose = vi.fn();
+    render(<ClimbActionsSheet visible={true} {...baseProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.fork'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(nav.dismiss).toHaveBeenCalledTimes(1);
+    expect(nav.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        forkFrames: 'p1r12',
+        forkName: 'Test Climb',
+        forkDescription: '',
+        boardName: 'kilter',
+        layoutId: '1',
+        sizeId: '10',
+        setIds: '1,2',
+        angle: '40',
+      },
+    });
+  });
+
+  it('pushes create in edit mode from the owner-only Edit row', () => {
+    ctrl.canUpdate = true;
+    render(<ClimbActionsSheet visible={true} {...baseProps} climb={ownerClimb} currentUserId="user-1" />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.edit'));
+
+    expect(nav.dismiss).toHaveBeenCalledTimes(1);
+    expect(nav.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        editClimbUuid: 'climb-1',
+        boardName: 'kilter',
+        layoutId: '1',
+        sizeId: '10',
+        setIds: '1,2',
+        angle: '40',
+      },
+    });
+  });
+
+  // On an iPad regular-width layout the player renders in the detail PANE, not the
+  // /play route — there is no modal to dismiss, and popping one would take the wrong
+  // screen with it.
+  it('does not dismiss when the player is a pane rather than the /play route', () => {
+    ctrl.segments = ['(tabs)', 'climbs'];
+    render(<ClimbActionsSheet visible={true} {...baseProps} />);
+
+    fireEvent.click(screen.getByText('mobile.climbActions.fork'));
+
+    expect(nav.dismiss).not.toHaveBeenCalled();
+    expect(nav.push).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -4,7 +4,9 @@ import { renderHook } from '@testing-library/react';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { ClimbActionId } from '../use-climb-actions';
 
-const ctrl = vi.hoisted(() => ({ canUpdate: false }));
+// `segments` drives the real `useCreateClimbNavigation` (deliberately NOT mocked here,
+// so fork/edit get end-to-end coverage through the hook that owns the player dismiss).
+const ctrl = vi.hoisted(() => ({ canUpdate: false, segments: ['(tabs)', 'climbs'] as readonly string[] }));
 const openers = vi.hoisted(() => ({
   openPlayDrawer: vi.fn(),
   openAddToPlaylist: vi.fn(),
@@ -13,11 +15,15 @@ const openers = vi.hoisted(() => ({
   addToQueue: vi.fn(),
   toggleFavoriteMutate: vi.fn(),
   push: vi.fn(),
+  dismiss: vi.fn(),
   shareClimb: vi.fn(async () => {}),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('expo-router', () => ({ useRouter: () => ({ push: openers.push }) }));
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ push: openers.push, dismiss: openers.dismiss }),
+  useSegments: () => ctrl.segments,
+}));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'queue-uuid' }));
 vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn(async () => {}) }));
 vi.mock('@boardsesh/create-climb-react', () => ({ computeCanUpdate: () => ctrl.canUpdate }));
@@ -86,6 +92,7 @@ function ids(args: ActionArgs): ClimbActionId[] {
 
 beforeEach(() => {
   ctrl.canUpdate = false;
+  ctrl.segments = ['(tabs)', 'climbs'];
   Object.values(openers).forEach((fn) => fn.mockClear?.());
 });
 
@@ -237,5 +244,72 @@ describe('useClimbActions colours and dispatch', () => {
     result.current.find((action) => action.id === 'preview')?.run();
     expect(openers.openPlayDrawer).toHaveBeenCalledTimes(1);
     expect(openers.openPlayDrawer).toHaveBeenCalledWith(climb, expect.objectContaining({ source: 'climb_view' }));
+  });
+});
+
+describe('useClimbActions create-climb navigation (fork / edit)', () => {
+  it('fork.run dismisses the overlay, then pushes create with the fork params', () => {
+    const onAfterAction = vi.fn();
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false, onAfterAction });
+    result.current.find((action) => action.id === 'fork')?.run();
+
+    expect(onAfterAction).toHaveBeenCalledTimes(1);
+    expect(openers.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        forkFrames: 'p1r12',
+        forkName: 'Test Climb',
+        forkDescription: '',
+        boardName: 'kilter',
+        layoutId: '1',
+        sizeId: '10',
+        setIds: '1,2',
+        angle: '40',
+      },
+    });
+  });
+
+  it('edit.run pushes create with the climb uuid, not the fork frames', () => {
+    ctrl.canUpdate = true;
+    const { result } = renderActions({
+      climb: ownerClimb,
+      boardConfig: kilterBoard,
+      isAuthenticated: true,
+      currentUserId: 'user-1',
+    });
+    result.current.find((action) => action.id === 'edit')?.run();
+
+    expect(openers.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        editClimbUuid: 'climb-1',
+        boardName: 'kilter',
+        layoutId: '1',
+        sizeId: '10',
+        setIds: '1,2',
+        angle: '40',
+      },
+    });
+  });
+
+  // The player is a transparentModal in the ROOT stack; create is a transparentModal in
+  // the CLIMBS-TAB stack underneath it. Pushing without dismissing stacks create under
+  // the live player (two drawers + a stranded scrim).
+  it('dismisses the player route first when the menu was opened from /play', () => {
+    ctrl.segments = ['play'];
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
+    result.current.find((action) => action.id === 'fork')?.run();
+
+    expect(openers.dismiss).toHaveBeenCalledTimes(1);
+    expect(openers.push).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dismiss anything when remixing from the climbs list', () => {
+    ctrl.segments = ['(tabs)', 'climbs'];
+    const { result } = renderActions({ climb, boardConfig: kilterBoard, isAuthenticated: false });
+    result.current.find((action) => action.id === 'fork')?.run();
+
+    expect(openers.dismiss).not.toHaveBeenCalled();
+    expect(openers.push).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -6,20 +6,20 @@
 // The hook self-sources most openers (preview / queue / tick / beta video) from
 // `useDrawerHost`, the favourite state + mutation from `useFavoriteStatus` /
 // `useToggleFavorite`, the native share from `useShareClimb`, and the create-climb
-// routes from the router, so a caller supplies the climb, its board config, the two
-// contextual flags (`currentUserId`, `isAuthenticated`), the required inline playlist
-// host (`onSelectPlaylist`), and the logbook-only `onEditEntry`.
+// routes from `useCreateClimbNavigation`, so a caller supplies the climb, its board
+// config, the two contextual flags (`currentUserId`, `isAuthenticated`), the required
+// inline playlist host (`onSelectPlaylist`), and the logbook-only `onEditEntry`.
 
 import { useCallback, useMemo } from 'react';
 import type { OpaqueColorValue } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useRouter } from 'expo-router';
 import { randomUUID } from 'expo-crypto';
 import * as WebBrowser from 'expo-web-browser';
 import type { Climb } from '@boardsesh/shared-schema';
 import { computeCanUpdate, type SavedClimbSnapshot } from '@boardsesh/create-climb-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { IconName } from '../icon-map';
+import { useCreateClimbNavigation } from '../create-climb/use-create-climb-navigation';
 import { useDrawerHost, boardConfigsMatch, type BoardConfig } from '../../providers/drawer-host-provider';
 import { useQueueActions } from '../../providers/queue-provider';
 import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
@@ -118,7 +118,7 @@ export function useClimbActions({
   onTick,
 }: UseClimbActionsArgs): ClimbActionItem[] {
   const { t } = useTranslation('climbs');
-  const router = useRouter();
+  const { openRemix, openEdit } = useCreateClimbNavigation();
   const { actionColors } = useTheme();
   const { addToQueue } = useQueueActions();
   const { mutate: toggleFavoriteMutate } = useToggleFavorite();
@@ -298,19 +298,11 @@ export function useClimbActions({
         title: t('mobile.climbActions.edit'),
         icon: 'edit',
         color: accentColor,
+        // Dismiss the overlay, then navigate. `openEdit` closes the player route
+        // first when we're inside it, so create doesn't stack under `/play`.
         run: () => {
           after();
-          router.push({
-            pathname: '/(tabs)/climbs/create',
-            params: {
-              editClimbUuid: climb.uuid,
-              boardName,
-              layoutId: String(layoutId),
-              sizeId: String(sizeId),
-              setIds,
-              angle: String(angle),
-            },
-          });
+          openEdit(climb, boardConfig);
         },
       });
     }
@@ -320,21 +312,10 @@ export function useClimbActions({
       title: t('mobile.climbActions.fork'),
       icon: 'branch',
       color: accentColor,
+      // Same as edit: `openRemix` closes the player route first when we're inside it.
       run: () => {
         after();
-        router.push({
-          pathname: '/(tabs)/climbs/create',
-          params: {
-            forkFrames: climb.frames,
-            forkName: climb.name,
-            forkDescription: climb.description ?? '',
-            boardName,
-            layoutId: String(layoutId),
-            sizeId: String(sizeId),
-            setIds,
-            angle: String(angle),
-          },
-        });
+        openRemix(climb, boardConfig);
       },
     });
 
@@ -388,7 +369,8 @@ export function useClimbActions({
     after,
     t,
     actionColors,
-    router,
+    openRemix,
+    openEdit,
     shareClimb,
     addToQueue,
     toggleFavoriteMutate,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { Climb } from '@boardsesh/shared-schema';
+
+const ctrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as readonly string[] }));
+const router = vi.hoisted(() => ({ push: vi.fn(), dismiss: vi.fn() }));
+
+vi.mock('expo-router', () => ({
+  useRouter: () => router,
+  useSegments: () => ctrl.segments,
+}));
+
+import { useCreateClimbNavigation } from '../use-create-climb-navigation';
+
+const climb = {
+  uuid: 'climb-1',
+  name: 'Sloper Traverse',
+  frames: 'p1129r15p1130r12',
+  description: 'Start matched on the jug',
+} as unknown as Climb;
+
+const board = { boardName: 'kilter', layoutId: 8, sizeId: 17, setIds: '26,27', angle: 40 };
+
+beforeEach(() => {
+  ctrl.segments = ['(tabs)', 'climbs'];
+  router.push.mockClear();
+  router.dismiss.mockClear();
+});
+
+describe('useCreateClimbNavigation player dismiss', () => {
+  // /play is a transparentModal in the ROOT stack; /(tabs)/climbs/create is a
+  // transparentModal in the CLIMBS-TAB stack, which is mounted BENEATH it. Pushing
+  // create without dismissing the player stacks it under the live player.
+  it('dismisses the player before pushing create when /play is focused', () => {
+    ctrl.segments = ['play'];
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openRemix(climb, board);
+
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledTimes(1);
+    expect(router.dismiss.mock.invocationCallOrder[0]).toBeLessThan(router.push.mock.invocationCallOrder[0]);
+  });
+
+  it('pushes without dismissing from the climbs list', () => {
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openRemix(climb, board);
+
+    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledTimes(1);
+  });
+
+  // The iPad regular-width layout hosts the player in the detail pane, so the focused
+  // route is still a tabs route and there is no modal to pop.
+  it('pushes without dismissing from a pushed climbs sub-route (iPad pane player)', () => {
+    ctrl.segments = ['(tabs)', 'climbs', '[climbUuid]'];
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openEdit(climb, board);
+
+    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useCreateClimbNavigation params', () => {
+  it('openRemix carries the fork seed plus stringified board params', () => {
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openRemix(climb, board);
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        forkFrames: 'p1129r15p1130r12',
+        forkName: 'Sloper Traverse',
+        forkDescription: 'Start matched on the jug',
+        boardName: 'kilter',
+        layoutId: '8',
+        sizeId: '17',
+        setIds: '26,27',
+        angle: '40',
+      },
+    });
+  });
+
+  it('openRemix sends an empty string for a description-less climb', () => {
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openRemix({ ...climb, description: null } as unknown as Climb, board);
+
+    expect(router.push.mock.calls[0][0].params.forkDescription).toBe('');
+  });
+
+  it('openEdit carries the climb uuid and no fork seed', () => {
+    const { result } = renderHook(() => useCreateClimbNavigation());
+
+    result.current.openEdit(climb, board);
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        editClimbUuid: 'climb-1',
+        boardName: 'kilter',
+        layoutId: '8',
+        sizeId: '17',
+        setIds: '26,27',
+        angle: '40',
+      },
+    });
+  });
+});
+
+describe('useCreateClimbNavigation callback stability', () => {
+  // `useSegments()` returns a fresh array on every navigation. If it were a dep rather
+  // than a ref read, these callbacks would change identity on each one and rebuild
+  // `useClimbActions`' memoised action list.
+  it('keeps openRemix / openEdit stable across a segments change', () => {
+    const { result, rerender } = renderHook(() => useCreateClimbNavigation());
+    const first = { openRemix: result.current.openRemix, openEdit: result.current.openEdit };
+
+    ctrl.segments = ['play'];
+    rerender();
+
+    expect(result.current.openRemix).toBe(first.openRemix);
+    expect(result.current.openEdit).toBe(first.openEdit);
+  });
+
+  it('still reads the CURRENT segments through the stable callback', () => {
+    const { result, rerender } = renderHook(() => useCreateClimbNavigation());
+    const openRemix = result.current.openRemix;
+
+    ctrl.segments = ['play'];
+    rerender();
+    openRemix(climb, board);
+
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -223,7 +223,7 @@ describe('climbToQueueItem board identity at the queue boundary', () => {
   // because the subscription selection sets (SUBSCRIPTION_CLIMB_FIELDS, and web's
   // CLIMB_FIELDS) don't select them either, so the local copy and the peer copy agree.
   // Carrying them here alone would make a peer's rebuild disagree with the creator's
-  // and let the next peer-side setQueue write the gap back. When that follow-up lands,
+  // and let the next peer-side setQueue write the gap back. When #3927 lands,
   // this expectation flips to `toMatchObject` — it is here so the boundary can't be
   // widened by halves without someone reading this comment.
   it('does not yet carry ownership / draft state (blocked on the subscription set)', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Guards the board identity a freshly created climb carries into the queue.
+//
+// `buildProvisionalClimb` used to omit boardType/layoutId (and most of the climb's
+// identity), so a just-saved climb — a remix, typically — round-tripped BOARD-LESS to
+// party peers via `toClimbInput` and into the board-presence report, and the owner-only
+// Edit action lost the `userId` it gates on.
+//
+// The important part of this file: it runs the REAL `climbToQueueItem`. Every other
+// create-screen test mocks it as a pass-through, and that pass-through is exactly what
+// hid the second half of the bug — the queue boundary was silently stripping fields the
+// provisional climb did carry. Mock it here and this test proves nothing.
+
+const cryptoMock = vi.hoisted(() => {
+  let counter = 0;
+  return { randomUUID: vi.fn(() => `uuid-${++counter}`) };
+});
+
+const board = vi.hoisted(() => ({
+  isAuthenticated: true,
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+  isDuplicateClimbError: vi.fn((_err: unknown) => false),
+}));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: cryptoMock.randomUUID }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: () => false,
+  withNoMatch: (description: string) => description,
+}));
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialHoldsMap: () => ({}),
+}));
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardActions: () => ({
+    isAuthenticated: board.isAuthenticated,
+    saveClimb: board.saveClimb,
+    updateClimb: board.updateClimb,
+  }),
+  isDuplicateClimbError: (err: unknown) => board.isDuplicateClimbError(err),
+}));
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { id: 'user-1', displayName: 'Tester' } }),
+  useClimb: () => ({ data: undefined }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+// NOTE: ../../../lib/climb-to-queue-item is deliberately NOT mocked — see the header.
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: () => 'draft-key',
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
+}));
+
+import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
+import { climbToQueueItem, toClimbInput } from '../../../lib/climb-to-queue-item';
+import { useCreateClimbScreen } from '../use-create-climb-screen';
+
+const kilterBoard = { boardName: 'kilter' as const, layoutId: 8, sizeId: 17, setIds: '26,27', angle: 40 };
+
+/** The queue item handed to setCurrentClimb by the last Set Active / save sync. */
+function lastQueuedItem(): ClimbQueueItem {
+  const calls = queue.setCurrentClimb.mock.calls;
+  return calls[calls.length - 1]?.[0] as ClimbQueueItem;
+}
+
+beforeEach(() => {
+  toast.showToast.mockClear();
+  queue.setCurrentClimb.mockClear();
+  router.push.mockClear();
+  cryptoMock.randomUUID.mockClear();
+  board.isAuthenticated = true;
+  board.isDuplicateClimbError.mockReturnValue(false);
+  board.saveClimb.mockReset();
+  board.updateClimb.mockReset();
+});
+
+describe('create-climb queue hand-off carries board identity', () => {
+  it('Set Active queues the WIP with the create board, through the real climbToQueueItem', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Sloper Traverse remix'));
+    act(() => result.current.handleSetActive());
+
+    const { climb } = lastQueuedItem();
+    // The whole point: a board-less climb is one a peer can't place and the presence
+    // report can't attribute.
+    expect(climb.boardType).toBe('kilter');
+    expect(climb.layoutId).toBe(8);
+    expect(climb.angle).toBe(40);
+    expect(climb.name).toBe('Sloper Traverse remix');
+    expect(climb.frames).toBe('p1r12p2r13p3r14');
+  });
+
+  it('carries ownership + draft state so the owner-only Edit action can gate on it', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Draft Project'));
+    act(() => result.current.handleSetActive());
+
+    const { climb } = lastQueuedItem();
+    expect(climb.userId).toBe('user-1');
+    expect(climb.is_draft).toBe(true);
+    expect(climb.setter_username).toBe('Tester');
+  });
+
+  it('survives toClimbInput with its board identity intact (the party-peer wire shape)', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Wire Test'));
+    act(() => result.current.handleSetActive());
+
+    const input = toClimbInput(lastQueuedItem().climb);
+    expect(input.boardType).toBe('kilter');
+    expect(input.layoutId).toBe(8);
+    expect(input.userId).toBe('user-1');
+    expect(input.is_draft).toBe(true);
+  });
+
+  it('keeps the board identity after a save syncs the server uuid into the queue', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'saved-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Published Remix'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    const { climb } = lastQueuedItem();
+    expect(climb.uuid).toBe('saved-1');
+    expect(climb.boardType).toBe('kilter');
+    expect(climb.layoutId).toBe(8);
+  });
+
+  it('marks the provisional climb single-frame so playback does not wait on a pace', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Single Frame'));
+    act(() => result.current.handleSetActive());
+
+    const { climb } = lastQueuedItem();
+    expect(climb.framesCount).toBe(1);
+    expect(climb.framesPace).toBeNull();
+  });
+});
+
+describe('climbToQueueItem field retention (the boundary that was stripping)', () => {
+  it('does not drop ownership / draft fields a climb already carries', () => {
+    // A direct guard on the queue boundary itself, independent of the create screen:
+    // these five were being stripped even when the source climb had them.
+    const source = {
+      uuid: 'climb-1',
+      boardType: 'tension',
+      layoutId: 9,
+      name: 'Peer Climb',
+      frames: 'p1r12',
+      setter_username: 'Someone',
+      userId: 'user-2',
+      description: 'crimpy',
+      mirrored: true,
+      is_draft: false,
+      published_at: '2026-07-01T00:00:00Z',
+      angle: 40,
+      ascensionist_count: 3,
+      difficulty: 'V5',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0',
+      benchmark_difficulty: null,
+    } as unknown as Climb;
+
+    const { climb } = climbToQueueItem(source);
+    expect(climb).toMatchObject({
+      userId: 'user-2',
+      description: 'crimpy',
+      mirrored: true,
+      is_draft: false,
+      published_at: '2026-07-01T00:00:00Z',
+    });
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -4,15 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Guards the board identity a freshly created climb carries into the queue.
 //
-// `buildProvisionalClimb` used to omit boardType/layoutId (and most of the climb's
-// identity), so a just-saved climb — a remix, typically — round-tripped BOARD-LESS to
-// party peers via `toClimbInput` and into the board-presence report, and the owner-only
-// Edit action lost the `userId` it gates on.
+// `buildProvisionalClimb` used to omit boardType/layoutId, so a just-saved climb — a
+// remix, typically — round-tripped BOARD-LESS to party peers via `toClimbInput` and
+// into the board-presence report.
 //
 // The important part of this file: it runs the REAL `climbToQueueItem`. Every other
-// create-screen test mocks it as a pass-through, and that pass-through is exactly what
-// hid the second half of the bug — the queue boundary was silently stripping fields the
-// provisional climb did carry. Mock it here and this test proves nothing.
+// create-screen test mocks it as a pass-through, which would let this suite pass on a
+// provisional climb whose fields never actually survive the queue boundary. Mock it
+// here and these assertions prove nothing about what a peer receives.
 
 const cryptoMock = vi.hoisted(() => {
   let counter = 0;
@@ -142,16 +141,16 @@ describe('create-climb queue hand-off carries board identity', () => {
     expect(climb.frames).toBe('p1r12p2r13p3r14');
   });
 
-  it('carries ownership + draft state so the owner-only Edit action can gate on it', () => {
+  it('carries the setter and the no-match flag through the real boundary', () => {
     const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
 
     act(() => result.current.setName('Draft Project'));
+    act(() => result.current.setNoMatch(true));
     act(() => result.current.handleSetActive());
 
     const { climb } = lastQueuedItem();
-    expect(climb.userId).toBe('user-1');
-    expect(climb.is_draft).toBe(true);
     expect(climb.setter_username).toBe('Tester');
+    expect(climb.is_no_match).toBe(true);
   });
 
   it('survives toClimbInput with its board identity intact (the party-peer wire shape)', () => {
@@ -163,8 +162,6 @@ describe('create-climb queue hand-off carries board identity', () => {
     const input = toClimbInput(lastQueuedItem().climb);
     expect(input.boardType).toBe('kilter');
     expect(input.layoutId).toBe(8);
-    expect(input.userId).toBe('user-1');
-    expect(input.is_draft).toBe(true);
   });
 
   it('keeps the board identity after a save syncs the server uuid into the queue', async () => {
@@ -194,38 +191,46 @@ describe('create-climb queue hand-off carries board identity', () => {
   });
 });
 
-describe('climbToQueueItem field retention (the boundary that was stripping)', () => {
-  it('does not drop ownership / draft fields a climb already carries', () => {
-    // A direct guard on the queue boundary itself, independent of the create screen:
-    // these five were being stripped even when the source climb had them.
-    const source = {
-      uuid: 'climb-1',
-      boardType: 'tension',
-      layoutId: 9,
-      name: 'Peer Climb',
-      frames: 'p1r12',
-      setter_username: 'Someone',
-      userId: 'user-2',
-      description: 'crimpy',
-      mirrored: true,
-      is_draft: false,
-      published_at: '2026-07-01T00:00:00Z',
-      angle: 40,
-      ascensionist_count: 3,
-      difficulty: 'V5',
-      quality_average: '3.0',
-      stars: 3,
-      difficulty_error: '0',
-      benchmark_difficulty: null,
-    } as unknown as Climb;
+describe('climbToQueueItem board identity at the queue boundary', () => {
+  const peerClimb = {
+    uuid: 'climb-1',
+    boardType: 'tension',
+    layoutId: 9,
+    name: 'Peer Climb',
+    frames: 'p1r12',
+    setter_username: 'Someone',
+    userId: 'user-2',
+    description: 'crimpy',
+    mirrored: true,
+    is_draft: false,
+    published_at: '2026-07-01T00:00:00Z',
+    angle: 40,
+    ascensionist_count: 3,
+    difficulty: 'V5',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+  } as unknown as Climb;
 
-    const { climb } = climbToQueueItem(source);
-    expect(climb).toMatchObject({
-      userId: 'user-2',
-      description: 'crimpy',
-      mirrored: true,
-      is_draft: false,
-      published_at: '2026-07-01T00:00:00Z',
-    });
+  it('forwards the board a climb belongs to', () => {
+    const { climb } = climbToQueueItem(peerClimb);
+    expect(climb.boardType).toBe('tension');
+    expect(climb.layoutId).toBe(9);
+  });
+
+  // Pins the CURRENT contract, deliberately. These five are droppable here only
+  // because the subscription selection sets (SUBSCRIPTION_CLIMB_FIELDS, and web's
+  // CLIMB_FIELDS) don't select them either, so the local copy and the peer copy agree.
+  // Carrying them here alone would make a peer's rebuild disagree with the creator's
+  // and let the next peer-side setQueue write the gap back. When that follow-up lands,
+  // this expectation flips to `toMatchObject` — it is here so the boundary can't be
+  // widened by halves without someone reading this comment.
+  it('does not yet carry ownership / draft state (blocked on the subscription set)', () => {
+    const { climb } = climbToQueueItem(peerClimb);
+    expect(climb.userId).toBeUndefined();
+    expect(climb.description).toBeUndefined();
+    expect(climb.is_draft).toBeUndefined();
+    expect(climb.published_at).toBeUndefined();
   });
 });

--- a/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
@@ -70,5 +70,7 @@ export function useCreateClimbNavigation() {
     [navigateToCreate],
   );
 
-  return { navigateToCreate, openRemix, openEdit };
+  // Only the two semantic wrappers are exposed. `navigateToCreate` stays internal so a
+  // caller can't hand-roll params and skip the dismiss reasoning that lives here.
+  return { openRemix, openEdit };
 }

--- a/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
@@ -1,0 +1,74 @@
+import { useCallback, useRef } from 'react';
+import { useRouter, useSegments } from 'expo-router';
+import type { Climb } from '@boardsesh/shared-schema';
+import { isPlayerRoute } from '../../lib/route-segments';
+import type { BoardConfig } from '../../providers/drawer-host-provider';
+
+/** expo-router params are strings; the create route reads them via `useLocalSearchParams`. */
+function boardParams(board: BoardConfig): Record<string, string> {
+  return {
+    boardName: board.boardName,
+    layoutId: String(board.layoutId),
+    sizeId: String(board.sizeId),
+    setIds: board.setIds,
+    angle: String(board.angle),
+  };
+}
+
+/**
+ * Navigation to the create-climb route (`/(tabs)/climbs/create`) for remix / edit.
+ *
+ * Remix and Edit can fire from INSIDE the player (`/play`, a `transparentModal` in the
+ * ROOT stack). The create route is another `transparentModal`, but it lives in the
+ * CLIMBS-TAB stack — a different navigator, mounted BENEATH the root modal. Pushing it
+ * while the player is up therefore stacks create under the still-live player: two
+ * drawers, and create's bottom sheet strands over the search list once you navigate
+ * away. So dismiss the player first, mirroring `handleSwitchBoardFromDrawer`
+ * (drawer-host-provider) — the same `router.dismiss()` → `router.push()` shape.
+ *
+ * The reaction menu that hosts Remix/Edit also opens from the climbs list and the board
+ * sheet, and on an iPad regular-width layout the player renders in the detail PANE
+ * rather than the `/play` route. Neither has a modal to close, so gate the dismiss on
+ * `isPlayerRoute` — otherwise we'd pop the wrong screen.
+ */
+export function useCreateClimbNavigation() {
+  const router = useRouter();
+  const segments = useSegments();
+  // `useSegments()` hands back a fresh array on every navigation. Reading it from a ref
+  // inside the callback — rather than listing it as a dep — keeps `navigateToCreate` /
+  // `openRemix` / `openEdit` referentially stable, so `useClimbActions`' memoised action
+  // list doesn't rebuild on every navigation. Only ever read from an event handler, well
+  // after render, so the ref is never stale at the point of use.
+  const segmentsRef = useRef(segments);
+  segmentsRef.current = segments;
+
+  const navigateToCreate = useCallback(
+    (params: Record<string, string>) => {
+      if (isPlayerRoute(segmentsRef.current)) router.dismiss();
+      router.push({ pathname: '/(tabs)/climbs/create', params });
+    },
+    [router],
+  );
+
+  const openRemix = useCallback(
+    (climb: Climb, board: BoardConfig) =>
+      navigateToCreate({
+        forkFrames: climb.frames,
+        forkName: climb.name,
+        forkDescription: climb.description ?? '',
+        ...boardParams(board),
+      }),
+    [navigateToCreate],
+  );
+
+  const openEdit = useCallback(
+    (climb: Climb, board: BoardConfig) =>
+      navigateToCreate({
+        editClimbUuid: climb.uuid,
+        ...boardParams(board),
+      }),
+    [navigateToCreate],
+  );
+
+  return { navigateToCreate, openRemix, openEdit };
+}

--- a/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
@@ -30,6 +30,11 @@ function boardParams(board: BoardConfig): Record<string, string> {
  * sheet, and on an iPad regular-width layout the player renders in the detail PANE
  * rather than the `/play` route. Neither has a modal to close, so gate the dismiss on
  * `isPlayerRoute` — otherwise we'd pop the wrong screen.
+ *
+ * The back-to-back `dismiss()` + `push()` is not a race: both enqueue onto expo-router's
+ * single `routingQueue` (`POP` then the navigate), so they drain in order. And `dismiss()`
+ * only enqueues — unlike `goBack()` it does not `assertIsReady()` — so an over-eager gate
+ * would pop a screen, never throw.
  */
 export function useCreateClimbNavigation() {
   const router = useRouter();

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -379,16 +379,16 @@ export function useCreateClimbScreen({
   // report, and the BLE auto-sender reads it to tell a board/layout "spill" from a
   // sendable climb. Omitting it left a freshly created climb board-less on the wire —
   // peers received a climb they couldn't place, and the presence row lost its board.
-  // Carry the create board plus the rest of the climb's identity so a just-saved climb
-  // is as complete a queue item as a searched one.
+  //
+  // Only fields `climbToQueueItem` actually forwards are set here; adding ones it
+  // strips (userId / description / mirrored / is_draft) would be dead weight until
+  // that boundary and both subscription selection sets widen together.
   const buildProvisionalClimb = useCallback(
     (uuid: string, frames: string): Climb => ({
       uuid,
       boardType: board.boardName,
       layoutId: board.layoutId,
-      userId: profile?.id ?? null,
       name: name.trim() || t('createClimbForm.draftBadge'),
-      description: withNoMatch(description, noMatch),
       frames,
       setter_username: profile?.displayName ?? '',
       angle: board.angle,
@@ -398,16 +398,14 @@ export function useCreateClimbScreen({
       stars: 0,
       difficulty_error: '0',
       benchmark_difficulty: null,
-      mirrored: false,
       is_no_match: noMatch,
-      is_draft: isDraft,
       userAscents: 0,
       userAttempts: 0,
       // The editor emits a single static frame (no multi-frame playback).
       framesCount: 1,
       framesPace: null,
     }),
-    [name, description, noMatch, isDraft, profile, board.angle, board.boardName, board.layoutId, t],
+    [name, noMatch, profile, board.angle, board.boardName, board.layoutId, t],
   );
 
   // Push the freshly saved climb into the queue as the current climb so the

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -373,10 +373,22 @@ export function useCreateClimbScreen({
   // climb. The mutation input (`ClimbInput`) is a strict subset of Climb, so
   // these placeholder grade fields are never sent to the server — they only
   // satisfy the type and render neutral values in the queue UI.
+  //
+  // Board identity (boardType/layoutId) is required, not optional: the queue item
+  // round-trips through `toClimbInput` to party peers and into the board-presence
+  // report, and the BLE auto-sender reads it to tell a board/layout "spill" from a
+  // sendable climb. Omitting it left a freshly created climb board-less on the wire —
+  // peers received a climb they couldn't place, and the presence row lost its board.
+  // Carry the create board plus the rest of the climb's identity so a just-saved climb
+  // is as complete a queue item as a searched one.
   const buildProvisionalClimb = useCallback(
     (uuid: string, frames: string): Climb => ({
       uuid,
+      boardType: board.boardName,
+      layoutId: board.layoutId,
+      userId: profile?.id ?? null,
       name: name.trim() || t('createClimbForm.draftBadge'),
+      description: withNoMatch(description, noMatch),
       frames,
       setter_username: profile?.displayName ?? '',
       angle: board.angle,
@@ -386,8 +398,16 @@ export function useCreateClimbScreen({
       stars: 0,
       difficulty_error: '0',
       benchmark_difficulty: null,
+      mirrored: false,
+      is_no_match: noMatch,
+      is_draft: isDraft,
+      userAscents: 0,
+      userAttempts: 0,
+      // The editor emits a single static frame (no multi-frame playback).
+      framesCount: 1,
+      framesPace: null,
     }),
-    [name, profile, board.angle, t],
+    [name, description, noMatch, isDraft, profile, board.angle, board.boardName, board.layoutId, t],
   );
 
   // Push the freshly saved climb into the queue as the current climb so the

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -74,6 +74,14 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       name: climb.name,
       frames: climb.frames,
       setter_username: climb.setter_username,
+      // Ownership + draft state. `toClimbInput` sends all five on to party peers, and
+      // the climb-actions menu gates its owner-only Edit action on `userId` — but they
+      // were being stripped here, at the queue boundary, so a queued climb lost them.
+      userId: climb.userId,
+      description: climb.description,
+      mirrored: climb.mirrored,
+      is_draft: climb.is_draft,
+      published_at: climb.published_at,
       angle: climb.angle,
       ascensionist_count: climb.ascensionist_count,
       difficulty: climb.difficulty,

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -74,14 +74,13 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       name: climb.name,
       frames: climb.frames,
       setter_username: climb.setter_username,
-      // Ownership + draft state. `toClimbInput` sends all five on to party peers, and
-      // the climb-actions menu gates its owner-only Edit action on `userId` — but they
-      // were being stripped here, at the queue boundary, so a queued climb lost them.
-      userId: climb.userId,
-      description: climb.description,
-      mirrored: climb.mirrored,
-      is_draft: climb.is_draft,
-      published_at: climb.published_at,
+      // NOTE: userId / description / mirrored / is_draft / published_at are deliberately
+      // NOT carried here yet. `toClimbInput` would send them to party peers, but the
+      // subscription selection set (SUBSCRIPTION_CLIMB_FIELDS in lib/graphql/operations.ts,
+      // and web's CLIMB_FIELDS) doesn't select them, so peers would rebuild the climb
+      // without them and the next peer-side setQueue would write the gap back. Widening
+      // this boundary has to land together with both selection sets and
+      // `toClimbQueueItem` — see the follow-up issue.
       angle: climb.angle,
       ascensionist_count: climb.ascensionist_count,
       difficulty: climb.difficulty,

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -80,7 +80,7 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       // and web's CLIMB_FIELDS) doesn't select them, so peers would rebuild the climb
       // without them and the next peer-side setQueue would write the gap back. Widening
       // this boundary has to land together with both selection sets and
-      // `toClimbQueueItem` — see the follow-up issue.
+      // `toClimbQueueItem` — see #3927.
       angle: climb.angle,
       ascensionist_count: climb.ascensionist_count,
       difficulty: climb.difficulty,


### PR DESCRIPTION
## Summary

Rebuilt on current `main`. The branch was ~3 weeks and 1176 commits behind, and one of its three original claims has since been fixed on `main` by a different, documented mechanism — so this PR is now the two fixes that are still real.

**Dropped: "action sheets flash open and close over the player."** `main` already fixes this with the in-tree opener override pattern (`onTick` / `onAddBetaVideo` threaded from `PlayDrawer`, plus a structurally inline-only playlist picker — #3452, #3902, `4c90de6b8`, `83f239477`). The old approach here (a `DeferredSheetHost` + `registerExternal` claim on `DrawerHostProvider`) was a competing second solution to the same problem and is gone. `docs/mobile-sheets-vs-routes.md` documents the surviving one.

### Remix / Edit from the player opened two drawers

Both `/play` and `/(tabs)/climbs/create` are `transparentModal`s, but in **different navigators** — the player is in the root stack, create is in the climbs-tab stack mounted beneath it. The fork/edit handlers pushed create without dismissing the player, so create stacked *under* the still-live player, and `CreateDrawer`'s root-window `BottomSheet` left a black scrim over the search list afterwards.

All create-climb navigation now goes through a new `useCreateClimbNavigation` hook: when the focused route is `/play` it dismisses the player first (mirroring `handleSwitchBoardFromDrawer`), then pushes. Gated on `isPlayerRoute`, so remix/edit from the climbs list, the board sheet, or the **iPad detail-pane player** (not a route at all) still opens create without popping the wrong screen. `useSegments()` is mirrored into a ref rather than listed as a dep — it returns a fresh array per navigation, which would otherwise churn the callbacks and rebuild `useClimbActions`' memoised action list on every nav.

### New climbs carried no board identity

`buildProvisionalClimb` omitted `boardType`/`layoutId`, so a just-created climb went board-less through `toClimbInput` to BLE party peers and into the board-presence report. It now carries the create board, plus the no-match flag, ascent counters, and the single-frame playback metadata the editor actually produces.

**Not claimed:** this does *not* explain "a fresh remix wouldn't light the wall". The spill guard treats a nullish board as sendable (`queue-conversion.ts:18-19`), so the local BLE send was never blocked by the missing board. This is a party-peer / board-presence correctness fix.

**Scope corrected mid-review.** An earlier revision of this branch also carried `userId` / `description` / `mirrored` / `is_draft` / `published_at` through `climbToQueueItem`. A paired QA review caught that this is actively harmful: neither subscription selection set (mobile `SUBSCRIPTION_CLIMB_FIELDS`, web `CLIMB_FIELDS`) selects those fields, so a peer rebuilds the climb without them and that peer's next `setQueue` writes the gap back over the creator's copy. Today they're never populated, so there's nothing to lose — populating one side alone is what creates the flapping. Fixing it properly means moving both selection sets, `toClimbQueueItem`, and web's equivalent together, which is a cross-platform change to the live party-mode wire format and doesn't belong here. Reverted, and filed as **#3927**. The queue test now asserts those five are still absent, so the boundary can't be widened by halves without someone reading why.

Board identity itself is unaffected by that revert: `boardType`/`layoutId` were already forwarded by `climbToQueueItem` *and* already in both subscription selection sets, so a fresh remix reaches peers with its board either way.

Adjacent but not claimed: #3804 (Crash feedback: Remixing climb) — no crash log, 4s app uptime. This PR removes a two-stacked-`transparentModal` state that's a plausible contributor, but nothing here is a proven crash fix. Left open.

## Release Notes

- Remix or edit a climb straight from the player without ending up with two stacked drawers — it closes the player and drops you into the create screen, pre-filled, with no leftover black panel over your search.
- A climb you just set now carries its board with it, so the rest of your crew sees it on the right wall.

## Test plan

- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — 544 files, 4493 tests passed.
- `vp run check:mobile-bundle` — iOS + Android bundles OK.
- `vp check` — lint + format clean (the one reported file, `packages/mobile/public/index.html`, is pre-existing drift on `main` and untouched here).

Both fixes were mutation-tested — the tests fail when the fix is reverted:

- Removing `boardType`/`layoutId` from `buildProvisionalClimb` fails 3 tests in `use-create-climb-screen-queue.test.tsx`.
- Removing the `router.dismiss()` fails 5 tests across all three layers (hook, `useClimbActions`, `ClimbActionsSheet`).

`use-create-climb-screen-queue.test.tsx` deliberately runs the **real** `climbToQueueItem`. Every other create-screen test mocks it as a pass-through, which would let the suite pass on a provisional climb whose fields never actually survive the queue boundary — so the assertions would prove nothing about what a peer receives.

Reviewed by a paired QA agent, which caught the wire-asymmetry defect described above (now #3927) and a stale doc precedent. Two of its findings I verified and closed out directly from expo-router source: `useSegments()` reads `global-state/useRouteInfo`, so it's global rather than mount-position-dependent (the root-mounted `ClimbReactionMenu` correctly sees `['play']`), and `dismiss()`/`push()` both enqueue on the same FIFO `routingQueue`, so their ordering is guaranteed by construction rather than by luck.

## Device QA checklist

JS-only, so this rides OTA. Please exercise all five — **gates 1 and 3 are the ones that can actually fail**; the rest are regression cover.

- [ ] **1. iPhone, player up (the risky one).** Open a climb in the player, then the ⋯ menu, then Remix. Expect: player closes, **one** create drawer, pre-filled `<name> remix`; backing out to search shows **no stranded black scrim**. Repeat via long-press then reaction menu then Remix, and via Edit on your own draft. *Why it can fail: `router.dismiss()` now fires while the reaction menu's `FullWindowOverlay` is still animating out. If it flickers or the dismiss is swallowed, the fix is a one-frame `requestAnimationFrame` defer.*
- [ ] **2. iPhone, no player.** Remix from the climbs list and from the board sheet — create opens normally and nothing else gets popped.
- [ ] **3. iPad, regular width (the other risky one).** The player renders in the detail **pane**, not the `/play` route, so no dismiss should fire. Remix from the pane — create opens in the content pane and the pane does **not** collapse. *Why it can fail: if the focused segments read as `play` in the pane layout, we would dismiss something we should not.*
- [ ] **4. Android.** Same flows as 1 and 2 — different modal implementation, and the reaction menu is an RN `<Modal>` overlay there rather than a `FullWindowOverlay`.
- [ ] **5. Party session, board identity.** Publish a remix on device A with a peer on device B. Confirm B receives the climb with its board (not board-less) and the presence row keeps its board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5bJnf8akrg4rpRKb5Y1vL
