### PR TITLE
fix(backend): exclude PlaybackStateChanged from the delta-replay buffer

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -811,6 +811,8 @@ On reconnect, the web client calls `eventsReplay(sessionId, sinceSequence)` when
 
 The `EVENTS_REPLAY` query uses the same GraphQL aliases as `queueUpdates` (`addedItem: item`, `currentItem: item`) so the event processor can apply live and replayed events through the same code path.
 
+`PlaybackStateChanged` events are excluded from the buffer. They broadcast at up to 3600/min during variable-speed playback and reuse the room's current sequence number instead of incrementing it, so buffering them would evict real queue events within seconds and hand replaying clients duplicate/non-monotonic sequences that fail the contiguity check above. `publishQueueEvent` skips buffering them and `getEventsSince` filters any out on read (defence for mixed-version rollouts); the live `queueUpdates` subscription still forwards them normally.
+
 ---
 
 ## Failure States and Recovery

--- a/packages/backend/src/__tests__/event-replay-buffer.test.ts
+++ b/packages/backend/src/__tests__/event-replay-buffer.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression coverage for the delta-replay buffer excluding
+ * `PlaybackStateChanged` events (see `publishQueueEvent` / `getEventsSince`
+ * in `pubsub/index.ts`).
+ *
+ * Before this fix, every `publishPlaybackState` broadcast (up to 3600/min
+ * during active playback) was buffered into the same 100-entry Redis list as
+ * real queue mutations. That silently evicted real events within seconds and
+ * handed reconnecting clients duplicate/non-monotonic sequences (playback
+ * events reuse the room's current sequence instead of incrementing it).
+ *
+ * These tests exercise the real `pubsub` singleton against Redis, mirroring
+ * the "holder state + hand-off (Redis)" pattern in board-presence.test.ts:
+ * `pubsub` only connects to Redis when REDIS_URL is configured (CI sets it
+ * to redis://localhost:6380; local runs without it skip cleanly, matching
+ * every other Redis-gated suite in this file tree).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vite-plus/test';
+import type { QueueEvent, ClimbQueueItem } from '@boardsesh/shared-schema';
+import { pubsub } from '../pubsub';
+import { redisClientManager } from '../redis/client';
+
+function makeClimbQueueItem(uuid: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: `climb-${uuid}`,
+      setter_username: 'test-setter',
+      name: 'Test Climb',
+      description: 'A test climb',
+      frames: 'test-frames',
+      angle: 40,
+      ascensionist_count: 10,
+      difficulty: 'V5',
+      quality_average: '4.5',
+      stars: 4.5,
+      difficulty_error: '0.5',
+      mirrored: false,
+      benchmark_difficulty: null,
+    },
+    tickedBy: [],
+    addedBy: undefined,
+    suggested: false,
+  };
+}
+
+function queueItemAddedEvent(sequence: number, uuid: string): QueueEvent {
+  return {
+    __typename: 'QueueItemAdded',
+    sequence,
+    stateHash: `hash-${sequence}`,
+    item: makeClimbQueueItem(uuid),
+    position: 0,
+  };
+}
+
+function playbackStateChangedEvent(sequence: number, overrides: Partial<QueueEvent> = {}): QueueEvent {
+  return {
+    __typename: 'PlaybackStateChanged',
+    sequence,
+    climbUuid: 'playback-climb-uuid',
+    frameIndex: 0,
+    isPlaying: true,
+    speed: 1,
+    paceMs: 250,
+    anchorTimestamp: String(Date.now()),
+    clientId: 'conn-playback',
+    ...overrides,
+  } as QueueEvent;
+}
+
+describe('event replay buffer excludes PlaybackStateChanged', () => {
+  let redisOn = false;
+
+  beforeAll(async () => {
+    await pubsub.initialize().catch(() => {});
+    redisOn = pubsub.isRedisConnected();
+    if (!redisOn) {
+      console.warn('[event-replay-buffer] pubsub Redis unavailable — skipping delta-replay buffer tests');
+    }
+  });
+
+  afterAll(async () => {
+    if (redisOn) await redisClientManager.disconnect().catch(() => {});
+  });
+
+  afterEach(async () => {
+    if (!redisOn) return;
+    const { publisher } = redisClientManager.getClients();
+    await publisher.del(`session:event-replay-flood:events`);
+    await publisher.del(`session:event-replay-preseed:events`);
+  });
+
+  it('a flood of PlaybackStateChanged events does not evict a real queue event from the buffer', async () => {
+    if (!redisOn) return;
+    const sessionId = 'event-replay-flood';
+
+    // A real queue mutation lands first...
+    pubsub.publishQueueEvent(sessionId, queueItemAddedEvent(1, 'flood-item'));
+
+    // ...then playback broadcasts flood in behind it. Under the old
+    // (buggy) behaviour, LPUSH + LTRIM(0,99) would push the QueueItemAdded
+    // out of the 100-entry buffer well before we reach 150.
+    for (let i = 0; i < 150; i++) {
+      pubsub.publishQueueEvent(sessionId, playbackStateChangedEvent(1));
+    }
+
+    // publishQueueEvent buffers fire-and-forget; give the async writes a
+    // moment to land before reading back.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const events = await pubsub.getEventsSince(sessionId, 0);
+
+    const playbackEvents = events.filter((event) => event.__typename === 'PlaybackStateChanged');
+    const queueItemAddedEvents = events.filter((event) => event.__typename === 'QueueItemAdded');
+
+    expect(playbackEvents).toHaveLength(0);
+    expect(queueItemAddedEvents).toHaveLength(1);
+    expect((queueItemAddedEvents[0] as Extract<QueueEvent, { __typename: 'QueueItemAdded' }>).item.uuid).toBe(
+      'flood-item',
+    );
+  });
+
+  it('filters a pre-seeded PlaybackStateChanged buffer entry on read (mixed-version rollout defense)', async () => {
+    if (!redisOn) return;
+    const sessionId = 'event-replay-preseed';
+    const { publisher } = redisClientManager.getClients();
+    const bufferKey = `session:${sessionId}:events`;
+
+    // Simulate an old-code instance that still buffered a playback event
+    // directly in Redis (bypassing publishQueueEvent's new skip), alongside
+    // a real queue event.
+    await publisher.lpush(bufferKey, JSON.stringify(queueItemAddedEvent(1, 'preseed-item')));
+    await publisher.lpush(bufferKey, JSON.stringify(playbackStateChangedEvent(1)));
+    await publisher.expire(bufferKey, 300);
+
+    const events = await pubsub.getEventsSince(sessionId, 0);
+
+    expect(events.some((event) => event.__typename === 'PlaybackStateChanged')).toBe(false);
+    const queueItemAddedEvents = events.filter((event) => event.__typename === 'QueueItemAdded');
+    expect(queueItemAddedEvents).toHaveLength(1);
+    expect((queueItemAddedEvents[0] as Extract<QueueEvent, { __typename: 'QueueItemAdded' }>).item.uuid).toBe(
+      'preseed-item',
+    );
+  });
+});

