### PR TITLE
perf(backend): faster wall sends, idempotent retries, seq continuity, stats cache

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -1268,12 +1268,14 @@ omit the `boardsesh:` namespace prefix.
 ```
 board:{boardId}:history             # List - latest BoardPresenceClimb payloads, newest first
 board:{boardId}:seq                 # String/integer - per-board monotonic event sequence
+board:{boardId}:writer              # String - current connection-holder emitter id
+board:{boardId}:lastReport          # String - "emitter|climb|angle" write-dedup marker (10s)
 presence:board:{boardId}:user:{id}  # String - proof-of-presence stamp for report authorization
 ```
 
-Board presence is a separate pub/sub domain from party sessions. `resolveBoardForSerial` maps a BLE serial to one active `user_boards.id`; `resolveBoardForConfig` maps serial-less hardware to one hidden system-owned board per normalized `(boardType, layoutId, sizeId, setIds)` config. `reportBoardClimb` requires a live proof-of-presence stamp for that board before it publishes a `BoardClimbSet` event.
+Board presence is a separate pub/sub domain from party sessions. `resolveBoardForSerial` maps a BLE serial to one active `user_boards.id`; `resolveBoardForConfig` maps serial-less hardware to one hidden system-owned board per normalized `(boardType, layoutId, sizeId, setIds)` config. `reportBoardClimb` requires a live proof-of-presence stamp for that board before it publishes a `BoardClimbSet` event. The report path is pipelined: `pubsub.getBoardReportGate` reads membership + first-seen + the dedup marker + the current writer in one round trip, and `pubsub.commitBoardClimb` writes the history append, the writer hand-off (atomic `SET ... GET`), the dedup marker, and the session→board mapping in another. An identical retry (same emitter, climb, and angle) within the 10 s dedup window is accepted as a no-op while that emitter still holds the wall.
 
-Redis-backed deployments keep the last 50 climbs for 24 hours so late subscribers can backfill before listening to `boardsesh:board:{boardId}`. Local-only deployments dispatch live board-presence events in process and keep proof-of-presence in memory with scheduled TTL cleanup; they do not provide board history backfill across process restarts.
+Redis-backed deployments keep the last 50 climbs for 1 week (`BOARD_HISTORY_TTL`) so late subscribers can backfill before listening to `boardsesh:board:{boardId}`; the seq counter shares that TTL and reseeds itself past the durable `board_climb_events` floor when it comes back small after expiry. Local-only deployments dispatch live board-presence events in process and keep proof-of-presence in memory with scheduled TTL cleanup; they do not provide board history backfill across process restarts.
 
 ### Graceful Shutdown
 
@@ -1564,27 +1566,28 @@ Requires user authentication and controller ownership.
 
 ### Timeouts and Limits
 
-| Setting                 | Value    | Purpose                                   |
-| ----------------------- | -------- | ----------------------------------------- |
-| Retry attempts          | 10       | WebSocket reconnection                    |
-| Max retry delay         | 30s      | Exponential backoff cap                   |
-| Keep-alive interval     | 10s      | Connection health check                   |
-| Mutation timeout        | 30s      | Prevent hanging mutations                 |
-| Redis TTL               | 4 hours  | Session cache expiry                      |
-| Postgres debounce       | 30s      | Batch writes                              |
-| Event buffer size       | 100      | Delta sync limit                          |
-| Event buffer TTL        | 5 min    | Old events cleanup                        |
-| Board history size      | 50       | Board-presence backfill limit             |
-| Board history TTL       | 24 hours | Board-presence history expiry             |
-| Board membership TTL    | 12 hours | Proof-of-presence report window           |
-| Hash verification       | 60s      | State drift detection                     |
-| Subscription queue      | 1000     | Max pending events                        |
-| Connection TTL          | 1 hour   | Distributed connection expiry             |
-| WebSocket ping interval | 30s      | Dead connection detection                 |
-| Instance heartbeat      | 30s      | Heartbeat update interval                 |
-| Instance heartbeat TTL  | 60s      | Dead instance detection                   |
-| Session members TTL     | 4 hours  | Matches session TTL                       |
-| Session grace period    | 60s      | In-memory retention after last disconnect |
+| Setting                 | Value                        | Purpose                                   |
+| ----------------------- | ---------------------------- | ----------------------------------------- |
+| Retry attempts          | 10                           | WebSocket reconnection                    |
+| Max retry delay         | 30s                          | Exponential backoff cap                   |
+| Keep-alive interval     | 10s                          | Connection health check                   |
+| Mutation timeout        | 30s                          | Prevent hanging mutations                 |
+| Redis TTL               | 4 hours                      | Session cache expiry                      |
+| Postgres debounce       | 30s                          | Batch writes                              |
+| Event buffer size       | 100                          | Delta sync limit                          |
+| Event buffer TTL        | 5 min                        | Old events cleanup                        |
+| Board history size      | 50                           | Board-presence backfill limit             |
+| Board history TTL       | 1 week (`BOARD_HISTORY_TTL`) | Board-presence history expiry             |
+| Board report dedup      | 10s                          | Write-side retry idempotency window       |
+| Board membership TTL    | 12 hours                     | Proof-of-presence report window           |
+| Hash verification       | 60s                          | State drift detection                     |
+| Subscription queue      | 1000                         | Max pending events                        |
+| Connection TTL          | 1 hour                       | Distributed connection expiry             |
+| WebSocket ping interval | 30s                          | Dead connection detection                 |
+| Instance heartbeat      | 30s                          | Heartbeat update interval                 |
+| Instance heartbeat TTL  | 60s                          | Dead instance detection                   |
+| Session members TTL     | 4 hours                      | Matches session TTL                       |
+| Session grace period    | 60s                          | In-memory retention after last disconnect |
 
 ---
 

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -22,6 +22,7 @@ import { boardPresenceMutations } from '../graphql/resolvers/board-presence/muta
 import { boardPresenceQueries } from '../graphql/resolvers/board-presence/queries';
 import { boardPresenceSubscriptions } from '../graphql/resolvers/board-presence/subscription';
 import { getBoardSeqFloor } from '../graphql/resolvers/board-presence/shared';
+import { setCachedBoardPresenceStats } from '../graphql/resolvers/board-presence/stats';
 import { tickMutations } from '../graphql/resolvers/ticks/mutations';
 
 // Board presence is always-on (the BOARD_PRESENCE_ENABLED env gate and the
@@ -2166,6 +2167,49 @@ describe('board-presence seq continuity across dormancy (Redis)', () => {
       pubsub.setBoardSeqFloorProvider(getBoardSeqFloor);
     }
   });
