### PR TITLE
fix(backend): clear session shadow maps in the inactivity sweep

### DIFF
--- a/packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts
+++ b/packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vite-plus/test';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../db/client';
 import { sessions } from '../db/schema';
 import { eq, inArray } from 'drizzle-orm';
 import { endStaleInactiveSessions } from '../services/room-manager/session-discovery';
+import { roomManager } from '../services/room-manager';
+import { pubsub } from '../pubsub/index';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
@@ -151,5 +153,87 @@ describe('endStaleInactiveSessions', () => {
 
     expect(endedIds).toContain(stale);
     expect(endedIds).not.toContain(fresh);
+  });
+});
+
+describe('RoomManager.runInactivitySweep', () => {
+  // `roomManager.reset()` runs in the suite-wide `beforeEach` (setup.ts) and
+  // is never followed by `initialize(redis)` here, so `distributedState`
+  // stays null for every test in this file — i.e. the no-Redis,
+  // single-instance fallback path that owns `localBoardSerialBySession` /
+  // `localRecentClimbsBySession` is exactly what's under test.
+
+  it('drains the local board-serial / recent-climbs shadows for swept sessions and still publishes SessionEnded', async () => {
+    const staleSessionId = uuidv4();
+    const climbUuid = uuidv4();
+    const boardSerial = 'KB-AB12-CD34';
+
+    await db.insert(sessions).values({
+      id: staleSessionId,
+      boardPath: '/kilter/1/2/3/40',
+      status: 'active',
+      isPermanent: false,
+      lastActivity: minutesAgo(90),
+    });
+
+    // Seed the shadow maps via the same public paths the queue-navigation /
+    // wall-confirm mutations use, rather than reaching into RoomManager's
+    // private fields.
+    await roomManager.setSessionBoardSerialAndReturnPrevious(staleSessionId, boardSerial);
+    await roomManager.pushRecentClimb(staleSessionId, climbUuid);
+
+    expect(await roomManager.getSessionBoardSerial(staleSessionId)).toBe(boardSerial);
+    expect(await roomManager.isRecentClimb(staleSessionId, climbUuid)).toBe(true);
+
+    const publishSpy = vi.spyOn(pubsub, 'publishSessionEvent').mockImplementation(() => {});
+
+    await roomManager.runInactivitySweep();
+
+    // Shadows are gone for the swept session.
+    expect(await roomManager.getSessionBoardSerial(staleSessionId)).toBeNull();
+    expect(await roomManager.isRecentClimb(staleSessionId, climbUuid)).toBe(false);
+
+    // The sweep's existing side effect (publishing SessionEnded) still fires.
+    expect(publishSpy).toHaveBeenCalledWith(staleSessionId, {
+      __typename: 'SessionEnded',
+      reason: 'Session ended due to inactivity',
+    });
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, staleSessionId)).limit(1);
+    expect(row?.status).toBe('ended');
+  });
+
+  it('leaves shadows for unrelated, still-active sessions untouched', async () => {
+    const staleSessionId = uuidv4();
+    const activeSessionId = uuidv4();
+    const activeSerial = 'KB-EF56-GH78';
+
+    await db.insert(sessions).values([
+      {
+        id: staleSessionId,
+        boardPath: '/kilter/1/2/3/40',
+        status: 'active',
+        isPermanent: false,
+        lastActivity: minutesAgo(90),
+      },
+      {
+        id: activeSessionId,
+        boardPath: '/kilter/1/2/3/40',
+        status: 'active',
+        isPermanent: false,
+        lastActivity: minutesAgo(5),
+      },
+    ]);
+
+    await roomManager.setSessionBoardSerialAndReturnPrevious(activeSessionId, activeSerial);
+
+    vi.spyOn(pubsub, 'publishSessionEvent').mockImplementation(() => {});
+
+    await roomManager.runInactivitySweep();
+
+    expect(await roomManager.getSessionBoardSerial(activeSessionId)).toBe(activeSerial);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, activeSessionId)).limit(1);
+    expect(row?.status).toBe('active');
   });
 });

--- a/packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts
+++ b/packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vite-plus/test';
+import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../db/client';
 import { sessions } from '../db/schema';
