### PR TITLE
feat(mobile): adopt shared sync gate for queue event ordering and drift detection

### DIFF
--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -724,6 +724,11 @@ export type GetSessionQueueStateQueryResponse = {
     // resolver returns a redacted preview rather than an error. Callers
     // already null-guard this (see resyncQueueFromServer in queue-provider.tsx).
     queueState: {
+      // Selected so the caller can re-baseline the shared sync gate
+      // (createQueueSyncGate) to this snapshot's authoritative sequence/hash
+      // after applying it — see resyncQueueFromServer in queue-provider.tsx.
+      sequence: number;
+      stateHash: string;
       queue: SubscriptionQueueItem[];
       currentClimbQueueItem: SubscriptionQueueItem | null;
     } | null;
@@ -1233,6 +1238,8 @@ export const GET_SESSION_QUEUE_STATE = gql`
   query GetSessionQueueState($sessionId: ID!) {
     session(sessionId: $sessionId) {
       queueState {
+        sequence
+        stateHash
         queue { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
         currentClimbQueueItem { uuid climb { ${SUBSCRIPTION_CLIMB_FIELDS} } }
       }

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -400,7 +400,7 @@ describe('QueueProvider queue sync gate', () => {
     );
   });
 
-  it('resyncs exactly once from a burst of sequence-gap events (single-flight)', async () => {
+  it('coalesces a burst of sequence-gap events into one in-flight fetch plus one trailing rerun', async () => {
     const snapshots: Snapshot[] = [];
     let queueStateCalls = 0;
     const serverItem = makeQueueItem('server-item', 'climb-server');
@@ -421,9 +421,13 @@ describe('QueueProvider queue sync gate', () => {
     });
 
     // Two events land back-to-back, both far ahead of the tracked sequence
-    // (1) — a gap. Firing them in one `act` keeps both calls to
-    // resyncQueueFromServerRef inside the same synchronous tick, so the
-    // single-flight guard (resyncInFlightRef) coalesces them into one fetch.
+    // (1) — a gap. Firing them in one `act` keeps both resync requests in the
+    // same synchronous tick: the first starts the fetch, the second arrives
+    // mid-flight. It must NOT be dropped outright (its mutation may postdate
+    // the in-flight snapshot — e.g. the tail of a clearQueue burst), so the
+    // single-flight guard coalesces it into exactly one trailing rerun after
+    // the first fetch settles: 2 fetches total for the burst, not 1, not one
+    // per event.
     act(() => {
       queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(5, 'hash-5', wireItem('q-gap-1')) } });
       queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(6, 'hash-6', wireItem('q-gap-2')) } });
@@ -435,11 +439,115 @@ describe('QueueProvider queue sync gate', () => {
       // in; only the server's item did.
       expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
     });
-    expect(queueStateCalls).toBe(1);
+    await waitFor(() => {
+      expect(queueStateCalls).toBe(2);
+    });
+    // Settled: the trailing rerun must not chain into a third fetch.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queueStateCalls).toBe(2);
     expect(analytics.track).toHaveBeenCalledWith(
       'Queue Sync Gap Resync',
       expect.objectContaining({ eventType: 'QueueItemAdded' }),
     );
+  });
+
+  it('re-baselines the gate to the snapshot sequence after a gap resync', async () => {
+    const snapshots: Snapshot[] = [];
+    const serverItem = makeQueueItem('server-item', 'climb-server');
+    // The resync snapshot reports sequence 99 — the gate must track it.
+    routeHttpRequest(queueStateResponse([serverItem], null, 99, 'post-resync-hash'));
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    // Single gap event (sequence 5 ≫ 1) → one resync, no coalesced rerun.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(5, 'hash-5', wireItem('q-gap')) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    });
+
+    // A stale delta at (or below) the snapshot's sequence must be dropped —
+    // the re-baseline set lastSequence to 99, not back to null (which would
+    // blindly apply whatever came next).
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(99, 'hash-99', wireItem('q-stale')) } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Queue Sync Stale Event Ignored',
+      expect.objectContaining({ eventType: 'QueueItemAdded', sequence: 99 }),
+    );
+
+    // The next contiguous delta (snapshot.sequence + 1) applies cleanly.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(100, 'hash-100', wireItem('q-next')) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item', 'q-next']);
+    });
+  });
+
+  it('falls back to restarting the WS subscriptions when the resync snapshot is unavailable', async () => {
+    const snapshots: Snapshot[] = [];
+    let queueStateCalls = 0;
+    // The backend returns queueState: null when the HTTP caller fails the
+    // session-membership check — permanently true for anonymous HTTP callers
+    // (membership lives on the WS connection; see PR #3341). The provider
+    // must restart the joined subscriptions instead (their initial FullSync
+    // heals state), and must not loop back into more doomed fetches.
+    http.request.mockImplementation(async (operation: string) => {
+      if (operation.includes('GetSessionQueueState')) {
+        queueStateCalls += 1;
+        return { session: { queueState: null } };
+      }
+      if (operation.includes('SessionStatus')) {
+        return statusResponse();
+      }
+      return { endSession: { sessionId: 'session-1' } };
+    });
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    // Initial mount: queueUpdates + sessionUpdates.
+    expect(ws.client.subscribe).toHaveBeenCalledTimes(2);
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(5, 'hash-5', wireItem('q-gap')) } });
+    });
+
+    // The gap resync fetched once, got no queueState, and restarted the
+    // joined subscriptions — both re-subscribed (2 + 2 = 4).
+    await waitFor(() => {
+      expect(ws.client.subscribe).toHaveBeenCalledTimes(4);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Exactly one fetch: the restart never chains into another HTTP resync.
+    expect(queueStateCalls).toBe(1);
   });
 
   it('lets PlaybackStateChanged bypass the gate and still reach transient listeners', async () => {
@@ -537,6 +645,19 @@ describe('QueueProvider queue sync gate', () => {
         'Queue Sync Hash Drift',
         expect.objectContaining({ verdict: 'backoff', consecutiveResyncs: 4 }),
       );
+
+      // Tick 5 (and beyond): still no resync, and no FURTHER backoff
+      // analytics — a stuck-drift session must report once per streak, not
+      // every 60s forever.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(queueStateCalls).toBe(3);
+      const backoffTrackCalls = analytics.track.mock.calls.filter(
+        ([eventName, properties]) =>
+          eventName === 'Queue Sync Hash Drift' && (properties as { verdict?: string }).verdict === 'backoff',
+      );
+      expect(backoffTrackCalls).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -1,0 +1,544 @@
+// @vitest-environment jsdom
+//
+// Sync-gate wiring for the queueUpdates subscription (W8): sequence-gap
+// detection, stale-event dedup, PlaybackStateChanged bypass, and the 60s
+// hash-drift watchdog. Reuses the WS/HTTP/store mock harness pattern from
+// queue-provider-session-updates.test.tsx, extended to also capture the
+// `queueUpdates` sink (that file only captures `sessionUpdates`).
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { SessionStatus, SessionUser, SubscriptionQueueEvent, UserBoard } from '@boardsesh/shared-schema';
+
+const ws = vi.hoisted(() => {
+  type WsEventName = 'connected' | 'closed';
+  type QueueUpdatesSink = { next: (payload: { data?: { queueUpdates?: unknown } }) => void };
+  type SessionUpdatesSink = { next: (payload: { data?: { sessionUpdates?: unknown } }) => void };
+  let queueUpdatesSink: QueueUpdatesSink | null = null;
+  let sessionUpdatesSink: SessionUpdatesSink | null = null;
+  const listeners: Record<WsEventName, Set<() => void>> = {
+    connected: new Set(),
+    closed: new Set(),
+  };
+  return {
+    getQueueUpdatesSink: () => queueUpdatesSink,
+    getSessionUpdatesSink: () => sessionUpdatesSink,
+    emit: (eventName: WsEventName) => {
+      for (const listener of listeners[eventName]) listener();
+    },
+    client: {
+      on: vi.fn((eventName: WsEventName, listener: () => void) => {
+        listeners[eventName].add(listener);
+        return () => {
+          listeners[eventName].delete(listener);
+        };
+      }),
+      subscribe: vi.fn((request: { query: string }, sink: { next: (payload: unknown) => void }) => {
+        if (request.query.includes('queueUpdates')) {
+          queueUpdatesSink = sink as QueueUpdatesSink;
+        }
+        if (request.query.includes('sessionUpdates')) {
+          sessionUpdatesSink = sink as SessionUpdatesSink;
+        }
+        return vi.fn();
+      }),
+    },
+    reset: () => {
+      queueUpdatesSink = null;
+      sessionUpdatesSink = null;
+      listeners.connected.clear();
+      listeners.closed.clear();
+    },
+  };
+});
+
+const graph = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+const http = vi.hoisted(() => ({
+  request: vi.fn(),
+}));
+
+const analytics = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
+const sessionStore = vi.hoisted(() => ({
+  getStoredSessionId: vi.fn(async () => 'session-1' as string | null),
+  setStoredSessionId: vi.fn(async () => {}),
+  clearStoredSessionId: vi.fn(async () => {}),
+}));
+
+const queueSnapshotStore = vi.hoisted(() => ({
+  getStoredQueueSnapshot: vi.fn(async () => null),
+  setStoredQueueSnapshot: vi.fn(async () => {}),
+  clearStoredQueueSnapshot: vi.fn(async () => {}),
+}));
+
+const activeBoard = vi.hoisted(() => ({
+  stored: {
+    uuid: 'board-1',
+    slug: 'board-1',
+    ownerId: 'owner-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '1,2',
+    name: 'Test board',
+    isPublic: true,
+    isUnlisted: false,
+    hideLocation: false,
+    isOwned: true,
+    angle: 40,
+    isAngleAdjustable: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    totalAscents: 0,
+    uniqueClimbers: 0,
+    followerCount: 0,
+    commentCount: 0,
+    isFollowedByMe: false,
+  } satisfies UserBoard,
+  getStoredActiveBoard: vi.fn(),
+  setActiveBoard: vi.fn(async () => {}),
+}));
+
+const toast = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+
+const queueMutations = vi.hoisted(() => ({
+  addQueueItem: vi.fn(async () => {}),
+  removeQueueItem: vi.fn(async () => {}),
+  reorderQueueItem: vi.fn(async () => {}),
+  setCurrentClimb: vi.fn(async () => {}),
+  mirrorCurrentClimb: vi.fn(async () => {}),
+  publishPlaybackState: vi.fn(async () => {}),
+  setQueue: vi.fn(async () => {}),
+  replaceQueueItem: vi.fn(async () => {}),
+  confirmClimbOnWall: vi.fn(async () => {}),
+  reportWallDisconnect: vi.fn(async () => {}),
+  setSessionBoardSerial: vi.fn(async () => {}),
+  setSessionBoardPath: vi.fn(async () => {}),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+}));
+
+vi.mock('expo-crypto', () => ({
+  randomUUID: () => 'test-correlation-id',
+}));
+
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  execute: graph.execute,
+}));
+
+vi.mock('@boardsesh/queue-react', () => ({
+  useQueueMutations: () => queueMutations,
+}));
+
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/play-view')>()),
+  emitWallConfirm: vi.fn(),
+}));
+
+vi.mock('../../lib/graphql/ws-client', () => ({
+  getWsClient: () => ws.client,
+}));
+
+vi.mock('../../lib/session-store', () => sessionStore);
+
+vi.mock('../../lib/queue-snapshot-store', () => queueSnapshotStore);
+
+vi.mock('../../lib/active-board-store', () => ({
+  getStoredActiveBoard: activeBoard.getStoredActiveBoard,
+}));
+
+vi.mock('../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoard.stored }),
+  useSetActiveBoard: () => activeBoard.setActiveBoard,
+}));
+
+vi.mock('../../lib/graphql/client', () => ({
+  getHttpClient: () => ({ request: http.request }),
+}));
+
+vi.mock('../../lib/analytics', () => analytics);
+
+vi.mock('../toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+
+vi.mock('../queue-snackbar-provider', () => ({
+  useQueueSnackbar: () => ({ showQueueAddedSnackbar: vi.fn() }),
+}));
+
+import { QueueProvider, useQueue } from '../queue-provider';
+
+type Snapshot = {
+  state: ReturnType<typeof useQueue>['state'];
+  sessionId: string | null;
+  subscribeToQueueEvents: ReturnType<typeof useQueue>['subscribeToQueueEvents'];
+};
+
+const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
+  id: 'participant-1',
+  username: 'Alex',
+  isLeader: false,
+  avatarUrl: undefined,
+  userId: 'db-user-1',
+  connectionState: 'CONNECTED',
+  ...overrides,
+});
+
+const statusResponse = (status: SessionStatus | null = 'active') => ({
+  sessionStatus: status,
+});
+
+function createJoinSessionResponse() {
+  return {
+    joinSession: {
+      participantId: 'participant-self',
+      clientId: 'client-self',
+      isLeader: false,
+      lastConnectedBoardSerial: null,
+      boardPath: '/kilter/1/10/1,2/40/list',
+      users: [user({ id: 'participant-self', username: 'Self', userId: 'db-self' })],
+    },
+  };
+}
+
+// Wire-shaped queue item matching SUBSCRIPTION_CLIMB_FIELDS — what a real
+// queueUpdates payload carries per climb (see queue-conversion.ts's
+// SubscriptionQueueItem).
+function wireItem(uuid: string, climbUuid = uuid) {
+  return {
+    uuid,
+    climb: {
+      uuid: climbUuid,
+      name: `Climb ${climbUuid}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+  };
+}
+
+// FullSync's `stateHash` is nested under `state` on the real wire response
+// (QUEUE_UPDATES_SUBSCRIPTION selects `state { sequence stateHash ... }`,
+// no top-level `stateHash` for this variant) — mirror that shape exactly so
+// these tests exercise the same flatten path (`toSyncQueueEvent`) production
+// traffic does.
+function wireFullSync(
+  sequence: number,
+  stateHash: string,
+  queue: ReturnType<typeof wireItem>[] = [],
+  currentClimbQueueItem: ReturnType<typeof wireItem> | null = null,
+) {
+  return {
+    __typename: 'FullSync',
+    sequence,
+    state: { sequence, stateHash, queue, currentClimbQueueItem },
+  };
+}
+
+function wireQueueItemAdded(sequence: number, stateHash: string, item: ReturnType<typeof wireItem>) {
+  return {
+    __typename: 'QueueItemAdded',
+    sequence,
+    stateHash,
+    addedItem: item,
+    position: null,
+  };
+}
+
+function queueStateResponse(
+  items: ClimbQueueItem[],
+  current: ClimbQueueItem | null = null,
+  sequence = 1,
+  stateHash = 'resync-hash',
+) {
+  return {
+    session: {
+      queueState: {
+        sequence,
+        stateHash,
+        queue: items.map((item) => ({ uuid: item.uuid, climb: item.climb })),
+        currentClimbQueueItem: current ? { uuid: current.uuid, climb: current.climb } : null,
+      },
+    },
+  };
+}
+
+function makeQueueItem(uuid: string, climbUuid = uuid): ClimbQueueItem {
+  return {
+    uuid,
+    climb: {
+      uuid: climbUuid,
+      name: `Climb ${climbUuid}`,
+      frames: 'p1r12',
+      setter_username: 'setter',
+      angle: 40,
+      ascensionist_count: 0,
+      difficulty: 'V3',
+      quality_average: '3.0',
+      stars: 3,
+      difficulty_error: '0.3',
+      benchmark_difficulty: null,
+    },
+    suggested: false,
+  };
+}
+
+function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
+  const queue = useQueue();
+  useEffect(() => {
+    onSnapshot({
+      state: queue.state,
+      sessionId: queue.sessionId,
+      subscribeToQueueEvents: queue.subscribeToQueueEvents,
+    });
+  }, [queue.state, queue.sessionId, queue.subscribeToQueueEvents, onSnapshot]);
+  return null;
+}
+
+function renderProvider(onSnapshot: (snapshot: Snapshot) => void) {
+  return render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot })));
+}
+
+function routeHttpRequest(queueStateResponsePayload: unknown, options: { onQueueStateCall?: () => void } = {}) {
+  http.request.mockImplementation(async (operation: string) => {
+    if (operation.includes('GetSessionQueueState')) {
+      options.onQueueStateCall?.();
+      return queueStateResponsePayload;
+    }
+    if (operation.includes('SessionStatus')) {
+      return statusResponse();
+    }
+    return { endSession: { sessionId: 'session-1' } };
+  });
+}
+
+describe('QueueProvider queue sync gate', () => {
+  beforeEach(() => {
+    ws.reset();
+    ws.client.on.mockClear();
+    ws.client.subscribe.mockClear();
+    activeBoard.stored = { ...activeBoard.stored };
+    activeBoard.getStoredActiveBoard.mockReset();
+    activeBoard.getStoredActiveBoard.mockResolvedValue(activeBoard.stored);
+    activeBoard.setActiveBoard.mockClear();
+    toast.showToast.mockClear();
+    analytics.track.mockClear();
+    for (const mutation of Object.values(queueMutations) as Array<ReturnType<typeof vi.fn>>) {
+      mutation.mockReset();
+      mutation.mockResolvedValue(undefined);
+    }
+    sessionStore.getStoredSessionId.mockReset();
+    sessionStore.getStoredSessionId.mockResolvedValue('session-1');
+    sessionStore.setStoredSessionId.mockClear();
+    sessionStore.clearStoredSessionId.mockClear();
+    graph.execute.mockReset();
+    graph.execute.mockResolvedValue(createJoinSessionResponse());
+    http.request.mockReset();
+    routeHttpRequest(queueStateResponse([]));
+  });
+
+  it('ignores an out-of-order stale event (no dispatch, no state change)', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    // Baseline via FullSync (sequence 1), then a genuine delta at sequence 2.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1')) } });
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1']);
+    });
+
+    // A duplicate/older event (same sequence 2 again) must be ignored: the
+    // reducer never sees it, so the queue stays exactly ['q1'].
+    act(() => {
+      queueUpdatesSink.next({
+        data: { queueUpdates: wireQueueItemAdded(2, 'hash-2-stale', wireItem('q-stale', 'c-stale')) },
+      });
+    });
+
+    // Give any (incorrectly scheduled) dispatch a chance to land before asserting.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1']);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Queue Sync Stale Event Ignored',
+      expect.objectContaining({ eventType: 'QueueItemAdded' }),
+    );
+  });
+
+  it('resyncs exactly once from a burst of sequence-gap events (single-flight)', async () => {
+    const snapshots: Snapshot[] = [];
+    let queueStateCalls = 0;
+    const serverItem = makeQueueItem('server-item', 'climb-server');
+    routeHttpRequest(queueStateResponse([serverItem], null, 99, 'post-resync-hash'), {
+      onQueueStateCall: () => (queueStateCalls += 1),
+    });
+
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+
+    // Two events land back-to-back, both far ahead of the tracked sequence
+    // (1) — a gap. Firing them in one `act` keeps both calls to
+    // resyncQueueFromServerRef inside the same synchronous tick, so the
+    // single-flight guard (resyncInFlightRef) coalesces them into one fetch.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(5, 'hash-5', wireItem('q-gap-1')) } });
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(6, 'hash-6', wireItem('q-gap-2')) } });
+    });
+
+    await waitFor(() => {
+      // The resync's INITIAL_QUEUE_DATA replaced local state with the
+      // server's authoritative snapshot — neither gap event's item made it
+      // in; only the server's item did.
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['server-item']);
+    });
+    expect(queueStateCalls).toBe(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Queue Sync Gap Resync',
+      expect.objectContaining({ eventType: 'QueueItemAdded' }),
+    );
+  });
+
+  it('lets PlaybackStateChanged bypass the gate and still reach transient listeners', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => {
+      expect(ws.getQueueUpdatesSink()).not.toBeNull();
+      expect(snapshots.at(-1)?.subscribeToQueueEvents).toBeDefined();
+    });
+    const queueUpdatesSink = ws.getQueueUpdatesSink();
+    if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+    const received: SubscriptionQueueEvent[] = [];
+    const unsubscribe = snapshots.at(-1)?.subscribeToQueueEvents((event) => received.push(event));
+
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'hash-1') } });
+    });
+
+    // The real wire payload for PlaybackStateChanged carries only
+    // `__typename` — QUEUE_UPDATES_SUBSCRIPTION has no `... on
+    // PlaybackStateChanged` fragment, so no sequence/stateHash is selected.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: { __typename: 'PlaybackStateChanged' } } });
+    });
+
+    await waitFor(() => {
+      expect(received.map((event) => event.__typename)).toContain('PlaybackStateChanged');
+    });
+    // It must not have touched the reducer or the gate's tracking: the very
+    // next real delta at sequence 2 (contiguous with the FullSync's 1) still
+    // applies cleanly — proving PlaybackStateChanged never occupied a
+    // sequence slot or otherwise got gated.
+    act(() => {
+      queueUpdatesSink.next({ data: { queueUpdates: wireQueueItemAdded(2, 'hash-2', wireItem('q1', 'c1')) } });
+    });
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.state.queue.map((item) => item.uuid)).toEqual(['q1']);
+    });
+
+    unsubscribe?.();
+  });
+
+  it('resyncs on hash drift and backs off after 3 consecutive strikes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const snapshots: Snapshot[] = [];
+      let queueStateCalls = 0;
+      // The resync snapshot always reports the SAME server hash the local
+      // (empty) queue can never independently reproduce via
+      // computeQueueStateHash — so every watchdog tick keeps disagreeing
+      // with the same tracked server hash, letting the 3-strike counter
+      // accumulate deterministically instead of resolving after one resync.
+      routeHttpRequest(queueStateResponse([], null, 1, 'server-hash-locked'), {
+        onQueueStateCall: () => (queueStateCalls += 1),
+      });
+
+      renderProvider((snapshot) => snapshots.push(snapshot));
+
+      await waitFor(() => {
+        expect(ws.getQueueUpdatesSink()).not.toBeNull();
+      });
+      const queueUpdatesSink = ws.getQueueUpdatesSink();
+      if (!queueUpdatesSink) throw new Error('queue updates sink was not captured');
+
+      act(() => {
+        queueUpdatesSink.next({ data: { queueUpdates: wireFullSync(1, 'server-hash-locked') } });
+      });
+      await waitFor(() => {
+        expect(snapshots.at(-1)?.sessionId).toBe('session-1');
+      });
+
+      // Ticks 1-3: local hash (of an empty queue) never equals
+      // 'server-hash-locked' — each resync-drift verdict triggers exactly
+      // one more resync.
+      for (let strike = 0; strike < 3; strike++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(60_000);
+        });
+      }
+      await waitFor(() => expect(queueStateCalls).toBe(3));
+      expect(analytics.track).toHaveBeenCalledWith(
+        'Queue Sync Hash Drift',
+        expect.objectContaining({ verdict: 'resync-drift' }),
+      );
+
+      // Tick 4: the loop-protection threshold trips — backoff reports but
+      // does NOT fire a 4th resync.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(queueStateCalls).toBe(3);
+      expect(analytics.track).toHaveBeenCalledWith(
+        'Queue Sync Hash Drift',
+        expect.objectContaining({ verdict: 'backoff', consecutiveResyncs: 4 }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -17,6 +17,7 @@ import {
   generateClientId,
   isPlaylistPeekQueueItemUuid,
   playlistSuggestionSourceMatches,
+  computeQueueStateHash,
 } from '@boardsesh/queue';
 import type {
   QueueState,
@@ -30,7 +31,10 @@ import type {
 import {
   applySessionRuntimeEvent,
   createJoinSessionTracker,
+  createQueueSyncGate,
   mapSubscriptionEnvelopeToAction,
+  type QueueSyncGate,
+  type QueueSyncGateEvent,
   type RuntimeSessionState,
   type SubscriptionWireEnvelope,
 } from '@boardsesh/queue-runtime';
@@ -392,6 +396,30 @@ const defaultSearchParams: QueueSearchParams = {};
 type QueueUpdateEvent = SubscriptionWireEnvelope<SubscriptionQueueItem>;
 type MobileSessionRuntimeState = RuntimeSessionState<SessionUser>;
 
+/**
+ * Flatten a raw queueUpdates wire event into the shape createQueueSyncGate's
+ * `evaluateIncoming`/`noteApplied` expect. Every variant except FullSync
+ * already carries a top-level `stateHash` matching
+ * QUEUE_UPDATES_SUBSCRIPTION's selection (`... on QueueItemAdded { sequence
+ * stateHash ... }`, etc.) — FullSync's `stateHash` is nested one level
+ * deeper instead (the subscription selects `state { stateHash ... }`, with
+ * no top-level `stateHash` for that variant), so pull it out here. Mirrors
+ * `sync-gate.ts`'s own doc: "for FullSync, pass `stateHash:
+ * event.state.stateHash` since the real wire event nests it under `state`."
+ * Widening `SubscriptionWireEnvelope`'s FullSync member instead would ripple
+ * into every other consumer of that shared type, so the flatten stays local.
+ */
+function toSyncQueueEvent(event: QueueUpdateEvent): QueueSyncGateEvent {
+  if (event.__typename === 'FullSync') {
+    return {
+      __typename: 'FullSync',
+      sequence: event.sequence,
+      stateHash: (event.state as { stateHash?: string | null }).stateHash ?? null,
+    };
+  }
+  return event;
+}
+
 const createEmptySessionRuntimeState = (): MobileSessionRuntimeState => ({
   users: [],
   isLeader: false,
@@ -432,6 +460,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // burst (e.g. clearQueue removes N items, the WS is down). Coalesce them into
   // one in-flight fetch so we don't hammer the server or thrash the reducer.
   const resyncInFlightRef = useRef(false);
+  // Sequence-gap / stale-event dedup / hash-drift gate for the active session's
+  // queueUpdates stream (createQueueSyncGate from @boardsesh/queue-runtime —
+  // the same decision logic web is being migrated to). One instance per
+  // session: the session effect below creates it, resets it on socket
+  // `closed`, and nulls it out when there's no session. The 60s hash watchdog
+  // effect (declared later, once resyncQueueFromServerRef exists) reads it
+  // through this ref so it always evaluates against the CURRENT session's
+  // gate rather than one captured in a stale closure.
+  const queueSyncGateRef = useRef<QueueSyncGate | null>(null);
 
   // The active board is the angle source of truth. Read it here so the
   // self-healing re-grade effect can compare each queued climb's display angle
@@ -583,10 +620,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setSessionRuntimeState(createEmptySessionRuntimeState());
       setIsSessionWallLit(false);
       joinTracker.reset();
+      queueSyncGateRef.current = null;
       return;
     }
 
     const wsClient = getWsClient();
+    // One sync gate per session — this effect re-runs (and creates a fresh
+    // gate) on every session change; `unsubClosed` below calls `gate.reset()`
+    // mid-session on a socket drop (same session, but the connection's
+    // ConnectionContext and in-flight sequence tracking are no longer valid).
+    const gate = createQueueSyncGate();
+    queueSyncGateRef.current = gate;
     let disposed = false;
     let subscriptionStartToken = 0;
     let queueUpdatesCleanup: (() => void) | null = null;
@@ -671,12 +715,54 @@ export function QueueProvider({ children }: { children: ReactNode }) {
               }
             }
             // PlaybackStateChanged is transient — it carries no queue state and
-            // reuses the room's current sequence, so it bypasses the reducer.
+            // reuses the room's current sequence, so it bypasses the reducer AND
+            // the sync gate below (the gate special-cases this typename too, but
+            // returning here keeps this path a true no-op, matching pre-gate
+            // behaviour exactly).
             if (queueEvent.__typename === 'PlaybackStateChanged') return;
+
+            // Sequence-gate every other event before touching the reducer. A
+            // stale duplicate (already-applied or older sequence — e.g. a
+            // redelivered frame after a brief reconnect) is dropped; a
+            // sequence gap (missed events) triggers the existing single-flight
+            // HTTP resync instead of applying a delta on top of state we know
+            // is incomplete.
+            const gateEvent = toSyncQueueEvent(event);
+            const decision = gate.evaluateIncoming(gateEvent);
+            if (decision === 'ignore-stale') {
+              if (__DEV__) console.info('[queue] ignoring stale queue event', event.__typename, gateEvent.sequence);
+              track(SHARED_EVENTS.QueueSyncStaleEventIgnored, {
+                eventType: event.__typename,
+                sequence: gateEvent.sequence ?? null,
+                boardName: activeBoardRef.current?.boardType,
+                layoutId: activeBoardRef.current?.layoutId,
+              });
+              return;
+            }
+            if (decision === 'resync-gap') {
+              if (__DEV__)
+                console.warn('[queue] sequence gap on queue event; resyncing', event.__typename, gateEvent.sequence);
+              track(SHARED_EVENTS.QueueSyncGapResync, {
+                eventType: event.__typename,
+                sequence: gateEvent.sequence ?? null,
+                boardName: activeBoardRef.current?.boardType,
+                layoutId: activeBoardRef.current?.layoutId,
+              });
+              void resyncQueueFromServerRef.current();
+              return;
+            }
+
             const result = mapSubscriptionEnvelopeToAction(event, {
               mapItem: toClimbQueueItem,
               context: { myClientId: coordinator.clientId },
             });
+            // Advance the gate's sequence/hash tracking for every applied
+            // event, whether or not it produced a dispatchable action — mirrors
+            // web's use-event-processor.ts, which updates tracking
+            // unconditionally after the switch that processes the delta (e.g.
+            // a QueueItemAdded with a null item payload still consumes its
+            // sequence slot).
+            gate.noteApplied(gateEvent);
             if (result.kind !== 'dispatch') return;
             dispatch(result.action);
             switch (result.eventType) {
@@ -857,6 +943,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       subscriptionStartToken++;
       joinRetryCount = 0;
       cleanupSubscriptions();
+      // The reconnect's FullSync re-baselines tracking on its own
+      // (evaluateIncoming always applies + resets a FullSync), but reset here
+      // too so a stray in-flight event from the dead connection can't be
+      // sequence-checked against the old connection's tracking in the gap
+      // before that FullSync arrives.
+      gate.reset();
     });
     const unsubConnected = wsClient.on('connected', () => {
       void startJoinedSubscriptions();
@@ -1166,6 +1258,21 @@ export function QueueProvider({ children }: { children: ReactNode }) {
             : null,
         },
       });
+      // Re-baseline the sync gate to this snapshot's authoritative
+      // sequence/hash — an HTTP resync applies state exactly like a
+      // reconnect FullSync (it replaces state with the server's current
+      // snapshot), so feed the gate a synthetic FullSync rather than
+      // `gate.reset()`. reset() would zero `lastSequence` back to null, and
+      // per evaluateIncoming a null lastSequence unconditionally applies the
+      // NEXT delta regardless of its sequence — so a stale/superseded event
+      // still in flight from before this resync could slip past the
+      // dedup/gap check and corrupt the just-fetched state. Feeding the real
+      // sequence/hash keeps that protection intact immediately.
+      queueSyncGateRef.current?.evaluateIncoming({
+        __typename: 'FullSync',
+        sequence: queueState.sequence,
+        stateHash: queueState.stateHash,
+      });
       return true;
     } catch (error) {
       if (__DEV__) console.warn('[queue] resyncQueueFromServer failed', error);
@@ -1177,6 +1284,61 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   }, []);
   const resyncQueueFromServerRef = useRef(resyncQueueFromServer);
   resyncQueueFromServerRef.current = resyncQueueFromServer;
+
+  // Periodic local-vs-server hash watchdog (mirrors web's 60s interval in
+  // use-session-subscriptions.ts, ported into the shared gate's
+  // verifyLocalHash). Active only while a session is live; reads current
+  // state through refs (stateRef, queueSyncGateRef, resyncQueueFromServerRef)
+  // so the closure never goes stale between renders — `sessionId` is the only
+  // dependency, matching this file's existing ref-driven interval pattern.
+  useEffect(() => {
+    if (!sessionId) return undefined;
+    const verifyIntervalId = setInterval(() => {
+      const gate = queueSyncGateRef.current;
+      if (!gate) return;
+      const { queue, currentClimbQueueItem } = stateRef.current;
+      const localHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid ?? null);
+      const result = gate.verifyLocalHash(localHash);
+      if (result.verdict === 'ok') return;
+
+      if (result.verdict === 'resync-drift') {
+        if (__DEV__) {
+          console.warn(
+            '[queue] hash drift detected; resyncing',
+            `local=${localHash} server=${result.serverHash} strikes=${result.consecutiveResyncs}`,
+          );
+        }
+        track(SHARED_EVENTS.QueueSyncHashDrift, {
+          verdict: result.verdict,
+          consecutiveResyncs: result.consecutiveResyncs,
+          boardName: activeBoardRef.current?.boardType,
+          layoutId: activeBoardRef.current?.layoutId,
+        });
+        void resyncQueueFromServerRef.current();
+        return;
+      }
+
+      // 'backoff' — the same server hash has triggered RESYNC_LOOP_THRESHOLD
+      // consecutive resyncs without the drift resolving. Report it so we can
+      // investigate, but STOP resyncing: once this happens the resync is a
+      // server-side no-op (the client and server already agree — the local
+      // computation keeps disagreeing with itself), so retrying every minute
+      // is just noise.
+      if (__DEV__) {
+        console.warn(
+          '[queue] hash drift backoff — resync loop threshold hit',
+          `local=${localHash} server=${result.serverHash} strikes=${result.consecutiveResyncs}`,
+        );
+      }
+      track(SHARED_EVENTS.QueueSyncHashDrift, {
+        verdict: result.verdict,
+        consecutiveResyncs: result.consecutiveResyncs,
+        boardName: activeBoardRef.current?.boardType,
+        layoutId: activeBoardRef.current?.layoutId,
+      });
+    }, 60_000);
+    return () => clearInterval(verifyIntervalId);
+  }, [sessionId]);
 
   // After a queue mutation fails in a party session, reconcile against the
   // server and tell the user their queue was refreshed. In solo (no session)

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -33,6 +33,7 @@ import {
   createJoinSessionTracker,
   createQueueSyncGate,
   mapSubscriptionEnvelopeToAction,
+  RESYNC_LOOP_THRESHOLD,
   type QueueSyncGate,
   type QueueSyncGateEvent,
   type RuntimeSessionState,
@@ -460,6 +461,20 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // burst (e.g. clearQueue removes N items, the WS is down). Coalesce them into
   // one in-flight fetch so we don't hammer the server or thrash the reducer.
   const resyncInFlightRef = useRef(false);
+  // Coalesce-then-rerun-once companion to the single-flight guard above: a
+  // resync requested while a fetch is already in flight may reflect a
+  // mutation the in-flight snapshot predates (e.g. the trailing removals of a
+  // clearQueue burst). Dropping it outright would apply the older snapshot,
+  // re-baseline the gate to it, and leave the watchdog blind (local hash ==
+  // tracked snapshot hash) — so remember the request and run exactly one more
+  // fetch after the current one settles.
+  const resyncPendingRef = useRef(false);
+  // Set by the session effect to a hook that tears down + restarts the joined
+  // WS subscriptions (its startJoinedSubscriptions closure). Used by
+  // resyncQueueFromServer as the fallback when the HTTP snapshot is
+  // unavailable — see the membership note there. Null when no session effect
+  // is live.
+  const restartJoinedSubscriptionsRef = useRef<(() => void) | null>(null);
   // Sequence-gap / stale-event dedup / hash-drift gate for the active session's
   // queueUpdates stream (createQueueSyncGate from @boardsesh/queue-runtime —
   // the same decision logic web is being migrated to). One instance per
@@ -621,6 +636,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setIsSessionWallLit(false);
       joinTracker.reset();
       queueSyncGateRef.current = null;
+      restartJoinedSubscriptionsRef.current = null;
       return;
     }
 
