### PR TITLE
refactor(web): extract single queue-actions factory shared by board and bridge surfaces

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -92,6 +92,10 @@ Both `PersistentSessionContext` and `QueueContext` are split into separate **Act
 
 Targeted hooks: `useQueueActions()`, `useQueueData()`, `usePersistentSessionActions()`, `usePersistentSessionState()`.
 
+### Shared queue-actions factory
+
+The queue-action surface itself (add/remove/set-current/navigate/mirror/replace/report-wall-disconnect) has a single implementation: `createQueueActionsCore(deps)` in `packages/web/app/components/queue-control/queue-actions-core.ts`. Both `GraphQLQueueProvider` (board routes) and the bridge's `usePersistentSessionQueueAdapter` (off-board) wire it with their own dependencies — most notably `applyLocal` (how an optimistic reducer action is applied: reducer `dispatch` on board routes; the shared `queueReducer` against the local store in bridge-solo; a **no-op in bridge-party**, which waits for the server echo instead of applying optimistic updates) and `discoverNext`/`discoverPrev` (search-results neighbor walk on board routes vs the shared `findNextQueueItemWithSuggestions` off-board). Every genuine per-surface behavioral difference is an explicit injected dep on `QueueActionsCoreDeps`, documented at the definition.
+
 ### QueueBridgeProvider — root-level QueueContext
 
 `QueueBridgeProvider` (`packages/web/app/components/queue-control/queue-bridge-context.tsx`) is mounted once at the root inside `PersistentSessionWrapper` so a `QueueContext` value is always available, even off board routes (e.g. `/you/logbook`, `/session/[sessionId]`, `/playlists/...`). It has two modes:
