### PR TITLE
feat(shared): load older board history in the board sheet

### DIFF
--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -25,6 +25,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import {
+  useBoardHistoryPagination,
   useBoardPresenceActions,
   useBoardPresenceCurrent,
   useBoardPresenceFeed,
@@ -595,6 +596,26 @@ function BoardSheetContent({
     [currentClimb, history],
   );
 
+  // "Load older" — pages further back through the durable history log, past
+  // the live feed's in-memory HISTORY_CAP window. `olderHistory` is already
+  // deduped against the live window (and every prior page) by the hook, so it
+  // appends onto `visibleHistory` with no overlap.
+  const handleHistoryPageLoaded = useCallback(
+    (info: { pageSize: number; returnedCount: number }) => {
+      track(SHARED_EVENTS.BoardHistoryPageLoaded, {
+        boardId: boardPresenceBoardId ?? undefined,
+        pageSize: info.pageSize,
+        returnedCount: info.returnedCount,
+      });
+    },
+    [boardPresenceBoardId],
+  );
+  const { olderHistory, isLoadingOlder, hasMore, loadOlder } = useBoardHistoryPagination(
+    undefined,
+    handleHistoryPageLoaded,
+  );
+  const combinedHistory = useMemo(() => [...visibleHistory, ...olderHistory], [visibleHistory, olderHistory]);
+
   // Fires once per presentation, when history is FIRST non-empty — not only at
   // mount, because presenting before the initial backfill resolves would find
   // an empty list and never fire for that presentation. This component mounts
@@ -801,13 +822,29 @@ function BoardSheetContent({
     [currentClimb, systemColors, t],
   );
 
+  const listFooter = useMemo(
+    () =>
+      isLoadingOlder ? (
+        <View style={styles.historyFooter}>
+          <ActivityIndicator size="small" accessibilityLabel={t('mobile.boardPresence.loadingMore')} />
+        </View>
+      ) : null,
+    [isLoadingOlder, t],
+  );
+
   return (
     <BottomSheetFlatList
-      data={visibleHistory}
+      data={combinedHistory}
       keyExtractor={boardPresenceHistoryKeyExtractor}
       renderItem={renderHistoryItem}
       ListHeaderComponent={listHeader}
       ListEmptyComponent={listEmpty}
+      ListFooterComponent={listFooter}
+      // `loadOlder` already no-ops once `hasMore` is false, but skipping the
+      // prop entirely once there's nothing left avoids FlatList re-evaluating
+      // the end-reached threshold on every scroll frame for no reason.
+      onEndReached={hasMore ? loadOlder : undefined}
+      onEndReachedThreshold={0.6}
       contentContainerStyle={{ paddingBottom: spacing[4] }}
       refreshControl={
         <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />
@@ -1461,6 +1498,10 @@ const styles = StyleSheet.create({
   },
   emptyBody: {
     textAlign: 'center',
+  },
+  historyFooter: {
+    paddingVertical: spacing[5],
+    alignItems: 'center',
   },
   footer: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -25,6 +25,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import {
+  boardHistoryEntryKey,
   useBoardHistoryPagination,
   useBoardPresenceActions,
   useBoardPresenceCurrent,
@@ -52,9 +53,6 @@ import { withAlpha } from '../../theme/colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 const ACTION_CLIMB_CACHE_LIMIT = 50;
-function boardPresenceHistoryKeyExtractor(item: BoardPresenceClimb): string {
-  return `${item.climbUuid}-${item.seq}`;
-}
 
 type BoardSheetRowBoard = {
   boardName: BoardName;
@@ -620,8 +618,8 @@ function BoardSheetContent({
   // must still suppress a durable copy of it leaking in from a page.
   const combinedHistory = useMemo(() => {
     if (olderHistory.length === 0) return visibleHistory;
-    const liveKeys = new Set(history.map(boardPresenceHistoryKeyExtractor));
-    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(boardPresenceHistoryKeyExtractor(climb)));
+    const liveKeys = new Set(history.map(boardHistoryEntryKey));
+    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(boardHistoryEntryKey(climb)));
     return dedupedOlder.length === 0 ? visibleHistory : [...visibleHistory, ...dedupedOlder];
   }, [visibleHistory, history, olderHistory]);
 
@@ -831,19 +829,40 @@ function BoardSheetContent({
   );
 
   const listEmpty = useMemo(
-    () =>
-      currentClimb ? null : (
-        <View style={styles.empty}>
-          <Icon name="lightbulb" size={36} color={systemColors.tertiaryLabel} />
-          <Text variant="headline" color={systemColors.label} style={styles.emptyTitle}>
-            {t('mobile.boardPresence.emptyTitle')}
-          </Text>
-          <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
-            {t('mobile.boardPresence.emptyBody')}
-          </Text>
-        </View>
-      ),
-    [currentClimb, systemColors, t],
+    () => (
+      <View>
+        {currentClimb ? null : (
+          <View style={styles.empty}>
+            <Icon name="lightbulb" size={36} color={systemColors.tertiaryLabel} />
+            <Text variant="headline" color={systemColors.label} style={styles.emptyTitle}>
+              {t('mobile.boardPresence.emptyTitle')}
+            </Text>
+            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
+              {t('mobile.boardPresence.emptyBody')}
+            </Text>
+          </View>
+        )}
+        {/* A wall that's been quiet longer than the Redis window's TTL has an
+            EMPTY live window but durable boardHistory rows. An empty list
+            can't scroll, so the scroll-gated onEndReached above can never
+            fire — this button is then the only path into the durable log
+            (the hook supports a cursor-less first page). */}
+        {hasMore ? (
+          <Pressable
+            onPress={loadOlder}
+            disabled={isLoadingOlder}
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.boardPresence.loadMore')}
+            style={styles.emptyLoadMore}
+          >
+            <Text variant="subheadline" color={brandColors.primary}>
+              {isLoadingOlder ? t('mobile.boardPresence.loadingMore') : t('mobile.boardPresence.loadMore')}
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    ),
+    [currentClimb, systemColors, t, hasMore, isLoadingOlder, loadOlder, brandColors.primary],
   );
 
   const listFooter = useMemo(
@@ -859,7 +878,7 @@ function BoardSheetContent({
   return (
     <BottomSheetFlatList
       data={combinedHistory}
-      keyExtractor={boardPresenceHistoryKeyExtractor}
+      keyExtractor={boardHistoryEntryKey}
       renderItem={renderHistoryItem}
       ListHeaderComponent={listHeader}
       ListEmptyComponent={listEmpty}
@@ -1529,6 +1548,10 @@ const styles = StyleSheet.create({
   historyFooter: {
     paddingVertical: spacing[5],
     alignItems: 'center',
+  },
+  emptyLoadMore: {
+    alignItems: 'center',
+    paddingVertical: spacing[3],
   },
   footer: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/board-presence/BoardSheet.tsx
+++ b/packages/mobile/src/components/board-presence/BoardSheet.tsx
@@ -597,9 +597,7 @@ function BoardSheetContent({
   );
 
   // "Load older" — pages further back through the durable history log, past
-  // the live feed's in-memory HISTORY_CAP window. `olderHistory` is already
-  // deduped against the live window (and every prior page) by the hook, so it
-  // appends onto `visibleHistory` with no overlap.
+  // the live feed's in-memory HISTORY_CAP window.
   const handleHistoryPageLoaded = useCallback(
     (info: { pageSize: number; returnedCount: number }) => {
       track(SHARED_EVENTS.BoardHistoryPageLoaded, {
@@ -614,7 +612,33 @@ function BoardSheetContent({
     undefined,
     handleHistoryPageLoaded,
   );
-  const combinedHistory = useMemo(() => [...visibleHistory, ...olderHistory], [visibleHistory, olderHistory]);
+  // The hook dedupes each page only at resolve time; the live window can gain
+  // lower seqs AFTERWARDS (backfill / pull-to-refresh merge — seam 2 in the
+  // hook's header), so re-filter here or overlapping entries would render
+  // twice with duplicate list keys. Filter against the FULL feed history, not
+  // `visibleHistory`: the current climb is excluded from the list but its key
+  // must still suppress a durable copy of it leaking in from a page.
+  const combinedHistory = useMemo(() => {
+    if (olderHistory.length === 0) return visibleHistory;
+    const liveKeys = new Set(history.map(boardPresenceHistoryKeyExtractor));
+    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(boardPresenceHistoryKeyExtractor(climb)));
+    return dedupedOlder.length === 0 ? visibleHistory : [...visibleHistory, ...dedupedOlder];
+  }, [visibleHistory, history, olderHistory]);
+
+  // FlatList fires onEndReached immediately when the content is shorter than
+  // the viewport, so without this gate every presentation of a quiet wall
+  // would auto-fire a durable history fetch (guaranteed-rejected for
+  // logged-out users). Require a real user scroll first. The ref lives in
+  // this component, which mounts fresh per presentation, so the gate re-arms
+  // on every open.
+  const hasUserScrolledRef = useRef(false);
+  const handleScrollBeginDrag = useCallback(() => {
+    hasUserScrolledRef.current = true;
+  }, []);
+  const handleEndReached = useCallback(() => {
+    if (!hasUserScrolledRef.current) return;
+    loadOlder();
+  }, [loadOlder]);
 
   // Fires once per presentation, when history is FIRST non-empty — not only at
   // mount, because presenting before the initial backfill resolves would find
@@ -842,9 +866,12 @@ function BoardSheetContent({
       ListFooterComponent={listFooter}
       // `loadOlder` already no-ops once `hasMore` is false, but skipping the
       // prop entirely once there's nothing left avoids FlatList re-evaluating
-      // the end-reached threshold on every scroll frame for no reason.
-      onEndReached={hasMore ? loadOlder : undefined}
+      // the end-reached threshold on every scroll frame for no reason. The
+      // handler itself is additionally gated on a real user scroll — see
+      // `hasUserScrolledRef` above.
+      onEndReached={hasMore ? handleEndReached : undefined}
       onEndReachedThreshold={0.6}
+      onScrollBeginDrag={handleScrollBeginDrag}
       contentContainerStyle={{ paddingBottom: spacing[4] }}
       refreshControl={
         <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} tintColor={systemColors.secondaryLabel} />

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -16,6 +16,9 @@ const historyPagination = vi.hoisted(() => ({
   isLoadingOlder: false,
   hasMore: true,
   loadOlder: vi.fn(),
+  // The onPageLoaded callback BoardSheetContent passes to the (mocked) hook,
+  // captured so tests can fire it and assert the analytics wiring.
+  capturedOnPageLoaded: null as ((info: { pageSize: number; returnedCount: number }) => void) | null,
 }));
 
 const presenceControls = vi.hoisted(() => ({
@@ -186,7 +189,19 @@ vi.mock('@boardsesh/board-presence-react', () => ({
   }),
   useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
   useBoardPresenceActions: () => ({ refresh: presence.refresh }),
-  useBoardHistoryPagination: () => historyPagination,
+  useBoardHistoryPagination: (
+    _pageSize?: number,
+    onPageLoaded?: (info: { pageSize: number; returnedCount: number }) => void,
+  ) => {
+    historyPagination.capturedOnPageLoaded = onPageLoaded ?? null;
+    return {
+      olderHistory: historyPagination.olderHistory,
+      isLoadingOlder: historyPagination.isLoadingOlder,
+      hasMore: historyPagination.hasMore,
+      loadOlder: historyPagination.loadOlder,
+    };
+  },
+  boardHistoryEntryKey: (climb: BoardPresenceClimb) => `${climb.climbUuid}:${climb.seq}`,
 }));
 
 vi.mock('../../../providers/board-presence-provider', () => ({
@@ -352,6 +367,7 @@ describe('BoardSheet', () => {
     historyPagination.isLoadingOlder = false;
     historyPagination.hasMore = true;
     historyPagination.loadOlder.mockClear();
+    historyPagination.capturedOnPageLoaded = null;
     analytics.track.mockClear();
     graphql.request.mockReset();
     toast.showToast.mockClear();
@@ -1325,6 +1341,71 @@ describe('BoardSheet', () => {
       );
 
       expect(queryByLabelText('mobile.boardPresence.loadingMore')).toBeNull();
+    });
+
+    it('offers Load more from the empty state — an empty list cannot scroll to trigger onEndReached', () => {
+      // A wall quiet longer than the Redis window's TTL: empty live window,
+      // but durable rows may exist. The empty-state button is the only path.
+      presence.history = [];
+      const ref = createRef<BoardSheetHandle>();
+      const { getByLabelText } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      fireEvent.click(getByLabelText('mobile.boardPresence.loadMore'));
+      expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the empty-state Load more once hasMore is false', () => {
+      presence.history = [];
+      historyPagination.hasMore = false;
+      const ref = createRef<BoardSheetHandle>();
+      const { queryByLabelText } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      expect(queryByLabelText('mobile.boardPresence.loadMore')).toBeNull();
+    });
+
+    it('tracks BoardHistoryPageLoaded with the boardId when a page resolves', () => {
+      presence.history = [makeClimb('c1', 3)];
+      const ref = createRef<BoardSheetHandle>();
+      render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      // The sheet hands its onPageLoaded callback to the pagination hook;
+      // firing it (as the real hook does when a page resolves) must emit the
+      // analytics event with the bound boardId attached.
+      expect(historyPagination.capturedOnPageLoaded).not.toBeNull();
+      act(() => historyPagination.capturedOnPageLoaded?.({ pageSize: 50, returnedCount: 37 }));
+
+      expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryPageLoaded, {
+        boardId: 123,
+        pageSize: 50,
+        returnedCount: 37,
+      });
     });
   });
 });

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -11,6 +11,13 @@ const presence = vi.hoisted(() => ({
   refresh: vi.fn(),
 }));
 
+const historyPagination = vi.hoisted(() => ({
+  olderHistory: [] as BoardPresenceClimb[],
+  isLoadingOlder: false,
+  hasMore: true,
+  loadOlder: vi.fn(),
+}));
+
 const presenceControls = vi.hoisted(() => ({
   boardId: 123 as number | null,
 }));
@@ -90,20 +97,26 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     },
   ),
   // Render the list inline so header + items + empty state appear in the DOM.
+  // A "reach end" button surfaces `onEndReached` for tests to trigger directly
+  // (real FlatList scroll-position math isn't exercised under jsdom).
   BottomSheetFlatList: ({
     data,
     renderItem,
     ListHeaderComponent,
     ListEmptyComponent,
+    ListFooterComponent,
     keyExtractor,
     refreshControl,
+    onEndReached,
   }: {
     data: BoardPresenceClimb[];
     renderItem: (info: { item: BoardPresenceClimb }) => ReactNode;
     ListHeaderComponent?: ReactNode;
     ListEmptyComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
     keyExtractor: (item: BoardPresenceClimb) => string;
     refreshControl?: ReactNode;
+    onEndReached?: () => void;
   }) =>
     createElement(
       'div',
@@ -113,6 +126,8 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
       data.length === 0
         ? ListEmptyComponent
         : data.map((item) => createElement('div', { key: keyExtractor(item) }, renderItem({ item }))),
+      ListFooterComponent,
+      createElement('button', { 'aria-label': 'reach list end', onClick: () => onEndReached?.() }),
     ),
 }));
 
@@ -167,6 +182,7 @@ vi.mock('@boardsesh/board-presence-react', () => ({
   }),
   useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
   useBoardPresenceActions: () => ({ refresh: presence.refresh }),
+  useBoardHistoryPagination: () => historyPagination,
 }));
 
 vi.mock('../../../providers/board-presence-provider', () => ({
@@ -328,6 +344,10 @@ describe('BoardSheet', () => {
     presence.stats = null;
     presenceControls.boardId = 123;
     presence.refresh.mockClear();
+    historyPagination.olderHistory = [];
+    historyPagination.isLoadingOlder = false;
+    historyPagination.hasMore = true;
+    historyPagination.loadOlder.mockClear();
     analytics.track.mockClear();
     graphql.request.mockReset();
     toast.showToast.mockClear();
@@ -1152,5 +1172,95 @@ describe('BoardSheet', () => {
     expect(container.querySelector('[data-icon="close"]')).toBeNull();
     fireEvent.click(getByLabelText('mobile.boardPresence.close'));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('load older history', () => {
+    it('calls loadOlder when the list end is reached', () => {
+      presence.history = [makeClimb('c1', 3)];
+      const ref = createRef<BoardSheetHandle>();
+      const { getByLabelText } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      fireEvent.click(getByLabelText('reach list end'));
+      expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not wire onEndReached once hasMore is false', () => {
+      presence.history = [makeClimb('c1', 3)];
+      historyPagination.hasMore = false;
+      const ref = createRef<BoardSheetHandle>();
+      const { getByLabelText } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      fireEvent.click(getByLabelText('reach list end'));
+      expect(historyPagination.loadOlder).not.toHaveBeenCalled();
+    });
+
+    it('renders loaded older rows appended after the live history', () => {
+      presence.history = [makeClimb('c2', 4)];
+      historyPagination.olderHistory = [makeClimb('c1', 3), makeClimb('c0', 2)];
+      const ref = createRef<BoardSheetHandle>();
+      const { container } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      expect(container.textContent).toContain('Climb c2');
+      expect(container.textContent).toContain('Climb c1');
+      expect(container.textContent).toContain('Climb c0');
+    });
+
+    it('shows the footer spinner while loading older history, and hides it once resolved', () => {
+      presence.history = [makeClimb('c1', 3)];
+      historyPagination.isLoadingOlder = true;
+      const ref = createRef<BoardSheetHandle>();
+      const { queryByLabelText, rerender } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      expect(queryByLabelText('mobile.boardPresence.loadingMore')).not.toBeNull();
+
+      historyPagination.isLoadingOlder = false;
+      rerender(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(queryByLabelText('mobile.boardPresence.loadingMore')).toBeNull();
+    });
   });
 });

--- a/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/mobile/src/components/board-presence/__tests__/board-sheet.test.tsx
@@ -97,8 +97,9 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     },
   ),
   // Render the list inline so header + items + empty state appear in the DOM.
-  // A "reach end" button surfaces `onEndReached` for tests to trigger directly
-  // (real FlatList scroll-position math isn't exercised under jsdom).
+  // "begin scroll" / "reach end" buttons surface `onScrollBeginDrag` /
+  // `onEndReached` for tests to trigger directly (real FlatList
+  // scroll-position math isn't exercised under jsdom).
   BottomSheetFlatList: ({
     data,
     renderItem,
@@ -108,6 +109,7 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     keyExtractor,
     refreshControl,
     onEndReached,
+    onScrollBeginDrag,
   }: {
     data: BoardPresenceClimb[];
     renderItem: (info: { item: BoardPresenceClimb }) => ReactNode;
@@ -117,6 +119,7 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     keyExtractor: (item: BoardPresenceClimb) => string;
     refreshControl?: ReactNode;
     onEndReached?: () => void;
+    onScrollBeginDrag?: () => void;
   }) =>
     createElement(
       'div',
@@ -127,6 +130,7 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
         ? ListEmptyComponent
         : data.map((item) => createElement('div', { key: keyExtractor(item) }, renderItem({ item }))),
       ListFooterComponent,
+      createElement('button', { 'aria-label': 'begin scroll', onClick: () => onScrollBeginDrag?.() }),
       createElement('button', { 'aria-label': 'reach list end', onClick: () => onEndReached?.() }),
     ),
 }));
@@ -1175,7 +1179,7 @@ describe('BoardSheet', () => {
   });
 
   describe('load older history', () => {
-    it('calls loadOlder when the list end is reached', () => {
+    it('calls loadOlder when the list end is reached after a user scroll', () => {
       presence.history = [makeClimb('c1', 3)];
       const ref = createRef<BoardSheetHandle>();
       const { getByLabelText } = render(
@@ -1189,6 +1193,32 @@ describe('BoardSheet', () => {
       );
       act(() => ref.current?.present());
 
+      fireEvent.click(getByLabelText('begin scroll'));
+      fireEvent.click(getByLabelText('reach list end'));
+      expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores an end-reach that fires without a user scroll (short-content auto-fire)', () => {
+      // FlatList fires onEndReached immediately when the content is shorter
+      // than the viewport — presenting on a quiet wall must not auto-fetch.
+      presence.history = [makeClimb('c1', 3)];
+      const ref = createRef<BoardSheetHandle>();
+      const { getByLabelText } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      fireEvent.click(getByLabelText('reach list end'));
+      expect(historyPagination.loadOlder).not.toHaveBeenCalled();
+
+      // A real scroll afterwards arms the gate.
+      fireEvent.click(getByLabelText('begin scroll'));
       fireEvent.click(getByLabelText('reach list end'));
       expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
     });
@@ -1208,8 +1238,42 @@ describe('BoardSheet', () => {
       );
       act(() => ref.current?.present());
 
+      fireEvent.click(getByLabelText('begin scroll'));
       fireEvent.click(getByLabelText('reach list end'));
       expect(historyPagination.loadOlder).not.toHaveBeenCalled();
+    });
+
+    it('drops olderHistory entries the live window has since absorbed (backfill overlap)', () => {
+      // The live window gained seqs 5..3 (e.g. the initial backfill resolved
+      // AFTER a page load); the loaded page overlaps on c1/3 and even carries
+      // a durable copy of the current climb (c3/5). Each key must render once.
+      presence.currentClimb = makeClimb('c3', 5);
+      presence.history = [makeClimb('c3', 5), makeClimb('c2', 4), makeClimb('c1', 3)];
+      historyPagination.olderHistory = [
+        makeClimb('c3', 5, { name: 'Durable Current' }),
+        makeClimb('c1', 3, { name: 'Durable Variant' }),
+        makeClimb('c0', 2),
+      ];
+      const ref = createRef<BoardSheetHandle>();
+      const { container } = render(
+        createElement(BoardSheet, {
+          ref,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          boardConfig,
+          onSwitchBoard: noop,
+        }),
+      );
+      act(() => ref.current?.present());
+
+      // The live variants win; the overlapping durable copies never render.
+      expect(container.textContent).not.toContain('Durable Variant');
+      expect(container.textContent).not.toContain('Durable Current');
+      expect(container.textContent?.match(/Climb c1/g)).toHaveLength(1);
+      // c3 renders once — in the hero only (visibleHistory excludes it).
+      expect(container.textContent?.match(/Climb c3/g)).toHaveLength(1);
+      // Non-overlapping older entries still append.
+      expect(container.textContent).toContain('Climb c0');
     });
 
     it('renders loaded older rows appended after the live history', () => {

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -135,6 +135,11 @@ export const SHARED_EVENTS = {
   //   events were silently dropped (Redis pub/sub has no replay) and just
   //   recovered — the signal for "history was slow/stale to update".
   BoardHistoryCatchUp: 'Board History Catch Up',
+  // Fired each time "load older" resolves a page of durable history (past the
+  // live feed's in-memory HISTORY_CAP window). Props:
+  // { boardId?, pageSize: number, returnedCount: number }. `returnedCount <
+  // pageSize` means that page was the last one.
+  BoardHistoryPageLoaded: 'Board History Page Loaded',
   // External platform integrations (Apple Health, Strava). Props:
   // { integration: 'apple_health' | 'strava', trigger?: 'auto' | 'manual',
   //   enabled?: boolean }

--- a/packages/shared/board-presence-react/src/__tests__/use-board-history-pagination.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-history-pagination.test.tsx
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import {
+  useBoardHistoryPagination,
+  type BoardHistoryPageLoadedInfo,
+  type BoardHistoryPagination,
+} from '../use-board-history-pagination';
+import { BoardPresenceClientContext, BoardPresenceFeedContext } from '../board-presence-provider';
+import type { BoardPresenceClient } from '../types';
+
+const climb = (climbUuid: string, seq: number, overrides: Partial<BoardPresenceClimb> = {}): BoardPresenceClimb => ({
+  climbUuid,
+  seq,
+  sentAt: new Date(seq * 1000).toISOString(),
+  name: `Climb ${climbUuid}`,
+  angle: 40,
+  ...overrides,
+});
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeClient(overrides: Partial<BoardPresenceClient> = {}) {
+  const fetchHistory =
+    vi.fn<(boardId: number, opts?: { limit?: number; before?: string }) => Promise<BoardPresenceClimb[]>>();
+  const client: BoardPresenceClient = {
+    subscribeNowPlaying: vi.fn(() => () => {}),
+    fetchRecentClimbs: vi.fn(async () => []),
+    fetchStats: vi.fn(async () => ({
+      climbsSentCount: 0,
+      distinctClimbersCount: 0,
+      hardestGrade: null,
+      topGrade: null,
+      lastSentAt: null,
+    })),
+    reportClimb: vi.fn(async () => true),
+    resolveBoardForSerial: vi.fn(),
+    fetchHistory,
+    ...overrides,
+  };
+  return { client, fetchHistory };
+}
+
+type ResultBox = { current: BoardHistoryPagination | null };
+
+function ResultReader({
+  pageSize,
+  onPageLoaded,
+  resultBox,
+}: {
+  pageSize?: number;
+  onPageLoaded?: (info: BoardHistoryPageLoadedInfo) => void;
+  resultBox: ResultBox;
+}) {
+  resultBox.current = useBoardHistoryPagination(pageSize, onPageLoaded);
+  return null;
+}
+
+function TestHarness({
+  boardId,
+  client,
+  history,
+  pageSize,
+  onPageLoaded,
+  resultBox,
+}: {
+  boardId: number | null;
+  client: BoardPresenceClient | null;
+  history: BoardPresenceClimb[];
+  pageSize?: number;
+  onPageLoaded?: (info: BoardHistoryPageLoadedInfo) => void;
+  resultBox: ResultBox;
+}) {
+  return (
+    <BoardPresenceClientContext.Provider value={{ boardId, client }}>
+      <BoardPresenceFeedContext.Provider value={{ history, stats: null }}>
+        <ResultReader pageSize={pageSize} onPageLoaded={onPageLoaded} resultBox={resultBox} />
+      </BoardPresenceFeedContext.Provider>
+    </BoardPresenceClientContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBoardHistoryPagination', () => {
+  it('pages append newest-first and the cursor is the lowest seq across the live window', async () => {
+    const { client, fetchHistory } = makeClient();
+    const page = deferred<BoardPresenceClimb[]>();
+    fetchHistory.mockReturnValueOnce(page.promise);
+    const resultBox: ResultBox = { current: null };
+    const liveHistory = [climb('c100', 100), climb('c99', 99), climb('c98', 98)];
+
+    render(<TestHarness boardId={1} client={client} history={liveHistory} pageSize={2} resultBox={resultBox} />);
+
+    act(() => resultBox.current?.loadOlder());
+    expect(fetchHistory).toHaveBeenCalledWith(1, { limit: 2, before: '98' });
+    expect(resultBox.current?.isLoadingOlder).toBe(true);
+
+    await act(async () => {
+      page.resolve([climb('c97', 97), climb('c96', 96)]);
+      await page.promise;
+    });
+
+    expect(resultBox.current?.olderHistory).toEqual([climb('c97', 97), climb('c96', 96)]);
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+    expect(resultBox.current?.hasMore).toBe(true);
+  });
+
+  it('derives the next cursor from the lowest seq including prior pages', async () => {
+    const { client, fetchHistory } = makeClient();
+    const firstPage = deferred<BoardPresenceClimb[]>();
+    const secondPage = deferred<BoardPresenceClimb[]>();
+    fetchHistory.mockReturnValueOnce(firstPage.promise).mockReturnValueOnce(secondPage.promise);
+    const resultBox: ResultBox = { current: null };
+    const liveHistory = [climb('c100', 100)];
+
+    render(<TestHarness boardId={1} client={client} history={liveHistory} pageSize={2} resultBox={resultBox} />);
+
+    act(() => resultBox.current?.loadOlder());
+    expect(fetchHistory).toHaveBeenNthCalledWith(1, 1, { limit: 2, before: '100' });
+    await act(async () => {
+      firstPage.resolve([climb('c99', 99), climb('c98', 98)]);
+      await firstPage.promise;
+    });
+
+    act(() => resultBox.current?.loadOlder());
+    // Cursor now anchors on the lowest seq across live window (100) AND the
+    // already-loaded page (99, 98) — 98, not 100.
+    expect(fetchHistory).toHaveBeenNthCalledWith(2, 1, { limit: 2, before: '98' });
+    await act(async () => {
+      secondPage.resolve([climb('c97', 97)]);
+      await secondPage.promise;
+    });
+
+    expect(resultBox.current?.olderHistory).toEqual([climb('c99', 99), climb('c98', 98), climb('c97', 97)]);
+  });
+
+  it('omits the cursor on the very first fetch when nothing is known yet', async () => {
+    const { client, fetchHistory } = makeClient();
+    fetchHistory.mockResolvedValueOnce([]);
+    const resultBox: ResultBox = { current: null };
+
+    render(<TestHarness boardId={1} client={client} history={[]} pageSize={2} resultBox={resultBox} />);
+
+    await act(async () => {
+      resultBox.current?.loadOlder();
+    });
+
+    expect(fetchHistory).toHaveBeenCalledWith(1, { limit: 2, before: undefined });
+  });
+
+  it('dedupes a page entry that overlaps the live window — the known entry wins', async () => {
+    const { client, fetchHistory } = makeClient();
+    const page = deferred<BoardPresenceClimb[]>();
+    fetchHistory.mockReturnValueOnce(page.promise);
+    const resultBox: ResultBox = { current: null };
+    // Live window already has c100/seq100.
+    const liveHistory = [climb('c100', 100)];
+
+    render(<TestHarness boardId={1} client={client} history={liveHistory} pageSize={2} resultBox={resultBox} />);
+
+    act(() => resultBox.current?.loadOlder());
+    await act(async () => {
+      // The durable query can return a re-resolved variant of an entry the
+      // live window already has (different name/fields, same climbUuid+seq
+      // key) — it must be dropped, not appended as a duplicate.
+      page.resolve([climb('c100', 100, { name: 'Stale Durable Variant' }), climb('c99', 99)]);
+      await page.promise;
+    });
+
+    expect(resultBox.current?.olderHistory).toEqual([climb('c99', 99)]);
+  });
+
+  it('flips hasMore false once a page comes back shorter than pageSize, and further loadOlder calls no-op', async () => {
+    const { client, fetchHistory } = makeClient();
+    fetchHistory.mockResolvedValueOnce([climb('c99', 99)]);
+    const resultBox: ResultBox = { current: null };
+
+    render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    await act(async () => {
+      resultBox.current?.loadOlder();
+    });
+
+    expect(resultBox.current?.hasMore).toBe(false);
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+
+    act(() => resultBox.current?.loadOlder());
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips hasMore false and stops silently on a rejected fetch', async () => {
+    const { client, fetchHistory } = makeClient();
+    fetchHistory.mockRejectedValueOnce(new Error('boardHistory requires auth'));
+    const resultBox: ResultBox = { current: null };
+
+    render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    await act(async () => {
+      resultBox.current?.loadOlder();
+    });
+
+    expect(resultBox.current?.hasMore).toBe(false);
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+    expect(resultBox.current?.olderHistory).toEqual([]);
+
+    act(() => resultBox.current?.loadOlder());
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets paging state on a board switch', async () => {
+    const { client, fetchHistory } = makeClient();
+    fetchHistory.mockResolvedValueOnce([climb('c99', 99), climb('c98', 98)]);
+    const resultBox: ResultBox = { current: null };
+
+    const { rerender } = render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    await act(async () => {
+      resultBox.current?.loadOlder();
+    });
+    expect(resultBox.current?.olderHistory).toHaveLength(2);
+    expect(resultBox.current?.hasMore).toBe(true);
+
+    fetchHistory.mockResolvedValueOnce([]);
+    rerender(<TestHarness boardId={2} client={client} history={[climb('d1', 5)]} pageSize={2} resultBox={resultBox} />);
+
+    expect(resultBox.current?.olderHistory).toEqual([]);
+    expect(resultBox.current?.hasMore).toBe(true);
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+
+    act(() => resultBox.current?.loadOlder());
+    // The next fetch anchors on board 2's own live window, not board 1's.
+    expect(fetchHistory).toHaveBeenLastCalledWith(2, { limit: 2, before: '5' });
+  });
+
+  it('coalesces loadOlder calls while a fetch is already in flight', async () => {
+    const { client, fetchHistory } = makeClient();
+    const page = deferred<BoardPresenceClimb[]>();
+    fetchHistory.mockReturnValueOnce(page.promise);
+    const resultBox: ResultBox = { current: null };
+
+    render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    act(() => {
+      resultBox.current?.loadOlder();
+      resultBox.current?.loadOlder();
+      resultBox.current?.loadOlder();
+    });
+    expect(fetchHistory).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      // Full page (length === pageSize) so `hasMore` stays true and the
+      // follow-up call below isn't suppressed by that flag instead.
+      page.resolve([climb('c99', 99), climb('c98', 98)]);
+      await page.promise;
+    });
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+
+    // Once resolved, a fresh call fetches again (not coalesced anymore).
+    fetchHistory.mockResolvedValueOnce([]);
+    await act(async () => {
+      resultBox.current?.loadOlder();
+    });
+    expect(fetchHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('no-ops when the active client does not implement fetchHistory', () => {
+    const { client } = makeClient({ fetchHistory: undefined });
+    const resultBox: ResultBox = { current: null };
+
+    render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    act(() => resultBox.current?.loadOlder());
+
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+    expect(resultBox.current?.olderHistory).toEqual([]);
+  });
+
+  it('no-ops when there is no bound board or client', () => {
+    const { client, fetchHistory } = makeClient();
+    const resultBox: ResultBox = { current: null };
+
+    render(<TestHarness boardId={null} client={client} history={[]} pageSize={2} resultBox={resultBox} />);
+    act(() => resultBox.current?.loadOlder());
+    expect(fetchHistory).not.toHaveBeenCalled();
+
+    const resultBox2: ResultBox = { current: null };
+    render(<TestHarness boardId={1} client={null} history={[]} pageSize={2} resultBox={resultBox2} />);
+    act(() => resultBox2.current?.loadOlder());
+    expect(fetchHistory).not.toHaveBeenCalled();
+  });
+
+  it('reports the resolved page via onPageLoaded', async () => {
+    const { client, fetchHistory } = makeClient();
+    fetchHistory.mockResolvedValueOnce([climb('c99', 99)]);
+    const onPageLoaded = vi.fn();
+    const resultBox: ResultBox = { current: null };
+
+    render(
+      <TestHarness
+        boardId={1}
+        client={client}
+        history={[climb('c100', 100)]}
+        pageSize={2}
+        onPageLoaded={onPageLoaded}
+        resultBox={resultBox}
+      />,
+    );
+
+    await act(async () => {
+      resultBox.current?.loadOlder();
+    });
+
+    expect(onPageLoaded).toHaveBeenCalledWith({ pageSize: 2, returnedCount: 1 });
+  });
+});

--- a/packages/shared/board-presence-react/src/__tests__/use-board-history-pagination.test.tsx
+++ b/packages/shared/board-presence-react/src/__tests__/use-board-history-pagination.test.tsx
@@ -255,6 +255,56 @@ describe('useBoardHistoryPagination', () => {
     expect(fetchHistory).toHaveBeenLastCalledWith(2, { limit: 2, before: '5' });
   });
 
+  it('ignores a page that resolves after a board switch (stale generation)', async () => {
+    const { client, fetchHistory } = makeClient();
+    const boardOnePage = deferred<BoardPresenceClimb[]>();
+    fetchHistory.mockReturnValueOnce(boardOnePage.promise);
+    const resultBox: ResultBox = { current: null };
+
+    const { rerender } = render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    act(() => resultBox.current?.loadOlder());
+    expect(resultBox.current?.isLoadingOlder).toBe(true);
+
+    // Switch boards while board 1's page is still in flight — the reset
+    // effect bumps the generation and clears the loading flag.
+    rerender(<TestHarness boardId={2} client={client} history={[]} pageSize={2} resultBox={resultBox} />);
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+
+    await act(async () => {
+      boardOnePage.resolve([climb('c99', 99), climb('c98', 98)]);
+      await boardOnePage.promise;
+    });
+
+    // Board 1's late page must not bleed into board 2's state.
+    expect(resultBox.current?.olderHistory).toEqual([]);
+    expect(resultBox.current?.isLoadingOlder).toBe(false);
+    expect(resultBox.current?.hasMore).toBe(true);
+  });
+
+  it('ignores a page that resolves after unmount', async () => {
+    const { client, fetchHistory } = makeClient();
+    const page = deferred<BoardPresenceClimb[]>();
+    fetchHistory.mockReturnValueOnce(page.promise);
+    const resultBox: ResultBox = { current: null };
+
+    const { unmount } = render(
+      <TestHarness boardId={1} client={client} history={[climb('c100', 100)]} pageSize={2} resultBox={resultBox} />,
+    );
+
+    act(() => resultBox.current?.loadOlder());
+    unmount();
+
+    // Resolving after unmount must not throw (the isActive guard swallows the
+    // late continuation instead of setting state on an unmounted tree).
+    await act(async () => {
+      page.resolve([climb('c99', 99), climb('c98', 98)]);
+      await page.promise;
+    });
+  });
+
   it('coalesces loadOlder calls while a fetch is already in flight', async () => {
     const { client, fetchHistory } = makeClient();
     const page = deferred<BoardPresenceClimb[]>();

--- a/packages/shared/board-presence-react/src/board-presence-provider.tsx
+++ b/packages/shared/board-presence-react/src/board-presence-provider.tsx
@@ -33,6 +33,19 @@ const BoardPresenceHasClimbContext = createContext<boolean | undefined>(undefine
 // holder/stats/undo-target churn that context also carries.
 const BoardPresenceWallClimbContext = createContext<BoardPresenceClimb | null | undefined>(undefined);
 
+/** The board + client pair a consumer needs to drive its own platform I/O
+ * against — currently just `use-board-history-pagination`'s `fetchHistory`
+ * paging, which lives outside the reducer/feed context on purpose (see that
+ * hook's docstring). Memoized on `[boardId, client]` only, so it changes
+ * exactly when the bound board or transport itself changes, never on a wall
+ * event. */
+export type BoardPresenceClientValue = {
+  boardId: number | null;
+  client: BoardPresenceClient | null;
+};
+
+const BoardPresenceClientContext = createContext<BoardPresenceClientValue | undefined>(undefined);
+
 export function BoardPresenceProvider({
   boardId,
   client,
@@ -86,6 +99,10 @@ export function BoardPresenceProvider({
   // when live (or the stable `null` literal otherwise), so there is nothing to
   // memoize: the reference only changes when `currentClimb` itself does.
   const wallClimb = value.isLive ? value.currentClimb : null;
+  // Changes only on a board switch or client rebuild (props identity), never
+  // on a wall event — safe for a hook like `use-board-history-pagination` to
+  // key an effect on without re-running per climb.
+  const clientValue = useMemo<BoardPresenceClientValue>(() => ({ boardId, client }), [boardId, client]);
 
   return (
     <BoardPresenceContext.Provider value={value}>
@@ -93,7 +110,11 @@ export function BoardPresenceProvider({
         <BoardPresenceCurrentContext.Provider value={current}>
           <BoardPresenceHasClimbContext.Provider value={hasClimb}>
             <BoardPresenceWallClimbContext.Provider value={wallClimb}>
-              <BoardPresenceFeedContext.Provider value={feed}>{children}</BoardPresenceFeedContext.Provider>
+              <BoardPresenceFeedContext.Provider value={feed}>
+                <BoardPresenceClientContext.Provider value={clientValue}>
+                  {children}
+                </BoardPresenceClientContext.Provider>
+              </BoardPresenceFeedContext.Provider>
             </BoardPresenceWallClimbContext.Provider>
           </BoardPresenceHasClimbContext.Provider>
         </BoardPresenceCurrentContext.Provider>
@@ -157,6 +178,22 @@ export function useBoardPresenceWallClimb(): BoardPresenceClimb | null {
   return context;
 }
 
+/**
+ * The bound `boardId` + injected `client`, for consumers that need to drive
+ * their own platform I/O against the same board/transport `useBoardPresence`
+ * is attached to — e.g. `use-board-history-pagination`'s `fetchHistory`
+ * paging. Prefer the narrower current/feed/actions hooks above for anything
+ * that only reads wall state; this one exists for callers that need the raw
+ * client.
+ */
+export function useBoardPresenceClient(): BoardPresenceClientValue {
+  const context = useContext(BoardPresenceClientContext);
+  if (context === undefined) {
+    throw new Error('useBoardPresenceClient must be used within a BoardPresenceProvider');
+  }
+  return context;
+}
+
 export {
   BoardPresenceContext,
   BoardPresenceActionsContext,
@@ -164,4 +201,5 @@ export {
   BoardPresenceFeedContext,
   BoardPresenceHasClimbContext,
   BoardPresenceWallClimbContext,
+  BoardPresenceClientContext,
 };

--- a/packages/shared/board-presence-react/src/index.ts
+++ b/packages/shared/board-presence-react/src/index.ts
@@ -20,18 +20,21 @@ export type {
 export {
   BoardPresenceProvider,
   useBoardPresenceActions,
+  useBoardPresenceClient,
   useBoardPresenceContext,
   useBoardPresenceCurrent,
   useBoardPresenceFeed,
   useBoardPresenceHasClimb,
   useBoardPresenceWallClimb,
   BoardPresenceActionsContext,
+  BoardPresenceClientContext,
   BoardPresenceContext,
   BoardPresenceCurrentContext,
   BoardPresenceFeedContext,
   BoardPresenceHasClimbContext,
   BoardPresenceWallClimbContext,
 } from './board-presence-provider';
+export type { BoardPresenceClientValue } from './board-presence-provider';
 
 export { boardHistoryCursor } from './types';
 export type { BoardHistoryCursor, BoardPresenceClient } from './types';
@@ -44,3 +47,6 @@ export type {
   FullBoardPresenceClient,
   SerialResolveArgs,
 } from './create-board-presence-client';
+
+export { useBoardHistoryPagination } from './use-board-history-pagination';
+export type { BoardHistoryPageLoadedInfo, BoardHistoryPagination } from './use-board-history-pagination';

--- a/packages/shared/board-presence-react/src/index.ts
+++ b/packages/shared/board-presence-react/src/index.ts
@@ -48,5 +48,5 @@ export type {
   SerialResolveArgs,
 } from './create-board-presence-client';
 
-export { useBoardHistoryPagination } from './use-board-history-pagination';
+export { boardHistoryEntryKey, useBoardHistoryPagination } from './use-board-history-pagination';
 export type { BoardHistoryPageLoadedInfo, BoardHistoryPagination } from './use-board-history-pagination';

--- a/packages/shared/board-presence-react/src/use-board-history-pagination.ts
+++ b/packages/shared/board-presence-react/src/use-board-history-pagination.ts
@@ -13,20 +13,33 @@
 // never scrolls that far, and keeps `use-board-presence`'s invariants/tests
 // untouched.
 //
-// KNOWN SEAM: on a very busy wall with the history sheet open a long time,
-// live events keep pushing into the capped in-memory window, evicting older
-// entries out the bottom (`HISTORY_CAP`). If that eviction races ahead of
-// this hook's own paging, a gap can open between the live window's oldest
-// entry and this hook's most recently loaded page. This is accepted as a rare
-// edge case — sheet sessions are short, and every `loadOlder` call re-anchors
-// its cursor on the current minimum known `seq` (across the live window AND
-// everything already paged in), so at worst a climb near that boundary is
-// skipped rather than duplicated.
+// KNOWN SEAMS between the live window and loaded pages:
+//
+// 1. Eviction gap: on a very busy wall with the history sheet open a long
+//    time, live events keep pushing into the capped in-memory window,
+//    evicting older entries out the bottom (`HISTORY_CAP`). If that eviction
+//    races ahead of this hook's own paging, a gap can open between the live
+//    window's oldest entry and this hook's most recently loaded page.
+//    Accepted as a rare edge case — sheet sessions are short, and every
+//    `loadOlder` call re-anchors its cursor on the current minimum known
+//    `seq` (across the live window AND everything already paged in), so at
+//    worst a climb near that boundary is skipped.
+//
+// 2. Backfill overlap: the live window can gain LOWER seqs AFTER a page has
+//    resolved — BACKFILL_HISTORY (and the stale-seq APPLY_CLIMB_SET branch)
+//    merge older entries into the window while it is under `HISTORY_CAP`.
+//    Concretely: present the sheet while the initial `fetchRecentClimbs`
+//    backfill is still in flight (the window holds only live-subscription
+//    events), a `loadOlder` resolves seqs the backfill also covers, then the
+//    backfill lands and merges those same seqs into the live window. This
+//    hook's dedup runs at page-RESOLVE time only, so `olderHistory` can end
+//    up overlapping the live window. Consumers that concatenate the two MUST
+//    therefore re-filter `olderHistory` against the live window's
+//    `(climbUuid, seq)` keys at render — both board sheets do.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
-import { useBoardPresenceClient } from './board-presence-provider';
-import { useBoardPresenceFeed } from './board-presence-provider';
+import { useBoardPresenceClient, useBoardPresenceFeed } from './board-presence-provider';
 import { boardHistoryCursor } from './types';
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -43,7 +56,11 @@ export type BoardHistoryPageLoadedInfo = {
 
 export type BoardHistoryPagination = {
   /** Older-than-the-live-window climbs loaded so far, newest-first, deduped
-   * against the live window and every prior page. */
+   * against the live window and every prior page AS OF EACH PAGE'S RESOLVE
+   * TIME. The live window can subsequently grow to overlap these entries
+   * (backfill merge — seam 2 in the file header), so consumers concatenating
+   * this with the live window must re-filter against the window's
+   * `(climbUuid, seq)` keys at render. */
   olderHistory: BoardPresenceClimb[];
   isLoadingOlder: boolean;
   /** False once a page came back shorter than `pageSize`, or a page fetch

--- a/packages/shared/board-presence-react/src/use-board-history-pagination.ts
+++ b/packages/shared/board-presence-react/src/use-board-history-pagination.ts
@@ -73,7 +73,13 @@ export type BoardHistoryPagination = {
   loadOlder: () => void;
 };
 
-function historyEntryKey(climb: BoardPresenceClimb): string {
+/**
+ * Canonical identity key for a wall-history entry — the immutable
+ * `(climbUuid, seq)` pair. One function so every layer agrees on what "the
+ * same entry" means: this hook's page dedup, both sheets' render-path dedup
+ * against the live window, and the list/React keys on both platforms.
+ */
+export function boardHistoryEntryKey(climb: BoardPresenceClimb): string {
   return `${climb.climbUuid}:${climb.seq}`;
 }
 
@@ -165,14 +171,14 @@ export function useBoardHistoryPagination(
         if (!isActiveRef.current || generationRef.current !== requestGeneration) {
           return;
         }
-        const knownKeys = new Set([...liveHistoryRef.current, ...olderHistoryRef.current].map(historyEntryKey));
+        const knownKeys = new Set([...liveHistoryRef.current, ...olderHistoryRef.current].map(boardHistoryEntryKey));
         // Duplicates always defer to the already-known entry: the durable
         // `boardHistory` query re-resolves sender identity via a live DB join
         // and nulls `queueItemUuid`/`gradeColor`, so the same (climbUuid, seq)
         // can differ in shape from the live-feed/prior-page variant — the
         // live-feed shape is the richer one (mirrors the reducer's
         // `mergeHistory` policy).
-        const deduped = page.filter((climb) => !knownKeys.has(historyEntryKey(climb)));
+        const deduped = page.filter((climb) => !knownKeys.has(boardHistoryEntryKey(climb)));
         const nextOlderHistory = [...olderHistoryRef.current, ...deduped];
         olderHistoryRef.current = nextOlderHistory;
         setOlderHistory(nextOlderHistory);
@@ -185,9 +191,14 @@ export function useBoardHistoryPagination(
         if (!isActiveRef.current || generationRef.current !== requestGeneration) {
           return;
         }
-        // `boardHistory` is auth-required server-side — an anonymous client
-        // (or any other failure) should degrade to "no more history" rather
-        // than retry forever.
+        // Deliberately terminal for ALL errors — auth failures AND transient
+        // network ones. `boardHistory` is auth-required server-side, so for an
+        // anonymous client every call is a guaranteed reject and quietly
+        // stopping IS the graceful degrade (no error/retry UI by design). A
+        // transient failure lands in the same "no more history" state on
+        // purpose: pagination state is scoped to the consumer's mount, so
+        // closing and reopening the sheet resets `hasMore` and retries
+        // naturally.
         hasMoreRef.current = false;
         setHasMore(false);
       })

--- a/packages/shared/board-presence-react/src/use-board-history-pagination.ts
+++ b/packages/shared/board-presence-react/src/use-board-history-pagination.ts
@@ -1,0 +1,190 @@
+// "Load older" pagination over the durable `boardHistory` query.
+//
+// The live window (`useBoardPresenceFeed().history`) is capped at
+// `HISTORY_CAP` (50) in-memory entries — plenty for "what just happened" but
+// not enough to scroll back through a busy wall's full session. This hook
+// pages further back through the durable, keyset-paged `board_climb_events`
+// log via `BoardPresenceClient.fetchHistory`, independent of the live feed's
+// reducer/context.
+//
+// Deliberately lives OUTSIDE the reducer/Feed context: it has its own
+// lifecycle (mount-on-demand when a sheet opens a history list, not always-on
+// like the live feed), costs zero render overhead for every consumer that
+// never scrolls that far, and keeps `use-board-presence`'s invariants/tests
+// untouched.
+//
+// KNOWN SEAM: on a very busy wall with the history sheet open a long time,
+// live events keep pushing into the capped in-memory window, evicting older
+// entries out the bottom (`HISTORY_CAP`). If that eviction races ahead of
+// this hook's own paging, a gap can open between the live window's oldest
+// entry and this hook's most recently loaded page. This is accepted as a rare
+// edge case — sheet sessions are short, and every `loadOlder` call re-anchors
+// its cursor on the current minimum known `seq` (across the live window AND
+// everything already paged in), so at worst a climb near that boundary is
+// skipped rather than duplicated.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { useBoardPresenceClient } from './board-presence-provider';
+import { useBoardPresenceFeed } from './board-presence-provider';
+import { boardHistoryCursor } from './types';
+
+const DEFAULT_PAGE_SIZE = 50;
+
+/** Telemetry payload for a single resolved `loadOlder` page, handed to the
+ * optional `onPageLoaded` callback so platforms can track it without this
+ * renderer-agnostic package importing an analytics client. */
+export type BoardHistoryPageLoadedInfo = {
+  pageSize: number;
+  /** Raw count `fetchHistory` returned for this page, BEFORE dedup against
+   * already-known entries — matches the number `hasMore` is derived from. */
+  returnedCount: number;
+};
+
+export type BoardHistoryPagination = {
+  /** Older-than-the-live-window climbs loaded so far, newest-first, deduped
+   * against the live window and every prior page. */
+  olderHistory: BoardPresenceClimb[];
+  isLoadingOlder: boolean;
+  /** False once a page came back shorter than `pageSize`, or a page fetch
+   * rejected. True before the first `loadOlder` call (unknown yet). */
+  hasMore: boolean;
+  /** Fetch the next page back. No-op while a load is already in flight, once
+   * `hasMore` is false, or when the active client doesn't implement
+   * `fetchHistory` (e.g. a logged-out web client — `boardHistory` is
+   * auth-required server-side). */
+  loadOlder: () => void;
+};
+
+function historyEntryKey(climb: BoardPresenceClimb): string {
+  return `${climb.climbUuid}:${climb.seq}`;
+}
+
+function lowestKnownSeq(climbs: BoardPresenceClimb[]): number | null {
+  if (climbs.length === 0) {
+    return null;
+  }
+  return climbs.reduce((lowest, climb) => Math.min(lowest, climb.seq), Number.POSITIVE_INFINITY);
+}
+
+/**
+ * Page backward through a board's durable history log, beyond the live feed's
+ * in-memory window. See the file header for why this lives outside the
+ * reducer/Feed context.
+ */
+export function useBoardHistoryPagination(
+  pageSize = DEFAULT_PAGE_SIZE,
+  onPageLoaded?: (info: BoardHistoryPageLoadedInfo) => void,
+): BoardHistoryPagination {
+  const { boardId, client } = useBoardPresenceClient();
+  const { history: liveHistory } = useBoardPresenceFeed();
+
+  const [olderHistory, setOlderHistory] = useState<BoardPresenceClimb[]>([]);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  // Unknown until the first page resolves — default to true so the first
+  // `loadOlder` call is never suppressed by this flag.
+  const [hasMore, setHasMore] = useState(true);
+
+  // Live refs so `loadOlder` stays identity-stable across renders while still
+  // reading the current board/client/live-window/already-loaded state, and so
+  // async continuations can validate they're still relevant.
+  const boardIdRef = useRef(boardId);
+  boardIdRef.current = boardId;
+  const clientRef = useRef(client);
+  clientRef.current = client;
+  const liveHistoryRef = useRef(liveHistory);
+  liveHistoryRef.current = liveHistory;
+  const olderHistoryRef = useRef(olderHistory);
+  olderHistoryRef.current = olderHistory;
+  const isLoadingRef = useRef(false);
+  const hasMoreRef = useRef(true);
+  const onPageLoadedRef = useRef(onPageLoaded);
+  onPageLoadedRef.current = onPageLoaded;
+  // Bumped every time the bound board/client changes; an in-flight request's
+  // continuation compares against this to detect a stale result. Paired with
+  // `isActiveRef`, which the reset effect's cleanup flips off — covering both
+  // a board switch AND an unmount the same way `use-board-presence` does.
+  const generationRef = useRef(0);
+  const isActiveRef = useRef(true);
+
+  // Reset all paging state whenever the bound board or client changes (a new
+  // board's durable history is a different cursor space entirely) — mirrors
+  // `use-board-presence`'s per-board RESET.
+  useEffect(() => {
+    isActiveRef.current = true;
+    generationRef.current += 1;
+    isLoadingRef.current = false;
+    hasMoreRef.current = true;
+    olderHistoryRef.current = [];
+    setOlderHistory([]);
+    setIsLoadingOlder(false);
+    setHasMore(true);
+    return () => {
+      isActiveRef.current = false;
+    };
+  }, [boardId, client]);
+
+  const loadOlder = useCallback(() => {
+    const activeBoardId = boardIdRef.current;
+    const activeClient = clientRef.current;
+    if (activeBoardId === null || activeClient === null || activeClient.fetchHistory === undefined) {
+      return;
+    }
+    if (isLoadingRef.current || !hasMoreRef.current) {
+      return;
+    }
+
+    const knownClimbs = [...liveHistoryRef.current, ...olderHistoryRef.current];
+    const minSeq = lowestKnownSeq(knownClimbs);
+    const cursor = minSeq === null ? undefined : boardHistoryCursor(minSeq);
+
+    const requestGeneration = generationRef.current;
+    isLoadingRef.current = true;
+    setIsLoadingOlder(true);
+
+    void activeClient
+      .fetchHistory(activeBoardId, { limit: pageSize, before: cursor })
+      .then((page) => {
+        if (!isActiveRef.current || generationRef.current !== requestGeneration) {
+          return;
+        }
+        const knownKeys = new Set([...liveHistoryRef.current, ...olderHistoryRef.current].map(historyEntryKey));
+        // Duplicates always defer to the already-known entry: the durable
+        // `boardHistory` query re-resolves sender identity via a live DB join
+        // and nulls `queueItemUuid`/`gradeColor`, so the same (climbUuid, seq)
+        // can differ in shape from the live-feed/prior-page variant — the
+        // live-feed shape is the richer one (mirrors the reducer's
+        // `mergeHistory` policy).
+        const deduped = page.filter((climb) => !knownKeys.has(historyEntryKey(climb)));
+        const nextOlderHistory = [...olderHistoryRef.current, ...deduped];
+        olderHistoryRef.current = nextOlderHistory;
+        setOlderHistory(nextOlderHistory);
+        const nextHasMore = page.length === pageSize;
+        hasMoreRef.current = nextHasMore;
+        setHasMore(nextHasMore);
+        onPageLoadedRef.current?.({ pageSize, returnedCount: page.length });
+      })
+      .catch(() => {
+        if (!isActiveRef.current || generationRef.current !== requestGeneration) {
+          return;
+        }
+        // `boardHistory` is auth-required server-side — an anonymous client
+        // (or any other failure) should degrade to "no more history" rather
+        // than retry forever.
+        hasMoreRef.current = false;
+        setHasMore(false);
+      })
+      .finally(() => {
+        if (!isActiveRef.current || generationRef.current !== requestGeneration) {
+          return;
+        }
+        isLoadingRef.current = false;
+        setIsLoadingOlder(false);
+      });
+  }, [pageSize]);
+
+  return useMemo<BoardHistoryPagination>(
+    () => ({ olderHistory, isLoadingOlder, hasMore, loadOlder }),
+    [olderHistory, isLoadingOlder, hasMore, loadOlder],
+  );
+}

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -422,7 +422,8 @@
       "undoAria": "Undo the wall change",
       "actionLoading": "Loading climb",
       "actionFailed": "Couldn't load that climb. Try again.",
-      "loadingMore": "Loading more history"
+      "loadingMore": "Loading more history",
+      "loadMore": "Load more"
     },
     "toast": {
       "sessionEnded": "Session ended"

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -43,7 +43,9 @@
     "statHardest": "hardest",
     "statTopGrade": "most sent",
     "wallChanged": "You changed the wall",
-    "undo": "Undo"
+    "undo": "Undo",
+    "loadMore": "Load more",
+    "loadingMore": "Loading…"
   },
   "detail": {
     "subtitleSends_one": "{{count}} send",
@@ -419,7 +421,8 @@
       "undo": "Undo",
       "undoAria": "Undo the wall change",
       "actionLoading": "Loading climb",
-      "actionFailed": "Couldn't load that climb. Try again."
+      "actionFailed": "Couldn't load that climb. Try again.",
+      "loadingMore": "Loading more history"
     },
     "toast": {
       "sessionEnded": "Session ended"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -43,7 +43,9 @@
     "statHardest": "más difícil",
     "statTopGrade": "más repetido",
     "wallChanged": "Has cambiado el muro",
-    "undo": "Deshacer"
+    "undo": "Deshacer",
+    "loadMore": "Cargar más",
+    "loadingMore": "Cargando…"
   },
   "detail": {
     "subtitleSends_one": "{{count}} encadene",
@@ -419,7 +421,8 @@
       "undo": "Deshacer",
       "undoAria": "Deshacer el cambio del muro",
       "actionLoading": "Cargando el bloque",
-      "actionFailed": "No se pudo cargar ese bloque. Inténtalo de nuevo."
+      "actionFailed": "No se pudo cargar ese bloque. Inténtalo de nuevo.",
+      "loadingMore": "Cargando más historial"
     },
     "toast": {
       "sessionEnded": "Sesión terminada"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -422,7 +422,8 @@
       "undoAria": "Deshacer el cambio del muro",
       "actionLoading": "Cargando el bloque",
       "actionFailed": "No se pudo cargar ese bloque. Inténtalo de nuevo.",
-      "loadingMore": "Cargando más historial"
+      "loadingMore": "Cargando más historial",
+      "loadMore": "Cargar más"
     },
     "toast": {
       "sessionEnded": "Sesión terminada"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -43,7 +43,9 @@
     "statHardest": "le plus dur",
     "statTopGrade": "la plus fréquente",
     "wallChanged": "Tu as changé le mur",
-    "undo": "Annuler"
+    "undo": "Annuler",
+    "loadMore": "Charger plus",
+    "loadingMore": "Chargement…"
   },
   "detail": {
     "subtitleSends_one": "{{count}} enchaînement",
@@ -419,7 +421,8 @@
       "undo": "Annuler",
       "undoAria": "Annuler le changement du mur",
       "actionLoading": "Chargement du bloc",
-      "actionFailed": "Impossible de charger ce bloc. Réessayez."
+      "actionFailed": "Impossible de charger ce bloc. Réessayez.",
+      "loadingMore": "Chargement de l'historique"
     },
     "toast": {
       "sessionEnded": "Session terminée"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -422,7 +422,8 @@
       "undoAria": "Annuler le changement du mur",
       "actionLoading": "Chargement du bloc",
       "actionFailed": "Impossible de charger ce bloc. Réessayez.",
-      "loadingMore": "Chargement de l'historique"
+      "loadingMore": "Chargement de l'historique",
+      "loadMore": "Charger plus"
     },
     "toast": {
       "sessionEnded": "Session terminée"

--- a/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
@@ -11,6 +11,13 @@ const presence = vi.hoisted(() => ({
   stats: null as BoardPresenceStats | null,
 }));
 
+const historyPagination = vi.hoisted(() => ({
+  olderHistory: [] as BoardPresenceClimb[],
+  isLoadingOlder: false,
+  hasMore: true,
+  loadOlder: vi.fn(),
+}));
+
 const presenceControls = vi.hoisted(() => ({
   boardId: 123 as number | null,
 }));
@@ -35,6 +42,7 @@ vi.mock('@boardsesh/board-presence-react', () => ({
     isLive: true,
   }),
   useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
+  useBoardHistoryPagination: () => historyPagination,
 }));
 
 vi.mock('@/app/hooks/use-grade-format', () => ({
@@ -71,6 +79,8 @@ const SWITCH_BOARD_ARIA = tFromCatalog('session', 'boardPresence.switchBoardAria
 const CLOSE_ARIA = tFromCatalog('session', 'boardPresence.close');
 const EMPTY_TITLE = tFromCatalog('session', 'boardPresence.emptyTitle');
 const HISTORY_HEADER = tFromCatalog('session', 'boardPresence.historyHeader');
+const LOAD_MORE = tFromCatalog('session', 'boardPresence.loadMore');
+const LOADING_MORE = tFromCatalog('session', 'boardPresence.loadingMore');
 
 describe('BoardSheet', () => {
   beforeEach(() => {
@@ -78,6 +88,10 @@ describe('BoardSheet', () => {
     presence.history = [];
     presence.stats = null;
     presenceControls.boardId = 123;
+    historyPagination.olderHistory = [];
+    historyPagination.isLoadingOlder = false;
+    historyPagination.hasMore = true;
+    historyPagination.loadOlder.mockClear();
     analytics.track.mockClear();
   });
 
@@ -244,5 +258,91 @@ describe('BoardSheet', () => {
     );
 
     expect(analytics.track).toHaveBeenCalledTimes(2);
+  });
+
+  describe('load older history', () => {
+    it('renders a Load more button and calls loadOlder on click', () => {
+      presence.history = [makeClimb('c1', 3)];
+
+      const { getByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      const button = getByText(LOAD_MORE);
+      fireEvent.click(button);
+      expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the Load more button when there is no history yet', () => {
+      presence.history = [];
+
+      const { queryByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(queryByText(LOAD_MORE)).toBeNull();
+    });
+
+    it('hides the Load more button once hasMore is false (a short page ended pagination)', () => {
+      presence.history = [makeClimb('c1', 3)];
+      historyPagination.hasMore = false;
+
+      const { queryByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(queryByText(LOAD_MORE)).toBeNull();
+    });
+
+    it('renders loaded older rows appended after the live history', () => {
+      presence.history = [makeClimb('c2', 4)];
+      historyPagination.olderHistory = [makeClimb('c1', 3), makeClimb('c0', 2, { name: 'Oldest Climb' })];
+
+      const { getByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(getByText('Climb c2')).not.toBeNull();
+      expect(getByText('Climb c1')).not.toBeNull();
+      expect(getByText('Oldest Climb')).not.toBeNull();
+    });
+
+    it('disables the button and swaps its label while loading', () => {
+      presence.history = [makeClimb('c1', 3)];
+      historyPagination.isLoadingOlder = true;
+
+      const { getByText, queryByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(queryByText(LOAD_MORE)).toBeNull();
+      const button = getByText(LOADING_MORE).closest('button');
+      expect(button?.disabled).toBe(true);
+    });
   });
 });

--- a/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
@@ -327,6 +327,27 @@ describe('BoardSheet', () => {
       expect(getByText('Oldest Climb')).not.toBeNull();
     });
 
+    it('renders an overlapping older row only once — the live window wins (backfill overlap)', () => {
+      // The live window gained c1/3 AFTER the page containing it resolved
+      // (backfill / foreground catch-up merge); the render-path dedup must
+      // drop the durable copy or the list would have duplicate React keys.
+      presence.history = [makeClimb('c2', 4), makeClimb('c1', 3)];
+      historyPagination.olderHistory = [makeClimb('c1', 3, { name: 'Durable Variant' }), makeClimb('c0', 2)];
+
+      const { getAllByText, getByText, queryByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(getAllByText('Climb c1')).toHaveLength(1);
+      expect(queryByText('Durable Variant')).toBeNull();
+      expect(getByText('Climb c0')).not.toBeNull();
+    });
+
     it('disables the button and swaps its label while loading', () => {
       presence.history = [makeClimb('c1', 3)];
       historyPagination.isLoadingOlder = true;

--- a/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
+++ b/packages/web/app/components/board-presence/__tests__/board-sheet.test.tsx
@@ -16,6 +16,9 @@ const historyPagination = vi.hoisted(() => ({
   isLoadingOlder: false,
   hasMore: true,
   loadOlder: vi.fn(),
+  // The onPageLoaded callback BoardSheetBody passes to the (mocked) hook,
+  // captured so tests can fire it and assert the analytics wiring.
+  capturedOnPageLoaded: null as ((info: { pageSize: number; returnedCount: number }) => void) | null,
 }));
 
 const presenceControls = vi.hoisted(() => ({
@@ -42,7 +45,19 @@ vi.mock('@boardsesh/board-presence-react', () => ({
     isLive: true,
   }),
   useBoardPresenceFeed: () => ({ history: presence.history, stats: presence.stats }),
-  useBoardHistoryPagination: () => historyPagination,
+  useBoardHistoryPagination: (
+    _pageSize?: number,
+    onPageLoaded?: (info: { pageSize: number; returnedCount: number }) => void,
+  ) => {
+    historyPagination.capturedOnPageLoaded = onPageLoaded ?? null;
+    return {
+      olderHistory: historyPagination.olderHistory,
+      isLoadingOlder: historyPagination.isLoadingOlder,
+      hasMore: historyPagination.hasMore,
+      loadOlder: historyPagination.loadOlder,
+    };
+  },
+  boardHistoryEntryKey: (climb: BoardPresenceClimb) => `${climb.climbUuid}:${climb.seq}`,
 }));
 
 vi.mock('@/app/hooks/use-grade-format', () => ({
@@ -92,6 +107,7 @@ describe('BoardSheet', () => {
     historyPagination.isLoadingOlder = false;
     historyPagination.hasMore = true;
     historyPagination.loadOlder.mockClear();
+    historyPagination.capturedOnPageLoaded = null;
     analytics.track.mockClear();
   });
 
@@ -278,8 +294,29 @@ describe('BoardSheet', () => {
       expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
     });
 
-    it('does not render the Load more button when there is no history yet', () => {
+    it('still offers Load more when the live window is empty — durable rows may exist beyond it', () => {
+      // A wall quiet longer than the Redis window's TTL: empty live window,
+      // but weeks of durable boardHistory. The button (rendered with the
+      // empty state) is the only way to reach them.
       presence.history = [];
+
+      const { getByText } = render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      expect(getByText(EMPTY_TITLE)).not.toBeNull();
+      fireEvent.click(getByText(LOAD_MORE));
+      expect(historyPagination.loadOlder).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the Load more button once hasMore is false (a short page ended pagination)', () => {
+      presence.history = [makeClimb('c1', 3)];
+      historyPagination.hasMore = false;
 
       const { queryByText } = render(
         createElement(BoardSheet, {
@@ -293,8 +330,8 @@ describe('BoardSheet', () => {
       expect(queryByText(LOAD_MORE)).toBeNull();
     });
 
-    it('hides the Load more button once hasMore is false (a short page ended pagination)', () => {
-      presence.history = [makeClimb('c1', 3)];
+    it('hides the Load more button on an empty window once hasMore is false', () => {
+      presence.history = [];
       historyPagination.hasMore = false;
 
       const { queryByText } = render(
@@ -364,6 +401,31 @@ describe('BoardSheet', () => {
       expect(queryByText(LOAD_MORE)).toBeNull();
       const button = getByText(LOADING_MORE).closest('button');
       expect(button?.disabled).toBe(true);
+    });
+
+    it('tracks BoardHistoryPageLoaded with the boardId when a page resolves', () => {
+      presence.history = [makeClimb('c1', 3)];
+
+      render(
+        createElement(BoardSheet, {
+          open: true,
+          boardLabel: 'Garage Wall',
+          onClose: noop,
+          onSwitchBoard: noop,
+        }),
+      );
+
+      // The sheet hands its onPageLoaded callback to the pagination hook;
+      // firing it (as the real hook does when a page resolves) must emit the
+      // analytics event with the bound boardId attached.
+      expect(historyPagination.capturedOnPageLoaded).not.toBeNull();
+      historyPagination.capturedOnPageLoaded?.({ pageSize: 50, returnedCount: 37 });
+
+      expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryPageLoaded, {
+        boardId: 123,
+        pageSize: 50,
+        returnedCount: 37,
+      });
     });
   });
 });

--- a/packages/web/app/components/board-presence/board-sheet.tsx
+++ b/packages/web/app/components/board-presence/board-sheet.tsx
@@ -47,6 +47,11 @@ import { track } from '@/app/lib/analytics';
 import { DEFAULT_GRADE_COLOR, getGradeTextColor } from '@/app/lib/grade-colors';
 import { useBoardPresenceControls } from './board-presence-context';
 
+/** History rows are keyed (and deduped) by the immutable `(climbUuid, seq)` pair. */
+function historyRowKey(climb: BoardPresenceClimb): string {
+  return `${climb.climbUuid}-${climb.seq}`;
+}
+
 type BoardSheetProps = {
   open: boolean;
   /** The active board label, shown as the sheet subtitle + footer subtitle. */
@@ -150,8 +155,7 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
   const { history, stats } = useBoardPresenceFeed();
 
   // "Load older" — pages further back through the durable history log, past
-  // the live feed's in-memory HISTORY_CAP window. `olderHistory` is already
-  // deduped against the live window (and every prior page) by the hook.
+  // the live feed's in-memory HISTORY_CAP window.
   const handleHistoryPageLoaded = useCallback(
     (info: { pageSize: number; returnedCount: number }) => {
       track(SHARED_EVENTS.BoardHistoryPageLoaded, {
@@ -166,7 +170,16 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
     undefined,
     handleHistoryPageLoaded,
   );
-  const combinedHistory = useMemo(() => [...history, ...olderHistory], [history, olderHistory]);
+  // The hook dedupes each page only at resolve time; the live window can gain
+  // lower seqs AFTERWARDS (backfill / foreground catch-up merge — seam 2 in
+  // the hook's header), so re-filter here or overlapping entries would render
+  // twice with duplicate React keys.
+  const combinedHistory = useMemo(() => {
+    if (olderHistory.length === 0) return history;
+    const liveKeys = new Set(history.map(historyRowKey));
+    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(historyRowKey(climb)));
+    return dedupedOlder.length === 0 ? history : [...history, ...dedupedOlder];
+  }, [history, olderHistory]);
 
   // Fires once per open, when history is first non-empty. This body mounts
   // fresh each time the Drawer opens (unmounted while closed), so the ref
@@ -261,7 +274,7 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
           <List disablePadding>
             {combinedHistory.map((climb) => (
               <HistoryRow
-                key={`${climb.climbUuid}-${climb.seq}`}
+                key={historyRowKey(climb)}
                 climb={climb}
                 formattedGrade={climb.grade ? formatGrade(climb.grade) : null}
                 gradeColor={getGradeColor(climb.grade) ?? DEFAULT_GRADE_COLOR}

--- a/packages/web/app/components/board-presence/board-sheet.tsx
+++ b/packages/web/app/components/board-presence/board-sheet.tsx
@@ -30,11 +30,16 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import ButtonBase from '@mui/material/ButtonBase';
+import Button from '@mui/material/Button';
 import CloseOutlined from '@mui/icons-material/CloseOutlined';
 import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
-import { useBoardPresenceCurrent, useBoardPresenceFeed } from '@boardsesh/board-presence-react';
+import {
+  useBoardHistoryPagination,
+  useBoardPresenceCurrent,
+  useBoardPresenceFeed,
+} from '@boardsesh/board-presence-react';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
@@ -144,6 +149,25 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
   const { currentClimb } = useBoardPresenceCurrent();
   const { history, stats } = useBoardPresenceFeed();
 
+  // "Load older" — pages further back through the durable history log, past
+  // the live feed's in-memory HISTORY_CAP window. `olderHistory` is already
+  // deduped against the live window (and every prior page) by the hook.
+  const handleHistoryPageLoaded = useCallback(
+    (info: { pageSize: number; returnedCount: number }) => {
+      track(SHARED_EVENTS.BoardHistoryPageLoaded, {
+        boardId: boardId ?? undefined,
+        pageSize: info.pageSize,
+        returnedCount: info.returnedCount,
+      });
+    },
+    [boardId],
+  );
+  const { olderHistory, isLoadingOlder, hasMore, loadOlder } = useBoardHistoryPagination(
+    undefined,
+    handleHistoryPageLoaded,
+  );
+  const combinedHistory = useMemo(() => [...history, ...olderHistory], [history, olderHistory]);
+
   // Fires once per open, when history is first non-empty. This body mounts
   // fresh each time the Drawer opens (unmounted while closed), so the ref
   // naturally resets per open — mirrors the mobile `BoardSheetContent`.
@@ -231,11 +255,11 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
         </Box>
       ) : null}
 
-      {history.length > 0 ? (
+      {combinedHistory.length > 0 ? (
         <Box sx={{ px: 2, pb: 1 }}>
           <SectionHeader>{t('boardPresence.historyHeader')}</SectionHeader>
           <List disablePadding>
-            {history.map((climb) => (
+            {combinedHistory.map((climb) => (
               <HistoryRow
                 key={`${climb.climbUuid}-${climb.seq}`}
                 climb={climb}
@@ -245,6 +269,13 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
               />
             ))}
           </List>
+          {hasMore && history.length > 0 ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', pt: 1 }}>
+              <Button onClick={loadOlder} disabled={isLoadingOlder} size="small">
+                {isLoadingOlder ? t('boardPresence.loadingMore') : t('boardPresence.loadMore')}
+              </Button>
+            </Box>
+          ) : null}
         </Box>
       ) : null}
     </Box>

--- a/packages/web/app/components/board-presence/board-sheet.tsx
+++ b/packages/web/app/components/board-presence/board-sheet.tsx
@@ -36,6 +36,7 @@ import LightbulbOutlined from '@mui/icons-material/LightbulbOutlined';
 import ChevronRightOutlined from '@mui/icons-material/ChevronRightOutlined';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import {
+  boardHistoryEntryKey,
   useBoardHistoryPagination,
   useBoardPresenceCurrent,
   useBoardPresenceFeed,
@@ -46,11 +47,6 @@ import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { track } from '@/app/lib/analytics';
 import { DEFAULT_GRADE_COLOR, getGradeTextColor } from '@/app/lib/grade-colors';
 import { useBoardPresenceControls } from './board-presence-context';
-
-/** History rows are keyed (and deduped) by the immutable `(climbUuid, seq)` pair. */
-function historyRowKey(climb: BoardPresenceClimb): string {
-  return `${climb.climbUuid}-${climb.seq}`;
-}
 
 type BoardSheetProps = {
   open: boolean;
@@ -176,8 +172,8 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
   // twice with duplicate React keys.
   const combinedHistory = useMemo(() => {
     if (olderHistory.length === 0) return history;
-    const liveKeys = new Set(history.map(historyRowKey));
-    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(historyRowKey(climb)));
+    const liveKeys = new Set(history.map(boardHistoryEntryKey));
+    const dedupedOlder = olderHistory.filter((climb) => !liveKeys.has(boardHistoryEntryKey(climb)));
     return dedupedOlder.length === 0 ? history : [...history, ...dedupedOlder];
   }, [history, olderHistory]);
 
@@ -274,7 +270,7 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
           <List disablePadding>
             {combinedHistory.map((climb) => (
               <HistoryRow
-                key={historyRowKey(climb)}
+                key={boardHistoryEntryKey(climb)}
                 climb={climb}
                 formattedGrade={climb.grade ? formatGrade(climb.grade) : null}
                 gradeColor={getGradeColor(climb.grade) ?? DEFAULT_GRADE_COLOR}
@@ -282,13 +278,20 @@ function BoardSheetBody({ boardId }: { boardId: number | null }) {
               />
             ))}
           </List>
-          {hasMore && history.length > 0 ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', pt: 1 }}>
-              <Button onClick={loadOlder} disabled={isLoadingOlder} size="small">
-                {isLoadingOlder ? t('boardPresence.loadingMore') : t('boardPresence.loadMore')}
-              </Button>
-            </Box>
-          ) : null}
+        </Box>
+      ) : null}
+
+      {/* Gated on `hasMore` alone — NOT the list being non-empty. A wall
+          that's been quiet longer than the Redis window's TTL has an EMPTY
+          live window but durable boardHistory rows; this button (the hook
+          supports a cursor-less first page) is then the only way to reach
+          them. It sits under the list when there is one, under the empty
+          state when there isn't. */}
+      {hasMore ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', px: 2, pb: 1 }}>
+          <Button onClick={loadOlder} disabled={isLoadingOlder} size="small">
+            {isLoadingOlder ? t('boardPresence.loadingMore') : t('boardPresence.loadMore')}
+          </Button>
         </Box>
       ) : null}
     </Box>


### PR DESCRIPTION
## Summary

Third and final PR of the board-history sync & speed work (after #3344 and #3343 — **stacked on #3343's branch; retarget/rebase onto main once it merges**).

The durable keyset-paginated `boardHistory` GraphQL query has existed since the backend landed it (PR #2901) but was wired into no UI — the board sheet could only ever show the ~50-climb live window. This PR makes older history reachable:

- **New shared `useBoardHistoryPagination` hook** (`@boardsesh/board-presence-react`): pages the durable log via the existing `boardHistoryCursor` helper (cursor = min seq across the live window and loaded pages), dedupes each page against known `(climbUuid, seq)` entries (known entry wins — durable rows resolve sender identity via a live DB join and null `queueItemUuid`/`gradeColor`), flips `hasMore` off on a short page or rejection (the query is auth-required; logged-out users degrade silently), coalesces in-flight loads, and resets safely on board/client switch via a generation guard. Loaded pages live *outside* the shared reducer by design, so the live-window sync invariants and their tests are untouched.
- **New `BoardPresenceClientContext`** exposing `{boardId, client}` for sheet-scoped hooks.
- **Mobile**: infinite scroll in the board sheet (`onEndReached`, footer spinner), gated behind a real user scroll so short lists don't auto-fire a fetch on every presentation.
- **Web**: a "Load more" button under the history list; keys added to en-US/es/fr catalogs.
- **Render-path dedup on both platforms** (review finding): the live window can re-acquire lower seqs after a page load (backfill merges), so both sheets filter loaded pages against the live window at render — overlap can never produce duplicate rows/keys.
- **Analytics**: new `BoardHistoryPageLoaded` event ({boardId, pageSize, returnedCount}) from both platforms.

## Release Notes

- Scroll back through everything that's been up on the wall — board history no longer stops at the last 50 climbs

## Test plan

- 15 hook tests (cursor math incl. loaded pages, dedup known-wins, short-page/rejection `hasMore` flips, board-switch + unmount stale-generation guards, in-flight coalescing)
- Mobile sheet tests: scroll-gated end-reach → `fetchHistory(before = lowest seq)`, footer spinner, overlap renders once, durable copy of the current climb suppressed
- Web sheet tests: button click → cursor args, rows append, button hides on short page, overlap renders once
- `vp run typecheck` / `typecheck:mobile` green; `vp run test:web` 4857 passed; `vp run test:mobile` 2993 passed; board-presence-react 72 passed; `vp run check:mobile-bundle`, `check:i18n`, `check:i18n:orphans` all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGPxKbADkgeCZa1uoDQEER