@@ -954,11 +970,21 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       void startJoinedSubscriptions();
     });
 
+    // Expose the restart path for resyncQueueFromServer's membership
+    // fallback (see there): startJoinedSubscriptions bumps the start token
+    // and tears down first, so an external call is exactly as safe as the
+    // reconnect path calling it. Nulled on teardown so a stale closure from
+    // a previous session can never be invoked.
+    restartJoinedSubscriptionsRef.current = () => {
+      void startJoinedSubscriptions();
+    };
+
     void startJoinedSubscriptions();
 
     return () => {
       disposed = true;
       subscriptionStartToken++;
+      restartJoinedSubscriptionsRef.current = null;
       cleanupSubscriptions();
       unsubConnected();
       unsubClosed();
@@ -1238,8 +1264,33 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const resyncQueueFromServer = useCallback(async (): Promise<boolean> => {
     const activeSessionId = sessionIdRef.current;
     if (!activeSessionId) return false;
-    if (resyncInFlightRef.current) return false;
+    if (resyncInFlightRef.current) {
+      // Coalesce-then-rerun-once: this request may reflect a mutation the
+      // in-flight fetch's snapshot predates (see resyncPendingRef). The
+      // `finally` below runs exactly one trailing fetch for the whole burst.
+      resyncPendingRef.current = true;
+      return false;
+    }
     resyncInFlightRef.current = true;
+
+    // Fallback when the HTTP snapshot is unavailable: restart the joined WS
+    // subscriptions instead. The HTTP `session` query returns
+    // `queueState: null` for callers that fail the session-membership check,
+    // and anonymous HTTP callers ALWAYS fail it (membership lives on the WS
+    // connection, which HTTP requests don't carry) — so for anonymous
+    // participants this fetch can never succeed and gap/drift recovery would
+    // silently stop converging. The WS connection IS a member, and a
+    // resubscribe's guaranteed initial FullSync heals state and re-baselines
+    // the gate through the normal subscription path. At most one restart per
+    // resync request, and it can't loop: the restart itself never requests a
+    // resync, and clearing the pending flag stops the trailing rerun from
+    // chaining into another doomed fetch (the FullSync supersedes whatever
+    // that rerun could return anyway).
+    const fallbackToSubscriptionRestart = () => {
+      resyncPendingRef.current = false;
+      restartJoinedSubscriptionsRef.current?.();
+    };
+
     try {
       const response = await getHttpClient().request<GetSessionQueueStateQueryResponse>(GET_SESSION_QUEUE_STATE, {
         sessionId: activeSessionId,
@@ -1248,7 +1299,27 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       // in flight — only apply when it's still the active one.
       if (sessionIdRef.current !== activeSessionId) return false;
       const queueState = response.session?.queueState;
-      if (!queueState) return false;
+      if (!queueState) {
+        fallbackToSubscriptionRestart();
+        return false;
+      }
+      // A slow snapshot can resolve AFTER a rejoin FullSync already
+      // re-baselined the gate to newer state — applying it would regress
+      // both the queue and the gate baseline backwards. Same server, so a
+      // higher sequence is strictly fresher: skip the apply/re-baseline and
+      // report success (the newer FullSync already did the refreshing). A
+      // pending trailing rerun still runs — it fetches a fresh snapshot that
+      // passes this guard, covering a resync requested after that FullSync.
+      const lastTrackedSequence = queueSyncGateRef.current?.getLastSequence() ?? -1;
+      if (queueState.sequence < lastTrackedSequence) {
+        if (__DEV__) {
+          console.info(
+            '[queue] skipping stale resync snapshot',
+            `snapshot=${queueState.sequence} tracked=${lastTrackedSequence}`,
+          );
+        }
+        return true;
+      }
       dispatch({
         type: 'INITIAL_QUEUE_DATA',
         payload: {
@@ -1277,9 +1348,23 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     } catch (error) {
       if (__DEV__) console.warn('[queue] resyncQueueFromServer failed', error);
       reportHandledError(error, { tags: { source: 'queue-sync', op: 'resync' } });
+      // Same membership rationale as the null-queueState branch — an errored
+      // query can't reconcile anything, but a resubscribe's FullSync can.
+      // Skip when the session changed mid-flight (the new session effect owns
+      // its own subscriptions).
+      if (sessionIdRef.current === activeSessionId) {
+        fallbackToSubscriptionRestart();
+      }
       return false;
     } finally {
       resyncInFlightRef.current = false;
+      // Trailing rerun for requests coalesced during this fetch (exactly one
+      // — the rerun clears the flag before fetching, and anything that lands
+      // during the rerun re-queues behind it the same way).
+      if (resyncPendingRef.current) {
+        resyncPendingRef.current = false;
+        void resyncQueueFromServerRef.current();
+      }
     }
   }, []);
   const resyncQueueFromServerRef = useRef(resyncQueueFromServer);
@@ -1330,12 +1415,20 @@ export function QueueProvider({ children }: { children: ReactNode }) {
           `local=${localHash} server=${result.serverHash} strikes=${result.consecutiveResyncs}`,
         );
       }
-      track(SHARED_EVENTS.QueueSyncHashDrift, {
-        verdict: result.verdict,
-        consecutiveResyncs: result.consecutiveResyncs,
-        boardName: activeBoardRef.current?.boardType,
-        layoutId: activeBoardRef.current?.layoutId,
-      });
+      // Report to analytics ONCE per drift streak — the first backoff tick
+      // (strike THRESHOLD+1). A session stuck in drift would otherwise emit
+      // an event every 60s for hours. The gate resets the counter when the
+      // hashes agree or the server hash changes, so a genuinely new streak
+      // reports again. Web one-shots its Sentry report at the same point
+      // (use-session-subscriptions.ts's sentryReportedHashRef).
+      if (result.consecutiveResyncs === RESYNC_LOOP_THRESHOLD + 1) {
+        track(SHARED_EVENTS.QueueSyncHashDrift, {
+          verdict: result.verdict,
+          consecutiveResyncs: result.consecutiveResyncs,
+          boardName: activeBoardRef.current?.boardType,
+          layoutId: activeBoardRef.current?.layoutId,
+        });
+      }
     }, 60_000);
     return () => clearInterval(verifyIntervalId);
   }, [sessionId]);
@@ -1730,6 +1823,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     // session switch and would block every future resync. Reset at the teardown
     // boundary so the next session always starts clean.
     resyncInFlightRef.current = false;
+    // Same for the coalesced-rerun flag: a pending rerun belongs to the old
+    // session and must not fire a fetch into the next one.
+    resyncPendingRef.current = false;
     sessionIdRef.current = null;
     setSessionId(null);
     dispatch({

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -29,6 +29,15 @@ export const SHARED_EVENTS = {
   SessionStarted: 'Session Started',
   SessionEnded: 'Session Ended',
   AngleChanged: 'Angle Changed',
+  // Queue sync-gate telemetry (createQueueSyncGate in @boardsesh/queue-runtime)
+  // — observability for the sequence-gap / stale-event / hash-drift guards so
+  // a resync loop or a dropped duplicate shows up in the field instead of only
+  // in dev logs. Mirrors the signal web's Sentry-based watchdog captures
+  // today (use-session-subscriptions.ts); mobile fires these via track()
+  // since it has no equivalent Sentry breadcrumb for this path yet.
+  QueueSyncStaleEventIgnored: 'Queue Sync Stale Event Ignored',
+  QueueSyncGapResync: 'Queue Sync Gap Resync',
+  QueueSyncHashDrift: 'Queue Sync Hash Drift',
   // Climb actions
   FavoriteToggle: 'Favorite Toggle',
   MirrorClimb: 'Mirror Climb',


### PR DESCRIPTION
## Summary

Stacked on #3339 (`feat/sessions-w2-sync-gate`), which adds `createQueueSyncGate` to `@boardsesh/queue-runtime`. This PR wires that gate into mobile's queue provider — the last consumer without any of the three guards web already has.

Mobile's `queueUpdates` subscription handler (`packages/mobile/src/providers/queue-provider.tsx`) previously applied every incoming event unconditionally: no sequence-gap detection, no stale/duplicate dedup, no local-vs-server hash verification. It leaned entirely on FullSync-on-reconnect and `resyncQueueFromServer` after a failed mutation.

- One `createQueueSyncGate()` instance per active session, created in the session effect and reset on socket `closed` (matches the gate's documented lifecycle contract: "session change or socket close").
- Before mapping/dispatching a queue event, `gate.evaluateIncoming(...)` decides `apply` / `ignore-stale` / `resync-gap`. Stale duplicates are dropped (with a `track()` breadcrumb); a sequence gap triggers the existing single-flight `resyncQueueFromServer()` — no new resync path invented.
- `PlaybackStateChanged` keeps bypassing the gate exactly as before (route-playback party-sync must never be sequence-gated).
- A successful HTTP resync re-baselines the gate to the snapshot's real `sequence`/`stateHash` via a synthetic `FullSync` fed through `evaluateIncoming` — **not** `gate.reset()`. `reset()` would zero `lastSequence` back to `null`, and a null `lastSequence` unconditionally applies the *next* delta regardless of its sequence, reopening the exact race the resync just closed (a stale event still in flight could slip past the dedup/gap check right after the fetch). `GET_SESSION_QUEUE_STATE` now selects `sequence`/`stateHash` too — the backend resolver (`buildSessionPayload`) already always computes them for `Session.queueState`, so this is a query-selection-only change, no backend work.
- New 60s watchdog (only while a session is live) computes `computeQueueStateHash(queue, currentClimbQueueItem?.uuid)` and calls `gate.verifyLocalHash(...)`: `resync-drift` triggers the same single-flight resync; `backoff` (3 consecutive strikes against the same server hash) only dev-logs, plus a single analytics event on the first backoff tick per drift streak — mirrors web's loop-protection (and its one-shot Sentry report) so a stuck disagreement doesn't hammer the server or PostHog every minute forever.
- Resync hardening (from review): a resync requested while a fetch is already in flight is no longer dropped — it coalesces into exactly one trailing rerun after the current fetch settles (otherwise the tail of a clearQueue burst could be lost, with the gate re-baselined to the older snapshot and the watchdog blinded). And a slow snapshot that resolves after a rejoin FullSync already re-baselined the gate to newer state is skipped instead of regressing state/baseline backwards (`snapshot.sequence < gate.getLastSequence()`).
- One subtlety worth flagging: `FullSync`'s `stateHash` is nested under `state.stateHash` on the wire (no top-level `stateHash` selected for that variant), unlike every other event type. Added a small `toSyncQueueEvent` flatten helper — the codebase's own forward-reference comment in `operations.ts` ("`toSyncQueueEvent` in queue-provider reads these aliased fields") named it for me.

## Interplay with #3341 (B3 membership check)

#3341 makes the HTTP `session` query return `queueState: null` for callers that fail the session-membership check — and anonymous HTTP callers **always** fail it (membership lives on the WS connection, which HTTP requests don't carry). A plain HTTP gap/drift resync would therefore permanently return nothing for anonymous session participants and queues would stop converging. This PR handles that: when `resyncQueueFromServer` gets a null/absent `queueState` (or the query errors), it falls back to restarting the joined WS subscriptions via the existing teardown + `startJoinedSubscriptions` path — the WS connection *is* a member, and the resubscribe's guaranteed initial FullSync heals state and re-baselines the gate through the normal subscription path. The fallback is single-flight-safe and can't loop: at most one restart per resync request, the restart itself never requests a resync, and it clears the coalesced-rerun flag so a doomed fetch can't chain.

**Merge-conflict note:** `GetSessionQueueStateQueryResponse` in `packages/mobile/src/lib/graphql/operations.ts` will conflict textually with #3341. Whoever rebases second must keep BOTH changes: #3341's nullable `queueState` AND this PR's `sequence`/`stateHash` selections.

## Test plan

- [x] `vp check --fix` — 0 errors (181 pre-existing warnings, unrelated files)
- [x] `vp run typecheck:mobile` — clean
- [x] `vp run test:mobile` — 389 files / 2987 tests pass, including 6 tests in `queue-provider-sync-gate.test.tsx` (stale-event ignored; gap-burst coalesces to one in-flight fetch + one trailing rerun; gate re-baselines to the snapshot sequence after a gap resync — stale delta at snapshot.sequence dropped, snapshot.sequence+1 applies; WS-restart fallback on null queueState without looping; PlaybackStateChanged bypasses the gate + still reaches transient listeners; hash-drift resyncs then backs off after 3 strikes with a single analytics event per streak) and the pre-existing 28 in `queue-provider-session-updates.test.tsx`
- [x] `vp run check:mobile-bundle` — iOS 12.7 MB / Android 12.8 MB, both OK
- [ ] `mobile-bundle` / `ci-status` CI checks are known-red on every mobile-touching PR right now (pre-existing Expo pin drift on `main`, tracked separately) — all other checks green on the first run

Related: filed #3358 for the pre-existing (out-of-scope) finding that mobile's inbound peer playback sync is dead on the wire — `QUEUE_UPDATES_SUBSCRIPTION` selects no `PlaybackStateChanged` fields, so `use-mobile-playback.ts` reads only `undefined`s.

## Release Notes

Party queues on your phone stay in step with the crew even on flaky gym wifi — dropped or out-of-order updates get caught and quietly resynced instead of drifting silently.