+
+  it('keeps retrying a failed floor consultation past the reseed threshold, then jumps the floor once it recovers', async () => {
+    if (!redisOn || !testRedis) return;
+    // The hazard: a fresh counter (post-dormancy) on a board whose durable
+    // floor is high, while the floor lookup fails transiently for the whole
+    // <= threshold window. Without a sticky retry, the counter would cross
+    // the threshold still below the floor and never consult Postgres again —
+    // clients holding pre-reset high seqs would treat every later event as
+    // stale and the live wall would freeze forever.
+    let providerHealthy = false;
+    let providerCalls = 0;
+    pubsub.setBoardSeqFloorProvider(async () => {
+      providerCalls += 1;
+      if (!providerHealthy) throw new Error('simulated transient Postgres blip');
+      return 500;
+    });
+    try {
+      // Fresh synthetic board = the post-counter-loss state (INCR from 1).
+      const syntheticBoardId = `sticky-${Date.now().toString(36)}`;
+      const allocatedDuringOutage: number[] = [];
+      for (let sendIndex = 0; sendIndex < 55; sendIndex++) {
+        allocatedDuringOutage.push(await pubsub.nextBoardSeq(syntheticBoardId));
+      }
+      // Every allocation degraded to the raw INCR (still below the floor)...
+      expect(allocatedDuringOutage[54]).toBe(55);
+      // ...and calls 51..55 prove the retry is sticky: without the pending
+      // flag the consultation would have stopped at the 50 threshold.
+      expect(providerCalls).toBe(55);
+
+      // Postgres recovers: the very next allocation consults the floor and
+      // jumps past it.
+      providerHealthy = true;
+      expect(await pubsub.nextBoardSeq(syntheticBoardId)).toBe(501);
+
+      // The pending flag is cleared by the success: subsequent allocations
+      // (now far past the threshold) skip the consultation again.
+      const callsAfterRecovery = providerCalls;
+      expect(await pubsub.nextBoardSeq(syntheticBoardId)).toBe(502);
+      expect(providerCalls).toBe(callsAfterRecovery);
+    } finally {
+      pubsub.setBoardSeqFloorProvider(getBoardSeqFloor);
+    }
+  });
 });
 
 describe('board-presence stats cache (Redis)', () => {
@@ -2338,6 +2382,65 @@ describe('board-presence stats cache (Redis)', () => {
 
     const afterDelete = await pollCacheUntil(testRedis, boardId, (stats) => stats.climbsSentCount === 0);
     expect(afterDelete).not.toBeNull();
+  });
+
+  it('updateTick refreshes the cache after the debounce window (attempt -> send)', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeStatsBoard();
+
+    // Log an ATTEMPT: counts toward distinct climbers but not sends.
+    const saved = (await tickMutations.saveTick(
+      undefined,
+      { input: { ...baseSaveTickInput(boardId), status: 'attempt', attemptCount: 2 } },
+      authCtx(),
+    )) as { uuid: string };
+
+    const afterSave = await pollCacheUntil(
+      testRedis,
+      boardId,
+      (stats) => stats.distinctClimbersCount === 1 && stats.climbsSentCount === 0,
+    );
+    expect(afterSave).not.toBeNull();
+
+    // The motivating edit: flipping attempt -> send must refresh the wall's
+    // live tiles + cache (pre-existing staleness this PR fixes).
+    await tickMutations.updateTick(undefined, { uuid: saved.uuid, input: { status: 'send' } }, authCtx());
+
+    const afterUpdate = await pollCacheUntil(testRedis, boardId, (stats) => stats.climbsSentCount === 1);
+    expect(afterUpdate).not.toBeNull();
+  });
+
+  it('a late query-miss cache write (SET NX) never rolls back a fresher publish-path snapshot', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeStatsBoard();
+    const emptyStats: BoardPresenceStats = {
+      climbsSentCount: 0,
+      distinctClimbersCount: 0,
+      hardestGrade: null,
+      hardestSend: null,
+      topGrade: null,
+      lastSentAt: null,
+    };
+    const staleSnapshot: BoardPresenceStats = { ...emptyStats, climbsSentCount: 4 };
+    const freshSnapshot: BoardPresenceStats = { ...emptyStats, climbsSentCount: 5 };
+    const readCache = async () => JSON.parse((await testRedis!.get(statsCacheKey(boardId)))!) as BoardPresenceStats;
+    const flushFireAndForget = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+    // True miss: the query-path NX write populates the key.
+    setCachedBoardPresenceStats(boardId, staleSnapshot, { onlyIfAbsent: true });
+    await flushFireAndForget();
+    expect(await readCache()).toEqual(staleSnapshot);
+
+    // The authoritative publish-path write (plain SET) overwrites it...
+    setCachedBoardPresenceStats(boardId, freshSnapshot);
+    await flushFireAndForget();
+    expect(await readCache()).toEqual(freshSnapshot);
+
+    // ...and a late query-miss write that lost the race (computed before the
+    // publish, landing after it) is a no-op instead of a rollback.
+    setCachedBoardPresenceStats(boardId, staleSnapshot, { onlyIfAbsent: true });
+    await flushFireAndForget();
+    expect(await readCache()).toEqual(freshSnapshot);
   });
 
   it('still computes stats correctly when Redis is unavailable (cache is best-effort)', async () => {

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -2136,6 +2136,36 @@ describe('board-presence seq continuity across dormancy (Redis)', () => {
     expect(first).toBe(501);
     expect(second).toBe(502);
   });
+
+  it('memoizes the floor check: one provider call while the counter grows, re-consulted after a counter loss', async () => {
+    if (!redisOn || !testRedis) return;
+    let providerCalls = 0;
+    pubsub.setBoardSeqFloorProvider(async () => {
+      providerCalls += 1;
+      return 0;
+    });
+    try {
+      const syntheticBoardId = `memo-${Date.now().toString(36)}`;
+      expect(await pubsub.nextBoardSeq(syntheticBoardId)).toBe(1);
+      expect(providerCalls).toBe(1);
+
+      // Early-life growth: each fresh INCR is strictly ahead of the
+      // watermark, so the Postgres floor lookup is not repeated.
+      await pubsub.nextBoardSeq(syntheticBoardId);
+      await pubsub.nextBoardSeq(syntheticBoardId);
+      expect(providerCalls).toBe(1);
+
+      // Counter loss while the process is up: INCR restarts at 1, which is
+      // NOT ahead of the watermark — the floor must be re-consulted (this is
+      // the hole a naive floor-value memo would leave open).
+      await testRedis.del(`board:${syntheticBoardId}:seq`);
+      await pubsub.nextBoardSeq(syntheticBoardId);
+      expect(providerCalls).toBe(2);
+    } finally {
+      // Restore this describe's real provider for any later Redis-gated test.
+      pubsub.setBoardSeqFloorProvider(getBoardSeqFloor);
+    }
+  });
 });
 
 describe('board-presence stats cache (Redis)', () => {
@@ -2317,5 +2347,63 @@ describe('board-presence stats cache (Redis)', () => {
     vi.spyOn(redisClientManager, 'isRedisConnected').mockReturnValue(false);
     const stats = await boardPresenceQueries.boardPresenceStats(undefined, { boardId }, authCtx());
     expect(stats.climbsSentCount).toBe(1);
+  });
+});
+
+// ============================================================
+// commitBoardClimb degraded path: a failed / unavailable writer slot must
+// never fabricate a hand-off broadcast (the writerSlotOk gate). Appended at
+// the END of the file (see the ordering note above).
+// ============================================================
+describe('board-presence commit degradation', () => {
+  beforeEach(async () => {
+    await cleanup();
+    await seedUser();
+    await seedCatalogClimb();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('commitBoardClimb reports writerSlotOk=false (previousWriter is a fabrication) when Redis is unavailable', async () => {
+    vi.spyOn(redisClientManager, 'isRedisConnected').mockReturnValue(false);
+    const result = await pubsub.commitBoardClimb({
+      boardId: '999999',
+      emitterId: 'emitter-degraded',
+      climb: { climbUuid: 'climb-degraded', sentAt: new Date().toISOString(), seq: 1 },
+      climbUuid: 'climb-degraded',
+      effectiveAngle: 40,
+      sessionId: null,
+    });
+    expect(result).toEqual({ previousWriter: null, writerSlotOk: false });
+  });
+
+  it('reportBoardClimb publishes the climb but no hand-off when the writer slot did not verifiably execute', async () => {
+    const resolved = await boardPresenceMutations.resolveBoardForSerial(
+      undefined,
+      { serial: `DEGR-${Date.now().toString(36)}`, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+      authCtx(),
+    );
+    const boardId = resolved.boardId;
+
+    // Simulate the failing-pipeline seam: previousWriter: null is a
+    // fabrication and writerSlotOk says so. The resolver must still accept
+    // the report and publish BoardClimbSet, but must NOT infer a free->held
+    // hand-off from the fabricated null.
+    vi.spyOn(pubsub, 'commitBoardClimb').mockResolvedValue({ previousWriter: null, writerSlotOk: false });
+    const publishSpy = vi.spyOn(pubsub, 'publishBoardPresenceEvent');
+
+    const accepted = await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    expect(accepted).toBe(true);
+
+    const publishedTypenames = publishSpy.mock.calls.map(([, event]) => event.__typename);
+    expect(publishedTypenames).toContain('BoardClimbSet');
+    expect(publishedTypenames).not.toContain('BoardConnectionChanged');
   });
 });

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -10,6 +10,7 @@ import type {
   BoardConnectionChanged,
   BoardStatsUpdated,
   BoardPresenceClimb,
+  BoardPresenceStats,
   ClimbQueueItemInput,
 } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
@@ -20,6 +21,7 @@ import { roomManager } from '../services/room-manager';
 import { boardPresenceMutations } from '../graphql/resolvers/board-presence/mutations';
 import { boardPresenceQueries } from '../graphql/resolvers/board-presence/queries';
 import { boardPresenceSubscriptions } from '../graphql/resolvers/board-presence/subscription';
+import { getBoardSeqFloor } from '../graphql/resolvers/board-presence/shared';
 import { tickMutations } from '../graphql/resolvers/ticks/mutations';
 
 // Board presence is always-on (the BOARD_PRESENCE_ENABLED env gate and the
@@ -1318,7 +1320,11 @@ describe('board-presence durable history (board_climb_events)', () => {
   it('does not persist a send before the 60s dwell gate, but still accepts the live report', async () => {
     const boardId = await resolveBoardId(`DWELL-A-${Date.now()}`);
     // First-seen = now → < 60s dwell → no durable persist.
-    vi.spyOn(pubsub, 'getBoardMembershipFirstSeen').mockResolvedValue(Date.now());
+    vi.spyOn(pubsub, 'getBoardReportGate').mockResolvedValue({
+      isMember: true,
+      firstSeenMs: Date.now(),
+      lastReport: null,
+    });
     const accepted = await boardPresenceMutations.reportBoardClimb(
       undefined,
       { boardId, climb: makeQueueItemInput(), angle: 40 },
@@ -1330,7 +1336,11 @@ describe('board-presence durable history (board_climb_events)', () => {
 
   it('drops a send when first-seen is unknown (fail-closed)', async () => {
     const boardId = await resolveBoardId(`DWELL-C-${Date.now()}`);
-    vi.spyOn(pubsub, 'getBoardMembershipFirstSeen').mockResolvedValue(null);
+    vi.spyOn(pubsub, 'getBoardReportGate').mockResolvedValue({
+      isMember: true,
+      firstSeenMs: null,
+      lastReport: null,
+    });
     await boardPresenceMutations.reportBoardClimb(
       undefined,
       { boardId, climb: makeQueueItemInput(), angle: 40 },
@@ -1342,7 +1352,11 @@ describe('board-presence durable history (board_climb_events)', () => {
   it('persists once the member has >= 60s of presence, and boardHistory returns it', async () => {
     const boardId = await resolveBoardId(`DWELL-B-${Date.now()}`);
     // Simulate sustained presence: first-seen 2 minutes ago → dwell met.
-    vi.spyOn(pubsub, 'getBoardMembershipFirstSeen').mockResolvedValue(Date.now() - 120_000);
+    vi.spyOn(pubsub, 'getBoardReportGate').mockResolvedValue({
+      isMember: true,
+      firstSeenMs: Date.now() - 120_000,
+      lastReport: null,
+    });
 
     const accepted = await boardPresenceMutations.reportBoardClimb(
       undefined,
@@ -1677,5 +1691,582 @@ describe('board-presence connection holder', () => {
         await roomManager.removeClient(otherConnectionId);
       }
     });
+  });
+});
+
+// ============================================================
+// PR A perf work: pipelined commit (A1), write-side idempotency (A2), seq
+// continuity across dormancy (A3), stats cache (A4). Appended at the END —
+// never disturb the timing-racy concurrent-config-create test earlier in the
+// file (the only permitted mid-file edit was retargeting the three dwell-gate
+// spies above from getBoardMembershipFirstSeen to getBoardReportGate).
+//
+// These describes reconnect `redisClientManager` directly rather than via
+// `pubsub.initialize()`: that call is a one-time no-op once the "holder state
+// + hand-off" describe above already initialized pubsub, and that describe's
+// own afterAll disconnects redisClientManager — so exercising the real Redis
+// paths again here needs an explicit reconnect.
+// ============================================================
+
+async function ensureRedisConnectedForTest(): Promise<boolean> {
+  if (redisClientManager.isRedisConnected()) return true;
+  try {
+    return await redisClientManager.connect();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Overwrites the NX-guarded first-seen stamp that resolveBoardForSerial /
+ * stampBoardMembership already wrote, so the *real* getBoardReportGate
+ * pipeline reads a "dwell met" value below — exercising the production read
+ * path end-to-end instead of mocking around it.
+ */
+async function stampSustainedFirstSeen(redis: Redis, boardId: number, userId: string, msAgo = 120_000): Promise<void> {
+  await redis.set(`presence:board:${boardId}:user:${userId}`, String(Date.now() - msAgo), 'EX', 43_200);
+}
+
+describe('board-presence pipelined commit (Redis)', () => {
+  let redisOn = false;
+  let testRedis: Redis | null = null;
+  const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
+
+  beforeAll(async () => {
+    redisOn = await ensureRedisConnectedForTest();
+    if (!redisOn) {
+      console.warn('[board-presence] Redis unavailable — skipping pipelined-commit tests');
+      return;
+    }
+    testRedis = new Redis(REDIS_URL, { lazyConnect: true, maxRetriesPerRequest: 1 });
+    await testRedis.connect();
+  });
+
+  afterAll(async () => {
+    if (testRedis) await testRedis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedUser();
+    await seedCatalogClimb();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  let pipelineSerialCounter = 0;
+  async function makePipelineBoard(ctx: ConnectionContext = authCtx()): Promise<number> {
+    const serial = `PIPE-${Date.now().toString(36)}-${pipelineSerialCounter++}`;
+    const resolved = await boardPresenceMutations.resolveBoardForSerial(
+      undefined,
+      { serial, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+      ctx,
+    );
+    return resolved.boardId;
+  }
+
+  it('one report populates the history list and the writer key, both with a live TTL', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makePipelineBoard();
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+
+    const historyKey = `board:${boardId}:history`;
+    const writerKey = `board:${boardId}:writer`;
+    const [historyEntries, writerValue, historyTtl, writerTtl] = await Promise.all([
+      testRedis.lrange(historyKey, 0, -1),
+      testRedis.get(writerKey),
+      testRedis.pttl(historyKey),
+      testRedis.pttl(writerKey),
+    ]);
+
+    expect(historyEntries).toHaveLength(1);
+    expect((JSON.parse(historyEntries[0]) as BoardPresenceClimb).climbUuid).toBe(TEST_CLIMB_UUID);
+    expect(writerValue).toBe(TEST_USER_ID);
+    expect(historyTtl).toBeGreaterThan(0);
+    expect(writerTtl).toBeGreaterThan(0);
+  });
+});
+
+describe('board-presence write-side idempotency (Redis)', () => {
+  let redisOn = false;
+  let testRedis: Redis | null = null;
+  const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
+
+  beforeAll(async () => {
+    redisOn = await ensureRedisConnectedForTest();
+    if (!redisOn) {
+      console.warn('[board-presence] Redis unavailable — skipping write-side idempotency tests');
+      return;
+    }
+    testRedis = new Redis(REDIS_URL, { lazyConnect: true, maxRetriesPerRequest: 1 });
+    await testRedis.connect();
+  });
+
+  afterAll(async () => {
+    if (testRedis) await testRedis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedUser();
+    await seedCatalogClimb();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  let idemSerialCounter = 0;
+  async function makeIdemBoard(ctx: ConnectionContext = authCtx()): Promise<number> {
+    const serial = `IDEM-${Date.now().toString(36)}-${idemSerialCounter++}`;
+    const resolved = await boardPresenceMutations.resolveBoardForSerial(
+      undefined,
+      { serial, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+      ctx,
+    );
+    return resolved.boardId;
+  }
+
+  async function countEvents(boardId: number): Promise<number> {
+    const [row] = await db.execute(
+      sql`SELECT count(*)::int AS count FROM board_climb_events WHERE board_id = ${boardId}`,
+    );
+    return Number((row as { count: number }).count);
+  }
+
+  // These tests verify through directly-observable state (the Redis FIFO
+  // history list, the writer key, and durable Postgres rows) rather than by
+  // subscribing to pubsub.subscribeBoardPresence: this file's earlier "holder
+  // state + hand-off (Redis)" describe already disconnected redisClientManager
+  // in its own afterAll (a describe we may not touch), which leaves pubsub's
+  // internal Redis *subscriber* connection permanently closed for the rest of
+  // this file — a test-harness artifact of reconnecting the publisher-side
+  // client directly, not a production concern (ioredis reconnects live
+  // clients automatically; only the test teardown calls `.quit()`). Every
+  // write path exercised below (INCR/SET/EVAL/pipelines) goes through the
+  // publisher client, which IS healthy after `ensureRedisConnectedForTest`.
+
+  it('collapses an exact retry (same user/climb/angle) into a no-op: one history entry, one durable row, seq consumed once', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeIdemBoard();
+    await stampSustainedFirstSeen(testRedis, boardId, TEST_USER_ID);
+
+    const firstAccepted = await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    const seqAfterFirst = await testRedis.get(`board:${boardId}:seq`);
+
+    const secondAccepted = await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    const seqAfterSecond = await testRedis.get(`board:${boardId}:seq`);
+
+    expect(firstAccepted).toBe(true);
+    expect(secondAccepted).toBe(true);
+    const history = await testRedis.lrange(`board:${boardId}:history`, 0, -1);
+    expect(history).toHaveLength(1);
+    expect(await countEvents(boardId)).toBe(1);
+    // The dedup path returns before allocating a seq, so the counter is unchanged.
+    expect(seqAfterSecond).toBe(seqAfterFirst);
+  });
+
+  it('does not suppress a different climb, angle, or user (and a user change still hands off the writer)', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeIdemBoard();
+    await pubsub.stampBoardMembership(String(boardId), SECOND_USER_ID);
+    const writerKey = `board:${boardId}:writer`;
+
+    expect(await testRedis.get(writerKey)).toBeNull();
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    expect(await testRedis.get(writerKey)).toBe(TEST_USER_ID);
+
+    // Different climb, same user/angle.
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput({ uuid: OTHER_TEST_CLIMB_UUID }), angle: 40 },
+      authCtx(),
+    );
+    // Different angle, back to the first climb.
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 45 },
+      authCtx(),
+    );
+    // Different user, same climb/angle as the previous send — a hand-off.
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 45 },
+      authCtx({ userId: SECOND_USER_ID }),
+    );
+
+    // None of the four sends were deduped — one FIFO entry each.
+    const history = await testRedis.lrange(`board:${boardId}:history`, 0, -1);
+    expect(history).toHaveLength(4);
+    expect(await testRedis.get(writerKey)).toBe(SECOND_USER_ID);
+  });
+
+  it('re-accepts a retry once the dedup window has expired', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeIdemBoard();
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    // Force the dedup marker to expire immediately instead of waiting out the real 10s window.
+    await testRedis.pexpire(`board:${boardId}:lastReport`, 1);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const secondAccepted = await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+
+    expect(secondAccepted).toBe(true);
+    const history = await testRedis.lrange(`board:${boardId}:history`, 0, -1);
+    expect(history).toHaveLength(2);
+  });
+});
+
+describe('board-presence seq continuity across dormancy (Redis)', () => {
+  let redisOn = false;
+  let testRedis: Redis | null = null;
+  const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
+
+  beforeAll(async () => {
+    redisOn = await ensureRedisConnectedForTest();
+    if (!redisOn) {
+      console.warn('[board-presence] Redis unavailable — skipping seq continuity tests');
+      return;
+    }
+    testRedis = new Redis(REDIS_URL, { lazyConnect: true, maxRetriesPerRequest: 1 });
+    await testRedis.connect();
+    pubsub.setBoardSeqFloorProvider(getBoardSeqFloor);
+  });
+
+  afterAll(async () => {
+    // Restore the no-op default so later test files in the same worker never
+    // inherit a floor provider that hits Postgres.
+    pubsub.setBoardSeqFloorProvider(async () => 0);
+    if (testRedis) await testRedis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedUser();
+    await seedCatalogClimb();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  let seqSerialCounter = 0;
+  async function makeSeqBoard(ctx: ConnectionContext = authCtx()): Promise<number> {
+    const serial = `SEQCONT-${Date.now().toString(36)}-${seqSerialCounter++}`;
+    const resolved = await boardPresenceMutations.resolveBoardForSerial(
+      undefined,
+      { serial, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+      ctx,
+    );
+    return resolved.boardId;
+  }
+
+  async function durableSeqs(boardId: number): Promise<number[]> {
+    const rows = await db.execute(sql`SELECT seq FROM board_climb_events WHERE board_id = ${boardId} ORDER BY seq ASC`);
+    return rows.map((row) => Number((row as { seq: number }).seq));
+  }
+
+  it('reseeds past the durable floor after the Redis seq counter is lost, keeping boardHistory newest-first intact', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeSeqBoard();
+    await stampSustainedFirstSeen(testRedis, boardId, TEST_USER_ID);
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    const [firstSeq] = await durableSeqs(boardId);
+    expect(firstSeq).toBeGreaterThan(0);
+
+    // Simulate dormancy: the Redis seq key expired/was evicted, but the
+    // durable Postgres row from the first send is still there.
+    await testRedis.del(`board:${boardId}:seq`);
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput({ uuid: OTHER_TEST_CLIMB_UUID }), angle: 40 },
+      authCtx(),
+    );
+
+    const seqs = await durableSeqs(boardId);
+    expect(seqs).toHaveLength(2);
+    expect(seqs[1]).toBeGreaterThan(firstSeq);
+
+    const history = await boardPresenceQueries.boardHistory(undefined, { boardId }, authCtx());
+    expect(history.map((row) => row.seq)).toEqual([seqs[1], seqs[0]]);
+  });
+
+  it('starts a brand-new board at seq 1 even right after a DEL with no durable rows', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeSeqBoard();
+    await testRedis.del(`board:${boardId}:seq`); // no-op: the board never sent, so this key never existed
+    expect(await pubsub.nextBoardSeq(String(boardId))).toBe(1);
+  });
+
+  it('allocates distinct seqs above the durable floor under concurrent reports issued right after a reset', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeSeqBoard();
+    await stampSustainedFirstSeen(testRedis, boardId, TEST_USER_ID);
+    await pubsub.stampBoardMembership(String(boardId), SECOND_USER_ID);
+    // Both concurrent senders below need the durable dwell gate satisfied, or
+    // the under-dwell one's send is correctly accepted live but skipped
+    // durably — which would make the "3 durable rows" assertion below fail
+    // for a reason unrelated to seq continuity.
+    await stampSustainedFirstSeen(testRedis, boardId, SECOND_USER_ID);
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    const [priorSeq] = await durableSeqs(boardId);
+
+    await testRedis.del(`board:${boardId}:seq`);
+
+    const [firstAccepted, secondAccepted] = await Promise.all([
+      boardPresenceMutations.reportBoardClimb(
+        undefined,
+        { boardId, climb: makeQueueItemInput({ uuid: OTHER_TEST_CLIMB_UUID }), angle: 40 },
+        authCtx(),
+      ),
+      boardPresenceMutations.reportBoardClimb(
+        undefined,
+        { boardId, climb: makeQueueItemInput(), angle: 45 },
+        authCtx({ userId: SECOND_USER_ID }),
+      ),
+    ]);
+    expect(firstAccepted).toBe(true);
+    expect(secondAccepted).toBe(true);
+
+    const seqs = await durableSeqs(boardId);
+    expect(seqs).toHaveLength(3);
+    const [, second, third] = seqs;
+    expect(second).toBeGreaterThan(priorSeq);
+    expect(third).toBeGreaterThan(priorSeq);
+    expect(second).not.toBe(third);
+  });
+
+  it('the Lua allocator (allocateBoardSeqAtLeast) advances monotonically above a given floor', async () => {
+    if (!redisOn) return;
+    const boardId = `lua-floor-test-${Date.now()}`;
+    const first = await pubsub.allocateBoardSeqAtLeast(boardId, 500);
+    const second = await pubsub.allocateBoardSeqAtLeast(boardId, 500);
+    expect(first).toBe(501);
+    expect(second).toBe(502);
+  });
+});
+
+describe('board-presence stats cache (Redis)', () => {
+  let redisOn = false;
+  let testRedis: Redis | null = null;
+  const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6380';
+
+  beforeAll(async () => {
+    redisOn = await ensureRedisConnectedForTest();
+    if (!redisOn) {
+      console.warn('[board-presence] Redis unavailable — skipping stats cache tests');
+      return;
+    }
+    testRedis = new Redis(REDIS_URL, { lazyConnect: true, maxRetriesPerRequest: 1 });
+    await testRedis.connect();
+  });
+
+  afterAll(async () => {
+    if (testRedis) await testRedis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await cleanup();
+    await seedUser();
+    await seedCatalogClimb();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function statsCacheKey(boardId: number): string {
+    return `boardsesh:board-stats:v1:${boardId}`;
+  }
+
+  let statsSerialCounter = 0;
+  async function makeStatsBoard(): Promise<number> {
+    const resolved = await boardPresenceMutations.resolveBoardForSerial(
+      undefined,
+      {
+        serial: `STATSCACHE-${Date.now().toString(36)}-${statsSerialCounter++}`,
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,2',
+      },
+      authCtx(),
+    );
+    return resolved.boardId;
+  }
+
+  async function insertSendTick(boardId: number, climbUuid: string, difficulty: number): Promise<void> {
+    await db.execute(sql`
+      INSERT INTO boardsesh_ticks
+        (uuid, user_id, board_type, climb_uuid, angle, is_mirror, status, attempt_count, difficulty, is_benchmark, comment, climbed_at, created_at, updated_at, board_id)
+      VALUES
+        (${uuidv4()}, ${TEST_USER_ID}, 'kilter', ${climbUuid}, 40, false, 'send', 1, ${difficulty}, false, '', ${new Date().toISOString()}, now(), now(), ${boardId})
+    `);
+  }
+
+  // saveTick's explicit-boardId fast path only attaches boardId when the
+  // FULL config matches the board (see saveTick's configMatches check in
+  // ticks/mutations.ts) — layoutId/sizeId/setIds must mirror makeStatsBoard's
+  // config below, or saveTick silently drops boardId (warns "config
+  // mismatch") and queueBoardStatsPublish never fires.
+  function baseSaveTickInput(boardId: number) {
+    return {
+      boardType: 'kilter',
+      climbUuid: TEST_CLIMB_UUID,
+      angle: 40,
+      isMirror: false,
+      status: 'send',
+      attemptCount: 1,
+      quality: null,
+      difficulty: 17,
+      isBenchmark: false,
+      comment: '',
+      climbedAt: new Date().toISOString(),
+      boardId,
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,2',
+    };
+  }
+
+  it('populates the cache on a miss and serves the same snapshot on a subsequent read', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeStatsBoard();
+    await insertSendTick(boardId, TEST_CLIMB_UUID, 17);
+
+    expect(await testRedis.get(statsCacheKey(boardId))).toBeNull();
+
+    const first = await boardPresenceQueries.boardPresenceStats(undefined, { boardId }, authCtx());
+    expect(first.climbsSentCount).toBe(1);
+
+    // The SET is fire-and-forget — give it a tick to land.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const cachedRaw = await testRedis.get(statsCacheKey(boardId));
+    expect(cachedRaw).not.toBeNull();
+    expect(JSON.parse(cachedRaw!)).toEqual(first);
+  });
+
+  it('serves the cached snapshot even after a fresh tick lands directly in Postgres', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeStatsBoard();
+    await insertSendTick(boardId, TEST_CLIMB_UUID, 17);
+
+    const first = await boardPresenceQueries.boardPresenceStats(undefined, { boardId }, authCtx());
+    expect(first.climbsSentCount).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // A second send lands straight in Postgres, bypassing saveTick (and so
+    // never calling queueBoardStatsPublish) — the query must still serve the
+    // cached snapshot rather than recomputing.
+    await insertSendTick(boardId, OTHER_TEST_CLIMB_UUID, 18);
+    const second = await boardPresenceQueries.boardPresenceStats(undefined, { boardId }, authCtx());
+    expect(second).toEqual(first);
+    expect(second.climbsSentCount).toBe(1);
+  });
+
+  // Polls the Redis cache key directly (never the rate-limited GraphQL
+  // query) so a several-second debounce wait can't trip applyRateLimit.
+  async function pollCacheUntil(
+    testRedisClient: Redis,
+    boardId: number,
+    predicate: (stats: BoardPresenceStats) => boolean,
+    timeoutMs = 6000,
+  ): Promise<BoardPresenceStats | null> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const cachedRaw = await testRedisClient.get(statsCacheKey(boardId));
+      if (cachedRaw) {
+        const stats = JSON.parse(cachedRaw) as BoardPresenceStats;
+        if (predicate(stats)) return stats;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return null;
+  }
+
+  it('saveTick refreshes the cache after the debounce window, matching a cold query', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeStatsBoard();
+
+    await tickMutations.saveTick(undefined, { input: baseSaveTickInput(boardId) }, authCtx());
+
+    // publishBoardStats sets the cache to the exact snapshot it also pushes
+    // as BoardStatsUpdated (see stats.ts), so a matching cache entry proves
+    // the debounced publish landed.
+    const cached = await pollCacheUntil(testRedis, boardId, (stats) => stats.climbsSentCount === 1);
+    expect(cached).not.toBeNull();
+
+    const queried = await boardPresenceQueries.boardPresenceStats(undefined, { boardId }, authCtx());
+    expect(queried).toEqual(cached);
+  });
+
+  it('deleteTick refreshes the cache after the debounce window', async () => {
+    if (!redisOn || !testRedis) return;
+    const boardId = await makeStatsBoard();
+
+    const saved = (await tickMutations.saveTick(undefined, { input: baseSaveTickInput(boardId) }, authCtx())) as {
+      uuid: string;
+    };
+
+    const afterSave = await pollCacheUntil(testRedis, boardId, (stats) => stats.climbsSentCount === 1);
+    expect(afterSave).not.toBeNull();
+
+    await tickMutations.deleteTick(undefined, { uuid: saved.uuid }, authCtx());
+
+    const afterDelete = await pollCacheUntil(testRedis, boardId, (stats) => stats.climbsSentCount === 0);
+    expect(afterDelete).not.toBeNull();
+  });
+
+  it('still computes stats correctly when Redis is unavailable (cache is best-effort)', async () => {
+    const boardId = await makeStatsBoard();
+    await insertSendTick(boardId, TEST_CLIMB_UUID, 17);
+
+    vi.spyOn(redisClientManager, 'isRedisConnected').mockReturnValue(false);
+    const stats = await boardPresenceQueries.boardPresenceStats(undefined, { boardId }, authCtx());
+    expect(stats.climbsSentCount).toBe(1);
   });
 });

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -1324,6 +1324,7 @@ describe('board-presence durable history (board_climb_events)', () => {
       isMember: true,
       firstSeenMs: Date.now(),
       lastReport: null,
+      currentWriter: null,
     });
     const accepted = await boardPresenceMutations.reportBoardClimb(
       undefined,
@@ -1340,6 +1341,7 @@ describe('board-presence durable history (board_climb_events)', () => {
       isMember: true,
       firstSeenMs: null,
       lastReport: null,
+      currentWriter: null,
     });
     await boardPresenceMutations.reportBoardClimb(
       undefined,
@@ -1356,6 +1358,7 @@ describe('board-presence durable history (board_climb_events)', () => {
       isMember: true,
       firstSeenMs: Date.now() - 120_000,
       lastReport: null,
+      currentWriter: null,
     });
 
     const accepted = await boardPresenceMutations.reportBoardClimb(
@@ -1550,9 +1553,10 @@ describe('board-presence connection holder', () => {
     });
   });
 
-  // The holder lives in Redis (setBoardWriter / clearBoardWriterIf are Redis-only).
-  // pubsub connects only when REDIS_URL is configured (CI sets it); skip cleanly
-  // otherwise, mirroring the FIFO-history test above.
+  // The holder lives in Redis (the commitBoardClimb writer take and
+  // clearBoardWriterIf are Redis-only). pubsub connects only when REDIS_URL is
+  // configured (CI sets it); skip cleanly otherwise, mirroring the
+  // FIFO-history test above.
   describe('holder state + hand-off (Redis)', () => {
     let redisOn = false;
     beforeAll(async () => {
@@ -1945,6 +1949,51 @@ describe('board-presence write-side idempotency (Redis)', () => {
     expect(secondAccepted).toBe(true);
     const history = await testRedis.lrange(`board:${boardId}:history`, 0, -1);
     expect(history).toHaveLength(2);
+  });
+
+  it('falls through (re-takes the writer) when the wall was freed between the send and its retry', async () => {
+    if (!redisOn || !testRedis) return;
+    // The canonical A2 retry cause is a socket drop right after the send — and
+    // that same drop fires the WS-close backstop, which DELETEs the writer key
+    // and broadcasts holder:null while the 10s lastReport marker survives. The
+    // retry must NOT short-circuit then: it has to re-take the writer (and so
+    // re-broadcast the hand-off), or every watcher shows the wall free while
+    // this emitter holds it. The accepted cost is a duplicate history/durable
+    // row with a fresh seq — holder correctness over row dedup.
+    const boardId = await makeIdemBoard();
+    await stampSustainedFirstSeen(testRedis, boardId, TEST_USER_ID);
+    const writerKey = `board:${boardId}:writer`;
+
+    await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    expect(await testRedis.get(writerKey)).toBe(TEST_USER_ID);
+    expect(await countEvents(boardId)).toBe(1);
+
+    // Simulate the WS-close backstop: the writer key is cleared, lastReport isn't.
+    await testRedis.del(writerKey);
+    expect(await testRedis.get(`board:${boardId}:lastReport`)).not.toBeNull();
+
+    // Identical retry, well inside the dedup window.
+    const retryAccepted = await boardPresenceMutations.reportBoardClimb(
+      undefined,
+      { boardId, climb: makeQueueItemInput(), angle: 40 },
+      authCtx(),
+    );
+    expect(retryAccepted).toBe(true);
+
+    // The retry fell through the dedup: writer re-taken, and a second
+    // history entry + durable row with a fresh, higher seq landed.
+    expect(await testRedis.get(writerKey)).toBe(TEST_USER_ID);
+    const history = await testRedis.lrange(`board:${boardId}:history`, 0, -1);
+    expect(history).toHaveLength(2);
+    expect(await countEvents(boardId)).toBe(2);
+    const [durableRow] = await db.execute(
+      sql`SELECT count(DISTINCT seq)::int AS distinct_seqs FROM board_climb_events WHERE board_id = ${boardId}`,
+    );
+    expect(Number((durableRow as { distinct_seqs: number }).distinct_seqs)).toBe(2);
   });
 });
 

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -469,6 +469,7 @@ export const schemaSQL = `
 
   -- Durable per-board send log (dwell-gated). Distinct from boardsesh_ticks: the
   -- raw wall-push stream, no flash/send/attempt status.
+  DROP TABLE IF EXISTS "board_climb_events" CASCADE;
   CREATE TABLE IF NOT EXISTS "board_climb_events" (
     "id" bigserial PRIMARY KEY NOT NULL,
     "board_id" bigint NOT NULL REFERENCES "user_boards"("id") ON DELETE CASCADE,
@@ -554,6 +555,54 @@ export const schemaSQL = `
     "deleted_at" timestamp
   );
   CREATE INDEX IF NOT EXISTS "comments_entity_created_at_idx" ON "comments" ("entity_type", "entity_id", "created_at");
+
+  -- Votes on a comment/tick/climb/etc. entity_type is text here (see the
+  -- comments-table note above — the real schema uses an enum).
+  DROP TABLE IF EXISTS "votes" CASCADE;
+  CREATE TABLE IF NOT EXISTS "votes" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "entity_type" text NOT NULL,
+    "entity_id" text NOT NULL,
+    "value" integer NOT NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS "votes_unique_user_entity" ON "votes" ("user_id", "entity_type", "entity_id");
+  CREATE INDEX IF NOT EXISTS "votes_entity_idx" ON "votes" ("entity_type", "entity_id");
+
+  -- Per-user activity feed rows (ascent/new_climb/comment/etc.), fanned out on
+  -- write. entity_type/type are text here (see the comments-table note above).
+  DROP TABLE IF EXISTS "feed_items" CASCADE;
+  CREATE TABLE IF NOT EXISTS "feed_items" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "recipient_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "actor_id" text REFERENCES "users"("id") ON DELETE SET NULL,
+    "type" text NOT NULL,
+    "entity_type" text NOT NULL,
+    "entity_id" text NOT NULL,
+    "board_uuid" text,
+    "metadata" jsonb,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS "feed_items_recipient_created_at_idx" ON "feed_items" ("recipient_id", "created_at" DESC, "id" DESC);
+  CREATE INDEX IF NOT EXISTS "feed_items_entity_type_entity_id_idx" ON "feed_items" ("entity_type", "entity_id");
+
+  -- User notifications (comment replies, votes, follows, etc.). type/entity_type
+  -- are text here (see the comments-table note above).
+  DROP TABLE IF EXISTS "notifications" CASCADE;
+  CREATE TABLE IF NOT EXISTS "notifications" (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "uuid" text NOT NULL UNIQUE,
+    "recipient_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "actor_id" text REFERENCES "users"("id") ON DELETE SET NULL,
+    "type" text NOT NULL,
+    "entity_type" text,
+    "entity_id" text,
+    "comment_id" bigint REFERENCES "comments"("id") ON DELETE SET NULL,
+    "read_at" timestamp,
+    "created_at" timestamp DEFAULT now() NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS "notifications_recipient_created_at_idx" ON "notifications" ("recipient_id", "created_at");
 
   -- Beta links the session feed INNER-joins for featured-beta enrichment. Empty
   -- in tests (no featured beta), but the relation must exist so the query plans.

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -449,7 +449,18 @@ export const boardPresenceMutations = {
     // doesn't let a stale backstop entry lapse. A different climb / angle /
     // user is never suppressed (a user change still needs to broadcast the
     // hand-off).
-    if (gate.lastReport === `${emitterId}|${climbUuid}|${effectiveAngle}`) {
+    //
+    // The short-circuit additionally requires this emitter to STILL hold the
+    // wall (`currentWriter === emitterId`). The canonical retry is a socket
+    // drop right after the original send — and that same drop fires the
+    // WS-close backstop, which deletes the writer key and broadcasts
+    // holder:null while lastReport survives. Short-circuiting on lastReport
+    // alone would then leave the wall looking free while this emitter holds
+    // it (writer never re-taken, hand-off never re-broadcast); falling
+    // through re-takes the writer and re-broadcasts. The cost is one
+    // duplicate history/durable row in exactly that edge — holder correctness
+    // wins over row dedup.
+    if (gate.lastReport === `${emitterId}|${climbUuid}|${effectiveAngle}` && gate.currentWriter === emitterId) {
       roomManager.noteBoardWriter(ctx.connectionId, boardId, emitterId);
       return true;
     }
@@ -545,7 +556,7 @@ export const boardPresenceMutations = {
     // One Redis pipeline: durable FIFO history append, connection-holder
     // handoff (atomic SET..GET), the A2 dedup marker, and the session→board
     // mapping. Non-fatal on failure (see commitBoardClimb's contract).
-    const { previousWriter } = await pubsub.commitBoardClimb({
+    const { previousWriter, writerSlotOk } = await pubsub.commitBoardClimb({
       boardId: String(boardId),
       emitterId,
       climb: presenceClimb,
@@ -562,13 +573,14 @@ export const boardPresenceMutations = {
       climb: presenceClimb,
     });
 
-    // This emitter is now the board's connection holder. The holder is Redis-only
-    // (degrades to "no holder" without Redis), so only broadcast a hand-off when
-    // Redis actually backs the writer — otherwise commitBoardClimb returns
-    // previousWriter: null and `null !== emitterId` would spuriously broadcast on
-    // every send.
+    // This emitter is now the board's connection holder. Only broadcast a
+    // hand-off when the writer slot verifiably executed (`writerSlotOk`) —
+    // that covers both Redis-off (holder degrades to "none", no broadcast)
+    // and a failing pipeline, where previousWriter: null is a fabrication and
+    // `null !== emitterId` would otherwise spuriously broadcast a hand-off
+    // (+ Live Activity push) on every send until Redis recovers.
     let writerChanged = false;
-    if (pubsub.isRedisConnected() && previousWriter !== emitterId) {
+    if (writerSlotOk && previousWriter !== emitterId) {
       writerChanged = true;
       pubsub.publishBoardPresenceEvent(String(boardId), {
         __typename: 'BoardConnectionChanged',

--- a/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/mutations.ts
@@ -391,6 +391,20 @@ export const boardPresenceMutations = {
    * Identity (`sentByDisplayName` / `sentByAvatarUrl`) is derived server-side
    * from `ctx.userId` and never read from the input, so a client can't forge
    * who lit the climb. The reported `climbUuid` must be a real catalog climb.
+   *
+   * Latency-critical path (fires on every wall send), so the Redis/Postgres
+   * work below is deliberately staged to overlap what can be overlapped:
+   *  - Stage A: board lookup + the combined report gate (proof-of-presence,
+   *    first-seen, and the write-side dedup marker) run in parallel — one
+   *    Redis pipeline instead of the old separate hasBoardMembership call.
+   *  - Stage B: the catalog climb lookup, sender identity lookup, and seq
+   *    allocation run in parallel too. This means a seq can be burned even
+   *    when the catalog lookup below turns out empty (climb unknown) — that's
+   *    a benign gap: seq only needs to stay monotonic per board, not
+   *    contiguous, and a gap never surfaces in any published event or durable
+   *    row.
+   *  - The Redis writes (history append, writer handoff, dedup marker,
+   *    session→board mapping) are one pipeline via `commitBoardClimb`.
    */
   reportBoardClimb: async (
     _: unknown,
@@ -398,19 +412,25 @@ export const boardPresenceMutations = {
     ctx: ConnectionContext,
   ): Promise<boolean> => {
     await applyRateLimit(ctx, 60, 'reportBoardClimb');
-    const board = await requireActiveBoardById(boardId);
 
     // Auth-optional: anyone connected to the board emits (logged-in or
     // anonymous). The emitter id is the userId, or `conn:{connectionId}` for an
     // anonymous client — both are stamped as board members on resolve/connect.
     const emitterId = ctx.userId ?? `conn:${ctx.connectionId}`;
 
+    // Stage A: board existence + the combined report gate (proof-of-presence,
+    // first-seen for the durable dwell gate, and the A2 dedup marker) — one
+    // Redis pipeline instead of the old separate hasBoardMembership call.
+    const [board, gate] = await Promise.all([
+      requireActiveBoardById(boardId),
+      pubsub.getBoardReportGate(String(boardId), emitterId),
+    ]);
+
     // Proof-of-presence: only an emitter that selected or connected to this board
     // (stamped in resolveBoardForUuid / resolveBoardForSerial /
     // resolveBoardForConfig) may post to its feed. Stops anyone injecting climbs
     // onto a board id they guess.
-    const isConnected = await pubsub.hasBoardMembership(String(boardId), emitterId);
-    if (!isConnected) {
+    if (!gate.isMember) {
       throw new GraphQLError('Not connected to this board');
     }
 
@@ -423,7 +443,18 @@ export const boardPresenceMutations = {
     const effectiveAngle = Math.round(validatedAngle ?? validatedClimb.climb.angle ?? Number(board.angle));
     const climbUuid = validatedClimb.climb.uuid;
 
-    const [catalogClimbRows, sender] = await Promise.all([
+    // Write-side idempotency (A2): a retry of the exact same (emitter, climb,
+    // angle) within REPORT_DEDUP_WINDOW_MS is a no-op — no new seq, no event,
+    // no durable insert. Still note the WS-close backstop so a deduped retry
+    // doesn't let a stale backstop entry lapse. A different climb / angle /
+    // user is never suppressed (a user change still needs to broadcast the
+    // hand-off).
+    if (gate.lastReport === `${emitterId}|${climbUuid}|${effectiveAngle}`) {
+      roomManager.noteBoardWriter(ctx.connectionId, boardId, emitterId);
+      return true;
+    }
+
+    const [catalogClimbRows, sender, seq] = await Promise.all([
       db
         .select({
           uuid: dbSchema.boardClimbs.uuid,
@@ -471,6 +502,7 @@ export const boardPresenceMutations = {
             .limit(1)
             .then((rows) => rows[0])
         : Promise.resolve(undefined),
+      pubsub.nextBoardSeq(String(boardId)),
     ]);
 
     const catalogClimb = catalogClimbRows[0];
@@ -478,7 +510,6 @@ export const boardPresenceMutations = {
       throw new GraphQLError('Unknown climb for this board');
     }
 
-    const seq = await pubsub.nextBoardSeq(String(boardId));
     const sentAt = new Date().toISOString();
 
     const presenceClimb: BoardPresenceClimb = {
@@ -499,15 +530,10 @@ export const boardPresenceMutations = {
       seq,
     };
 
-    await pubsub.storeBoardClimb(String(boardId), presenceClimb);
-    pubsub.publishBoardPresenceEvent(String(boardId), {
-      __typename: 'BoardClimbSet',
-      climb: presenceClimb,
-    });
-
     // Record the hold on this connection (in-memory) so the WS-close backstop can
     // free the wall if the holder crashes without an explicit reportBoardDisconnect.
-    // Outside the Redis try below since it can't fail and must not be swallowed.
+    // Before the Redis commit below: it can't fail and must not be skipped by an
+    // early return or a later throw.
     roomManager.noteBoardWriter(ctx.connectionId, boardId, emitterId);
 
     // Remember which board this connection's party session is on (when it's in
@@ -515,38 +541,45 @@ export const boardPresenceMutations = {
     // session — QueueState/push-token rows carry sessionId but not boardId. Best-
     // effort: a solo (no-session) sender just doesn't establish a mapping.
     const reportingSessionId = roomManager.getClient(ctx.connectionId)?.sessionId ?? null;
-    if (reportingSessionId) {
-      try {
-        await pubsub.setSessionBoard(reportingSessionId, String(boardId));
-      } catch (error) {
-        logger.warn(`[board-presence] setSessionBoard failed: ${String(error)}`);
-      }
-    }
+
+    // One Redis pipeline: durable FIFO history append, connection-holder
+    // handoff (atomic SET..GET), the A2 dedup marker, and the session→board
+    // mapping. Non-fatal on failure (see commitBoardClimb's contract).
+    const { previousWriter } = await pubsub.commitBoardClimb({
+      boardId: String(boardId),
+      emitterId,
+      climb: presenceClimb,
+      climbUuid,
+      effectiveAngle,
+      sessionId: reportingSessionId,
+    });
+
+    // Store before publish: commitBoardClimb above already awaited the history
+    // append, so a late joiner reading the FIFO right after this publish will
+    // already see the new entry.
+    pubsub.publishBoardPresenceEvent(String(boardId), {
+      __typename: 'BoardClimbSet',
+      climb: presenceClimb,
+    });
 
     // This emitter is now the board's connection holder. The holder is Redis-only
     // (degrades to "no holder" without Redis), so only broadcast a hand-off when
-    // Redis actually backs the writer — otherwise setBoardWriter returns null and
-    // `null !== emitterId` would spuriously broadcast on every send. Non-fatal.
+    // Redis actually backs the writer — otherwise commitBoardClimb returns
+    // previousWriter: null and `null !== emitterId` would spuriously broadcast on
+    // every send.
     let writerChanged = false;
-    if (pubsub.isRedisConnected()) {
-      try {
-        const previousHolder = await pubsub.setBoardWriter(String(boardId), emitterId);
-        if (previousHolder !== emitterId) {
-          writerChanged = true;
-          pubsub.publishBoardPresenceEvent(String(boardId), {
-            __typename: 'BoardConnectionChanged',
-            holder: {
-              userId: ctx.userId ?? null,
-              displayName: presenceClimb.sentByDisplayName,
-              avatarUrl: presenceClimb.sentByAvatarUrl,
-              lastSentAt: sentAt,
-            },
-            seq,
-          });
-        }
-      } catch (error) {
-        logger.warn(`[board-presence] board writer update failed: ${String(error)}`);
-      }
+    if (pubsub.isRedisConnected() && previousWriter !== emitterId) {
+      writerChanged = true;
+      pubsub.publishBoardPresenceEvent(String(boardId), {
+        __typename: 'BoardConnectionChanged',
+        holder: {
+          userId: ctx.userId ?? null,
+          displayName: presenceClimb.sentByDisplayName,
+          avatarUrl: presenceClimb.sentByAvatarUrl,
+          lastSentAt: sentAt,
+        },
+        seq,
+      });
     }
 
     // A board hand-off (a peer took over) changes every device's
@@ -579,11 +612,10 @@ export const boardPresenceMutations = {
     const DURABLE_DWELL_MS = 60_000;
     try {
       // `sentAt` is the server-generated ISO timestamp from above, so
-      // `Date.parse(sentAt)` is always valid; `firstSeen` is already guarded to
-      // a plausible epoch-ms or null in getBoardMembershipFirstSeen. A null
-      // firstSeen correctly skips the insert (presence not yet proven for 60s).
-      const firstSeen = ctx.userId ? await pubsub.getBoardMembershipFirstSeen(String(boardId), emitterId) : null;
-      if (ctx.userId && firstSeen !== null && Date.parse(sentAt) - firstSeen >= DURABLE_DWELL_MS) {
+      // `Date.parse(sentAt)` is always valid; `gate.firstSeenMs` (read in Stage
+      // A, above) is already guarded to a plausible epoch-ms or null. A null
+      // firstSeenMs correctly skips the insert (presence not yet proven for 60s).
+      if (ctx.userId && gate.firstSeenMs !== null && Date.parse(sentAt) - gate.firstSeenMs >= DURABLE_DWELL_MS) {
         await db
           .insert(dbSchema.boardClimbEvents)
           .values({
@@ -595,6 +627,12 @@ export const boardPresenceMutations = {
             // Reserved for session recaps. reportBoardClimb has no sessionId arg
             // yet, so every durable row is solo-attributed until the
             // session-attribution follow-up threads the active session through.
+            // Do NOT wire `reportingSessionId` here even though it's in scope
+            // above: it's a room-manager party-session uuid, not a
+            // `board_sessions` row id — board_climb_events.sessionId is a real
+            // FK to `board_sessions`, a different id space entirely. Writing a
+            // party-session uuid would violate the FK and roll back this whole
+            // insert, silently losing the durable row.
             sessionId: null,
             seq,
             frames: catalogClimb.frames ?? null,

--- a/packages/backend/src/graphql/resolvers/board-presence/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/queries.ts
@@ -11,7 +11,7 @@ import * as dbSchema from '@boardsesh/db/schema';
 import { pubsub } from '../../../pubsub/index';
 import { applyRateLimit, requireAuthenticated } from '../shared/helpers';
 import { requireActiveBoardById, requireAnonReadableBoard, resolveBoardHolder } from './shared';
-import { computeBoardPresenceStats } from './stats';
+import { computeBoardPresenceStats, getCachedBoardPresenceStats, setCachedBoardPresenceStats } from './stats';
 
 export const boardPresenceQueries = {
   /**
@@ -128,6 +128,13 @@ export const boardPresenceQueries = {
    *
    * Includes the representative hardest send so the board sheet can show the
    * climber + climb that established the wall's hardest logged grade.
+   *
+   * Cached for 60s (`boardsesh:board-stats:v1:{boardId}`, best-effort — a
+   * Redis miss or outage just falls through to a fresh compute) since the
+   * underlying aggregate scans every tick on the board. Every write path that
+   * changes these stats (`saveTick` / `updateTick` / `deleteTick` via
+   * `queueBoardStatsPublish`) refreshes the cache within its own debounce
+   * window, so a cache hit is never more than ~60s + the debounce stale.
    */
   boardPresenceStats: async (
     _: unknown,
@@ -137,7 +144,13 @@ export const boardPresenceQueries = {
     requireAuthenticated(ctx);
     await applyRateLimit(ctx, 30, 'boardPresenceStats');
     const board = await requireActiveBoardById(boardId);
-    return computeBoardPresenceStats(boardId, board.boardType);
+
+    const cached = await getCachedBoardPresenceStats(boardId);
+    if (cached) return cached;
+
+    const stats = await computeBoardPresenceStats(boardId, board.boardType);
+    setCachedBoardPresenceStats(boardId, stats);
+    return stats;
   },
 
   /**

--- a/packages/backend/src/graphql/resolvers/board-presence/queries.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/queries.ts
@@ -149,7 +149,11 @@ export const boardPresenceQueries = {
     if (cached) return cached;
 
     const stats = await computeBoardPresenceStats(boardId, board.boardType);
-    setCachedBoardPresenceStats(boardId, stats);
+    // NX (only-if-absent): this fire-and-forget write races the debounced
+    // publish path, which could land a FRESHER snapshot between our compute
+    // and this SET — NX keeps that one instead of rolling the cache back;
+    // on a true miss it populates the key as before.
+    setCachedBoardPresenceStats(boardId, stats, { onlyIfAbsent: true });
     return stats;
   },
 

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -442,6 +442,23 @@ async function ensureSystemBoardOwner(): Promise<void> {
     .onConflictDoNothing();
 }
 
+/**
+ * Durable seq floor for a board: the highest `seq` ever persisted to
+ * `board_climb_events`. Backs the Redis `board:{id}:seq` counter's dormancy
+ * reseed (see `PubSub.nextBoardSeq` / A3) — after the 1-week Redis TTL
+ * expires, INCR would otherwise restart at 1 and collide with / precede rows
+ * that still exist in Postgres. Injected via `pubsub.setBoardSeqFloorProvider`
+ * at backend bootstrap so the pubsub module itself stays DB-free (and easy to
+ * unit test without Postgres).
+ */
+export async function getBoardSeqFloor(boardId: number): Promise<number> {
+  const [row] = await db
+    .select({ maxSeq: sql<number | null>`max(${dbSchema.boardClimbEvents.seq})` })
+    .from(dbSchema.boardClimbEvents)
+    .where(eq(dbSchema.boardClimbEvents.boardId, boardId));
+  return Number(row?.maxSeq ?? 0);
+}
+
 export async function resolveSharedBoardForConfig(
   boardType: string,
   layoutId: number,

--- a/packages/backend/src/graphql/resolvers/board-presence/stats.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/stats.ts
@@ -65,16 +65,35 @@ export async function getCachedBoardPresenceStats(boardId: number): Promise<Boar
   }
 }
 
-/** Fire-and-forget cache write; never blocks or throws for the caller. */
-export function setCachedBoardPresenceStats(boardId: number, stats: BoardPresenceStats): void {
+/**
+ * Fire-and-forget cache write; never blocks or throws for the caller.
+ *
+ * Two write modes keep the cache from moving backwards:
+ * - The publish path (`publishBoardStats`) writes unconditionally — it's the
+ *   authoritative snapshot, serialized per board by the debounce+nonce
+ *   machinery, so a plain SET can never clobber something fresher.
+ * - The query-miss path passes `onlyIfAbsent`, which maps to `SET NX`: its
+ *   fire-and-forget write races the publish path (a miss → compute → SET can
+ *   land AFTER a fresher publish-time SET), and NX makes the late, staler
+ *   write a no-op instead of an overwrite. On a true miss (no key) NX still
+ *   populates the cache.
+ */
+export function setCachedBoardPresenceStats(
+  boardId: number,
+  stats: BoardPresenceStats,
+  options?: { onlyIfAbsent?: boolean },
+): void {
   if (!redisClientManager.isRedisConnected()) return;
   try {
     const { publisher } = redisClientManager.getClients();
-    publisher
-      .set(boardStatsCacheKey(boardId), JSON.stringify(stats), 'EX', BOARD_STATS_CACHE_TTL_SECONDS)
-      .catch((error: unknown) => {
-        logger.error(`[board-presence] stats cache write failed for board ${boardId}:`, error);
-      });
+    const key = boardStatsCacheKey(boardId);
+    const payload = JSON.stringify(stats);
+    const write = options?.onlyIfAbsent
+      ? publisher.set(key, payload, 'EX', BOARD_STATS_CACHE_TTL_SECONDS, 'NX')
+      : publisher.set(key, payload, 'EX', BOARD_STATS_CACHE_TTL_SECONDS);
+    write.catch((error: unknown) => {
+      logger.error(`[board-presence] stats cache write failed for board ${boardId}:`, error);
+    });
   } catch (error) {
     logger.error(`[board-presence] stats cache write initiation failed for board ${boardId}:`, error);
   }
@@ -212,9 +231,10 @@ export async function computeBoardPresenceStats(boardId: number, boardType: stri
 export async function publishBoardStats(boardId: number, boardType: string): Promise<void> {
   try {
     const stats = await computeBoardPresenceStats(boardId, boardType);
-    // Refresh the cache with the exact snapshot this push carries, so a
-    // concurrent boardPresenceStats query never observes a snapshot older
-    // than what watchers just received live.
+    // Refresh the cache with the exact snapshot this push carries (plain SET
+    // — this is the authoritative, per-board-serialized write; the query-miss
+    // path uses SET NX so its racing fire-and-forget write can't land after
+    // this one and roll the cache back to a staler snapshot).
     setCachedBoardPresenceStats(boardId, stats);
     const seq = await pubsub.nextBoardSeq(String(boardId));
     pubsub.publishBoardPresenceEvent(String(boardId), {

--- a/packages/backend/src/graphql/resolvers/board-presence/stats.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/stats.ts
@@ -39,6 +39,47 @@ function parsePostgresUtcTimestamp(timestamp: string | Date | null | undefined):
   return new Date(zonedTimestamp).toISOString();
 }
 
+// Live stats cache: SearchCacheService's pattern (best-effort GET returning
+// null on error/Redis-off, fire-and-forget SET), but keyed per board and
+// short-lived — a stat tile that's up to 60s stale is fine, and every write
+// path (saveTick/updateTick/deleteTick's queueBoardStatsPublish) refreshes it
+// anyway via the debounced live push below.
+const BOARD_STATS_CACHE_PREFIX = 'boardsesh:board-stats:v1:';
+const BOARD_STATS_CACHE_TTL_SECONDS = 60;
+
+function boardStatsCacheKey(boardId: number): string {
+  return `${BOARD_STATS_CACHE_PREFIX}${boardId}`;
+}
+
+/** Best-effort cache read. Returns null on a miss, a Redis error, or when Redis is off. */
+export async function getCachedBoardPresenceStats(boardId: number): Promise<BoardPresenceStats | null> {
+  if (!redisClientManager.isRedisConnected()) return null;
+  try {
+    const { publisher } = redisClientManager.getClients();
+    const raw = await publisher.get(boardStatsCacheKey(boardId));
+    if (raw === null) return null;
+    return JSON.parse(raw) as BoardPresenceStats;
+  } catch (error) {
+    logger.error(`[board-presence] stats cache read failed for board ${boardId}:`, error);
+    return null;
+  }
+}
+
+/** Fire-and-forget cache write; never blocks or throws for the caller. */
+export function setCachedBoardPresenceStats(boardId: number, stats: BoardPresenceStats): void {
+  if (!redisClientManager.isRedisConnected()) return;
+  try {
+    const { publisher } = redisClientManager.getClients();
+    publisher
+      .set(boardStatsCacheKey(boardId), JSON.stringify(stats), 'EX', BOARD_STATS_CACHE_TTL_SECONDS)
+      .catch((error: unknown) => {
+        logger.error(`[board-presence] stats cache write failed for board ${boardId}:`, error);
+      });
+  } catch (error) {
+    logger.error(`[board-presence] stats cache write initiation failed for board ${boardId}:`, error);
+  }
+}
+
 function toHardestSend(row: BoardPresenceStatsRow | undefined): BoardPresenceHardestSend | null {
   if (!row?.hardestSendClimbUuid || !row.grade || !row.sentByUserId) return null;
   const sentAt = parsePostgresUtcTimestamp(row.sentAt);
@@ -171,6 +212,10 @@ export async function computeBoardPresenceStats(boardId: number, boardType: stri
 export async function publishBoardStats(boardId: number, boardType: string): Promise<void> {
   try {
     const stats = await computeBoardPresenceStats(boardId, boardType);
+    // Refresh the cache with the exact snapshot this push carries, so a
+    // concurrent boardPresenceStats query never observes a snapshot older
+    // than what watchers just received live.
+    setCachedBoardPresenceStats(boardId, stats);
     const seq = await pubsub.nextBoardSeq(String(boardId));
     pubsub.publishBoardPresenceEvent(String(boardId), {
       __typename: 'BoardStatsUpdated',

--- a/packages/backend/src/graphql/resolvers/board-presence/subscription.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/subscription.ts
@@ -27,9 +27,10 @@ export const boardPresenceSubscriptions = {
 
       const boardKey = String(boardId);
 
-      const asyncIterator = await createEagerAsyncIterator<BoardPresenceEvent>((push) => {
-        return pubsub.subscribeBoardPresence(boardKey, push);
-      });
+      const asyncIterator = await createEagerAsyncIterator<BoardPresenceEvent>(
+        (push) => pubsub.subscribeBoardPresence(boardKey, push),
+        `boardNowPlaying:${boardId}`,
+      );
 
       for await (const event of asyncIterator) {
         yield { boardNowPlaying: event };

--- a/packages/backend/src/graphql/resolvers/shared/__tests__/async-iterators.test.ts
+++ b/packages/backend/src/graphql/resolvers/shared/__tests__/async-iterators.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression tests for the subscription async-iterator helpers' bounded
+ * queue (A5). A consumer that never reads (or reads too slowly) must not let
+ * the in-memory queue grow unbounded — the oldest events are dropped once the
+ * queue hits MAX_SUBSCRIPTION_QUEUE_SIZE (1000), and the drop is logged with
+ * the caller-supplied label instead of an unconditional per-event warn.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+
+vi.mock('../../../../utils/logger', () => ({
+  logger: { warn: warnMock, error: vi.fn(), info: vi.fn() },
+}));
+
+import { createAsyncIterator, createEagerAsyncIterator } from '../async-iterators';
+
+describe('async-iterators overflow', () => {
+  beforeEach(() => {
+    warnMock.mockClear();
+  });
+
+  it('createAsyncIterator: 1001 pushes with no consumer drops the oldest, retains the newest 1000, and logs the first drop with the label', async () => {
+    let push!: (value: number) => void;
+    const iterable = await createAsyncIterator<number>(async (pushFn) => {
+      push = pushFn;
+      return () => {};
+    }, 'test-label');
+
+    for (let value = 1; value <= 1001; value++) {
+      push(value);
+    }
+
+    const iterator = iterable[Symbol.asyncIterator]();
+    const drained: number[] = [];
+    for (let index = 0; index < 1000; index++) {
+      const { value, done } = await iterator.next();
+      expect(done).toBe(false);
+      drained.push(value);
+    }
+
+    // Oldest (1) was dropped; the newest 1000 events (2..1001) survive, in order.
+    expect(drained[0]).toBe(2);
+    expect(drained[drained.length - 1]).toBe(1001);
+    expect(drained).toHaveLength(1000);
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('test-label');
+    expect(warnMock.mock.calls[0][0]).toContain('1 dropped so far');
+  });
+
+  it('createAsyncIterator: logs the first drop and every 100th thereafter, not every drop', async () => {
+    let push!: (value: number) => void;
+    const iterable = await createAsyncIterator<number>(async (pushFn) => {
+      push = pushFn;
+      return () => {};
+    }, 'flood-label');
+
+    // 1000 to fill the queue, then 250 more overflow pushes (drops 1..250).
+    for (let value = 1; value <= 1250; value++) {
+      push(value);
+    }
+    void iterable;
+
+    // Drops 1, 100, 200 logged; 250 not yet (waits for the next multiple of 100).
+    expect(warnMock).toHaveBeenCalledTimes(3);
+    expect(warnMock.mock.calls[0][0]).toContain('1 dropped so far');
+    expect(warnMock.mock.calls[1][0]).toContain('100 dropped so far');
+    expect(warnMock.mock.calls[2][0]).toContain('200 dropped so far');
+  });
+
+  it('createAsyncIterator: defaults the label to "unknown" when the caller omits it', async () => {
+    let push!: (value: number) => void;
+    const iterable = await createAsyncIterator<number>(async (pushFn) => {
+      push = pushFn;
+      return () => {};
+    });
+    void iterable;
+
+    for (let value = 1; value <= 1001; value++) {
+      push(value);
+    }
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('unknown');
+  });
+
+  it('createEagerAsyncIterator: 1001 pushes with no consumer drops the oldest, retains the newest 1000, and logs with the label', async () => {
+    let push!: (value: number) => void;
+    const iterable = await createEagerAsyncIterator<number>(async (pushFn) => {
+      push = pushFn;
+      return () => {};
+    }, 'boardNowPlaying:42');
+
+    for (let value = 1; value <= 1001; value++) {
+      push(value);
+    }
+
+    const iterator = iterable[Symbol.asyncIterator]();
+    const drained: number[] = [];
+    for (let index = 0; index < 1000; index++) {
+      const { value, done } = await iterator.next();
+      expect(done).toBe(false);
+      drained.push(value);
+    }
+
+    expect(drained[0]).toBe(2);
+    expect(drained[drained.length - 1]).toBe(1001);
+    expect(drained).toHaveLength(1000);
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('boardNowPlaying:42');
+  });
+
+  it('does not log anything when the queue never overflows', async () => {
+    let push!: (value: number) => void;
+    const iterable = await createAsyncIterator<number>(async (pushFn) => {
+      push = pushFn;
+      return () => {};
+    }, 'quiet-label');
+    void iterable;
+
+    for (let value = 1; value <= 999; value++) {
+      push(value);
+    }
+
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/shared/async-iterators.ts
+++ b/packages/backend/src/graphql/resolvers/shared/async-iterators.ts
@@ -3,6 +3,18 @@ import { logger } from '../../../utils/logger';
 const MAX_SUBSCRIPTION_QUEUE_SIZE = 1000;
 
 /**
+ * Logs the first overflow drop for an iterator, then every 100th thereafter.
+ * A single persistently-slow-or-absent consumer would otherwise flood the log
+ * with one warn per dropped event; this still surfaces that it's happening
+ * (and how much) without the spam.
+ */
+function logOverflowDrop(label: string, droppedCount: number): void {
+  if (droppedCount === 1 || droppedCount % 100 === 0) {
+    logger.warn(`[Subscription] Queue full for "${label}", dropping oldest event (${droppedCount} dropped so far)`);
+  }
+}
+
+/**
  * Helper to create an async iterator from an async callback-based subscription.
  * Used for GraphQL subscriptions.
  * Includes bounded queue to prevent memory issues with slow clients.
@@ -10,13 +22,19 @@ const MAX_SUBSCRIPTION_QUEUE_SIZE = 1000;
  * NOTE: This function is async because the subscribe function may need to
  * establish Redis connections before returning. We must await subscription
  * setup to ensure multi-instance pub/sub is ready before yielding events.
+ *
+ * @param label identifies this iterator in overflow logs (e.g.
+ *   `boardNowPlaying:42`). Defaults to 'unknown' for call sites that haven't
+ *   been updated to pass one.
  */
 export async function createAsyncIterator<T>(
   subscribe: (push: (value: T) => void) => Promise<() => void>,
+  label = 'unknown',
 ): Promise<AsyncIterable<T>> {
   const queue: T[] = [];
   const pending: Array<(value: IteratorResult<T>) => void> = [];
   let done = false;
+  let droppedCount = 0;
 
   // Subscribe and await Redis channel setup before returning iterator
   const unsubscribe = await subscribe((value: T) => {
@@ -26,7 +44,8 @@ export async function createAsyncIterator<T>(
       // Bounded queue: drop oldest events if queue is full
       if (queue.length >= MAX_SUBSCRIPTION_QUEUE_SIZE) {
         queue.shift(); // Drop oldest
-        logger.warn('[Subscription] Queue full, dropping oldest event');
+        droppedCount += 1;
+        logOverflowDrop(label, droppedCount);
       }
       queue.push(value);
     }
@@ -64,13 +83,19 @@ export async function createAsyncIterator<T>(
  * NOTE: This function is async because the subscribe function may need to
  * establish Redis connections before returning. We must await subscription
  * setup to ensure multi-instance pub/sub is ready before yielding events.
+ *
+ * @param label identifies this iterator in overflow logs (e.g.
+ *   `boardNowPlaying:42`). Defaults to 'unknown' for call sites that haven't
+ *   been updated to pass one.
  */
 export async function createEagerAsyncIterator<T>(
   subscribe: (push: (value: T) => void) => Promise<() => void>,
+  label = 'unknown',
 ): Promise<AsyncIterable<T>> {
   const queue: T[] = [];
   const pending: Array<(value: IteratorResult<T>) => void> = [];
   let done = false;
+  let droppedCount = 0;
 
   // Subscribe IMMEDIATELY and await Redis channel setup
   const unsubscribe = await subscribe((value: T) => {
@@ -80,7 +105,8 @@ export async function createEagerAsyncIterator<T>(
       // Bounded queue: drop oldest events if queue is full
       if (queue.length >= MAX_SUBSCRIPTION_QUEUE_SIZE) {
         queue.shift(); // Drop oldest
-        logger.warn('[Subscription] Queue full, dropping oldest event');
+        droppedCount += 1;
+        logOverflowDrop(label, droppedCount);
       }
       queue.push(value);
     }

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -349,6 +349,7 @@ export const tickMutations = {
         boardType: dbSchema.boardseshTicks.boardType,
         climbUuid: dbSchema.boardseshTicks.climbUuid,
         angle: dbSchema.boardseshTicks.angle,
+        boardId: dbSchema.boardseshTicks.boardId,
       })
       .from(dbSchema.boardseshTicks)
       .where(eq(dbSchema.boardseshTicks.uuid, uuid))
@@ -405,6 +406,14 @@ export const tickMutations = {
     // Recompute the stats row so a deleted ascent doesn't leave the count
     // inflated or the FA pinned to a now-vanished tick.
     queueClimbStatsRecompute(tick.boardType, tick.climbUuid, tick.angle);
+
+    // Board presence: a deleted tick on a connected wall changes that wall's
+    // durable stats (sends / climbers / hardest / top grade) — refresh the
+    // live tiles + cache the same way saveTick does. See the longer comment
+    // on the saveTick call site below.
+    if (tick.boardId != null) {
+      queueBoardStatsPublish(tick.boardId, tick.boardType);
+    }
 
     logger.info(`[deleteTick] deleted tick=${uuid} user=${userId}`);
 
@@ -822,6 +831,13 @@ export const tickMutations = {
     // toward ascensionist_count, and a quality/difficulty/comment edit can
     // also change downstream derived stats once we aggregate those. Recompute.
     queueClimbStatsRecompute(updated.boardType, updated.climbUuid, updated.angle);
+
+    // Board presence: an edited tick on a connected wall can change that
+    // wall's durable stats (e.g. attempt -> send). See the longer comment on
+    // the saveTick call site above.
+    if (updated.boardId != null) {
+      queueBoardStatsPublish(updated.boardId, updated.boardType);
+    }
 
     logger.info(
       `[updateTick] updated tick=${updated.uuid} user=${userId} ` +

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -18,19 +18,72 @@ type CommentSubscriber = (event: CommentEvent) => void;
 type NewClimbSubscriber = (event: NewClimbCreatedEvent) => void;
 type BoardPresenceSubscriber = (event: BoardPresenceEvent) => void;
 
+/** Result of the Stage-A report gate read (one pipeline, see `getBoardReportGate`). */
+export type BoardReportGate = {
+  /** Whether `emitterId` currently has a live proof-of-presence stamp on the board. */
+  isMember: boolean;
+  /** First-seen epoch-ms for the durable-history dwell gate, or null when unknown/implausible. */
+  firstSeenMs: number | null;
+  /** Value of `board:{id}:lastReport` ("emitterId|climbUuid|angle"), or null when never set / expired. */
+  lastReport: string | null;
+};
+
+export type CommitBoardClimbInput = {
+  boardId: string;
+  emitterId: string;
+  climb: BoardPresenceClimb;
+  climbUuid: string;
+  effectiveAngle: number;
+  /** The reporting connection's party-session id, when it's in one. */
+  sessionId: string | null;
+};
+
+export type CommitBoardClimbResult = {
+  /** The writer key's previous value (from the atomic SET..GET), or null when
+   * the board was free / the commit failed. Non-fatal failures collapse to
+   * null here, matching `setBoardWriter`'s existing swallow-and-log contract. */
+  previousWriter: string | null;
+};
+
 // Board-presence durable history (Redis FIFO) configuration. The live
 // "now on the wall" feed is ephemeral; this buffer backfills late joiners
 // before the `boardNowPlaying` subscription takes over.
 const BOARD_HISTORY_SIZE = 50; // Keep the last 50 climbs per board
 const BOARD_HISTORY_TTL = 604_800; // 1 week
-// Must track BOARD_HISTORY_TTL: the per-board seq counter and the history buffer
-// expire together, so the seq never resets to 1 while history rows still exist
-// (which would collide / mis-order the keyset cursor).
+// The per-board seq counter's TTL matches BOARD_HISTORY_TTL so the common
+// case (an active board) never sees the counter expire while the Redis
+// history buffer is still populated. But `board_climb_events` rows are
+// durable forever, so a board dormant for *longer* than a week still has a
+// live durable floor after this key expires — INCR would otherwise restart
+// at 1 and collide with / precede rows that still exist in Postgres. That
+// residual gap is closed by the dormancy reseed in `nextBoardSeq` (see
+// `boardSeqFloorProvider` / `allocateBoardSeqAtLeast` below), not by this TTL
+// alone.
 const BOARD_SEQ_TTL = 604_800; // 1 week
+// Once INCR returns a value at or below this, nextBoardSeq consults the
+// durable floor provider — a small INCR result is the signature of a
+// freshly-(re)created Redis key, which happens both for a genuinely new board
+// and for a dormant board whose key just expired.
+const BOARD_SEQ_RESEED_THRESHOLD = 50;
 // Proof-of-presence window: how long after connecting (resolveBoardForSerial /
 // resolveBoardForConfig) a user may report climbs to that board's feed. Long
 // enough for a climbing session; a reconnect re-stamps it.
 const BOARD_MEMBERSHIP_TTL = 43_200; // 12 hours
+// Write-side idempotency window for reportBoardClimb: a retry of the exact
+// same (emitter, climb, angle) within this window is treated as a no-op
+// duplicate rather than a new send (see `getBoardReportGate` / A2 dedup).
+const REPORT_DEDUP_WINDOW_MS = 10_000;
+// Epoch-ms floor a first-seen stamp must clear to be trusted. Guards against
+// legacy sentinel values (e.g. an old '1') that would otherwise trivially
+// satisfy the durable-history dwell gate.
+const PLAUSIBLE_EPOCH_MS_FLOOR = 1_600_000_000_000;
+
+function parsePlausibleFirstSeenMs(raw: string | null): number | null {
+  if (raw === null) return null;
+  const firstSeen = Number(raw);
+  if (!Number.isFinite(firstSeen) || firstSeen < PLAUSIBLE_EPOCH_MS_FLOOR) return null;
+  return firstSeen;
+}
 
 /** External hook called after every queue event publish. Fire-and-forget. */
 type QueueEventHook = (sessionId: string, event: QueueEvent) => void;
@@ -70,6 +123,12 @@ class PubSub {
   private initialized = false;
   private redisRequired = false;
   private queueEventHook: QueueEventHook | null = null;
+  // Durable seq floor lookup for the `nextBoardSeq` dormancy reseed (A3).
+  // Injected via `setBoardSeqFloorProvider` at bootstrap so pubsub itself
+  // stays DB-free (and trivially unit-testable without Postgres). Defaults to
+  // "no durable floor" — a board with no floor provider wired never reseeds,
+  // matching pre-A3 behavior.
+  private boardSeqFloorProvider: (boardId: number) => Promise<number> = async () => 0;
 
   /**
    * Initialize the PubSub system.
@@ -147,6 +206,16 @@ class PubSub {
    */
   setQueueEventHook(hook: QueueEventHook): void {
     this.queueEventHook = hook;
+  }
+
+  /**
+   * Inject the durable seq-floor lookup used by `nextBoardSeq`'s dormancy
+   * reseed (A3). Wired once at backend bootstrap (`server.ts`) to a Drizzle
+   * query over `board_climb_events`; defaults to `async () => 0` so pubsub
+   * unit tests never need a database.
+   */
+  setBoardSeqFloorProvider(provider: (boardId: number) => Promise<number>): void {
+    this.boardSeqFloorProvider = provider;
   }
 
   private setupRedisMessageHandlers(): void {
@@ -737,18 +806,37 @@ class PubSub {
 
   /**
    * Atomically allocate the next monotonic sequence number for a board.
-   * Redis `INCR` (cluster-safe across instances); falls back to an in-memory
-   * counter in local-only mode. The key expires after a week of inactivity so
-   * an idle board's counter doesn't leak in Redis — a new climb that day just
-   * restarts at 1, which is fine because the history buffer expires together.
+   * Redis `INCR` + `EXPIRE` (pipelined — 1 RTT), cluster-safe across
+   * instances; falls back to an in-memory counter in local-only mode.
+   *
+   * The key expires after a week of inactivity. For a genuinely fresh board
+   * that's harmless (INCR restarts at 1 and the empty history buffer expired
+   * along with it). For a board dormant *longer* than the TTL whose durable
+   * `board_climb_events` rows outlive the key, restarting at 1 would collide
+   * with / precede still-existing rows — so whenever INCR comes back small
+   * (<= BOARD_SEQ_RESEED_THRESHOLD, the signature of a fresh key either way),
+   * we check the durable floor via `boardSeqFloorProvider` and, if the floor
+   * is at or above the INCR result, reseed atomically past it with
+   * `allocateBoardSeqAtLeast`.
    */
   async nextBoardSeq(boardId: string): Promise<number> {
     if (this.redisAdapter && this.isRedisConnected()) {
       try {
         const { publisher } = redisClientManager.getClients();
         const key = `board:${boardId}:seq`;
-        const next = await publisher.incr(key);
-        await publisher.expire(key, BOARD_SEQ_TTL);
+        const results = await publisher.pipeline().incr(key).expire(key, BOARD_SEQ_TTL).exec();
+        if (!results) {
+          throw new Error('nextBoardSeq pipeline returned null');
+        }
+        const [incrError, incrResult] = results[0];
+        if (incrError) throw incrError;
+        const next = incrResult as number;
+
+        if (next <= BOARD_SEQ_RESEED_THRESHOLD) {
+          const reseeded = await this.reseedBoardSeqIfBehindDurableFloor(boardId, next);
+          if (reseeded !== null) return reseeded;
+        }
+
         return next;
       } catch (error) {
         if (this.redisRequired) {
@@ -762,6 +850,57 @@ class PubSub {
     const next = (this.localBoardSeq.get(boardId) ?? 0) + 1;
     this.localBoardSeq.set(boardId, next);
     return next;
+  }
+
+  /**
+   * Compares an INCR result against the durable seq floor and, if the board's
+   * durable history has already passed it, reseeds atomically via
+   * `allocateBoardSeqAtLeast`. Returns null when no reseed is needed (the
+   * caller should use the original INCR result) — never throws; a floor
+   * lookup failure (e.g. a Postgres hiccup) just falls back to the INCR
+   * result, matching `nextBoardSeq`'s existing non-fatal-degrade contract.
+   */
+  private async reseedBoardSeqIfBehindDurableFloor(boardId: string, incrResult: number): Promise<number | null> {
+    let floor: number;
+    try {
+      floor = await this.boardSeqFloorProvider(Number(boardId));
+    } catch (error) {
+      logger.error('[PubSub] board seq floor provider failed, using INCR result:', error);
+      return null;
+    }
+    if (floor < incrResult) return null;
+    try {
+      return await this.allocateBoardSeqAtLeast(boardId, floor);
+    } catch (error) {
+      logger.error('[PubSub] board seq Lua reseed failed, using INCR result:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Atomically allocate a board seq value guaranteed to exceed both the
+   * current Redis counter and `floor` (`max(currentValue, floor) + 1`),
+   * re-arming the TTL. A single Lua script keeps the read-compare-write
+   * atomic under concurrent callers — two racing reseeds still get distinct,
+   * monotonic results because Redis serializes the script execution.
+   * Redis-only; callers must already know Redis is connected (internal reseed
+   * path checks this; the method is also exported for direct unit testing).
+   */
+  async allocateBoardSeqAtLeast(boardId: string, floor: number): Promise<number> {
+    const { publisher } = redisClientManager.getClients();
+    const key = `board:${boardId}:seq`;
+    const result = await publisher.eval(
+      "local cur = tonumber(redis.call('get', KEYS[1]) or '0'); " +
+        'local nxt = math.max(cur, tonumber(ARGV[1])) + 1; ' +
+        "redis.call('set', KEYS[1], nxt); " +
+        "redis.call('expire', KEYS[1], ARGV[2]); " +
+        'return nxt',
+      1,
+      key,
+      floor,
+      BOARD_SEQ_TTL,
+    );
+    return Number(result);
   }
 
   /**
@@ -863,6 +1002,10 @@ class PubSub {
         logger.error('[PubSub] Failed to check board membership, falling back to local:', error);
       }
     }
+    return this.checkLocalBoardMembership(boardId, userId);
+  }
+
+  private checkLocalBoardMembership(boardId: string, userId: string): boolean {
     const localKey = `${boardId}:${userId}`;
     const expiry = this.localBoardMembership.get(localKey);
     if (expiry === undefined) return false;
@@ -874,31 +1017,122 @@ class PubSub {
   }
 
   /**
-   * First-seen epoch-ms for a member's presence on a board, or null when
-   * unknown. Drives the durable-history dwell gate (persist only after ~60s on
-   * the board). Redis-only: the single-instance local fallback returns null
-   * (durable history degrades to off without Redis, like the live feed).
-   * Fails closed on legacy '1' / non-plausible values so they can't bypass the
-   * gate.
+   * One Redis pipeline (1 RTT) that answers everything `reportBoardClimb`'s
+   * Stage A needs before validating the incoming climb: proof-of-presence
+   * (+ first-seen, for the durable-history dwell gate) and the last-report
+   * dedup marker (for write-side idempotency, A2). Replaces what used to be
+   * separate `hasBoardMembership` + `getBoardMembershipFirstSeen` + a
+   * `lastReport` GET — 3 RTTs collapsed into 1.
+   *
+   * Preserves `hasBoardMembership`'s fail-closed `redisRequired` semantics
+   * (throws when Redis is required but the pipeline fails) and
+   * `getBoardMembershipFirstSeen`'s plausible-epoch guard on `firstSeenMs`
+   * (a legacy/implausible stamp still counts as a member but never satisfies
+   * the dwell gate). Local-only fallback mirrors today: membership from the
+   * in-memory map, `firstSeenMs`/`lastReport` unknown (null) — durable history
+   * and write-side dedup both degrade to off without Redis, same as before.
    */
-  async getBoardMembershipFirstSeen(boardId: string, userId: string): Promise<number | null> {
+  async getBoardReportGate(boardId: string, emitterId: string): Promise<BoardReportGate> {
+    const membershipKey = `presence:board:${boardId}:user:${emitterId}`;
+    const lastReportKey = `board:${boardId}:lastReport`;
+
     if (this.redisAdapter && this.isRedisConnected()) {
       try {
         const { publisher } = redisClientManager.getClients();
-        const raw = await publisher.get(`presence:board:${boardId}:user:${userId}`);
-        if (raw === null) return null;
-        const firstSeen = Number(raw);
-        if (!Number.isFinite(firstSeen) || firstSeen < 1_600_000_000_000) return null;
-        return firstSeen;
+        const results = await publisher.pipeline().get(membershipKey).get(lastReportKey).exec();
+        if (!results) {
+          throw new Error('getBoardReportGate pipeline returned null');
+        }
+        const [[membershipError, membershipRaw], [lastReportError, lastReportRaw]] = results;
+        if (membershipError) throw membershipError;
+        if (lastReportError) throw lastReportError;
+        const raw = membershipRaw as string | null;
+        return {
+          isMember: raw !== null,
+          firstSeenMs: parsePlausibleFirstSeenMs(raw),
+          lastReport: (lastReportRaw as string | null) ?? null,
+        };
       } catch (error) {
         if (this.redisRequired) {
-          logger.error('[PubSub] Failed to read board membership first-seen in required Redis:', error);
+          logger.error('[PubSub] Failed to read board report gate from required Redis:', error);
           throw error;
         }
-        logger.error('[PubSub] Failed to read board membership first-seen, treating as unknown:', error);
+        logger.error('[PubSub] Failed to read board report gate, falling back to local:', error);
       }
     }
-    return null;
+
+    return {
+      isMember: this.checkLocalBoardMembership(boardId, emitterId),
+      firstSeenMs: null,
+      lastReport: null,
+    };
+  }
+
+  /**
+   * One Redis pipeline (1 RTT) that commits an accepted `reportBoardClimb`
+   * send: appends to the durable FIFO history (LPUSH/LTRIM/EXPIRE), takes the
+   * connection-holder slot (atomic `SET writer EX GET` — same single-command
+   * handoff-dedup as `setBoardWriter`, so two concurrent reports still can't
+   * both observe the same previous holder), stamps the write-side dedup
+   * marker (A2's `lastReport`), and — when this connection is in a party
+   * session — remembers the session→board mapping (`setSessionBoard`'s key).
+   * Replaces what used to be 3 separate round trips.
+   *
+   * Non-fatal: the whole pipeline (or an individual command within it) can
+   * fail without failing the accepted report — same swallow-and-log contract
+   * `storeBoardClimb` / `setBoardWriter` / `setSessionBoard` each had on their
+   * own. A failure returns `{ previousWriter: null }`, which the resolver
+   * treats as "board was free" — the same false-negative that a swallowed
+   * `setBoardWriter` failure already produced before this pipeline existed.
+   */
+  async commitBoardClimb(input: CommitBoardClimbInput): Promise<CommitBoardClimbResult> {
+    if (!this.redisAdapter || !this.isRedisConnected()) {
+      return { previousWriter: null };
+    }
+
+    try {
+      const { publisher } = redisClientManager.getClients();
+      const historyKey = `board:${input.boardId}:history`;
+      const writerKey = `board:${input.boardId}:writer`;
+      const lastReportKey = `board:${input.boardId}:lastReport`;
+      const lastReportValue = `${input.emitterId}|${input.climbUuid}|${input.effectiveAngle}`;
+
+      const pipeline = publisher.pipeline();
+      const commandLabels: string[] = [];
+      pipeline.lpush(historyKey, JSON.stringify(input.climb));
+      commandLabels.push('history-lpush');
+      pipeline.ltrim(historyKey, 0, BOARD_HISTORY_SIZE - 1);
+      commandLabels.push('history-ltrim');
+      pipeline.expire(historyKey, BOARD_HISTORY_TTL);
+      commandLabels.push('history-expire');
+      const writerCommandIndex = commandLabels.length;
+      pipeline.set(writerKey, input.emitterId, 'EX', BOARD_MEMBERSHIP_TTL, 'GET');
+      commandLabels.push('writer-set');
+      pipeline.set(lastReportKey, lastReportValue, 'PX', REPORT_DEDUP_WINDOW_MS);
+      commandLabels.push('last-report-set');
+      if (input.sessionId) {
+        pipeline.set(`session:${input.sessionId}:board`, input.boardId, 'EX', BOARD_MEMBERSHIP_TTL);
+        commandLabels.push('session-board-set');
+      }
+
+      const results = await pipeline.exec();
+      if (!results) {
+        throw new Error('commitBoardClimb pipeline returned null');
+      }
+
+      results.forEach(([error], index) => {
+        if (error) {
+          logger.warn(`[PubSub] commitBoardClimb ${commandLabels[index]} command failed: ${String(error)}`);
+        }
+      });
+
+      const [writerError, writerValue] = results[writerCommandIndex];
+      if (writerError) return { previousWriter: null };
+      return { previousWriter: (writerValue as string | null) ?? null };
+    } catch (error) {
+      logger.error('[PubSub] commitBoardClimb pipeline failed:', error);
+      return { previousWriter: null };
+    }
   }
 
   /**

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -140,6 +140,15 @@ class PubSub {
   // board that allocates during the process lifetime (bounded like
   // `localBoardSeq`); never TTL'd — see the safety analysis on the method.
   private boardSeqVerifiedThrough = new Map<string, number>();
+  // Sticky "the floor consultation FAILED and hasn't succeeded since" marker.
+  // While a board is in here, every nextBoardSeq call retries the floor
+  // consultation — regardless of the INCR value and bypassing the watermark
+  // skip — so a transient Postgres/Lua failure during the reseed window can't
+  // let the counter grow past BOARD_SEQ_RESEED_THRESHOLD while still below
+  // the durable floor (which would permanently freeze clients holding
+  // pre-reset high seqs). Cleared only by a successful verification/reseed.
+  // Same lifecycle/bounds as the watermark map.
+  private boardSeqReseedPending = new Set<string>();
   // Local-only proof-of-presence: `${boardId}:${userId}` → expiry epoch ms.
   private localBoardMembership = new Map<string, number>();
   private localBoardMembershipCleanupTimer: ReturnType<typeof setTimeout> | null = null;
@@ -843,7 +852,12 @@ class PubSub {
    * `ensureBoardSeqClearOfDurableFloor` checks the durable floor and, if the
    * floor is at or above the INCR result, reseeds atomically past it. The
    * check memoizes per board so a brand-new board's early sends don't repeat
-   * the Postgres lookup ~50 times (see that method's safety analysis).
+   * the Postgres lookup ~50 times (see that method's safety analysis). A
+   * FAILED consultation marks the board reseed-pending, which keeps the
+   * consultation retrying on every subsequent allocation even after the
+   * counter crosses the threshold — otherwise a transient Postgres blip in
+   * the reseed window would leave the counter permanently below the durable
+   * floor.
    */
   async nextBoardSeq(boardId: string): Promise<number> {
     if (this.redisAdapter && this.isRedisConnected()) {
@@ -858,7 +872,7 @@ class PubSub {
         if (incrError) throw incrError;
         const next = incrResult as number;
 
-        if (next <= BOARD_SEQ_RESEED_THRESHOLD) {
+        if (next <= BOARD_SEQ_RESEED_THRESHOLD || this.boardSeqReseedPending.has(boardId)) {
           return await this.ensureBoardSeqClearOfDurableFloor(boardId, next);
         }
 
@@ -878,12 +892,18 @@ class PubSub {
   }
 
   /**
-   * Ensures a small INCR result (<= BOARD_SEQ_RESEED_THRESHOLD) is clear of
-   * the durable `board_climb_events` floor, reseeding atomically via
+   * Ensures a small (or reseed-pending) INCR result is clear of the durable
+   * `board_climb_events` floor, reseeding atomically via
    * `allocateBoardSeqAtLeast` when it isn't. Returns the seq to use. Never
-   * throws: a floor-lookup or reseed failure falls back to the INCR result,
-   * matching `nextBoardSeq`'s existing non-fatal-degrade contract (and is
-   * deliberately NOT memoized, so the very next small INCR retries).
+   * throws: a floor-lookup or reseed failure falls back to the INCR result —
+   * but marks the board reseed-pending, so every subsequent allocation
+   * retries the consultation (bypassing the watermark skip) until one
+   * succeeds. Without the sticky flag, a transient Postgres blip covering
+   * the whole <= BOARD_SEQ_RESEED_THRESHOLD window would let the counter
+   * cross the threshold still below the durable floor and never consult
+   * Postgres again — clients holding pre-reset high seqs would then treat
+   * every subsequent event as stale and the live wall would freeze until the
+   * next counter loss.
    *
    * Memoization: without it, every send of a brand-new board's first
    * ~BOARD_SEQ_RESEED_THRESHOLD would run the MAX(seq) Postgres lookup. The
@@ -909,8 +929,12 @@ class PubSub {
    * concurrent sends in the reseed window, so we take the simple memo.
    */
   private async ensureBoardSeqClearOfDurableFloor(boardId: string, incrResult: number): Promise<number> {
+    const reseedPending = this.boardSeqReseedPending.has(boardId);
     const verifiedThrough = this.boardSeqVerifiedThrough.get(boardId);
-    if (verifiedThrough !== undefined && incrResult > verifiedThrough) {
+    // The watermark skip is only trustworthy when no consultation has failed
+    // since the last success — while reseed-pending, the floor may be far
+    // above anything this instance ever verified, so always re-consult.
+    if (!reseedPending && verifiedThrough !== undefined && incrResult > verifiedThrough) {
       this.boardSeqVerifiedThrough.set(boardId, incrResult);
       return incrResult;
     }
@@ -919,21 +943,30 @@ class PubSub {
     try {
       floor = await this.boardSeqFloorProvider(Number(boardId));
     } catch (error) {
-      logger.error('[PubSub] board seq floor provider failed, using INCR result:', error);
+      this.boardSeqReseedPending.add(boardId);
+      logger.error('[PubSub] board seq floor provider failed, using INCR result (reseed pending):', error);
       return incrResult;
     }
 
     if (floor < incrResult) {
+      this.boardSeqReseedPending.delete(boardId);
       this.boardSeqVerifiedThrough.set(boardId, Math.max(incrResult, verifiedThrough ?? 0));
       return incrResult;
     }
 
     try {
       const reseeded = await this.allocateBoardSeqAtLeast(boardId, floor);
+      if (reseeded === null) {
+        // Redis went away between the INCR and the reseed — keep retrying.
+        this.boardSeqReseedPending.add(boardId);
+        return incrResult;
+      }
+      this.boardSeqReseedPending.delete(boardId);
       this.boardSeqVerifiedThrough.set(boardId, Math.max(reseeded, verifiedThrough ?? 0));
       return reseeded;
     } catch (error) {
-      logger.error('[PubSub] board seq Lua reseed failed, using INCR result:', error);
+      this.boardSeqReseedPending.add(boardId);
+      logger.error('[PubSub] board seq Lua reseed failed, using INCR result (reseed pending):', error);
       return incrResult;
     }
   }
@@ -944,10 +977,13 @@ class PubSub {
    * re-arming the TTL. A single Lua script keeps the read-compare-write
    * atomic under concurrent callers — two racing reseeds still get distinct,
    * monotonic results because Redis serializes the script execution.
-   * Redis-only; callers must already know Redis is connected (internal reseed
-   * path checks this; the method is also exported for direct unit testing).
+   * Redis-only: returns null when Redis is unavailable (callers fall back to
+   * the plain INCR result and mark the reseed pending). May still reject on
+   * a command failure against a connected Redis — the internal reseed path
+   * catches that. Public for direct unit testing.
    */
-  async allocateBoardSeqAtLeast(boardId: string, floor: number): Promise<number> {
+  async allocateBoardSeqAtLeast(boardId: string, floor: number): Promise<number | null> {
+    if (!this.redisAdapter || !this.isRedisConnected()) return null;
     const { publisher } = redisClientManager.getClients();
     const key = `board:${boardId}:seq`;
     const result = await publisher.eval(

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -26,6 +26,15 @@ export type BoardReportGate = {
   firstSeenMs: number | null;
   /** Value of `board:{id}:lastReport` ("emitterId|climbUuid|angle"), or null when never set / expired. */
   lastReport: string | null;
+  /**
+   * The board's current connection holder (`board:{id}:writer`), or null when
+   * free / unknown. The dedup short-circuit must only fire while the retrying
+   * emitter still holds the wall — a WS-close backstop clear between the
+   * original send and the retry deletes the writer key but leaves lastReport,
+   * and short-circuiting then would strand the wall looking free while the
+   * emitter holds it (no re-take, no re-broadcast).
+   */
+  currentWriter: string | null;
 };
 
 export type CommitBoardClimbInput = {
@@ -40,9 +49,17 @@ export type CommitBoardClimbInput = {
 
 export type CommitBoardClimbResult = {
   /** The writer key's previous value (from the atomic SET..GET), or null when
-   * the board was free / the commit failed. Non-fatal failures collapse to
-   * null here, matching `setBoardWriter`'s existing swallow-and-log contract. */
+   * the board was free / the commit failed. */
   previousWriter: string | null;
+  /**
+   * True only when the writer SET..GET slot actually executed without error —
+   * i.e. `previousWriter` is a real observation, not a failure collapsed to
+   * null. The caller must gate the hand-off broadcast on this: a failing
+   * pipeline otherwise looks like "board was free" (`null !== emitterId`) and
+   * would spuriously broadcast a hand-off + kick a Live Activity push on
+   * every send while Redis is unhealthy.
+   */
+  writerSlotOk: boolean;
 };
 
 // Board-presence durable history (Redis FIFO) configuration. The live
@@ -904,28 +921,6 @@ class PubSub {
   }
 
   /**
-   * Append a climb to a board's durable FIFO history (newest-first, capped at
-   * 50, 1-week TTL). No-op without Redis — late joiners then just rely on the
-   * live subscription.
-   */
-  async storeBoardClimb(boardId: string, climb: BoardPresenceClimb): Promise<void> {
-    if (!this.redisAdapter || !this.isRedisConnected()) {
-      return;
-    }
-
-    try {
-      const { publisher } = redisClientManager.getClients();
-      const key = `board:${boardId}:history`;
-      await publisher.lpush(key, JSON.stringify(climb));
-      await publisher.ltrim(key, 0, BOARD_HISTORY_SIZE - 1);
-      await publisher.expire(key, BOARD_HISTORY_TTL);
-    } catch (error) {
-      logger.error('[PubSub] Failed to store board climb in history:', error);
-      // Non-fatal: the live event was already published.
-    }
-  }
-
-  /**
    * Read a board's recent climbs, newest-first by seq (cap 50). Empty without
    * Redis.
    */
@@ -1019,38 +1014,44 @@ class PubSub {
   /**
    * One Redis pipeline (1 RTT) that answers everything `reportBoardClimb`'s
    * Stage A needs before validating the incoming climb: proof-of-presence
-   * (+ first-seen, for the durable-history dwell gate) and the last-report
-   * dedup marker (for write-side idempotency, A2). Replaces what used to be
-   * separate `hasBoardMembership` + `getBoardMembershipFirstSeen` + a
-   * `lastReport` GET — 3 RTTs collapsed into 1.
+   * (+ first-seen, for the durable-history dwell gate), the last-report dedup
+   * marker (for write-side idempotency, A2), and the current writer (so the
+   * dedup short-circuit can require the retrying emitter to still hold the
+   * wall — see `BoardReportGate.currentWriter`). Replaces what used to be
+   * separate `hasBoardMembership` + first-seen + `lastReport` reads — 3 RTTs
+   * collapsed into 1, with the writer read riding the same pipeline for free.
    *
    * Preserves `hasBoardMembership`'s fail-closed `redisRequired` semantics
-   * (throws when Redis is required but the pipeline fails) and
-   * `getBoardMembershipFirstSeen`'s plausible-epoch guard on `firstSeenMs`
-   * (a legacy/implausible stamp still counts as a member but never satisfies
-   * the dwell gate). Local-only fallback mirrors today: membership from the
-   * in-memory map, `firstSeenMs`/`lastReport` unknown (null) — durable history
-   * and write-side dedup both degrade to off without Redis, same as before.
+   * (throws when Redis is required but the pipeline fails) and the
+   * plausible-epoch guard on `firstSeenMs` (a legacy/implausible stamp still
+   * counts as a member but never satisfies the dwell gate). Local-only
+   * fallback mirrors today: membership from the in-memory map,
+   * `firstSeenMs`/`lastReport`/`currentWriter` unknown (null) — durable
+   * history and write-side dedup both degrade to off without Redis, same as
+   * before.
    */
   async getBoardReportGate(boardId: string, emitterId: string): Promise<BoardReportGate> {
     const membershipKey = `presence:board:${boardId}:user:${emitterId}`;
     const lastReportKey = `board:${boardId}:lastReport`;
+    const writerKey = `board:${boardId}:writer`;
 
     if (this.redisAdapter && this.isRedisConnected()) {
       try {
         const { publisher } = redisClientManager.getClients();
-        const results = await publisher.pipeline().get(membershipKey).get(lastReportKey).exec();
+        const results = await publisher.pipeline().get(membershipKey).get(lastReportKey).get(writerKey).exec();
         if (!results) {
           throw new Error('getBoardReportGate pipeline returned null');
         }
-        const [[membershipError, membershipRaw], [lastReportError, lastReportRaw]] = results;
+        const [[membershipError, membershipRaw], [lastReportError, lastReportRaw], [writerError, writerRaw]] = results;
         if (membershipError) throw membershipError;
         if (lastReportError) throw lastReportError;
+        if (writerError) throw writerError;
         const raw = membershipRaw as string | null;
         return {
           isMember: raw !== null,
           firstSeenMs: parsePlausibleFirstSeenMs(raw),
           lastReport: (lastReportRaw as string | null) ?? null,
+          currentWriter: (writerRaw as string | null) ?? null,
         };
       } catch (error) {
         if (this.redisRequired) {
@@ -1065,29 +1066,35 @@ class PubSub {
       isMember: this.checkLocalBoardMembership(boardId, emitterId),
       firstSeenMs: null,
       lastReport: null,
+      currentWriter: null,
     };
   }
 
   /**
    * One Redis pipeline (1 RTT) that commits an accepted `reportBoardClimb`
    * send: appends to the durable FIFO history (LPUSH/LTRIM/EXPIRE), takes the
-   * connection-holder slot (atomic `SET writer EX GET` — same single-command
-   * handoff-dedup as `setBoardWriter`, so two concurrent reports still can't
-   * both observe the same previous holder), stamps the write-side dedup
-   * marker (A2's `lastReport`), and — when this connection is in a party
-   * session — remembers the session→board mapping (`setSessionBoard`'s key).
-   * Replaces what used to be 3 separate round trips.
+   * connection-holder slot (atomic `SET writer EX GET` — a single command, so
+   * two concurrent reports still can't both observe the same previous
+   * holder), stamps the write-side dedup marker (A2's `lastReport`), and —
+   * when this connection is in a party session — remembers the session→board
+   * mapping (`session:{id}:board`). Replaces what used to be 3 separate
+   * round trips.
    *
    * Non-fatal: the whole pipeline (or an individual command within it) can
-   * fail without failing the accepted report — same swallow-and-log contract
-   * `storeBoardClimb` / `setBoardWriter` / `setSessionBoard` each had on their
-   * own. A failure returns `{ previousWriter: null }`, which the resolver
-   * treats as "board was free" — the same false-negative that a swallowed
-   * `setBoardWriter` failure already produced before this pipeline existed.
+   * fail without failing the accepted report — failures are logged and
+   * swallowed. But a swallowed failure means `previousWriter: null` is a
+   * fabrication, not an observation, so the result also carries
+   * `writerSlotOk`: false whenever the writer slot didn't verifiably execute
+   * (Redis off, pipeline threw, or the SET..GET slot itself errored). The
+   * resolver gates the hand-off broadcast on it — without that gate, a
+   * failing pipeline would look like "board was free" on every send and
+   * spuriously re-broadcast the hand-off each time (the pre-pipeline code
+   * never had this failure mode: a writer-update failure was either swallowed
+   * with no broadcast, or thrown in redisRequired mode).
    */
   async commitBoardClimb(input: CommitBoardClimbInput): Promise<CommitBoardClimbResult> {
     if (!this.redisAdapter || !this.isRedisConnected()) {
-      return { previousWriter: null };
+      return { previousWriter: null, writerSlotOk: false };
     }
 
     try {
@@ -1127,37 +1134,11 @@ class PubSub {
       });
 
       const [writerError, writerValue] = results[writerCommandIndex];
-      if (writerError) return { previousWriter: null };
-      return { previousWriter: (writerValue as string | null) ?? null };
+      if (writerError) return { previousWriter: null, writerSlotOk: false };
+      return { previousWriter: (writerValue as string | null) ?? null, writerSlotOk: true };
     } catch (error) {
       logger.error('[PubSub] commitBoardClimb pipeline failed:', error);
-      return { previousWriter: null };
-    }
-  }
-
-  /**
-   * The board's current connection holder = the emitter id (a `userId`, or
-   * `conn:{connectionId}` for an anonymous client) of the most recent confirmed
-   * send. Set as a side-effect of reportBoardClimb; drives the "who's connected"
-   * indicator. Redis-only (degrades to "no holder" without Redis, like the
-   * durable feed). Returns the previous holder so the caller can detect a
-   * hand-off and only broadcast on a real change.
-   */
-  async setBoardWriter(boardId: string, emitterId: string): Promise<string | null> {
-    if (!this.redisAdapter || !this.isRedisConnected()) return null;
-    try {
-      const { publisher } = redisClientManager.getClients();
-      const key = `board:${boardId}:writer`;
-      // Atomic set-and-return-previous (`SET key val EX ttl GET`, Redis 6.2+) so
-      // two concurrent reports can't both read the same previous holder and both
-      // broadcast a hand-off — only the real change is detected. The writer key
-      // only ever holds a string, so GET can't hit a WRONGTYPE.
-      const previous = await publisher.set(key, emitterId, 'EX', BOARD_MEMBERSHIP_TTL, 'GET');
-      return (previous as string | null) ?? null;
-    } catch (error) {
-      if (this.redisRequired) throw error;
-      logger.error('[PubSub] Failed to set board writer:', error);
-      return null;
+      return { previousWriter: null, writerSlotOk: false };
     }
   }
 
@@ -1198,29 +1179,18 @@ class PubSub {
   }
 
   /**
-   * Remember which shared board_id a party session is on, written as a
-   * side-effect of `reportBoardClimb` (the only moment a session is provably
-   * tied to a board). The APNs Live Activity path needs this to resolve the
-   * board's current holder for a given session — `QueueState` and the push-token
-   * rows carry sessionId but not boardId.
+   * The shared board_id this party session is on, or null when unknown.
    *
-   * Redis-only and TTL'd to the same window as proof-of-presence so an idle
-   * session's mapping doesn't leak; a fresh send re-stamps it. No-op without
-   * Redis: the holder lookup then degrades to "unknown" and the APNs path omits
-   * boardConnection (device falls back to its own App-Group state).
+   * The mapping (`session:{id}:board`) is written by `commitBoardClimb` as a
+   * side-effect of `reportBoardClimb` — the only moment a session is provably
+   * tied to a board. The APNs Live Activity path reads it to resolve the
+   * board's current holder for a given session (`QueueState` and the
+   * push-token rows carry sessionId but not boardId). Redis-only and TTL'd to
+   * the same window as proof-of-presence so an idle session's mapping doesn't
+   * leak; a fresh send re-stamps it. Without Redis the holder lookup degrades
+   * to "unknown" and the APNs path omits boardConnection (device falls back
+   * to its own App-Group state).
    */
-  async setSessionBoard(sessionId: string, boardId: string): Promise<void> {
-    if (!this.redisAdapter || !this.isRedisConnected()) return;
-    try {
-      const { publisher } = redisClientManager.getClients();
-      await publisher.set(`session:${sessionId}:board`, boardId, 'EX', BOARD_MEMBERSHIP_TTL);
-    } catch (error) {
-      if (this.redisRequired) throw error;
-      logger.error('[PubSub] Failed to set session board:', error);
-    }
-  }
-
-  /** The shared board_id this session is on, or null when unknown. */
   async getSessionBoard(sessionId: string): Promise<string | null> {
     if (!this.redisAdapter || !this.isRedisConnected()) return null;
     try {

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -132,6 +132,14 @@ class PubSub {
   // mode the authoritative counter is `board:${boardId}:seq` (INCR); this map
   // only ever serves single-instance deployments that have no Redis.
   private localBoardSeq = new Map<string, number>();
+  // Per-board watermark for the seq dormancy reseed (see
+  // `ensureBoardSeqClearOfDurableFloor`): the highest seq this instance has
+  // verified clear of the durable floor or allocated through the reseed
+  // check. Lets a brand-new board skip the repeated MAX(seq) Postgres lookup
+  // on each of its first ~BOARD_SEQ_RESEED_THRESHOLD sends. One number per
+  // board that allocates during the process lifetime (bounded like
+  // `localBoardSeq`); never TTL'd — see the safety analysis on the method.
+  private boardSeqVerifiedThrough = new Map<string, number>();
   // Local-only proof-of-presence: `${boardId}:${userId}` → expiry epoch ms.
   private localBoardMembership = new Map<string, number>();
   private localBoardMembershipCleanupTimer: ReturnType<typeof setTimeout> | null = null;
@@ -832,9 +840,10 @@ class PubSub {
    * `board_climb_events` rows outlive the key, restarting at 1 would collide
    * with / precede still-existing rows — so whenever INCR comes back small
    * (<= BOARD_SEQ_RESEED_THRESHOLD, the signature of a fresh key either way),
-   * we check the durable floor via `boardSeqFloorProvider` and, if the floor
-   * is at or above the INCR result, reseed atomically past it with
-   * `allocateBoardSeqAtLeast`.
+   * `ensureBoardSeqClearOfDurableFloor` checks the durable floor and, if the
+   * floor is at or above the INCR result, reseeds atomically past it. The
+   * check memoizes per board so a brand-new board's early sends don't repeat
+   * the Postgres lookup ~50 times (see that method's safety analysis).
    */
   async nextBoardSeq(boardId: string): Promise<number> {
     if (this.redisAdapter && this.isRedisConnected()) {
@@ -850,8 +859,7 @@ class PubSub {
         const next = incrResult as number;
 
         if (next <= BOARD_SEQ_RESEED_THRESHOLD) {
-          const reseeded = await this.reseedBoardSeqIfBehindDurableFloor(boardId, next);
-          if (reseeded !== null) return reseeded;
+          return await this.ensureBoardSeqClearOfDurableFloor(boardId, next);
         }
 
         return next;
@@ -870,27 +878,63 @@ class PubSub {
   }
 
   /**
-   * Compares an INCR result against the durable seq floor and, if the board's
-   * durable history has already passed it, reseeds atomically via
-   * `allocateBoardSeqAtLeast`. Returns null when no reseed is needed (the
-   * caller should use the original INCR result) — never throws; a floor
-   * lookup failure (e.g. a Postgres hiccup) just falls back to the INCR
-   * result, matching `nextBoardSeq`'s existing non-fatal-degrade contract.
+   * Ensures a small INCR result (<= BOARD_SEQ_RESEED_THRESHOLD) is clear of
+   * the durable `board_climb_events` floor, reseeding atomically via
+   * `allocateBoardSeqAtLeast` when it isn't. Returns the seq to use. Never
+   * throws: a floor-lookup or reseed failure falls back to the INCR result,
+   * matching `nextBoardSeq`'s existing non-fatal-degrade contract (and is
+   * deliberately NOT memoized, so the very next small INCR retries).
+   *
+   * Memoization: without it, every send of a brand-new board's first
+   * ~BOARD_SEQ_RESEED_THRESHOLD would run the MAX(seq) Postgres lookup. The
+   * memo is a per-board watermark = the highest seq this instance has either
+   * verified clear of the floor or allocated through this check; the lookup
+   * is skipped only when the fresh INCR result is strictly ahead of it
+   * (normal early-life counter growth, provably not a reset this instance
+   * could collide on). Deliberately NOT the raw floor value: a floor-only
+   * memo (e.g. 0 for a new board) would keep skipping after a mid-process
+   * counter loss (FLUSHALL / failover to an empty replica) once durable rows
+   * exist — INCR restarts at 1, `1 > 0` skips, collision. With the
+   * watermark, any allocation pushes it to >= 1, so the first post-reset
+   * INCR (= 1) can never be ahead of it and always re-consults the floor.
+   *
+   * Accepted residual (documented, not defended): in multi-instance, an
+   * instance holding a small stale watermark can race another instance's
+   * first post-reset reseed and skip the check for a seq the durable floor
+   * already covers. The colliding durable insert lands on the (boardId, seq)
+   * unique index's `onConflictDoNothing` — one dropped duplicate row, no
+   * corruption, and exactly the failure mode every post-dormancy send had
+   * before the reseed existed. That needs a mid-process Redis counter loss
+   * (not mere dormancy — any send or stats publish re-arms the TTL) plus
+   * concurrent sends in the reseed window, so we take the simple memo.
    */
-  private async reseedBoardSeqIfBehindDurableFloor(boardId: string, incrResult: number): Promise<number | null> {
+  private async ensureBoardSeqClearOfDurableFloor(boardId: string, incrResult: number): Promise<number> {
+    const verifiedThrough = this.boardSeqVerifiedThrough.get(boardId);
+    if (verifiedThrough !== undefined && incrResult > verifiedThrough) {
+      this.boardSeqVerifiedThrough.set(boardId, incrResult);
+      return incrResult;
+    }
+
     let floor: number;
     try {
       floor = await this.boardSeqFloorProvider(Number(boardId));
     } catch (error) {
       logger.error('[PubSub] board seq floor provider failed, using INCR result:', error);
-      return null;
+      return incrResult;
     }
-    if (floor < incrResult) return null;
+
+    if (floor < incrResult) {
+      this.boardSeqVerifiedThrough.set(boardId, Math.max(incrResult, verifiedThrough ?? 0));
+      return incrResult;
+    }
+
     try {
-      return await this.allocateBoardSeqAtLeast(boardId, floor);
+      const reseeded = await this.allocateBoardSeqAtLeast(boardId, floor);
+      this.boardSeqVerifiedThrough.set(boardId, Math.max(reseeded, verifiedThrough ?? 0));
+      return reseeded;
     } catch (error) {
       logger.error('[PubSub] board seq Lua reseed failed, using INCR result:', error);
-      return null;
+      return incrResult;
     }
   }
 

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -52,7 +52,7 @@ import {
 import { startApnsHeartbeat, stopApnsHeartbeat } from './services/apns/heartbeat';
 import { startApnsStaleTokenCleanup, stopApnsStaleTokenCleanup } from './services/apns/cleanup';
 import { buildContentStateFromQueueState } from './services/apns/content-state';
-import { resolveBoardHolder } from './graphql/resolvers/board-presence/shared';
+import { getBoardSeqFloor, resolveBoardHolder } from './graphql/resolvers/board-presence/shared';
 import { logger, setInstanceIdProvider } from './utils/logger';
 import { isClientAbortError } from './utils/http-errors';
 import type { QueueEvent } from '@boardsesh/shared-schema';
@@ -88,6 +88,11 @@ export async function startServer(): Promise<ServerResources> {
   // Initialize PubSub (connects to Redis if configured)
   // This must happen before we start accepting connections
   await pubsub.initialize();
+
+  // Wire the durable seq-floor lookup for board-presence's dormancy reseed
+  // (A3) — pubsub stays DB-free at import time, but the running server needs
+  // Postgres to answer "what's the highest seq we've durably persisted".
+  pubsub.setBoardSeqFloorProvider(getBoardSeqFloor);
 
   // Wire the logger to the pubsub instance id. The format step in the
   // logger reads this provider at log time, so we get the `[i:abcd1234]`

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -187,10 +187,11 @@ class RoomManager {
 
   /**
    * Record that this connection is the board-presence holder of `boardId` (set
-   * from reportBoardClimb after setBoardWriter). The WS-close backstop
-   * (clearBoardWriterForConnection) reads this to free the wall if the holder
-   * crashes without an explicit reportBoardDisconnect. No-op if the connection
-   * isn't registered (e.g. an internal/controller transport without a client).
+   * from reportBoardClimb around the commitBoardClimb writer take). The
+   * WS-close backstop (clearBoardWriterForConnection) reads this to free the
+   * wall if the holder crashes without an explicit reportBoardDisconnect.
+   * No-op if the connection isn't registered (e.g. an internal/controller
+   * transport without a client).
    */
   noteBoardWriter(connectionId: string, boardId: number, emitterId: string): void {
     const client = this.clients.get(connectionId);

--- a/packages/db/src/schema/app/board-climb-events.ts
+++ b/packages/db/src/schema/app/board-climb-events.ts
@@ -9,8 +9,8 @@ import { userBoards } from './boards';
  * Distinct from `boardsesh_ticks` (a climber's deliberate logbook entry, with
  * flash/send/attempt status): this records every climb that was actually pushed
  * to a board's LEDs, regardless of whether anyone logged it. It survives past
- * the 24h Redis presence window and is the substrate for "what was on last" and
- * future board leaderboards/competitions.
+ * the 1-week Redis presence window (BOARD_HISTORY_TTL) and is the substrate
+ * for "what was on last" and future board leaderboards/competitions.
  *
  * Writes are dwell-gated: a member's sends are only persisted once they've had
  * sustained presence on the board for ~60s, so app-swiping noise doesn't land

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4289,20 +4289,21 @@ type Query {
   newClimbFeed(input: NewClimbFeedInput!): NewClimbFeedResult!
 
   """
-  Backfill the recent "now on the wall" history for a board (last ~50, 24h
-  window) from the Redis FIFO. Used by late joiners before the live
-  `boardNowPlaying` subscription takes over.
+  Backfill the recent "now on the wall" history for a board (last ~50, 1
+  week window (BOARD_HISTORY_TTL)) from the Redis FIFO. Used by late joiners
+  before the live `boardNowPlaying` subscription takes over.
   """
   boardRecentClimbs(boardId: Int!): [BoardPresenceClimb!]!
 
   """
-  Durable history of what was pushed to a board (survives past the 24h Redis
-  window), newest-first by `seq`. For keyset paging pass the `seq` of the
-  last item from the previous page as `before` (not `sentAt`) — `seq` is
-  unique and monotonic per board, so paging never repeats or skips even when
-  several sends share a `sentAt` second. A non-integer `before` is rejected
-  with BAD_USER_INPUT. `limit` is capped at 100. This is the lasting "what
-  was on the wall" record; `boardRecentClimbs` is the hot 24h cache.
+  Durable history of what was pushed to a board (survives past the 1 week
+  Redis window (BOARD_HISTORY_TTL)), newest-first by `seq`. For keyset
+  paging pass the `seq` of the last item from the previous page as
+  `before` (not `sentAt`) — `seq` is unique and monotonic per board, so
+  paging never repeats or skips even when several sends share a `sentAt`
+  second. A non-integer `before` is rejected with BAD_USER_INPUT. `limit`
+  is capped at 100. This is the lasting "what was on the wall" record;
+  `boardRecentClimbs` is the hot 1 week cache.
   """
   boardHistory(boardId: Int!, limit: Int, before: String): [BoardPresenceClimb!]!
 

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -3538,13 +3538,14 @@ export type Query = {
    */
   boardConnection?: Maybe<BoardConnectionHolder>;
   /**
-   * Durable history of what was pushed to a board (survives past the 24h Redis
-   * window), newest-first by `seq`. For keyset paging pass the `seq` of the
-   * last item from the previous page as `before` (not `sentAt`) — `seq` is
-   * unique and monotonic per board, so paging never repeats or skips even when
-   * several sends share a `sentAt` second. A non-integer `before` is rejected
-   * with BAD_USER_INPUT. `limit` is capped at 100. This is the lasting "what
-   * was on the wall" record; `boardRecentClimbs` is the hot 24h cache.
+   * Durable history of what was pushed to a board (survives past the 1 week
+   * Redis window (BOARD_HISTORY_TTL)), newest-first by `seq`. For keyset
+   * paging pass the `seq` of the last item from the previous page as
+   * `before` (not `sentAt`) — `seq` is unique and monotonic per board, so
+   * paging never repeats or skips even when several sends share a `sentAt`
+   * second. A non-integer `before` is rejected with BAD_USER_INPUT. `limit`
+   * is capped at 100. This is the lasting "what was on the wall" record;
+   * `boardRecentClimbs` is the hot 1 week cache.
    */
   boardHistory: Array<BoardPresenceClimb>;
   /** Get leaderboard for a board. */
@@ -3555,9 +3556,9 @@ export type Query = {
    */
   boardPresenceStats: BoardPresenceStats;
   /**
-   * Backfill the recent "now on the wall" history for a board (last ~50, 24h
-   * window) from the Redis FIFO. Used by late joiners before the live
-   * `boardNowPlaying` subscription takes over.
+   * Backfill the recent "now on the wall" history for a board (last ~50, 1
+   * week window (BOARD_HISTORY_TTL)) from the Redis FIFO. Used by late joiners
+   * before the live `boardNowPlaying` subscription takes over.
    */
   boardRecentClimbs: Array<BoardPresenceClimb>;
   /**

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -405,20 +405,21 @@ export const queriesTypeDefs = /* GraphQL */ `
     newClimbFeed(input: NewClimbFeedInput!): NewClimbFeedResult!
 
     """
-    Backfill the recent "now on the wall" history for a board (last ~50, 24h
-    window) from the Redis FIFO. Used by late joiners before the live
-    \`boardNowPlaying\` subscription takes over.
+    Backfill the recent "now on the wall" history for a board (last ~50, 1
+    week window (BOARD_HISTORY_TTL)) from the Redis FIFO. Used by late joiners
+    before the live \`boardNowPlaying\` subscription takes over.
     """
     boardRecentClimbs(boardId: Int!): [BoardPresenceClimb!]!
 
     """
-    Durable history of what was pushed to a board (survives past the 24h Redis
-    window), newest-first by \`seq\`. For keyset paging pass the \`seq\` of the
-    last item from the previous page as \`before\` (not \`sentAt\`) — \`seq\` is
-    unique and monotonic per board, so paging never repeats or skips even when
-    several sends share a \`sentAt\` second. A non-integer \`before\` is rejected
-    with BAD_USER_INPUT. \`limit\` is capped at 100. This is the lasting "what
-    was on the wall" record; \`boardRecentClimbs\` is the hot 24h cache.
+    Durable history of what was pushed to a board (survives past the 1 week
+    Redis window (BOARD_HISTORY_TTL)), newest-first by \`seq\`. For keyset
+    paging pass the \`seq\` of the last item from the previous page as
+    \`before\` (not \`sentAt\`) — \`seq\` is unique and monotonic per board, so
+    paging never repeats or skips even when several sends share a \`sentAt\`
+    second. A non-integer \`before\` is rejected with BAD_USER_INPUT. \`limit\`
+    is capped at 100. This is the lasting "what was on the wall" record;
+    \`boardRecentClimbs\` is the hot 1 week cache.
     """
     boardHistory(boardId: Int!, limit: Int, before: String): [BoardPresenceClimb!]!
 

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -3535,13 +3535,14 @@ export type Query = {
    */
   boardConnection?: Maybe<BoardConnectionHolder>;
   /**
-   * Durable history of what was pushed to a board (survives past the 24h Redis
-   * window), newest-first by `seq`. For keyset paging pass the `seq` of the
-   * last item from the previous page as `before` (not `sentAt`) — `seq` is
-   * unique and monotonic per board, so paging never repeats or skips even when
-   * several sends share a `sentAt` second. A non-integer `before` is rejected
-   * with BAD_USER_INPUT. `limit` is capped at 100. This is the lasting "what
-   * was on the wall" record; `boardRecentClimbs` is the hot 24h cache.
+   * Durable history of what was pushed to a board (survives past the 1 week
+   * Redis window (BOARD_HISTORY_TTL)), newest-first by `seq`. For keyset
+   * paging pass the `seq` of the last item from the previous page as
+   * `before` (not `sentAt`) — `seq` is unique and monotonic per board, so
+   * paging never repeats or skips even when several sends share a `sentAt`
+   * second. A non-integer `before` is rejected with BAD_USER_INPUT. `limit`
+   * is capped at 100. This is the lasting "what was on the wall" record;
+   * `boardRecentClimbs` is the hot 1 week cache.
    */
   boardHistory: Array<BoardPresenceClimb>;
   /** Get leaderboard for a board. */
@@ -3552,9 +3553,9 @@ export type Query = {
    */
   boardPresenceStats: BoardPresenceStats;
   /**
-   * Backfill the recent "now on the wall" history for a board (last ~50, 24h
-   * window) from the Redis FIFO. Used by late joiners before the live
-   * `boardNowPlaying` subscription takes over.
+   * Backfill the recent "now on the wall" history for a board (last ~50, 1
+   * week window (BOARD_HISTORY_TTL)) from the Redis FIFO. Used by late joiners
+   * before the live `boardNowPlaying` subscription takes over.
    */
   boardRecentClimbs: Array<BoardPresenceClimb>;
   /**

--- a/packages/shared/graphql/src/operations/board-presence.ts
+++ b/packages/shared/graphql/src/operations/board-presence.ts
@@ -235,8 +235,8 @@ export const BOARD_RECENT_CLIMBS = `
 `;
 
 // Query — durable, keyset-paged history of what was lit on a board, from
-// `board_climb_events` (survives past the 24h Redis window that backs
-// BOARD_RECENT_CLIMBS). Newest-first; `before` is an opaque cursor equal to the
+// `board_climb_events` (survives past the 1-week Redis window (BOARD_HISTORY_TTL)
+// that backs BOARD_RECENT_CLIMBS). Newest-first; `before` is an opaque cursor equal to the
 // `seq` of the previous page's last row, and `limit` is server-capped 1–100
 // (default 50). Reuses the same climb fields as the live feed so every wall
 // surface decodes one shape.


### PR DESCRIPTION
## Summary

Backend half of the board-presence ("now on the wall") sync & speed work. Fixes the latency a climber feels on every "light this climb" tap, plus three correctness gaps in the event pipeline.

**Speed:**
- `reportBoardClimb` critical path collapsed from ~8 serial Redis round-trips + 3 sequential Postgres windows to 3 pipelined Redis RTTs with the Postgres work overlapped: new `getBoardReportGate` (membership + dwell + dedup + writer in one pipeline), pipelined `nextBoardSeq`, and `commitBoardClimb` (history FIFO + atomic `SET..GET` writer handoff + dedup marker + session mapping in one pipeline). The atomic handoff SET..GET stays a single command; store-before-publish ordering, rate-limit-first, and the fail-closed dwell gate are all preserved.
- `boardPresenceStats` — the 4-CTE aggregate over every tick on the board — is now cached in Redis (60s TTL, `boardsesh:board-stats:v1:{boardId}`), written inside the already-serialized debounce+nonce publish path and on query miss. Opening a busy board's sheet goes from a full recompute to a Redis GET.
- `deleteTick`/`updateTick` now queue a stats publish like `saveTick` does — fixes pre-existing live-tile staleness on tick edit/delete.

**Correctness:**
- Write-side idempotency: a retried `reportBoardClimb` (same emitter + climb + angle within 10s) no longer allocates a new seq and duplicates the feed/durable row. The short-circuit also requires the emitter to still hold the wall, so the WS-close-backstop + reconnect-retry case re-takes the holder instead of stranding the wall looking free.
- Seq continuity: the Redis seq counter TTLs at 1 week while `board_climb_events` rows are durable; after a dormant week a reset counter silently dropped inserts (`onConflictDoNothing` collisions) and corrupted history ordering. `nextBoardSeq` now reseeds from the durable `MAX(seq)` via an atomic Lua allocator when it detects a low counter (floor lookup injected at bootstrap; pubsub stays DB-free in tests).
- A failing commit pipeline can no longer fabricate a spurious holder-handoff broadcast (`writerSlotOk` gating).
- Subscription backpressure drops (>1000 queued events) are now labelled and throttled in logs instead of silent-ish per-event spam.
- Doc drift fixed: the Redis history window is 1 week (`BOARD_HISTORY_TTL`), not the "24h" several comments claimed; `board_climb_events.session_id` FK hazard documented (room-manager party-session ids are a different id space — intentionally not wired).

Reviewed against the plan's do-not-regress checklist (eager-subscribe iterator, debounce+nonce serialization, dwell gate, atomic handoff, WS-close backstop, rate limits) before push. One accepted test deviation: the idempotency tests assert suppression via the Redis FIFO + durable rows + seq counter rather than a live subscription (a pre-existing `afterAll` in an earlier describe tears down the pubsub subscriber connection for the rest of the file); event suppression is structurally guaranteed since the short-circuit precedes `publishBoardPresenceEvent`.

## Release Notes

- Sending a climb to the wall is snappier, and an accidental double-send no longer shows up twice in board history

## Test plan

- Full backend suite against real postgres+redis: 141/141 files, 1848 passed, 0 failed (stable across repeated runs, with and without Redis)
- New Redis-gated describes appended to `board-presence.test.ts` (71 board-presence tests): pipelined commit key/TTL contract, idempotency window (same/different climb/angle/user, expiry, backstop-clear retry re-takes the writer), seq reseed after counter loss (ordering, fresh board, concurrency, Lua allocator), stats cache (miss/hit/push-coherence/deleteTick refresh/Redis-off)
- New `async-iterators.test.ts` (overflow drop + labelled throttled warn)
- `vp run typecheck:backend`, `vp check`, `vp run codegen` (SDL description changes only) all green
- Test-infra fix folded in: `schema-sql.ts` was missing `DROP TABLE` for `board_climb_events` (+ the `feed_items`/`votes`/`notifications` tables `deleteTick`'s transaction touches) — a pre-existing local-only flake source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPxKbADkgeCZa1uoDQEER
