### PR TITLE
feat(shared): add shared queue sync gate

### DIFF
--- a/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createQueueSyncGate,
+  hasContiguousReplayCoverage,
+  RESYNC_LOOP_THRESHOLD,
+  CORRUPTION_RESYNC_COOLDOWN_MS,
+  type QueueSyncGateEvent,
+} from '../sync-gate';
+
+function fullSync(sequence: number, stateHash: string): QueueSyncGateEvent {
+  return { __typename: 'FullSync', sequence, stateHash };
+}
+
+function delta(typename: string, sequence: number, stateHash: string): QueueSyncGateEvent {
+  return { __typename: typename, sequence, stateHash };
+}
+
+function playbackStateChanged(sequence: number): QueueSyncGateEvent {
+  return { __typename: 'PlaybackStateChanged', sequence };
+}
+
+describe('createQueueSyncGate', () => {
+  describe('evaluateIncoming / noteApplied', () => {
+    it('applies the first event unconditionally (lastSequence starts null)', () => {
+      const gate = createQueueSyncGate();
+      expect(gate.evaluateIncoming(delta('QueueItemAdded', 1, 'hash-1'))).toBe('apply');
+    });
+
+    it('applies in-order events and advances tracking via noteApplied', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 1, 'hash-1');
+      expect(gate.evaluateIncoming(first)).toBe('apply');
+      gate.noteApplied(first);
+      expect(gate.getLastSequence()).toBe(1);
+
+      const second = delta('QueueItemRemoved', 2, 'hash-2');
+      expect(gate.evaluateIncoming(second)).toBe('apply');
+      gate.noteApplied(second);
+      expect(gate.getLastSequence()).toBe(2);
+    });
+
+    it('ignores a stale duplicate event (sequence <= lastSequence)', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 5, 'hash-5');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+
+      expect(gate.evaluateIncoming(delta('QueueItemAdded', 5, 'hash-5'))).toBe('ignore-stale');
+      expect(gate.evaluateIncoming(delta('QueueItemAdded', 3, 'hash-3'))).toBe('ignore-stale');
+      // Tracking is untouched by ignored events.
+      expect(gate.getLastSequence()).toBe(5);
+    });
+
+    it('detects a sequence gap and reports resync-gap without advancing tracking', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 1, 'hash-1');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+
+      // Jump straight to sequence 5 — a gap of missed events 2,3,4.
+      expect(gate.evaluateIncoming(delta('QueueItemAdded', 5, 'hash-5'))).toBe('resync-gap');
+      expect(gate.getLastSequence()).toBe(1);
+    });
+
+    it('FullSync always applies and resets tracking to the FullSync payload, even after a gap', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 1, 'hash-1');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+
+      // A gap would normally block further deltas...
+      expect(gate.evaluateIncoming(delta('QueueItemAdded', 9, 'hash-9'))).toBe('resync-gap');
+
+      // ...but a FullSync always applies and re-baselines tracking.
+      expect(gate.evaluateIncoming(fullSync(20, 'hash-20'))).toBe('apply');
+      expect(gate.getLastSequence()).toBe(20);
+
+      // Subsequent deltas are now sequenced against the FullSync's baseline.
+      const next = delta('QueueItemAdded', 21, 'hash-21');
+      expect(gate.evaluateIncoming(next)).toBe('apply');
+    });
+
+    it('FullSync resets tracking even as the very first event (no prior baseline)', () => {
+      const gate = createQueueSyncGate();
+      expect(gate.evaluateIncoming(fullSync(42, 'hash-42'))).toBe('apply');
+      expect(gate.getLastSequence()).toBe(42);
+    });
+
+    it('PlaybackStateChanged always applies and never advances sequence/hash tracking', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 1, 'hash-1');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+
+      // The server reuses the *current* sequence for playback events (no
+      // queue mutation happened), so this looks like a stale duplicate by
+      // sequence number alone — the gate must exempt it entirely.
+      expect(gate.evaluateIncoming(playbackStateChanged(1))).toBe('apply');
+      gate.noteApplied(playbackStateChanged(1));
+      expect(gate.getLastSequence()).toBe(1);
+
+      // A genuinely stale PlaybackStateChanged (lower sequence) still applies.
+      expect(gate.evaluateIncoming(playbackStateChanged(0))).toBe('apply');
+      expect(gate.getLastSequence()).toBe(1);
+
+      // The next real delta at sequence 2 is still contiguous — proves the
+      // playback event never silently occupied slot 2 or otherwise disturbed
+      // the sequence dedup gate for the *following* real event.
+      const next = delta('CurrentClimbChanged', 2, 'hash-2');
+      expect(gate.evaluateIncoming(next)).toBe('apply');
+    });
+  });
+
+  describe('verifyLocalHash', () => {
+    it('returns ok with no server hash tracked yet', () => {
+      const gate = createQueueSyncGate();
+      expect(gate.verifyLocalHash('anything')).toEqual({ verdict: 'ok', consecutiveResyncs: 0 });
+    });
+
+    it('returns ok when the local hash matches the tracked server hash', () => {
+      const gate = createQueueSyncGate();
+      const event = fullSync(1, 'hash-a');
+      gate.evaluateIncoming(event);
+
+      expect(gate.verifyLocalHash('hash-a')).toEqual({ verdict: 'ok', consecutiveResyncs: 0 });
+    });
+
+    it('escalates through resync-drift for the first RESYNC_LOOP_THRESHOLD mismatches, then backs off', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSync(1, 'server-hash'));
+
+      const results = Array.from({ length: RESYNC_LOOP_THRESHOLD + 2 }, () => gate.verifyLocalHash('local-hash'));
+
+      for (let strike = 0; strike < RESYNC_LOOP_THRESHOLD; strike++) {
+        expect(results[strike]).toEqual({ verdict: 'resync-drift', consecutiveResyncs: strike + 1 });
+      }
+      // Past the threshold: back off, but keep counting so the caller can see
+      // the loop is still ongoing.
+      expect(results[RESYNC_LOOP_THRESHOLD]).toEqual({
+        verdict: 'backoff',
+        consecutiveResyncs: RESYNC_LOOP_THRESHOLD + 1,
+      });
+      expect(results[RESYNC_LOOP_THRESHOLD + 1]).toEqual({
+        verdict: 'backoff',
+        consecutiveResyncs: RESYNC_LOOP_THRESHOLD + 2,
+      });
+    });
+
+    it('recovers immediately once the hashes agree, resetting the strike counter', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSync(1, 'server-hash'));
+
+      gate.verifyLocalHash('local-hash');
+      gate.verifyLocalHash('local-hash');
+      expect(gate.verifyLocalHash('server-hash')).toEqual({ verdict: 'ok', consecutiveResyncs: 0 });
+
+      // A subsequent mismatch against the *same* server hash starts a fresh
+      // streak at strike 1, not 3.
+      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 1 });
+    });
+
+    it('restarts the strike counter when the server hash itself changes mid-streak', () => {
+      const gate = createQueueSyncGate();
+      gate.evaluateIncoming(fullSync(1, 'server-hash-a'));
+
+      gate.verifyLocalHash('local-hash');
+      gate.verifyLocalHash('local-hash');
+      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 3 });
+
+      // Server hash changes (e.g. a delta landed) — new drift streak, even
+      // though the local hash is still mismatched.
+      const next = delta('QueueItemAdded', 2, 'server-hash-b');
+      gate.evaluateIncoming(next);
+      gate.noteApplied(next);
+
+      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 1 });
+    });
+  });
+
+  describe('evaluateCorruption', () => {
+    it('resyncs immediately on first corruption and starts a cooldown window', () => {
+      const currentTime = 1_000;
+      const gate = createQueueSyncGate({ now: () => currentTime });
+
+      expect(gate.evaluateCorruption()).toBe('resync');
+    });
+
+    it('reports cooldown for corruption detected within the cooldown window, then resync once it expires', () => {
+      let currentTime = 1_000;
+      const gate = createQueueSyncGate({ now: () => currentTime });
+
+      expect(gate.evaluateCorruption()).toBe('resync');
+
+      currentTime += CORRUPTION_RESYNC_COOLDOWN_MS - 1;
+      expect(gate.evaluateCorruption()).toBe('cooldown');
+
+      currentTime += 1;
+      expect(gate.evaluateCorruption()).toBe('resync');
+    });
+
+    it('defaults to Date.now when no clock is injected', () => {
+      const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(5_000);
+      try {
+        const gate = createQueueSyncGate();
+        expect(gate.evaluateCorruption()).toBe('resync');
+        expect(dateNowSpy).toHaveBeenCalled();
+      } finally {
+        dateNowSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('decideReconnectStrategy', () => {
+    it('full-syncs on first connection (lastSequence == null)', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: null,
+          serverSequence: 10,
+          serverStateHash: 'server-hash',
+          localStateHash: 'local-hash',
+        }),
+      ).toBe('full-sync');
+    });
+
+    it('does nothing when gap is 0 and hashes match', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 10,
+          serverStateHash: 'same-hash',
+          localStateHash: 'same-hash',
+        }),
+      ).toBe('none');
+    });
+
+    it('full-syncs when gap is 0 but hashes mismatch', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 10,
+          serverStateHash: 'server-hash',
+          localStateHash: 'local-hash',
+        }),
+      ).toBe('full-sync');
+    });
+
+    it('delta-replays for a small gap (1..100)', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 10,
+          serverSequence: 11,
+          serverStateHash: 'server-hash',
+          localStateHash: 'local-hash',
+        }),
+      ).toBe('delta-replay');
+
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 0,
+          serverSequence: 100,
+          serverStateHash: 'server-hash',
+          localStateHash: 'local-hash',
+        }),
+      ).toBe('delta-replay');
+    });
+
+    it('full-syncs when the gap exceeds 100', () => {
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 0,
+          serverSequence: 101,
+          serverStateHash: 'server-hash',
+          localStateHash: 'local-hash',
+        }),
+      ).toBe('full-sync');
+    });
+
+    it('does nothing when the server-reported sequence is behind the last one applied (negative gap)', () => {
+      // Matches web's current use-session-lifecycle.ts behaviour: none of
+      // the gap>0/gap>100/lastSeq===null/gap===0 branches fire for a
+      // negative gap, so the reconnect flow falls through with no resync.
+      const gate = createQueueSyncGate();
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: 50,
+          serverSequence: 40,
+          serverStateHash: 'server-hash',
+          localStateHash: 'local-hash',
+        }),
+      ).toBe('none');
+    });
+
+    it('is pure with respect to gate-tracked state — ignores getLastSequence() and only reads its input', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 5, 'hash-5');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+      expect(gate.getLastSequence()).toBe(5);
+
+      // Pass a completely different lastSequence than the gate's own
+      // tracked value — the decision must follow the explicit input.
+      expect(
+        gate.decideReconnectStrategy({
+          lastSequence: null,
+          serverSequence: 5,
+          serverStateHash: 'h',
+          localStateHash: 'h',
+        }),
+      ).toBe('full-sync');
+    });
+  });
+
+  describe('reset', () => {
+    it('clears sequence/hash tracking, the resync-loop counter, and the corruption cooldown', () => {
+      let currentTime = 1_000;
+      const gate = createQueueSyncGate({ now: () => currentTime });
+
+      const event = fullSync(10, 'server-hash');
+      gate.evaluateIncoming(event);
+      gate.verifyLocalHash('local-hash');
+      gate.verifyLocalHash('local-hash');
+      gate.evaluateCorruption();
+
+      gate.reset();
+
+      expect(gate.getLastSequence()).toBeNull();
+      // A fresh mismatch streak starts at strike 1 again, not continuing
+      // from 2.
+      const event2 = fullSync(1, 'server-hash-2');
+      gate.evaluateIncoming(event2);
+      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 1 });
+
+      // Corruption cooldown cleared too — an immediate check resyncs again
+      // rather than reporting cooldown.
+      currentTime += 1;
+      expect(gate.evaluateCorruption()).toBe('resync');
+    });
+
+    it('evaluateIncoming treats the next event as the first again after reset', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 1, 'hash-1');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+
+      gate.reset();
+
+      // Would have been ignore-stale before reset; now it's the first event.
+      expect(gate.evaluateIncoming(delta('QueueItemAdded', 1, 'hash-1'))).toBe('apply');
+    });
+  });
+});
+
+describe('hasContiguousReplayCoverage', () => {
+  // Scenario shapes ported from
+  // `packages/web/app/components/persistent-session/__tests__/session-lifecycle-replay.test.ts`,
+  // using a minimal `{ __typename, sequence }` shape since this function
+  // doesn't need the full event payload.
+  it('returns true immediately when currentSequence <= sinceSequence', () => {
+    expect(hasContiguousReplayCoverage([], 8, 8)).toBe(true);
+    expect(hasContiguousReplayCoverage([], 8, 5)).toBe(true);
+  });
+
+  it('rejects replay coverage with a missing sequence', () => {
+    const events = [
+      { __typename: 'QueueItemAdded', sequence: 6 },
+      { __typename: 'CurrentClimbChanged', sequence: 8 },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(false);
+  });
+
+  it('allows FullSync to cover earlier missing sequences and same-sequence controller events', () => {
+    const events = [
+      { __typename: 'FullSync', sequence: 8 },
+      { __typename: 'CurrentClimbChanged', sequence: 8 },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
+
+  it('handles reverse-order FullSync + same-sequence delta from the backend', () => {
+    const events = [
+      { __typename: 'CurrentClimbChanged', sequence: 8 },
+      { __typename: 'FullSync', sequence: 8 },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
+
+  it('handles QueueItemAdded co-sequenced with a FullSync (delta arrives first)', () => {
+    const events = [
+      { __typename: 'QueueItemAdded', sequence: 8 },
+      { __typename: 'FullSync', sequence: 8 },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
+
+  it('returns true for exactly-contiguous coverage across multiple deltas', () => {
+    const events = [
+      { __typename: 'QueueItemAdded', sequence: 6 },
+      { __typename: 'QueueItemRemoved', sequence: 7 },
+      { __typename: 'CurrentClimbChanged', sequence: 8 },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 8)).toBe(true);
+  });
+
+  it('returns false when a later FullSync leaves a gap before currentSequence', () => {
+    const events = [
+      { __typename: 'FullSync', sequence: 6 },
+      { __typename: 'QueueItemAdded', sequence: 7 },
+      // Missing sequence 8 and 9 — currentSequence is 10.
+      { __typename: 'CurrentClimbChanged', sequence: 10 },
+    ];
+
+    expect(hasContiguousReplayCoverage(events, 5, 10)).toBe(false);
+  });
+});

--- a/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/sync-gate.test.ts
@@ -20,10 +20,35 @@ function playbackStateChanged(sequence: number): QueueSyncGateEvent {
 }
 
 describe('createQueueSyncGate', () => {
+  it('pins the ported web constants so silent threshold drift fails a test', () => {
+    // These mirror web's RESYNC_LOOP_THRESHOLD (use-session-subscriptions.ts)
+    // and CORRUPTION_RESYNC_COOLDOWN_MS (persistent-session/types.ts). The
+    // behavioral tests below derive from the exported constants, so without
+    // this pin a 3→5 or 30s→10s change would still pass everything.
+    expect(RESYNC_LOOP_THRESHOLD).toBe(3);
+    expect(CORRUPTION_RESYNC_COOLDOWN_MS).toBe(30_000);
+  });
+
   describe('evaluateIncoming / noteApplied', () => {
     it('applies the first event unconditionally (lastSequence starts null)', () => {
       const gate = createQueueSyncGate();
       expect(gate.evaluateIncoming(delta('QueueItemAdded', 1, 'hash-1'))).toBe('apply');
+    });
+
+    it('bypasses the gate for a delta with no sequence number (never ignore-stale)', () => {
+      const gate = createQueueSyncGate();
+      const first = delta('QueueItemAdded', 5, 'hash-5');
+      gate.evaluateIncoming(first);
+      gate.noteApplied(first);
+
+      // A caller whose subscription doesn't select `sequence` must not have
+      // its events coerced to 0 and dropped as stale after the first one.
+      const unsequenced: QueueSyncGateEvent = { __typename: 'QueueItemAdded' };
+      expect(gate.evaluateIncoming(unsequenced)).toBe('apply');
+      expect(gate.evaluateIncoming(unsequenced)).toBe('apply');
+      // Tracking is untouched — noteApplied has nothing to advance with.
+      gate.noteApplied(unsequenced);
+      expect(gate.getLastSequence()).toBe(5);
     });
 
     it('applies in-order events and advances tracking via noteApplied', () => {
@@ -114,7 +139,7 @@ describe('createQueueSyncGate', () => {
   describe('verifyLocalHash', () => {
     it('returns ok with no server hash tracked yet', () => {
       const gate = createQueueSyncGate();
-      expect(gate.verifyLocalHash('anything')).toEqual({ verdict: 'ok', consecutiveResyncs: 0 });
+      expect(gate.verifyLocalHash('anything')).toEqual({ verdict: 'ok', consecutiveResyncs: 0, serverHash: null });
     });
 
     it('returns ok when the local hash matches the tracked server hash', () => {
@@ -122,7 +147,7 @@ describe('createQueueSyncGate', () => {
       const event = fullSync(1, 'hash-a');
       gate.evaluateIncoming(event);
 
-      expect(gate.verifyLocalHash('hash-a')).toEqual({ verdict: 'ok', consecutiveResyncs: 0 });
+      expect(gate.verifyLocalHash('hash-a')).toEqual({ verdict: 'ok', consecutiveResyncs: 0, serverHash: 'hash-a' });
     });
 
     it('escalates through resync-drift for the first RESYNC_LOOP_THRESHOLD mismatches, then backs off', () => {
@@ -132,17 +157,23 @@ describe('createQueueSyncGate', () => {
       const results = Array.from({ length: RESYNC_LOOP_THRESHOLD + 2 }, () => gate.verifyLocalHash('local-hash'));
 
       for (let strike = 0; strike < RESYNC_LOOP_THRESHOLD; strike++) {
-        expect(results[strike]).toEqual({ verdict: 'resync-drift', consecutiveResyncs: strike + 1 });
+        expect(results[strike]).toEqual({
+          verdict: 'resync-drift',
+          consecutiveResyncs: strike + 1,
+          serverHash: 'server-hash',
+        });
       }
       // Past the threshold: back off, but keep counting so the caller can see
       // the loop is still ongoing.
       expect(results[RESYNC_LOOP_THRESHOLD]).toEqual({
         verdict: 'backoff',
         consecutiveResyncs: RESYNC_LOOP_THRESHOLD + 1,
+        serverHash: 'server-hash',
       });
       expect(results[RESYNC_LOOP_THRESHOLD + 1]).toEqual({
         verdict: 'backoff',
         consecutiveResyncs: RESYNC_LOOP_THRESHOLD + 2,
+        serverHash: 'server-hash',
       });
     });
 
@@ -152,11 +183,19 @@ describe('createQueueSyncGate', () => {
 
       gate.verifyLocalHash('local-hash');
       gate.verifyLocalHash('local-hash');
-      expect(gate.verifyLocalHash('server-hash')).toEqual({ verdict: 'ok', consecutiveResyncs: 0 });
+      expect(gate.verifyLocalHash('server-hash')).toEqual({
+        verdict: 'ok',
+        consecutiveResyncs: 0,
+        serverHash: 'server-hash',
+      });
 
       // A subsequent mismatch against the *same* server hash starts a fresh
       // streak at strike 1, not 3.
-      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 1 });
+      expect(gate.verifyLocalHash('local-hash')).toEqual({
+        verdict: 'resync-drift',
+        consecutiveResyncs: 1,
+        serverHash: 'server-hash',
+      });
     });
 
     it('restarts the strike counter when the server hash itself changes mid-streak', () => {
@@ -165,15 +204,25 @@ describe('createQueueSyncGate', () => {
 
       gate.verifyLocalHash('local-hash');
       gate.verifyLocalHash('local-hash');
-      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 3 });
+      expect(gate.verifyLocalHash('local-hash')).toEqual({
+        verdict: 'resync-drift',
+        consecutiveResyncs: 3,
+        serverHash: 'server-hash-a',
+      });
 
       // Server hash changes (e.g. a delta landed) — new drift streak, even
-      // though the local hash is still mismatched.
+      // though the local hash is still mismatched. The reported serverHash
+      // follows the gate's tracking so a wired Sentry report never needs a
+      // parallel copy of it.
       const next = delta('QueueItemAdded', 2, 'server-hash-b');
       gate.evaluateIncoming(next);
       gate.noteApplied(next);
 
-      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 1 });
+      expect(gate.verifyLocalHash('local-hash')).toEqual({
+        verdict: 'resync-drift',
+        consecutiveResyncs: 1,
+        serverHash: 'server-hash-b',
+      });
     });
   });
 
@@ -333,7 +382,11 @@ describe('createQueueSyncGate', () => {
       // from 2.
       const event2 = fullSync(1, 'server-hash-2');
       gate.evaluateIncoming(event2);
-      expect(gate.verifyLocalHash('local-hash')).toEqual({ verdict: 'resync-drift', consecutiveResyncs: 1 });
+      expect(gate.verifyLocalHash('local-hash')).toEqual({
+        verdict: 'resync-drift',
+        consecutiveResyncs: 1,
+        serverHash: 'server-hash-2',
+      });
 
       // Corruption cooldown cleared too — an immediate check resyncs again
       // rather than reporting cooldown.

--- a/packages/shared/queue-runtime/src/index.ts
+++ b/packages/shared/queue-runtime/src/index.ts
@@ -23,3 +23,21 @@ export type {
   RuntimeSessionState,
   RuntimeSessionUser,
 } from './session-events';
+
+export {
+  createQueueSyncGate,
+  hasContiguousReplayCoverage,
+  RESYNC_LOOP_THRESHOLD,
+  CORRUPTION_RESYNC_COOLDOWN_MS,
+} from './sync-gate';
+export type {
+  QueueSyncGate,
+  QueueSyncGateOptions,
+  QueueSyncGateEvent,
+  IncomingEventDecision,
+  HashVerifyVerdict,
+  HashVerifyResult,
+  CorruptionVerdict,
+  ReconnectStrategy,
+  ReconnectStrategyInput,
+} from './sync-gate';

--- a/packages/shared/queue-runtime/src/subscription-adapter.ts
+++ b/packages/shared/queue-runtime/src/subscription-adapter.ts
@@ -23,6 +23,11 @@ import {
  * conventions are accepted: `addedItem`/`item` on QueueItemAdded,
  * `currentItem`/`item` on CurrentClimbChanged, `mirroredUuid`/`uuid` on
  * ClimbMirrored.
+ *
+ * `sequence`/`stateHash` are optional on every variant so callers can pass
+ * the same envelope through `@boardsesh/queue-runtime`'s `createQueueSyncGate`
+ * (see `sync-gate.ts`) for resync decisions before lifting it to a reducer
+ * action here. Additive — existing callers that omit them are unaffected.
  */
 export type SubscriptionWireEnvelope<TWireItem> =
   | {
@@ -31,22 +36,30 @@ export type SubscriptionWireEnvelope<TWireItem> =
         queue: TWireItem[];
         currentClimbQueueItem: TWireItem | null;
       };
+      sequence?: number | null;
+      stateHash?: string | null;
     }
   | {
       __typename: 'QueueItemAdded';
       addedItem?: TWireItem;
       item?: TWireItem;
       position?: number | null;
+      sequence?: number | null;
+      stateHash?: string | null;
     }
   | {
       __typename: 'QueueItemRemoved';
       uuid: string;
+      sequence?: number | null;
+      stateHash?: string | null;
     }
   | {
       __typename: 'QueueReordered';
       uuid: string;
       oldIndex: number;
       newIndex: number;
+      sequence?: number | null;
+      stateHash?: string | null;
     }
   | {
       __typename: 'CurrentClimbChanged';
@@ -54,12 +67,16 @@ export type SubscriptionWireEnvelope<TWireItem> =
       item?: TWireItem | null;
       clientId?: string | null;
       correlationId?: string | null;
+      sequence?: number | null;
+      stateHash?: string | null;
     }
   | {
       __typename: 'ClimbMirrored';
       mirrored: boolean;
       mirroredUuid?: string | null;
       uuid?: string | null;
+      sequence?: number | null;
+      stateHash?: string | null;
     };
 
 export type MapEnvelopeOptions<TWireItem> = {

--- a/packages/shared/queue-runtime/src/sync-gate.ts
+++ b/packages/shared/queue-runtime/src/sync-gate.ts
@@ -65,6 +65,12 @@ export type HashVerifyResult = {
    *  streak by checking `consecutiveResyncs === RESYNC_LOOP_THRESHOLD`
    *  (the same one-shot point `use-session-subscriptions.ts` reports at). */
   consecutiveResyncs: number;
+  /** The server hash the local hash was compared against (the gate's tracked
+   *  `lastServerStateHash`), or `null` when nothing was tracked yet. Web's
+   *  Sentry drift report includes it (`use-session-subscriptions.ts:150-160`)
+   *  — returning it here keeps callers from mirroring the exact value the
+   *  gate exists to own. */
+  serverHash: string | null;
 };
 
 export type CorruptionVerdict = 'resync' | 'cooldown';
@@ -156,6 +162,9 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
     if (event.sequence != null) {
       lastSequence = event.sequence;
     }
+    // Skipping a null stateHash diverges (unreachably, with current web
+    // types — every gated delta carries a non-null stateHash) from web's
+    // unconditional `setLastReceivedStateHash(event.stateHash)` assignment.
     if (event.stateHash != null) {
       lastServerStateHash = event.stateHash;
     }
@@ -173,7 +182,16 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
         return 'apply';
       }
 
-      const sequenceDecision = evaluateQueueEventSequence(lastSequence, event.sequence ?? 0);
+      // A delta with no sequence number can't be sequence-gated: coercing
+      // null to 0 would classify every such event after the first as
+      // 'ignore-stale' and silently drop it (e.g. a mobile caller whose
+      // subscription doesn't select `sequence`). Bypass the gate instead —
+      // an ungated apply matches the pre-gate behaviour for such callers.
+      if (event.sequence == null) {
+        return 'apply';
+      }
+
+      const sequenceDecision = evaluateQueueEventSequence(lastSequence, event.sequence);
       if (sequenceDecision === 'ignore-stale') {
         return 'ignore-stale';
       }
@@ -196,7 +214,7 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
         // counter so future drift starts fresh.
         resyncLoopHash = null;
         consecutiveResyncCount = 0;
-        return { verdict: 'ok', consecutiveResyncs: 0 };
+        return { verdict: 'ok', consecutiveResyncs: 0, serverHash: lastServerStateHash };
       }
 
       if (resyncLoopHash === lastServerStateHash) {
@@ -207,7 +225,7 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
       }
 
       const verdict: HashVerifyVerdict = consecutiveResyncCount <= RESYNC_LOOP_THRESHOLD ? 'resync-drift' : 'backoff';
-      return { verdict, consecutiveResyncs: consecutiveResyncCount };
+      return { verdict, consecutiveResyncs: consecutiveResyncCount, serverHash: lastServerStateHash };
     },
 
     evaluateCorruption() {
@@ -227,6 +245,9 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
 
       const gap = serverSequence - lastSeq;
 
+      // NOTE: web's original delta-replay branch also required a truthy
+      // sessionId (falsy → no resync at all); the wiring workstream must
+      // handle missing-sessionId itself before acting on 'delta-replay'.
       if (gap > 0 && gap <= 100) {
         return 'delta-replay';
       }
@@ -253,6 +274,9 @@ export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSy
       lastServerStateHash = null;
       resyncLoopHash = null;
       consecutiveResyncCount = 0;
+      // Deliberate per-session scoping: web's `lastCorruptionResyncRef`
+      // survived session changes (it lived in the provider, not the
+      // lifecycle effect), but a fresh session deserves a fresh cooldown.
       lastCorruptionResyncAt = Number.NEGATIVE_INFINITY;
     },
 

--- a/packages/shared/queue-runtime/src/sync-gate.ts
+++ b/packages/shared/queue-runtime/src/sync-gate.ts
@@ -1,0 +1,316 @@
+// Pure "resync decider" for queue subscription sync. One shared module both
+// web and mobile will adopt in a later workstream — this file only creates
+// the decider + tests; wiring it into either platform's hooks is out of
+// scope here.
+//
+// Web currently spreads five overlapping resync triggers across
+// `packages/web/app/components/persistent-session/hooks/*`. This module
+// ports their exact decision logic (not the React/effect plumbing around
+// them) so both platforms can share one source of truth:
+//
+//   1. Sequence-gap detection on incoming queue events (`evaluateIncoming` +
+//      `noteApplied`) — ported from `use-event-processor.ts:80-213`.
+//   2. Corrupted-item detection with a cooldown (`evaluateCorruption`) —
+//      ported from `use-session-subscriptions.ts:55-96`.
+//   3. Periodic local-vs-server hash verification with 3-strike backoff
+//      (`verifyLocalHash`) — ported from `use-session-subscriptions.ts:98-180`.
+//   4. Reconnect strategy selection: none / delta-replay / full-sync
+//      (`decideReconnectStrategy`) — ported from
+//      `use-session-lifecycle.ts:519-609`.
+//   5. Replay-coverage validation (`hasContiguousReplayCoverage`) — MOVED
+//      verbatim from `use-session-lifecycle.ts:146-189`; web now re-exports
+//      it from here instead of defining it locally.
+//
+// Closure-factory style matching `createJoinSessionTracker` in
+// `ensure-joined.ts`: no React, no DOM, no timers of its own. Callers own
+// their `setInterval`/effect wiring (and, for `verifyLocalHash`, their own
+// Sentry reporting) and just ask the gate what to do next.
+
+import { evaluateQueueEventSequence } from '@boardsesh/queue';
+
+/** Same threshold as the web watchdog: once a local hash mismatch has
+ *  triggered this many consecutive resyncs against the *same* server hash
+ *  without the drift resolving, back off instead of resyncing forever
+ *  (the resync itself is a server-side no-op once this happens — see
+ *  `use-session-subscriptions.ts:160-166` / issue #2359). */
+export const RESYNC_LOOP_THRESHOLD = 3;
+
+/** Minimum time between corruption-triggered resyncs. Mirrors
+ *  `CORRUPTION_RESYNC_COOLDOWN_MS` in
+ *  `packages/web/app/components/persistent-session/types.ts`. Duplicated
+ *  (not imported) — shared packages must not depend on `packages/web`. */
+export const CORRUPTION_RESYNC_COOLDOWN_MS = 30_000;
+
+/**
+ * Flattened incoming-event envelope the gate reasons about. Callers flatten
+ * their richer wire types into this shape before calling `evaluateIncoming`/
+ * `noteApplied` — e.g. for `FullSync`, pass `stateHash: event.state.stateHash`
+ * since the real wire event nests it under `state`; `PlaybackStateChanged`
+ * naturally has no `stateHash` to pass since it doesn't mutate the queue.
+ */
+export type QueueSyncGateEvent = {
+  __typename: string;
+  sequence?: number | null;
+  stateHash?: string | null;
+};
+
+export type IncomingEventDecision = 'apply' | 'ignore-stale' | 'resync-gap';
+
+export type HashVerifyVerdict = 'ok' | 'resync-drift' | 'backoff';
+
+export type HashVerifyResult = {
+  verdict: HashVerifyVerdict;
+  /** Consecutive mismatches against the current server hash; `0` when
+   *  `verdict` is `'ok'`. A caller reports to Sentry exactly once per drift
+   *  streak by checking `consecutiveResyncs === RESYNC_LOOP_THRESHOLD`
+   *  (the same one-shot point `use-session-subscriptions.ts` reports at). */
+  consecutiveResyncs: number;
+};
+
+export type CorruptionVerdict = 'resync' | 'cooldown';
+
+export type ReconnectStrategy = 'none' | 'delta-replay' | 'full-sync';
+
+export type ReconnectStrategyInput = {
+  lastSequence: number | null;
+  serverSequence: number;
+  serverStateHash: string;
+  localStateHash: string;
+};
+
+export type QueueSyncGateOptions = {
+  /** Injected clock for testability. Defaults to `Date.now`. */
+  now?: () => number;
+};
+
+export type QueueSyncGate = {
+  /**
+   * Sequence-gate an incoming queue event.
+   *
+   * `FullSync` always applies and resets sequence/hash tracking to the
+   * event's own values.
+   *
+   * `PlaybackStateChanged` is exempt: always `'apply'`, and never advances
+   * tracking. The server stamps it with the *current* sequence number (it
+   * doesn't mutate the queue, so the room manager doesn't bump) — routing it
+   * through the dedup gate below would mark every event after the first as
+   * stale and silently drop party-mode playback sync
+   * (`use-event-processor.ts:82-115`).
+   *
+   * All other event types are checked against the tracked `lastSequence`;
+   * call `noteApplied` after actually applying the resulting mutation to
+   * advance tracking (mirrors `use-event-processor.ts:199-207`, where the
+   * sequence/hash update happens *after* the switch that applies the delta).
+   */
+  evaluateIncoming(event: QueueSyncGateEvent): IncomingEventDecision;
+  /**
+   * Advance `lastSequence`/`lastServerStateHash` after the caller applied a
+   * delta event that `evaluateIncoming` returned `'apply'` for. No-op for
+   * `PlaybackStateChanged` (see `evaluateIncoming`).
+   */
+  noteApplied(event: QueueSyncGateEvent): void;
+  /**
+   * Periodic watchdog: compare a freshly computed local hash against the
+   * last known server hash. Tracks consecutive resyncs against the same
+   * server hash and backs off after `RESYNC_LOOP_THRESHOLD` strikes.
+   */
+  verifyLocalHash(localHash: string): HashVerifyResult;
+  /**
+   * Corrupted (null/undefined) queue item detected locally. Returns
+   * `'cooldown'` when a corruption-triggered resync already happened within
+   * the last `CORRUPTION_RESYNC_COOLDOWN_MS`, otherwise `'resync'` and starts
+   * a new cooldown window.
+   */
+  evaluateCorruption(): CorruptionVerdict;
+  /**
+   * Pick a reconnect strategy from a freshly rejoined session's sequence and
+   * hash vs. what this client last saw. Pure with respect to gate state — it
+   * only reads `input`, so callers can pass an explicit `lastSequence`
+   * snapshot rather than relying on `getLastSequence()`.
+   */
+  decideReconnectStrategy(input: ReconnectStrategyInput): ReconnectStrategy;
+  /** Clear all tracking. Call on session change or socket close. */
+  reset(): void;
+  /** Last sequence number tracked, or `null` before the first event/FullSync.
+   *  Web's offline reconciliation reads this. */
+  getLastSequence(): number | null;
+};
+
+export function createQueueSyncGate(options: QueueSyncGateOptions = {}): QueueSyncGate {
+  const clock = options.now ?? Date.now;
+
+  let lastSequence: number | null = null;
+  let lastServerStateHash: string | null = null;
+
+  let resyncLoopHash: string | null = null;
+  let consecutiveResyncCount = 0;
+
+  // Sentinel is -Infinity (not 0) so the *first* corruption check always
+  // resyncs regardless of the injected clock's starting value — web's
+  // `useRef<number>(0)` sentinel only works because real `Date.now()` epoch
+  // millis always dwarf the 30s cooldown, which doesn't hold for an
+  // arbitrary test clock starting near zero.
+  let lastCorruptionResyncAt = Number.NEGATIVE_INFINITY;
+
+  function advanceTracking(event: QueueSyncGateEvent): void {
+    if (event.sequence != null) {
+      lastSequence = event.sequence;
+    }
+    if (event.stateHash != null) {
+      lastServerStateHash = event.stateHash;
+    }
+  }
+
+  return {
+    evaluateIncoming(event) {
+      if (event.__typename === 'FullSync') {
+        lastSequence = event.sequence ?? null;
+        lastServerStateHash = event.stateHash ?? null;
+        return 'apply';
+      }
+
+      if (event.__typename === 'PlaybackStateChanged') {
+        return 'apply';
+      }
+
+      const sequenceDecision = evaluateQueueEventSequence(lastSequence, event.sequence ?? 0);
+      if (sequenceDecision === 'ignore-stale') {
+        return 'ignore-stale';
+      }
+      if (sequenceDecision === 'gap') {
+        return 'resync-gap';
+      }
+      return 'apply';
+    },
+
+    noteApplied(event) {
+      if (event.__typename === 'PlaybackStateChanged') {
+        return;
+      }
+      advanceTracking(event);
+    },
+
+    verifyLocalHash(localHash) {
+      if (lastServerStateHash === null || localHash === lastServerStateHash) {
+        // Hashes agree (or nothing to compare against yet) — reset the loop
+        // counter so future drift starts fresh.
+        resyncLoopHash = null;
+        consecutiveResyncCount = 0;
+        return { verdict: 'ok', consecutiveResyncs: 0 };
+      }
+
+      if (resyncLoopHash === lastServerStateHash) {
+        consecutiveResyncCount += 1;
+      } else {
+        resyncLoopHash = lastServerStateHash;
+        consecutiveResyncCount = 1;
+      }
+
+      const verdict: HashVerifyVerdict = consecutiveResyncCount <= RESYNC_LOOP_THRESHOLD ? 'resync-drift' : 'backoff';
+      return { verdict, consecutiveResyncs: consecutiveResyncCount };
+    },
+
+    evaluateCorruption() {
+      const nowMs = clock();
+      const elapsedMs = nowMs - lastCorruptionResyncAt;
+      if (elapsedMs < CORRUPTION_RESYNC_COOLDOWN_MS) {
+        return 'cooldown';
+      }
+      lastCorruptionResyncAt = nowMs;
+      return 'resync';
+    },
+
+    decideReconnectStrategy({ lastSequence: lastSeq, serverSequence, serverStateHash, localStateHash }) {
+      if (lastSeq === null) {
+        return 'full-sync';
+      }
+
+      const gap = serverSequence - lastSeq;
+
+      if (gap > 0 && gap <= 100) {
+        return 'delta-replay';
+      }
+      if (gap > 100) {
+        return 'full-sync';
+      }
+      if (gap === 0) {
+        return localStateHash !== serverStateHash ? 'full-sync' : 'none';
+      }
+
+      // gap < 0: the freshly rejoined session reports a sequence *behind*
+      // what this client already applied. Web's
+      // `use-session-lifecycle.ts:555-609` if/else-if chain has no branch
+      // for this case — `gap > 0 && gap <= 100` and `gap > 100` both fail
+      // (gap is negative), `lastSeq === null` fails (we're in the `else`
+      // already), and `gap === 0` fails too, so the chain falls straight
+      // through with no resync at all before `setSession`/resubscribe.
+      // Match that behaviour exactly instead of assuming a full-sync.
+      return 'none';
+    },
+
+    reset() {
+      lastSequence = null;
+      lastServerStateHash = null;
+      resyncLoopHash = null;
+      consecutiveResyncCount = 0;
+      lastCorruptionResyncAt = Number.NEGATIVE_INFINITY;
+    },
+
+    getLastSequence() {
+      return lastSequence;
+    },
+  };
+}
+
+/**
+ * Verify that a set of replay events gives contiguous coverage from
+ * `sinceSequence` (exclusive) through `currentSequence` (inclusive), with no
+ * gaps. MOVED verbatim from
+ * `packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts:146-189`
+ * — `use-session-lifecycle.ts` now imports this instead of defining it
+ * locally, so its existing tests keep passing unchanged.
+ */
+export function hasContiguousReplayCoverage<TEvent extends { __typename: string; sequence: number }>(
+  events: TEvent[],
+  sinceSequence: number,
+  currentSequence: number,
+): boolean {
+  if (currentSequence <= sinceSequence) {
+    return true;
+  }
+
+  let expectedSequence = sinceSequence + 1;
+  // FullSync and CurrentClimbChanged can share a sequence number when a
+  // controller-issued climb change races with a snapshot. Process FullSync
+  // first within a tie so the snapshot establishes the new expected sequence
+  // before the same-sequence delta is checked — otherwise the delta would
+  // fail the `event.sequence !== expectedSequence` invariant and we'd
+  // wrongly report a gap. We can't rely on sort stability for this — even
+  // with ECMAScript 2019's stable sort, the assertion still depends on the
+  // caller's insertion order, which is not contractual.
+  const sortedEvents = [...events].sort((a, b) => {
+    if (a.sequence !== b.sequence) return a.sequence - b.sequence;
+    if (a.__typename === 'FullSync' && b.__typename !== 'FullSync') return -1;
+    if (b.__typename === 'FullSync' && a.__typename !== 'FullSync') return 1;
+    return 0;
+  });
+
+  for (const event of sortedEvents) {
+    if (event.sequence < expectedSequence) {
+      continue;
+    }
+
+    if (event.__typename === 'FullSync') {
+      expectedSequence = event.sequence + 1;
+      continue;
+    }
+
+    if (event.sequence !== expectedSequence) {
+      return false;
+    }
+
+    expectedSequence++;
+  }
+
+  return expectedSequence > currentSequence;
+}

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -19,7 +19,11 @@ import {
   SESSION_UPDATES,
   EVENTS_REPLAY,
 } from '@boardsesh/graphql/operations/queue-session';
-import { applySessionRuntimeEvent, type RuntimeSessionEvent } from '@boardsesh/queue-runtime';
+import {
+  applySessionRuntimeEvent,
+  hasContiguousReplayCoverage,
+  type RuntimeSessionEvent,
+} from '@boardsesh/queue-runtime';
 import type {
   SubscriptionQueueEvent,
   SessionEvent,
@@ -143,50 +147,11 @@ export function applySessionEvent(prev: Session | null, event: SessionEvent): Se
   return runtimeEvent ? applySessionRuntimeEvent(prev, runtimeEvent, { coerceUser: coerceSessionUser }) : prev;
 }
 
-export function hasContiguousReplayCoverage(
-  events: SubscriptionQueueEvent[],
-  sinceSequence: number,
-  currentSequence: number,
-): boolean {
-  if (currentSequence <= sinceSequence) {
-    return true;
-  }
-
-  let expectedSequence = sinceSequence + 1;
-  // FullSync and CurrentClimbChanged can share a sequence number when a
-  // controller-issued climb change races with a snapshot. Process FullSync
-  // first within a tie so the snapshot establishes the new expected sequence
-  // before the same-sequence delta is checked — otherwise the delta would
-  // fail the `event.sequence !== expectedSequence` invariant and we'd
-  // wrongly report a gap. We can't rely on sort stability for this — even
-  // with ECMAScript 2019's stable sort, the assertion still depends on the
-  // caller's insertion order, which is not contractual.
-  const sortedEvents = [...events].sort((a, b) => {
-    if (a.sequence !== b.sequence) return a.sequence - b.sequence;
-    if (a.__typename === 'FullSync' && b.__typename !== 'FullSync') return -1;
-    if (b.__typename === 'FullSync' && a.__typename !== 'FullSync') return 1;
-    return 0;
-  });
-
-  for (const event of sortedEvents) {
-    if (event.sequence < expectedSequence) {
-      continue;
-    }
-
-    if (event.__typename === 'FullSync') {
-      expectedSequence = event.sequence + 1;
-      continue;
-    }
-
-    if (event.sequence !== expectedSequence) {
-      return false;
-    }
-
-    expectedSequence++;
-  }
-
-  return expectedSequence > currentSequence;
-}
+// `hasContiguousReplayCoverage` moved to
+// `@boardsesh/queue-runtime`'s `sync-gate.ts` (Workstream W2) so mobile can
+// share it too. Re-export the imported binding so existing importers of this
+// module (e.g. `session-lifecycle-replay.test.ts`) keep working unchanged.
+export { hasContiguousReplayCoverage };
 
 type UseSessionLifecycleArgs = {
   isAuthLoading: boolean;


### PR DESCRIPTION
## Summary

Workstream W2 of the multi-user-sessions improvement plan: creates one pure, shared "resync decider" (`createQueueSyncGate`) in `@boardsesh/queue-runtime` that ports the exact decision logic behind web's five overlapping queue-resync triggers, spread today across `packages/web/app/components/persistent-session/hooks/*`. This PR is **shared-package-only** — it does not wire the gate into web or mobile call sites (that lands in follow-up workstreams).

- `evaluateIncoming` / `noteApplied` — sequence-gap detection on incoming queue events, ported from `use-event-processor.ts:80-213`. `FullSync` always applies and re-baselines tracking; `PlaybackStateChanged` is exempt and never advances tracking (ported exemption comments intact).
- `verifyLocalHash` — periodic local-vs-server hash watchdog with the 3-strike resync-loop backoff (`RESYNC_LOOP_THRESHOLD`), ported from `use-session-subscriptions.ts:98-180`. Returns `{ verdict, consecutiveResyncs }`; the caller still owns Sentry reporting.
- `evaluateCorruption` — 30s cooldown between corruption-triggered resyncs, ported from `use-session-subscriptions.ts:55-96`.
- `decideReconnectStrategy` — none / delta-replay / full-sync selection, ported from `use-session-lifecycle.ts:547-609`, including the (previously undocumented) negative-gap fallthrough — see Deviations below.
- `hasContiguousReplayCoverage` — **moved verbatim** from `use-session-lifecycle.ts:146-189` into the shared package; `use-session-lifecycle.ts` now re-exports the shared binding instead of defining it locally, so its existing tests (`session-lifecycle-replay.test.ts`) pass unchanged.
- `reset()` / `getLastSequence()` — tracking reset (session change / socket close) and the accessor web's offline reconciliation will read later.

Also extends every variant of `SubscriptionWireEnvelope` (`subscription-adapter.ts`) with optional `sequence`/`stateHash` fields — additive, non-breaking — so a future wiring PR can route the same envelope through both the gate and the reducer adapter.

Closure-factory style matches `createJoinSessionTracker` (`ensure-joined.ts`): no React, no DOM, no timers — an injected `now?: () => number` clock keeps it fully unit-testable.

### Deviations from the workstream spec

- **Negative-gap `decideReconnectStrategy` returns `'none'`, not `'full-sync'`.** The spec text guessed `'full-sync'` for "server behind?" but flagged "check what web does and match it." Tracing `use-session-lifecycle.ts`'s `gap>0&&gap<=100` / `gap>100` / `lastSeq===null` / `gap===0` if/else-if chain shows none of the branches fire for a negative gap — it silently falls through to `setSession`/resubscribe with no resync at all. The gate matches that real behavior exactly (documented inline).
- **Corruption-cooldown sentinel is `-Infinity`, not `0`.** Web's `useRef<number>(0)` only works as "always resync first" because real `Date.now()` epoch millis dwarf the 30s cooldown; an injected test clock starting near zero would wrongly report `'cooldown'` on the very first check. Using `-Infinity` keeps the gate correct for any injected clock while remaining identical to web's behavior in production (found via a failing unit test, fixed before commit).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project queue-runtime --reporter=agent` — 66/66 new + existing queue-runtime tests pass (comprehensive coverage: in-order apply, stale-duplicate ignore, gap detection, FullSync reset incl. from mid-gap, PlaybackStateChanged exemption, hash-verify 3-strike backoff + recovery + server-hash-change restart, corruption cooldown incl. expiry + default-clock path, all `decideReconnectStrategy` branches incl. negative gap, `hasContiguousReplayCoverage` scenarios ported from the web replay test, `reset()`).
- `vp run typecheck:queue-runtime` — pass.
- `vp run typecheck:web` — pass (verifies the `use-session-lifecycle.ts` re-export compiles cleanly).
- `vp test run --project web --reporter=agent` (targeted at `session-lifecycle-replay`, ran full suite) — 369/369 files, 4840/4840 tests pass, confirming zero behavior change from moving `hasContiguousReplayCoverage`.
- `vp check --fix` — clean on all touched files (pre-existing unrelated warnings elsewhere untouched).