### PR TITLE
ci: decouple iOS/Android store-metadata jobs so iOS can't block the Play upload

### DIFF
--- a/.github/workflows/mobile-store-metadata.yml
+++ b/.github/workflows/mobile-store-metadata.yml
@@ -16,13 +16,23 @@ name: Mobile Store Metadata
 # live listing stale). iOS deliver still lands text on the editable version
 # without submitting (submit_for_review: false).
 #
+# iOS and Android run as SEPARATE jobs, in parallel. They own independent store
+# listings and share no state, so a failure on one must never block the other.
+# This matters because deliver can only edit the *editable* App Store version:
+# between releases there is often none, and deliver would retry "Cannot find edit
+# app store version" for ~20 minutes before failing. When both stores shared one
+# job, that iOS retry loop ran first and ate the whole time budget, so the Play
+# screenshot upload never ran. Split jobs keep the Android upload independent; the
+# ios metadata lane also skips cleanly when there's no editable version (see the
+# Fastfile), so the iOS job no longer burns the budget either.
+#
 # Runs automatically when the committed listing assets change on main
 # (fastlane/metadata/**, fastlane/Fastfile, or app-stores/google/screenshots/**),
 # pushing to both stores. The Android screenshot set is refreshed by
 # mobile-screenshots-android.yml, which captures fresh shots and commits them
 # back to main — that commit re-triggers this workflow, which uploads them. Also
 # dispatchable by hand to push a single store on demand. A push build always
-# targets `all`; a manual build uses the chosen platform input.
+# targets both stores; a manual build uses the chosen platform input.
 #
 # iOS "What's New" (release_notes.txt) is part of the deliver text and IS pushed
 # here. The Android "What's new", by contrast, is NOT pushed here: it ships with
@@ -53,17 +63,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  metadata:
+  ios:
+    # Push runs (no input) push both stores; a manual run honours the platform input.
+    # (Job-level `if` can't read the `env` context, so gate on the raw inputs here.)
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # A backstop only: the metadata lane skips cleanly when nothing is editable, so
+    # the happy path is a couple of minutes. Kept well under the shared 20 so a
+    # genuine deliver hang fails fast instead of dragging — and it can't touch the
+    # android job regardless, since they're independent.
+    timeout-minutes: 12
     # Scopes the job to the Production GitHub Environment so it can read the
-    # App Store Connect / Google Play credentials (same secrets as the screenshot
-    # upload jobs in mobile-screenshots-ios.yml / mobile-screenshots-android.yml).
+    # App Store Connect credentials (same secrets as the screenshot upload job in
+    # mobile-screenshots-ios.yml).
     environment: Production
-    # Manual runs honour the chosen platform input; automatic push runs have no
-    # input, so default to pushing both stores.
-    env:
-      PLATFORM: ${{ github.event.inputs.platform || 'all' }}
 
     steps:
       - name: Checkout repository
@@ -77,7 +90,6 @@ jobs:
           working-directory: fastlane
 
       - name: Decode App Store Connect API key
-        if: ${{ env.PLATFORM == 'ios' || env.PLATFORM == 'all' }}
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
@@ -92,7 +104,6 @@ jobs:
           echo "ASC_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Upload App Store listing text
