### PR TITLE
feat(backend): expose hasBetaVideo on userAscentsFeed items

### DIFF
--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -156,6 +156,7 @@ const insertBoardClimbStats = async (params: {
 
 const cleanup = async () => {
   await db.execute(sql`DELETE FROM user_climb_percentiles WHERE user_id IN (${TEST_USER_ID}, ${OTHER_USER_ID})`);
+  await db.execute(sql`DELETE FROM board_beta_links WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
   await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id IN (${TEST_USER_ID}, ${OTHER_USER_ID})`);
   await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid LIKE ${CLIMB_PREFIX + '%'}`);
   await db.execute(
@@ -508,6 +509,26 @@ describe('tickQueries — behavior fixes', () => {
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].climbName).toBe('Sloper Madness');
+    });
+  });
+
+  describe('userAscentsFeed — hasBetaVideo', () => {
+    it('marks only the ascents with a directly-attached beta link', async () => {
+      const climbUuid = `${CLIMB_PREFIX}beta`;
+      await insertClimb(climbUuid, 'Beta Test Climb');
+      await insertTick({ uuid: 'tick-beta-1', climbUuid, climbedAt: '2026-06-01T10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-beta-2', climbUuid, climbedAt: '2026-06-02T10:00:00', status: 'send' });
+      await db.execute(sql`
+        INSERT INTO board_beta_links (board_type, climb_uuid, link, tick_uuid)
+        VALUES ('kilter', ${climbUuid}, 'https://instagram.com/p/test-beta', 'tick-beta-1')
+      `);
+
+      const result = await callUserAscentsFeed(TEST_USER_ID, { sortBy: 'recent' });
+      const byUuid = new Map(
+        (result.items as Array<FeedItem & { hasBetaVideo: boolean }>).map((item) => [item.uuid, item.hasBetaVideo]),
+      );
+      expect(byUuid.get('tick-beta-1')).toBe(true);
+      expect(byUuid.get('tick-beta-2')).toBe(false);
     });
   });
 

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -64,7 +64,14 @@ const callUserGroupedAscentsFeed = (userId: string, input: Record<string, unknow
 
 const callUserAscentCaptionMatches = (userId: string, caption: string) =>
   tickQueries.userAscentCaptionMatches(undefined, { userId, caption }) as Promise<
-    Array<{ uuid: string; climbUuid: string; climbName: string; status: string; frames: string | null }>
+    Array<{
+      uuid: string;
+      climbUuid: string;
+      climbName: string;
+      status: string;
+      frames: string | null;
+      hasBetaVideo: boolean;
+    }>
   >;
 
 const callUserClimbPercentile = (userId: string) =>
@@ -541,10 +548,7 @@ describe('tickQueries — behavior fixes', () => {
         VALUES ('kilter', ${climbUuid}, 'https://instagram.com/p/test-beta-cap', 'tick-beta-cap-1')
       `);
 
-      const matches = (await callUserAscentCaptionMatches(TEST_USER_ID, 'Sent "Beta Caption Climb" @ 40°')) as Array<{
-        uuid: string;
-        hasBetaVideo: boolean;
-      }>;
+      const matches = await callUserAscentCaptionMatches(TEST_USER_ID, 'Sent "Beta Caption Climb" @ 40°');
       const byUuid = new Map(matches.map((match) => [match.uuid, match.hasBetaVideo]));
       expect(byUuid.get('tick-beta-cap-1')).toBe(true);
       expect(byUuid.get('tick-beta-cap-2')).toBe(false);

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -539,16 +539,34 @@ describe('tickQueries — behavior fixes', () => {
     });
 
     it('flows hasBetaVideo through the caption-matches shared builder', async () => {
-      const climbUuid = `${CLIMB_PREFIX}beta-caption`;
-      await insertClimb(climbUuid, 'Beta Caption Climb');
-      await insertTick({ uuid: 'tick-beta-cap-1', climbUuid, climbedAt: '2026-06-01T10:00:00', status: 'send' });
-      await insertTick({ uuid: 'tick-beta-cap-2', climbUuid, climbedAt: '2026-06-02T10:00:00', status: 'send' });
+      // Caption matches de-dupe by CLIMB (keeping the most recent send), so
+      // use two climbs with one tick each — a same-climb pair would collapse
+      // to the newest tick and hide the beta-carrying one.
+      const withBetaUuid = `${CLIMB_PREFIX}beta-cap-with`;
+      const withoutBetaUuid = `${CLIMB_PREFIX}beta-cap-without`;
+      await insertClimb(withBetaUuid, 'Beta Caption With');
+      await insertClimb(withoutBetaUuid, 'Beta Caption Without');
+      await insertTick({
+        uuid: 'tick-beta-cap-1',
+        climbUuid: withBetaUuid,
+        climbedAt: '2026-06-01T10:00:00',
+        status: 'send',
+      });
+      await insertTick({
+        uuid: 'tick-beta-cap-2',
+        climbUuid: withoutBetaUuid,
+        climbedAt: '2026-06-02T10:00:00',
+        status: 'send',
+      });
       await db.execute(sql`
         INSERT INTO board_beta_links (board_type, climb_uuid, link, tick_uuid)
-        VALUES ('kilter', ${climbUuid}, 'https://instagram.com/p/test-beta-cap', 'tick-beta-cap-1')
+        VALUES ('kilter', ${withBetaUuid}, 'https://instagram.com/p/test-beta-cap', 'tick-beta-cap-1')
       `);
 
-      const matches = await callUserAscentCaptionMatches(TEST_USER_ID, 'Sent "Beta Caption Climb" @ 40°');
+      const matches = await callUserAscentCaptionMatches(
+        TEST_USER_ID,
+        'Sent "Beta Caption With" and "Beta Caption Without" @ 40°',
+      );
       const byUuid = new Map(matches.map((match) => [match.uuid, match.hasBetaVideo]));
       expect(byUuid.get('tick-beta-cap-1')).toBe(true);
       expect(byUuid.get('tick-beta-cap-2')).toBe(false);

--- a/packages/backend/src/__tests__/tick-queries.test.ts
+++ b/packages/backend/src/__tests__/tick-queries.test.ts
@@ -530,6 +530,25 @@ describe('tickQueries — behavior fixes', () => {
       expect(byUuid.get('tick-beta-1')).toBe(true);
       expect(byUuid.get('tick-beta-2')).toBe(false);
     });
+
+    it('flows hasBetaVideo through the caption-matches shared builder', async () => {
+      const climbUuid = `${CLIMB_PREFIX}beta-caption`;
+      await insertClimb(climbUuid, 'Beta Caption Climb');
+      await insertTick({ uuid: 'tick-beta-cap-1', climbUuid, climbedAt: '2026-06-01T10:00:00', status: 'send' });
+      await insertTick({ uuid: 'tick-beta-cap-2', climbUuid, climbedAt: '2026-06-02T10:00:00', status: 'send' });
+      await db.execute(sql`
+        INSERT INTO board_beta_links (board_type, climb_uuid, link, tick_uuid)
+        VALUES ('kilter', ${climbUuid}, 'https://instagram.com/p/test-beta-cap', 'tick-beta-cap-1')
+      `);
+
+      const matches = (await callUserAscentCaptionMatches(TEST_USER_ID, 'Sent "Beta Caption Climb" @ 40°')) as Array<{
+        uuid: string;
+        hasBetaVideo: boolean;
+      }>;
+      const byUuid = new Map(matches.map((match) => [match.uuid, match.hasBetaVideo]));
+      expect(byUuid.get('tick-beta-cap-1')).toBe(true);
+      expect(byUuid.get('tick-beta-cap-2')).toBe(false);
+    });
   });
 
   describe('userGroupedAscentsFeed — pagination & grouping', () => {

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -533,7 +533,9 @@ export const tickQueries = {
             .from(dbSchema.boardBetaLinks)
             .where(inArray(dbSchema.boardBetaLinks.tickUuid, pageTickUuids))
         : [];
-    const ticksWithBeta = new Set(betaLinkRows.map((row) => row.tickUuid));
+    const ticksWithBeta = new Set(
+      betaLinkRows.map((row) => row.tickUuid).filter((tickUuid): tickUuid is string => tickUuid !== null),
+    );
 
     // Map results to response format
     const items = results.map(

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -46,6 +46,7 @@ type AscentFeedRow = {
   comment: string;
   climbedAt: string;
   frames: string | null;
+  hasBetaVideo: boolean;
 };
 
 export const tickQueries = {
@@ -521,6 +522,19 @@ export const tickQueries = {
       .limit(limit)
       .offset(offset);
 
+    // One query for the whole page: which of these ascents have a beta video
+    // directly attached (board_beta_links.tick_uuid, unique per tick). Drives
+    // the logbook row's video marker without an N+1.
+    const pageTickUuids = results.map(({ tick }) => tick.uuid);
+    const betaLinkRows =
+      pageTickUuids.length > 0
+        ? await db
+            .select({ tickUuid: dbSchema.boardBetaLinks.tickUuid })
+            .from(dbSchema.boardBetaLinks)
+            .where(inArray(dbSchema.boardBetaLinks.tickUuid, pageTickUuids))
+        : [];
+    const ticksWithBeta = new Set(betaLinkRows.map((row) => row.tickUuid));
+
     // Map results to response format
     const items = results.map(
       ({
@@ -568,6 +582,7 @@ export const tickQueries = {
           comment: tick.comment || '',
           climbedAt: tick.climbedAt,
           frames,
+          hasBetaVideo: ticksWithBeta.has(tick.uuid),
         };
       },
     );

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -983,6 +983,12 @@ type AscentFeedItem {
   consensusDifficultyName: String
   "Average quality rating from all users"
   qualityAverage: Float
+  """
+  Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
+  Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
+  don't resolve it (following/global activity).
+  """
+  hasBetaVideo: Boolean
   "Whether this is a benchmark climb"
   isBenchmark: Boolean!
   "Whether matching is disallowed on this climb"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -238,6 +238,12 @@ export type AscentFeedItem = {
   difficultyName?: Maybe<Scalars['String']['output']>;
   /** Encoded hold frames for thumbnail display */
   frames?: Maybe<Scalars['String']['output']>;
+  /**
+   * Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
+   * Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
+   * don't resolve it (following/global activity).
+   */
+  hasBetaVideo?: Maybe<Scalars['Boolean']['output']>;
   /** Whether this is a benchmark climb */
   isBenchmark: Scalars['Boolean']['output'];
   /** Whether climb was mirrored */
@@ -6854,6 +6860,7 @@ export type AscentFeedItemResolvers<
   difficulty?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   difficultyName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   frames?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hasBetaVideo?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   isBenchmark?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isMirror?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isNoMatch?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -43,6 +43,12 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     consensusDifficultyName: String
     "Average quality rating from all users"
     qualityAverage: Float
+    """
+    Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
+    Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
+    don't resolve it (following/global activity).
+    """
+    hasBetaVideo: Boolean
     "Whether this is a benchmark climb"
     isBenchmark: Boolean!
     "Whether matching is disallowed on this climb"

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -235,6 +235,12 @@ export type AscentFeedItem = {
   difficultyName?: Maybe<Scalars['String']['output']>;
   /** Encoded hold frames for thumbnail display */
   frames?: Maybe<Scalars['String']['output']>;
+  /**
+   * Whether a beta video is attached to this ascent (board_beta_links.tick_uuid).
+   * Populated by userAscentsFeed/userAscentCaptionMatches; null on feeds that
+   * don't resolve it (following/global activity).
+   */
+  hasBetaVideo?: Maybe<Scalars['Boolean']['output']>;
   /** Whether this is a benchmark climb */
   isBenchmark: Scalars['Boolean']['output'];
   /** Whether climb was mirrored */


### PR DESCRIPTION
## Summary

Adds `hasBetaVideo: Boolean` to `AscentFeedItem`, resolved in `userAscentsFeed` via one batched `board_beta_links.tick_uuid IN (…)` query per page (the unique index guarantees at most one clip per tick). `userAscentCaptionMatches` inherits it through the shared builder. Purely additive — no consumer selects the field yet.

**Ordering matters:** this must merge and deploy **before** [#3350](https://github.com/boardsesh/boardsesh/pull/3350) re-adds the field to the mobile feed queries. Production GraphQL rejects unknown fields, and the per-PR OTA bundles point at production — shipping the query first briefly broke the logbook feed on the preview channel (since rolled back there). Backend-first is the expand step; #3350 completes it.

Integration test covers the marked/unmarked split per tick.

## Release Notes

- [x] No release note needed (internal / technical change — the user-facing part ships with the logbook redesign)

## Test plan

- `vp run typecheck:backend` / `typecheck:shared` — green.
- New integration test in `tick-queries.test.ts`: two ticks on one climb, beta link attached to one → `hasBetaVideo` true/false respectively (runs in CI; local backend DB tests are environment-flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