@@ -1900,6 +1904,7 @@ A GraphQL mutation would require either the JS GraphQL client (not available in 
 - `packages/web/app/components/graphql-queue/use-queue-session.ts` - Session hook
 - `packages/web/app/components/persistent-session/persistent-session-context.tsx` - Root-level session management (split into ActionsContext + StateContext for render performance)
 - `packages/web/app/components/graphql-queue/QueueContext.tsx` - Queue state context (split into ActionsContext + DataContext; actions use `latestRef` pattern for stable callback identity)
+- `packages/web/app/components/queue-control/queue-actions-core.ts` - Single queue-actions factory (`createQueueActionsCore`) wired by both `QueueContext.tsx` and `queue-bridge-context.tsx`; per-surface differences are injected deps
 
 ### Native iOS
 

--- a/packages/web/app/components/graphql-queue/QueueContext.tsx
+++ b/packages/web/app/components/graphql-queue/QueueContext.tsx
@@ -6,21 +6,9 @@ import { useSearchParams } from 'next/navigation';
 import { v4 as uuidv4 } from 'uuid';
 import { useQueueReducer } from '../queue-control/reducer';
 import { useQueueDataFetching } from '../queue-control/hooks/use-queue-data-fetching';
-import type {
-  ClimbQueueItem,
-  UserName,
-  QueueItemUser,
-  AddToQueueSource,
-  PlaylistSuggestionSource,
-  SetCurrentClimbOptions,
-} from '../queue-control/types';
-import {
-  getPlaylistPeekQueueItemUuid,
-  getPlaylistSuggestedClimbs,
-  insertQueueItemAfterCurrent,
-  isPlaylistPeekQueueItemUuid,
-  pruneSuggestedQueueItemsAfterCurrent,
-} from '../queue-control/playlist-suggestions';
+import type { ClimbQueueItem, UserName, QueueItemUser, PlaylistSuggestionSource } from '../queue-control/types';
+import { getPlaylistPeekQueueItemUuid, getPlaylistSuggestedClimbs } from '../queue-control/playlist-suggestions';
+import { createQueueActionsCore, type QueueActionsCoreDeps } from '../queue-control/queue-actions-core';
 import { urlParamsToSearchParams, searchParamsToUrlParams } from '@/app/lib/url-utils';
 import type { Climb, SearchRequestPagination } from '@/app/lib/types';
 import { usePartyProfile } from '../party-manager/party-profile-context';
@@ -31,9 +19,8 @@ import { useClimbActionsData } from '@/app/hooks/use-climb-actions-data';
 import { SUGGESTIONS_THRESHOLD } from '../board-page/constants';
 import { useSnackbar } from '../providers/snackbar-provider';
 import SessionSummaryDialog from '../session-summary/session-summary-dialog';
-import { trackQueueOperation, trackQueueOperationError, resolveQueueOperationMode } from '@/app/lib/queue-metrics';
+import { trackQueueOperation, trackQueueOperationError } from '@/app/lib/queue-metrics';
 
-import { dispatchOpenPlayDrawer } from '../queue-control/play-drawer-event';
 import { useSessionIdManagement } from './hooks/use-session-id-management';
 import { useQueueRestoration } from './hooks/use-queue-restoration';
 import { useQueueEventSubscription } from './hooks/use-queue-event-subscription';
@@ -479,273 +466,225 @@ export const GraphQLQueueProvider = ({
     return clientId ? `${clientId}-${++correlationCounterRef.current}` : undefined;
   }, []);
 
-  const addToQueue = useCallback((climb: Climb, source: AddToQueueSource = 'unknown') => {
-    const startTime = performance.now();
-    const latest = latestRef.current;
-    if (latest.guardMutation()) return;
-    if (!latest.validateQueueAdd(climb)) return;
-    const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-    const newItem = createClimbQueueItem(climb, latest.clientId, latest.currentUserInfo);
-    latest.dispatch({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item: newItem } });
-    const partyMode = latest.isPersistentSessionActive && latest.persistentSession.users.length > 1;
-    // `latest.state.queue.length` reflects the most recent committed render,
-    // so two adds dispatched back-to-back in the same tick will both report
-    // the same `currentQueueLength + 1`. Acceptable for the queue-churn
-    // dashboard tile; the dispatched reducer state will still be correct.
-    track('Climb Added to Queue', {
-      boardLayout: latest.boardDetails?.layout_name ?? null,
-      addedFromTab: source,
-      currentQueueLength: latest.state.queue.length + 1,
-      partyMode,
-    });
-    if (latest.isDisconnected && latest.isPersistentSessionActive) {
-      latest.offlineBuffer.bufferAddition(newItem);
-      trackQueueOperation('addToQueue', performance.now() - startTime, mode);
-    } else if (latest.hasConnected && latest.isPersistentSessionActive) {
-      latest.persistentSession
-        .addQueueItem(newItem)
-        .then(() => trackQueueOperation('addToQueue', performance.now() - startTime, mode))
-        .catch((error: unknown) => {
-          console.error('Failed to add queue item:', error);
-          trackQueueOperationError('addToQueue', mode);
-        });
-    } else {
-      trackQueueOperation('addToQueue', performance.now() - startTime, mode);
-    }
-  }, []);
-
-  const removeFromQueue = useCallback((item: ClimbQueueItem) => {
-    const startTime = performance.now();
-    const latest = latestRef.current;
-    if (latest.guardMutation()) return;
-    const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-    latest.dispatch({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid: item.uuid } });
-    const partyMode = latest.isPersistentSessionActive && latest.persistentSession.users.length > 1;
-    track('Climb Removed from Queue', {
-      boardLayout: latest.boardDetails?.layout_name ?? null,
-      partyMode,
-      removedBy: 'self',
-    });
-    if (!latest.isDisconnected && latest.hasConnected && latest.isPersistentSessionActive) {
-      latest.persistentSession
-        .removeQueueItem(item.uuid)
-        .then(() => trackQueueOperation('removeFromQueue', performance.now() - startTime, mode))
-        .catch((error: unknown) => {
-          console.error('Failed to remove queue item:', error);
-          trackQueueOperationError('removeFromQueue', mode);
-        });
-    } else {
-      trackQueueOperation('removeFromQueue', performance.now() - startTime, mode);
-    }
-  }, []);
-
-  // Resolves to the freshly-created ClimbQueueItem so callers (notably the
-  // create form) can capture its uuid and later call replaceQueueItem on
-  // subsequent edits. Resolves to null when validation fails or the mutation
-  // is guarded.
-  const setCurrentClimb = useCallback(
-    async (climb: Climb, options: SetCurrentClimbOptions): Promise<ClimbQueueItem | null> => {
-      const startTime = performance.now();
-      const latest = latestRef.current;
-      if (latest.guardMutation()) return null;
-      if (!latest.validateQueueAdd(climb)) return null;
-      const { playlistSuggestionSource } = options;
-      const previousPlaylistSuggestionSource = latest.state.playlistSuggestionSource;
-      const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-      const newItem = createClimbQueueItem(climb, latest.clientId, latest.currentUserInfo);
-      const correlationId = nextCorrelationId();
-      latest.dispatch({
-        type: 'DELTA_UPDATE_CURRENT_CLIMB',
-        payload: {
-          item: newItem,
-          shouldAddToQueue: true,
-          insertAfterCurrent: true,
-          correlationId,
-          playlistSuggestionSource,
-        },
-      });
-      // Central funnel instrumentation — fires from every UI path that
-      // activates a new climb (queue list tap, browse preview, playlist
-      // activation, SetActiveAction button, lightbulb re-assert). Previously
-      // this event only fired from the SetActiveAction button, missing the
-      // ~7 other entry points and dropping the "Session Started → Set
-      // Active Climb" funnel conversion to ~6%.
-      track('Set Active Climb', {
-        climbUuid: climb.uuid,
-        boardType: climb.boardType ?? null,
-        layoutId: climb.layoutId ?? null,
-        source: 'setCurrentClimb' satisfies SetActiveClimbSource,
-      });
-      if (latest.sessionId) incrementSessionClimbsAttempted(latest.sessionId);
-      if (latest.isDisconnected && latest.isPersistentSessionActive) {
-        latest.offlineBuffer.bufferAddition(newItem);
-        trackQueueOperation('setCurrentClimb', performance.now() - startTime, mode);
-      } else if (latest.hasConnected && latest.isPersistentSessionActive) {
-        const currentIndex = latest.state.currentClimbQueueItem
-          ? latest.state.queue.findIndex((queueItem) => queueItem.uuid === latest.state.currentClimbQueueItem?.uuid)
-          : -1;
-        const position = currentIndex === -1 ? undefined : currentIndex + 1;
-        try {
-          if (playlistSuggestionSource) {
-            const queueWithNewItem = insertQueueItemAfterCurrent(
-              latest.state.queue,
-              latest.state.currentClimbQueueItem,
-              newItem,
-            );
-            const prunedQueue = pruneSuggestedQueueItemsAfterCurrent(queueWithNewItem, newItem);
-            await latest.persistentSession.setQueue(prunedQueue, newItem);
-          } else {
-            await latest.persistentSession.addQueueItem(newItem, position);
-            await latest.persistentSession.setCurrentClimb(newItem, false, correlationId);
-          }
-          trackQueueOperation('setCurrentClimb', performance.now() - startTime, mode);
-        } catch (error: unknown) {
-          console.error('Failed to set current climb:', error);
-          if (correlationId) latest.dispatch({ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId } });
-          latest.dispatch({ type: 'SET_PLAYLIST_SUGGESTION_SOURCE', payload: previousPlaylistSuggestionSource });
-          trackQueueOperationError('setCurrentClimb', mode);
+  // --- Single shared queue-actions implementation (see queue-actions-core.ts) ---
+  // Every field here is a closure that reads `latestRef.current` at call
+  // time, so this can be constructed once (`useMemo(..., [])`) and still stay
+  // fresh — the callbacks it returns are as stable as `nextCorrelationId`
+  // above.
+  const actionsCoreDeps = useMemo<QueueActionsCoreDeps>(
+    () => ({
+      getSnapshot: () => ({
+        queue: latestRef.current.state.queue,
+        currentClimbQueueItem: latestRef.current.state.currentClimbQueueItem,
+        playlistSuggestionSource: latestRef.current.state.playlistSuggestionSource,
+      }),
+      applyLocal: (action) => latestRef.current.dispatch(action),
+      setPlaylistSuggestionSourceLocal: (source) =>
+        latestRef.current.dispatch({ type: 'SET_PLAYLIST_SUGGESTION_SOURCE', payload: source }),
+      // Dispatch the reducer's REFRESH action (it does the identity-match
+      // check against live reducer state, not a possibly-stale ref snapshot).
+      refreshPlaylistSuggestionSourceLocal: (source) =>
+        latestRef.current.dispatch({ type: 'REFRESH_PLAYLIST_SUGGESTION_SOURCE', payload: source }),
+      buildItem: (climb, suggested) =>
+        createClimbQueueItem(climb, latestRef.current.clientId, latestRef.current.currentUserInfo, suggested),
+      guardMutation: () => latestRef.current.guardMutation(),
+      validateClimbForQueue: (climb) => latestRef.current.validateQueueAdd(climb),
+      offlineBuffer: {
+        bufferAddition: (item) => latestRef.current.offlineBuffer.bufferAddition(item),
+      },
+      // Only suggestion-derived items get auto-queued (mirrors the reducer's
+      // own DELTA_UPDATE_CURRENT_CLIMB `shouldAddToQueue` gate).
+      resolveShouldAddToQueueOnActivate: (item) => !!item.suggested,
+      // QueueContext always keeps the existing current climb on setQueue,
+      // even if it fell out of the new queue — callers are expected to keep
+      // it consistent themselves (e.g. drag-reorder never drops it).
+      resolveNextCurrentForSetQueue: () => latestRef.current.state.currentClimbQueueItem,
+      buildReplacementItem: (existing, climb, queueItemUuid) => {
+        const base = createClimbQueueItem(climb, latestRef.current.clientId, latestRef.current.currentUserInfo);
+        return {
+          ...base,
+          uuid: queueItemUuid,
+          addedBy: existing?.addedBy ?? base.addedBy,
+          addedByUser: existing?.addedByUser ?? base.addedByUser,
+          tickedBy: existing?.tickedBy,
+        };
+      },
+      discoverNext: (anchor) => {
+        const latest = latestRef.current;
+        const buildSuggestedQueueItem = makeBuildSuggestedQueueItem(latest);
+        const queue = latest.state.queue;
+        // With no anchor at all (no current climb, no `from`), Next surfaces
+        // queue[0] so the Queue bar's Next button can start a queue the user
+        // has built but not yet activated. If the queue is also empty, fall
+        // through to suggestedClimbs[0] so a fresh load with populated
+        // suggestions still exposes a Next.
+        if (anchor == null) {
+          if (queue[0]) return queue[0];
+          const firstSuggestion = latest.suggestedClimbs[0];
+          return firstSuggestion ? buildSuggestedQueueItem(firstSuggestion) : null;
         }
-      } else {
-        trackQueueOperation('setCurrentClimb', performance.now() - startTime, mode);
-      }
-      return newItem;
-    },
+        const anchorClimbUuid = anchor.climb?.uuid;
+        const queueItemIndex = queue.findIndex((queueItem) => queueItem.uuid === anchor.uuid);
+        if (queueItemIndex >= 0 && queueItemIndex < queue.length - 1) {
+          return queue[queueItemIndex + 1];
+        }
+        // Playlist-suggestion mode: suggestedClimbs is the curated next-up
+        // feed (climbs after the activated one, queued items already
+        // filtered out). The anchor isn't in this feed, so position-based
+        // walking doesn't apply — the next-up is whatever sits at the head.
+        if (latest.state.playlistSuggestionSource) {
+          const nextClimb = latest.suggestedClimbs[0];
+          return nextClimb ? buildSuggestedQueueItem(nextClimb) : null;
+        }
+        const fromSearch = findUnqueuedNeighborInSearchResults(
+          latest.climbSearchResults,
+          anchorClimbUuid,
+          queue,
+          1,
+          buildSuggestedQueueItem,
+        );
+        if (fromSearch) return fromSearch;
+        // Cross-search-session continuity: anchor isn't in current
+        // climbSearchResults (e.g. queue was built from a previous search).
+        // Surface the first unqueued suggestion rather than dead-ending the
+        // Next button.
+        const fallback = pickUnqueuedSuggestion(latest.suggestedClimbs, queue, anchorClimbUuid);
+        return fallback ? buildSuggestedQueueItem(fallback) : null;
+      },
+      discoverPrev: (anchor) => {
+        // No anchor (no current climb, no `from`): backward navigation has
+        // no semantic answer — don't fabricate one from suggestions. Forward
+        // surfaces queue[0] to start an unactivated queue; backward has no
+        // symmetric "start" semantics.
+        if (anchor == null) return null;
+        const latest = latestRef.current;
+        const buildSuggestedQueueItem = makeBuildSuggestedQueueItem(latest);
+        const anchorClimbUuid = anchor.climb?.uuid;
+        const queue = latest.state.queue;
+        const queueItemIndex = queue.findIndex((queueItem) => queueItem.uuid === anchor.uuid);
+        if (queueItemIndex > 0) return queue[queueItemIndex - 1];
+        // In playlist-suggestion mode there's no "previous playlist climb"
+        // once the activated climb is current — the playlist is consumed
+        // forward only. Don't fall through to climbSearchResults, that would
+        // surface unrelated results.
+        if (latest.state.playlistSuggestionSource) return null;
+        // Backward navigation is history-oriented: the queue walk above is
+        // the history step. When neither queue nor search results yield a
+        // backward neighbour, don't fall through to suggestedClimbs — that's
+        // discovery (the forward direction).
+        return findUnqueuedNeighborInSearchResults(
+          latest.climbSearchResults,
+          anchorClimbUuid,
+          queue,
+          -1,
+          buildSuggestedQueueItem,
+        );
+      },
+      party: {
+        get isActive() {
+          return latestRef.current.isPersistentSessionActive;
+        },
+        get hasConnected() {
+          return latestRef.current.hasConnected;
+        },
+        get isDisconnected() {
+          return latestRef.current.isDisconnected;
+        },
+        get attemptMutation() {
+          return latestRef.current.hasConnected && !latestRef.current.isDisconnected;
+        },
+        reuseExistingQueueItemOnSetCurrentClimb: false,
+        returnNullOnSetCurrentClimbFailure: false,
+        mutations: {
+          addQueueItem: (item, position) => latestRef.current.persistentSession.addQueueItem(item, position),
+          removeQueueItem: (uuid) => latestRef.current.persistentSession.removeQueueItem(uuid),
+          setCurrentClimb: (item, shouldAddToQueue, correlationId) =>
+            latestRef.current.persistentSession.setCurrentClimb(item, shouldAddToQueue, correlationId),
+          mirrorCurrentClimb: (mirrored) => latestRef.current.persistentSession.mirrorCurrentClimb(mirrored),
+          setQueue: (queue, currentClimbQueueItem) =>
+            latestRef.current.persistentSession.setQueue(queue, currentClimbQueueItem),
+          replaceQueueItem: (uuid, item) => latestRef.current.persistentSession.replaceQueueItem(uuid, item),
+          reportWallDisconnect: () => latestRef.current.persistentSession.reportWallDisconnect(),
+        },
+        nextCorrelationId: () => nextCorrelationId(),
+      },
+      hooks: {
+        resolveSetActiveClimbSource: (kind) =>
+          (kind === 'setCurrentClimb' ? 'setCurrentClimb' : 'setCurrentClimbQueueItem') satisfies SetActiveClimbSource,
+        // Central funnel instrumentation — fires from every UI path that
+        // activates a new climb (queue list tap, browse preview, playlist
+        // activation, SetActiveAction button, lightbulb re-assert).
+        // Previously this event only fired from the SetActiveAction button,
+        // missing the ~7 other entry points and dropping the "Session
+        // Started → Set Active Climb" funnel conversion to ~6%.
+        onSetActiveClimb: (payload) => track('Set Active Climb', payload),
+        onClimbActivated: () => {
+          const { sessionId } = latestRef.current;
+          if (sessionId) incrementSessionClimbsAttempted(sessionId);
+        },
+        onQueueItemAdded: ({ source, queueLengthAfter }) => {
+          const latest = latestRef.current;
+          const partyMode = latest.isPersistentSessionActive && latest.persistentSession.users.length > 1;
+          // `queueLengthAfter` reflects the most recent committed render, so
+          // two adds dispatched back-to-back in the same tick will both
+          // report the same length. Acceptable for the queue-churn dashboard
+          // tile; the dispatched reducer state will still be correct.
+          track('Climb Added to Queue', {
+            boardLayout: latest.boardDetails?.layout_name ?? null,
+            addedFromTab: source,
+            currentQueueLength: queueLengthAfter,
+            partyMode,
+          });
+        },
+        onQueueItemRemoved: () => {
+          const latest = latestRef.current;
+          const partyMode = latest.isPersistentSessionActive && latest.persistentSession.users.length > 1;
+          track('Climb Removed from Queue', {
+            boardLayout: latest.boardDetails?.layout_name ?? null,
+            partyMode,
+            removedBy: 'self',
+          });
+        },
+        onOperationMetric: {
+          success: (operation, durationMs, mode) => trackQueueOperation(operation, durationMs, mode),
+          error: (operation, mode) => trackQueueOperationError(operation, mode),
+        },
+      },
+      errorMessages: {
+        addToQueue: 'Failed to add queue item:',
+        removeFromQueue: 'Failed to remove queue item:',
+        setQueue: 'Failed to set queue:',
+        mirrorClimb: 'Failed to mirror climb:',
+        replaceQueueItem: 'Failed to replace queue item:',
+        setCurrentClimb: {
+          reuse: 'Failed to set current climb:',
+          playlist: 'Failed to set current climb:',
+          add: 'Failed to set current climb:',
+          activate: 'Failed to set current climb:',
+        },
+        setCurrentClimbQueueItem: 'Failed to set current climb:',
+        reportWallDisconnect: 'Failed to report wall disconnect:',
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
-
-  // Browse-initiated drawer open. Always-live model: every participant
-  // broadcasts on browse exactly like solo — pre-mutate state (which the
-  // persistent session broadcasts when a party session is active) then open
-  // the drawer. Pass `playlistSuggestionSource: null` so activating a
-  // non-playlist climb clears any stale playlist source carried over from a
-  // prior activation.
-  const previewClimbFromBrowse = useCallback(
-    (climb: Climb) => {
-      void setCurrentClimb(climb, { playlistSuggestionSource: null });
-      dispatchOpenPlayDrawer();
-    },
-    [setCurrentClimb],
-  );
-
-  // Report this client's own BLE link drop to the session so every member's
-  // wall-confirmed lightbulb clears. Best-effort and a no-op in solo (the
-  // persistent-session helper short-circuits with no active session).
-  const reportWallDisconnect = useCallback(async (): Promise<void> => {
-    const latest = latestRef.current;
-    if (!latest.isPersistentSessionActive) return;
-    if (!latest.hasConnected) return;
-    try {
-      await latest.persistentSession.reportWallDisconnect();
-    } catch (error: unknown) {
-      console.error('Failed to report wall disconnect:', error);
-    }
-  }, []);
-
-  // Replace an existing queue item in place with a new climb, preserving the
-  // queue-item uuid and the existing addedBy attribution. Used by the create
-  // form on subsequent saves so the queue item stays in the same slot instead
-  // of piling up duplicates.
-  const replaceQueueItem = useCallback((queueItemUuid: string, climb: Climb) => {
-    const startTime = performance.now();
-    const latest = latestRef.current;
-    if (latest.guardMutation()) return;
-    if (!latest.validateQueueAdd(climb)) return;
-    const existing = latest.state.queue.find((qItem) => qItem.uuid === queueItemUuid);
-    const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-    const base = createClimbQueueItem(climb, latest.clientId, latest.currentUserInfo);
-    const newItem: ClimbQueueItem = {
-      ...base,
-      uuid: queueItemUuid,
-      addedBy: existing?.addedBy ?? base.addedBy,
-      addedByUser: existing?.addedByUser ?? base.addedByUser,
-      tickedBy: existing?.tickedBy,
-    };
-    latest.dispatch({
-      type: 'DELTA_REPLACE_QUEUE_ITEM',
-      payload: { uuid: queueItemUuid, item: newItem },
-    });
-    if (!latest.isDisconnected && latest.hasConnected && latest.isPersistentSessionActive) {
-      latest.persistentSession
-        .replaceQueueItem(queueItemUuid, newItem)
-        .then(() => trackQueueOperation('replaceQueueItem', performance.now() - startTime, mode))
-        .catch((error: unknown) => {
-          console.error('Failed to replace queue item:', error);
-          trackQueueOperationError('replaceQueueItem', mode);
-        });
-    } else {
-      trackQueueOperation('replaceQueueItem', performance.now() - startTime, mode);
-    }
-  }, []);
-
-  const setQueue = useCallback((queue: ClimbQueueItem[]) => {
-    const startTime = performance.now();
-    const latest = latestRef.current;
-    if (latest.guardMutation()) return;
-    const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-    latest.dispatch({
-      type: 'UPDATE_QUEUE',
-      payload: { queue, currentClimbQueueItem: latest.state.currentClimbQueueItem },
-    });
-    if (!latest.isDisconnected && latest.hasConnected && latest.isPersistentSessionActive) {
-      latest.persistentSession
-        .setQueue(queue, latest.state.currentClimbQueueItem)
-        .then(() => trackQueueOperation('setQueue', performance.now() - startTime, mode))
-        .catch((error: unknown) => {
-          console.error('Failed to set queue:', error);
-          trackQueueOperationError('setQueue', mode);
-        });
-    } else {
-      trackQueueOperation('setQueue', performance.now() - startTime, mode);
-    }
-  }, []);
-
-  const setCurrentClimbQueueItem = useCallback((item: ClimbQueueItem) => {
-    const startTime = performance.now();
-    const latest = latestRef.current;
-    if (latest.guardMutation()) return;
-    // Playlist "peek" items use a deterministic synthetic uuid so repeated
-    // peeks of the same suggestion produce a stable queue uuid. Once a peek
-    // is promoted to the actual current climb, mint a fresh queue-item uuid
-    // so it lives as a regular queue entry rather than a transient peek.
-    const queueItem = isPlaylistPeekQueueItemUuid(item.uuid)
-      ? createClimbQueueItem(item.climb, latest.clientId, latest.currentUserInfo, item.suggested)
-      : item;
-    const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-    const correlationId = nextCorrelationId();
-    latest.dispatch({
-      type: 'DELTA_UPDATE_CURRENT_CLIMB',
-      payload: { item: queueItem, shouldAddToQueue: queueItem.suggested, correlationId },
-    });
-    if (queueItem.climb) {
-      track('Set Active Climb', {
-        climbUuid: queueItem.climb.uuid,
-        boardType: queueItem.climb.boardType ?? null,
-        layoutId: queueItem.climb.layoutId ?? null,
-        source: 'setCurrentClimbQueueItem' satisfies SetActiveClimbSource,
-      });
-    }
-    if (latest.sessionId) incrementSessionClimbsAttempted(latest.sessionId);
-    if (!latest.isDisconnected && latest.hasConnected && latest.isPersistentSessionActive) {
-      latest.persistentSession
-        .setCurrentClimb(queueItem, queueItem.suggested, correlationId)
-        .then(() => trackQueueOperation('setCurrentClimbQueueItem', performance.now() - startTime, mode))
-        .catch((error: unknown) => {
-          console.error('Failed to set current climb:', error);
-          if (correlationId) latest.dispatch({ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId } });
-          trackQueueOperationError('setCurrentClimbQueueItem', mode);
-        });
-    } else {
-      trackQueueOperation('setCurrentClimbQueueItem', performance.now() - startTime, mode);
-    }
-  }, []);
-
-  const setPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource | null) => {
-    latestRef.current.dispatch({ type: 'SET_PLAYLIST_SUGGESTION_SOURCE', payload: source ?? null });
-  }, []);
-
-  const refreshPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource) => {
-    latestRef.current.dispatch({ type: 'REFRESH_PLAYLIST_SUGGESTION_SOURCE', payload: source });
-  }, []);
+  const actionsCore = useMemo(() => createQueueActionsCore(actionsCoreDeps), [actionsCoreDeps]);
+  const {
+    addToQueue,
+    removeFromQueue,
+    setCurrentClimb,
+    previewClimbFromBrowse,
+    reportWallDisconnect,
+    replaceQueueItem,
+    setQueue,
+    setCurrentClimbQueueItem,
+    setPlaylistSuggestionSource,
+    refreshPlaylistSuggestionSource,
+    mirrorClimb,
+    getNextClimbQueueItem,
+    getPreviousClimbQueueItem,
+  } = actionsCore;
 
   const setClimbSearchParams = useCallback((params: SearchRequestPagination) => {
     const latest = latestRef.current;
@@ -762,114 +701,8 @@ export const GraphQLQueueProvider = ({
     latestRef.current.setCountSearchParams(params);
   }, []);
 
-  const mirrorClimb = useCallback(() => {
-    const startTime = performance.now();
-    const latest = latestRef.current;
-    if (latest.guardMutation()) return;
-    if (!latest.state.currentClimbQueueItem?.climb) return;
-    const mode = resolveQueueOperationMode(latest.isPersistentSessionActive, latest.isDisconnected);
-    const newMirroredState = !latest.state.currentClimbQueueItem.climb?.mirrored;
-    // Local-origin dispatch: pass the current climb's uuid so the reducer's
-    // server-event uuid guard is a no-op here (it only suppresses when uuid
-    // diverges).
-    latest.dispatch({
-      type: 'DELTA_MIRROR_CURRENT_CLIMB',
-      payload: { mirrored: newMirroredState, mirroredUuid: latest.state.currentClimbQueueItem.uuid },
-    });
-    if (!latest.isDisconnected && latest.hasConnected && latest.isPersistentSessionActive) {
-      latest.persistentSession
-        .mirrorCurrentClimb(newMirroredState)
-        .then(() => trackQueueOperation('mirrorClimb', performance.now() - startTime, mode))
-        .catch((error: unknown) => {
-          console.error('Failed to mirror climb:', error);
-          trackQueueOperationError('mirrorClimb', mode);
-        });
-    } else {
-      trackQueueOperation('mirrorClimb', performance.now() - startTime, mode);
-    }
-  }, []);
-
   const stableFetchMoreClimbs = useCallback(() => {
     latestRef.current.fetchMoreClimbs();
-  }, []);
-
-  const getNextClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }) => {
-    const latest = latestRef.current;
-    // `from` lets the drawer walk navigation from its locally-displayed climb
-    // without first writing to state.currentClimbQueueItem. Default anchor is
-    // the current wall climb, preserving existing callers. Always-live model:
-    // every participant navigates the shared queue (there is no non-driver
-    // suggestions-only path).
-    const anchorUuid = options?.from ? options.from.uuid : latest.state.currentClimbQueueItem?.uuid;
-    const anchorClimbUuid = options?.from ? options.from.climb?.uuid : latest.state.currentClimbQueueItem?.climb?.uuid;
-    const buildSuggestedQueueItem = makeBuildSuggestedQueueItem(latest);
-    const queue = latest.state.queue;
-    // With no anchor at all (no current climb, no `from`), Next surfaces queue[0]
-    // so the Queue bar's Next button can start a queue the user has built but
-    // not yet activated. If the queue is also empty, fall through to
-    // suggestedClimbs[0] so a fresh load with populated suggestions still
-    // exposes a Next.
-    if (anchorUuid == null) {
-      if (queue[0]) return queue[0];
-      const firstSuggestion = latest.suggestedClimbs[0];
-      return firstSuggestion ? buildSuggestedQueueItem(firstSuggestion) : null;
-    }
-    const queueItemIndex = queue.findIndex((queueItem: ClimbQueueItem) => queueItem.uuid === anchorUuid);
-    if (queueItemIndex >= 0 && queueItemIndex < queue.length - 1) {
-      return queue[queueItemIndex + 1];
-    }
-    // Playlist-suggestion mode: suggestedClimbs is the curated next-up feed
-    // (climbs after the activated one, queued items already filtered out).
-    // The anchor isn't in this feed, so position-based walking doesn't apply —
-    // the next-up is whatever sits at the head.
-    if (latest.state.playlistSuggestionSource) {
-      const nextClimb = latest.suggestedClimbs[0];
-      return nextClimb ? buildSuggestedQueueItem(nextClimb) : null;
-    }
-    const fromSearch = findUnqueuedNeighborInSearchResults(
-      latest.climbSearchResults,
-      anchorClimbUuid,
-      queue,
-      1,
-      buildSuggestedQueueItem,
-    );
-    if (fromSearch) return fromSearch;
-    // Cross-search-session continuity: anchor isn't in current
-    // climbSearchResults (e.g. queue was built from a previous search). Surface
-    // the first unqueued suggestion rather than dead-ending the Next button.
-    const fallback = pickUnqueuedSuggestion(latest.suggestedClimbs, queue, anchorClimbUuid);
-    return fallback ? buildSuggestedQueueItem(fallback) : null;
-  }, []);
-
-  const getPreviousClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }) => {
-    const latest = latestRef.current;
-    const anchorUuid = options?.from ? options.from.uuid : latest.state.currentClimbQueueItem?.uuid;
-    const anchorClimbUuid = options?.from ? options.from.climb?.uuid : latest.state.currentClimbQueueItem?.climb?.uuid;
-    const buildSuggestedQueueItem = makeBuildSuggestedQueueItem(latest);
-    // No anchor (no current climb, no `from`): backward navigation has no
-    // semantic answer — don't fabricate one from suggestions. Forward
-    // surfaces queue[0] to start an unactivated queue; backward has no
-    // symmetric "start" semantics.
-    if (anchorUuid == null) return null;
-    const queue = latest.state.queue;
-    const queueItemIndex = queue.findIndex((queueItem: ClimbQueueItem) => queueItem.uuid === anchorUuid);
-    if (queueItemIndex > 0) return queue[queueItemIndex - 1];
-    // In playlist-suggestion mode there's no "previous playlist climb" once
-    // the activated climb is current — the playlist is consumed forward
-    // only. Don't fall through to climbSearchResults, that would surface
-    // unrelated results.
-    if (latest.state.playlistSuggestionSource) return null;
-    // Backward navigation is history-oriented: the queue walk above is the
-    // history step. When neither queue nor search results yield a backward
-    // neighbour, don't fall through to suggestedClimbs — that's discovery
-    // (the forward direction).
-    return findUnqueuedNeighborInSearchResults(
-      latest.climbSearchResults,
-      anchorClimbUuid,
-      queue,
-      -1,
-      buildSuggestedQueueItem,
-    );
   }, []);
 
   // Optimistic dispatch for widget navigation (Next/Previous from Live Activity).

