### PR TITLE
fix(shared): board presence sync parity and render performance

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -198,7 +198,6 @@
     },
     "packages/mobile": {
       "name": "@boardsesh/mobile",
-      "version": "2.0.0",
       "dependencies": {
         "@boardsesh/analytics": "*",
         "@boardsesh/ble-protocol": "*",
@@ -399,6 +398,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@boardsesh/board-presence": "*",
+        "@boardsesh/graphql": "*",
         "@boardsesh/shared-schema": "*",
       },
       "devDependencies": {

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -440,6 +440,27 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     [managed.handle, invalidatePendingActions],
   );
 
+  // Index-based re-mount backstop for a re-present that lands inside a dismiss
+  // settle window. Sequence without this: dismiss starts → user re-taps →
+  // `present()` sets isPresented(true) (no-op, still true) and the coordinator
+  // QUEUES the present (its pump early-returns while the dismiss is in flight)
+  // → the dismiss settles → `handleFullyDismissed` sets isPresented(false) →
+  // only THEN does the coordinator present the native sheet — leaving it fully
+  // up with the content unmounted until a close+reopen. The native `onChange`
+  // fires with index >= 0 whenever the sheet is actually up, so re-mounting
+  // here closes that gap. The synchronous set in `present()` stays as the fast
+  // path for the common (no-race) open.
+  const managedOnChange = managed.onChange;
+  const handleSheetChange = useCallback(
+    (index: number) => {
+      if (index >= 0) {
+        setIsPresented(true);
+      }
+      managedOnChange(index);
+    },
+    [managedOnChange],
+  );
+
   return (
     <BottomSheetModal
       ref={sheetRef}
@@ -450,7 +471,7 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       // bounded content height to measure).
       enableDynamicSizing={false}
       enablePanDownToClose
-      onChange={managed.onChange}
+      onChange={handleSheetChange}
       handleIndicatorStyle={sheet.handleStyle}
       style={styles.sheet}
     >
@@ -588,19 +609,20 @@ function BoardSheetContent({
     [currentClimb, history],
   );
 
-  // Fires once per presentation: this component mounts fresh every time the
-  // sheet opens (`BoardSheet`'s `isPresented` gate), so a mount-only effect IS
-  // "once per presentation" — no `historyCountRef`/imperative-present coupling
-  // needed anymore.
+  // Fires once per presentation, when history is FIRST non-empty — not only at
+  // mount, because presenting before the initial backfill resolves would find
+  // an empty list and never fire for that presentation. This component mounts
+  // fresh every time the sheet opens (`BoardSheet`'s `isPresented` gate), so
+  // the ref naturally resets per presentation. Mirrors web's `BoardSheetBody`.
+  const historyViewedForPresentationRef = useRef(false);
   useEffect(() => {
-    if (visibleHistory.length > 0) {
-      track(SHARED_EVENTS.BoardHistoryViewed, {
-        boardId: boardPresenceBoardId ?? undefined,
-        itemCount: visibleHistory.length,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: fire once per presentation, not on every history change while open.
-  }, []);
+    if (historyViewedForPresentationRef.current || visibleHistory.length === 0) return;
+    historyViewedForPresentationRef.current = true;
+    track(SHARED_EVENTS.BoardHistoryViewed, {
+      boardId: boardPresenceBoardId ?? undefined,
+      itemCount: visibleHistory.length,
+    });
+  }, [visibleHistory.length, boardPresenceBoardId]);
 
   const renderHistoryItem = useCallback(
     ({ item }: { item: BoardPresenceClimb }) => {

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -10,6 +10,19 @@
 // State comes from `@boardsesh/board-presence-react`'s split current/feed
 // contexts, which are inert when the `board-presence` flag is off — so this
 // sheet is only ever opened from the board glyph when the flag is on.
+//
+// PERF: the sheet stays MOUNTED across dismiss (like QueueSheet — see
+// `useManagedSheet` below), but its presence-consuming content does not. The
+// header/footer chrome here is cheap and always rendered; everything that
+// reads `useBoardPresenceCurrent`/`useBoardPresenceFeed` (hero, stats, the
+// virtualized history list) lives in `BoardSheetContent`, gated on an explicit
+// `isPresented` flag this component owns and flips itself — NOT the sheet
+// library's own child-mounting behavior, which isn't reliable here. That
+// content component mounts fresh on every `present()` and unmounts on
+// `handleFullyDismissed`, so a dismissed sheet does zero list/hero work.
+// `BoardNowPlayingReceived` telemetry moved OUT of this file entirely — it now
+// lives in `BoardPresenceInstrument` (mobile provider), so it keeps firing
+// while the sheet is dismissed.
 
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Platform, Pressable, RefreshControl, StyleSheet, View, type ColorValue } from 'react-native';
@@ -183,9 +196,8 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
 ) {
   const { t } = useTranslation('session');
   const insets = useSafeAreaInsets();
-  const { systemColors, brandColors, sheet } = useTheme();
+  const { systemColors, sheet } = useTheme();
   const { showToast } = useToast();
-  const { formatGrade } = useGradeFormat();
   const sheetRef = useRef<BottomSheetModal>(null);
   const boardConfigRef = useRef(boardConfig);
   boardConfigRef.current = boardConfig;
@@ -193,70 +205,18 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   const boardConfigSignatureRef = useRef(boardConfigSignature);
   boardConfigSignatureRef.current = boardConfigSignature;
 
-  const { currentClimb } = useBoardPresenceCurrent();
-  const { history, stats } = useBoardPresenceFeed();
-  const { refresh } = useBoardPresenceActions();
-  const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
-  const boardPresenceBoardIdRef = useRef(boardPresenceBoardId);
-  boardPresenceBoardIdRef.current = boardPresenceBoardId;
+  // Gates `BoardSheetContent` (the presence-consuming hero/stats/history list)
+  // so it does zero work while dismissed. Flipped true SYNCHRONOUSLY in the
+  // imperative `present()` below (before the sheet's own present animation
+  // starts) and false once the dismiss animation has fully settled — see
+  // `handleFullyDismissed`.
+  const [isPresented, setIsPresented] = useState(false);
 
-  // Pull-to-refresh: a manual catch-up for when a user notices the wall feed is
-  // stale. `refresh()` is fire-and-forget (the durable history merges back in
-  // via context), so show the spinner briefly, then clear it.
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const handleRefresh = useCallback(() => {
-    refresh('manual');
-    setIsRefreshing(true);
-    if (refreshTimerRef.current) {
-      clearTimeout(refreshTimerRef.current);
-    }
-    refreshTimerRef.current = setTimeout(() => setIsRefreshing(false), 800);
-  }, [refresh]);
-  useEffect(
-    () => () => {
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-      }
-    },
-    [],
-  );
-  const visibleHistory = useMemo(
-    () =>
-      currentClimb
-        ? history.filter((historyClimb) => {
-            return historyClimb.climbUuid !== currentClimb.climbUuid || historyClimb.seq !== currentClimb.seq;
-          })
-        : history,
-    [currentClimb, history],
-  );
-  const historyCountRef = useRef(visibleHistory.length);
-  historyCountRef.current = visibleHistory.length;
-
-  const lastReceivedWallClimbRef = useRef<string | null>(null);
-  // `seq` rides along in the telemetry payload but must NOT trigger the effect —
-  // a same-uuid seq bump (e.g. a backfill merge) shouldn't re-evaluate the
-  // "new climb on the wall" event. Read it from a ref so the effect keys only on
-  // the climb uuid.
-  const currentClimbSeqRef = useRef(currentClimb?.seq);
-  currentClimbSeqRef.current = currentClimb?.seq;
   const actionClimbCacheRef = useRef(new Map<string, Climb>());
   const actionClimbRequestRef = useRef(new Map<string, Promise<Climb | null>>());
   const pendingActionKeysRef = useRef(new Set<string>());
   const actionGenerationRef = useRef(0);
   const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
-  useEffect(() => {
-    const currentClimbUuid = currentClimb?.climbUuid;
-    if (!currentClimbUuid) return;
-    if (lastReceivedWallClimbRef.current === currentClimbUuid) return;
-    lastReceivedWallClimbRef.current = currentClimbUuid;
-    track(SHARED_EVENTS.BoardNowPlayingReceived, {
-      boardId: boardPresenceBoardIdRef.current ?? undefined,
-      climbUuid: currentClimbUuid,
-      // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
-      seq: currentClimbSeqRef.current ?? undefined,
-    });
-  }, [currentClimb?.climbUuid]);
 
   const snapPoints = useMemo(() => ['55%', '92%'], []);
   const rowBoard = useMemo<BoardSheetRowBoard | null>(
@@ -445,8 +405,10 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
 
   // Fired once the dismiss animation has actually SETTLED (coordinator), not on
   // the synchronous early callback — so we never tear anything down mid-animation.
+  // This is also where `BoardSheetContent` unmounts (zero work while dismissed).
   const handleFullyDismissed = useCallback(() => {
     invalidatePendingActions();
+    setIsPresented(false);
     onDismissed?.();
   }, [invalidatePendingActions, onDismissed]);
 
@@ -464,12 +426,10 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     ref,
     () => ({
       present: () => {
-        if (historyCountRef.current > 0) {
-          track(SHARED_EVENTS.BoardHistoryViewed, {
-            boardId: boardPresenceBoardIdRef.current ?? undefined,
-            itemCount: historyCountRef.current,
-          });
-        }
+        // Synchronous, before the sheet's own present animation starts, so
+        // `BoardSheetContent` mounts (and its history/hero read) right away —
+        // no reliance on the sheet library's own child-mounting timing.
+        setIsPresented(true);
         managed.handle.present();
       },
       dismiss: () => {
@@ -479,6 +439,168 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     }),
     [managed.handle, invalidatePendingActions],
   );
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      // Height is driven by explicit snapPoints, so disable gorhom's dynamic
+      // content sizing — it doesn't play well with a BottomSheetFlatList (no
+      // bounded content height to measure).
+      enableDynamicSizing={false}
+      enablePanDownToClose
+      onChange={managed.onChange}
+      handleIndicatorStyle={sheet.handleStyle}
+      style={styles.sheet}
+    >
+      <View style={[styles.header, { borderBottomColor: systemColors.separator }]}>
+        <Pressable
+          onPress={handleClose}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.boardPresence.close')}
+          style={styles.headerAction}
+        >
+          <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
+        </Pressable>
+        <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
+          {boardLabel ?? t('mobile.boardPresence.title')}
+        </Text>
+        <View pointerEvents="none" style={styles.headerAction} />
+      </View>
+
+      {isPresented ? (
+        <BoardSheetContent
+          boardConfig={boardConfig}
+          rowBoard={rowBoard}
+          canUseInteractiveRows={canUseInteractiveRows}
+          onClimbPress={onClimbPress}
+          isActionLoading={isActionLoading}
+          pendingActionKeys={pendingActionKeys}
+          onInteractiveClimbPress={handleInteractiveClimbPress}
+          onInteractiveAddToQueue={handleInteractiveAddToQueue}
+          onInteractiveOpenPlaylist={handleInteractiveOpenPlaylist}
+          onInteractiveOpenActions={handleInteractiveOpenActions}
+        />
+      ) : null}
+
+      <Pressable
+        onPress={handleSwitchBoard}
+        accessibilityRole="button"
+        accessibilityLabel={t('mobile.boardPresence.switchBoardAria')}
+        style={[styles.footer, { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] }]}
+      >
+        <View style={[styles.footerIcon, { backgroundColor: systemColors.secondaryBackground }]}>
+          <Icon name="transfer" size={20} color={systemColors.label} />
+        </View>
+        <View style={styles.footerText}>
+          <Text variant="body" color={systemColors.label}>
+            {t('mobile.boardPresence.switchBoard')}
+          </Text>
+          {boardLabel ? (
+            <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
+              {boardLabel}
+            </Text>
+          ) : null}
+        </View>
+        <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
+      </Pressable>
+    </BottomSheetModal>
+  );
+});
+
+type BoardSheetContentProps = {
+  boardConfig: BoardConfig | null;
+  rowBoard: BoardSheetRowBoard | null;
+  canUseInteractiveRows: boolean;
+  onClimbPress?: (action: BoardSheetClimbAction) => void;
+  isActionLoading: (presenceClimb: BoardPresenceClimb) => boolean;
+  pendingActionKeys: ReadonlySet<string>;
+  onInteractiveClimbPress: (presenceClimb: BoardPresenceClimb) => void;
+  onInteractiveAddToQueue: (presenceClimb: BoardPresenceClimb) => void;
+  onInteractiveOpenPlaylist: (presenceClimb: BoardPresenceClimb) => void;
+  onInteractiveOpenActions: (presenceClimb: BoardPresenceClimb) => void;
+};
+
+/**
+ * Everything that reads the wall's live state: the hero, stat tiles, and the
+ * virtualized history list. Mounted by `BoardSheet` only while `isPresented`
+ * is true, so a dismissed sheet subscribes to none of the presence contexts
+ * and does none of this rendering work — this component mounts fresh on every
+ * `present()` and unmounts on `handleFullyDismissed`.
+ *
+ * The action-hydration state (`pendingActionKeys`, the climb cache, generation
+ * counter) stays in the parent `BoardSheet` — it doesn't depend on presence
+ * data, and keeping it there means an in-flight action survives this
+ * component's own mount/unmount cycle exactly as before (the parent's
+ * `invalidatePendingActions` on close/dismiss is unaffected by this refactor).
+ */
+function BoardSheetContent({
+  boardConfig,
+  rowBoard,
+  canUseInteractiveRows,
+  onClimbPress,
+  isActionLoading,
+  pendingActionKeys,
+  onInteractiveClimbPress,
+  onInteractiveAddToQueue,
+  onInteractiveOpenPlaylist,
+  onInteractiveOpenActions,
+}: BoardSheetContentProps) {
+  const { t } = useTranslation('session');
+  const { systemColors, brandColors } = useTheme();
+  const { formatGrade } = useGradeFormat();
+  const { currentClimb } = useBoardPresenceCurrent();
+  const { history, stats } = useBoardPresenceFeed();
+  const { refresh } = useBoardPresenceActions();
+  const { boardId: boardPresenceBoardId } = useBoardPresenceControls();
+
+  // Pull-to-refresh: a manual catch-up for when a user notices the wall feed is
+  // stale. `refresh()` is fire-and-forget (the durable history merges back in
+  // via context), so show the spinner briefly, then clear it.
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleRefresh = useCallback(() => {
+    refresh('manual');
+    setIsRefreshing(true);
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+    }
+    refreshTimerRef.current = setTimeout(() => setIsRefreshing(false), 800);
+  }, [refresh]);
+  useEffect(
+    () => () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const visibleHistory = useMemo(
+    () =>
+      currentClimb
+        ? history.filter((historyClimb) => {
+            return historyClimb.climbUuid !== currentClimb.climbUuid || historyClimb.seq !== currentClimb.seq;
+          })
+        : history,
+    [currentClimb, history],
+  );
+
+  // Fires once per presentation: this component mounts fresh every time the
+  // sheet opens (`BoardSheet`'s `isPresented` gate), so a mount-only effect IS
+  // "once per presentation" — no `historyCountRef`/imperative-present coupling
+  // needed anymore.
+  useEffect(() => {
+    if (visibleHistory.length > 0) {
+      track(SHARED_EVENTS.BoardHistoryViewed, {
+        boardId: boardPresenceBoardId ?? undefined,
+        itemCount: visibleHistory.length,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: fire once per presentation, not on every history change while open.
+  }, []);
 
   const renderHistoryItem = useCallback(
     ({ item }: { item: BoardPresenceClimb }) => {
@@ -496,10 +618,10 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             formattedGrade={formattedGrade}
             gradeColor={gradeColor}
             isActionLoading={isActionLoading(item)}
-            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
-            onAddToQueue={handleInteractiveAddToQueue}
-            onOpenPlaylist={handleInteractiveOpenPlaylist}
-            onOpenActions={handleInteractiveOpenActions}
+            onPress={onClimbPress ? onInteractiveClimbPress : undefined}
+            onAddToQueue={onInteractiveAddToQueue}
+            onOpenPlaylist={onInteractiveOpenPlaylist}
+            onOpenActions={onInteractiveOpenActions}
           />
         );
       }
@@ -522,14 +644,31 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       systemColors.label,
       systemColors.secondaryLabel,
       formatGrade,
-      handleInteractiveClimbPress,
-      handleInteractiveAddToQueue,
-      handleInteractiveOpenPlaylist,
-      handleInteractiveOpenActions,
+      onInteractiveClimbPress,
+      onInteractiveAddToQueue,
+      onInteractiveOpenPlaylist,
+      onInteractiveOpenActions,
+      // `isActionLoading` (a function of `pendingActionKeys`, ANY row's action
+      // state) is intentionally kept here — rows are `React.memo`'d, so this
+      // only re-renders the specific row whose own loading flag actually
+      // changed. `listHeader` below deliberately does NOT depend on this same
+      // function for the hero — see `heroActionLoading`.
       isActionLoading,
       onClimbPress,
     ],
   );
+
+  // Primitive derived from `pendingActionKeys` for just the hero's own climb —
+  // NOT the `isActionLoading` function itself, which changes identity on every
+  // row's action-state flip. Keeping `listHeader` keyed on this boolean instead
+  // means an unrelated history-row tap no longer rebuilds the whole header
+  // (hero + stat tiles + hardest-send row).
+  const heroActionLoading =
+    currentClimb && boardConfig
+      ? pendingActionKeys.has(
+          actionCacheKey(actionBoardConfigForPresenceClimb(boardConfig, currentClimb), currentClimb.climbUuid),
+        )
+      : false;
 
   const listHeader = useMemo(
     () => (
@@ -545,11 +684,11 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
             surfaceColor={systemColors.secondaryBackground}
             formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
             gradeColor={getGradeColor(currentClimb.grade ?? '') ?? DEFAULT_GRADE_COLOR}
-            isActionLoading={isActionLoading(currentClimb)}
-            onPress={onClimbPress ? handleInteractiveClimbPress : undefined}
-            onAddToQueue={handleInteractiveAddToQueue}
-            onOpenPlaylist={handleInteractiveOpenPlaylist}
-            onOpenActions={handleInteractiveOpenActions}
+            isActionLoading={heroActionLoading}
+            onPress={onClimbPress ? onInteractiveClimbPress : undefined}
+            onAddToQueue={onInteractiveAddToQueue}
+            onOpenPlaylist={onInteractiveOpenPlaylist}
+            onOpenActions={onInteractiveOpenActions}
           />
         ) : (
           <NowOnTheWallHero
@@ -629,11 +768,11 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
       t,
       canUseInteractiveRows,
       rowBoard,
-      handleInteractiveClimbPress,
-      handleInteractiveAddToQueue,
-      handleInteractiveOpenPlaylist,
-      handleInteractiveOpenActions,
-      isActionLoading,
+      onInteractiveClimbPress,
+      onInteractiveAddToQueue,
+      onInteractiveOpenPlaylist,
+      onInteractiveOpenActions,
+      heroActionLoading,
       onClimbPress,
     ],
   );
@@ -655,71 +794,19 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
   );
 
   return (
-    <BottomSheetModal
-      ref={sheetRef}
-      index={0}
-      snapPoints={snapPoints}
-      // Height is driven by explicit snapPoints, so disable gorhom's dynamic
-      // content sizing — it doesn't play well with a BottomSheetFlatList (no
-      // bounded content height to measure).
-      enableDynamicSizing={false}
-      enablePanDownToClose
-      onChange={managed.onChange}
-      handleIndicatorStyle={sheet.handleStyle}
-      style={styles.sheet}
-    >
-      <View style={[styles.header, { borderBottomColor: systemColors.separator }]}>
-        <Pressable
-          onPress={handleClose}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.boardPresence.close')}
-          style={styles.headerAction}
-        >
-          <Icon name="chevron.down" size={20} color={systemColors.secondaryLabel} />
-        </Pressable>
-        <Text variant="title3" color={systemColors.label} numberOfLines={1} style={styles.headerTitle}>
-          {boardLabel ?? t('mobile.boardPresence.title')}
-        </Text>
-        <View pointerEvents="none" style={styles.headerAction} />
-      </View>
-
-      <BottomSheetFlatList
-        data={visibleHistory}
-        keyExtractor={boardPresenceHistoryKeyExtractor}
-        renderItem={renderHistoryItem}
-        ListHeaderComponent={listHeader}
-        ListEmptyComponent={listEmpty}
-        contentContainerStyle={{ paddingBottom: spacing[4] }}
-        refreshControl={
-          <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />
-        }
-      />
-
-      <Pressable
-        onPress={handleSwitchBoard}
-        accessibilityRole="button"
-        accessibilityLabel={t('mobile.boardPresence.switchBoardAria')}
-        style={[styles.footer, { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] }]}
-      >
-        <View style={[styles.footerIcon, { backgroundColor: systemColors.secondaryBackground }]}>
-          <Icon name="transfer" size={20} color={systemColors.label} />
-        </View>
-        <View style={styles.footerText}>
-          <Text variant="body" color={systemColors.label}>
-            {t('mobile.boardPresence.switchBoard')}
-          </Text>
-          {boardLabel ? (
-            <Text variant="caption1" color={systemColors.secondaryLabel} numberOfLines={1}>
-              {boardLabel}
-            </Text>
-          ) : null}
-        </View>
-        <Icon name="chevron.right" size={16} color={systemColors.tertiaryLabel} />
-      </Pressable>
-    </BottomSheetModal>
+    <BottomSheetFlatList
+      data={visibleHistory}
+      keyExtractor={boardPresenceHistoryKeyExtractor}
+      renderItem={renderHistoryItem}
+      ListHeaderComponent={listHeader}
+      ListEmptyComponent={listEmpty}
+      contentContainerStyle={{ paddingBottom: spacing[4] }}
+      refreshControl={
+        <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />
+      }
+    />
   );
-});
+}
 
 type HeroProps = {
   climb: BoardPresenceClimb | null;

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -11,18 +11,9 @@
 // contexts, which are inert when the `board-presence` flag is off — so this
 // sheet is only ever opened from the board glyph when the flag is on.
 //
-// PERF: the sheet stays MOUNTED across dismiss (like QueueSheet — see
-// `useManagedSheet` below), but its presence-consuming content does not. The
-// header/footer chrome here is cheap and always rendered; everything that
-// reads `useBoardPresenceCurrent`/`useBoardPresenceFeed` (hero, stats, the
-// virtualized history list) lives in `BoardSheetContent`, gated on an explicit
-// `isPresented` flag this component owns and flips itself — NOT the sheet
-// library's own child-mounting behavior, which isn't reliable here. That
-// content component mounts fresh on every `present()` and unmounts on
-// `handleFullyDismissed`, so a dismissed sheet does zero list/hero work.
-// `BoardNowPlayingReceived` telemetry moved OUT of this file entirely — it now
-// lives in `BoardPresenceInstrument` (mobile provider), so it keeps firing
-// while the sheet is dismissed.
+// Presence-consuming content is gated on `isPresented` (see `BoardSheetContent`)
+// so a dismissed sheet does zero work; `BoardNowPlayingReceived` telemetry lives
+// in the provider's `BoardPresenceInstrument` so it fires while dismissed.
 
 import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { Platform, Pressable, RefreshControl, StyleSheet, View, type ColorValue } from 'react-native';
@@ -440,16 +431,11 @@ export const BoardSheet = forwardRef<BoardSheetHandle, BoardSheetProps>(function
     [managed.handle, invalidatePendingActions],
   );
 
-  // Index-based re-mount backstop for a re-present that lands inside a dismiss
-  // settle window. Sequence without this: dismiss starts → user re-taps →
-  // `present()` sets isPresented(true) (no-op, still true) and the coordinator
-  // QUEUES the present (its pump early-returns while the dismiss is in flight)
-  // → the dismiss settles → `handleFullyDismissed` sets isPresented(false) →
-  // only THEN does the coordinator present the native sheet — leaving it fully
-  // up with the content unmounted until a close+reopen. The native `onChange`
-  // fires with index >= 0 whenever the sheet is actually up, so re-mounting
-  // here closes that gap. The synchronous set in `present()` stays as the fast
-  // path for the common (no-race) open.
+  // Re-mount backstop: a re-present queued inside a dismiss settle window gets
+  // its isPresented(true) clobbered by the late-settling `handleFullyDismissed`
+  // BEFORE the coordinator presents the native sheet — which would leave the
+  // sheet up with the content unmounted. index >= 0 means the sheet is really
+  // up, so re-mount here; the synchronous set in `present()` is the fast path.
   const managedOnChange = managed.onChange;
   const handleSheetChange = useCallback(
     (index: number) => {

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -334,10 +334,18 @@ describe('BoardSheet', () => {
     expect(sheetModal.dismiss).toHaveBeenCalled();
   });
 
-  it('tracks distinct now-on-the-wall climbs from the presence feed', () => {
+  it('renders no presence content while dismissed — zero list/hero work', () => {
     presence.currentClimb = makeClimb('c1', 3);
+    presence.history = [makeClimb('c1', 3)];
+    presence.stats = {
+      climbsSentCount: 14,
+      distinctClimbersCount: 5,
+      hardestGrade: 'V9',
+      topGrade: 'V5',
+      lastSentAt: null,
+    };
 
-    render(
+    const { container, queryByLabelText, getAllByText } = render(
       createElement(BoardSheet, {
         boardLabel: 'Garage Wall',
         onClose: noop,
@@ -346,29 +354,56 @@ describe('BoardSheet', () => {
       }),
     );
 
-    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardNowPlayingReceived, {
-      boardId: 123,
-      climbUuid: 'c1',
-      seq: 3,
-    });
+    // The header/footer chrome (cheap, presence-free) still renders — both the
+    // header title and the footer subtitle show the board label.
+    expect(getAllByText('Garage Wall')).toHaveLength(2);
+    // ...but nothing that reads the wall's presence state does.
+    expect(container.querySelector('[data-list="true"]')).toBeNull();
+    expect(queryByLabelText('refresh')).toBeNull();
+    expect(container.textContent).not.toContain('Climb c1');
+    expect(container.textContent).not.toContain('mobile.boardPresence.emptyTitle');
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
+  });
+
+  it('mounts the presence content (history list) once presented', () => {
+    presence.history = [makeClimb('c1', 3)];
+    const ref = createRef<BoardSheetHandle>();
+    const { container } = render(
+      createElement(BoardSheet, {
+        ref,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+    expect(container.querySelector('[data-list="true"]')).toBeNull();
+
+    act(() => ref.current?.present());
+
+    expect(container.querySelector('[data-list="true"]')).not.toBeNull();
+    expect(sheetModal.present).toHaveBeenCalled();
   });
 
   it('triggers a manual catch-up when the history list is pulled to refresh', () => {
     presence.history = [makeClimb('c1', 3)];
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         boardConfig,
         onSwitchBoard: noop,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('refresh'));
     expect(presence.refresh).toHaveBeenCalledWith('manual');
   });
 
-  it('tracks history views from the imperative present call', () => {
+  it('tracks history views once per presentation, from the content mount effect', () => {
     presence.history = [makeClimb('c1', 3), makeClimb('c0', 2)];
     const ref = createRef<BoardSheetHandle>();
     render(
@@ -381,7 +416,7 @@ describe('BoardSheet', () => {
       }),
     );
 
-    ref.current?.present();
+    act(() => ref.current?.present());
 
     expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, {
       boardId: 123,
@@ -390,9 +425,29 @@ describe('BoardSheet', () => {
     expect(sheetModal.present).toHaveBeenCalled();
   });
 
+  it('does not track history views on present when there is no history', () => {
+    presence.history = [];
+    const ref = createRef<BoardSheetHandle>();
+    render(
+      createElement(BoardSheet, {
+        ref,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    act(() => ref.current?.present());
+
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
+  });
+
   it('renders the empty state when no climb is on the wall', () => {
+    const ref = createRef<BoardSheetHandle>();
     const { container } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -400,6 +455,7 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
+    act(() => ref.current?.present());
     expect(container.textContent).toContain('mobile.boardPresence.emptyTitle');
   });
 
@@ -423,8 +479,10 @@ describe('BoardSheet', () => {
       lastSentAt: null,
     };
 
+    const ref = createRef<BoardSheetHandle>();
     const { container } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -432,6 +490,7 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
+    act(() => ref.current?.present());
 
     // The current climb renders as the hero only; it is filtered out of history.
     expect(container.textContent?.match(/Climb c1/g) ?? []).toHaveLength(1);
@@ -452,8 +511,10 @@ describe('BoardSheet', () => {
     presence.currentClimb = makeClimb('c1', 3);
     presence.history = [makeClimb('c1', 3)];
 
+    const ref = createRef<BoardSheetHandle>();
     const { container } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -461,6 +522,7 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
+    act(() => ref.current?.present());
 
     expect(container.textContent?.match(/Climb c1/g) ?? []).toHaveLength(1);
     expect(container.textContent).not.toContain('mobile.boardPresence.historyHeader');
@@ -501,8 +563,10 @@ describe('BoardSheet', () => {
     });
     graphql.request.mockResolvedValueOnce({ climb: heroDetail }).mockResolvedValueOnce({ climb: oldDetail });
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose,
         onDismissed: noop,
@@ -514,6 +578,7 @@ describe('BoardSheet', () => {
         onOpenActions,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('press hero-climb'));
     await waitFor(() =>
@@ -612,8 +677,10 @@ describe('BoardSheet', () => {
     });
     graphql.request.mockResolvedValueOnce({ climb: oldDetail });
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -622,6 +689,7 @@ describe('BoardSheet', () => {
         onOpenPlaylist,
       }),
     );
+    act(() => ref.current?.present());
 
     expect(climbRows.props[0]?.onPress).toBeUndefined();
     fireEvent.click(getByLabelText('playlist old-climb'));
@@ -662,8 +730,10 @@ describe('BoardSheet', () => {
     });
     graphql.request.mockResolvedValueOnce({ climb: oldDetail });
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -672,6 +742,7 @@ describe('BoardSheet', () => {
         onOpenActions,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('actions old-climb'));
 
@@ -706,8 +777,10 @@ describe('BoardSheet', () => {
     const climbRequest = createDeferred<{ climb: Climb | null }>();
     graphql.request.mockReturnValueOnce(climbRequest.promise);
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText, queryByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose,
         onDismissed: noop,
@@ -716,6 +789,7 @@ describe('BoardSheet', () => {
         onClimbPress,
       }),
     );
+    act(() => ref.current?.present());
 
     expect(queryByLabelText('mobile.boardPresence.actionLoading')).toBeNull();
 
@@ -754,8 +828,10 @@ describe('BoardSheet', () => {
     const climbRequest = createDeferred<{ climb: Climb | null }>();
     graphql.request.mockReturnValueOnce(climbRequest.promise);
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText, queryByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose,
         onDismissed: noop,
@@ -764,6 +840,7 @@ describe('BoardSheet', () => {
         onClimbPress,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('press hero-climb'));
     await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
@@ -792,8 +869,10 @@ describe('BoardSheet', () => {
     const heroDetail = makeFullClimb('hero-climb', { name: 'Hydrated Hero' });
     graphql.request.mockResolvedValueOnce({ climb: heroDetail });
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose,
         onDismissed: noop,
@@ -802,6 +881,7 @@ describe('BoardSheet', () => {
         onClimbPress,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('press hero-climb'));
 
@@ -821,8 +901,10 @@ describe('BoardSheet', () => {
     const climbRequest = createDeferred<{ climb: Climb | null }>();
     graphql.request.mockReturnValueOnce(climbRequest.promise).mockResolvedValueOnce({ climb: retryDetail });
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText, queryByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -831,6 +913,7 @@ describe('BoardSheet', () => {
         onClimbPress,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('press hero-climb'));
     await waitFor(() => expect(queryByLabelText('mobile.boardPresence.actionLoading')).not.toBeNull());
@@ -866,8 +949,10 @@ describe('BoardSheet', () => {
     const retryDetail = makeFullClimb('hero-climb', { name: 'Retry Hero' });
     graphql.request.mockResolvedValueOnce({ climb: null }).mockResolvedValueOnce({ climb: retryDetail });
 
+    const ref = createRef<BoardSheetHandle>();
     const { getByLabelText, queryByLabelText } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -876,6 +961,7 @@ describe('BoardSheet', () => {
         onClimbPress,
       }),
     );
+    act(() => ref.current?.present());
 
     fireEvent.click(getByLabelText('press hero-climb'));
 
@@ -902,8 +988,10 @@ describe('BoardSheet', () => {
     presence.currentClimb = makeClimb('hero-climb', 3);
     const onClimbPress = vi.fn();
 
+    const ref = createRef<BoardSheetHandle>();
     const { rerender } = render(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,
@@ -912,10 +1000,12 @@ describe('BoardSheet', () => {
         onClimbPress,
       }),
     );
+    act(() => ref.current?.present());
     const stalePress = climbRows.props[0]?.onPress;
 
     rerender(
       createElement(BoardSheet, {
+        ref,
         boardLabel: 'Garage Wall',
         onClose: noop,
         onDismissed: noop,

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -27,7 +27,20 @@ const toast = vi.hoisted(() => ({
   showToast: vi.fn(),
 }));
 
-const sheetModal = vi.hoisted(() => ({ present: vi.fn(), dismiss: vi.fn() }));
+const sheetModal = vi.hoisted(() => ({
+  present: vi.fn(),
+  dismiss: vi.fn(),
+  // The BottomSheetModal's `onChange` prop, captured so tests can fire native
+  // index changes (index >= 0 = the sheet actually came up).
+  onChange: null as ((index: number) => void) | null,
+}));
+const managedSheet = vi.hoisted(() => ({
+  // When true, `handle.dismiss` does NOT fire onFullyDismissed synchronously —
+  // simulating the coordinator's dismiss settle window (up to 550ms). The test
+  // then fires `lastOnFullyDismissed` itself to settle the dismiss late.
+  deferSettle: false,
+  lastOnFullyDismissed: null as (() => void) | null,
+}));
 const climbRows = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 const thumbnails = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 
@@ -69,10 +82,13 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  BottomSheetModal: forwardRef(({ children }: { children?: ReactNode }, ref: Ref<unknown>) => {
-    useImperativeHandle(ref, () => ({ present: sheetModal.present, dismiss: sheetModal.dismiss }));
-    return createElement('div', { 'data-sheet': 'true' }, children);
-  }),
+  BottomSheetModal: forwardRef(
+    ({ children, onChange }: { children?: ReactNode; onChange?: (index: number) => void }, ref: Ref<unknown>) => {
+      sheetModal.onChange = onChange ?? null;
+      useImperativeHandle(ref, () => ({ present: sheetModal.present, dismiss: sheetModal.dismiss }));
+      return createElement('div', { 'data-sheet': 'true' }, children);
+    },
+  ),
   // Render the list inline so header + items + empty state appear in the DOM.
   BottomSheetFlatList: ({
     data,
@@ -102,22 +118,29 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
 
 // Isolate from the real coordinator (covered by sheet-presentation-provider.test):
 // route the handle straight to the mocked native ref and simulate an immediate
-// settle on dismiss so onFullyDismissed-driven behaviour still fires.
+// settle on dismiss so onFullyDismissed-driven behaviour still fires. With
+// `managedSheet.deferSettle` the settle is withheld (the coordinator's dismiss
+// settle window) and the test fires `lastOnFullyDismissed` itself.
 vi.mock('../../../providers/sheet-presentation-provider', () => ({
   useManagedSheet: (opts: {
     sheetRef: { current: { present?: () => void; dismiss?: () => void } | null };
     onFullyDismissed?: () => void;
-  }) => ({
-    onChange: () => {},
-    onFullyDismissed: () => opts.onFullyDismissed?.(),
-    handle: {
-      present: () => opts.sheetRef.current?.present?.(),
-      dismiss: () => {
-        opts.sheetRef.current?.dismiss?.();
-        opts.onFullyDismissed?.();
+  }) => {
+    managedSheet.lastOnFullyDismissed = () => opts.onFullyDismissed?.();
+    return {
+      onChange: () => {},
+      onFullyDismissed: () => opts.onFullyDismissed?.(),
+      handle: {
+        present: () => opts.sheetRef.current?.present?.(),
+        dismiss: () => {
+          opts.sheetRef.current?.dismiss?.();
+          if (!managedSheet.deferSettle) {
+            opts.onFullyDismissed?.();
+          }
+        },
       },
-    },
-  }),
+    };
+  },
 }));
 
 vi.mock('react-native-safe-area-context', () => ({
@@ -310,6 +333,9 @@ describe('BoardSheet', () => {
     toast.showToast.mockClear();
     sheetModal.present.mockClear();
     sheetModal.dismiss.mockClear();
+    sheetModal.onChange = null;
+    managedSheet.deferSettle = false;
+    managedSheet.lastOnFullyDismissed = null;
     climbRows.props = [];
     thumbnails.props = [];
   });
@@ -385,6 +411,47 @@ describe('BoardSheet', () => {
     expect(sheetModal.present).toHaveBeenCalled();
   });
 
+  it('re-mounts content when the native sheet comes up after a dismiss settles mid-re-present (settle-window race)', () => {
+    presence.history = [makeClimb('c1', 3)];
+    // Withhold the dismiss settle, simulating the coordinator's settle window
+    // (up to 550ms on iOS) between a dismiss and its onFullyDismissed.
+    managedSheet.deferSettle = true;
+    const ref = createRef<BoardSheetHandle>();
+    const { container } = render(
+      createElement(BoardSheet, {
+        ref,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        boardConfig,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    // Open: content mounts.
+    act(() => ref.current?.present());
+    expect(container.querySelector('[data-list="true"]')).not.toBeNull();
+
+    // User dismisses; the settle window opens. Content stays mounted
+    // mid-animation (we never tear down before the settle).
+    act(() => ref.current?.dismiss());
+    expect(container.querySelector('[data-list="true"]')).not.toBeNull();
+
+    // User re-taps the entry point BEFORE the dismiss settles: the coordinator
+    // queues the present (its pump early-returns while the dismiss is in
+    // flight), so nothing native happens yet.
+    act(() => ref.current?.present());
+
+    // The dismiss now settles — AFTER the re-present request — unmounting the
+    // content. Without the onChange backstop this is where it would stay stuck.
+    act(() => managedSheet.lastOnFullyDismissed?.());
+    expect(container.querySelector('[data-list="true"]')).toBeNull();
+
+    // The coordinator pumps and presents the native sheet: index >= 0 through
+    // the native onChange re-mounts the content.
+    act(() => sheetModal.onChange?.(0));
+    expect(container.querySelector('[data-list="true"]')).not.toBeNull();
+  });
+
   it('triggers a manual catch-up when the history list is pulled to refresh', () => {
     presence.history = [makeClimb('c1', 3)];
     const ref = createRef<BoardSheetHandle>();
@@ -440,6 +507,37 @@ describe('BoardSheet', () => {
 
     act(() => ref.current?.present());
 
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
+  });
+
+  it('fires BoardHistoryViewed when history first arrives after presenting (late backfill), once per presentation', () => {
+    // Presented before the initial backfill resolves: empty at mount.
+    presence.history = [];
+    const ref = createRef<BoardSheetHandle>();
+    const sheetProps = {
+      ref,
+      boardLabel: 'Garage Wall',
+      onClose: noop,
+      boardConfig,
+      onSwitchBoard: noop,
+    };
+    const view = render(createElement(BoardSheet, sheetProps));
+    act(() => ref.current?.present());
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
+
+    // The backfill lands while the sheet is up.
+    presence.history = [makeClimb('c1', 3), makeClimb('c0', 2)];
+    view.rerender(createElement(BoardSheet, sheetProps));
+
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, {
+      boardId: 123,
+      itemCount: 2,
+    });
+
+    // More history arriving in the SAME presentation does not re-fire.
+    analytics.track.mockClear();
+    presence.history = [makeClimb('c2', 4), makeClimb('c1', 3), makeClimb('c0', 2)];
+    view.rerender(createElement(BoardSheet, sheetProps));
     expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
   });
 

--- a/packages/mobile/src/components/queue-control/__tests__/use-wall-or-queue-climb.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/use-wall-or-queue-climb.test.tsx
@@ -5,7 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const cfg = vi.hoisted(() => ({
   enabled: true,
   boardId: 1 as number | null,
-  isLive: true,
+  // Mirrors `BoardPresenceWallClimbContext`'s own value: `isLive ? currentClimb
+  // : null` is computed by the provider, so the hook under test only ever sees
+  // the already-collapsed wall climb (or null).
   wallClimb: { climbUuid: 'wall-1', name: 'Wax On', difficulty: 15 } as {
     climbUuid: string;
     name: string;
@@ -17,7 +19,7 @@ vi.mock('../../../providers/board-presence-provider', () => ({
   useBoardPresenceControls: () => ({ enabled: cfg.enabled, boardId: cfg.boardId }),
 }));
 vi.mock('@boardsesh/board-presence-react', () => ({
-  useBoardPresenceCurrent: () => ({ currentClimb: cfg.wallClimb, isLive: cfg.isLive }),
+  useBoardPresenceWallClimb: () => cfg.wallClimb,
 }));
 
 import { useWallClimbIfDistinct } from '../use-wall-or-queue-climb';
@@ -26,7 +28,6 @@ describe('useWallClimbIfDistinct', () => {
   beforeEach(() => {
     cfg.enabled = true;
     cfg.boardId = 1;
-    cfg.isLive = true;
     cfg.wallClimb = { climbUuid: 'wall-1', name: 'Wax On', difficulty: 15 };
   });
 
@@ -57,8 +58,8 @@ describe('useWallClimbIfDistinct', () => {
     expect(result.current).toBeNull();
   });
 
-  it('returns null when the feed is not live', () => {
-    cfg.isLive = false;
+  it('returns null when the feed is not live (context already collapses to null)', () => {
+    cfg.wallClimb = null;
     const { result } = renderHook(() => useWallClimbIfDistinct('queue-head'));
     expect(result.current).toBeNull();
   });

--- a/packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts
+++ b/packages/mobile/src/components/queue-control/use-wall-or-queue-climb.ts
@@ -13,7 +13,7 @@
 
 import { useMemo } from 'react';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
-import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
+import { useBoardPresenceWallClimb } from '@boardsesh/board-presence-react';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
 
 /**
@@ -34,16 +34,19 @@ import { useBoardPresenceControls } from '../../providers/board-presence-provide
  */
 export function useWallClimbIfDistinct(localClimbUuid: string | null): BoardPresenceClimb | null {
   const { enabled, boardId } = useBoardPresenceControls();
-  const { currentClimb: wallClimb, isLive } = useBoardPresenceCurrent();
+  // Already `null` unless a feed is live with a current climb — the isLive gate
+  // is subsumed by this narrower context, so this hook re-renders only on an
+  // actual wall-climb change instead of every presence event (holder/stats too).
+  const wallClimb = useBoardPresenceWallClimb();
 
   // `wallClimb` only changes on a wall event (bounded, not per-frame), so the memo
   // recomputes off a stable input set and the read stays O(1) on the hot path.
   return useMemo(() => {
-    const live = enabled && boardId !== null && isLive && wallClimb !== null;
+    const live = enabled && boardId !== null && wallClimb !== null;
     if (!live || !wallClimb) return null;
     // Hide when the wall is showing the user's own current climb — the bottom
     // queue bar already carries it.
     if (wallClimb.climbUuid === localClimbUuid) return null;
     return wallClimb;
-  }, [enabled, boardId, isLive, wallClimb, localClimbUuid]);
+  }, [enabled, boardId, wallClimb, localClimbUuid]);
 }

--- a/packages/mobile/src/lib/board-presence/board-presence-client.ts
+++ b/packages/mobile/src/lib/board-presence/board-presence-client.ts
@@ -1,16 +1,6 @@
-// Mobile transport for the board-presence ("now on the wall") feature.
-//
-// A thin wrapper around the shared `createBoardPresenceClient` factory
-// (`@boardsesh/board-presence-react`) — the operation strings, response
-// unwrapping, and reconnect-catch-up semantics all live there now, shared with
-// the web adapter (`packages/web/app/components/board-presence/board-presence-client.ts`),
-// so a fix in one place lands on both platforms. This file only supplies the
-// mobile graphql-ws `Client` (the same one the queue provider uses) as the
-// three transport primitives the factory needs.
-//
-// Pass a getter (not the client itself) so the live client — which graphql-ws
-// may dispose and recreate — is read at call time, matching
-// `getClient: () => getWsClient()` in the queue provider.
+// Mobile board-presence transport: binds the mobile graphql-ws `Client` to the
+// shared `createBoardPresenceClient` factory (see there for all semantics).
+// A getter (not the client) so a graphql-ws-recreated client is read at call time.
 
 import { type Client, execute, subscribe } from '@boardsesh/graphql-client';
 import {

--- a/packages/mobile/src/lib/board-presence/board-presence-client.ts
+++ b/packages/mobile/src/lib/board-presence/board-presence-client.ts
@@ -1,209 +1,49 @@
 // Mobile transport for the board-presence ("now on the wall") feature.
 //
-// `@boardsesh/board-presence-react` is renderer-agnostic: it never imports a
-// GraphQL client. This factory adapts the mobile graphql-ws `Client` (the same
-// one the queue provider uses) to the injected `BoardPresenceClient` interface,
-// running the board-presence operations over the wire — the core feed/report
-// plus the holder ops (fetchConnection / reportDisconnect) and the serial
-// disambiguation extension. (The web client implements only the subset it needs
-// and deliberately omits the optional holder ops — see board-presence-react's
-// optional interface methods.)
+// A thin wrapper around the shared `createBoardPresenceClient` factory
+// (`@boardsesh/board-presence-react`) — the operation strings, response
+// unwrapping, and reconnect-catch-up semantics all live there now, shared with
+// the web adapter (`packages/web/app/components/board-presence/board-presence-client.ts`),
+// so a fix in one place lands on both platforms. This file only supplies the
+// mobile graphql-ws `Client` (the same one the queue provider uses) as the
+// three transport primitives the factory needs.
 //
-// Mirrors how the queue provider runs SESSION_UPDATES/QUEUE_UPDATES (subscribe)
-// and confirmClimbOnWall (execute), reusing the shared `execute`/`subscribe`
-// helpers from @boardsesh/graphql-client.
+// Pass a getter (not the client itself) so the live client — which graphql-ws
+// may dispose and recreate — is read at call time, matching
+// `getClient: () => getWsClient()` in the queue provider.
 
 import { type Client, execute, subscribe } from '@boardsesh/graphql-client';
 import {
-  BOARD_CONNECTION,
-  BOARD_HISTORY,
-  BOARD_NOW_PLAYING,
-  BOARD_PRESENCE_STATS,
-  BOARD_RECENT_CLIMBS,
-  CHOOSE_BOARD_FOR_SERIAL,
-  REPORT_BOARD_CLIMB,
-  REPORT_BOARD_DISCONNECT,
-  RESOLVE_BOARD_CANDIDATES_FOR_SERIAL,
-  RESOLVE_BOARD_FOR_CONFIG,
-  RESOLVE_BOARD_FOR_SERIAL,
-  RESOLVE_BOARD_FOR_UUID,
-} from '@boardsesh/graphql/operations/board-presence';
-import type { BoardPresenceClient } from '@boardsesh/board-presence-react';
-import type {
-  BoardConnectionHolder,
-  BoardPresenceClimb,
-  BoardPresenceEvent,
-  BoardPresenceStats,
-  ClimbQueueItemInput,
-  ResolveBoardResult,
-  ResolvedBoard,
-} from '@boardsesh/shared-schema';
+  createBoardPresenceClient,
+  type BoardPresenceOperation,
+  type BoardPresenceSink,
+  type FullBoardPresenceClient,
+  type SerialResolveArgs,
+} from '@boardsesh/board-presence-react';
 
-type BoardNowPlayingData = { boardNowPlaying: BoardPresenceEvent };
-type BoardRecentClimbsData = { boardRecentClimbs: BoardPresenceClimb[] };
-type BoardHistoryData = { boardHistory: BoardPresenceClimb[] };
-type BoardPresenceStatsData = { boardPresenceStats: BoardPresenceStats };
-type BoardConnectionData = { boardConnection: BoardConnectionHolder | null };
-type ReportBoardClimbData = { reportBoardClimb: boolean };
-type ReportBoardDisconnectData = { reportBoardDisconnect: boolean };
-type ResolveBoardForSerialData = { resolveBoardForSerial: ResolvedBoard };
-type ResolveBoardForUuidData = { resolveBoardForUuid: ResolvedBoard };
-type ResolveBoardForConfigData = { resolveBoardForConfig: ResolvedBoard };
-type ResolveBoardCandidatesData = { resolveBoardCandidatesForSerial: ResolveBoardResult };
-type ChooseBoardForSerialData = { chooseBoardForSerial: ResolvedBoard };
-
-/** Config + serial needed to resolve a board (with possible disambiguation). */
-export type SerialResolveArgs = {
-  serial: string;
-  boardType: string;
-  layoutId: number;
-  sizeId: number;
-  setIds: string;
-};
+export type { SerialResolveArgs };
 
 /**
- * The mobile board-presence client extends the shared `BoardPresenceClient`
- * with serial disambiguation (the shared interface stays minimal so web can
- * keep using the legacy single-board resolver).
+ * The mobile board-presence client. Every method on `FullBoardPresenceClient`
+ * is implemented by the shared factory, including the serial disambiguation
+ * extension (`resolveBoardCandidatesForSerial`, `chooseBoardForSerial`) only
+ * mobile's board picker calls today.
  */
-export type MobileBoardPresenceClient = BoardPresenceClient & {
-  // Always implemented here (unlike the optional shared method), so callers and
-  // tests can invoke it directly without optional chaining.
-  fetchHistory: NonNullable<BoardPresenceClient['fetchHistory']>;
-  resolveBoardCandidatesForSerial(args: SerialResolveArgs): Promise<ResolveBoardResult>;
-  chooseBoardForSerial(args: { boardId: number; serial: string }): Promise<ResolvedBoard>;
-};
+export type MobileBoardPresenceClient = FullBoardPresenceClient;
 
 /**
- * Build a `MobileBoardPresenceClient` over a mobile graphql-ws client. Pass a
- * getter (not the client itself) so the live client — which graphql-ws may
- * dispose and recreate — is read at call time, matching
- * `getClient: () => getWsClient()` in the queue provider.
+ * Build a `MobileBoardPresenceClient` over a mobile graphql-ws client.
  */
 export function createMobileBoardPresenceClient(getClient: () => Client): MobileBoardPresenceClient {
-  return {
-    subscribeNowPlaying(boardId, onEvent, onError, onComplete) {
-      return subscribe<BoardNowPlayingData>(
-        getClient(),
-        { query: BOARD_NOW_PLAYING, variables: { boardId } },
-        {
-          next: (data) => {
-            if (data?.boardNowPlaying) {
-              onEvent(data.boardNowPlaying);
-            }
-          },
-          error: (err) => {
-            onError?.(err);
-          },
-          complete: () => {
-            onComplete?.();
-          },
-        },
-      );
+  return createBoardPresenceClient({
+    execute<TData>(operation: BoardPresenceOperation) {
+      return execute<TData>(getClient(), operation);
     },
-
-    onReconnect(callback) {
-      // graphql-ws fires `connected` on the first connect AND on every
-      // reconnect. Skip the first (the initial backfill already covers it) and
-      // fire on each reconnect so the hook can re-read the durable history for
-      // anything the Redis pub/sub feed dropped during the gap. Same mechanism
-      // the queue provider uses (queue-provider.tsx on('connected')). `on`
-      // returns its own unsubscribe.
-      let connectedOnce = false;
-      return getClient().on('connected', () => {
-        if (connectedOnce) {
-          callback();
-        }
-        connectedOnce = true;
-      });
+    subscribe<TData>(operation: BoardPresenceOperation, sink: BoardPresenceSink<TData>) {
+      return subscribe<TData>(getClient(), operation, sink);
     },
-
-    async fetchRecentClimbs(boardId) {
-      const data = await execute<BoardRecentClimbsData>(getClient(), {
-        query: BOARD_RECENT_CLIMBS,
-        variables: { boardId },
-      });
-      return data.boardRecentClimbs ?? [];
+    onConnected(callback: () => void) {
+      return getClient().on('connected', callback);
     },
-
-    async fetchHistory(boardId, opts) {
-      const data = await execute<BoardHistoryData>(getClient(), {
-        query: BOARD_HISTORY,
-        variables: { boardId, limit: opts?.limit ?? null, before: opts?.before ?? null },
-      });
-      return data.boardHistory ?? [];
-    },
-
-    async fetchStats(boardId) {
-      const data = await execute<BoardPresenceStatsData>(getClient(), {
-        query: BOARD_PRESENCE_STATS,
-        variables: { boardId },
-      });
-      return data.boardPresenceStats;
-    },
-
-    async reportClimb(boardId, climb: ClimbQueueItemInput, angle) {
-      const data = await execute<ReportBoardClimbData>(getClient(), {
-        query: REPORT_BOARD_CLIMB,
-        variables: { boardId, climb, angle },
-      });
-      return data.reportBoardClimb === true;
-    },
-
-    async fetchConnection(boardId) {
-      const data = await execute<BoardConnectionData>(getClient(), {
-        query: BOARD_CONNECTION,
-        variables: { boardId },
-      });
-      return data.boardConnection ?? null;
-    },
-
-    async reportDisconnect(boardId) {
-      const data = await execute<ReportBoardDisconnectData>(getClient(), {
-        query: REPORT_BOARD_DISCONNECT,
-        variables: { boardId },
-      });
-      return data.reportBoardDisconnect === true;
-    },
-
-    async resolveBoardForSerial(args) {
-      const data = await execute<ResolveBoardForSerialData>(getClient(), {
-        query: RESOLVE_BOARD_FOR_SERIAL,
-        variables: args,
-      });
-      return data.resolveBoardForSerial;
-    },
-
-    async resolveBoardForUuid(args) {
-      const data = await execute<ResolveBoardForUuidData>(getClient(), {
-        query: RESOLVE_BOARD_FOR_UUID,
-        variables: args,
-      });
-      return data.resolveBoardForUuid;
-    },
-
-    async resolveBoardForConfig(args) {
-      const data = await execute<ResolveBoardForConfigData>(getClient(), {
-        query: RESOLVE_BOARD_FOR_CONFIG,
-        variables: args,
-      });
-      return data.resolveBoardForConfig;
-    },
-
-    async resolveBoardCandidatesForSerial(args) {
-      const data = await execute<ResolveBoardCandidatesData>(getClient(), {
-        query: RESOLVE_BOARD_CANDIDATES_FOR_SERIAL,
-        variables: args,
-      });
-      return data.resolveBoardCandidatesForSerial;
-    },
-
-    async chooseBoardForSerial(args) {
-      const data = await execute<ChooseBoardForSerialData>(getClient(), {
-        query: CHOOSE_BOARD_FOR_SERIAL,
-        variables: args,
-      });
-      return data.chooseBoardForSerial;
-    },
-  };
+  });
 }

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -2,7 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act, waitFor } from '@testing-library/react';
 import { createElement, useEffect, type ReactNode } from 'react';
-import type { ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { BoardPresenceClimb, ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
 
 const transport = vi.hoisted(() => ({
   resolveBoardForSerial: vi.fn(
@@ -23,6 +24,12 @@ const transport = vi.hoisted(() => ({
 const sharedProvider = vi.hoisted(() => ({
   lastBoardId: undefined as number | null | undefined,
   lastOnCatchUp: undefined as ((info: { reason: string; recoveredThroughSeqDelta: number }) => void) | undefined,
+}));
+// Drives the mocked `useBoardPresenceCurrent` — controls what
+// `BoardPresenceInstrument` (rendered inside the provider, independent of any
+// sheet UI) sees as the wall's current climb.
+const presence = vi.hoisted(() => ({
+  currentClimb: null as BoardPresenceClimb | null,
 }));
 // The refresh action exposed by the (mocked) shared actions context, and a track
 // spy — so we can assert the foreground sync and catch-up telemetry wiring.
@@ -93,6 +100,8 @@ vi.mock('@boardsesh/board-presence-react', () => ({
   },
   // BoardPresenceForegroundSync (rendered inside the provider) reads this.
   useBoardPresenceActions: () => ({ refresh: refreshMock }),
+  // BoardPresenceInstrument (rendered inside the provider) reads this.
+  useBoardPresenceCurrent: () => ({ currentClimb: presence.currentClimb }),
 }));
 
 import { MobileBoardPresenceProvider, useBoardPresenceControls } from '../board-presence-provider';
@@ -141,6 +150,7 @@ describe('MobileBoardPresenceProvider', () => {
     transport.reportClimb.mockResolvedValue(true);
     sharedProvider.lastBoardId = undefined;
     sharedProvider.lastOnCatchUp = undefined;
+    presence.currentClimb = null;
     refreshMock.mockClear();
     trackMock.mockClear();
     appState.addEventListener.mockClear();
@@ -519,5 +529,67 @@ describe('MobileBoardPresenceProvider', () => {
       reason: 'reconnect',
       recoveredThroughSeqDelta: 2,
     });
+  });
+
+  it('tracks BoardNowPlayingReceived from the provider-level instrument, independent of any sheet UI', async () => {
+    // No BoardSheet is mounted anywhere in this tree — `BoardPresenceInstrument`
+    // lives inside `MobileBoardPresenceProvider` itself (see the provider), so
+    // this telemetry fires whether or not a sheet happens to be presented.
+    const rendered = renderProvider();
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoard({
+        serial: 'SERIAL-1',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+    await waitFor(() => expect(sharedProvider.lastBoardId).toBe(42));
+
+    trackMock.mockClear();
+    presence.currentClimb = {
+      climbUuid: 'wall-climb-1',
+      seq: 7,
+      sentAt: '2026-06-09T00:00:00.000Z',
+      name: 'Wall Climb',
+      angle: 40,
+    } as BoardPresenceClimb;
+    act(() => {
+      rendered.rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.BoardNowPlayingReceived, {
+      boardId: 42,
+      climbUuid: 'wall-climb-1',
+      seq: 7,
+    });
+  });
+
+  it('does not re-track the same wall climb on a re-render (dedup by climbUuid)', async () => {
+    const rendered = renderProvider();
+    presence.currentClimb = {
+      climbUuid: 'wall-climb-1',
+      seq: 7,
+      sentAt: '2026-06-09T00:00:00.000Z',
+      name: 'Wall Climb',
+      angle: 40,
+    } as BoardPresenceClimb;
+    act(() => {
+      rendered.rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
+    });
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.BoardNowPlayingReceived,
+      expect.objectContaining({ climbUuid: 'wall-climb-1' }),
+    );
+
+    trackMock.mockClear();
+    // A same-uuid seq bump (e.g. a backfill merge) must not re-fire.
+    presence.currentClimb = { ...presence.currentClimb, seq: 8 };
+    act(() => {
+      rendered.rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
+    });
+
+    expect(trackMock).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardNowPlayingReceived, expect.anything());
   });
 });

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -25,6 +25,7 @@ import { AppState } from 'react-native';
 import {
   BoardPresenceProvider,
   useBoardPresenceActions,
+  useBoardPresenceCurrent,
   type BoardPresenceCatchUpInfo,
 } from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -344,6 +345,7 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     <BoardPresenceControlsContext.Provider value={controls}>
       <BoardPresenceProvider boardId={boardId} client={client} onCatchUp={handleCatchUp}>
         <BoardPresenceForegroundSync />
+        <BoardPresenceInstrument boardId={boardId} />
         {children}
       </BoardPresenceProvider>
       <BoardDisambiguationSheet
@@ -375,6 +377,41 @@ function BoardPresenceForegroundSync(): null {
     });
     return () => subscription.remove();
   }, [refresh]);
+  return null;
+}
+
+/**
+ * Fires `BoardNowPlayingReceived` once per distinct wall climb received from
+ * the live feed — instrumenting the "viewed the wall" signal. Lives as a
+ * null-rendering child of `BoardPresenceProvider` (mirroring web's
+ * `BoardNowPlayingInstrument`) rather than inside `BoardSheet`, so it keeps
+ * firing regardless of whether the sheet is presented — `BoardSheet` now
+ * unmounts its presence-consuming content while dismissed (see
+ * `BoardSheetContent` there), and this telemetry must NOT depend on that.
+ */
+function BoardPresenceInstrument({ boardId }: { boardId: number | null }) {
+  const { currentClimb } = useBoardPresenceCurrent();
+  const boardIdRef = useRef(boardId);
+  boardIdRef.current = boardId;
+  const lastReceivedWallClimbRef = useRef<string | null>(null);
+  // `seq` rides along in the telemetry payload but must NOT trigger the effect
+  // — a same-uuid seq bump (e.g. a backfill merge) shouldn't re-evaluate the
+  // "new climb on the wall" event. Read it from a ref so the effect keys only
+  // on the climb uuid (matching `boardId` being read via a ref too).
+  const currentClimbSeqRef = useRef(currentClimb?.seq);
+  currentClimbSeqRef.current = currentClimb?.seq;
+  useEffect(() => {
+    const currentClimbUuid = currentClimb?.climbUuid;
+    if (!currentClimbUuid) return;
+    if (lastReceivedWallClimbRef.current === currentClimbUuid) return;
+    lastReceivedWallClimbRef.current = currentClimbUuid;
+    track(SHARED_EVENTS.BoardNowPlayingReceived, {
+      boardId: boardIdRef.current ?? undefined,
+      climbUuid: currentClimbUuid,
+      // `seq` lets PostHog spot gaps in the live stream (a jump = dropped pushes).
+      seq: currentClimbSeqRef.current ?? undefined,
+    });
+  }, [currentClimb?.climbUuid]);
   return null;
 }
 

--- a/packages/shared/board-presence-react/package.json
+++ b/packages/shared/board-presence-react/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@boardsesh/board-presence": "*",
+    "@boardsesh/graphql": "*",
     "@boardsesh/shared-schema": "*"
   },
   "devDependencies": {

--- a/packages/shared/board-presence-react/src/__tests__/create-board-presence-client.test.ts
+++ b/packages/shared/board-presence-react/src/__tests__/create-board-presence-client.test.ts
@@ -35,9 +35,15 @@ function makeTransport() {
 
   const connectedListeners: Array<() => void> = [];
   const onConnectedUnsubscribe = vi.fn();
+  // Unsubscribe really removes the listener (like graphql-ws's `on`), so tests
+  // can assert an unsubscribed registration stops receiving events.
   const onConnected = vi.fn((callback: () => void) => {
     connectedListeners.push(callback);
-    return onConnectedUnsubscribe;
+    return () => {
+      onConnectedUnsubscribe();
+      const listenerIndex = connectedListeners.indexOf(callback);
+      if (listenerIndex !== -1) connectedListeners.splice(listenerIndex, 1);
+    };
   });
 
   // `vi.fn()` produces a concretely-typed mock (always `Promise<unknown>`),
@@ -323,27 +329,57 @@ describe('createBoardPresenceClient — onReconnect', () => {
     expect(harness.onConnectedUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('tracks connectedOnce independently across two separate registrations', () => {
+  it('fires a re-registration on its first observed connected once the initial connect has been seen (board switch)', () => {
+    // graphql-ws does not replay `connected` to a listener added on an
+    // already-open socket, so after a mid-session re-registration (the hook
+    // effect re-running on a board switch) the new registration's first
+    // observed `connected` is a GENUINE reconnect. The skip-first flag is
+    // therefore factory-level (`everConnected`), not per-registration.
+    const client = createBoardPresenceClient(harness.transport);
+    const firstRegistration = vi.fn();
+
+    const unsubscribeFirst = client.onReconnect(firstRegistration);
+    harness.fireConnected(); // initial connect — skipped
+    expect(firstRegistration).not.toHaveBeenCalled();
+
+    // Board switch: the old registration tears down, a new one registers on
+    // the (still-open) socket, then the socket drops and reconnects.
+    unsubscribeFirst();
+    const secondRegistration = vi.fn();
+    client.onReconnect(secondRegistration);
+
+    harness.fireConnected(); // reconnect — the new registration's FIRST observed event
+    expect(secondRegistration).toHaveBeenCalledTimes(1);
+    // The unsubscribed registration stays silent.
+    expect(firstRegistration).not.toHaveBeenCalled();
+  });
+
+  it('two live registrations both fire on a reconnect (shared everConnected)', () => {
     const client = createBoardPresenceClient(harness.transport);
     const firstCallback = vi.fn();
     const secondCallback = vi.fn();
 
     client.onReconnect(firstCallback);
-    // A second registration made AFTER the transport has already connected
-    // once (from the first registration's perspective) still treats its own
-    // next event as "first connect" — connectedOnce is scoped per call.
-    harness.fireConnected();
+    harness.fireConnected(); // initial connect — skipped for everyone
     expect(firstCallback).not.toHaveBeenCalled();
 
     client.onReconnect(secondCallback);
-    harness.fireConnected();
-    // First registration: this is its second connected event → fires.
+    harness.fireConnected(); // reconnect — both fire (an extra catch-up coalesces safely)
     expect(firstCallback).toHaveBeenCalledTimes(1);
-    // Second registration: this is its first connected event → still skipped.
-    expect(secondCallback).not.toHaveBeenCalled();
-
-    harness.fireConnected();
-    expect(firstCallback).toHaveBeenCalledTimes(2);
     expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('an unsubscribed registration stops receiving reconnects', () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const callback = vi.fn();
+
+    const unsubscribe = client.onReconnect(callback);
+    harness.fireConnected(); // initial — skipped
+    harness.fireConnected(); // reconnect — fires
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    harness.fireConnected();
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/shared/board-presence-react/src/__tests__/create-board-presence-client.test.ts
+++ b/packages/shared/board-presence-react/src/__tests__/create-board-presence-client.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BoardPresenceEvent, ClimbQueueItemInput } from '@boardsesh/shared-schema';
+import { createBoardPresenceClient, type BoardPresenceTransport } from '../create-board-presence-client';
+import { boardHistoryCursor } from '../types';
+
+function makeClimb(climbUuid: string) {
+  return { climbUuid, seq: 1, sentAt: '2026-06-09T00:00:00.000Z', name: `Climb ${climbUuid}`, angle: 40 };
+}
+
+// A fake transport that just records every call so we can assert the factory
+// wires the right operation strings + variables and unwraps the right
+// response field — the same shape both platform adapters bind to their
+// graphql-ws `Client`, without a real websocket.
+function makeTransport() {
+  const executeCalls: Array<{ query: string; variables?: Record<string, unknown> }> = [];
+  const execute = vi.fn(async (operation: { query: string; variables?: Record<string, unknown> }) => {
+    executeCalls.push(operation);
+    return executeMock.mockResult;
+  });
+  const executeMock: { mockResult: unknown } = { mockResult: undefined };
+
+  const subscribeCalls: Array<{ query: string; variables?: Record<string, unknown> }> = [];
+  let lastSink: { next: (data: unknown) => void; error: (err: unknown) => void; complete: () => void } | null = null;
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(
+    (
+      operation: { query: string; variables?: Record<string, unknown> },
+      sink: { next: (data: unknown) => void; error: (err: unknown) => void; complete: () => void },
+    ) => {
+      subscribeCalls.push(operation);
+      lastSink = sink;
+      return unsubscribe;
+    },
+  );
+
+  const connectedListeners: Array<() => void> = [];
+  const onConnectedUnsubscribe = vi.fn();
+  const onConnected = vi.fn((callback: () => void) => {
+    connectedListeners.push(callback);
+    return onConnectedUnsubscribe;
+  });
+
+  // `vi.fn()` produces a concretely-typed mock (always `Promise<unknown>`),
+  // which can't structurally satisfy the transport's generic `execute<TData>`
+  // signature — the real adapters use generic method shorthand instead (see
+  // `create-board-presence-client.ts`'s two platform wrappers). The cast is
+  // safe here: every call site in the factory casts its own expected shape.
+  const transport = { execute, subscribe, onConnected } as unknown as BoardPresenceTransport;
+
+  return {
+    transport,
+    execute,
+    executeCalls,
+    setExecuteResult: (value: unknown) => {
+      executeMock.mockResult = value;
+    },
+    subscribe,
+    subscribeCalls,
+    getLastSink: () => lastSink,
+    unsubscribe,
+    onConnected,
+    connectedListeners,
+    onConnectedUnsubscribe,
+    fireConnected: () => connectedListeners.forEach((listener) => listener()),
+  };
+}
+
+describe('createBoardPresenceClient', () => {
+  let harness: ReturnType<typeof makeTransport>;
+
+  beforeEach(() => {
+    harness = makeTransport();
+  });
+
+  it('subscribes to BOARD_NOW_PLAYING and forwards set events to the callback', () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+    const onComplete = vi.fn();
+
+    const unsub = client.subscribeNowPlaying(42, onEvent, onError, onComplete);
+
+    expect(harness.subscribe).toHaveBeenCalledTimes(1);
+    expect(harness.subscribeCalls[0].variables).toEqual({ boardId: 42 });
+    expect(harness.subscribeCalls[0].query).toContain('boardNowPlaying');
+
+    const event: BoardPresenceEvent = { __typename: 'BoardClimbSet', climb: makeClimb('c1') };
+    harness.getLastSink()?.next({ boardNowPlaying: event });
+    expect(onEvent).toHaveBeenCalledWith(event);
+
+    harness.getLastSink()?.error(new Error('socket dropped'));
+    expect(onError).toHaveBeenCalledWith(new Error('socket dropped'));
+
+    harness.getLastSink()?.complete();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    expect(typeof unsub).toBe('function');
+    unsub();
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not forward an empty now-playing payload', () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const onEvent = vi.fn();
+    client.subscribeNowPlaying(1, onEvent);
+    harness.getLastSink()?.next({});
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it('fetches recent climbs and unwraps the boardRecentClimbs field, falling back to [] when missing', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const recent = [makeClimb('c2'), makeClimb('c3')];
+    harness.setExecuteResult({ boardRecentClimbs: recent });
+
+    const climbs = await client.fetchRecentClimbs(7);
+
+    expect(climbs).toEqual(recent);
+    expect(harness.executeCalls[0].variables).toEqual({ boardId: 7 });
+    expect(harness.executeCalls[0].query).toContain('boardRecentClimbs');
+
+    harness.setExecuteResult({});
+    expect(await client.fetchRecentClimbs(7)).toEqual([]);
+  });
+
+  it('fetches durable history, forwarding limit + before and unwrapping boardHistory, falling back to []', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const history = [makeClimb('h1'), makeClimb('h2')];
+    harness.setExecuteResult({ boardHistory: history });
+
+    const climbs = await client.fetchHistory(7, { limit: 25, before: boardHistoryCursor(900) });
+
+    expect(climbs).toEqual(history);
+    expect(harness.executeCalls[0].variables).toEqual({ boardId: 7, limit: 25, before: '900' });
+    expect(harness.executeCalls[0].query).toContain('boardHistory');
+
+    harness.setExecuteResult({ boardHistory: [] });
+    await client.fetchHistory(7);
+    expect(harness.executeCalls[1].variables).toEqual({ boardId: 7, limit: null, before: null });
+
+    harness.setExecuteResult({});
+    expect(await client.fetchHistory(7)).toEqual([]);
+  });
+
+  it('fetches stats and unwraps the boardPresenceStats field', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const stats = {
+      climbsSentCount: 3,
+      distinctClimbersCount: 2,
+      hardestGrade: 'V7',
+      topGrade: 'V4',
+      lastSentAt: null,
+    };
+    harness.setExecuteResult({ boardPresenceStats: stats });
+
+    const result = await client.fetchStats(9);
+
+    expect(result).toEqual(stats);
+    expect(harness.executeCalls[0].variables).toEqual({ boardId: 9 });
+    expect(harness.executeCalls[0].query).toContain('boardPresenceStats');
+  });
+
+  it('fetches the connection holder, unwrapping boardConnection and falling back to null', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const holder = { userId: 'u1', displayName: 'Climber', avatarUrl: null, lastSentAt: null };
+    harness.setExecuteResult({ boardConnection: holder });
+
+    expect(await client.fetchConnection(9)).toEqual(holder);
+    expect(harness.executeCalls[0].query).toContain('boardConnection');
+
+    harness.setExecuteResult({});
+    expect(await client.fetchConnection(9)).toBeNull();
+  });
+
+  it('reports a climb with the boardId, climb and angle, treating a non-true response as not accepted', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const climb = { uuid: 'q1', climb: { uuid: 'c1', name: 'X' } } as unknown as ClimbQueueItemInput;
+    harness.setExecuteResult({ reportBoardClimb: true });
+
+    expect(await client.reportClimb(5, climb, 40)).toBe(true);
+    expect(harness.executeCalls[0].variables).toEqual({ boardId: 5, climb, angle: 40 });
+    expect(harness.executeCalls[0].query).toContain('reportBoardClimb');
+
+    harness.setExecuteResult({ reportBoardClimb: false });
+    expect(await client.reportClimb(5, climb, null)).toBe(false);
+  });
+
+  it('reports a disconnect, treating a non-true response as not accepted', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    harness.setExecuteResult({ reportBoardDisconnect: true });
+
+    expect(await client.reportDisconnect(5)).toBe(true);
+    expect(harness.executeCalls[0].variables).toEqual({ boardId: 5 });
+    expect(harness.executeCalls[0].query).toContain('reportBoardDisconnect');
+
+    harness.setExecuteResult({ reportBoardDisconnect: false });
+    expect(await client.reportDisconnect(5)).toBe(false);
+  });
+
+  it('resolves a board for a serial, forwarding the board config args', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const resolved = {
+      boardId: 11,
+      boardName: 'Garage Wall',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+    harness.setExecuteResult({ resolveBoardForSerial: resolved });
+
+    const args = { serial: 'SERIAL-1', boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' };
+    const result = await client.resolveBoardForSerial(args);
+
+    expect(result).toEqual(resolved);
+    expect(harness.executeCalls[0].variables).toEqual(args);
+    expect(harness.executeCalls[0].query).toContain('resolveBoardForSerial');
+  });
+
+  it('resolves a selected named board by uuid', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const resolved = {
+      boardId: 13,
+      boardName: 'Named Board',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+    harness.setExecuteResult({ resolveBoardForUuid: resolved });
+
+    const result = await client.resolveBoardForUuid({ boardUuid: '11111111-1111-4111-8111-111111111111' });
+
+    expect(result).toEqual(resolved);
+    expect(harness.executeCalls[0].variables).toEqual({ boardUuid: '11111111-1111-4111-8111-111111111111' });
+    expect(harness.executeCalls[0].query).toContain('resolveBoardForUuid');
+  });
+
+  it('resolves a board by config for serial-less boards', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const resolved = {
+      boardId: 12,
+      boardName: 'MoonBoard 40',
+      boardType: 'moonboard',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '2019',
+    };
+    harness.setExecuteResult({ resolveBoardForConfig: resolved });
+
+    const args = { boardType: 'moonboard', layoutId: 1, sizeId: 1, setIds: '2019' };
+    const result = await client.resolveBoardForConfig(args);
+
+    expect(result).toEqual(resolved);
+    expect(harness.executeCalls[0].variables).toEqual(args);
+    expect(harness.executeCalls[0].query).toContain('resolveBoardForConfig');
+  });
+
+  it('resolves board candidates for a serial (the disambiguation extension)', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const result = { board: null, candidates: [{ boardId: 1 }] };
+    harness.setExecuteResult({ resolveBoardCandidatesForSerial: result });
+
+    const args = { serial: 'SHARED', boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' };
+    expect(await client.resolveBoardCandidatesForSerial(args)).toEqual(result);
+    expect(harness.executeCalls[0].variables).toEqual(args);
+    expect(harness.executeCalls[0].query).toContain('resolveBoardCandidatesForSerial');
+  });
+
+  it('chooses a board for a serial after disambiguation', async () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const resolved = {
+      boardId: 77,
+      boardName: 'Picked Wall',
+      boardType: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+    harness.setExecuteResult({ chooseBoardForSerial: resolved });
+
+    const result = await client.chooseBoardForSerial({ boardId: 77, serial: 'SHARED' });
+
+    expect(result).toEqual(resolved);
+    expect(harness.executeCalls[0].variables).toEqual({ boardId: 77, serial: 'SHARED' });
+    expect(harness.executeCalls[0].query).toContain('chooseBoardForSerial');
+  });
+});
+
+describe('createBoardPresenceClient — onReconnect', () => {
+  let harness: ReturnType<typeof makeTransport>;
+
+  beforeEach(() => {
+    harness = makeTransport();
+  });
+
+  it('skips the first connected event and fires on the second (reconnect)', () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const callback = vi.fn();
+
+    client.onReconnect(callback);
+    expect(harness.onConnected).toHaveBeenCalledTimes(1);
+
+    harness.fireConnected();
+    expect(callback).not.toHaveBeenCalled();
+
+    harness.fireConnected();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    harness.fireConnected();
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an unsubscribe that stops further callbacks', () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const callback = vi.fn();
+
+    const unsubscribe = client.onReconnect(callback);
+    harness.fireConnected(); // first — skipped
+    harness.fireConnected(); // second — fires
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    expect(harness.onConnectedUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks connectedOnce independently across two separate registrations', () => {
+    const client = createBoardPresenceClient(harness.transport);
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    client.onReconnect(firstCallback);
+    // A second registration made AFTER the transport has already connected
+    // once (from the first registration's perspective) still treats its own
+    // next event as "first connect" — connectedOnce is scoped per call.
+    harness.fireConnected();
+    expect(firstCallback).not.toHaveBeenCalled();
+
+    client.onReconnect(secondCallback);
+    harness.fireConnected();
+    // First registration: this is its second connected event → fires.
+    expect(firstCallback).toHaveBeenCalledTimes(1);
+    // Second registration: this is its first connected event → still skipped.
+    expect(secondCallback).not.toHaveBeenCalled();
+
+    harness.fireConnected();
+    expect(firstCallback).toHaveBeenCalledTimes(2);
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-presence.test.tsx
@@ -13,6 +13,7 @@ import {
   useBoardPresenceCurrent,
   useBoardPresenceFeed,
   useBoardPresenceHasClimb,
+  useBoardPresenceWallClimb,
 } from '../board-presence-provider';
 import type { BoardPresenceClient } from '../types';
 
@@ -958,5 +959,50 @@ describe('BoardPresenceProvider — split contexts', () => {
       harness.emit(clearEvent(3));
     });
     await waitFor(() => expect(hasClimbSnapshots.at(-1)).toBe(false));
+  });
+
+  it('narrows wall-climb consumers to climb changes only — no re-render on stats/connection churn', async () => {
+    const harness = makeClient();
+    let wallClimbRenderCount = 0;
+    const wallClimbSnapshots: Array<BoardPresenceClimb | null> = [];
+
+    function WallClimbConsumer() {
+      wallClimbRenderCount += 1;
+      wallClimbSnapshots.push(useBoardPresenceWallClimb());
+      return null;
+    }
+
+    render(
+      <BoardPresenceProvider boardId={1} client={harness.client}>
+        <WallClimbConsumer />
+      </BoardPresenceProvider>,
+    );
+
+    // Live feed, no climb yet → null.
+    await waitFor(() => expect(wallClimbRenderCount).toBeGreaterThan(0));
+    expect(wallClimbSnapshots.at(-1)).toBeNull();
+
+    // A climb lights up → the consumer re-renders with the new wall climb.
+    act(() => {
+      harness.emit(setEvent(climb('wall-1', 1)));
+    });
+    await waitFor(() => expect(wallClimbSnapshots.at(-1)?.climbUuid).toBe('wall-1'));
+    const rendersAfterClimb = wallClimbRenderCount;
+
+    // Stats and connection pushes must NOT re-render this narrow consumer — it
+    // only reads the wall's lit climb, not the whole current/feed state.
+    act(() => {
+      harness.emit(statsEvent(2, { climbsSentCount: 5 }));
+      harness.emit(connectionEvent(3, holder({ userId: 'holder-1' })));
+    });
+    expect(wallClimbRenderCount).toBe(rendersAfterClimb);
+    expect(wallClimbSnapshots.at(-1)?.climbUuid).toBe('wall-1');
+
+    // A genuine new climb set DOES re-render it.
+    act(() => {
+      harness.emit(setEvent(climb('wall-2', 4)));
+    });
+    await waitFor(() => expect(wallClimbSnapshots.at(-1)?.climbUuid).toBe('wall-2'));
+    expect(wallClimbRenderCount).toBeGreaterThan(rendersAfterClimb);
   });
 });

--- a/packages/shared/board-presence-react/src/board-presence-provider.tsx
+++ b/packages/shared/board-presence-react/src/board-presence-provider.tsx
@@ -12,6 +12,7 @@ import {
   type UseBoardPresenceResult,
 } from './use-board-presence';
 import type { BoardPresenceClient } from './types';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 
 const BoardPresenceContext = createContext<UseBoardPresenceResult | undefined>(undefined);
 const BoardPresenceActionsContext = createContext<BoardPresenceActions | undefined>(undefined);
@@ -24,6 +25,13 @@ const BoardPresenceFeedContext = createContext<BoardPresenceFeedState | undefine
 // `useActiveClimbUuid` — lets chrome (tab tree, bottom-chrome metrics) gate on
 // presence without re-rendering on every board-level climb change.
 const BoardPresenceHasClimbContext = createContext<boolean | undefined>(undefined);
+// Narrow selector: the wall's lit climb when live, else `null`. `undefined`
+// means "outside the provider" (mirrors every other context here); `null` is a
+// real value (no board bound, or the feed isn't live). Consumers that only
+// need "what's lit right now" (e.g. mobile's `useWallClimbIfDistinct`) read
+// this instead of `BoardPresenceCurrentContext`, so they don't re-render on
+// holder/stats/undo-target churn that context also carries.
+const BoardPresenceWallClimbContext = createContext<BoardPresenceClimb | null | undefined>(undefined);
 
 export function BoardPresenceProvider({
   boardId,
@@ -74,13 +82,19 @@ export function BoardPresenceProvider({
   // the context only re-renders consumers when it actually flips (not on every
   // currentClimb identity change). Wrapping it in useMemo would add nothing.
   const hasClimb = value.isLive && value.currentClimb !== null;
+  // No useMemo here either — this value IS `value.currentClimb`'s own identity
+  // when live (or the stable `null` literal otherwise), so there is nothing to
+  // memoize: the reference only changes when `currentClimb` itself does.
+  const wallClimb = value.isLive ? value.currentClimb : null;
 
   return (
     <BoardPresenceContext.Provider value={value}>
       <BoardPresenceActionsContext.Provider value={actions}>
         <BoardPresenceCurrentContext.Provider value={current}>
           <BoardPresenceHasClimbContext.Provider value={hasClimb}>
-            <BoardPresenceFeedContext.Provider value={feed}>{children}</BoardPresenceFeedContext.Provider>
+            <BoardPresenceWallClimbContext.Provider value={wallClimb}>
+              <BoardPresenceFeedContext.Provider value={feed}>{children}</BoardPresenceFeedContext.Provider>
+            </BoardPresenceWallClimbContext.Provider>
           </BoardPresenceHasClimbContext.Provider>
         </BoardPresenceCurrentContext.Provider>
       </BoardPresenceActionsContext.Provider>
@@ -128,10 +142,26 @@ export function useBoardPresenceHasClimb(): boolean {
   return context;
 }
 
+/**
+ * The wall's lit climb when the feed is live, else `null`. Narrower than
+ * `useBoardPresenceCurrent()`: this context only changes when the lit climb
+ * itself changes, not on holder/undo-target/isLive-independent churn, so
+ * consumers that just need "what's on the wall right now" (e.g. mobile's
+ * `useWallClimbIfDistinct`) avoid re-rendering on every presence event.
+ */
+export function useBoardPresenceWallClimb(): BoardPresenceClimb | null {
+  const context = useContext(BoardPresenceWallClimbContext);
+  if (context === undefined) {
+    throw new Error('useBoardPresenceWallClimb must be used within a BoardPresenceProvider');
+  }
+  return context;
+}
+
 export {
   BoardPresenceContext,
   BoardPresenceActionsContext,
   BoardPresenceCurrentContext,
   BoardPresenceFeedContext,
   BoardPresenceHasClimbContext,
+  BoardPresenceWallClimbContext,
 };

--- a/packages/shared/board-presence-react/src/create-board-presence-client.ts
+++ b/packages/shared/board-presence-react/src/create-board-presence-client.ts
@@ -116,6 +116,19 @@ export type FullBoardPresenceClient = Required<BoardPresenceClient> & {
  * see the header comment for why this factory exists.
  */
 export function createBoardPresenceClient(transport: BoardPresenceTransport): FullBoardPresenceClient {
+  // Whether ANY `onReconnect` registration made through this factory instance
+  // has observed a `connected` event. Factory-level, NOT per-registration, on
+  // purpose: graphql-ws does not replay `connected` to a listener added on an
+  // already-open socket, so after a mid-session re-registration (e.g. the
+  // shared hook's effect re-running on a board switch) the new registration's
+  // FIRST observed `connected` is a genuine reconnect — a per-registration
+  // skip-first would swallow exactly the catch-up that registration exists
+  // for. With this shared flag, only the first `connected` ever observed
+  // through this factory instance (the initial connect, whose backfill already
+  // covers it) is skipped; everything after fires, including a fresh
+  // registration's first observed event. Erring toward an occasional extra
+  // catch-up is safe — the hook's runCatchUp coalesces in-flight requests.
+  let everConnected = false;
   return {
     subscribeNowPlaying(boardId, onEvent, onError, onComplete) {
       return transport.subscribe<BoardNowPlayingData>(
@@ -138,18 +151,15 @@ export function createBoardPresenceClient(transport: BoardPresenceTransport): Fu
 
     onReconnect(callback) {
       // The transport fires `onConnected` on the first connect AND on every
-      // reconnect. Skip the first (the initial backfill already covers it) and
-      // fire on each reconnect so the hook can re-read the durable history for
-      // anything the Redis pub/sub feed dropped during the gap. `connectedOnce`
-      // is scoped to THIS registration call, so two independent `onReconnect`
-      // registrations (e.g. two hook instances sharing a transport) each track
-      // their own skip-first state.
-      let connectedOnce = false;
+      // reconnect. Skip the first ever observed through this factory (see
+      // `everConnected` above for why the flag is factory-level) and fire on
+      // each one after, so the hook can re-read the durable history for
+      // anything the Redis pub/sub feed dropped during the gap.
       return transport.onConnected(() => {
-        if (connectedOnce) {
+        if (everConnected) {
           callback();
         }
-        connectedOnce = true;
+        everConnected = true;
       });
     },
 

--- a/packages/shared/board-presence-react/src/create-board-presence-client.ts
+++ b/packages/shared/board-presence-react/src/create-board-presence-client.ts
@@ -1,0 +1,244 @@
+// Renderer-agnostic factory for the board-presence GraphQL client.
+//
+// Builds a `FullBoardPresenceClient` (every optional method on the shared
+// `BoardPresenceClient` interface implemented, plus the serial-disambiguation
+// extension mobile's board picker needs) from a platform-injected `transport`
+// — the three primitives (`execute`/`subscribe`/`onConnected`) that differ
+// between web's and mobile's graphql-ws `Client`. This package still never
+// imports a GraphQL client: `@boardsesh/graphql/operations/board-presence`
+// exports plain query strings (not a client or a codegen'd DocumentNode), and
+// the actual wire I/O is entirely the caller's — see `BoardPresenceTransport`.
+//
+// Both platform adapters (`packages/mobile/src/lib/board-presence/board-presence-client.ts`,
+// `packages/web/app/components/board-presence/board-presence-client.ts`) are
+// thin wrappers around this factory now — one place owns the operation
+// strings, the response-unwrapping, and the reconnect-catch-up semantics, so a
+// fix here (e.g. the reconnect catch-up mobile already had) lands on both
+// platforms at once instead of drifting. That drift was exactly how web ended
+// up without a reconnect catch-up before this factory existed.
+
+import {
+  BOARD_CONNECTION,
+  BOARD_HISTORY,
+  BOARD_NOW_PLAYING,
+  BOARD_PRESENCE_STATS,
+  BOARD_RECENT_CLIMBS,
+  CHOOSE_BOARD_FOR_SERIAL,
+  REPORT_BOARD_CLIMB,
+  REPORT_BOARD_DISCONNECT,
+  RESOLVE_BOARD_CANDIDATES_FOR_SERIAL,
+  RESOLVE_BOARD_FOR_CONFIG,
+  RESOLVE_BOARD_FOR_SERIAL,
+  RESOLVE_BOARD_FOR_UUID,
+} from '@boardsesh/graphql/operations/board-presence';
+import type {
+  BoardConnectionHolder,
+  BoardPresenceClimb,
+  BoardPresenceEvent,
+  BoardPresenceStats,
+  ClimbQueueItemInput,
+  ResolveBoardResult,
+  ResolvedBoard,
+} from '@boardsesh/shared-schema';
+import type { BoardPresenceClient } from './types';
+
+type BoardNowPlayingData = { boardNowPlaying: BoardPresenceEvent };
+type BoardRecentClimbsData = { boardRecentClimbs: BoardPresenceClimb[] };
+type BoardHistoryData = { boardHistory: BoardPresenceClimb[] };
+type BoardPresenceStatsData = { boardPresenceStats: BoardPresenceStats };
+type BoardConnectionData = { boardConnection: BoardConnectionHolder | null };
+type ReportBoardClimbData = { reportBoardClimb: boolean };
+type ReportBoardDisconnectData = { reportBoardDisconnect: boolean };
+type ResolveBoardForSerialData = { resolveBoardForSerial: ResolvedBoard };
+type ResolveBoardForUuidData = { resolveBoardForUuid: ResolvedBoard };
+type ResolveBoardForConfigData = { resolveBoardForConfig: ResolvedBoard };
+type ResolveBoardCandidatesData = { resolveBoardCandidatesForSerial: ResolveBoardResult };
+type ChooseBoardForSerialData = { chooseBoardForSerial: ResolvedBoard };
+
+/** Config + serial needed to resolve a board (with possible disambiguation). */
+export type SerialResolveArgs = {
+  serial: string;
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+};
+
+/** A GraphQL operation: the query/mutation/subscription string plus variables. */
+export type BoardPresenceOperation<TVariables = Record<string, unknown>> = {
+  query: string;
+  variables?: TVariables;
+};
+
+/** Callback sink for a subscription's push events, mirroring graphql-ws's `Sink`. */
+export type BoardPresenceSink<TData> = {
+  next: (data: TData) => void;
+  error: (err: unknown) => void;
+  complete: () => void;
+};
+
+/**
+ * Platform I/O this factory needs: run a mutation/query, open a subscription,
+ * and observe the transport's connect events. Both web and mobile inject this
+ * bound to their graphql-ws `Client` (see the two adapters); tests inject a
+ * fake transport.
+ */
+export type BoardPresenceTransport = {
+  execute<TData>(operation: BoardPresenceOperation): Promise<TData>;
+  subscribe<TData>(operation: BoardPresenceOperation, sink: BoardPresenceSink<TData>): () => void;
+  /**
+   * Register a callback fired on every `connected` event the transport emits
+   * (including the very first connect). `createBoardPresenceClient` derives
+   * `onReconnect` from this by skipping the first call per registration — see
+   * there for why.
+   */
+  onConnected(callback: () => void): () => void;
+};
+
+/**
+ * `BoardPresenceClient` with every optional method required, plus the serial
+ * disambiguation extension (`resolveBoardCandidatesForSerial`,
+ * `chooseBoardForSerial`) that neither platform's base interface needs but
+ * both platform clients implement identically (mobile's board picker; web
+ * currently has no caller for it, same as any other unused method). Both
+ * adapters return this type — mobile's `MobileBoardPresenceClient` and web's
+ * `WebBoardPresenceClient` are aliases of it.
+ */
+export type FullBoardPresenceClient = Required<BoardPresenceClient> & {
+  resolveBoardCandidatesForSerial(args: SerialResolveArgs): Promise<ResolveBoardResult>;
+  chooseBoardForSerial(args: { boardId: number; serial: string }): Promise<ResolvedBoard>;
+};
+
+/**
+ * Build a `FullBoardPresenceClient` over an injected `transport`. Both
+ * platform adapters (mobile, web) are one-line wrappers that supply
+ * `execute`/`subscribe`/`onConnected` bound to their own graphql-ws `Client` —
+ * see the header comment for why this factory exists.
+ */
+export function createBoardPresenceClient(transport: BoardPresenceTransport): FullBoardPresenceClient {
+  return {
+    subscribeNowPlaying(boardId, onEvent, onError, onComplete) {
+      return transport.subscribe<BoardNowPlayingData>(
+        { query: BOARD_NOW_PLAYING, variables: { boardId } },
+        {
+          next: (data) => {
+            if (data?.boardNowPlaying) {
+              onEvent(data.boardNowPlaying);
+            }
+          },
+          error: (err) => {
+            onError?.(err);
+          },
+          complete: () => {
+            onComplete?.();
+          },
+        },
+      );
+    },
+
+    onReconnect(callback) {
+      // The transport fires `onConnected` on the first connect AND on every
+      // reconnect. Skip the first (the initial backfill already covers it) and
+      // fire on each reconnect so the hook can re-read the durable history for
+      // anything the Redis pub/sub feed dropped during the gap. `connectedOnce`
+      // is scoped to THIS registration call, so two independent `onReconnect`
+      // registrations (e.g. two hook instances sharing a transport) each track
+      // their own skip-first state.
+      let connectedOnce = false;
+      return transport.onConnected(() => {
+        if (connectedOnce) {
+          callback();
+        }
+        connectedOnce = true;
+      });
+    },
+
+    async fetchRecentClimbs(boardId) {
+      const data = await transport.execute<BoardRecentClimbsData>({
+        query: BOARD_RECENT_CLIMBS,
+        variables: { boardId },
+      });
+      return data.boardRecentClimbs ?? [];
+    },
+
+    async fetchHistory(boardId, opts) {
+      const data = await transport.execute<BoardHistoryData>({
+        query: BOARD_HISTORY,
+        variables: { boardId, limit: opts?.limit ?? null, before: opts?.before ?? null },
+      });
+      return data.boardHistory ?? [];
+    },
+
+    async fetchStats(boardId) {
+      const data = await transport.execute<BoardPresenceStatsData>({
+        query: BOARD_PRESENCE_STATS,
+        variables: { boardId },
+      });
+      return data.boardPresenceStats;
+    },
+
+    async reportClimb(boardId, climb: ClimbQueueItemInput, angle) {
+      const data = await transport.execute<ReportBoardClimbData>({
+        query: REPORT_BOARD_CLIMB,
+        variables: { boardId, climb, angle },
+      });
+      return data.reportBoardClimb === true;
+    },
+
+    async fetchConnection(boardId) {
+      const data = await transport.execute<BoardConnectionData>({
+        query: BOARD_CONNECTION,
+        variables: { boardId },
+      });
+      return data.boardConnection ?? null;
+    },
+
+    async reportDisconnect(boardId) {
+      const data = await transport.execute<ReportBoardDisconnectData>({
+        query: REPORT_BOARD_DISCONNECT,
+        variables: { boardId },
+      });
+      return data.reportBoardDisconnect === true;
+    },
+
+    async resolveBoardForSerial(args) {
+      const data = await transport.execute<ResolveBoardForSerialData>({
+        query: RESOLVE_BOARD_FOR_SERIAL,
+        variables: args,
+      });
+      return data.resolveBoardForSerial;
+    },
+
+    async resolveBoardForUuid(args) {
+      const data = await transport.execute<ResolveBoardForUuidData>({
+        query: RESOLVE_BOARD_FOR_UUID,
+        variables: args,
+      });
+      return data.resolveBoardForUuid;
+    },
+
+    async resolveBoardForConfig(args) {
+      const data = await transport.execute<ResolveBoardForConfigData>({
+        query: RESOLVE_BOARD_FOR_CONFIG,
+        variables: args,
+      });
+      return data.resolveBoardForConfig;
+    },
+
+    async resolveBoardCandidatesForSerial(args) {
+      const data = await transport.execute<ResolveBoardCandidatesData>({
+        query: RESOLVE_BOARD_CANDIDATES_FOR_SERIAL,
+        variables: args,
+      });
+      return data.resolveBoardCandidatesForSerial;
+    },
+
+    async chooseBoardForSerial(args) {
+      const data = await transport.execute<ChooseBoardForSerialData>({
+        query: CHOOSE_BOARD_FOR_SERIAL,
+        variables: args,
+      });
+      return data.chooseBoardForSerial;
+    },
+  };
+}

--- a/packages/shared/board-presence-react/src/index.ts
+++ b/packages/shared/board-presence-react/src/index.ts
@@ -24,12 +24,23 @@ export {
   useBoardPresenceCurrent,
   useBoardPresenceFeed,
   useBoardPresenceHasClimb,
+  useBoardPresenceWallClimb,
   BoardPresenceActionsContext,
   BoardPresenceContext,
   BoardPresenceCurrentContext,
   BoardPresenceFeedContext,
   BoardPresenceHasClimbContext,
+  BoardPresenceWallClimbContext,
 } from './board-presence-provider';
 
 export { boardHistoryCursor } from './types';
 export type { BoardHistoryCursor, BoardPresenceClient } from './types';
+
+export { createBoardPresenceClient } from './create-board-presence-client';
+export type {
+  BoardPresenceOperation,
+  BoardPresenceSink,
+  BoardPresenceTransport,
+  FullBoardPresenceClient,
+  SerialResolveArgs,
+} from './create-board-presence-client';

--- a/packages/shared/board-presence-react/src/types.ts
+++ b/packages/shared/board-presence-react/src/types.ts
@@ -1,9 +1,11 @@
 // Injected platform I/O for the board-presence React hook.
 //
 // This package never imports a GraphQL client (it must stay renderer-agnostic
-// and platform-free), so the consumer supplies a `BoardPresenceClient` that
-// wires the actual transport — graphql-ws on web/mobile, or a fake in tests.
-// The hook only sees these five methods.
+// and platform-free) — `create-board-presence-client.ts` imports only plain
+// operation strings from `@boardsesh/graphql/operations/board-presence`, never
+// a client — so the consumer supplies a `BoardPresenceClient` that wires the
+// actual transport — graphql-ws on web/mobile, or a fake in tests. The hook
+// only sees these methods.
 
 import type {
   BoardConnectionHolder,

--- a/packages/shared/board-presence/src/__tests__/reducer.test.ts
+++ b/packages/shared/board-presence/src/__tests__/reducer.test.ts
@@ -114,6 +114,36 @@ describe('APPLY_CLIMB_SET', () => {
     expect(result).toBe(state);
   });
 
+  it('preserves object identity of a previously-merged stale entry across another stale merge', () => {
+    const current = makeClimb({ seq: 10 });
+    let state = makeState({ currentClimb: current, history: [current], lastSeq: 10 });
+
+    const staleA = makeClimb({ seq: 6, climbUuid: 'stale-a' });
+    state = boardPresenceReducer(state, { type: 'APPLY_CLIMB_SET', payload: staleA });
+    const mergedStaleA = state.history.find((entry) => entry.climbUuid === 'stale-a');
+    expect(mergedStaleA).toBe(staleA);
+
+    const staleB = makeClimb({ seq: 4, climbUuid: 'stale-b' });
+    const result = boardPresenceReducer(state, { type: 'APPLY_CLIMB_SET', payload: staleB });
+
+    // The previously-merged stale entry keeps its exact reference across the
+    // second merge — mergeHistory seeds from `existing` first.
+    expect(result.history.find((entry) => entry.climbUuid === 'stale-a')).toBe(mergedStaleA);
+    expect(result.history.map((entry) => entry.seq)).toEqual([10, 6, 4]);
+  });
+
+  it('returns the SAME state object when a stale climb set is immediately capped away', () => {
+    let state = initialBoardPresenceState;
+    for (let seq = HISTORY_CAP + 1; seq <= 2 * HISTORY_CAP; seq += 1) {
+      state = boardPresenceReducer(state, { type: 'APPLY_CLIMB_SET', payload: makeClimb({ seq }) });
+    }
+
+    const tooOldToKeep = makeClimb({ seq: 1, climbUuid: 'ancient' });
+    const result = boardPresenceReducer(state, { type: 'APPLY_CLIMB_SET', payload: tooOldToKeep });
+
+    expect(result).toBe(state);
+  });
+
   it('applies a re-send of the same climbUuid when the server assigns a new seq', () => {
     const firstSend = makeClimb({ climbUuid: 'project', seq: 4 });
     const afterFirst = boardPresenceReducer(initialBoardPresenceState, {
@@ -249,6 +279,56 @@ describe('BACKFILL_HISTORY', () => {
   it('no-ops on an empty backfill', () => {
     const state = makeState({ lastSeq: 4 });
     const result = boardPresenceReducer(state, { type: 'BACKFILL_HISTORY', payload: [] });
+    expect(result).toBe(state);
+  });
+
+  it('re-backfilling identical climbs returns the SAME state object (render no-op)', () => {
+    const backfill = [makeClimb({ seq: 1 }), makeClimb({ seq: 2 }), makeClimb({ seq: 3 })];
+
+    const once = boardPresenceReducer(initialBoardPresenceState, {
+      type: 'BACKFILL_HISTORY',
+      payload: backfill,
+    });
+    const twice = boardPresenceReducer(once, { type: 'BACKFILL_HISTORY', payload: backfill });
+
+    // Reference equality, not just deep equality — a foreground/reconnect
+    // catch-up that finds nothing new must not force a full history re-render.
+    expect(twice).toBe(once);
+  });
+
+  it('preserves per-entry object identity for pre-existing keys, even when the backfill payload carries a different (re-fetched) object for the same key', () => {
+    const existingEntry = makeClimb({ seq: 5, climbUuid: 'stable' });
+    const state = makeState({ history: [existingEntry], lastSeq: 5 });
+
+    // Same (climbUuid, seq) key, but a distinct object instance — as a real
+    // re-fetch over the wire would produce.
+    const refetchedDuplicate = makeClimb({ seq: 5, climbUuid: 'stable' });
+    expect(refetchedDuplicate).not.toBe(existingEntry);
+    const genuinelyNew = makeClimb({ seq: 6, climbUuid: 'fresh' });
+
+    const result = boardPresenceReducer(state, {
+      type: 'BACKFILL_HISTORY',
+      payload: [refetchedDuplicate, genuinelyNew],
+    });
+
+    // The pre-existing key keeps ITS original object, not the backfill's.
+    expect(result.history.find((entry) => entry.climbUuid === 'stable')).toBe(existingEntry);
+    expect(result.history.map((entry) => entry.climbUuid)).toEqual(['fresh', 'stable']);
+  });
+
+  it('preserves state identity when a backfilled climb is older than everything in a full history (immediately capped away)', () => {
+    let state = initialBoardPresenceState;
+    for (let seq = HISTORY_CAP + 1; seq <= 2 * HISTORY_CAP; seq += 1) {
+      state = boardPresenceReducer(state, { type: 'APPLY_CLIMB_SET', payload: makeClimb({ seq }) });
+    }
+    expect(state.history).toHaveLength(HISTORY_CAP);
+
+    // Older than every entry already in the (full, capped) history, and not
+    // already present, so it merges in then immediately falls off the cap —
+    // the visible history is unchanged.
+    const tooOldToKeep = makeClimb({ seq: 1, climbUuid: 'ancient' });
+    const result = boardPresenceReducer(state, { type: 'BACKFILL_HISTORY', payload: [tooOldToKeep] });
+
     expect(result).toBe(state);
   });
 });

--- a/packages/shared/board-presence/src/reducer.ts
+++ b/packages/shared/board-presence/src/reducer.ts
@@ -33,15 +33,37 @@ function historyHasEntry(history: BoardPresenceClimb[], climb: BoardPresenceClim
   return history.some((entry) => entry.climbUuid === climb.climbUuid && entry.seq === climb.seq);
 }
 
-/** Merge into history, dedup by `(climbUuid, seq)`, sort newest-first, cap. */
+/**
+ * Merge into history, dedup by `(climbUuid, seq)`, sort newest-first, cap.
+ *
+ * Identity-preserving: seeded from `existing` FIRST, so an incoming entry that
+ * duplicates an already-present key is skipped rather than replacing it — the
+ * existing object identity wins. That's correct because `(climbUuid, seq)` is
+ * immutable server-side (a re-delivery of the same key is always the same
+ * data), and it's what lets `React.memo`'d history rows bail on a backfill
+ * that repeats everything the client already has (every app resume, foreground
+ * catch-up, and pull-to-refresh when nothing new happened). When the merged
+ * result is element-wise identical to `existing`, we return `existing` itself
+ * so callers can cheaply detect "nothing changed" by reference.
+ */
 function mergeHistory(existing: BoardPresenceClimb[], incoming: BoardPresenceClimb[]): BoardPresenceClimb[] {
   const byKey = new Map<string, BoardPresenceClimb>();
-  for (const climb of [...existing, ...incoming]) {
+  for (const climb of existing) {
     byKey.set(`${climb.climbUuid}:${climb.seq}`, climb);
   }
-  return Array.from(byKey.values())
+  for (const climb of incoming) {
+    const key = `${climb.climbUuid}:${climb.seq}`;
+    if (!byKey.has(key)) {
+      byKey.set(key, climb);
+    }
+  }
+  const merged = Array.from(byKey.values())
     .sort((left, right) => right.seq - left.seq)
     .slice(0, HISTORY_CAP);
+  if (merged.length === existing.length && merged.every((entry, index) => entry === existing[index])) {
+    return existing;
+  }
+  return merged;
 }
 
 export function boardPresenceReducer(state: BoardPresenceState, action: BoardPresenceAction): BoardPresenceState {
@@ -55,9 +77,13 @@ export function boardPresenceReducer(state: BoardPresenceState, action: BoardPre
         if (historyHasEntry(state.history, incomingClimb)) {
           return state;
         }
+        const mergedHistory = mergeHistory(state.history, [incomingClimb]);
+        if (mergedHistory === state.history) {
+          return state;
+        }
         return {
           ...state,
-          history: mergeHistory(state.history, [incomingClimb]),
+          history: mergedHistory,
         };
       }
 
@@ -105,6 +131,15 @@ export function boardPresenceReducer(state: BoardPresenceState, action: BoardPre
       // in flight.
       const newestHistoryClimb = mergedHistory[0] ?? null;
       const shouldAdoptHistoryClimb = newestHistoryClimb !== null && newestHistoryClimb.seq > state.lastSeq;
+
+      // Nothing actually changed: the merge produced the same history array
+      // (by reference — every entry already present) and the seq cursor + the
+      // adoption decision are also unchanged. Returning `state` lets a
+      // foreground/reconnect catch-up that finds nothing new be a total render
+      // no-op instead of a full-list re-render.
+      if (mergedHistory === state.history && highestSeq === state.lastSeq && !shouldAdoptHistoryClimb) {
+        return state;
+      }
 
       return {
         ...state,

--- a/packages/shared/board-presence/src/reducer.ts
+++ b/packages/shared/board-presence/src/reducer.ts
@@ -38,13 +38,23 @@ function historyHasEntry(history: BoardPresenceClimb[], climb: BoardPresenceClim
  *
  * Identity-preserving: seeded from `existing` FIRST, so an incoming entry that
  * duplicates an already-present key is skipped rather than replacing it — the
- * existing object identity wins. That's correct because `(climbUuid, seq)` is
- * immutable server-side (a re-delivery of the same key is always the same
- * data), and it's what lets `React.memo`'d history rows bail on a backfill
- * that repeats everything the client already has (every app resume, foreground
- * catch-up, and pull-to-refresh when nothing new happened). When the merged
- * result is element-wise identical to `existing`, we return `existing` itself
- * so callers can cheaply detect "nothing changed" by reference.
+ * existing object identity wins. This is what lets `React.memo`'d history rows
+ * bail on a backfill that repeats everything the client already has (every app
+ * resume, foreground catch-up, and pull-to-refresh when nothing new happened).
+ * When the merged result is element-wise identical to `existing`, we return
+ * `existing` itself so callers can cheaply detect "nothing changed" by
+ * reference.
+ *
+ * On "the same key is the same data": that holds within one source (the live
+ * feed and `boardRecentClimbs` share the Redis-backed payload verbatim), but
+ * the durable `boardHistory` query is a known asymmetry — it re-resolves the
+ * sender identity via a live users/profiles join and nulls `queueItemUuid` /
+ * `gradeColor` (backend board-presence queries.ts), so the same
+ * `(climbUuid, seq)` CAN differ in those fields across sources. Existing-wins
+ * is still the right policy (the live-feed shape is the richer one), but a
+ * future caller routing `fetchHistory` results through BACKFILL_HISTORY should
+ * know the merge keeps the already-present variant rather than "refreshing"
+ * those fields.
  */
 function mergeHistory(existing: BoardPresenceClimb[], incoming: BoardPresenceClimb[]): BoardPresenceClimb[] {
   const byKey = new Map<string, BoardPresenceClimb>();

--- a/packages/web/app/components/board-presence/__tests__/board-presence-client.test.ts
+++ b/packages/web/app/components/board-presence/__tests__/board-presence-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { Client } from '@boardsesh/graphql-client';
+import { boardHistoryCursor } from '@boardsesh/board-presence-react';
 import type { BoardPresenceEvent, ClimbQueueItemInput } from '@boardsesh/shared-schema';
 
 // Stub the shared transport helpers (re-exported by the web graphql-queue
@@ -24,8 +25,18 @@ vi.mock('../../graphql-queue/graphql-client', () => ({
 
 import { createWebBoardPresenceClient } from '../board-presence-client';
 
-const fakeClient = { id: 'ws-client' } as unknown as Client;
+// A `.on('connected', ...)` recorder — web's `ExtendedClient` supports `.on`
+// the same way mobile's graphql-ws `Client` does, so `onReconnect` (derived
+// from it) is exercisable here without a real websocket.
+const connectedListeners: Array<() => void> = [];
+const onUnsubscribe = vi.fn();
+const onMock = vi.fn((_event: string, listener: () => void) => {
+  connectedListeners.push(listener);
+  return onUnsubscribe;
+});
+const fakeClient = { id: 'ws-client', on: onMock } as unknown as Client;
 const getClient = () => fakeClient;
+const fireConnected = () => connectedListeners.forEach((listener) => listener());
 
 function makeClimb(climbUuid: string) {
   return { climbUuid, seq: 1, sentAt: '2026-06-09T00:00:00.000Z', name: `Climb ${climbUuid}`, angle: 40 };
@@ -36,6 +47,9 @@ describe('createWebBoardPresenceClient', () => {
     transport.execute.mockReset();
     transport.subscribe.mockReset();
     transport.subscribe.mockReturnValue(vi.fn());
+    connectedListeners.length = 0;
+    onUnsubscribe.mockClear();
+    onMock.mockClear();
   });
 
   it('subscribes to BOARD_NOW_PLAYING and forwards set events to the callback', () => {
@@ -190,5 +204,68 @@ describe('createWebBoardPresenceClient', () => {
       setIds: '1',
     });
     expect(operation.query).toContain('resolveBoardForConfig');
+  });
+
+  it('fetches durable history, forwarding limit + before and unwrapping boardHistory', async () => {
+    const history = [makeClimb('h1'), makeClimb('h2')];
+    transport.execute.mockResolvedValue({ boardHistory: history });
+
+    const climbs = await createWebBoardPresenceClient(getClient).fetchHistory(7, {
+      limit: 25,
+      before: boardHistoryCursor(900),
+    });
+
+    expect(climbs).toEqual(history);
+    const [passedClient, operation] = transport.execute.mock.calls[0];
+    expect(passedClient).toBe(fakeClient);
+    expect(operation.variables).toEqual({ boardId: 7, limit: 25, before: '900' });
+    expect(operation.query).toContain('boardHistory');
+  });
+
+  it('defaults history limit + before to null when no paging opts are given', async () => {
+    transport.execute.mockResolvedValue({ boardHistory: [] });
+    await createWebBoardPresenceClient(getClient).fetchHistory(7);
+    expect(transport.execute.mock.calls[0][1].variables).toEqual({ boardId: 7, limit: null, before: null });
+  });
+
+  it('fetches the current connection holder, unwrapping boardConnection and falling back to null', async () => {
+    const holder = { userId: 'u1', displayName: 'Climber', avatarUrl: null, lastSentAt: null };
+    transport.execute.mockResolvedValue({ boardConnection: holder });
+
+    const result = await createWebBoardPresenceClient(getClient).fetchConnection(9);
+
+    expect(result).toEqual(holder);
+    expect(transport.execute.mock.calls[0][1].variables).toEqual({ boardId: 9 });
+    expect(transport.execute.mock.calls[0][1].query).toContain('boardConnection');
+
+    transport.execute.mockResolvedValue({});
+    expect(await createWebBoardPresenceClient(getClient).fetchConnection(9)).toBeNull();
+  });
+
+  it('reports a disconnect, treating a non-true response as not accepted', async () => {
+    transport.execute.mockResolvedValue({ reportBoardDisconnect: true });
+
+    const accepted = await createWebBoardPresenceClient(getClient).reportDisconnect(5);
+
+    expect(accepted).toBe(true);
+    const [, operation] = transport.execute.mock.calls[0];
+    expect(operation.variables).toEqual({ boardId: 5 });
+    expect(operation.query).toContain('reportBoardDisconnect');
+  });
+
+  it('registers onReconnect against the client’s "connected" event, skipping the first connect', () => {
+    const callback = vi.fn();
+    const unsubscribe = createWebBoardPresenceClient(getClient).onReconnect(callback);
+
+    expect(onMock).toHaveBeenCalledWith('connected', expect.any(Function));
+
+    fireConnected(); // first connect — skipped (initial backfill already covers it)
+    expect(callback).not.toHaveBeenCalled();
+
+    fireConnected(); // reconnect — fires
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/app/components/board-presence/__tests__/board-presence-context.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-presence-context.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, act, waitFor } from '@testing-library/react';
 import React, { createElement, useEffect, type ReactNode } from 'react';
 import type { ResolvedBoard } from '@boardsesh/shared-schema';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 
 const transport = vi.hoisted(() => ({
   resolveBoardForSerial: vi.fn(async () => ({ boardId: 42, boardName: 'Garage Wall' }) as unknown as ResolvedBoard),
@@ -12,8 +13,13 @@ const sharedProvider = vi.hoisted(() => ({
   lastBoardId: undefined as number | null | undefined,
   lastClient: null as unknown,
   clientHistory: [] as unknown[],
+  lastOnCatchUp: undefined as ((info: { reason: string; recoveredThroughSeqDelta: number }) => void) | undefined,
 }));
 const wsClient = vi.hoisted(() => ({ created: 0, disposed: 0, lastId: 0 }));
+// The refresh action exposed by the (mocked) shared actions context — asserts
+// the foreground-sync wiring the same way the mobile provider test does.
+const refreshMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: () => ({ token: auth.token, isAuthenticated: auth.isAuthenticated, isLoading: false, error: null }),
@@ -43,7 +49,7 @@ vi.mock('../board-presence-client', () => ({
   }),
 }));
 
-vi.mock('@/app/lib/analytics', () => ({ track: () => {} }));
+vi.mock('@/app/lib/analytics', () => ({ track: trackMock }));
 
 // Capture the boardId handed to the shared provider so we can assert it updates
 // after resolve.
@@ -60,17 +66,22 @@ vi.mock('@boardsesh/board-presence-react', async () => {
     BoardPresenceProvider: ({
       boardId,
       client,
+      onCatchUp,
       children,
     }: {
       boardId: number | null;
       client: unknown;
+      onCatchUp?: (info: { reason: string; recoveredThroughSeqDelta: number }) => void;
       children: ReactNode;
     }) => {
       sharedProvider.lastBoardId = boardId;
       sharedProvider.lastClient = client;
       sharedProvider.clientHistory.push(client);
+      sharedProvider.lastOnCatchUp = onCatchUp;
       return createElement('div', { 'data-board-id': String(boardId) }, children);
     },
+    // WebBoardPresenceForegroundSync (rendered inside the provider) reads this.
+    useBoardPresenceActions: () => ({ refresh: refreshMock }),
   };
 });
 
@@ -98,10 +109,13 @@ describe('WebBoardPresenceProvider', () => {
     sharedProvider.lastBoardId = undefined;
     sharedProvider.lastClient = null;
     sharedProvider.clientHistory = [];
+    sharedProvider.lastOnCatchUp = undefined;
     capturedControls = null;
     wsClient.created = 0;
     wsClient.disposed = 0;
     wsClient.lastId = 0;
+    refreshMock.mockClear();
+    trackMock.mockClear();
   });
 
   it('is always-on: builds a WS client, null boardId until a board is bound', async () => {
@@ -269,6 +283,53 @@ describe('WebBoardPresenceProvider', () => {
       expect(wsClient.created).toBe(2);
       expect(wsClient.disposed).toBe(1);
       expect(sharedProvider.lastClient).not.toBe(initialPresenceClient);
+    });
+  });
+
+  it('refetches the wall feed when the tab returns to the foreground', () => {
+    renderProvider();
+    refreshMock.mockClear();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(refreshMock).toHaveBeenCalledWith('foreground');
+  });
+
+  it('does not refetch when the tab goes to the background', () => {
+    renderProvider();
+    refreshMock.mockClear();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('tracks a catch-up telemetry event with the active boardId, reason, and recovered delta', async () => {
+    renderProvider();
+    await act(async () => {
+      await capturedControls?.resolveAndBindBoard({
+        serial: 'SERIAL-1',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      });
+    });
+    await waitFor(() => expect(sharedProvider.lastBoardId).toBe(42));
+
+    trackMock.mockClear();
+    act(() => sharedProvider.lastOnCatchUp?.({ reason: 'reconnect', recoveredThroughSeqDelta: 2 }));
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryCatchUp, {
+      boardId: 42,
+      reason: 'reconnect',
+      recoveredThroughSeqDelta: 2,
     });
   });
 });

--- a/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import React, { createElement } from 'react';
 import type { BoardPresenceClimb, BoardPresenceStats } from '@boardsesh/shared-schema';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -208,10 +208,10 @@ describe('BoardSheet', () => {
     expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
   });
 
-  it('re-arms BoardHistoryViewed after a close/re-open cycle', () => {
+  it('re-arms BoardHistoryViewed after a close/re-open cycle (body unmounts with the Drawer)', async () => {
     presence.history = [makeClimb('c1', 3)];
 
-    const { rerender } = render(
+    const { rerender, queryByText } = render(
       createElement(BoardSheet, {
         open: true,
         boardLabel: 'Garage Wall',
@@ -229,6 +229,11 @@ describe('BoardSheet', () => {
         onSwitchBoard: noop,
       }),
     );
+    // The MUI temporary Drawer (no keepMounted) unmounts the body once the
+    // close transition finishes — that unmount is what resets the
+    // once-per-open ref, so wait for it before reopening.
+    await waitFor(() => expect(queryByText(HISTORY_HEADER)).toBeNull());
+
     rerender(
       createElement(BoardSheet, {
         open: true,

--- a/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
@@ -2,12 +2,21 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, fireEvent } from '@testing-library/react';
 import React, { createElement } from 'react';
 import type { BoardPresenceClimb, BoardPresenceStats } from '@boardsesh/shared-schema';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
 const presence = vi.hoisted(() => ({
   currentClimb: null as BoardPresenceClimb | null,
   history: [] as BoardPresenceClimb[],
   stats: null as BoardPresenceStats | null,
+}));
+
+const presenceControls = vi.hoisted(() => ({
+  boardId: 123 as number | null,
+}));
+
+const analytics = vi.hoisted(() => ({
+  track: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -33,6 +42,12 @@ vi.mock('@/app/hooks/use-grade-format', () => ({
     formatGrade: (grade: string | null | undefined) => grade ?? null,
     getGradeColor: () => '#abcdef',
   }),
+}));
+
+vi.mock('@/app/lib/analytics', () => ({ track: analytics.track }));
+
+vi.mock('../board-presence-context', () => ({
+  useBoardPresenceControls: () => ({ boardId: presenceControls.boardId }),
 }));
 
 import { BoardSheet } from '../board-sheet';
@@ -62,6 +77,8 @@ describe('BoardSheet', () => {
     presence.currentClimb = null;
     presence.history = [];
     presence.stats = null;
+    presenceControls.boardId = 123;
+    analytics.track.mockClear();
   });
 
   it('renders nothing visible when closed', () => {
@@ -145,5 +162,82 @@ describe('BoardSheet', () => {
     );
     fireEvent.click(getByLabelText(CLOSE_ARIA));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires BoardHistoryViewed once on open, with the item count and boardId', () => {
+    presence.history = [makeClimb('c1', 3), makeClimb('c0', 2)];
+
+    const { rerender } = render(
+      createElement(BoardSheet, {
+        open: false,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onSwitchBoard: noop,
+      }),
+    );
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
+
+    rerender(
+      createElement(BoardSheet, {
+        open: true,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, {
+      boardId: 123,
+      itemCount: 2,
+    });
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire BoardHistoryViewed on open when there is no history', () => {
+    presence.history = [];
+
+    render(
+      createElement(BoardSheet, {
+        open: true,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    expect(analytics.track).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryViewed, expect.anything());
+  });
+
+  it('re-arms BoardHistoryViewed after a close/re-open cycle', () => {
+    presence.history = [makeClimb('c1', 3)];
+
+    const { rerender } = render(
+      createElement(BoardSheet, {
+        open: true,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onSwitchBoard: noop,
+      }),
+    );
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+
+    rerender(
+      createElement(BoardSheet, {
+        open: false,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onSwitchBoard: noop,
+      }),
+    );
+    rerender(
+      createElement(BoardSheet, {
+        open: true,
+        boardLabel: 'Garage Wall',
+        onClose: noop,
+        onSwitchBoard: noop,
+      }),
+    );
+
+    expect(analytics.track).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/app/components/board-presence/board-presence-client.ts
+++ b/packages/web/app/components/board-presence/board-presence-client.ts
@@ -1,57 +1,28 @@
 // Web transport for the board-presence ("now on the wall") feature.
 //
-// `@boardsesh/board-presence-react` is renderer-agnostic: it never imports a
-// GraphQL client. This factory adapts the web graphql-ws `Client` (the same
-// one the persistent-session provider uses) to the injected
-// `BoardPresenceClient` interface, running the board-presence operations over
-// the wire: the live subscription (BOARD_NOW_PLAYING), the late-joiner backfill
-// + stats queries, REPORT_BOARD_CLIMB, REPORT_BOARD_DISCONNECT (holder release
-// on BLE drop, matching mobile), and the serial/config/uuid resolvers. It still
-// omits the optional `fetchConnection` holder backfill — web degrades to "no
-// seeded holder on cold join", which the optional interface method models.
+// A thin wrapper around the shared `createBoardPresenceClient` factory
+// (`@boardsesh/board-presence-react`) — the operation strings, response
+// unwrapping, and reconnect-catch-up semantics all live there now, shared with
+// the mobile adapter (`packages/mobile/src/lib/board-presence/board-presence-client.ts`),
+// so a fix in one place (e.g. the reconnect catch-up) lands on both platforms
+// instead of drifting. This file only supplies the web graphql-ws `Client`
+// (the same one the persistent-session provider uses) as the three transport
+// primitives the factory needs — reusing the shared `execute`/`subscribe`
+// helpers re-exported from the web graphql-queue client.
 //
-// Mirrors the mobile `createMobileBoardPresenceClient` (and how the
-// persistent-session provider runs its subscriptions / mutations), reusing the
-// shared `execute`/`subscribe` helpers re-exported from the web graphql-queue
-// client.
+// Web now implements the full client, including `onReconnect` (reconnect
+// catch-up — web's `ExtendedClient` supports `.on('connected', ...)` the same
+// as mobile), `fetchConnection` (cold-join holder seed), and `fetchHistory`.
 
 import { type Client, execute, subscribe } from '../graphql-queue/graphql-client';
 import {
-  BOARD_NOW_PLAYING,
-  BOARD_PRESENCE_STATS,
-  BOARD_RECENT_CLIMBS,
-  REPORT_BOARD_CLIMB,
-  REPORT_BOARD_DISCONNECT,
-  RESOLVE_BOARD_FOR_CONFIG,
-  RESOLVE_BOARD_FOR_SERIAL,
-} from '@boardsesh/graphql/operations/board-presence';
-import type { BoardPresenceClient } from '@boardsesh/board-presence-react';
-import type {
-  BoardPresenceClimb,
-  BoardPresenceEvent,
-  BoardPresenceStats,
-  ClimbQueueItemInput,
-  ResolvedBoard,
-} from '@boardsesh/shared-schema';
+  createBoardPresenceClient,
+  type BoardPresenceOperation,
+  type BoardPresenceSink,
+  type FullBoardPresenceClient,
+} from '@boardsesh/board-presence-react';
 
-type BoardNowPlayingData = { boardNowPlaying: BoardPresenceEvent };
-type BoardRecentClimbsData = { boardRecentClimbs: BoardPresenceClimb[] };
-type BoardPresenceStatsData = { boardPresenceStats: BoardPresenceStats };
-type ReportBoardClimbData = { reportBoardClimb: boolean };
-type ReportBoardDisconnectData = { reportBoardDisconnect: boolean };
-type ResolveBoardForSerialData = { resolveBoardForSerial: ResolvedBoard };
-type ResolveBoardForConfigData = { resolveBoardForConfig: ResolvedBoard };
-
-export type BoardConfigResolveArgs = {
-  boardType: string;
-  layoutId: number;
-  sizeId: number;
-  setIds: string;
-};
-
-export type WebBoardPresenceClient = BoardPresenceClient & {
-  resolveBoardForConfig(args: BoardConfigResolveArgs): Promise<ResolvedBoard>;
-};
+export type WebBoardPresenceClient = FullBoardPresenceClient;
 
 /**
  * Build a `BoardPresenceClient` over a web graphql-ws client. Pass a getter
@@ -60,73 +31,15 @@ export type WebBoardPresenceClient = BoardPresenceClient & {
  * time, matching how the queue provider passes `getClient: () => getWsClient()`.
  */
 export function createWebBoardPresenceClient(getClient: () => Client): WebBoardPresenceClient {
-  return {
-    subscribeNowPlaying(boardId, onEvent, onError, onComplete) {
-      return subscribe<BoardNowPlayingData>(
-        getClient(),
-        { query: BOARD_NOW_PLAYING, variables: { boardId } },
-        {
-          next: (data) => {
-            if (data?.boardNowPlaying) {
-              onEvent(data.boardNowPlaying);
-            }
-          },
-          error: (err) => {
-            onError?.(err);
-          },
-          complete: () => {
-            onComplete?.();
-          },
-        },
-      );
+  return createBoardPresenceClient({
+    execute<TData>(operation: BoardPresenceOperation) {
+      return execute<TData>(getClient(), operation);
     },
-
-    async fetchRecentClimbs(boardId) {
-      const data = await execute<BoardRecentClimbsData>(getClient(), {
-        query: BOARD_RECENT_CLIMBS,
-        variables: { boardId },
-      });
-      return data.boardRecentClimbs ?? [];
+    subscribe<TData>(operation: BoardPresenceOperation, sink: BoardPresenceSink<TData>) {
+      return subscribe<TData>(getClient(), operation, sink);
     },
-
-    async fetchStats(boardId) {
-      const data = await execute<BoardPresenceStatsData>(getClient(), {
-        query: BOARD_PRESENCE_STATS,
-        variables: { boardId },
-      });
-      return data.boardPresenceStats;
+    onConnected(callback: () => void) {
+      return getClient().on('connected', callback);
     },
-
-    async reportClimb(boardId, climb: ClimbQueueItemInput, angle) {
-      const data = await execute<ReportBoardClimbData>(getClient(), {
-        query: REPORT_BOARD_CLIMB,
-        variables: { boardId, climb, angle },
-      });
-      return data.reportBoardClimb === true;
-    },
-
-    async reportDisconnect(boardId) {
-      const data = await execute<ReportBoardDisconnectData>(getClient(), {
-        query: REPORT_BOARD_DISCONNECT,
-        variables: { boardId },
-      });
-      return data.reportBoardDisconnect === true;
-    },
-
-    async resolveBoardForSerial(args) {
-      const data = await execute<ResolveBoardForSerialData>(getClient(), {
-        query: RESOLVE_BOARD_FOR_SERIAL,
-        variables: args,
-      });
-      return data.resolveBoardForSerial;
-    },
-
-    async resolveBoardForConfig(args) {
-      const data = await execute<ResolveBoardForConfigData>(getClient(), {
-        query: RESOLVE_BOARD_FOR_CONFIG,
-        variables: args,
-      });
-      return data.resolveBoardForConfig;
-    },
-  };
+  });
 }

--- a/packages/web/app/components/board-presence/board-presence-context.tsx
+++ b/packages/web/app/components/board-presence/board-presence-context.tsx
@@ -39,6 +39,8 @@ import {
   BoardPresenceActionsContext,
   BoardPresenceCurrentContext,
   BoardPresenceProvider,
+  useBoardPresenceActions,
+  type BoardPresenceCatchUpInfo,
   type UseBoardPresenceResult,
 } from '@boardsesh/board-presence-react';
 import type { ClimbQueueItemInput, ResolvedBoard } from '@boardsesh/shared-schema';
@@ -194,14 +196,54 @@ export function WebBoardPresenceProvider({ children }: { children: ReactNode }) 
     [boardId, resolveAndBindBoard, reportDisconnect],
   );
 
+  // Telemetry for every catch-up. `recoveredThroughSeqDelta > 0` means the live
+  // feed silently dropped pushes (Redis pub/sub has no replay) and we just
+  // recovered them — the measurable "history was slow to update" signal.
+  // Mirrors the mobile provider's `handleCatchUp`. Stable identity (reads
+  // boardIdRef) so it never re-binds the presence subscription.
+  const handleCatchUp = useCallback((info: BoardPresenceCatchUpInfo) => {
+    track(SHARED_EVENTS.BoardHistoryCatchUp, {
+      boardId: boardIdRef.current ?? undefined,
+      reason: info.reason,
+      recoveredThroughSeqDelta: info.recoveredThroughSeqDelta,
+    });
+  }, []);
+
   return (
     <BoardPresenceControlsContext.Provider value={controls}>
-      <BoardPresenceProvider boardId={boardId} client={presenceClient}>
+      <BoardPresenceProvider boardId={boardId} client={presenceClient} onCatchUp={handleCatchUp}>
         <BoardNowPlayingInstrument boardId={boardId} />
+        <WebBoardPresenceForegroundSync />
         {children}
       </BoardPresenceProvider>
     </BoardPresenceControlsContext.Provider>
   );
+}
+
+/**
+ * Refetch the wall feed when the tab returns to the foreground. The browser
+ * can suspend/throttle a background tab's WebSocket without a clean
+ * reconnect, so climbs pushed in the meantime are dropped (Redis pub/sub has
+ * no replay) and the seq-gap detector only recovers them if a *later* event
+ * happens to arrive. A foreground catch-up pulls them from the durable
+ * history right away — mirrors the mobile provider's `BoardPresenceForegroundSync`
+ * (AppState there, `visibilitychange` here). Rendered inside
+ * `BoardPresenceProvider` so it can read the `refresh` action; the catch-up
+ * coalescer dedups it against any reconnect/gap catch-up, and `refresh`
+ * no-ops while inert (no board bound).
+ */
+function WebBoardPresenceForegroundSync(): null {
+  const { refresh } = useBoardPresenceActions();
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refresh('foreground');
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [refresh]);
+  return null;
 }
 
 /**

--- a/packages/web/app/components/board-presence/board-presence-panel.tsx
+++ b/packages/web/app/components/board-presence/board-presence-panel.tsx
@@ -11,14 +11,14 @@
 // Mounted as a child of WebBoardPresenceProvider (so it can read the wall
 // context) and of the queue bridge (so it can label the active board).
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ButtonBase from '@mui/material/ButtonBase';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
-import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
+import { useBoardPresenceCurrent } from '@boardsesh/board-presence-react';
 import { themeTokens } from '@/app/theme/theme-config';
 import { track } from '@/app/lib/analytics';
 import { useQueueBridgeBoardInfo } from '../queue-control/queue-bridge-context';
@@ -26,14 +26,18 @@ import { useBoardPresenceControls } from './board-presence-context';
 import { BoardSheet } from './board-sheet';
 import { BOARD_PRESENCE_SWITCH_BOARD_EVENT } from './board-presence-events';
 
+// PERF: this panel is always mounted once a board is bound (it's the entry
+// pill's host), so it must stay off the volatile Feed context — reading
+// `useBoardPresenceFeed()` here would re-render the whole always-on pill on
+// every history change even while the sheet is closed. `BoardHistoryViewed`
+// moved into `BoardSheet` (keyed on its own `open` prop), which already
+// consumes the feed for its own rendering.
 export function BoardPresencePanel() {
   const { t } = useTranslation('session');
   const { boardId } = useBoardPresenceControls();
   const { boardDetails, angle } = useQueueBridgeBoardInfo();
   const { currentClimb } = useBoardPresenceCurrent();
-  const { history } = useBoardPresenceFeed();
   const [open, setOpen] = useState(false);
-  const historyViewedForOpenRef = useRef(false);
 
   const boardLabel = boardDetails
     ? [boardDetails.layout_name, Number.isFinite(angle) ? `${angle}°` : null].filter(Boolean).join(' • ') || null
@@ -54,19 +58,6 @@ export function BoardPresencePanel() {
     setOpen(false);
     window.dispatchEvent(new CustomEvent(BOARD_PRESENCE_SWITCH_BOARD_EVENT));
   }, [boardId]);
-
-  useEffect(() => {
-    if (!open) {
-      historyViewedForOpenRef.current = false;
-      return;
-    }
-    if (historyViewedForOpenRef.current || history.length === 0) return;
-    historyViewedForOpenRef.current = true;
-    track(SHARED_EVENTS.BoardHistoryViewed, {
-      boardId: boardId ?? undefined,
-      itemCount: history.length,
-    });
-  }, [open, history.length, boardId]);
 
   // No board bound: render nothing. The shared wall context is inert in this
   // state, so there's nothing meaningful to show anyway.

--- a/packages/web/app/components/board-presence/board-presence-panel.tsx
+++ b/packages/web/app/components/board-presence/board-presence-panel.tsx
@@ -26,12 +26,6 @@ import { useBoardPresenceControls } from './board-presence-context';
 import { BoardSheet } from './board-sheet';
 import { BOARD_PRESENCE_SWITCH_BOARD_EVENT } from './board-presence-events';
 
-// PERF: this panel is always mounted once a board is bound (it's the entry
-// pill's host), so it must stay off the volatile Feed context — reading
-// `useBoardPresenceFeed()` here would re-render the whole always-on pill on
-// every history change even while the sheet is closed. `BoardHistoryViewed`
-// moved into `BoardSheet` (keyed on its own `open` prop), which already
-// consumes the feed for its own rendering.
 export function BoardPresencePanel() {
   const { t } = useTranslation('session');
   const { boardId } = useBoardPresenceControls();

--- a/packages/web/app/components/board-presence/board-sheet.tsx
+++ b/packages/web/app/components/board-presence/board-sheet.tsx
@@ -101,7 +101,7 @@ export function BoardSheet({ open, boardLabel, onClose, onSwitchBoard }: BoardSh
       </Box>
       <Divider />
 
-      <BoardSheetBody open={open} boardId={boardId} />
+      <BoardSheetBody boardId={boardId} />
 
       <Divider />
       <ButtonBase
@@ -138,29 +138,24 @@ export function BoardSheet({ open, boardLabel, onClose, onSwitchBoard }: BoardSh
  * gated by a prop check) so it mounts/unmounts with the Drawer itself — a
  * closed sheet subscribes to none of the presence contexts.
  */
-function BoardSheetBody({ open, boardId }: { open: boolean; boardId: number | null }) {
+function BoardSheetBody({ boardId }: { boardId: number | null }) {
   const { t } = useTranslation('session');
   const { formatGrade, getGradeColor } = useGradeFormat();
   const { currentClimb } = useBoardPresenceCurrent();
   const { history, stats } = useBoardPresenceFeed();
 
-  // Fires once per open (not on every history change while open) — reset when
-  // the sheet closes so the next open re-evaluates. Keyed on `open` rather
-  // than relying solely on Drawer's own unmount timing, so this stays correct
-  // even if a future change adds `keepMounted`.
+  // Fires once per open, when history is first non-empty. This body mounts
+  // fresh each time the Drawer opens (unmounted while closed), so the ref
+  // naturally resets per open — mirrors the mobile `BoardSheetContent`.
   const historyViewedForOpenRef = useRef(false);
   useEffect(() => {
-    if (!open) {
-      historyViewedForOpenRef.current = false;
-      return;
-    }
     if (historyViewedForOpenRef.current || history.length === 0) return;
     historyViewedForOpenRef.current = true;
     track(SHARED_EVENTS.BoardHistoryViewed, {
       boardId: boardId ?? undefined,
       itemCount: history.length,
     });
-  }, [open, history.length, boardId]);
+  }, [history.length, boardId]);
 
   const statTiles = useMemo(() => {
     if (!stats) return [];

--- a/packages/web/app/components/board-presence/board-sheet.tsx
+++ b/packages/web/app/components/board-presence/board-sheet.tsx
@@ -7,11 +7,18 @@
 // "Switch board" footer row that opens the existing board switcher (via a
 // window event the bottom tab bar listens for).
 //
-// State comes from `@boardsesh/board-presence-react`'s split current/feed
-// contexts, which are inert until a board is bound — so this sheet is only ever
-// opened from the entry pill once a BLE serial has resolved to a board.
+// PERF: `BoardSheet` itself (the header/footer chrome + the boardId lookup)
+// never reads the volatile current/feed contexts — those live in
+// `BoardSheetBody`, rendered as an actual JSX CHILD of `<Drawer>`. A MUI
+// temporary Drawer without `keepMounted` unmounts its children once fully
+// closed, so `BoardSheetBody` (and thus its presence subscriptions) mounts and
+// unmounts with the sheet — a closed sheet subscribes to nothing. Calling
+// `useBoardPresenceCurrent`/`useBoardPresenceFeed` directly in `BoardSheet`
+// would defeat this: that top-level hook call runs on every render of
+// `BoardSheet` regardless of Drawer's own mount state, since `BoardSheet` is
+// rendered unconditionally by the always-mounted entry pill.
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
@@ -28,9 +35,12 @@ import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
+import { track } from '@/app/lib/analytics';
 import { DEFAULT_GRADE_COLOR, getGradeTextColor } from '@/app/lib/grade-colors';
+import { useBoardPresenceControls } from './board-presence-context';
 
 type BoardSheetProps = {
   open: boolean;
@@ -43,27 +53,10 @@ type BoardSheetProps = {
 
 export function BoardSheet({ open, boardLabel, onClose, onSwitchBoard }: BoardSheetProps) {
   const { t } = useTranslation('session');
-  const { formatGrade, getGradeColor } = useGradeFormat();
-  const { currentClimb } = useBoardPresenceCurrent();
-  const { history, stats } = useBoardPresenceFeed();
-
-  const statTiles = useMemo(() => {
-    if (!stats) return [];
-    return [
-      { key: 'sent', value: String(stats.climbsSentCount), label: t('boardPresence.statSent') },
-      { key: 'climbers', value: String(stats.distinctClimbersCount), label: t('boardPresence.statClimbers') },
-      {
-        key: 'hardest',
-        value: stats.hardestGrade ? (formatGrade(stats.hardestGrade) ?? '–') : '–',
-        label: t('boardPresence.statHardest'),
-      },
-      {
-        key: 'top',
-        value: stats.topGrade ? (formatGrade(stats.topGrade) ?? '–') : '–',
-        label: t('boardPresence.statTopGrade'),
-      },
-    ];
-  }, [stats, formatGrade, t]);
+  // `boardId` comes from the stable controls context (changes only when the
+  // bound board itself changes, not on every wall event), so reading it here
+  // in the always-mounted wrapper is cheap — unlike current/feed below.
+  const { boardId } = useBoardPresenceControls();
 
   return (
     <Drawer
@@ -108,72 +101,7 @@ export function BoardSheet({ open, boardLabel, onClose, onSwitchBoard }: BoardSh
       </Box>
       <Divider />
 
-      <Box sx={{ overflowY: 'auto', flex: 1 }}>
-        {currentClimb ? (
-          <NowOnTheWallHero
-            climb={currentClimb}
-            formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
-            gradeColor={getGradeColor(currentClimb.grade) ?? DEFAULT_GRADE_COLOR}
-            setByLine={(setter) => t('boardPresence.setByLine', { setter })}
-            litByLine={(name) => t('boardPresence.litByLine', { name })}
-          />
-        ) : (
-          <Box sx={{ textAlign: 'center', px: 4, py: 6 }}>
-            <LightbulbOutlined sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
-            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-              {t('boardPresence.emptyTitle')}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {t('boardPresence.emptyBody')}
-            </Typography>
-          </Box>
-        )}
-
-        {statTiles.length > 0 ? (
-          <Box sx={{ px: 2, pb: 1 }}>
-            <SectionHeader>{t('boardPresence.statsHeader')}</SectionHeader>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {statTiles.map((tile) => (
-                <Box
-                  key={tile.key}
-                  sx={{
-                    flexGrow: 1,
-                    flexBasis: '47%',
-                    bgcolor: 'action.hover',
-                    borderRadius: `${themeTokens.borderRadius.md}px`,
-                    px: 1.5,
-                    py: 1.25,
-                  }}
-                >
-                  <Typography variant="h6" sx={{ fontVariantNumeric: 'tabular-nums', lineHeight: 1.2 }} noWrap>
-                    {tile.value}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary" noWrap>
-                    {tile.label}
-                  </Typography>
-                </Box>
-              ))}
-            </Box>
-          </Box>
-        ) : null}
-
-        {history.length > 0 ? (
-          <Box sx={{ px: 2, pb: 1 }}>
-            <SectionHeader>{t('boardPresence.historyHeader')}</SectionHeader>
-            <List disablePadding>
-              {history.map((climb) => (
-                <HistoryRow
-                  key={`${climb.climbUuid}-${climb.seq}`}
-                  climb={climb}
-                  formattedGrade={climb.grade ? formatGrade(climb.grade) : null}
-                  gradeColor={getGradeColor(climb.grade) ?? DEFAULT_GRADE_COLOR}
-                  litByLine={(name) => t('boardPresence.litByLine', { name })}
-                />
-              ))}
-            </List>
-          </Box>
-        ) : null}
-      </Box>
+      <BoardSheetBody open={open} boardId={boardId} />
 
       <Divider />
       <ButtonBase
@@ -204,6 +132,130 @@ export function BoardSheet({ open, boardLabel, onClose, onSwitchBoard }: BoardSh
   );
 }
 
+/**
+ * Everything that reads the wall's live state: the hero, stat tiles, and the
+ * history list. Rendered as a real JSX child of `<Drawer>` (not conditionally
+ * gated by a prop check) so it mounts/unmounts with the Drawer itself — a
+ * closed sheet subscribes to none of the presence contexts.
+ */
+function BoardSheetBody({ open, boardId }: { open: boolean; boardId: number | null }) {
+  const { t } = useTranslation('session');
+  const { formatGrade, getGradeColor } = useGradeFormat();
+  const { currentClimb } = useBoardPresenceCurrent();
+  const { history, stats } = useBoardPresenceFeed();
+
+  // Fires once per open (not on every history change while open) — reset when
+  // the sheet closes so the next open re-evaluates. Keyed on `open` rather
+  // than relying solely on Drawer's own unmount timing, so this stays correct
+  // even if a future change adds `keepMounted`.
+  const historyViewedForOpenRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      historyViewedForOpenRef.current = false;
+      return;
+    }
+    if (historyViewedForOpenRef.current || history.length === 0) return;
+    historyViewedForOpenRef.current = true;
+    track(SHARED_EVENTS.BoardHistoryViewed, {
+      boardId: boardId ?? undefined,
+      itemCount: history.length,
+    });
+  }, [open, history.length, boardId]);
+
+  const statTiles = useMemo(() => {
+    if (!stats) return [];
+    return [
+      { key: 'sent', value: String(stats.climbsSentCount), label: t('boardPresence.statSent') },
+      { key: 'climbers', value: String(stats.distinctClimbersCount), label: t('boardPresence.statClimbers') },
+      {
+        key: 'hardest',
+        value: stats.hardestGrade ? (formatGrade(stats.hardestGrade) ?? '–') : '–',
+        label: t('boardPresence.statHardest'),
+      },
+      {
+        key: 'top',
+        value: stats.topGrade ? (formatGrade(stats.topGrade) ?? '–') : '–',
+        label: t('boardPresence.statTopGrade'),
+      },
+    ];
+  }, [stats, formatGrade, t]);
+
+  // Stabilized so `NowOnTheWallHero`/`HistoryRow` (both `React.memo`'d) can
+  // actually bail on an unrelated re-render (e.g. a stats-only push) instead
+  // of recreating these as fresh inline arrows every render.
+  const setByLine = useCallback((setter: string) => t('boardPresence.setByLine', { setter }), [t]);
+  const litByLine = useCallback((name: string) => t('boardPresence.litByLine', { name }), [t]);
+
+  return (
+    <Box sx={{ overflowY: 'auto', flex: 1 }}>
+      {currentClimb ? (
+        <NowOnTheWallHero
+          climb={currentClimb}
+          formattedGrade={currentClimb.grade ? formatGrade(currentClimb.grade) : null}
+          gradeColor={getGradeColor(currentClimb.grade) ?? DEFAULT_GRADE_COLOR}
+          setByLine={setByLine}
+          litByLine={litByLine}
+        />
+      ) : (
+        <Box sx={{ textAlign: 'center', px: 4, py: 6 }}>
+          <LightbulbOutlined sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            {t('boardPresence.emptyTitle')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t('boardPresence.emptyBody')}
+          </Typography>
+        </Box>
+      )}
+
+      {statTiles.length > 0 ? (
+        <Box sx={{ px: 2, pb: 1 }}>
+          <SectionHeader>{t('boardPresence.statsHeader')}</SectionHeader>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {statTiles.map((tile) => (
+              <Box
+                key={tile.key}
+                sx={{
+                  flexGrow: 1,
+                  flexBasis: '47%',
+                  bgcolor: 'action.hover',
+                  borderRadius: `${themeTokens.borderRadius.md}px`,
+                  px: 1.5,
+                  py: 1.25,
+                }}
+              >
+                <Typography variant="h6" sx={{ fontVariantNumeric: 'tabular-nums', lineHeight: 1.2 }} noWrap>
+                  {tile.value}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {tile.label}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      ) : null}
+
+      {history.length > 0 ? (
+        <Box sx={{ px: 2, pb: 1 }}>
+          <SectionHeader>{t('boardPresence.historyHeader')}</SectionHeader>
+          <List disablePadding>
+            {history.map((climb) => (
+              <HistoryRow
+                key={`${climb.climbUuid}-${climb.seq}`}
+                climb={climb}
+                formattedGrade={climb.grade ? formatGrade(climb.grade) : null}
+                gradeColor={getGradeColor(climb.grade) ?? DEFAULT_GRADE_COLOR}
+                litByLine={litByLine}
+              />
+            ))}
+          </List>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
     <Typography variant="overline" color="text.secondary" sx={{ display: 'block', pt: 1.5, pb: 1, letterSpacing: 0.5 }}>
@@ -220,7 +272,17 @@ type HeroProps = {
   litByLine: (name: string) => string;
 };
 
-function NowOnTheWallHero({ climb, formattedGrade, gradeColor, setByLine, litByLine }: HeroProps) {
+// React.memo — the reducer preserves per-entry object identity across a
+// backfill/catch-up that doesn't actually change this climb (see
+// `mergeHistory` in `@boardsesh/board-presence`), so with `setByLine`/
+// `litByLine` stabilized above, this bails on an unrelated stats-only update.
+const NowOnTheWallHero = React.memo(function NowOnTheWallHeroInner({
+  climb,
+  formattedGrade,
+  gradeColor,
+  setByLine,
+  litByLine,
+}: HeroProps) {
   const setter = climb.setter?.trim();
   const litBy = climb.sentByDisplayName?.trim();
   return (
@@ -261,7 +323,7 @@ function NowOnTheWallHero({ climb, formattedGrade, gradeColor, setByLine, litByL
       ) : null}
     </Box>
   );
-}
+});
 
 type HistoryRowProps = {
   climb: BoardPresenceClimb;
@@ -270,7 +332,15 @@ type HistoryRowProps = {
   litByLine: (name: string) => string;
 };
 
-function HistoryRow({ climb, formattedGrade, gradeColor, litByLine }: HistoryRowProps) {
+// React.memo for the same reason as `NowOnTheWallHero` — pairs with the
+// reducer's identity-preserving backfill merge so an unrelated stats/current
+// update doesn't re-render every row in the list.
+const HistoryRow = React.memo(function HistoryRowInner({
+  climb,
+  formattedGrade,
+  gradeColor,
+  litByLine,
+}: HistoryRowProps) {
   const litBy = climb.sentByDisplayName?.trim();
   return (
     <ListItem
@@ -297,4 +367,4 @@ function HistoryRow({ climb, formattedGrade, gradeColor, litByLine }: HistoryRow
       />
     </ListItem>
   );
-}
+});


### PR DESCRIPTION
## Summary

Fixes the board-presence ("now on the wall") sync and speed complaints on the client side.

**Sync — web was a strict subset of mobile and silently lost events:**
- Extracts a shared `createBoardPresenceClient` transport factory into `@boardsesh/board-presence-react` (injected `execute`/`subscribe`/`onConnected` closures). Both platform adapters are now ~40-line wrappers, so web gains what it was missing: **reconnect catch-up** (`onReconnect` → `runCatchUp`; Redis pub/sub has no replay, so a socket blip on web previously left the feed stale until an unrelated later event exposed the seq gap), **cold-join holder seed** (`fetchConnection`), and `fetchHistory` (unblocks durable-history pagination next).
- Reconnect detection hardened: the skip-first-connect flag is now factory-scoped, so a re-registration on an already-open socket (board switch, client rebuild) no longer swallows the first genuine reconnect.
- Web now re-syncs on tab foreground (`visibilitychange` → `refresh('foreground')`), mirroring mobile's AppState sync.
- Web now reports `BoardHistoryCatchUp` telemetry, so web drop/recovery rates are finally measurable in PostHog.

**Speed — render storms on every presence event:**
- `mergeHistory` preserves object identity for already-known `(climbUuid, seq)` entries and returns the same array/state when nothing changed — the catch-up that runs on *every* app resume no longer re-renders the whole history list.
- New narrow `useBoardPresenceWallClimb` context: the mobile search chrome and wall capsule stop re-rendering on holder/stats churn.
- Mobile BoardSheet content is mounted only while the sheet is presented (with a native `onChange` re-mount backstop for the re-present-during-dismiss-settle race), and the `BoardNowPlayingReceived` telemetry moved to the provider so it keeps firing regardless.
- Web sheet body unmounts while the drawer is closed; history rows and hero memoized; the always-mounted entry pill no longer subscribes to the volatile feed context.

Diff reviewed against the plan's do-not-regress checklist (reducer dedup/ordering/cap invariants, catch-up coalescing, renderer-agnostic package rules) before push.

## Release Notes

- Board history keeps itself in sync — the wall feed catches up automatically after connection blips and when you come back to the app
- Smoother board history: no more full-list redraws when you reopen the app

## Test plan

- New shared factory suite (`create-board-presence-client.test.ts`, 20 cases incl. reconnect skip-first/re-registration semantics)
- Reducer identity-preservation cases (`toBe` assertions), wall-climb context render-count probe
- Mobile board-sheet tests incl. the dismiss-settle race (mutation-verified: fails with the backstop removed) and late-backfill `BoardHistoryViewed`
- Web client/context/sheet tests extended (onReconnect, fetchConnection, fetchHistory, visibilitychange catch-up, telemetry)
- `vp run typecheck` + `typecheck:mobile` green; `vp run test:web` 4851 passed; `vp run test:mobile` 2987 passed; shared board-presence suites 106 passed; `vp run check:mobile-bundle` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPxKbADkgeCZa1uoDQEER