@@ -162,6 +162,12 @@ describe('RoomManager.runInactivitySweep', () => {
   // stays null for every test in this file — i.e. the no-Redis,
   // single-instance fallback path that owns `localBoardSerialBySession` /
   // `localRecentClimbsBySession` is exactly what's under test.
+
+  // The tests below spy on the shared pubsub singleton; restore it so the
+  // no-op mock can't bleed into other suites (no global restoreMocks).
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('drains the local board-serial / recent-climbs shadows for swept sessions and still publishes SessionEnded', async () => {
     const staleSessionId = uuidv4();

--- a/packages/backend/src/graphql/resolvers/sessions/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sessions/queries.ts
@@ -90,8 +90,11 @@ export const sessionQueries = {
    * Returns empty array if user is not authenticated
    */
   mySessions: async (_: unknown, __: unknown, ctx: ConnectionContext): Promise<DiscoverableSession[]> => {
-    // For now, we use userId from context if available
-    // In production, this should use authenticated user ID
+    // ctx.userId is set by the auth middleware (middleware/auth.ts) only
+    // after verifying the caller's JWT — it is never client-supplied.
+    // Unauthenticated requests have no userId, so they get an empty list
+    // rather than an auth error (this query is used for optional
+    // "your sessions" UI, not gated behind a login wall).
     if (!ctx.userId) {
       return [];
     }

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -147,25 +147,22 @@ class RoomManager {
    *
    * Extracted from the `setInterval` callback in `initialize()` so tests can
    * drive a single sweep tick directly instead of waiting on the real
-   * interval. Errors are caught and logged rather than rethrown, matching
-   * the original inline callback's behavior.
+   * interval. Rethrows on failure: the interval callback catches and logs so
+   * a bad tick never kills the timer, while direct callers (tests) see the
+   * error.
    */
   async runInactivitySweep(): Promise<void> {
-    try {
-      const endedIds = await endStaleInactiveSessions(INACTIVITY_THRESHOLD_MS);
-      for (const sessionId of endedIds) {
-        this.clearLocalSessionShadows(sessionId);
-        const event: SessionEvent = {
-          __typename: 'SessionEnded',
-          reason: 'Session ended due to inactivity',
-        };
-        pubsub.publishSessionEvent(sessionId, event);
-        endLiveActivity(sessionId).catch((err) => {
-          logger.error(`[APNs] endLiveActivity failed for auto-ended session ${sessionId}:`, err);
-        });
-      }
-    } catch (err) {
-      logger.error('[RoomManager] Inactivity sweep failed:', err);
+    const endedIds = await endStaleInactiveSessions(INACTIVITY_THRESHOLD_MS);
+    for (const sessionId of endedIds) {
+      this.clearLocalSessionShadows(sessionId);
+      const event: SessionEvent = {
+        __typename: 'SessionEnded',
+        reason: 'Session ended due to inactivity',
+      };
+      pubsub.publishSessionEvent(sessionId, event);
+      endLiveActivity(sessionId).catch((err) => {
+        logger.error(`[APNs] endLiveActivity failed for auto-ended session ${sessionId}:`, err);
+      });
     }
   }
 

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -124,32 +124,48 @@ class RoomManager {
 
     if (!this.inactivitySweepInterval) {
       this.inactivitySweepInterval = setInterval(() => {
-        endStaleInactiveSessions(INACTIVITY_THRESHOLD_MS)
-          .then((endedIds) => {
-            // For every auto-ended session, mirror the side effects of the
-            // explicit endSession mutation: publish SessionEnded so connected
-            // clients tear down, and end the iOS Live Activity so lock-screen
-            // tiles don't linger with stale data until ActivityKit's stale
-            // date elapses.
-            for (const sessionId of endedIds) {
-              const event: SessionEvent = {
-                __typename: 'SessionEnded',
-                reason: 'Session ended due to inactivity',
-              };
-              pubsub.publishSessionEvent(sessionId, event);
-              endLiveActivity(sessionId).catch((err) => {
-                logger.error(`[APNs] endLiveActivity failed for auto-ended session ${sessionId}:`, err);
-              });
-            }
-          })
-          .catch((err) => {
-            logger.error('[RoomManager] Inactivity sweep failed:', err);
-          });
+        this.runInactivitySweep().catch((err) => {
+          logger.error('[RoomManager] Inactivity sweep failed:', err);
+        });
       }, INACTIVITY_SWEEP_INTERVAL_MS);
       this.inactivitySweepInterval.unref();
       logger.info(
         `[RoomManager] Inactivity sweep enabled (threshold ${INACTIVITY_THRESHOLD_MS / 60000}m, interval ${INACTIVITY_SWEEP_INTERVAL_MS / 60000}m)`,
       );
+    }
+  }
+
+  /**
+   * Run one inactivity-sweep tick: end sessions whose `lastActivity` predates
+   * the threshold, then mirror the side effects of the explicit `endSession`
+   * mutation for each swept id — publish `SessionEnded` so connected clients
+   * tear down, end the iOS Live Activity so lock-screen tiles don't linger
+   * with stale data, and drop this instance's local board-serial /
+   * recent-climbs shadows (see `clearLocalSessionShadows`; same single-
+   * instance leak `endSession` guards against, just reached via the
+   * inactivity path instead of an explicit end).
+   *
+   * Extracted from the `setInterval` callback in `initialize()` so tests can
+   * drive a single sweep tick directly instead of waiting on the real
+   * interval. Errors are caught and logged rather than rethrown, matching
+   * the original inline callback's behavior.
+   */
+  async runInactivitySweep(): Promise<void> {
+    try {
+      const endedIds = await endStaleInactiveSessions(INACTIVITY_THRESHOLD_MS);
+      for (const sessionId of endedIds) {
+        this.clearLocalSessionShadows(sessionId);
+        const event: SessionEvent = {
+          __typename: 'SessionEnded',
+          reason: 'Session ended due to inactivity',
+        };
+        pubsub.publishSessionEvent(sessionId, event);
+        endLiveActivity(sessionId).catch((err) => {
+          logger.error(`[APNs] endLiveActivity failed for auto-ended session ${sessionId}:`, err);
+        });
+      }
+    } catch (err) {
+      logger.error('[RoomManager] Inactivity sweep failed:', err);
     }
   }
 
@@ -612,16 +628,25 @@ class RoomManager {
     return getUserSessionsFn(userId);
   }
 
-  async endSession(sessionId: string): Promise<void> {
-    // Drop the in-memory board-serial / recent-climbs shadows for this session
-    // before delegating to the discovery layer. The shadows are local to
-    // this RoomManager instance and were growing unbounded across session
-    // lifecycles — endSession is the only deterministic hook to clear them.
-    // Distributed-state's Redis keys for these are cleaned up by
-    // `cleanupEmptySession` when the session set drains; this is the
-    // single-instance / single-process equivalent.
+  /**
+   * Drop the in-memory board-serial / recent-climbs shadows for this
+   * session. The shadows are local to this RoomManager instance (the
+   * single-instance / no-Redis fallback for `localBoardSerialBySession` and
+   * `localRecentClimbsBySession` — see their field comments) and otherwise
+   * grow unbounded across session lifecycles, since nothing else ever
+   * deletes their entries. Distributed-state's Redis keys for the same data
+   * are cleaned up by `cleanupEmptySession` when the session set drains;
+   * this is the single-instance / single-process equivalent, called from
+   * every path that durably ends a session (explicit `endSession` and the
+   * inactivity sweep).
+   */
+  private clearLocalSessionShadows(sessionId: string): void {
     this.localBoardSerialBySession.delete(sessionId);
     this.localRecentClimbsBySession.delete(sessionId);
+  }
+
+  async endSession(sessionId: string): Promise<void> {
+    this.clearLocalSessionShadows(sessionId);
     return endSessionFn(
       sessionId,
       this.sessions,


### PR DESCRIPTION
## Summary

Fixes a slow, unbounded memory leak in no-Redis (single-instance) backend deployments, and makes the hourly inactivity sweep testable.

- `RoomManager` keeps two in-memory shadow maps for the no-Redis fallback path: `localBoardSerialBySession` and `localRecentClimbsBySession`. Only the explicit `endSession` path cleared them — the inactivity sweep (which auto-ends sessions idle for over an hour) published `SessionEnded` but left both maps' entries behind forever.
- Extracted a private `clearLocalSessionShadows(sessionId)` on `RoomManager` and call it from both `endSession` and the sweep's per-ended-id loop. Deliberately scoped to the two shadow maps: `sessions` / `sessionParticipants` / `sessionGraceTimers` / `pendingJoinPersists` carry live timers and promise chains managed by `client-lifecycle.ts` and `endSessionFn`, so clearing them from the sweep would duplicate lifecycle management the sweep doesn't own.
- Extracted the sweep interval body into `runInactivitySweep()` so tests can drive a single tick directly; the `setInterval` callback now just calls it. Behavior is identical (same events, same Live Activity teardown, errors still caught and logged).
- Rewrote a stale comment on the `mySessions` resolver: it claimed "in production this should use authenticated user ID" when `ctx.userId` already is the auth-middleware-verified JWT subject.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Extended `packages/backend/src/__tests__/end-stale-inactive-sessions.test.ts` with a `RoomManager.runInactivitySweep` suite (no-Redis mode):
  - seeds the shadow maps through the public paths (`setSessionBoardSerialAndReturnPrevious`, `pushRecentClimb`), ages a session past the threshold, runs one sweep tick, and asserts both shadows are drained for the swept id while `SessionEnded` still publishes and the row flips to `ended`;
  - asserts shadows for a still-active session survive the sweep untouched.
- `vp check --fix` — clean (0 errors).
- `vp run typecheck` — clean.
- `vp test run --project backend --reporter=agent` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9eAY2yZDGSqossL5UtUQo
