### PR TITLE
refactor(backend): pass RoomManager deps as a context object

### DIFF
--- a/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
+++ b/packages/backend/src/__tests__/leave-session-multi-instance.test.ts
@@ -27,7 +27,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { leaveSession } from '../services/room-manager/client-lifecycle';
-import type { ConnectedClient, LocalSessionParticipant } from '../services/room-manager/types';
+import type { ConnectedClient, LocalSessionParticipant, RoomManagerDeps } from '../services/room-manager/types';
 import type { RedisSessionStore } from '../services/redis-session-store';
 import type { DistributedStateManager } from '../services/distributed-state';
 import type { WriteScheduler } from '../services/room-manager/write-scheduler';
@@ -79,6 +79,20 @@ describe('leaveSession multi-instance markInactive race', () => {
   const LOCAL_CONN = 'conn-local';
   const REMOTE_CONN = 'conn-on-other-instance';
 
+  function makeDeps(distributedState: MockedDistState | null): RoomManagerDeps {
+    return {
+      clients,
+      sessions: sessionsMap,
+      sessionParticipants,
+      redisStore: redisStore as unknown as RedisSessionStore,
+      distributedState: distributedState as unknown as DistributedStateManager | null,
+      writeScheduler: writeScheduler as unknown as WriteScheduler,
+      sessionGraceTimers,
+      pendingJoinPersists,
+      sessionGracePeriodMs: GRACE_PERIOD_MS,
+    };
+  }
+
   beforeEach(() => {
     clients = new Map();
     sessionsMap = new Map();
@@ -129,18 +143,7 @@ describe('leaveSession multi-instance markInactive race', () => {
       removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
-    const result = await leaveSession(
-      LOCAL_CONN,
-      clients,
-      sessionsMap,
-      sessionParticipants,
-      redisStore as unknown as RedisSessionStore,
-      distributedState as unknown as DistributedStateManager,
-      writeScheduler as unknown as WriteScheduler,
-      sessionGraceTimers,
-      pendingJoinPersists,
-      GRACE_PERIOD_MS,
-    );
+    const result = await leaveSession(makeDeps(distributedState), LOCAL_CONN);
 
     expect(result?.sessionId).toBe(SESSION_ID);
     expect(result?.newLeaderId).toBe(REMOTE_CONN);
@@ -165,18 +168,7 @@ describe('leaveSession multi-instance markInactive race', () => {
       removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
-    const result = await leaveSession(
-      LOCAL_CONN,
-      clients,
-      sessionsMap,
-      sessionParticipants,
-      redisStore as unknown as RedisSessionStore,
-      distributedState as unknown as DistributedStateManager,
-      writeScheduler as unknown as WriteScheduler,
-      sessionGraceTimers,
-      pendingJoinPersists,
-      GRACE_PERIOD_MS,
-    );
+    const result = await leaveSession(makeDeps(distributedState), LOCAL_CONN);
 
     expect(result?.sessionId).toBe(SESSION_ID);
     expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);
@@ -206,18 +198,7 @@ describe('leaveSession multi-instance markInactive race', () => {
       removeParticipant: vi.fn().mockResolvedValue(undefined),
     };
 
-    await leaveSession(
-      LOCAL_CONN,
-      clients,
-      sessionsMap,
-      sessionParticipants,
-      redisStore as unknown as RedisSessionStore,
-      distributedState as unknown as DistributedStateManager,
-      writeScheduler as unknown as WriteScheduler,
-      sessionGraceTimers,
-      pendingJoinPersists,
-      GRACE_PERIOD_MS,
-    );
+    await leaveSession(makeDeps(distributedState), LOCAL_CONN);
 
     expect(callOrder).toEqual(['leaveSession', 'getSessionMembers']);
     expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
@@ -226,18 +207,7 @@ describe('leaveSession multi-instance markInactive race', () => {
   });
 
   it('falls back to markInactive when distributedState is unavailable (single-instance dev mode)', async () => {
-    const result = await leaveSession(
-      LOCAL_CONN,
-      clients,
-      sessionsMap,
-      sessionParticipants,
-      redisStore as unknown as RedisSessionStore,
-      null, // no distributed state
-      writeScheduler as unknown as WriteScheduler,
-      sessionGraceTimers,
-      pendingJoinPersists,
-      GRACE_PERIOD_MS,
-    );
+    const result = await leaveSession(makeDeps(null), LOCAL_CONN);
 
     expect(result?.sessionId).toBe(SESSION_ID);
 
@@ -260,18 +230,7 @@ describe('leaveSession multi-instance markInactive race', () => {
     // Silence the expected logger.error from the catch branch.
     const errSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
 
-    await leaveSession(
-      LOCAL_CONN,
-      clients,
-      sessionsMap,
-      sessionParticipants,
-      redisStore as unknown as RedisSessionStore,
-      distributedState as unknown as DistributedStateManager,
-      writeScheduler as unknown as WriteScheduler,
-      sessionGraceTimers,
-      pendingJoinPersists,
-      GRACE_PERIOD_MS,
-    );
+    await leaveSession(makeDeps(distributedState), LOCAL_CONN);
 
     expect(redisStore.markInactive).toHaveBeenCalledWith(SESSION_ID);
     expect(writeScheduler.cancelPendingWrites).toHaveBeenCalledWith(SESSION_ID);

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -9,6 +9,8 @@ import type {
   RoomManagerDeps,
   JoinSessionCallbacks,
   JoinSessionOptions,
+  SessionLeaveResult,
+  SessionDisconnectResult,
 } from './types';
 import { restoreSessionWithLock } from './session-restoration';
 import { logger } from '../../utils/logger';
@@ -704,29 +706,6 @@ export async function disconnectClient(
 
   return { sessionId, participantId, presenceUser, newLeaderId, newLeaderParticipantId };
 }
-
-export type SessionLeaveResult = {
-  sessionId: string;
-  participantId?: string;
-  newLeaderId?: string;
-  newLeaderParticipantId?: string;
-  /**
-   * True when this leave drained the last connection for the participant —
-   * peers should see a `UserLeft` event. False when the participant still has
-   * sibling connections (e.g. another tab open as the same authenticated
-   * user); in that case the leave is per-tab and peers should not be told
-   * the user departed.
-   */
-  participantFullyLeft: boolean;
-};
-
-export type SessionDisconnectResult = {
-  sessionId: string;
-  participantId: string;
-  presenceUser?: SessionUser;
-  newLeaderId?: string;
-  newLeaderParticipantId?: string;
-};
 
 async function resolveLeaderParticipantId(
   leaderConnectionId: string,

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -1,9 +1,15 @@
 import { GraphQLError } from 'graphql';
 import type { ClimbQueueItem, SessionUser } from '@boardsesh/shared-schema';
 import { db } from '../../db/client';
-import { sessions, boardSessionParticipants, type Session } from '../../db/schema';
+import { sessions, boardSessionParticipants } from '../../db/schema';
 import type { DistributedStateManager } from '../distributed-state';
-import type { ConnectedClient, LocalSessionParticipant, RoomManagerDeps } from './types';
+import type {
+  ConnectedClient,
+  LocalSessionParticipant,
+  RoomManagerDeps,
+  JoinSessionCallbacks,
+  JoinSessionOptions,
+} from './types';
 import { restoreSessionWithLock } from './session-restoration';
 import { logger } from '../../utils/logger';
 import { markErrorReported } from '../../utils/sentry-dedupe';
@@ -44,43 +50,6 @@ export async function registerClient(
 
   return connectionId;
 }
-
-/**
- * Injected functions `joinSession` needs but doesn't own — mostly
- * RoomManager methods that themselves delegate elsewhere (e.g.
- * `getQueueState`/`updateQueueStateImmediate` route through Redis vs.
- * Postgres, `leaveSession` is the sibling free function in this module).
- * Passed separately from `RoomManagerDeps` since these are behaviour, not
- * plumbing state.
- */
-export type JoinSessionCallbacks = {
-  getQueueState: (sessionId: string) => Promise<{
-    queue: ClimbQueueItem[];
-    currentClimbQueueItem: ClimbQueueItem | null;
-    version: number;
-    sequence: number;
-    stateHash: string;
-  }>;
-  getSessionUsers: (sessionId: string) => Promise<SessionUser[]>;
-  getSessionUsersLocal: (sessionId: string) => SessionUser[];
-  getSessionById: (sessionId: string) => Promise<Session | null>;
-  updateQueueStateImmediate: (
-    sessionId: string,
-    queue: ClimbQueueItem[],
-    currentClimbQueueItem: ClimbQueueItem | null,
-    expectedVersion?: number,
-  ) => Promise<number>;
-  leaveSession: (connectionId: string) => Promise<SessionLeaveResult | null>;
-};
-
-export type JoinSessionOptions = {
-  username?: string;
-  avatarUrl?: string;
-  initialQueue?: ClimbQueueItem[];
-  initialCurrentClimb?: ClimbQueueItem | null;
-  sessionName?: string;
-  participantId?: string | null;
-};
 
 /**
  * Join a session - handles restoration, leader election, and initial state setup.

--- a/packages/backend/src/services/room-manager/client-lifecycle.ts
+++ b/packages/backend/src/services/room-manager/client-lifecycle.ts
@@ -2,11 +2,9 @@ import { GraphQLError } from 'graphql';
 import type { ClimbQueueItem, SessionUser } from '@boardsesh/shared-schema';
 import { db } from '../../db/client';
 import { sessions, boardSessionParticipants, type Session } from '../../db/schema';
-import type { RedisSessionStore } from '../redis-session-store';
 import type { DistributedStateManager } from '../distributed-state';
-import type { ConnectedClient, LocalSessionParticipant } from './types';
+import type { ConnectedClient, LocalSessionParticipant, RoomManagerDeps } from './types';
 import { restoreSessionWithLock } from './session-restoration';
-import type { WriteScheduler } from './write-scheduler';
 import { logger } from '../../utils/logger';
 import { markErrorReported } from '../../utils/sentry-dedupe';
 
@@ -48,43 +46,52 @@ export async function registerClient(
 }
 
 /**
- * Join a session - handles restoration, leader election, and initial state setup.
+ * Injected functions `joinSession` needs but doesn't own — mostly
+ * RoomManager methods that themselves delegate elsewhere (e.g.
+ * `getQueueState`/`updateQueueStateImmediate` route through Redis vs.
+ * Postgres, `leaveSession` is the sibling free function in this module).
+ * Passed separately from `RoomManagerDeps` since these are behaviour, not
+ * plumbing state.
  */
-export async function joinSession(
-  connectionId: string,
-  sessionId: string,
-  boardPath: string,
-  clients: Map<string, ConnectedClient>,
-  sessionsMap: Map<string, Set<string>>,
-  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
-  redisStore: RedisSessionStore | null,
-  distributedState: DistributedStateManager | null,
-  writeScheduler: WriteScheduler,
-  sessionGraceTimers: Map<string, NodeJS.Timeout>,
-  pendingJoinPersists: Map<string, Promise<void>>,
-  getQueueStateFn: (sessionId: string) => Promise<{
+export type JoinSessionCallbacks = {
+  getQueueState: (sessionId: string) => Promise<{
     queue: ClimbQueueItem[];
     currentClimbQueueItem: ClimbQueueItem | null;
     version: number;
     sequence: number;
     stateHash: string;
-  }>,
-  getSessionUsers: (sessionId: string) => Promise<SessionUser[]>,
-  getSessionUsersLocal: (sessionId: string) => SessionUser[],
-  getSessionById: (sessionId: string) => Promise<Session | null>,
+  }>;
+  getSessionUsers: (sessionId: string) => Promise<SessionUser[]>;
+  getSessionUsersLocal: (sessionId: string) => SessionUser[];
+  getSessionById: (sessionId: string) => Promise<Session | null>;
   updateQueueStateImmediate: (
     sessionId: string,
     queue: ClimbQueueItem[],
     currentClimbQueueItem: ClimbQueueItem | null,
     expectedVersion?: number,
-  ) => Promise<number>,
-  leaveSessionFn: (connectionId: string) => Promise<SessionLeaveResult | null>,
-  username?: string,
-  avatarUrl?: string,
-  initialQueue?: ClimbQueueItem[],
-  initialCurrentClimb?: ClimbQueueItem | null,
-  sessionName?: string,
-  participantId?: string | null,
+  ) => Promise<number>;
+  leaveSession: (connectionId: string) => Promise<SessionLeaveResult | null>;
+};
+
+export type JoinSessionOptions = {
+  username?: string;
+  avatarUrl?: string;
+  initialQueue?: ClimbQueueItem[];
+  initialCurrentClimb?: ClimbQueueItem | null;
+  sessionName?: string;
+  participantId?: string | null;
+};
+
+/**
+ * Join a session - handles restoration, leader election, and initial state setup.
+ */
+export async function joinSession(
+  deps: RoomManagerDeps,
+  connectionId: string,
+  sessionId: string,
+  boardPath: string,
+  callbacks: JoinSessionCallbacks,
+  options: JoinSessionOptions = {},
 ): Promise<{
   clientId: string;
   users: SessionUser[];
@@ -98,6 +105,25 @@ export async function joinSession(
   participantWasKnown: boolean;
   participantWasReconnecting: boolean;
 }> {
+  const {
+    clients,
+    sessions: sessionsMap,
+    sessionParticipants,
+    redisStore,
+    distributedState,
+    sessionGraceTimers,
+    pendingJoinPersists,
+  } = deps;
+  const {
+    getQueueState: getQueueStateFn,
+    getSessionUsers,
+    getSessionUsersLocal,
+    getSessionById,
+    updateQueueStateImmediate,
+    leaveSession: leaveSessionFn,
+  } = callbacks;
+  const { username, avatarUrl, initialQueue, initialCurrentClimb, sessionName, participantId } = options;
+
   const client = clients.get(connectionId);
   if (!client) {
     throw new Error('Client not registered');
@@ -278,18 +304,19 @@ export async function joinSession(
 /**
  * Leave a session - handles leader re-election and cleanup.
  */
-export async function leaveSession(
-  connectionId: string,
-  clients: Map<string, ConnectedClient>,
-  sessionsMap: Map<string, Set<string>>,
-  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
-  redisStore: RedisSessionStore | null,
-  distributedState: DistributedStateManager | null,
-  writeScheduler: WriteScheduler,
-  sessionGraceTimers: Map<string, NodeJS.Timeout>,
-  pendingJoinPersists: Map<string, Promise<void>>,
-  SESSION_GRACE_PERIOD_MS: number,
-): Promise<SessionLeaveResult | null> {
+export async function leaveSession(deps: RoomManagerDeps, connectionId: string): Promise<SessionLeaveResult | null> {
+  const {
+    clients,
+    sessions: sessionsMap,
+    sessionParticipants,
+    redisStore,
+    distributedState,
+    writeScheduler,
+    sessionGraceTimers,
+    pendingJoinPersists,
+    sessionGracePeriodMs: SESSION_GRACE_PERIOD_MS,
+  } = deps;
+
   const client = clients.get(connectionId);
   if (!client || !client.sessionId) {
     return null;
@@ -472,18 +499,22 @@ export async function leaveSession(
  * as having explicitly left the session.
  */
 export async function disconnectClient(
+  deps: RoomManagerDeps,
   connectionId: string,
-  clients: Map<string, ConnectedClient>,
-  sessionsMap: Map<string, Set<string>>,
-  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>,
-  redisStore: RedisSessionStore | null,
-  distributedState: DistributedStateManager | null,
-  writeScheduler: WriteScheduler,
-  sessionGraceTimers: Map<string, NodeJS.Timeout>,
-  pendingJoinPersists: Map<string, Promise<void>>,
-  SESSION_GRACE_PERIOD_MS: number,
   onParticipantExpired?: (sessionId: string, participantId: string) => void,
 ): Promise<SessionDisconnectResult | null> {
+  const {
+    clients,
+    sessions: sessionsMap,
+    sessionParticipants,
+    redisStore,
+    distributedState,
+    writeScheduler,
+    sessionGraceTimers,
+    pendingJoinPersists,
+    sessionGracePeriodMs: SESSION_GRACE_PERIOD_MS,
+  } = deps;
+
   const client = clients.get(connectionId);
   if (!client) {
     return null;
@@ -756,11 +787,10 @@ async function resolveLeaderParticipantId(
  * Remove a client from the system entirely.
  */
 export async function removeClient(
+  deps: RoomManagerDeps,
   connectionId: string,
-  clients: Map<string, ConnectedClient>,
-  sessionsMap: Map<string, Set<string>>,
-  distributedState: DistributedStateManager | null,
 ): Promise<{ distributedStateCleanedUp: boolean }> {
+  const { clients, sessions: sessionsMap, distributedState } = deps;
   let distributedStateCleanedUp = true;
 
   if (distributedState) {

--- a/packages/backend/src/services/room-manager/queue-state.ts
+++ b/packages/backend/src/services/room-manager/queue-state.ts
@@ -3,23 +3,22 @@ import { db } from '../../db/client';
 import { sessionQueues } from '../../db/schema';
 import { eq, and, sql } from 'drizzle-orm';
 import type { RedisSessionStore } from '../redis-session-store';
-import type { DistributedStateManager } from '../distributed-state';
 import { computeQueueStateHash } from '@boardsesh/queue';
-import { VersionConflictError, type QueueState } from './types';
-import { type WriteScheduler, writeQueueStateToPostgres } from './write-scheduler';
+import { VersionConflictError, type QueueState, type RoomManagerDeps } from './types';
+import { writeQueueStateToPostgres } from './write-scheduler';
 
 /**
  * Update queue state with Redis as source of truth and debounced Postgres writes.
  */
 export async function updateQueueState(
+  deps: RoomManagerDeps,
   sessionId: string,
   queue: ClimbQueueItem[],
   currentClimbQueueItem: ClimbQueueItem | null,
   expectedVersion: number | undefined,
-  redisStore: RedisSessionStore | null,
-  writeScheduler: WriteScheduler,
-  distributedState: DistributedStateManager | null,
 ): Promise<{ version: number; sequence: number; stateHash: string; previousStateHash: string | null }> {
+  const { redisStore, writeScheduler, distributedState } = deps;
+
   // Get current version, sequence, and prior state hash from Redis if
   // available, otherwise from Postgres. The prior hash is returned so
   // callers (currently setQueue) can detect no-op resyncs without a
@@ -100,12 +99,14 @@ export async function updateQueueState(
  * Use this when you need immediate Postgres consistency (e.g., session creation).
  */
 export async function updateQueueStateImmediate(
+  deps: RoomManagerDeps,
   sessionId: string,
   queue: ClimbQueueItem[],
   currentClimbQueueItem: ClimbQueueItem | null,
   expectedVersion: number | undefined,
-  redisStore: RedisSessionStore | null,
 ): Promise<number> {
+  const { redisStore } = deps;
+
   if (expectedVersion !== undefined) {
     if (expectedVersion === 0) {
       // Version 0 means no row exists yet - try to insert
@@ -215,13 +216,13 @@ export async function updateQueueStateImmediate(
  * Uses Redis as source of truth for real-time state. Postgres writes are debounced.
  */
 export async function updateQueueOnly(
+  deps: RoomManagerDeps,
   sessionId: string,
   queue: ClimbQueueItem[],
   expectedVersion: number | undefined,
-  redisStore: RedisSessionStore | null,
-  writeScheduler: WriteScheduler,
-  distributedState: DistributedStateManager | null,
 ): Promise<{ version: number; sequence: number; stateHash: string }> {
+  const { redisStore, writeScheduler, distributedState } = deps;
+
   // Get current state from Redis (source of truth for real-time sync)
   let currentVersion = 0;
   let currentSequence = 0;

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -10,7 +10,13 @@ import {
 } from '../distributed-state';
 import { RECENT_CLIMBS_BUFFER_SIZE } from '../distributed-state/constants';
 import { logger } from '../../utils/logger';
-import type { ConnectedClient, DiscoverableSession, LocalSessionParticipant, QueueState } from './types';
+import type {
+  ConnectedClient,
+  DiscoverableSession,
+  LocalSessionParticipant,
+  QueueState,
+  RoomManagerDeps,
+} from './types';
 import { WriteScheduler } from './write-scheduler';
 import {
   updateQueueState as updateQueueStateFn,
@@ -65,6 +71,28 @@ class RoomManager {
   private pendingJoinPersists = new Map<string, Promise<void>>();
   private writeScheduler = new WriteScheduler();
   private inactivitySweepInterval: NodeJS.Timeout | null = null;
+
+  /**
+   * Build the plumbing object passed to the room-manager/* free functions
+   * (client-lifecycle.ts, session-discovery.ts, queue-state.ts). Built fresh
+   * on every call rather than cached on the instance — `redisStore` and
+   * `distributedState` are (re)assigned in `initialize()` and nulled in
+   * `reset()`, so a cached object would silently go stale (e.g. keep
+   * pointing at a pre-reset `distributedState` after `reset()` nulls it).
+   */
+  private deps(): RoomManagerDeps {
+    return {
+      clients: this.clients,
+      sessions: this.sessions,
+      sessionParticipants: this.sessionParticipants,
+      redisStore: this.redisStore,
+      distributedState: this.distributedState,
+      writeScheduler: this.writeScheduler,
+      sessionGraceTimers: this.sessionGraceTimers,
+      pendingJoinPersists: this.pendingJoinPersists,
+      sessionGracePeriodMs: this.SESSION_GRACE_PERIOD_MS,
+    };
+  }
 
   /**
    * Reset all state (for testing purposes)
@@ -289,71 +317,45 @@ class RoomManager {
     participantWasReconnecting: boolean;
   }> {
     return joinSessionFn(
+      this.deps(),
       connectionId,
       sessionId,
       boardPath,
-      this.clients,
-      this.sessions,
-      this.sessionParticipants,
-      this.redisStore,
-      this.distributedState,
-      this.writeScheduler,
-      this.sessionGraceTimers,
-      this.pendingJoinPersists,
-      (sid) => this.getQueueState(sid),
-      (sid) => this.getSessionUsers(sid),
-      (sid) => this.getSessionUsersLocal(sid),
-      (sid) => this.getSessionById(sid),
-      (sid, q, c, v) => this.updateQueueStateImmediate(sid, q, c, v),
-      (cid) => this.leaveSession(cid),
-      username,
-      avatarUrl,
-      initialQueue,
-      initialCurrentClimb,
-      sessionName,
-      participantId,
-    );
-  }
-
-  async leaveSession(connectionId: string): Promise<SessionLeaveResult | null> {
-    const result = await leaveSessionFn(
-      connectionId,
-      this.clients,
-      this.sessions,
-      this.sessionParticipants,
-      this.redisStore,
-      this.distributedState,
-      this.writeScheduler,
-      this.sessionGraceTimers,
-      this.pendingJoinPersists,
-      this.SESSION_GRACE_PERIOD_MS,
-    );
-    return result;
-  }
-
-  async disconnectClient(connectionId: string): Promise<SessionDisconnectResult | null> {
-    return disconnectClientFn(
-      connectionId,
-      this.clients,
-      this.sessions,
-      this.sessionParticipants,
-      this.redisStore,
-      this.distributedState,
-      this.writeScheduler,
-      this.sessionGraceTimers,
-      this.pendingJoinPersists,
-      this.SESSION_GRACE_PERIOD_MS,
-      (sessionId, participantId) => {
-        pubsub.publishSessionEvent(sessionId, {
-          __typename: 'UserLeft',
-          userId: participantId,
-        });
+      {
+        getQueueState: (sid) => this.getQueueState(sid),
+        getSessionUsers: (sid) => this.getSessionUsers(sid),
+        getSessionUsersLocal: (sid) => this.getSessionUsersLocal(sid),
+        getSessionById: (sid) => this.getSessionById(sid),
+        updateQueueStateImmediate: (sid, q, c, v) => this.updateQueueStateImmediate(sid, q, c, v),
+        leaveSession: (cid) => this.leaveSession(cid),
+      },
+      {
+        username,
+        avatarUrl,
+        initialQueue,
+        initialCurrentClimb,
+        sessionName,
+        participantId,
       },
     );
   }
 
+  async leaveSession(connectionId: string): Promise<SessionLeaveResult | null> {
+    const result = await leaveSessionFn(this.deps(), connectionId);
+    return result;
+  }
+
+  async disconnectClient(connectionId: string): Promise<SessionDisconnectResult | null> {
+    return disconnectClientFn(this.deps(), connectionId, (sessionId, participantId) => {
+      pubsub.publishSessionEvent(sessionId, {
+        __typename: 'UserLeft',
+        userId: participantId,
+      });
+    });
+  }
+
   async removeClient(connectionId: string): Promise<{ distributedStateCleanedUp: boolean }> {
-    return removeClientFn(connectionId, this.clients, this.sessions, this.distributedState);
+    return removeClientFn(this.deps(), connectionId);
   }
 
   /**
@@ -534,15 +536,7 @@ class RoomManager {
     currentClimbQueueItem: ClimbQueueItem | null,
     expectedVersion?: number,
   ): Promise<{ version: number; sequence: number; stateHash: string; previousStateHash: string | null }> {
-    return updateQueueStateFn(
-      sessionId,
-      queue,
-      currentClimbQueueItem,
-      expectedVersion,
-      this.redisStore,
-      this.writeScheduler,
-      this.distributedState,
-    );
+    return updateQueueStateFn(this.deps(), sessionId, queue, currentClimbQueueItem, expectedVersion);
   }
 
   async updateQueueStateImmediate(
@@ -551,7 +545,7 @@ class RoomManager {
     currentClimbQueueItem: ClimbQueueItem | null,
     expectedVersion?: number,
   ): Promise<number> {
-    return updateQueueStateImmediateFn(sessionId, queue, currentClimbQueueItem, expectedVersion, this.redisStore);
+    return updateQueueStateImmediateFn(this.deps(), sessionId, queue, currentClimbQueueItem, expectedVersion);
   }
 
   async updateQueueOnly(
@@ -559,14 +553,7 @@ class RoomManager {
     queue: ClimbQueueItem[],
     expectedVersion?: number,
   ): Promise<{ version: number; sequence: number; stateHash: string }> {
-    return updateQueueOnlyFn(
-      sessionId,
-      queue,
-      expectedVersion,
-      this.redisStore,
-      this.writeScheduler,
-      this.distributedState,
-    );
+    return updateQueueOnlyFn(this.deps(), sessionId, queue, expectedVersion);
   }
 
   async getQueueState(sessionId: string): Promise<QueueState> {
@@ -612,14 +599,7 @@ class RoomManager {
   }
 
   async findNearbySessions(latitude: number, longitude: number, radiusMeters?: number): Promise<DiscoverableSession[]> {
-    return findNearbySessionsFn(
-      latitude,
-      longitude,
-      radiusMeters,
-      this.sessions,
-      this.redisStore,
-      this.distributedState,
-    );
+    return findNearbySessionsFn(this.deps(), latitude, longitude, radiusMeters);
   }
 
   async getUserSessions(userId: string): Promise<Session[]> {
@@ -645,14 +625,7 @@ class RoomManager {
 
   async endSession(sessionId: string): Promise<void> {
     this.clearLocalSessionShadows(sessionId);
-    return endSessionFn(
-      sessionId,
-      this.sessions,
-      this.redisStore,
-      this.writeScheduler,
-      this.sessionGraceTimers,
-      this.pendingJoinPersists,
-    );
+    return endSessionFn(this.deps(), sessionId);
   }
 
   async flushPendingWrites(): Promise<void> {

--- a/packages/backend/src/services/room-manager/room-manager.ts
+++ b/packages/backend/src/services/room-manager/room-manager.ts
@@ -16,6 +16,8 @@ import type {
   LocalSessionParticipant,
   QueueState,
   RoomManagerDeps,
+  SessionDisconnectResult,
+  SessionLeaveResult,
 } from './types';
 import { WriteScheduler } from './write-scheduler';
 import {
@@ -30,8 +32,6 @@ import {
   leaveSession as leaveSessionFn,
   disconnectClient as disconnectClientFn,
   removeClient as removeClientFn,
-  type SessionDisconnectResult,
-  type SessionLeaveResult,
 } from './client-lifecycle';
 import { pubsub } from '../../pubsub/index';
 import { endLiveActivity } from '../apns/index';

--- a/packages/backend/src/services/room-manager/session-discovery.ts
+++ b/packages/backend/src/services/room-manager/session-discovery.ts
@@ -2,11 +2,8 @@ import { db } from '../../db/client';
 import { sessions, type Session } from '../../db/schema';
 import { userBoards } from '@boardsesh/db/schema/app';
 import { eq, and, gt, gte, lt, lte, ne, isNull, sql } from 'drizzle-orm';
-import type { RedisSessionStore } from '../redis-session-store';
-import type { DistributedStateManager } from '../distributed-state';
-import type { WriteScheduler } from './write-scheduler';
 import { haversineDistance, getBoundingBox, DEFAULT_SEARCH_RADIUS_METERS } from '../../utils/geo';
-import type { DiscoverableSession } from './types';
+import type { DiscoverableSession, RoomManagerDeps } from './types';
 import { logger } from '../../utils/logger';
 
 /**
@@ -133,13 +130,12 @@ export async function createDiscoverableSession(
  * Uses bounding box for initial SQL filter, then precise Haversine distance.
  */
 export async function findNearbySessions(
+  deps: RoomManagerDeps,
   latitude: number,
   longitude: number,
   radiusMeters: number = DEFAULT_SEARCH_RADIUS_METERS,
-  sessionsMap: Map<string, Set<string>>,
-  redisStore: RedisSessionStore | null,
-  distributedState: DistributedStateManager | null,
 ): Promise<DiscoverableSession[]> {
+  const { sessions: sessionsMap, redisStore, distributedState } = deps;
   const box = getBoundingBox(latitude, longitude, radiusMeters);
 
   const candidates = await db
@@ -231,14 +227,9 @@ export async function getUserSessions(userId: string): Promise<Session[]> {
 /**
  * Explicitly end a session (user action).
  */
-export async function endSession(
-  sessionId: string,
-  sessionsMap: Map<string, Set<string>>,
-  redisStore: RedisSessionStore | null,
-  writeScheduler: WriteScheduler,
-  sessionGraceTimers: Map<string, NodeJS.Timeout>,
-  pendingJoinPersists: Map<string, Promise<void>>,
-): Promise<void> {
+export async function endSession(deps: RoomManagerDeps, sessionId: string): Promise<void> {
+  const { sessions: sessionsMap, redisStore, writeScheduler, sessionGraceTimers, pendingJoinPersists } = deps;
+
   // Cancel any pending writes to prevent FK violations after session ends
   writeScheduler.cancelPendingWrites(sessionId);
 

--- a/packages/backend/src/services/room-manager/types.ts
+++ b/packages/backend/src/services/room-manager/types.ts
@@ -3,10 +3,6 @@ import type { Session } from '../../db/schema';
 import type { RedisSessionStore } from '../redis-session-store';
 import type { DistributedStateManager } from '../distributed-state';
 import type { WriteScheduler } from './write-scheduler';
-// Type-only import — safe despite client-lifecycle.ts importing RoomManagerDeps
-// back from this module; `import type` is erased at compile time, so there's
-// no runtime circular dependency, only a type-level one.
-import type { SessionLeaveResult } from './client-lifecycle';
 
 // Custom error for version conflicts
 export class VersionConflictError extends Error {
@@ -75,6 +71,29 @@ export type RoomManagerDeps = {
   sessionGraceTimers: Map<string, NodeJS.Timeout>;
   pendingJoinPersists: Map<string, Promise<void>>;
   sessionGracePeriodMs: number;
+};
+
+export type SessionLeaveResult = {
+  sessionId: string;
+  participantId?: string;
+  newLeaderId?: string;
+  newLeaderParticipantId?: string;
+  /**
+   * True when this leave drained the last connection for the participant —
+   * peers should see a `UserLeft` event. False when the participant still has
+   * sibling connections (e.g. another tab open as the same authenticated
+   * user); in that case the leave is per-tab and peers should not be told
+   * the user departed.
+   */
+  participantFullyLeft: boolean;
+};
+
+export type SessionDisconnectResult = {
+  sessionId: string;
+  participantId: string;
+  presenceUser?: SessionUser;
+  newLeaderId?: string;
+  newLeaderParticipantId?: string;
 };
 
 /**

--- a/packages/backend/src/services/room-manager/types.ts
+++ b/packages/backend/src/services/room-manager/types.ts
@@ -1,4 +1,7 @@
 import type { ClimbQueueItem } from '@boardsesh/shared-schema';
+import type { RedisSessionStore } from '../redis-session-store';
+import type { DistributedStateManager } from '../distributed-state';
+import type { WriteScheduler } from './write-scheduler';
 
 // Custom error for version conflicts
 export class VersionConflictError extends Error {
@@ -47,6 +50,26 @@ export type LocalSessionParticipant = {
   connectionState: 'CONNECTED' | 'RECONNECTING';
   connectionIds: Set<string>;
   reconnectTimer?: NodeJS.Timeout;
+};
+
+/**
+ * Plumbing RoomManager injects into the room-manager/* free functions
+ * (client-lifecycle.ts, session-discovery.ts, queue-state.ts) instead of
+ * passing every private map/store as a positional argument. Built fresh per
+ * call by RoomManager's private `deps()` method — never cached, since
+ * `redisStore` / `distributedState` are (re)assigned in `initialize()` and
+ * nulled in `reset()`, so a cached object would go stale.
+ */
+export type RoomManagerDeps = {
+  clients: Map<string, ConnectedClient>;
+  sessions: Map<string, Set<string>>;
+  sessionParticipants: Map<string, Map<string, LocalSessionParticipant>>;
+  redisStore: RedisSessionStore | null;
+  distributedState: DistributedStateManager | null;
+  writeScheduler: WriteScheduler;
+  sessionGraceTimers: Map<string, NodeJS.Timeout>;
+  pendingJoinPersists: Map<string, Promise<void>>;
+  sessionGracePeriodMs: number;
 };
 
 export type DiscoverableSession = {

--- a/packages/backend/src/services/room-manager/types.ts
+++ b/packages/backend/src/services/room-manager/types.ts
@@ -1,7 +1,12 @@
-import type { ClimbQueueItem } from '@boardsesh/shared-schema';
+import type { ClimbQueueItem, SessionUser } from '@boardsesh/shared-schema';
+import type { Session } from '../../db/schema';
 import type { RedisSessionStore } from '../redis-session-store';
 import type { DistributedStateManager } from '../distributed-state';
 import type { WriteScheduler } from './write-scheduler';
+// Type-only import — safe despite client-lifecycle.ts importing RoomManagerDeps
+// back from this module; `import type` is erased at compile time, so there's
+// no runtime circular dependency, only a type-level one.
+import type { SessionLeaveResult } from './client-lifecycle';
 
 // Custom error for version conflicts
 export class VersionConflictError extends Error {
@@ -70,6 +75,43 @@ export type RoomManagerDeps = {
   sessionGraceTimers: Map<string, NodeJS.Timeout>;
   pendingJoinPersists: Map<string, Promise<void>>;
   sessionGracePeriodMs: number;
+};
+
+/**
+ * Injected functions `joinSession` needs but doesn't own — mostly
+ * RoomManager methods that themselves delegate elsewhere (e.g.
+ * `getQueueState`/`updateQueueStateImmediate` route through Redis vs.
+ * Postgres, `leaveSession` is the sibling free function in client-lifecycle.ts).
+ * Passed separately from `RoomManagerDeps` since these are behaviour, not
+ * plumbing state.
+ */
+export type JoinSessionCallbacks = {
+  getQueueState: (sessionId: string) => Promise<{
+    queue: ClimbQueueItem[];
+    currentClimbQueueItem: ClimbQueueItem | null;
+    version: number;
+    sequence: number;
+    stateHash: string;
+  }>;
+  getSessionUsers: (sessionId: string) => Promise<SessionUser[]>;
+  getSessionUsersLocal: (sessionId: string) => SessionUser[];
+  getSessionById: (sessionId: string) => Promise<Session | null>;
+  updateQueueStateImmediate: (
+    sessionId: string,
+    queue: ClimbQueueItem[],
+    currentClimbQueueItem: ClimbQueueItem | null,
+    expectedVersion?: number,
+  ) => Promise<number>;
+  leaveSession: (connectionId: string) => Promise<SessionLeaveResult | null>;
+};
+
+export type JoinSessionOptions = {
+  username?: string;
+  avatarUrl?: string;
+  initialQueue?: ClimbQueueItem[];
+  initialCurrentClimb?: ClimbQueueItem | null;
+  sessionName?: string;
+  participantId?: string | null;
 };
 
 export type DiscoverableSession = {


### PR DESCRIPTION
## Summary

- `RoomManager` delegated to the `client-lifecycle.ts` / `session-discovery.ts` / `queue-state.ts` free functions by forwarding every private map/store as a positional argument — `joinSession` alone forwarded ~22 positional args (`room-manager.ts` → `joinSessionFn`). Transposition-prone and unreadable.
- Adds a `RoomManagerDeps` type (`packages/backend/src/services/room-manager/types.ts`) and a private `RoomManager.deps()` builder that assembles the plumbing object fresh **per call** (not cached — `redisStore`/`distributedState` are reassigned in `initialize()` and nulled in `reset()`, so a cached object would go stale).
- Rewrites the free-function signatures to `(deps, <domain args>, callbacks, options)`: `joinSession`, `leaveSession`, `disconnectClient`, `removeClient`, `endSession`, `findNearbySessions`, and the queue-state update functions (`updateQueueState`, `updateQueueStateImmediate`, `updateQueueOnly`).
- Pure signature refactor — function **bodies are unchanged** except for the top-of-function destructure that maps `deps`/`callbacks`/`options` back onto the exact same local identifiers the body already used (verifiable as a rename-only diff below the destructure).
- `RoomManagerDeps`, `JoinSessionCallbacks`, and `JoinSessionOptions` all live in `types.ts` (moved `JoinSessionCallbacks`/`JoinSessionOptions` there per review feedback, since they were originally left in `client-lifecycle.ts`, which undermined the point of centralising the plumbing types). In the final revision `SessionLeaveResult`/`SessionDisconnectResult` were also moved into `types.ts`, eliminating the earlier type-only import cycle between `types.ts` and `client-lifecycle.ts` entirely.
- `registerClient` and `getQueueState` are intentionally left with their existing (already-small, 2-arg) signatures — outside the arity/transposition problem this refactor targets, and `getQueueState` has an external caller (`session-restoration.ts`) not otherwise in scope.
- `leave-session-multi-instance.test.ts` (the only direct-import test caller of these free functions) is updated to build a `RoomManagerDeps` object via a local `makeDeps()` helper instead of passing 10 positional args.

**Stacked on #3347** (`fix/sessions-b2-sweep-shadow-cleanup`) — this PR bases off that branch, not `main`, since it touches the same files. `clearLocalSessionShadows` / `runInactivitySweep` (added in #3347) are untouched.

**Expected conflict surface:** #3345 (leader-election, based on `main`, not in this branch's history) also touches `client-lifecycle.ts` / `distributed-state.ts` around the `newLeaderId`/`newLeaderParticipantId` plumbing on `removeConnection`/`leaveSession` results (`client-lifecycle.ts` ~lines 368-369 and ~536-537 pre-refactor). This PR only changes the surrounding parameter list and adds a destructure above that code — the `newLeaderId`/`newLeaderParticipantId` logic itself is untouched — so the merge conflict there should be purely mechanical (re-apply #3345's line edits inside the now-destructured body). Flagging so the coordinator can sequence the merges.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check --fix` — 0 errors (181 pre-existing warnings in unrelated files).
- `vp run typecheck` — full repo, green (also confirms the `types.ts` ↔ `client-lifecycle.ts` type-only circular import resolves cleanly).
- `vp test run --project backend --reporter=agent` (under the shared lock) — run twice cleanly:
  - Run 1: 1787 passed, 1 failed (`integration-export-claim.test.ts`, unrelated FK violation), 4 suites failed on `Cannot initialise worker database` (cross-agent DB contention, non-deterministic file set).
  - Run 2: 1766 passed, 1 failed (documented `board-presence` slug-collision flake), 7 suites failed on the same `Cannot initialise worker database` infra issue (different file set than run 1, confirming it's shared-DB contention from concurrent agents, not this change).
  - Neither run's infra-only failures touched `room-manager/*` logic.
- No test file directly imports `findNearbySessions` / `updateQueueState` / `updateQueueStateImmediate` (only `leaveSession` and `endStaleInactiveSessions` have direct-import test callers), but every refactored function is exercised indirectly through `RoomManager`'s unchanged public API, whose signatures this PR does not touch:
  - `findNearbySessions` → `session-persistence.test.ts` (4 call sites via `roomManager.findNearbySessions(...)`).
  - `updateQueueState` / `updateQueueStateImmediate` → exercised via the `queue` GraphQL mutation resolvers in `queue-sync-fixes.test.ts`, `navigate-queue.test.ts`, `queue-client-session.test.ts`, `websocket-sync.test.ts`.
  - `leaveSession` → both `leave-session-multi-instance.test.ts` (direct) and indirectly via session-lifecycle tests.
  - Ran `vp test run --project backend leave-session-multi-instance session-persistence queue-sync-fixes navigate-queue --reporter=agent` in isolation after the refactor: 4 files, 70/70 tests passed.