-        if: ${{ env.PLATFORM == 'ios' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -108,8 +119,28 @@ jobs:
         if: always()
         run: rm -f "$HOME/.private_keys/AuthKey_"*.p8 2>/dev/null || true
 
+  android:
+    # Push runs (no input) push both stores; a manual run honours the platform input.
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Scopes the job to the Production GitHub Environment so it can read the
+    # Google Play credentials (same secret as the screenshot upload job in
+    # mobile-screenshots-android.yml).
+    environment: Production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby and fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+          working-directory: fastlane
+
       - name: Upload Play Store listing text
-        if: ${{ env.PLATFORM == 'android' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -121,7 +152,6 @@ jobs:
           bundle exec fastlane android metadata
 
       - name: Upload Play Store listing images
-        if: ${{ env.PLATFORM == 'android' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -140,7 +170,6 @@ jobs:
       # if no screenshots are committed yet (the lane requires >= 2), so this
       # never blocks a text/icon push.
       - name: Upload Play Store screenshots
-        if: ${{ env.PLATFORM == 'android' || env.PLATFORM == 'all' }}
         working-directory: fastlane
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,6 +70,28 @@ def asc_api_key
   )
 end
 
+# True when App Store Connect has a version deliver can edit (Prepare for
+# Submission / a rejected state), false when there is none, so the `metadata` lane
+# can skip instead of letting deliver retry "Cannot find edit app store version"
+# for ~20 minutes. Requires the Spaceship token to already be set (asc_api_key sets
+# it by default). On ANY uncertainty — app not found, credentials/API error — it
+# returns true so deliver still runs; this never suppresses a legitimate push, it
+# only avoids the pointless retry loop when we're certain there's nothing to edit.
+# Mirrors deliver's own lookup (App#get_edit_app_store_version, which returns nil
+# when no version is editable).
+def editable_app_store_version_present?
+  require "spaceship"
+  app = Spaceship::ConnectAPI::App.find(APP_IDENTIFIER)
+  if app.nil?
+    UI.important("App #{APP_IDENTIFIER} not found on App Store Connect; letting deliver decide.")
+    return true
+  end
+  !app.get_edit_app_store_version.nil?
+rescue => error
+  UI.important("Could not check for an editable App Store version (#{error.message}); proceeding with deliver.")
+  true
+end
+
 # Hand a resolved number back to the calling GitHub Actions step via the step's
 # output file (consumed as steps.<id>.outputs.value). No-op when run locally.
 def emit_ci_output(value)
@@ -239,8 +261,25 @@ platform :ios do
 
   desc "Upload App Store listing text + What's New to the editable version (no binary, no screenshots, no review)"
   lane :metadata do
+    # asc_api_key also sets Spaceship::ConnectAPI.token (set_spaceship_token
+    # defaults to true), which the editable-version pre-flight below relies on.
+    api_key = asc_api_key
+
+    # deliver (skip_app_version_update: true) can only write listing text onto the
+    # *editable* App Store version — the one in "Prepare for Submission" (or a
+    # rejected state). Between releases there is often nothing editable: the live
+    # version is Ready for Distribution and no new version has been created. In that
+    # state deliver retries "Cannot find edit app store version" through a ~20-minute
+    # backoff ladder and then fails — which used to burn the whole metadata job's
+    # time budget. Skip cleanly when there's nothing to edit; the text lands on the
+    # next run once a version is editable (and it's pushed again at release time).
+    unless editable_app_store_version_present?
+      UI.important("No editable App Store version in 'Prepare for Submission' — nothing for deliver to edit. Skipping the listing-text upload; it will be pushed once a version is editable.")
+      next
+    end
+
     upload_to_app_store(
-      api_key: asc_api_key,
+      api_key: api_key,
       app_identifier: APP_IDENTIFIER,
       metadata_path: APPLE_METADATA_DIR,
       skip_binary_upload: true,


### PR DESCRIPTION
## What & why

The `Mobile Store Metadata` workflow ran the App Store text upload and the Google Play uploads in **one sequential job**. `deliver` can only edit the *editable* App Store version, and between releases there is often none — so it retries `Cannot find edit app store version` through a ~20-minute backoff ladder (20 → 40 → 80 → 160 → 300 → 300 → 300s) and then fails.

Because that iOS step ran **first** in the shared job, it consumed the entire 20-minute `timeout-minutes` budget and the Play steps never executed. Concretely, on 2026-07-01 a fresh Android screenshot commit landed on `main` (`0e4795109`) but its triggered metadata run ([28555245943](https://github.com/boardsesh/boardsesh/actions/runs/28555245943)) timed out on `Upload App Store listing text` and the screenshots never reached Google Play. (I completed that upload out-of-band by dispatching the workflow with `platform=android`.)

## Changes

- **Split the single job into independent `ios` and `android` jobs** that run in parallel. They own separate store listings and share no state, so an iOS failure/hang can never block the Play upload again.
- **Pre-flight the editable-version check in the `ios metadata` lane** — it mirrors deliver's own lookup (`Spaceship::ConnectAPI::App#get_edit_app_store_version`, which returns `nil` when nothing is editable) and skips the upload cleanly when there's nothing to edit, instead of letting deliver burn ~20 minutes of retries. It's defensive: app-not-found or any API error returns `true` so deliver still runs — it never suppresses a legitimate push, it only avoids the pointless retry loop when we're certain there's nothing editable.
- **Cap the iOS job at `timeout-minutes: 12`** as a backstop (Android stays at 20).

The `platform` dispatch input (`all` / `ios` / `android`) and the push trigger behave exactly as before; the job-level `if` gates on the raw inputs because a job `if` can't read the `env` context.

## Validation

- `ruby -c fastlane/Fastfile` → `Syntax OK` (checked in `ruby:3.4-slim`, matching the pinned fastlane 2.236.1 toolchain).
- YAML parses; two jobs (`ios` 12m, `android` 20m), both scoped to the `Production` environment.
- Confirmed the deliver/spaceship API against the `2.236.1` source: `App.find(bundle_id)`, `App#get_edit_app_store_version` (platform defaults to IOS, returns `nil` when none), and `app_store_connect_api_key` sets `Spaceship::ConnectAPI.token` by default.
- No other workflow `needs:` this job and it has no `pull_request` trigger, so splitting the job id breaks no required status checks.

Can't be dry-run pre-merge without publishing to the live stores (the job is gated to the `Production` environment, main-only), so the real exercise is the next metadata push after merge. The no-editable-version path is the common between-releases state, so it'll be exercised immediately.

## Release Notes

none