--- a/packages/web/app/components/queue-control/__tests__/queue-actions-core.test.ts
+++ b/packages/web/app/components/queue-control/__tests__/queue-actions-core.test.ts
@@ -1,0 +1,987 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { queueReducer, initialState } from '@boardsesh/queue';
+import { createQueueActionsCore, type QueueActionsCoreDeps, type QueueActionsCoreParty } from '../queue-actions-core';
+import { getPlaylistPeekQueueItemUuid, createPlaylistSuggestionSource } from '../playlist-suggestions';
+import type { Climb, SearchRequestPagination } from '@/app/lib/types';
+import type { BoardDetails } from '@/app/lib/types';
+import type { ClimbQueueItem, PlaylistSuggestionSource, QueueAction, QueueState } from '../types';
+
+// -----------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------
+
+const mockSearchParams: SearchRequestPagination = {
+  page: 1,
+  pageSize: 20,
+  gradeAccuracy: 1,
+  maxGrade: 18,
+  minAscents: 1,
+  minGrade: 1,
+  minRating: 1,
+  sortBy: 'quality',
+  sortOrder: 'desc',
+  name: '',
+  onlyClassics: false,
+  onlyTallClimbs: false,
+  onlyWideClimbs: false,
+  onlyWithBetaVideos: false,
+  settername: [],
+  setternameSuggestion: '',
+  holdsFilter: {},
+  hideAttempted: false,
+  hideCompleted: false,
+  showOnlyAttempted: false,
+  showOnlyCompleted: false,
+  onlyDrafts: false,
+  projectsOnly: false,
+  boulders: true,
+  routes: false,
+  zoneBox: null,
+  zoneMode: 'allHolds',
+};
+
+const testBoardDetails: BoardDetails = {
+  board_name: 'kilter',
+  layout_id: 1,
+  size_id: 1,
+  set_ids: '1',
+  images_to_holds: {},
+  layout_name: 'Original',
+  size_name: '12x12',
+  size_description: 'Standard',
+  set_names: ['Base'],
+  edge_left: 0,
+  edge_right: 0,
+  edge_bottom: 0,
+  edge_top: 0,
+} as unknown as BoardDetails;
+
+function makeClimb(overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid: 'climb-1',
+    setter_username: 'setter',
+    name: 'Test Climb',
+    description: '',
+    frames: '',
+    angle: 40,
+    ascensionist_count: 5,
+    difficulty: '7',
+    quality_average: '3.5',
+    stars: 3,
+    difficulty_error: '',
+    mirrored: false,
+    benchmark_difficulty: null,
+    userAscents: 0,
+    userAttempts: 0,
+    ...overrides,
+  };
+}
+
+let itemCounter = 0;
+function makeQueueItem(overrides: Partial<ClimbQueueItem> = {}): ClimbQueueItem {
+  itemCounter += 1;
+  return {
+    climb: makeClimb(),
+    addedBy: 'client-1',
+    uuid: `item-${itemCounter}`,
+    suggested: false,
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------
+// Test harness
+// -----------------------------------------------------------------------
+
+type HarnessOptions = {
+  /** When true, mimics the board-route provider: `applyLocal` always
+   * dispatches into the real reducer, and party mutations are gated on
+   * `hasConnected && !isDisconnected` (QueueContext model). When false,
+   * mimics the bridge: `applyLocal` no-ops while a party session is active
+   * (optimistic updates wait for the server echo) and party mutations are
+   * attempted unconditionally whenever a party session is active. */
+  gateOnConnection: boolean;
+  initialQueue?: ClimbQueueItem[];
+  initialCurrent?: ClimbQueueItem | null;
+  initialPlaylistSource?: PlaylistSuggestionSource | null;
+  partyOverrides?: Partial<QueueActionsCoreParty>;
+  depsOverrides?: Partial<QueueActionsCoreDeps>;
+};
+
+function createHarness(options: HarnessOptions) {
+  let state: QueueState = {
+    ...initialState(mockSearchParams),
+    queue: options.initialQueue ?? [],
+    currentClimbQueueItem: options.initialCurrent ?? null,
+    playlistSuggestionSource: options.initialPlaylistSource ?? null,
+  };
+
+  let isPartyActive = false;
+  let hasConnected = true;
+  let isDisconnected = false;
+
+  const mutations = {
+    addQueueItem: vi.fn().mockResolvedValue(undefined),
+    removeQueueItem: vi.fn().mockResolvedValue(undefined),
+    setCurrentClimb: vi.fn().mockResolvedValue(undefined),
+    mirrorCurrentClimb: vi.fn().mockResolvedValue(undefined),
+    setQueue: vi.fn().mockResolvedValue(undefined),
+    replaceQueueItem: vi.fn().mockResolvedValue(undefined),
+    reportWallDisconnect: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const onOperationMetric = {
+    success: vi.fn(),
+    error: vi.fn(),
+  };
+  const onSetActiveClimb = vi.fn();
+  const onClimbActivated = vi.fn();
+  const onQueueItemAdded = vi.fn();
+  const onQueueItemRemoved = vi.fn();
+  const setPlaylistSuggestionSourceLocal = vi.fn((source: PlaylistSuggestionSource | null) => {
+    state = { ...state, playlistSuggestionSource: source };
+  });
+  const refreshPlaylistSuggestionSourceLocal = vi.fn((source: PlaylistSuggestionSource) => {
+    state = queueReducer(state, { type: 'REFRESH_PLAYLIST_SUGGESTION_SOURCE', payload: source });
+  });
+  const guardMutation = vi.fn(() => false);
+  const validateClimbForQueue = vi.fn(() => true);
+  const bufferAddition = vi.fn();
+  const offlineBufferSpy = { bufferAddition };
+  const tryAddToQueue = vi.fn(() => false);
+  const trySetCurrentClimb = vi.fn((): 'seeded' | 'failed' | 'not-applicable' => 'not-applicable');
+
+  const applyLocal = vi.fn((action: QueueAction) => {
+    // Bridge model: while a party session is active, applyLocal is a no-op —
+    // the surface waits for the server echo instead of applying an
+    // optimistic update. QueueContext model: always applies.
+    if (!options.gateOnConnection && isPartyActive) return;
+    state = queueReducer(state, action);
+  });
+
+  const party: QueueActionsCoreParty = {
+    get isActive() {
+      return isPartyActive;
+    },
+    get hasConnected() {
+      return hasConnected;
+    },
+    get isDisconnected() {
+      return isDisconnected;
+    },
+    get attemptMutation() {
+      return options.gateOnConnection ? hasConnected && !isDisconnected : true;
+    },
+    reuseExistingQueueItemOnSetCurrentClimb: false,
+    returnNullOnSetCurrentClimbFailure: false,
+    mutations,
+    nextCorrelationId: vi.fn(() => (isPartyActive ? `client-1-${itemCounter}` : undefined)),
+    ...options.partyOverrides,
+  };
+
+  const deps: QueueActionsCoreDeps = {
+    getSnapshot: () => ({
+      queue: state.queue,
+      currentClimbQueueItem: state.currentClimbQueueItem,
+      playlistSuggestionSource: state.playlistSuggestionSource,
+    }),
+    applyLocal,
+    setPlaylistSuggestionSourceLocal,
+    refreshPlaylistSuggestionSourceLocal,
+    buildItem: (climb, suggested) => makeQueueItem({ climb, suggested: !!suggested, addedBy: 'client-1' }),
+    guardMutation,
+    validateClimbForQueue,
+    offlineBuffer: offlineBufferSpy,
+    resolveShouldAddToQueueOnActivate: (item) => !!item.suggested,
+    resolveNextCurrentForSetQueue: () => state.currentClimbQueueItem,
+    buildReplacementItem: (existing, climb, uuid) => {
+      if (!existing) return null;
+      return { ...existing, climb, uuid };
+    },
+    discoverNext: vi.fn(() => null),
+    discoverPrev: vi.fn(() => null),
+    coldStart: { tryAddToQueue, trySetCurrentClimb },
+    party,
+    hooks: {
+      resolveSetActiveClimbSource: (kind) =>
+        kind === 'setCurrentClimb' ? 'setCurrentClimb' : 'setCurrentClimbQueueItem',
+      onSetActiveClimb,
+      onClimbActivated,
+      onQueueItemAdded,
+      onQueueItemRemoved,
+      onOperationMetric,
+    },
+    errorMessages: {
+      addToQueue: 'Failed to add queue item:',
+      removeFromQueue: 'Failed to remove queue item:',
+      setQueue: 'Failed to set queue:',
+      mirrorClimb: 'Failed to mirror climb:',
+      replaceQueueItem: 'Failed to replace queue item:',
+      setCurrentClimb: {
+        reuse: 'Failed to set current climb (reuse):',
+        playlist: 'Failed to set current climb (playlist):',
+        add: 'Failed to set current climb (add):',
+        activate: 'Failed to set current climb (activate):',
+      },
+      setCurrentClimbQueueItem: 'Failed to set current climb queue item:',
+      reportWallDisconnect: 'Failed to report wall disconnect:',
+    },
+    ...options.depsOverrides,
+  };
+
+  const actions = createQueueActionsCore(deps);
+
+  return {
+    actions,
+    deps,
+    mutations,
+    onOperationMetric,
+    onSetActiveClimb,
+    onClimbActivated,
+    onQueueItemAdded,
+    onQueueItemRemoved,
+    setPlaylistSuggestionSourceLocal,
+    refreshPlaylistSuggestionSourceLocal,
+    guardMutation,
+    validateClimbForQueue,
+    bufferAddition,
+    tryAddToQueue,
+    trySetCurrentClimb,
+    applyLocal,
+    getState: () => state,
+    setPartyActive: (value: boolean) => {
+      isPartyActive = value;
+    },
+    setHasConnected: (value: boolean) => {
+      hasConnected = value;
+    },
+    setDisconnected: (value: boolean) => {
+      isDisconnected = value;
+    },
+  };
+}
+
+beforeEach(() => {
+  itemCounter = 0;
+});
+
+// -----------------------------------------------------------------------
+// addToQueue
+// -----------------------------------------------------------------------
+
+describe('addToQueue', () => {
+  it('dispatches DELTA_ADD_QUEUE_ITEM through applyLocal', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.getState().queue).toHaveLength(1);
+    expect(harness.getState().queue[0].climb.uuid).toBe('climb-1');
+  });
+
+  it('is blocked by guardMutation', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.guardMutation.mockReturnValue(true);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.getState().queue).toHaveLength(0);
+    expect(harness.applyLocal).not.toHaveBeenCalled();
+  });
+
+  it('is blocked by validateClimbForQueue rejection', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.validateClimbForQueue.mockReturnValue(false);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.getState().queue).toHaveLength(0);
+  });
+
+  it('calls onQueueItemAdded with the source and post-add queue length', () => {
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialQueue: [makeQueueItem()],
+    });
+    harness.actions.addToQueue(makeClimb(), 'search');
+    expect(harness.onQueueItemAdded).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'search', queueLengthAfter: 2 }),
+    );
+  });
+
+  it('buffers offline additions instead of calling the party mutation (isDisconnected && party.isActive)', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    harness.setDisconnected(true);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.bufferAddition).toHaveBeenCalledTimes(1);
+    expect(harness.mutations.addQueueItem).not.toHaveBeenCalled();
+    expect(harness.onOperationMetric.success).toHaveBeenCalledWith('addToQueue', expect.any(Number), 'party-offline');
+  });
+
+  it('calls the party mutation when connected (QueueContext model)', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.mutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the party mutation unconditionally whenever active, regardless of connection (bridge model)', () => {
+    const harness = createHarness({ gateOnConnection: false });
+    harness.setPartyActive(true);
+    harness.setHasConnected(false);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.mutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not apply an optimistic local update while a party session is active (bridge model)', () => {
+    const harness = createHarness({ gateOnConnection: false });
+    harness.setPartyActive(true);
+    harness.actions.addToQueue(makeClimb());
+    // applyLocal was invoked (unconditionally, matching QueueContext's shape)
+    // but the wiring's no-op-while-party guard means state never changes —
+    // this is THE documented pre-existing behavior difference this PR
+    // preserves rather than fixes.
+    expect(harness.applyLocal).toHaveBeenCalled();
+    expect(harness.getState().queue).toHaveLength(0);
+    expect(harness.mutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to cold-start seeding when solo and no board is active', () => {
+    const harness = createHarness({ gateOnConnection: false });
+    harness.tryAddToQueue.mockReturnValue(true);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.tryAddToQueue).toHaveBeenCalledTimes(1);
+    expect(harness.mutations.addQueueItem).not.toHaveBeenCalled();
+  });
+
+  it('does not consult cold-start seeding while a party session is active', () => {
+    const harness = createHarness({ gateOnConnection: false });
+    harness.setPartyActive(true);
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.tryAddToQueue).not.toHaveBeenCalled();
+  });
+
+  it('tracks a local-mode success metric when solo and cold-start does not apply', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.addToQueue(makeClimb());
+    expect(harness.onOperationMetric.success).toHaveBeenCalledWith('addToQueue', expect.any(Number), 'local');
+  });
+
+  it('logs and tracks an error metric when the party mutation rejects', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    harness.mutations.addQueueItem.mockRejectedValueOnce(new Error('boom'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    harness.actions.addToQueue(makeClimb());
+    await vi.waitFor(() => expect(harness.onOperationMetric.error).toHaveBeenCalledWith('addToQueue', 'party'));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to add queue item:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+// -----------------------------------------------------------------------
+// removeFromQueue
+// -----------------------------------------------------------------------
+
+describe('removeFromQueue', () => {
+  it('dispatches DELTA_REMOVE_QUEUE_ITEM and clears the current climb when it was removed', () => {
+    const item = makeQueueItem();
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [item], initialCurrent: item });
+    harness.actions.removeFromQueue(item);
+    expect(harness.getState().queue).toHaveLength(0);
+    // With the shared reducer as the applyLocal backend (QueueContext model),
+    // removing the current item clears current to null. The bridge's solo
+    // wiring layers its own promote-the-new-head override on top of the
+    // reducer (see applyLocalSolo in queue-bridge-context.tsx) — that quirk is
+    // a wiring concern, not factory semantics.
+    expect(harness.getState().currentClimbQueueItem).toBeNull();
+  });
+
+  it('fires onQueueItemRemoved', () => {
+    const item = makeQueueItem();
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [item] });
+    harness.actions.removeFromQueue(item);
+    expect(harness.onQueueItemRemoved).toHaveBeenCalledWith({ item });
+  });
+
+  it('calls the party mutation when attemptMutation is true', () => {
+    const item = makeQueueItem();
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [item] });
+    harness.setPartyActive(true);
+    harness.actions.removeFromQueue(item);
+    expect(harness.mutations.removeQueueItem).toHaveBeenCalledWith(item.uuid);
+  });
+
+  it('is blocked by guardMutation', () => {
+    const item = makeQueueItem();
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [item] });
+    harness.guardMutation.mockReturnValue(true);
+    harness.actions.removeFromQueue(item);
+    expect(harness.getState().queue).toHaveLength(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// setCurrentClimb
+// -----------------------------------------------------------------------
+
+describe('setCurrentClimb', () => {
+  it('inserts the new item immediately after the current item (insertAfterCurrent positioning)', async () => {
+    const first = makeQueueItem({ uuid: 'first' });
+    const second = makeQueueItem({ uuid: 'second' });
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialQueue: [first, second],
+      initialCurrent: first,
+    });
+    await harness.actions.setCurrentClimb(makeClimb({ uuid: 'new-climb' }), { playlistSuggestionSource: null });
+    const queue = harness.getState().queue;
+    expect(queue.map((queueItem) => queueItem.uuid)).toEqual(['first', queue[1].uuid, 'second']);
+    expect(queue[1].climb.uuid).toBe('new-climb');
+    expect(harness.getState().currentClimbQueueItem?.climb.uuid).toBe('new-climb');
+  });
+
+  it('appends when there is no current climb', async () => {
+    const existing = makeQueueItem({ uuid: 'existing' });
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [existing], initialCurrent: null });
+    await harness.actions.setCurrentClimb(makeClimb({ uuid: 'new-climb' }), { playlistSuggestionSource: null });
+    const queue = harness.getState().queue;
+    expect(queue).toHaveLength(2);
+    expect(queue[1].climb.uuid).toBe('new-climb');
+  });
+
+  it('resolves to null and short-circuits when guardMutation blocks', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.guardMutation.mockReturnValue(true);
+    const result = await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: null });
+    expect(result).toBeNull();
+    expect(harness.applyLocal).not.toHaveBeenCalled();
+  });
+
+  it('resolves to null when validation rejects the climb', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.validateClimbForQueue.mockReturnValue(false);
+    const result = await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: null });
+    expect(result).toBeNull();
+  });
+
+  it('splits the party-mode add+activate into two sequential awaits, in FIFO order', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    const callOrder: string[] = [];
+    harness.mutations.addQueueItem.mockImplementation(async () => {
+      callOrder.push('addQueueItem');
+    });
+    harness.mutations.setCurrentClimb.mockImplementation(async () => {
+      callOrder.push('setCurrentClimb');
+    });
+    await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: null });
+    expect(callOrder).toEqual(['addQueueItem', 'setCurrentClimb']);
+    expect(harness.mutations.setCurrentClimb).toHaveBeenCalledWith(expect.any(Object), false, expect.any(String));
+  });
+
+  it('reuses an existing queue entry matched by climb.uuid instead of adding a duplicate (bridge invariant)', async () => {
+    const climb = makeClimb({ uuid: 'shared-climb' });
+    const existing = makeQueueItem({ climb, uuid: 'existing-item' });
+    const harness = createHarness({
+      gateOnConnection: false,
+      initialQueue: [existing],
+      partyOverrides: { reuseExistingQueueItemOnSetCurrentClimb: true },
+    });
+    harness.setPartyActive(true);
+    const result = await harness.actions.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    expect(harness.mutations.addQueueItem).not.toHaveBeenCalled();
+    expect(harness.mutations.setCurrentClimb).toHaveBeenCalledWith(existing, false, expect.any(String));
+    expect(result).toEqual(existing);
+  });
+
+  it('does not reuse an existing entry when reuseExistingQueueItemOnSetCurrentClimb is false (QueueContext invariant)', async () => {
+    const climb = makeClimb({ uuid: 'shared-climb' });
+    const existing = makeQueueItem({ climb, uuid: 'existing-item' });
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [existing] });
+    harness.setPartyActive(true);
+    await harness.actions.setCurrentClimb(climb, { playlistSuggestionSource: null });
+    expect(harness.mutations.addQueueItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back the optimistic playlistSuggestionSource on mutation failure (plain add+activate branch)', async () => {
+    const previousSource: PlaylistSuggestionSource = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'activated' }),
+      climbs: [makeClimb({ uuid: 'activated' })],
+      boardDetails: testBoardDetails,
+    });
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialPlaylistSource: previousSource,
+    });
+    harness.setPartyActive(true);
+    harness.mutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // A `null` next playlist source drives the plain add+activate branch
+    // (not the playlist-source setQueue branch), so mocking addQueueItem to
+    // reject exercises the failure path this test targets.
+    const result = await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: null });
+
+    // harness default is returnNullOnSetCurrentClimbFailure: false (QueueContext
+    // model) — the optimistic item is still returned even though the party
+    // mutation failed; only the playlist-source rollback + error tracking fire.
+    expect(result).not.toBeNull();
+    expect(harness.setPlaylistSuggestionSourceLocal).toHaveBeenLastCalledWith(previousSource);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to set current climb (add):', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('rolls back the optimistic playlistSuggestionSource on mutation failure (playlist-source branch)', async () => {
+    const previousSource: PlaylistSuggestionSource = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'activated' }),
+      climbs: [makeClimb({ uuid: 'activated' })],
+      boardDetails: testBoardDetails,
+    });
+    const nextSource: PlaylistSuggestionSource = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-2',
+      activatedClimb: makeClimb({ uuid: 'other' }),
+      climbs: [makeClimb({ uuid: 'other' })],
+      boardDetails: testBoardDetails,
+    });
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialPlaylistSource: previousSource,
+    });
+    harness.setPartyActive(true);
+    harness.mutations.setQueue.mockRejectedValueOnce(new Error('queue replace failed'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: nextSource });
+
+    expect(result).not.toBeNull();
+    expect(harness.setPlaylistSuggestionSourceLocal).toHaveBeenLastCalledWith(previousSource);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to set current climb (playlist):', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns the optimistic item on mutation failure when returnNullOnSetCurrentClimbFailure is false (QueueContext model)', async () => {
+    const harness = createHarness({
+      gateOnConnection: true,
+      partyOverrides: { returnNullOnSetCurrentClimbFailure: false },
+    });
+    harness.setPartyActive(true);
+    harness.mutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await harness.actions.setCurrentClimb(makeClimb({ uuid: 'x' }), { playlistSuggestionSource: null });
+    expect(result).not.toBeNull();
+    expect(result?.climb.uuid).toBe('x');
+  });
+
+  it('returns null on mutation failure when returnNullOnSetCurrentClimbFailure is true (bridge model)', async () => {
+    const harness = createHarness({
+      gateOnConnection: false,
+      partyOverrides: { returnNullOnSetCurrentClimbFailure: true },
+    });
+    harness.setPartyActive(true);
+    harness.mutations.addQueueItem.mockRejectedValueOnce(new Error('add failed'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: null });
+    expect(result).toBeNull();
+  });
+
+  it('buffers offline instead of sending the mutation when isDisconnected && party.isActive', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    harness.setDisconnected(true);
+    const result = await harness.actions.setCurrentClimb(makeClimb(), { playlistSuggestionSource: null });
+    expect(harness.bufferAddition).toHaveBeenCalledTimes(1);
+    expect(harness.mutations.addQueueItem).not.toHaveBeenCalled();
+    expect(harness.mutations.setCurrentClimb).not.toHaveBeenCalled();
+    expect(result).not.toBeNull();
+  });
+
+  it('replaces the party queue in one setQueue call when a playlist source is supplied', async () => {
+    const current = makeQueueItem({ uuid: 'current' });
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [current], initialCurrent: current });
+    harness.setPartyActive(true);
+    const source = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'new-climb' }),
+      climbs: [makeClimb({ uuid: 'new-climb' })],
+      boardDetails: testBoardDetails,
+    });
+    await harness.actions.setCurrentClimb(makeClimb({ uuid: 'new-climb' }), { playlistSuggestionSource: source });
+    expect(harness.mutations.setQueue).toHaveBeenCalledTimes(1);
+    expect(harness.mutations.addQueueItem).not.toHaveBeenCalled();
+    expect(harness.mutations.setCurrentClimb).not.toHaveBeenCalled();
+  });
+
+  describe('cold-start seeding', () => {
+    it('seeds and returns the item when trySetCurrentClimb reports "seeded"', async () => {
+      const harness = createHarness({ gateOnConnection: false });
+      harness.trySetCurrentClimb.mockReturnValue('seeded');
+      const result = await harness.actions.setCurrentClimb(makeClimb({ uuid: 'cold' }), {
+        playlistSuggestionSource: null,
+      });
+      expect(result?.climb.uuid).toBe('cold');
+      expect(harness.onOperationMetric.success).toHaveBeenCalled();
+    });
+
+    it('rolls back playlistSuggestionSource and returns null when trySetCurrentClimb reports "failed"', async () => {
+      const previousSource: PlaylistSuggestionSource = createPlaylistSuggestionSource({
+        playlistUuid: 'pl-1',
+        activatedClimb: makeClimb({ uuid: 'activated' }),
+        climbs: [makeClimb({ uuid: 'activated' })],
+        boardDetails: testBoardDetails,
+      });
+      const harness = createHarness({ gateOnConnection: false, initialPlaylistSource: previousSource });
+      harness.trySetCurrentClimb.mockReturnValue('failed');
+      const result = await harness.actions.setCurrentClimb(makeClimb({ uuid: 'orphan' }), {
+        playlistSuggestionSource: null,
+      });
+      expect(result).toBeNull();
+      expect(harness.setPlaylistSuggestionSourceLocal).toHaveBeenLastCalledWith(previousSource);
+    });
+
+    it('falls through to the local branch when trySetCurrentClimb reports "not-applicable"', async () => {
+      const harness = createHarness({ gateOnConnection: false });
+      harness.trySetCurrentClimb.mockReturnValue('not-applicable');
+      const result = await harness.actions.setCurrentClimb(makeClimb({ uuid: 'x' }), {
+        playlistSuggestionSource: null,
+      });
+      expect(result?.climb.uuid).toBe('x');
+      expect(harness.getState().currentClimbQueueItem?.climb.uuid).toBe('x');
+    });
+  });
+});
+
+// -----------------------------------------------------------------------
+// setCurrentClimbQueueItem
+// -----------------------------------------------------------------------
+
+describe('setCurrentClimbQueueItem', () => {
+  it('promotes a playlist-peek item to a fresh queue-item uuid on activation', () => {
+    const climb = makeClimb({ uuid: 'peeked' });
+    const peekItem: ClimbQueueItem = {
+      climb,
+      uuid: getPlaylistPeekQueueItemUuid(climb.uuid),
+      suggested: true,
+    };
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.setCurrentClimbQueueItem(peekItem);
+    const current = harness.getState().currentClimbQueueItem;
+    expect(current).not.toBeNull();
+    expect(current?.uuid).not.toBe(peekItem.uuid);
+    expect(current?.climb.uuid).toBe('peeked');
+    expect(current?.suggested).toBe(true);
+  });
+
+  it('leaves a non-peek item untouched (no fresh uuid minted)', () => {
+    const item = makeQueueItem({ uuid: 'plain-item' });
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.setCurrentClimbQueueItem(item);
+    expect(harness.getState().currentClimbQueueItem?.uuid).toBe('plain-item');
+  });
+
+  it('adds the item to the queue only when resolveShouldAddToQueueOnActivate says so', () => {
+    const item = makeQueueItem({ uuid: 'not-queued', suggested: false });
+    const harness = createHarness({
+      gateOnConnection: true,
+      depsOverrides: { resolveShouldAddToQueueOnActivate: (queueItem) => !!queueItem.suggested },
+    });
+    harness.actions.setCurrentClimbQueueItem(item);
+    expect(harness.getState().queue).toHaveLength(0);
+    expect(harness.getState().currentClimbQueueItem?.uuid).toBe('not-queued');
+  });
+
+  it('always adds the item when resolveShouldAddToQueueOnActivate returns true unconditionally (bridge invariant)', () => {
+    const item = makeQueueItem({ uuid: 'always-queued', suggested: false });
+    const harness = createHarness({
+      gateOnConnection: false,
+      depsOverrides: { resolveShouldAddToQueueOnActivate: () => true },
+    });
+    harness.actions.setCurrentClimbQueueItem(item);
+    expect(harness.getState().queue.map((queueItem) => queueItem.uuid)).toContain('always-queued');
+  });
+
+  it('resolves the Set Active Climb source using the party/solo variant', () => {
+    const bridgeHooks: QueueActionsCoreDeps['hooks'] = {
+      resolveSetActiveClimbSource: (kind, variant) =>
+        kind === 'setCurrentClimb'
+          ? 'bridge.setCurrentClimb'
+          : variant === 'party'
+            ? 'bridge.setCurrentClimbQueueItem.party'
+            : 'bridge.setCurrentClimbQueueItem.solo',
+      onSetActiveClimb: vi.fn(),
+    };
+    const harness = createHarness({
+      gateOnConnection: false,
+      depsOverrides: { hooks: bridgeHooks },
+    });
+    const onSetActiveClimb = harness.deps.hooks.onSetActiveClimb as ReturnType<typeof vi.fn>;
+    harness.actions.setCurrentClimbQueueItem(makeQueueItem());
+    expect(onSetActiveClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'bridge.setCurrentClimbQueueItem.solo' }),
+    );
+
+    harness.setPartyActive(true);
+    harness.actions.setCurrentClimbQueueItem(makeQueueItem());
+    expect(onSetActiveClimb).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'bridge.setCurrentClimbQueueItem.party' }),
+    );
+  });
+
+  it('always re-sends the party mutation even when the item is already current (bridge invariant)', () => {
+    const item = makeQueueItem({ uuid: 'already-current' });
+    const harness = createHarness({ gateOnConnection: false, initialQueue: [item], initialCurrent: item });
+    harness.setPartyActive(true);
+    harness.actions.setCurrentClimbQueueItem(item);
+    expect(harness.mutations.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// setQueue
+// -----------------------------------------------------------------------
+
+describe('setQueue', () => {
+  it('uses resolveNextCurrentForSetQueue to pick the next current climb', () => {
+    const survivor = makeQueueItem({ uuid: 'survivor' });
+    const other = makeQueueItem({ uuid: 'other' });
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialCurrent: survivor,
+      depsOverrides: {
+        resolveNextCurrentForSetQueue: (newQueue, current) =>
+          current && newQueue.some((queueItem) => queueItem.uuid === current.uuid) ? current : (newQueue[0] ?? null),
+      },
+    });
+    harness.actions.setQueue([survivor, other]);
+    expect(harness.getState().currentClimbQueueItem?.uuid).toBe('survivor');
+  });
+
+  it('falls back to the new queue head when the current climb did not survive', () => {
+    const gone = makeQueueItem({ uuid: 'gone' });
+    const replacement = makeQueueItem({ uuid: 'replacement' });
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialCurrent: gone,
+      depsOverrides: {
+        resolveNextCurrentForSetQueue: (newQueue, current) =>
+          current && newQueue.some((queueItem) => queueItem.uuid === current.uuid) ? current : (newQueue[0] ?? null),
+      },
+    });
+    harness.actions.setQueue([replacement]);
+    expect(harness.getState().currentClimbQueueItem?.uuid).toBe('replacement');
+  });
+
+  it('QueueContext model: always keeps the existing current climb regardless of new queue contents', () => {
+    const current = makeQueueItem({ uuid: 'stays-current' });
+    const harness = createHarness({ gateOnConnection: true, initialCurrent: current });
+    harness.actions.setQueue([makeQueueItem({ uuid: 'unrelated' })]);
+    expect(harness.getState().currentClimbQueueItem?.uuid).toBe('stays-current');
+  });
+
+  it('sends the resolved current climb to the party mutation', () => {
+    const survivor = makeQueueItem({ uuid: 'survivor' });
+    const harness = createHarness({
+      gateOnConnection: true,
+      initialCurrent: survivor,
+      depsOverrides: { resolveNextCurrentForSetQueue: () => survivor },
+    });
+    harness.setPartyActive(true);
+    harness.actions.setQueue([survivor]);
+    expect(harness.mutations.setQueue).toHaveBeenCalledWith([survivor], survivor);
+  });
+});
+
+// -----------------------------------------------------------------------
+// mirrorClimb
+// -----------------------------------------------------------------------
+
+describe('mirrorClimb', () => {
+  it('no-ops when there is no current climb', () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.mirrorClimb();
+    expect(harness.applyLocal).not.toHaveBeenCalled();
+  });
+
+  it('toggles mirrored on the current climb', () => {
+    const current = makeQueueItem({ climb: makeClimb({ mirrored: false }) });
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [current], initialCurrent: current });
+    harness.actions.mirrorClimb();
+    expect(harness.getState().currentClimbQueueItem?.climb.mirrored).toBe(true);
+    expect(harness.getState().queue[0].climb.mirrored).toBe(true);
+  });
+
+  it('calls the party mirror mutation when active', () => {
+    const current = makeQueueItem({ climb: makeClimb({ mirrored: false }) });
+    const harness = createHarness({ gateOnConnection: true, initialCurrent: current });
+    harness.setPartyActive(true);
+    harness.actions.mirrorClimb();
+    expect(harness.mutations.mirrorCurrentClimb).toHaveBeenCalledWith(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// replaceQueueItem
+// -----------------------------------------------------------------------
+
+describe('replaceQueueItem', () => {
+  it('aborts when buildReplacementItem returns null (bridge: no existing entry)', () => {
+    const harness = createHarness({
+      gateOnConnection: false,
+      depsOverrides: {
+        buildReplacementItem: (existing, climb, uuid) => (existing ? { ...existing, climb, uuid } : null),
+      },
+    });
+    harness.actions.replaceQueueItem('missing-uuid', makeClimb());
+    expect(harness.applyLocal).not.toHaveBeenCalled();
+  });
+
+  it('replaces the item in place, preserving its uuid', () => {
+    const existing = makeQueueItem({ uuid: 'slot-1', climb: makeClimb({ uuid: 'old' }) });
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [existing] });
+    harness.actions.replaceQueueItem('slot-1', makeClimb({ uuid: 'new' }));
+    expect(harness.getState().queue[0].uuid).toBe('slot-1');
+    expect(harness.getState().queue[0].climb.uuid).toBe('new');
+  });
+
+  it('is blocked by validateClimbForQueue', () => {
+    const existing = makeQueueItem({ uuid: 'slot-1' });
+    const harness = createHarness({ gateOnConnection: true, initialQueue: [existing] });
+    harness.validateClimbForQueue.mockReturnValue(false);
+    harness.actions.replaceQueueItem('slot-1', makeClimb());
+    expect(harness.applyLocal).not.toHaveBeenCalled();
+  });
+});
+
+// -----------------------------------------------------------------------
+// getNextClimbQueueItem / getPreviousClimbQueueItem
+// -----------------------------------------------------------------------
+
+describe('getNextClimbQueueItem / getPreviousClimbQueueItem', () => {
+  it('resolves the anchor from options.from when provided', () => {
+    const from = makeQueueItem({ uuid: 'from-item' });
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.getNextClimbQueueItem({ from });
+    expect(harness.deps.discoverNext).toHaveBeenCalledWith(from);
+  });
+
+  it('falls back to the current climb when options.from is omitted', () => {
+    const current = makeQueueItem({ uuid: 'current-item' });
+    const harness = createHarness({ gateOnConnection: true, initialCurrent: current });
+    harness.actions.getNextClimbQueueItem();
+    expect(harness.deps.discoverNext).toHaveBeenCalledWith(current);
+  });
+
+  it('falls back to the current climb when options.from is explicitly null', () => {
+    const current = makeQueueItem({ uuid: 'current-item' });
+    const harness = createHarness({ gateOnConnection: true, initialCurrent: current });
+    harness.actions.getNextClimbQueueItem({ from: null });
+    expect(harness.deps.discoverNext).toHaveBeenCalledWith(current);
+  });
+
+  it('delegates getPreviousClimbQueueItem the same way', () => {
+    const from = makeQueueItem({ uuid: 'from-item' });
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.getPreviousClimbQueueItem({ from });
+    expect(harness.deps.discoverPrev).toHaveBeenCalledWith(from);
+  });
+});
+
+// -----------------------------------------------------------------------
+// previewClimbFromBrowse
+// -----------------------------------------------------------------------
+
+describe('previewClimbFromBrowse', () => {
+  it('activates the climb with a null playlistSuggestionSource', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.previewClimbFromBrowse(makeClimb({ uuid: 'browsed' }));
+    // setCurrentClimb runs asynchronously (fire-and-forget `void`); flush it.
+    await vi.waitFor(() => expect(harness.getState().currentClimbQueueItem?.climb.uuid).toBe('browsed'));
+    expect(harness.getState().playlistSuggestionSource).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------
+// setPlaylistSuggestionSource / refreshPlaylistSuggestionSource
+// -----------------------------------------------------------------------
+
+describe('setPlaylistSuggestionSource / refreshPlaylistSuggestionSource', () => {
+  it('setPlaylistSuggestionSource always applies the new value', () => {
+    const source = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'a' }),
+      climbs: [makeClimb({ uuid: 'a' })],
+      boardDetails: testBoardDetails,
+    });
+    const harness = createHarness({ gateOnConnection: true });
+    harness.actions.setPlaylistSuggestionSource(source);
+    expect(harness.setPlaylistSuggestionSourceLocal).toHaveBeenCalledWith(source);
+  });
+
+  it('refreshPlaylistSuggestionSource delegates to the surface-injected refresher (which does the identity-match check against live state)', () => {
+    // The match semantics themselves live in the wiring — the reducer's
+    // REFRESH_PLAYLIST_SUGGESTION_SOURCE case for QueueContext, a functional
+    // setState updater for the bridge — because both must read live store
+    // state, not a latestRef snapshot. The harness's refresher runs the real
+    // reducer, so this also pins the end-to-end match/no-match outcome.
+    const original = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'a' }),
+      climbs: [makeClimb({ uuid: 'a' })],
+      boardDetails: testBoardDetails,
+    });
+    const staleRefresh = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'b' }),
+      climbs: [makeClimb({ uuid: 'b' })],
+      boardDetails: testBoardDetails,
+    });
+    const matchingRefresh = createPlaylistSuggestionSource({
+      playlistUuid: 'pl-1',
+      activatedClimb: makeClimb({ uuid: 'a' }),
+      climbs: [makeClimb({ uuid: 'a' }), makeClimb({ uuid: 'c' })],
+      boardDetails: testBoardDetails,
+    });
+    const harness = createHarness({ gateOnConnection: true, initialPlaylistSource: original });
+
+    harness.actions.refreshPlaylistSuggestionSource(staleRefresh);
+    expect(harness.refreshPlaylistSuggestionSourceLocal).toHaveBeenCalledWith(staleRefresh);
+    expect(harness.getState().playlistSuggestionSource).toEqual(original);
+
+    harness.actions.refreshPlaylistSuggestionSource(matchingRefresh);
+    expect(harness.getState().playlistSuggestionSource).toEqual(matchingRefresh);
+  });
+});
+
+// -----------------------------------------------------------------------
+// reportWallDisconnect
+// -----------------------------------------------------------------------
+
+describe('reportWallDisconnect', () => {
+  it('is a no-op in solo (no active party session)', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    await harness.actions.reportWallDisconnect();
+    expect(harness.mutations.reportWallDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op while the WS is reconnecting (hasConnected false)', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    harness.setHasConnected(false);
+    await harness.actions.reportWallDisconnect();
+    expect(harness.mutations.reportWallDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the party mutation when active and connected', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    await harness.actions.reportWallDisconnect();
+    expect(harness.mutations.reportWallDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('catches and logs mutation errors instead of throwing', async () => {
+    const harness = createHarness({ gateOnConnection: true });
+    harness.setPartyActive(true);
+    harness.mutations.reportWallDisconnect.mockRejectedValueOnce(new Error('ws down'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(harness.actions.reportWallDisconnect()).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to report wall disconnect:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
+++ b/packages/web/app/components/queue-control/__tests__/queue-bridge-context.test.tsx
@@ -599,6 +599,39 @@ describe('queue-bridge-context', () => {
         expect(newQueue[0].climb.mirrored).toBe(true);
       });
 
+      it('replaceQueueItem updates the current item in place when the replaced uuid is current', () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const item2 = createTestQueueItem(climb2, 'u2');
+        const { result } = renderWithLocalQueue([item1, item2], item1);
+        const editedClimb = createTestClimb({ uuid: 'c1-edited', name: 'Edited Climb' });
+        act(() => {
+          result.current!.replaceQueueItem('u1', editedClimb);
+        });
+        expect(mockSetLocalQueueState).toHaveBeenCalled();
+        const [newQueue, newCurrent] = mockSetLocalQueueState.mock.calls[0];
+        // Slot uuid preserved, climb swapped, and the current item follows the
+        // replacement (it was the replaced entry).
+        expect(newQueue.map((queueItem: ClimbQueueItem) => queueItem.uuid)).toEqual(['u1', 'u2']);
+        expect(newQueue[0].climb.uuid).toBe('c1-edited');
+        expect(newCurrent.uuid).toBe('u1');
+        expect(newCurrent.climb.uuid).toBe('c1-edited');
+      });
+
+      it('replaceQueueItem leaves the current item alone when a different uuid is replaced', () => {
+        const item1 = createTestQueueItem(climb1, 'u1');
+        const item2 = createTestQueueItem(climb2, 'u2');
+        const { result } = renderWithLocalQueue([item1, item2], item1);
+        const editedClimb = createTestClimb({ uuid: 'c2-edited', name: 'Edited Climb 2' });
+        act(() => {
+          result.current!.replaceQueueItem('u2', editedClimb);
+        });
+        expect(mockSetLocalQueueState).toHaveBeenCalled();
+        const [newQueue, newCurrent] = mockSetLocalQueueState.mock.calls[0];
+        expect(newQueue[1].climb.uuid).toBe('c2-edited');
+        expect(newCurrent.uuid).toBe('u1');
+        expect(newCurrent.climb.uuid).toBe('c1');
+      });
+
       it('setQueue replaces queue and preserves current if present', () => {
         const item1 = createTestQueueItem(climb1, 'u1');
         const item2 = createTestQueueItem(climb2, 'u2');

--- a/packages/web/app/components/queue-control/queue-actions-core.ts
+++ b/packages/web/app/components/queue-control/queue-actions-core.ts
@@ -1,0 +1,644 @@
+/**
+ * Single implementation of the queue-action surface (add/remove/set-current/
+ * navigate/mirror/replace/etc.), shared by the board-route provider
+ * (`graphql-queue/QueueContext.tsx`) and the off-board bridge
+ * (`queue-control/queue-bridge-context.tsx`). Those two files independently
+ * reimplemented this surface and drifted apart; this factory is now the one
+ * place the semantics live. Both wiring sites inject their own state access,
+ * party-mutation plumbing, and analytics hooks — see `QueueActionsCoreDeps`.
+ *
+ * Every dependency here exists because the two call sites genuinely differ,
+ * not for abstraction's own sake:
+ *   - `applyLocal` differs in mechanism (dispatch a reducer action / reduce
+ *     against a useState-backed local store / no-op while a party mutation is
+ *     in flight — party mode intentionally waits for the server echo instead
+ *     of applying an optimistic update; see docs/websocket-implementation.md).
+ *   - `party.attemptMutation` differs in *when* a party mutation fires:
+ *     QueueContext gates on `hasConnected && !isDisconnected` (buffering adds
+ *     while offline); the bridge has no such gate and always attempts the
+ *     mutation whenever a party session is active.
+ *   - `discoverNext`/`discoverPrev` differ in strategy: QueueContext walks
+ *     `climbSearchResults` as a discovery fallback; the bridge delegates to
+ *     the shared `findNextQueueItemWithSuggestions` (mobile parity).
+ *   - `errorMessages` and `resolveSetActiveClimbSource` preserve each
+ *     surface's exact (test-pinned) console/analytics text.
+ */
+
+import type { Climb } from '@/app/lib/types';
+import type {
+  AddToQueueSource,
+  ClimbQueueItem,
+  PlaylistSuggestionSource,
+  QueueAction,
+  QueueActionsType,
+  SetCurrentClimbOptions,
+} from './types';
+import {
+  insertQueueItemAfterCurrent,
+  isPlaylistPeekQueueItemUuid,
+  pruneSuggestedQueueItemsAfterCurrent,
+} from './playlist-suggestions';
+import { resolveQueueOperationMode, type QueueOperation, type QueueOperationMode } from '@/app/lib/queue-metrics';
+import type { SetActiveClimbSource } from '../graphql-queue/set-active-climb-event';
+import { dispatchOpenPlayDrawer } from './play-drawer-event';
+
+export type QueueActionsCoreSnapshot = {
+  queue: ClimbQueueItem[];
+  currentClimbQueueItem: ClimbQueueItem | null;
+  playlistSuggestionSource: PlaylistSuggestionSource | null;
+};
+
+export type PartyMutations = {
+  addQueueItem: (item: ClimbQueueItem, position?: number) => Promise<void>;
+  removeQueueItem: (uuid: string) => Promise<void>;
+  setCurrentClimb: (item: ClimbQueueItem, shouldAddToQueue?: boolean, correlationId?: string) => Promise<void>;
+  mirrorCurrentClimb: (mirrored: boolean) => Promise<void>;
+  setQueue: (queue: ClimbQueueItem[], currentClimbQueueItem?: ClimbQueueItem | null) => Promise<void>;
+  replaceQueueItem: (uuid: string, item: ClimbQueueItem) => Promise<void>;
+  reportWallDisconnect: () => Promise<void>;
+};
+
+export type QueueActionsCoreParty = {
+  /** A party session is active right now (QueueContext: isPersistentSessionActive; bridge: !!ps.activeSession). */
+  isActive: boolean;
+  /** The connection has been established at least once. Real value in both
+   * surfaces — used by the (identical) reportWallDisconnect gate. */
+  hasConnected: boolean;
+  /** Previously connected but currently offline. Only meaningful for
+   * QueueContext's offline-buffering path — the bridge always passes `false`
+   * (it has no offline-buffering behavior to preserve). */
+  isDisconnected: boolean;
+  /** Whether a party mutation should be attempted right now, recomputed by
+   * the wiring on every call. QueueContext: `hasConnected && !isDisconnected`
+   * (so it buffers/no-ops instead of sending while offline). Bridge: always
+   * `true` (it sends whenever a party session is active, with no connection
+   * gate — pre-existing behavior, not something this refactor should add). */
+  attemptMutation: boolean;
+  /** setCurrentClimb, party mode only: reuse an existing queue entry matched
+   * by `climb.uuid` instead of adding a duplicate. Bridge-only behavior —
+   * QueueContext has never done this. */
+  reuseExistingQueueItemOnSetCurrentClimb: boolean;
+  /** setCurrentClimb: what to return when the party mutation fails.
+   * QueueContext keeps the optimistic item (the local dispatch already
+   * happened and isn't rolled back); the bridge returns `null` so callers
+   * like `navigateToClimb` can skip navigating to a climb the board was
+   * never actually told to display. */
+  returnNullOnSetCurrentClimbFailure: boolean;
+  mutations: PartyMutations;
+  /** Mint a correlation id for a local->party round trip, or `undefined`
+   * outside a party session. */
+  nextCorrelationId: () => string | undefined;
+};
+
+export type QueueActionsCoreColdStart = {
+  /** addToQueue only: bridge-solo cold-start seeding when no board is active
+   * yet (selecting a climb from a surface with no board context, e.g. a
+   * playlist view). Returns `true` when it handled the add (seeded or
+   * legitimately no-opped because the climb can't be seeded), `false` when
+   * not applicable (a board is already active) so the caller falls through
+   * to the normal local-update path. */
+  tryAddToQueue: (item: ClimbQueueItem) => boolean;
+  /** setCurrentClimb only: same cold-start seeding, distinguishing a
+   * successful seed from "climb has no board to seed from" so the caller can
+   * roll back the optimistic playlistSuggestionSource set on failure. */
+  trySetCurrentClimb: (item: ClimbQueueItem) => 'seeded' | 'failed' | 'not-applicable';
+};
+
+export type QueueActionsCoreHooks = {
+  /** Resolves the literal `source` tag for the 'Set Active Climb' analytics
+   * event. Differs by surface, and — for setCurrentClimbQueueItem only — by
+   * whether a party session is active. */
+  resolveSetActiveClimbSource: (
+    kind: 'setCurrentClimb' | 'setCurrentClimbQueueItem',
+    variant: 'party' | 'solo' | null,
+  ) => SetActiveClimbSource;
+  /** Fires the 'Set Active Climb' analytics event. Both surfaces fire this,
+   * unconditionally, on every climb activation. */
+  onSetActiveClimb: (payload: {
+    climbUuid: string;
+    boardType: string | null;
+    layoutId: number | null;
+    source: SetActiveClimbSource;
+  }) => void;
+  /** QueueContext only: increments the session's climbs-attempted counter.
+   * Omit (bridge) to skip — the bridge has never tracked this. */
+  onClimbActivated?: () => void;
+  /** QueueContext only: fires 'Climb Added to Queue'. Omit (bridge) to skip —
+   * the bridge has never fired this event. */
+  onQueueItemAdded?: (payload: { item: ClimbQueueItem; source: AddToQueueSource; queueLengthAfter: number }) => void;
+  /** QueueContext only: fires 'Climb Removed from Queue'. Omit (bridge) to
+   * skip — the bridge has never fired this event. */
+  onQueueItemRemoved?: (payload: { item: ClimbQueueItem }) => void;
+  /** QueueContext only: per-operation timing/error metrics ('Queue Operation'
+   * / 'Queue Operation Error'). Omit (bridge) to skip — the bridge has never
+   * tracked these. */
+  onOperationMetric?: {
+    success: (operation: QueueOperation, durationMs: number, mode: QueueOperationMode) => void;
+    error: (operation: QueueOperation, mode: QueueOperationMode) => void;
+  };
+};
+
+export type SetCurrentClimbErrorMessages = {
+  /** party mode, reuse-existing-item branch (bridge only; unreachable when
+   * `party.reuseExistingQueueItemOnSetCurrentClimb` is false). */
+  reuse: string;
+  /** party mode, playlist-source branch (insert-after-current + prune, then
+   * a single `setQueue` call). */
+  playlist: string;
+  /** party mode, plain branch, the `addQueueItem` step. */
+  add: string;
+  /** party mode, plain branch, the `setCurrentClimb` step (after addQueueItem
+   * already succeeded — the item is queued but not yet activated). */
+  activate: string;
+};
+
+export type QueueActionsCoreErrorMessages = {
+  addToQueue: string;
+  removeFromQueue: string;
+  setQueue: string;
+  mirrorClimb: string;
+  replaceQueueItem: string;
+  setCurrentClimb: SetCurrentClimbErrorMessages;
+  setCurrentClimbQueueItem: string;
+  reportWallDisconnect: string;
+};
+
+export type QueueActionsCoreDeps = {
+  /** Fresh-every-call read of the state the actions operate on. Backed by a
+   * `latestRef`-style ref on both surfaces so this function can be called
+   * from a `[]`-deps stable callback without staleness. */
+  getSnapshot: () => QueueActionsCoreSnapshot;
+  /** Applies a queue-reducer action to whatever store backs *local* state.
+   * QueueContext: `dispatch` (the `@boardsesh/queue` reducer via
+   * `useReducer`, always applied). Bridge solo: reduce against the
+   * useState-backed local store via the same shared reducer, then persist via
+   * `ps.setLocalQueueState`. Bridge party: a no-op — party mode waits for the
+   * server echo instead of applying an optimistic update (this is the one
+   * documented pre-existing behavior difference this refactor preserves). */
+  applyLocal: (action: QueueAction) => void;
+  /** Sets `playlistSuggestionSource` outside of `applyLocal` because both
+   * surfaces update it unconditionally, even when a party mutation is in
+   * flight and `applyLocal` is a no-op — it's pure client-local navigation
+   * bookkeeping the server never echoes back. QueueContext: dispatches
+   * `SET_PLAYLIST_SUGGESTION_SOURCE`. Bridge: a raw `useState` setter. */
+  setPlaylistSuggestionSourceLocal: (source: PlaylistSuggestionSource | null) => void;
+  /** Conditionally refreshes `playlistSuggestionSource` when its activation
+   * identity still matches. Delegated (not implemented over `getSnapshot`)
+   * because both surfaces resolve the match against their live store —
+   * QueueContext via the reducer's `REFRESH_PLAYLIST_SUGGESTION_SOURCE`
+   * action, the bridge via a functional `setState` updater — which sees
+   * same-tick updates a `latestRef` snapshot would miss. */
+  refreshPlaylistSuggestionSourceLocal: (source: PlaylistSuggestionSource) => void;
+  /** Builds a fresh queue item from a climb, attributing it to the current
+   * user. Mirrors `createClimbQueueItem` (QueueContext) / `buildQueueItem`
+   * (bridge) — identical shape, differing only in how each surface sources
+   * `clientId`/`currentUserInfo`. */
+  buildItem: (climb: Climb, suggested?: boolean) => ClimbQueueItem;
+  /** Returns `true` to block the mutation (and show its own "blocked" UI).
+   * QueueContext: `useMutationGuard`'s `guardMutation`. Bridge: `() => false`
+   * — the bridge has never gated mutations this way. */
+  guardMutation: () => boolean;
+  /** Validates + (on rejection) surfaces its own error UI, returning `false`
+   * to short-circuit the caller. QueueContext: `useQueueAddValidator`.
+   * Bridge: board-compatibility validation via a Snackbar. */
+  validateClimbForQueue: (climb: Climb) => boolean;
+  /** Buffer for additions made while offline in party mode. Only QueueContext
+   * has this; the bridge passes `null` (no offline-buffering behavior to
+   * preserve there). */
+  offlineBuffer: { bufferAddition: (item: ClimbQueueItem) => void } | null;
+  /** setCurrentClimbQueueItem: whether the activated item should be added to
+   * the queue when it isn't already present. QueueContext: `item.suggested`
+   * (only suggestion-derived items get auto-queued). Bridge: always `true`
+   * (it queues any not-yet-queued item regardless of `suggested`). */
+  resolveShouldAddToQueueOnActivate: (item: ClimbQueueItem) => boolean;
+  /** setQueue: resolves the next `currentClimbQueueItem` for the new queue.
+   * QueueContext: always keeps the existing current climb, even if it fell
+   * out of the new queue (callers are expected to keep it consistent
+   * themselves). Bridge: keeps the existing current climb only if it
+   * survived in the new queue, otherwise falls back to the new queue's first
+   * item (or `null` if empty). */
+  resolveNextCurrentForSetQueue: (
+    newQueue: ClimbQueueItem[],
+    currentClimbQueueItem: ClimbQueueItem | null,
+  ) => ClimbQueueItem | null;
+  /** replaceQueueItem: builds the replacement item from the existing queue
+   * entry (if any) and the new climb. Returning `null` aborts the action
+   * (bridge requires an existing entry; QueueContext always proceeds,
+   * falling back to its own freshly-attributed base item when there's no
+   * existing entry to borrow `addedBy`/`addedByUser`/`tickedBy`/`suggested`
+   * from). */
+  buildReplacementItem: (
+    existing: ClimbQueueItem | undefined,
+    climb: Climb,
+    queueItemUuid: string,
+  ) => ClimbQueueItem | null;
+  /** getNextClimbQueueItem/getPreviousClimbQueueItem strategy, given the
+   * resolved anchor (`options.from` or the current climb). QueueContext:
+   * queue walk, then the playlist-suggestion-or-climbSearchResults discovery
+   * fallback. Bridge: delegates the whole walk to
+   * `findNextQueueItemWithSuggestions`/a queue-only walk (@boardsesh/play-view
+   * parity with mobile). */
+  discoverNext: (anchor: ClimbQueueItem | null) => ClimbQueueItem | null;
+  discoverPrev: (anchor: ClimbQueueItem | null) => ClimbQueueItem | null;
+  /** Cold-start seeding (bridge-solo only, board not yet active). Omitted by
+   * QueueContext, which is always board-route-bound. */
+  coldStart?: QueueActionsCoreColdStart;
+  party: QueueActionsCoreParty;
+  hooks: QueueActionsCoreHooks;
+  errorMessages: QueueActionsCoreErrorMessages;
+};
+
+export type QueueActionsCore = Pick<
+  QueueActionsType,
+  | 'addToQueue'
+  | 'removeFromQueue'
+  | 'setCurrentClimb'
+  | 'setCurrentClimbQueueItem'
+  | 'previewClimbFromBrowse'
+  | 'setPlaylistSuggestionSource'
+  | 'refreshPlaylistSuggestionSource'
+  | 'replaceQueueItem'
+  | 'mirrorClimb'
+  | 'getNextClimbQueueItem'
+  | 'getPreviousClimbQueueItem'
+  | 'setQueue'
+  | 'reportWallDisconnect'
+>;
+
+export function createQueueActionsCore(deps: QueueActionsCoreDeps): QueueActionsCore {
+  const {
+    getSnapshot,
+    applyLocal,
+    setPlaylistSuggestionSourceLocal,
+    refreshPlaylistSuggestionSourceLocal,
+    buildItem,
+    guardMutation,
+    validateClimbForQueue,
+    offlineBuffer,
+    resolveShouldAddToQueueOnActivate,
+    resolveNextCurrentForSetQueue,
+    buildReplacementItem,
+    discoverNext,
+    discoverPrev,
+    coldStart,
+    party,
+    hooks,
+    errorMessages,
+  } = deps;
+
+  const attemptPartyMutation = () => party.isActive && party.attemptMutation;
+
+  function addToQueue(climb: Climb, source: AddToQueueSource = 'unknown'): void {
+    const startTime = performance.now();
+    if (guardMutation()) return;
+    if (!validateClimbForQueue(climb)) return;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+    const newItem = buildItem(climb, false);
+    const queueLengthAfter = getSnapshot().queue.length + 1;
+
+    applyLocal({ type: 'DELTA_ADD_QUEUE_ITEM', payload: { item: newItem } });
+    hooks.onQueueItemAdded?.({ item: newItem, source, queueLengthAfter });
+
+    if (party.isActive && party.isDisconnected && offlineBuffer) {
+      offlineBuffer.bufferAddition(newItem);
+      hooks.onOperationMetric?.success('addToQueue', performance.now() - startTime, mode);
+      return;
+    }
+    if (attemptPartyMutation()) {
+      party.mutations
+        .addQueueItem(newItem)
+        .then(() => hooks.onOperationMetric?.success('addToQueue', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error(errorMessages.addToQueue, error);
+          hooks.onOperationMetric?.error('addToQueue', mode);
+        });
+      return;
+    }
+    if (!party.isActive && coldStart) {
+      const handled = coldStart.tryAddToQueue(newItem);
+      if (handled) return;
+    }
+    hooks.onOperationMetric?.success('addToQueue', performance.now() - startTime, mode);
+  }
+
+  function removeFromQueue(item: ClimbQueueItem): void {
+    const startTime = performance.now();
+    if (guardMutation()) return;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+
+    applyLocal({ type: 'DELTA_REMOVE_QUEUE_ITEM', payload: { uuid: item.uuid } });
+    hooks.onQueueItemRemoved?.({ item });
+
+    if (attemptPartyMutation()) {
+      party.mutations
+        .removeQueueItem(item.uuid)
+        .then(() => hooks.onOperationMetric?.success('removeFromQueue', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error(errorMessages.removeFromQueue, error);
+          hooks.onOperationMetric?.error('removeFromQueue', mode);
+        });
+      return;
+    }
+    hooks.onOperationMetric?.success('removeFromQueue', performance.now() - startTime, mode);
+  }
+
+  async function setCurrentClimb(climb: Climb, options: SetCurrentClimbOptions): Promise<ClimbQueueItem | null> {
+    const startTime = performance.now();
+    if (guardMutation()) return null;
+    if (!validateClimbForQueue(climb)) return null;
+
+    const nextPlaylistSuggestionSource = options.playlistSuggestionSource;
+    const previousPlaylistSuggestionSource = getSnapshot().playlistSuggestionSource;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+    const newItem = buildItem(climb, false);
+    const correlationId = party.nextCorrelationId();
+
+    setPlaylistSuggestionSourceLocal(nextPlaylistSuggestionSource);
+    hooks.onSetActiveClimb({
+      climbUuid: climb.uuid,
+      boardType: climb.boardType ?? null,
+      layoutId: climb.layoutId ?? null,
+      source: hooks.resolveSetActiveClimbSource('setCurrentClimb', null),
+    });
+    hooks.onClimbActivated?.();
+
+    const rollbackPlaylistSuggestionSource = () => setPlaylistSuggestionSourceLocal(previousPlaylistSuggestionSource);
+    const finishSuccess = () =>
+      hooks.onOperationMetric?.success('setCurrentClimb', performance.now() - startTime, mode);
+    const finishError = (message: string, error: unknown) => {
+      console.error(message, error);
+      if (correlationId) applyLocal({ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId } });
+      rollbackPlaylistSuggestionSource();
+      hooks.onOperationMetric?.error('setCurrentClimb', mode);
+    };
+
+    applyLocal({
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: {
+        item: newItem,
+        shouldAddToQueue: true,
+        insertAfterCurrent: true,
+        correlationId,
+        playlistSuggestionSource: nextPlaylistSuggestionSource,
+      },
+    });
+
+    if (party.isActive && party.isDisconnected && offlineBuffer) {
+      offlineBuffer.bufferAddition(newItem);
+      finishSuccess();
+      return newItem;
+    }
+
+    if (attemptPartyMutation()) {
+      const { queue, currentClimbQueueItem } = getSnapshot();
+
+      if (party.reuseExistingQueueItemOnSetCurrentClimb) {
+        const existing = queue.find((queueItem) => queueItem.climb?.uuid === climb.uuid);
+        if (existing) {
+          try {
+            if (nextPlaylistSuggestionSource) {
+              await party.mutations.setQueue(pruneSuggestedQueueItemsAfterCurrent(queue, existing), existing);
+            } else {
+              await party.mutations.setCurrentClimb(existing, false, correlationId);
+            }
+            finishSuccess();
+            return existing;
+          } catch (error: unknown) {
+            finishError(errorMessages.setCurrentClimb.reuse, error);
+            return party.returnNullOnSetCurrentClimbFailure ? null : existing;
+          }
+        }
+      }
+
+      const currentIndex = currentClimbQueueItem
+        ? queue.findIndex((queueItem) => queueItem.uuid === currentClimbQueueItem.uuid)
+        : -1;
+      const position = currentIndex === -1 ? undefined : currentIndex + 1;
+
+      if (nextPlaylistSuggestionSource) {
+        try {
+          const queueWithNewItem = insertQueueItemAfterCurrent(queue, currentClimbQueueItem, newItem);
+          const prunedQueue = pruneSuggestedQueueItemsAfterCurrent(queueWithNewItem, newItem);
+          await party.mutations.setQueue(prunedQueue, newItem);
+          finishSuccess();
+          return newItem;
+        } catch (error: unknown) {
+          finishError(errorMessages.setCurrentClimb.playlist, error);
+          return party.returnNullOnSetCurrentClimbFailure ? null : newItem;
+        }
+      }
+
+      try {
+        await party.mutations.addQueueItem(newItem, position);
+      } catch (error: unknown) {
+        finishError(errorMessages.setCurrentClimb.add, error);
+        return party.returnNullOnSetCurrentClimbFailure ? null : newItem;
+      }
+      try {
+        // Sequential awaits over a single graphql-ws connection preserve FIFO
+        // ordering, so the server processes the add before the setCurrentClimb
+        // that references it.
+        await party.mutations.setCurrentClimb(newItem, false, correlationId);
+      } catch (error: unknown) {
+        finishError(errorMessages.setCurrentClimb.activate, error);
+        return party.returnNullOnSetCurrentClimbFailure ? null : newItem;
+      }
+      finishSuccess();
+      return newItem;
+    }
+
+    if (!party.isActive && coldStart) {
+      const outcome = coldStart.trySetCurrentClimb(newItem);
+      if (outcome === 'seeded') {
+        finishSuccess();
+        return newItem;
+      }
+      if (outcome === 'failed') {
+        rollbackPlaylistSuggestionSource();
+        hooks.onOperationMetric?.error('setCurrentClimb', mode);
+        return null;
+      }
+      // 'not-applicable' — a board is already active, fall through.
+    }
+
+    finishSuccess();
+    return newItem;
+  }
+
+  function setCurrentClimbQueueItem(item: ClimbQueueItem): void {
+    const startTime = performance.now();
+    if (guardMutation()) return;
+    // Playlist "peek" items use a deterministic synthetic uuid so repeated
+    // peeks of the same suggestion produce a stable queue uuid. Once a peek
+    // is promoted to the actual current climb, mint a fresh queue-item uuid
+    // so it lives as a regular queue entry rather than a transient peek.
+    const queueItem = isPlaylistPeekQueueItemUuid(item.uuid) ? buildItem(item.climb, item.suggested) : item;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+    const correlationId = party.nextCorrelationId();
+
+    applyLocal({
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item: queueItem, shouldAddToQueue: resolveShouldAddToQueueOnActivate(queueItem), correlationId },
+    });
+    if (queueItem.climb) {
+      hooks.onSetActiveClimb({
+        climbUuid: queueItem.climb.uuid,
+        boardType: queueItem.climb.boardType ?? null,
+        layoutId: queueItem.climb.layoutId ?? null,
+        source: hooks.resolveSetActiveClimbSource('setCurrentClimbQueueItem', party.isActive ? 'party' : 'solo'),
+      });
+    }
+    hooks.onClimbActivated?.();
+
+    if (attemptPartyMutation()) {
+      party.mutations
+        .setCurrentClimb(queueItem, queueItem.suggested, correlationId)
+        .then(() => hooks.onOperationMetric?.success('setCurrentClimbQueueItem', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error(errorMessages.setCurrentClimbQueueItem, error);
+          if (correlationId) applyLocal({ type: 'CLEANUP_PENDING_UPDATE', payload: { correlationId } });
+          hooks.onOperationMetric?.error('setCurrentClimbQueueItem', mode);
+        });
+      return;
+    }
+    hooks.onOperationMetric?.success('setCurrentClimbQueueItem', performance.now() - startTime, mode);
+  }
+
+  function setQueue(newQueue: ClimbQueueItem[]): void {
+    const startTime = performance.now();
+    if (guardMutation()) return;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+    const nextCurrent = resolveNextCurrentForSetQueue(newQueue, getSnapshot().currentClimbQueueItem);
+
+    applyLocal({ type: 'UPDATE_QUEUE', payload: { queue: newQueue, currentClimbQueueItem: nextCurrent } });
+
+    if (attemptPartyMutation()) {
+      party.mutations
+        .setQueue(newQueue, nextCurrent)
+        .then(() => hooks.onOperationMetric?.success('setQueue', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error(errorMessages.setQueue, error);
+          hooks.onOperationMetric?.error('setQueue', mode);
+        });
+      return;
+    }
+    hooks.onOperationMetric?.success('setQueue', performance.now() - startTime, mode);
+  }
+
+  function mirrorClimb(): void {
+    const startTime = performance.now();
+    if (guardMutation()) return;
+    const { currentClimbQueueItem } = getSnapshot();
+    if (!currentClimbQueueItem?.climb) return;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+    const newMirroredState = !currentClimbQueueItem.climb.mirrored;
+
+    // Local-origin dispatch: pass the current climb's uuid so the reducer's
+    // server-event uuid guard is a no-op here (it only suppresses when uuid
+    // diverges).
+    applyLocal({
+      type: 'DELTA_MIRROR_CURRENT_CLIMB',
+      payload: { mirrored: newMirroredState, mirroredUuid: currentClimbQueueItem.uuid },
+    });
+
+    if (attemptPartyMutation()) {
+      party.mutations
+        .mirrorCurrentClimb(newMirroredState)
+        .then(() => hooks.onOperationMetric?.success('mirrorClimb', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error(errorMessages.mirrorClimb, error);
+          hooks.onOperationMetric?.error('mirrorClimb', mode);
+        });
+      return;
+    }
+    hooks.onOperationMetric?.success('mirrorClimb', performance.now() - startTime, mode);
+  }
+
+  function replaceQueueItem(queueItemUuid: string, climb: Climb): void {
+    const startTime = performance.now();
+    if (guardMutation()) return;
+    if (!validateClimbForQueue(climb)) return;
+    const { queue } = getSnapshot();
+    const existing = queue.find((queueItem) => queueItem.uuid === queueItemUuid);
+    const newItem = buildReplacementItem(existing, climb, queueItemUuid);
+    if (!newItem) return;
+    const mode = resolveQueueOperationMode(party.isActive, party.isDisconnected);
+
+    applyLocal({ type: 'DELTA_REPLACE_QUEUE_ITEM', payload: { uuid: queueItemUuid, item: newItem } });
+
+    if (attemptPartyMutation()) {
+      party.mutations
+        .replaceQueueItem(queueItemUuid, newItem)
+        .then(() => hooks.onOperationMetric?.success('replaceQueueItem', performance.now() - startTime, mode))
+        .catch((error: unknown) => {
+          console.error(errorMessages.replaceQueueItem, error);
+          hooks.onOperationMetric?.error('replaceQueueItem', mode);
+        });
+      return;
+    }
+    hooks.onOperationMetric?.success('replaceQueueItem', performance.now() - startTime, mode);
+  }
+
+  // Browse-initiated drawer open. Always-live model: every participant
+  // broadcasts on browse exactly like solo — pre-mutate state (which the
+  // persistent session broadcasts when a party session is active) then open
+  // the drawer. `playlistSuggestionSource: null` so activating a non-playlist
+  // climb clears any stale playlist source carried over from a prior
+  // activation.
+  function previewClimbFromBrowse(climb: Climb): void {
+    void setCurrentClimb(climb, { playlistSuggestionSource: null });
+    dispatchOpenPlayDrawer();
+  }
+
+  function setPlaylistSuggestionSource(source: PlaylistSuggestionSource | null): void {
+    setPlaylistSuggestionSourceLocal(source ?? null);
+  }
+
+  function refreshPlaylistSuggestionSource(source: PlaylistSuggestionSource): void {
+    refreshPlaylistSuggestionSourceLocal(source);
+  }
+
+  function getNextClimbQueueItem(options?: { from?: ClimbQueueItem | null }): ClimbQueueItem | null {
+    // `??` (not a truthy check) so an explicit `from: null` falls back to the
+    // current climb exactly like an omitted `from` — matches both surfaces'
+    // pre-refactor behavior (QueueContext's `options?.from ? ... : ...` and
+    // the bridge's `options?.from ?? current` are equivalent for object-or-
+    // null values).
+    const anchor = options?.from ?? getSnapshot().currentClimbQueueItem;
+    return discoverNext(anchor);
+  }
+
+  function getPreviousClimbQueueItem(options?: { from?: ClimbQueueItem | null }): ClimbQueueItem | null {
+    const anchor = options?.from ?? getSnapshot().currentClimbQueueItem;
+    return discoverPrev(anchor);
+  }
+
+  // Report this client's own BLE link drop to the session so every member's
+  // wall-confirmed lightbulb clears. Best-effort and a no-op in solo (the
+  // persistent-session helper short-circuits with no active session).
+  async function reportWallDisconnect(): Promise<void> {
+    if (!party.isActive) return;
+    if (!party.hasConnected) return;
+    try {
+      await party.mutations.reportWallDisconnect();
+    } catch (error: unknown) {
+      console.error(errorMessages.reportWallDisconnect, error);
+    }
+  }
+
+  return {
+    addToQueue,
+    removeFromQueue,
+    setCurrentClimb,
+    setCurrentClimbQueueItem,
+    previewClimbFromBrowse,
+    setPlaylistSuggestionSource,
+    refreshPlaylistSuggestionSource,
+    replaceQueueItem,
+    mirrorClimb,
+    getNextClimbQueueItem,
+    getPreviousClimbQueueItem,
+    setQueue,
+    reportWallDisconnect,
+  };
+}

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -27,7 +27,7 @@ import { usePersistentSession } from '../persistent-session';
 import { usePartyProfile } from '../party-manager/party-profile-context';
 import { getBaseBoardPath, extractAngleFromPathname, DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import type { BoardDetails, Angle, Climb, SearchRequestPagination } from '@/app/lib/types';
-import type { ClimbQueueItem, QueueItemUser, PlaylistSuggestionSource, SetCurrentClimbOptions } from './types';
+import type { ClimbQueueItem, QueueItemUser, PlaylistSuggestionSource, QueueState, QueueAction } from './types';
 import { usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { canAddClimbToBoard } from '@/app/lib/board-compatibility';
@@ -35,22 +35,20 @@ import { getBoardDetailsForPlaylist } from '@/app/lib/board-config-for-playlist'
 import { useSnackbar } from '../providers/snackbar-provider';
 import { queueAddErrorMessage } from '../board-lock/queue-add-error-messages';
 import { QueueBridgeBoardInfoContext, type QueueBridgeBoardInfo } from './queue-bridge-board-info-context';
-import { dispatchOpenPlayDrawer } from './play-drawer-event';
-import type { SetActiveClimbSource } from '../graphql-queue/set-active-climb-event';
 import { track } from '@/app/lib/analytics';
-import {
-  getPlaylistSuggestedClimbs,
-  insertQueueItemAfterCurrent,
-  isPlaylistPeekQueueItemUuid,
-  playlistSuggestionSourceMatches,
-  pruneSuggestedQueueItemsAfterCurrent,
-} from './playlist-suggestions';
+import { getPlaylistSuggestedClimbs, playlistSuggestionSourceMatches } from './playlist-suggestions';
 import { findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
+import { queueReducer } from '@boardsesh/queue';
 import type {
   ClimbQueue as SharedClimbQueue,
   ClimbQueueItem as SharedClimbQueueItem,
   PlaylistSuggestionSource as SharedPlaylistSuggestionSource,
 } from '@boardsesh/queue';
+import {
+  createQueueActionsCore,
+  type QueueActionsCoreColdStart,
+  type QueueActionsCoreDeps,
+} from './queue-actions-core';
 
 const LiveActivityBridge = dynamic(() => import('@/app/lib/live-activity/live-activity-bridge'), {
   ssr: false,
@@ -266,311 +264,205 @@ function usePersistentSessionQueueAdapter(): {
     return false;
   }, []);
 
-  // Bridge-mode nav delegates to the shared @boardsesh/play-view helper
-  // (`findNextQueueItemWithSuggestions`) so web's off-board swipe path stays in
-  // lockstep with mobile, which already uses that helper. The helper is
-  // queue-first and, once the queue is exhausted, re-walks the playlist from
-  // the CURRENT climb's position in the source — re-activating a playlist
-  // climb starts a fresh pass instead of jumping to the first un-queued climb.
-  //
-  // `from`: pass `options.from ?? current` as the helper's
-  // currentClimbQueueItem. This reproduces the old anchor selection
-  // (anchor = the `from` item when supplied, else the current wall climb).
-  // The web↔shared type-seam casts live in `findNextQueueItemAcrossSeam`.
-  const getNextClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }): ClimbQueueItem | null => {
-    const { queue, currentClimbQueueItem: current, playlistSuggestionSource } = latestRef.current;
-    const anchor = options?.from ?? current;
-    return findNextQueueItemAcrossSeam(queue, anchor, playlistSuggestionSource);
-  }, []);
+  // --- Single shared queue-actions implementation (see queue-actions-core.ts) ---
+  // Every field here is a closure over `latestRef`, so this can be built once
+  // (`useMemo(..., [])`) and stay fresh — same pattern as GraphQLQueueProvider.
 
-  const getPreviousClimbQueueItem = useCallback((options?: { from?: ClimbQueueItem | null }): ClimbQueueItem | null => {
-    const { queue, currentClimbQueueItem: current } = latestRef.current;
-    const anchorUuid = options?.from ? options.from.uuid : current?.uuid;
-    const idx = queue.findIndex(({ uuid }) => uuid === anchorUuid);
-    return idx > 0 ? queue[idx - 1] : null;
-  }, []);
-
-  const setCurrentClimbQueueItem = useCallback(
-    (item: ClimbQueueItem) => {
-      const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
-      const queueItem = isPlaylistPeekQueueItemUuid(item.uuid)
-        ? { ...buildQueueItem(item.climb), suggested: item.suggested }
-        : item;
-      const alreadyInQueue = queue.some((q) => q.uuid === item.uuid);
-      const fireSetActive = (source: SetActiveClimbSource) => {
-        if (!queueItem.climb) return;
-        track('Set Active Climb', {
-          climbUuid: queueItem.climb.uuid,
-          boardType: queueItem.climb.boardType ?? null,
-          layoutId: queueItem.climb.layoutId ?? null,
-          source,
-        });
-      };
-      if (ps.activeSession) {
-        // Don't bail on the "already current" optimistic state in party mode —
-        // a peer may have moved the current climb away and our local view
-        // hasn't caught up yet. Always re-send so the server reconciles.
-        const correlationId = ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
-        ps.setCurrentClimb(queueItem, queueItem.suggested, correlationId).catch((err: unknown) => {
-          console.error('Failed to set current climb queue item:', err);
-        });
-        fireSetActive('bridge.setCurrentClimbQueueItem.party');
-        return;
-      }
-      if (alreadyInQueue && current?.uuid === queueItem.uuid) return;
-      if (!boardDetails) return;
-      const newQueue = alreadyInQueue ? queue : [...queue, queueItem];
-      ps.setLocalQueueState(newQueue, queueItem, baseBoardPath, boardDetails);
-      fireSetActive('bridge.setCurrentClimbQueueItem.solo');
-    },
-    [buildQueueItem],
-  );
-
-  const addToQueue = useCallback(
-    (climb: Climb) => {
-      const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
-      if (!validateClimbForQueue(climb)) return;
-      const newItem = buildQueueItem(climb);
-      if (ps.activeSession) {
-        ps.addQueueItem(newItem).catch((err: unknown) => {
-          console.error('Failed to add queue item:', err);
-        });
-        return;
-      }
-      if (!boardDetails) {
-        // Cold-start path: no active board yet. Seed local state from the
-        // climb's own board config so the queue bar begins showing.
-        const seed = deriveSeedStateFromClimb(climb);
-        if (!seed) return;
-        ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
-        return;
-      }
-      ps.setLocalQueueState([...queue, newItem], current ?? newItem, baseBoardPath, boardDetails);
-    },
-    [validateClimbForQueue, buildQueueItem],
-  );
-
-  const removeFromQueue = useCallback((item: ClimbQueueItem) => {
-    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
-    if (ps.activeSession) {
-      ps.removeQueueItem(item.uuid).catch((err: unknown) => {
-        console.error('Failed to remove queue item:', err);
-      });
-      return;
-    }
+  // Bridge-solo local store: reduce against the shared `@boardsesh/queue`
+  // reducer (the same one QueueContext dispatches to) and persist the result
+  // via `ps.setLocalQueueState`. This makes the reducer the single semantic
+  // definition of "apply a queue action" even for the bridge's useState-backed
+  // local store. Bridge PARTY mode is untouched: `applyLocal` no-ops there
+  // (returns before running the reducer), matching the pre-existing behavior
+  // of waiting for the server echo instead of applying an optimistic update.
+  const applyLocalSolo = useCallback((action: QueueAction) => {
+    const { ps, boardDetails, baseBoardPath, queue, currentClimbQueueItem, playlistSuggestionSource } =
+      latestRef.current;
+    if (ps.activeSession) return;
     if (!boardDetails) return;
-    const newQueue = queue.filter((q) => q.uuid !== item.uuid);
-    const newCurrent = current?.uuid === item.uuid ? (newQueue[0] ?? null) : current;
-    ps.setLocalQueueState(newQueue, newCurrent, baseBoardPath, boardDetails);
-  }, []);
-
-  const setQueue = useCallback((newQueue: ClimbQueueItem[]) => {
-    const { currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
-    // Pick the new current climb: keep the existing one if it survived the
-    // queue update, otherwise fall back to the first item (or null when empty).
-    const pickCurrent = (): ClimbQueueItem | null => {
-      if (newQueue.length === 0) return null;
-      if (current && newQueue.some((q) => q.uuid === current.uuid)) return current;
-      return newQueue[0];
+    const pseudoState: QueueState = {
+      queue,
+      currentClimbQueueItem,
+      playlistSuggestionSource,
+      climbSearchParams: DEFAULT_SEARCH_PARAMS,
+      hasDoneFirstFetch: false,
+      initialQueueDataReceivedFromPeers: false,
+      pendingCurrentClimbUpdates: [],
+      lastReceivedSequence: null,
+      lastReceivedStateHash: null,
+      needsResync: false,
     };
-    if (ps.activeSession) {
-      ps.setQueue(newQueue, pickCurrent()).catch((err: unknown) => {
-        console.error('Failed to set queue:', err);
-      });
-      return;
+    let nextState = queueReducer(pseudoState, action);
+    // Two bridge-only quirks the shared reducer's generic DELTA_ADD_QUEUE_ITEM
+    // / DELTA_REMOVE_QUEUE_ITEM cases don't reproduce (they only touch `queue`,
+    // matching QueueContext, whose addToQueue/removeFromQueue never set the
+    // current climb as a side effect). The bridge's pre-refactor local-state
+    // math did, and existing tests pin it: adding to an un-activated queue also
+    // activates the new item; removing the current item promotes the new head
+    // instead of clearing to null. Behavior-preserving overrides, kept narrow.
+    if (action.type === 'DELTA_ADD_QUEUE_ITEM' && !pseudoState.currentClimbQueueItem) {
+      nextState = { ...nextState, currentClimbQueueItem: action.payload.item };
+    } else if (
+      action.type === 'DELTA_REMOVE_QUEUE_ITEM' &&
+      pseudoState.currentClimbQueueItem?.uuid === action.payload.uuid
+    ) {
+      nextState = { ...nextState, currentClimbQueueItem: nextState.queue[0] ?? null };
     }
-    if (!boardDetails) return;
-    ps.setLocalQueueState(newQueue, pickCurrent(), baseBoardPath, boardDetails);
+    // Reducer returned the same reference (a guard no-op, e.g. re-activating
+    // the already-current item) — skip the redundant persist call.
+    if (nextState === pseudoState) return;
+    ps.setLocalQueueState(nextState.queue, nextState.currentClimbQueueItem, baseBoardPath, boardDetails);
   }, []);
 
-  const mirrorClimb = useCallback(() => {
-    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
-    if (!current?.climb) return;
-    const mirrored = !current.climb.mirrored;
-    if (ps.activeSession) {
-      ps.mirrorCurrentClimb(mirrored).catch((err: unknown) => {
-        console.error('Failed to mirror current climb:', err);
-      });
-      return;
-    }
-    if (!boardDetails) return;
-    const updatedItem: ClimbQueueItem = {
-      ...current,
-      climb: { ...current.climb, mirrored },
-    };
-    const newQueue = queue.map((q) => (q.uuid === updatedItem.uuid ? updatedItem : q));
-    ps.setLocalQueueState(newQueue, updatedItem, baseBoardPath, boardDetails);
-  }, []);
-
-  const setCurrentClimb = useCallback(
-    async (climb: Climb, options: SetCurrentClimbOptions): Promise<ClimbQueueItem | null> => {
-      const {
-        queue,
-        currentClimbQueueItem: current,
-        ps,
-        boardDetails,
-        baseBoardPath,
-        playlistSuggestionSource: previousPlaylistSuggestionSource,
-      } = latestRef.current;
-      if (!validateClimbForQueue(climb)) return null;
-      const nextPlaylistSuggestionSource = options.playlistSuggestionSource;
-      const rollbackPlaylistSuggestionSource = () => {
-        setPlaylistSuggestionSourceState(previousPlaylistSuggestionSource);
-      };
-      setPlaylistSuggestionSourceState(nextPlaylistSuggestionSource);
-      track('Set Active Climb', {
-        climbUuid: climb.uuid,
-        boardType: climb.boardType ?? null,
-        layoutId: climb.layoutId ?? null,
-        source: 'bridge.setCurrentClimb' satisfies SetActiveClimbSource,
-      });
-      if (ps.activeSession) {
-        const correlationId = ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
-        // If the climb is already in the queue, reuse the existing item
-        // instead of adding a duplicate. This mirrors the natural behavior
-        // expected by users tapping a logbook/session-view climb that's
-        // already queued from another peer or earlier in the sesh.
-        const existing = queue.find((q) => q.climb?.uuid === climb.uuid);
-        if (existing) {
-          try {
-            if (nextPlaylistSuggestionSource) {
-              await ps.setQueue(pruneSuggestedQueueItemsAfterCurrent(queue, existing), existing);
-            } else {
-              await ps.setCurrentClimb(existing, false, correlationId);
-            }
-            return existing;
-          } catch (err: unknown) {
-            console.error('Failed to set current climb:', err);
-            rollbackPlaylistSuggestionSource();
-            return null;
-          }
-        }
-        const newItem = buildQueueItem(climb);
-        const currentIdx = current ? queue.findIndex((q) => q.uuid === current.uuid) : -1;
-        const position = currentIdx === -1 ? undefined : currentIdx + 1;
-        if (nextPlaylistSuggestionSource) {
-          const queueWithNewItem = insertQueueItemAfterCurrent(queue, current, newItem);
-          const prunedQueue = pruneSuggestedQueueItemsAfterCurrent(queueWithNewItem, newItem);
-          try {
-            await ps.setQueue(prunedQueue, newItem);
-            return newItem;
-          } catch (err: unknown) {
-            console.error('Failed to replace queue before setting playlist current:', err);
-            rollbackPlaylistSuggestionSource();
-            return null;
-          }
-        }
-        // Split the awaits so a partial failure is observable: addQueueItem
-        // adds the item to the shared queue, then setCurrentClimb activates
-        // it. If addQueueItem fails, nothing landed on the server. If
-        // setCurrentClimb fails after addQueueItem succeeded, the item is
-        // queued but not active — return null so the caller (e.g.
-        // SessionDetailContent.navigateToClimb) doesn't navigate to a climb
-        // the board never actually got told to display.
-        try {
-          await ps.addQueueItem(newItem, position);
-        } catch (err: unknown) {
-          console.error('Failed to add queue item before setting current:', err);
-          rollbackPlaylistSuggestionSource();
-          return null;
-        }
-        try {
-          // Sequential awaits over a single graphql-ws connection preserve
-          // FIFO ordering, so the server processes the add before the
-          // setCurrentClimb that references it. This mirrors
-          // GraphQLQueueProvider.setCurrentClimb.
-          await ps.setCurrentClimb(newItem, false, correlationId);
-          return newItem;
-        } catch (err: unknown) {
-          console.error('Failed to set current climb after queue add:', err);
-          rollbackPlaylistSuggestionSource();
-          return null;
-        }
-      }
-      const newItem = buildQueueItem(climb);
-      if (!boardDetails) {
-        // Cold-start path: no active board yet. Seed local state from the
-        // climb's own board config so the queue bar begins showing.
-        const seed = deriveSeedStateFromClimb(climb);
-        if (!seed) {
-          rollbackPlaylistSuggestionSource();
-          return null;
-        }
-        ps.setLocalQueueState([newItem], newItem, seed.baseBoardPath, seed.boardDetails);
-        return newItem;
-      }
-      const currentIdx = current ? queue.findIndex((q) => q.uuid === current.uuid) : -1;
-      const newQueue = [...queue];
-      if (currentIdx >= 0) {
-        newQueue.splice(currentIdx + 1, 0, newItem);
-      } else {
-        newQueue.push(newItem);
-      }
-      const nextQueue = nextPlaylistSuggestionSource
-        ? pruneSuggestedQueueItemsAfterCurrent(newQueue, newItem)
-        : newQueue;
-      ps.setLocalQueueState(nextQueue, newItem, baseBoardPath, boardDetails);
-      return newItem;
-    },
-    [validateClimbForQueue, buildQueueItem],
+  // Cold-start seeding: selecting a climb from a surface with no active board
+  // (e.g. a playlist view) auto-activates the climb's own board. Solo-only —
+  // party mode always has a board (the session carries one).
+  const coldStart: QueueActionsCoreColdStart = useMemo(
+    () => ({
+      tryAddToQueue: (item) => {
+        const { boardDetails, ps } = latestRef.current;
+        if (boardDetails) return false;
+        const seed = deriveSeedStateFromClimb(item.climb);
+        if (!seed) return true;
+        ps.setLocalQueueState([item], item, seed.baseBoardPath, seed.boardDetails);
+        return true;
+      },
+      trySetCurrentClimb: (item) => {
+        const { boardDetails, ps } = latestRef.current;
+        if (boardDetails) return 'not-applicable';
+        const seed = deriveSeedStateFromClimb(item.climb);
+        if (!seed) return 'failed';
+        ps.setLocalQueueState([item], item, seed.baseBoardPath, seed.boardDetails);
+        return 'seeded';
+      },
+    }),
+    [],
   );
 
-  // Bridge-mode browse helper. Always-live model: every participant broadcasts
-  // via setCurrentClimb so the wall climb changes for everyone, then opens the
-  // drawer. Mirrors QueueContext.previewClimbFromBrowse.
-  const previewClimbFromBrowse = useCallback(
-    (climb: Climb) => {
-      void setCurrentClimb(climb, { playlistSuggestionSource: null });
-      dispatchOpenPlayDrawer();
-    },
-    [setCurrentClimb],
+  const actionsCoreDeps = useMemo<QueueActionsCoreDeps>(
+    () => ({
+      getSnapshot: () => ({
+        queue: latestRef.current.queue,
+        currentClimbQueueItem: latestRef.current.currentClimbQueueItem,
+        playlistSuggestionSource: latestRef.current.playlistSuggestionSource,
+      }),
+      applyLocal: applyLocalSolo,
+      setPlaylistSuggestionSourceLocal: (source) => setPlaylistSuggestionSourceState(source),
+      // Functional updater so the identity-match check reads the latest state
+      // (including same-tick updates a `latestRef` snapshot would miss).
+      refreshPlaylistSuggestionSourceLocal: (source) =>
+        setPlaylistSuggestionSourceState((current) =>
+          playlistSuggestionSourceMatches(current, source) ? source : current,
+        ),
+      // `buildQueueItem` always builds `suggested: false`; override it here so
+      // peek-promotion (setCurrentClimbQueueItem) can carry the peek's own flag
+      // through, mirroring the pre-refactor `{ ...buildQueueItem(climb), suggested }`.
+      buildItem: (climb, suggested) => ({ ...buildQueueItem(climb), suggested: !!suggested }),
+      guardMutation: () => false,
+      validateClimbForQueue,
+      offlineBuffer: null,
+      resolveShouldAddToQueueOnActivate: () => true,
+      resolveNextCurrentForSetQueue: (newQueue, currentClimbQueueItem) => {
+        if (newQueue.length === 0) return null;
+        if (currentClimbQueueItem && newQueue.some((queueItem) => queueItem.uuid === currentClimbQueueItem.uuid)) {
+          return currentClimbQueueItem;
+        }
+        return newQueue[0];
+      },
+      buildReplacementItem: (existing, climb) => (existing ? { ...existing, climb } : null),
+      // Bridge-mode nav delegates to the shared @boardsesh/play-view helper
+      // (`findNextQueueItemWithSuggestions`) so web's off-board swipe path
+      // stays in lockstep with mobile, which already uses that helper. The
+      // helper is queue-first and, once the queue is exhausted, re-walks the
+      // playlist from the CURRENT climb's position in the source —
+      // re-activating a playlist climb starts a fresh pass instead of
+      // jumping to the first un-queued climb. The web↔shared type-seam casts
+      // live in `findNextQueueItemAcrossSeam`.
+      discoverNext: (anchor) => {
+        const { queue, playlistSuggestionSource } = latestRef.current;
+        return findNextQueueItemAcrossSeam(queue, anchor, playlistSuggestionSource);
+      },
+      discoverPrev: (anchor) => {
+        const { queue } = latestRef.current;
+        const idx = queue.findIndex(({ uuid }) => uuid === anchor?.uuid);
+        return idx > 0 ? queue[idx - 1] : null;
+      },
+      coldStart,
+      party: {
+        get isActive() {
+          return !!latestRef.current.ps.activeSession;
+        },
+        get hasConnected() {
+          return latestRef.current.ps.hasConnected;
+        },
+        isDisconnected: false,
+        attemptMutation: true,
+        // The bridge (unlike QueueContext) reuses an existing queue entry
+        // matched by climb.uuid instead of adding a duplicate — a peer may
+        // have already queued this same climb from a logbook/session-view tap.
+        reuseExistingQueueItemOnSetCurrentClimb: true,
+        returnNullOnSetCurrentClimbFailure: true,
+        mutations: {
+          addQueueItem: (item, position) => latestRef.current.ps.addQueueItem(item, position),
+          removeQueueItem: (uuid) => latestRef.current.ps.removeQueueItem(uuid),
+          setCurrentClimb: (item, shouldAddToQueue, correlationId) =>
+            latestRef.current.ps.setCurrentClimb(item, shouldAddToQueue, correlationId),
+          mirrorCurrentClimb: (mirrored) => latestRef.current.ps.mirrorCurrentClimb(mirrored),
+          setQueue: (queue, currentClimbQueueItem) => latestRef.current.ps.setQueue(queue, currentClimbQueueItem),
+          replaceQueueItem: (uuid, item) => latestRef.current.ps.replaceQueueItem(uuid, item),
+          reportWallDisconnect: () => latestRef.current.ps.reportWallDisconnect(),
+        },
+        nextCorrelationId: () => {
+          const { ps } = latestRef.current;
+          return ps.clientId ? `${ps.clientId}-${++correlationCounterRef.current}` : undefined;
+        },
+      },
+      hooks: {
+        resolveSetActiveClimbSource: (kind, variant) => {
+          if (kind === 'setCurrentClimb') return 'bridge.setCurrentClimb';
+          return variant === 'party' ? 'bridge.setCurrentClimbQueueItem.party' : 'bridge.setCurrentClimbQueueItem.solo';
+        },
+        onSetActiveClimb: (payload) => track('Set Active Climb', payload),
+        // onClimbActivated / onQueueItemAdded / onQueueItemRemoved /
+        // onOperationMetric are intentionally omitted — the bridge has never
+        // tracked session-climbs-attempted, 'Climb Added/Removed to/from
+        // Queue', or per-operation timing metrics.
+      },
+      errorMessages: {
+        addToQueue: 'Failed to add queue item:',
+        removeFromQueue: 'Failed to remove queue item:',
+        setQueue: 'Failed to set queue:',
+        mirrorClimb: 'Failed to mirror current climb:',
+        replaceQueueItem: 'Failed to replace queue item:',
+        setCurrentClimb: {
+          reuse: 'Failed to set current climb:',
+          playlist: 'Failed to replace queue before setting playlist current:',
+          add: 'Failed to add queue item before setting current:',
+          activate: 'Failed to set current climb after queue add:',
+        },
+        setCurrentClimbQueueItem: 'Failed to set current climb queue item:',
+        reportWallDisconnect: 'Failed to report wall disconnect:',
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [applyLocalSolo, coldStart, validateClimbForQueue],
   );
-
-  // Bridge-mode wall-disconnect report. Tells the session this client's own
-  // BLE link dropped so every member's wall-confirmed lightbulb clears.
-  // Best-effort; no-op in solo or while disconnected. Mirrors
-  // QueueContext.reportWallDisconnect.
-  const reportWallDisconnect = useCallback(async (): Promise<void> => {
-    const { ps } = latestRef.current;
-    if (!ps.activeSession) return;
-    if (!ps.hasConnected) return;
-    try {
-      await ps.reportWallDisconnect();
-    } catch (err: unknown) {
-      console.error('Failed to report wall disconnect:', err);
-    }
-  }, []);
-
-  // Bridge-mode replace: in party mode, delegate to the persistent session's
-  // WebSocket-backed replaceQueueItem; otherwise mirror the local-state update
-  // with a new climb while preserving the queue-item uuid and existing
-  // addedBy attribution.
-  const replaceQueueItem = useCallback((queueItemUuid: string, climb: Climb) => {
-    const { queue, currentClimbQueueItem: current, ps, boardDetails, baseBoardPath } = latestRef.current;
-    const existing = queue.find((q) => q.uuid === queueItemUuid);
-    if (!existing) return;
-    const updated: ClimbQueueItem = { ...existing, climb };
-    if (ps.activeSession) {
-      ps.replaceQueueItem(queueItemUuid, updated).catch((err: unknown) => {
-        console.error('Failed to replace queue item:', err);
-      });
-      return;
-    }
-    if (!boardDetails) return;
-    const newQueue = queue.map((q) => (q.uuid === queueItemUuid ? updated : q));
-    const nextCurrent = current?.uuid === queueItemUuid ? updated : current;
-    ps.setLocalQueueState(newQueue, nextCurrent, baseBoardPath, boardDetails);
-  }, []);
-
-  const setPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource | null) => {
-    setPlaylistSuggestionSourceState(source);
-  }, []);
-
-  const refreshPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource) => {
-    setPlaylistSuggestionSourceState((current) =>
-      playlistSuggestionSourceMatches(current, source) ? source : current,
-    );
-  }, []);
+  const actionsCore = useMemo(() => createQueueActionsCore(actionsCoreDeps), [actionsCoreDeps]);
+  const {
+    addToQueue,
+    removeFromQueue,
+    setCurrentClimb,
+    previewClimbFromBrowse,
+    setCurrentClimbQueueItem,
+    setPlaylistSuggestionSource,
+    refreshPlaylistSuggestionSource,
+    replaceQueueItem,
+    mirrorClimb,
+    getNextClimbQueueItem,
+    getPreviousClimbQueueItem,
+    setQueue,
+    reportWallDisconnect,
+  } = actionsCore;
 
   // No-op functions for fields not used by the bottom bar
   const noop = useCallback(() => {}, []);

--- a/packages/web/app/components/queue-control/queue-bridge-context.tsx
+++ b/packages/web/app/components/queue-control/queue-bridge-context.tsx
@@ -265,8 +265,11 @@ function usePersistentSessionQueueAdapter(): {
   }, []);
 
   // --- Single shared queue-actions implementation (see queue-actions-core.ts) ---
-  // Every field here is a closure over `latestRef`, so this can be built once
-  // (`useMemo(..., [])`) and stay fresh — same pattern as GraphQLQueueProvider.
+  // Every field is a closure over `latestRef`, so the deps memo below only
+  // needs its three helper callbacks — each itself a `[]`-dep hook — meaning
+  // it still computes exactly once and the returned actions keep stable
+  // identity for the provider's lifetime (same net effect as
+  // GraphQLQueueProvider's `useMemo(..., [])`).
 
   // Bridge-solo local store: reduce against the shared `@boardsesh/queue`
   // reducer (the same one QueueContext dispatches to) and persist the result
@@ -293,6 +296,11 @@ function usePersistentSessionQueueAdapter(): {
       needsResync: false,
     };
     let nextState = queueReducer(pseudoState, action);
+    // Reducer returned the same reference (a guard no-op, e.g. re-activating
+    // the already-current item, or an idempotent duplicate add) — skip the
+    // persist call AND the bridge-quirk overrides below, so a reducer no-op
+    // can never be turned into a spurious state write.
+    if (nextState === pseudoState) return;
     // Two bridge-only quirks the shared reducer's generic DELTA_ADD_QUEUE_ITEM
     // / DELTA_REMOVE_QUEUE_ITEM cases don't reproduce (they only touch `queue`,
     // matching QueueContext, whose addToQueue/removeFromQueue never set the
@@ -308,9 +316,6 @@ function usePersistentSessionQueueAdapter(): {
     ) {
       nextState = { ...nextState, currentClimbQueueItem: nextState.queue[0] ?? null };
     }
-    // Reducer returned the same reference (a guard no-op, e.g. re-activating
-    // the already-current item) — skip the redundant persist call.
-    if (nextState === pseudoState) return;
     ps.setLocalQueueState(nextState.queue, nextState.currentClimbQueueItem, baseBoardPath, boardDetails);
   }, []);
 


### PR DESCRIPTION
## Summary

Web had two parallel implementations of the entire queue-action surface (add/remove/set-current/navigate/mirror/replace/report-wall-disconnect), drifting apart:

- `graphql-queue/QueueContext.tsx` (board routes) — action callbacks built on the `latestRef` stable-callback pattern, next/prev discovery hand-rolled via a search-results neighbor walk.
- `queue-control/queue-bridge-context.tsx` (off-board) — `usePersistentSessionQueueAdapter` action bodies with subtly different logic, nav via the shared `findNextQueueItemWithSuggestions`.

This PR extracts **one implementation** as a pure factory — `createQueueActionsCore(deps)` in `queue-control/queue-actions-core.ts` — and wires both surfaces through it. **Behavior-preserving**: every per-surface difference is expressed as an injected dependency, not silently unified.

### Factory deps shape (`QueueActionsCoreDeps`)

- `getSnapshot()` — fresh `{queue, currentClimbQueueItem, playlistSuggestionSource}` read (backed by each surface's `latestRef`)
- `applyLocal(action)` — how the surface applies an optimistic reducer action:
  - QueueContext: `dispatch` into its `useReducer`
  - Bridge **solo**: runs the shared `@boardsesh/queue` `queueReducer` against the useState-backed local store, then persists via `ps.setLocalQueueState` — the reducer is now the single semantic definition even for the local store (two narrow, test-pinned bridge quirks are layered as documented overrides)
  - Bridge **party**: **no-op** — party mode keeps waiting for the server echo instead of applying optimistic updates (pre-existing behavior, preserved; a later workstream flips it)
- `setPlaylistSuggestionSourceLocal` / `refreshPlaylistSuggestionSourceLocal` — playlist-source bookkeeping against each surface's live store (reducer `SET`/`REFRESH` actions vs functional `setState`)
- `buildItem`, `guardMutation`, `validateClimbForQueue`, `offlineBuffer | null`
- `resolveShouldAddToQueueOnActivate`, `resolveNextCurrentForSetQueue`, `buildReplacementItem` — the three spots where the surfaces' semantics genuinely differ per action
- `discoverNext` / `discoverPrev` — navigation strategy (QueueContext: queue walk + search-results neighbor walk + suggestion fallbacks; bridge: shared `findNextQueueItemWithSuggestions` for mobile parity)
- `coldStart?` — bridge-solo board seeding from a climb's own board config
- `party` — `{isActive, hasConnected, isDisconnected, attemptMutation, reuseExistingQueueItemOnSetCurrentClimb, returnNullOnSetCurrentClimbFailure, mutations, nextCorrelationId}`
- `hooks` — analytics preserved exactly per surface (`Set Active Climb` source tags, `Climb Added/Removed`, queue-metrics timing; bridge omits the QueueContext-only events)
- `errorMessages` — each surface's exact console error strings

### Invariants pinned by the new factory tests (59 tests)

- playlist-peek uuid promotion (`isPlaylistPeekQueueItemUuid` → fresh uuid on activation)
- `insertAfterCurrent` positioning (and append when no current)
- playlist-source rollback on mutation failure (both the plain add+activate branch and the playlist-setQueue branch)
- offline buffering when `isDisconnected && party.isActive` (no server mutation sent)
- split add+setCurrent awaits with FIFO ordering
- setCurrentClimb existing-queue-entry reuse by `climb.uuid` (bridge) vs always-add (QueueContext)
- bridge party mode applies **no** optimistic local update; solo does
- `returnNullOnSetCurrentClimbFailure` split (bridge null vs QueueContext optimistic item)
- guard/validation short-circuits, mirror toggle, replace-in-place, setQueue next-current resolution, `from`-anchor navigation resolution, reportWallDisconnect gates

### Wiring notes

- QueueContext keeps the `latestRef` pattern: the factory deps are all closures over `latestRef.current`, built once (`useMemo(..., [])`), so every action callback keeps `[]`-deps stable identity — the context-split perf model is unchanged (`context-split` tests still green).
- Both wiring files shrank: `QueueContext.tsx` 1201 → 1034 lines, `queue-bridge-context.tsx` 1069 → 961 lines (−275 combined), with the single implementation now in `queue-actions-core.ts`.

### Known micro-deviations (documented)

- Bridge `replaceQueueItem` now validates board compatibility before replacing (previously only the board-route path validated). Practically unreachable — the only caller is the create-climb form on board routes with a just-created same-board climb — and arguably corrective.
- Bridge-solo: re-tapping a current item that is *not* in the queue no longer appends it (the shared reducer's own-tap guard short-circuits first). Near-unreachable state in bridge-solo; the visible current climb is unchanged either way.

### Known micro-deviations (documented, analytics-only)
- Ordering: on the board route, `Set Active Climb` analytics + the climbs-attempted counter now fire just before (not after) the optimistic dispatch, and bridge-party `setCurrentClimbQueueItem` tracks before initiating the mutation. Final state and payloads identical (same React batch; payloads read only arguments).

- Bridge-solo: re-tapping the already-current queue item now emits `Set Active Climb` (aligning with board-route behavior, where it always fired); local state remains unchanged either way.
- Bridge-solo: activating a climb with no board details emits the analytics event before the no-op (previously bailed before the event).

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9eAY2yZDGSqossL5UtUQo