--- a/packages/backend/src/__tests__/event-replay-buffer.test.ts
+++ b/packages/backend/src/__tests__/event-replay-buffer.test.ts
@@ -55,7 +55,7 @@ function queueItemAddedEvent(sequence: number, uuid: string): QueueEvent {
   };
 }
 
-function playbackStateChangedEvent(sequence: number, overrides: Partial<QueueEvent> = {}): QueueEvent {
+function playbackStateChangedEvent(sequence: number): QueueEvent {
   return {
     __typename: 'PlaybackStateChanged',
     sequence,
@@ -66,8 +66,7 @@ function playbackStateChangedEvent(sequence: number, overrides: Partial<QueueEve
     paceMs: 250,
     anchorTimestamp: String(Date.now()),
     clientId: 'conn-playback',
-    ...overrides,
-  } as QueueEvent;
+  };
 }
 
 describe('event replay buffer excludes PlaybackStateChanged', () => {
@@ -106,11 +105,16 @@ describe('event replay buffer excludes PlaybackStateChanged', () => {
       pubsub.publishQueueEvent(sessionId, playbackStateChangedEvent(1));
     }
 
-    // publishQueueEvent buffers fire-and-forget; give the async writes a
-    // moment to land before reading back.
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    const events = await pubsub.getEventsSince(sessionId, 0);
+    // publishQueueEvent buffers fire-and-forget, so poll until the
+    // QueueItemAdded write has landed rather than sleeping a fixed interval
+    // (a hardcoded sleep flakes under I/O contention).
+    let events: QueueEvent[] = [];
+    const deadline = Date.now() + 5000;
+    do {
+      events = await pubsub.getEventsSince(sessionId, 0);
+      if (events.some((event) => event.__typename === 'QueueItemAdded')) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    } while (Date.now() < deadline);
 
     const playbackEvents = events.filter((event) => event.__typename === 'PlaybackStateChanged');
     const queueItemAddedEvents = events.filter((event) => event.__typename === 'QueueItemAdded');

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -422,10 +422,13 @@ export const queueMutations = {
    * trips. The server stamps `anchorTimestamp` so peers can extrapolate
    * elapsed frames. Echo-suppressed by `clientId` on receipt.
    *
-   * Playback events are intentionally not buffered for delta replay — they're
-   * superseded by the next broadcast and have no value when a peer reconnects
-   * mid-playback. Sequence numbers are taken from the room manager's monotonic
-   * counter for ordering consistency with other queue events.
+   * Playback events are intentionally not buffered for delta replay (skipped
+   * in `publishQueueEvent`, `pubsub/index.ts`) — they're superseded by the
+   * next broadcast and have no value when a peer reconnects mid-playback.
+   * Sequence numbers are taken from the room manager's monotonic counter for
+   * ordering consistency with other queue events, but are reused rather than
+   * incremented, so they are non-monotonic/duplicate across playback events —
+   * another reason they must never enter the replay buffer.
    */
   publishPlaybackState: async (
     _: unknown,

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -308,6 +308,12 @@ class PubSub {
    * Retrieve events since a given sequence number (Phase 2).
    * Used for delta sync on reconnection.
    * Returns events in ascending sequence order.
+   *
+   * Defensively drops any `PlaybackStateChanged` entries found in the buffer.
+   * `publishQueueEvent` no longer writes them (see `storeEventInBuffer` call
+   * site below), but during a mixed-version rollout an old instance may still
+   * have buffered one within the 5-minute TTL — its reused, non-monotonic
+   * sequence would otherwise break the client's replay-contiguity check.
    */
   async getEventsSince(sessionId: string, sinceSequence: number): Promise<QueueEvent[]> {
     if (!this.redisAdapter) {
@@ -326,6 +332,9 @@ class PubSub {
       for (const json of eventJsons) {
         try {
           const event = JSON.parse(json) as QueueEvent;
+          if (event.__typename === 'PlaybackStateChanged') {
+            continue;
+          }
           if (event.sequence > sinceSequence) {
             events.push(event);
           }
@@ -349,6 +358,13 @@ class PubSub {
    * Dispatches locally first, then publishes to Redis for other instances.
    * Also stores event in buffer for delta sync (Phase 2).
    *
+   * `PlaybackStateChanged` events are excluded from buffering: they reuse the
+   * room's current sequence number (rather than incrementing it) and can fire
+   * up to 3600/min, so buffering them would both evict real queue events from
+   * the 100-entry buffer within seconds and hand replaying clients
+   * non-monotonic/duplicate sequences. See `publishPlaybackState` in
+   * `graphql/resolvers/queue/mutations.ts`.
+   *
    * Note: Redis publish errors are logged but not thrown to avoid blocking
    * the local dispatch. In Redis mode, events may not reach other instances
    * if Redis publish fails.
@@ -357,12 +373,14 @@ class PubSub {
     // Always dispatch to local subscribers first (low latency)
     this.dispatchToLocalQueueSubscribers(sessionId, event);
 
-    // Store event in buffer for delta sync (Phase 2)
-    // Fire and forget - don't block on buffer storage
-    this.storeEventInBuffer(sessionId, event).catch((error) => {
-      logger.error(`[PubSub] Failed to buffer event for session ${sessionId}:`, error);
-      // Non-fatal: clients will fall back to full sync if delta sync fails
-    });
+    // Store event in buffer for delta sync (Phase 2), except playback events
+    // (see docstring above). Fire and forget - don't block on buffer storage.
+    if (event.__typename !== 'PlaybackStateChanged') {
+      this.storeEventInBuffer(sessionId, event).catch((error) => {
+        logger.error(`[PubSub] Failed to buffer event for session ${sessionId}:`, error);
+        // Non-fatal: clients will fall back to full sync if delta sync fails
+      });
+    }
 
     // Also publish to Redis if available
     if (this.redisAdapter) {


### PR DESCRIPTION
## Summary

- `publishQueueEvent` buffered every queue event into the Redis delta-replay list (LPUSH + LTRIM 0,99), including `PlaybackStateChanged` broadcasts from `publishPlaybackState`, which fire at up to 3600/min during active climb playback and reuse the current sequence number instead of incrementing it.
- During playback this flooded the 100-entry replay buffer within seconds, silently evicting real queue events (adds/removes/reorders) so a reconnecting client's delta sync would miss them and fall back to (or worse, drift from) a full sync. The buffered playback entries also carried non-monotonic/duplicate sequences, violating the web client's replay-contiguity check.
- The doc comment on `publishPlaybackState` already claimed playback events "are intentionally not buffered for delta replay" — this PR makes that true.
- `publishQueueEvent` now skips `storeEventInBuffer` for `PlaybackStateChanged` events. `getEventsSince` also filters them out defensively on read, so an old-code instance that still buffers one within its 5-minute TTL during a mixed-version rollout can't leak it to a replaying client either.
- The live subscription path (`queueUpdates` in `subscriptions.ts`) already special-cased `PlaybackStateChanged` correctly and is untouched.

## Release Notes

- The shared queue catches up reliably after a dropped connection, even when someone in the party is running a variable-speed playback.

## Test plan

- New `packages/backend/src/__tests__/event-replay-buffer.test.ts`, run against the real `pubsub` singleton + Redis (mirrors the `board-presence.test.ts` "holder state (Redis)" pattern — connects when `REDIS_URL` is configured, skips cleanly otherwise):
  - Publishes 150 `PlaybackStateChanged` events plus 1 real `QueueItemAdded` and confirms `getEventsSince` returns only the real event (buffer not evicted) and zero playback events.
  - Pre-seeds the Redis buffer directly with a serialized `PlaybackStateChanged` entry (simulating an old instance) and confirms `getEventsSince` filters it out on read.
- `vp check --fix` — clean (0 errors; pre-existing unrelated warnings elsewhere in the repo untouched).
- `vp run typecheck:backend` — clean.
- `vp test run --project backend --reporter=agent` (with `REDIS_URL=redis://localhost:6380` so the Redis-gated tests actually execute rather than skip) — 141/141 files, 1833/1833 tests passed.