### PR TITLE
refactor(web): drive persistent-session queue state through the shared reducer and sync gate

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -704,10 +704,13 @@ sequenceDiagram
     S->>C: Event (sequence: 6)
     C->>C: 6 == 5+1 ✓ Apply event
 
+    S->>C: Event (sequence: 5)
+    C->>C: 5 <= 6 → stale duplicate, drop silently
+
     S->>C: Event (sequence: 8)
     C->>C: 8 != 6+1 ⚠️ Gap detected!
-    C->>C: Log warning
-    C->>C: Apply anyway (hash will catch drift)
+    C->>C: Drop event, trigger resync
+    S->>C: FullSync event
 
     Note over C: Periodic hash verification (60s)
     C->>C: Compute local state hash
@@ -719,6 +722,15 @@ sequenceDiagram
         S->>C: FullSync event
     end
 ```
+
+### Web Root Event Processor (shared reducer + sync gate)
+
+The web app's root queue mirror (`persistent-session/hooks/use-event-processor.ts`) runs every incoming queue event through the **same shared `queueReducer`** (`@boardsesh/queue`) that the board-route `graphql-queue/QueueContext` uses, so both copies apply identical semantics. Resync decisions — sequence gating, the reconnect strategy, the 60s hash watchdog's 3-strike backoff, and the corruption-resync cooldown — all live in one `createQueueSyncGate` instance (`@boardsesh/queue-runtime`, see `sync-gate.ts`) created by `PersistentSessionProvider` and shared by the event processor, `use-session-lifecycle` (which resets it on connection teardown), and `use-session-subscriptions`.
+
+Two root-processor specifics:
+
+- **FullSync offline merge**: offline-buffered additions are merged into the FullSync payload before dispatch (visual continuity during reconciliation), but external subscribers receive the original unmerged event — `useOfflineReconciliation` compares the raw server queue against its buffer.
+- **Reorder pre-validation**: a `QueueReordered` event is applied only when the item at `oldIndex` matches the uuid the server says it moved; on mismatch the client resyncs instead of guessing. Order drift is invisible to the sorted-uuid state hash, so a bad guess would never be caught by the watchdog.
 
 ---
 
@@ -1015,6 +1027,7 @@ sequenceDiagram
 - Current climb must exist in queue
 - Sequence numbers must increment by 1
 - Hash updated after each delta event
+- The comparison and backoff live in the shared sync gate's `verifyLocalHash()`: after `RESYNC_LOOP_THRESHOLD` (3) consecutive resyncs against the *same* unchanging server hash, the gate returns a `backoff` verdict — the client reports to Sentry once per drift streak and stops refiring the per-minute resync (issue #2359). The counter resets when the hashes agree again or the server hash changes.
 
 ### 6. Queue Item Corruption Detection
 
@@ -1022,29 +1035,30 @@ The client detects and recovers from corrupted queue items (null/undefined entri
 
 ```mermaid
 sequenceDiagram
-    participant C as Client
+    participant R as queueReducer
     participant PS as PersistentSession
     participant S as Server
 
-    Note over C: useEffect runs on queue change
-
-    C->>C: Check for null/undefined items
+    S->>R: FullSync / queue update payload
+    R->>R: Filter null / climbless items
 
     alt No corrupted items
-        C->>C: Compute and update state hash
-    else Corrupted items detected
-        C->>C: Check resync cooldown (30s)
+        R->>R: needsResync stays false
+    else Corrupted items filtered
+        R->>R: Set needsResync = true
+        PS->>PS: Consult sync gate cooldown (30s)
 
         alt Within cooldown
-            C->>C: Filter items locally
-            C->>C: Log error (Sentry)
-            Note over C: Prevents infinite loops
+            PS->>PS: Keep locally filtered state
+            PS->>PS: Log error (Sentry)
+            Note over PS: Prevents resync storms
         else Cooldown expired
-            C->>C: Log error (Sentry)
-            C->>S: Trigger resync
-            S->>C: FullSync event
-            C->>C: Apply clean state
+            PS->>PS: Log error (Sentry)
+            PS->>S: Trigger resync
+            S->>PS: FullSync event
+            PS->>R: Apply clean state
         end
+        PS->>R: CLEAR_RESYNC_FLAG
     end
 ```
 
@@ -1056,22 +1070,21 @@ sequenceDiagram
 
 **Detection points:**
 
-1. **FullSync handler**: Filters null items when receiving initial/full state
-2. **QueueItemAdded handler**: Skips events with null items
-3. **State hash effect**: Detects corruption in current queue state
+1. **Reducer (`INITIAL_QUEUE_DATA` / `UPDATE_QUEUE`)**: filters null/climbless items out of every incoming full payload and raises the `needsResync` flag when it filtered anything — reducer state can never contain nulls post-dispatch, so there is no separate local re-filtering step
+2. **Action mapper**: `QueueItemAdded` events with no item payload are ignored (sequence tracking still advances)
 
 **Resync cooldown:**
 
-- 30 second cooldown between corruption-triggered resyncs
+- 30 second cooldown between corruption-triggered resyncs, owned by the shared sync gate (`evaluateCorruption()` in `@boardsesh/queue-runtime`)
 - Prevents infinite loop if server keeps returning corrupted data
-- During cooldown: filter corrupted items locally instead of resyncing
+- During cooldown: keep the reducer-filtered local state instead of resyncing
 - All corruption events logged at `logger.error` level (see [Backend Logging](./logging.md)) for Sentry visibility
 
 **Implementation:**
 
 - `computeQueueStateHash()` defensively filters null/undefined items
-- `isFilteringCorruptedItemsRef` prevents useEffect re-trigger loops
-- `lastCorruptionResyncRef` tracks cooldown timing
+- `useSessionSubscriptions` watches the reducer's `needsResync` flag, consults `syncGate.evaluateCorruption()`, then acknowledges the flag via `CLEAR_RESYNC_FLAG`
+- The gate is reset on connection teardown, so a new session starts with a fresh cooldown
 
 ### 7. Subscription Error / Complete
 

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -1027,7 +1027,7 @@ sequenceDiagram
 - Current climb must exist in queue
 - Sequence numbers must increment by 1
 - Hash updated after each delta event
-- The comparison and backoff live in the shared sync gate's `verifyLocalHash()`: after `RESYNC_LOOP_THRESHOLD` (3) consecutive resyncs against the *same* unchanging server hash, the gate returns a `backoff` verdict — the client reports to Sentry once per drift streak and stops refiring the per-minute resync (issue #2359). The counter resets when the hashes agree again or the server hash changes.
+- The comparison and backoff live in the shared sync gate's `verifyLocalHash()`: after `RESYNC_LOOP_THRESHOLD` (3) consecutive resyncs against the _same_ unchanging server hash, the gate returns a `backoff` verdict — the client reports to Sentry once per drift streak and stops refiring the per-minute resync (issue #2359). The counter resets when the hashes agree again or the server hash changes.
 
 ### 6. Queue Item Corruption Detection
 

--- a/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
+++ b/packages/web/app/components/graphql-queue/hooks/use-queue-event-subscription.ts
@@ -1,79 +1,16 @@
 import { type Dispatch, type RefObject, useEffect } from 'react';
 import type { SubscriptionQueueEvent } from '@boardsesh/shared-schema';
-import type { ClimbQueueItem } from '@boardsesh/queue';
-import { mapSubscriptionEnvelopeToAction, type SubscriptionWireEnvelope } from '@boardsesh/queue-runtime';
+import { mapSubscriptionEnvelopeToAction } from '@boardsesh/queue-runtime';
+import { toWireEnvelope } from '../../persistent-session/event-utils';
 import type { QueueAction } from '../../queue-control/types';
 import { track } from '@/app/lib/analytics';
 
-/**
- * Queue-state events only — `PlaybackStateChanged` is ephemeral (consumed by
- * `use-drawer-playback` for the engine; doesn't mutate queue state) and is
- * filtered out at the subscription callback before reaching `toWireEnvelope`.
- */
-export type QueueStateEvent = Exclude<SubscriptionQueueEvent, { __typename: 'PlaybackStateChanged' }>;
-
-/**
- * Adapt the wire-format `SubscriptionQueueEvent` (from `@boardsesh/shared-schema`)
- * to the runtime's structural `SubscriptionWireEnvelope<ClimbQueueItem>` (from
- * `@boardsesh/queue-runtime`). Both unions share the same `__typename` set and
- * the same aliased field names, but their `ClimbQueueItem` declarations come
- * from different packages so direct assignment isn't possible.
- *
- * Explicit per-variant rebuild + `assertNever` default rather than an
- * `as unknown as` cast: TypeScript — not runtime — surfaces drift between the
- * two unions (new variant, renamed field, narrowed field type). A silent cast
- * would let an unrecognized __typename fall through to
- * `mapSubscriptionEnvelopeToAction`'s switch which has no `default` clause and
- * would silently drop the event.
- */
-export function toWireEnvelope(event: QueueStateEvent): SubscriptionWireEnvelope<ClimbQueueItem> {
-  switch (event.__typename) {
-    case 'FullSync':
-      return {
-        __typename: 'FullSync',
-        state: {
-          queue: event.state.queue,
-          currentClimbQueueItem: event.state.currentClimbQueueItem,
-        },
-      };
-    case 'QueueItemAdded':
-      return {
-        __typename: 'QueueItemAdded',
-        addedItem: event.addedItem,
-        position: event.position,
-      };
-    case 'QueueItemRemoved':
-      return { __typename: 'QueueItemRemoved', uuid: event.uuid };
-    case 'QueueReordered':
-      return {
-        __typename: 'QueueReordered',
-        uuid: event.uuid,
-        oldIndex: event.oldIndex,
-        newIndex: event.newIndex,
-      };
-    case 'CurrentClimbChanged':
-      return {
-        __typename: 'CurrentClimbChanged',
-        currentItem: event.currentItem,
-        clientId: event.clientId,
-        correlationId: event.correlationId,
-      };
-    case 'ClimbMirrored':
-      return {
-        __typename: 'ClimbMirrored',
-        mirrored: event.mirrored,
-        mirroredUuid: event.mirroredUuid,
-      };
-    default:
-      return assertNever(event);
-  }
-}
-
-function assertNever(unhandledEvent: never): never {
-  throw new Error(`Unhandled SubscriptionQueueEvent variant: ${JSON.stringify(unhandledEvent)}`);
-}
-
-export const toSyncQueueEvent = toWireEnvelope;
+// `toWireEnvelope` (and its `QueueStateEvent` input type) moved to
+// `persistent-session/event-utils.ts` so the root persistent-session event
+// processor can share it. Re-export for this hook's existing importers; a
+// later workstream deletes this hook entirely.
+export { toWireEnvelope, toSyncQueueEvent } from '../../persistent-session/event-utils';
+export type { QueueStateEvent } from '../../persistent-session/event-utils';
 
 type UseQueueEventSubscriptionParams = {
   isPersistentSessionActive: boolean;

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-offline.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createQueueSyncGate } from '@boardsesh/queue-runtime';
 import { useEventProcessor } from '../hooks/use-event-processor';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import type { Climb } from '@/app/lib/types';
@@ -34,16 +35,15 @@ function createItem(uuid: string): LocalClimbQueueItem {
   };
 }
 
-function createRefs(offlineBuffer: LocalClimbQueueItem[] = []) {
-  return {
+function createHarness(offlineBuffer: LocalClimbQueueItem[] = []) {
+  const refs = {
     lastReceivedSequenceRef: { current: null as number | null },
     triggerResyncRef: { current: null as (() => void) | null },
-    lastCorruptionResyncRef: { current: 0 },
-    isFilteringCorruptedItemsRef: { current: false },
     queueEventSubscribersRef: { current: new Set<(event: SubscriptionQueueEvent) => void>() },
     sessionEventSubscribersRef: { current: new Set() } as never,
     offlineBufferRef: { current: offlineBuffer },
   };
+  return { refs, syncGate: createQueueSyncGate() };
 }
 
 function createWrapper() {
@@ -54,8 +54,8 @@ function createWrapper() {
 
 describe('useEventProcessor - offline FullSync merge', () => {
   it('FullSync with no offline buffer behaves normally', () => {
-    const refs = createRefs([]);
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([]);
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
 
     const serverItem = createItem('server-1');
 
@@ -74,12 +74,13 @@ describe('useEventProcessor - offline FullSync merge', () => {
 
     expect(result.current.queue).toEqual([serverItem]);
     expect(result.current.lastReceivedStateHash).toBe('hash-1');
+    expect(refs.lastReceivedSequenceRef.current).toBe(5);
   });
 
   it('FullSync merges offline buffer items into server queue', () => {
     const offlineItem = createItem('offline-1');
-    const refs = createRefs([offlineItem]);
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([offlineItem]);
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
 
     const serverItem = createItem('server-1');
 
@@ -104,8 +105,8 @@ describe('useEventProcessor - offline FullSync merge', () => {
 
   it('FullSync does not duplicate items with same UUID', () => {
     const sharedItem = createItem('shared-1');
-    const refs = createRefs([sharedItem]);
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([sharedItem]);
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
 
     act(() => {
       result.current.handleQueueEvent({
@@ -125,10 +126,10 @@ describe('useEventProcessor - offline FullSync merge', () => {
     expect(result.current.queue[0]).toEqual(sharedItem);
   });
 
-  it('FullSync still filters null/corrupted items with merge', () => {
+  it('FullSync still filters null/corrupted items with merge, and flags needsResync', () => {
     const offlineItem = createItem('offline-1');
-    const refs = createRefs([offlineItem]);
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([offlineItem]);
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
 
     const serverItem = createItem('server-1');
 
@@ -145,16 +146,20 @@ describe('useEventProcessor - offline FullSync merge', () => {
       });
     });
 
-    // null/undefined items filtered, offline item appended
+    // null/undefined items filtered (by the reducer's INITIAL_QUEUE_DATA
+    // filter), offline item appended
     expect(result.current.queue).toHaveLength(2);
     expect(result.current.queue[0]).toEqual(serverItem);
     expect(result.current.queue[1]).toEqual(offlineItem);
+    // Reducer-side corruption detection is the resync mechanism now.
+    expect(result.current.needsResync).toBe(true);
   });
 
   it('non-FullSync events still work normally', () => {
-    const refs = createRefs([]);
-    refs.lastReceivedSequenceRef.current = 4;
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([]);
+    // Seed the gate's sequence tracking (the gate owns it now, not the ref).
+    syncGate.noteApplied({ __typename: 'QueueItemAdded', sequence: 4, stateHash: 'hash-1' });
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
 
     const addedItem = createItem('added-1');
 
@@ -171,11 +176,12 @@ describe('useEventProcessor - offline FullSync merge', () => {
     expect(result.current.queue).toHaveLength(1);
     expect(result.current.queue[0]).toEqual(addedItem);
     expect(result.current.lastReceivedStateHash).toBe('hash-2');
+    expect(refs.lastReceivedSequenceRef.current).toBe(5);
   });
 
   it('QueueItemRemoved clears current climb and advances state hash', () => {
-    const refs = createRefs([]);
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([]);
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
     const removedItem = createItem('removed-1');
     const keptItem = createItem('kept-1');
 
@@ -208,10 +214,10 @@ describe('useEventProcessor - offline FullSync merge', () => {
     // current room sequence (no bump), so two consecutive events share the
     // same number. The dedup gate would otherwise mark the second as
     // ignore-stale and silently drop party-mode playback sync.
-    const refs = createRefs([]);
+    const { refs, syncGate } = createHarness([]);
     const subscribers: SubscriptionQueueEvent[] = [];
     refs.queueEventSubscribersRef.current.add((event) => subscribers.push(event));
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
 
     act(() => {
       result.current.handleQueueEvent({
@@ -249,8 +255,8 @@ describe('useEventProcessor - offline FullSync merge', () => {
   });
 
   it('ClimbMirrored updates both queue item and current climb', () => {
-    const refs = createRefs([]);
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { refs, syncGate } = createHarness([]);
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
     const item = createItem('mirror-1');
 
     act(() => {
@@ -276,5 +282,151 @@ describe('useEventProcessor - offline FullSync merge', () => {
     expect(result.current.queue[0]?.climb.mirrored).toBe(true);
     expect(result.current.currentClimbQueueItem?.climb.mirrored).toBe(true);
     expect(result.current.lastReceivedStateHash).toBe('hash-2');
+  });
+});
+
+describe('useEventProcessor - sync gate at the root', () => {
+  it('ignores stale events (sequence <= last received) without applying or notifying', () => {
+    const { refs, syncGate } = createHarness([]);
+    const subscribers: SubscriptionQueueEvent[] = [];
+    refs.queueEventSubscribersRef.current.add((event) => subscribers.push(event));
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
+
+    const serverItem = createItem('server-1');
+    const staleItem = createItem('stale-1');
+
+    act(() => {
+      result.current.handleQueueEvent({
+        __typename: 'FullSync',
+        sequence: 5,
+        state: { queue: [serverItem as never], currentClimbQueueItem: null, stateHash: 'hash-1', sequence: 5 },
+      });
+      // Duplicate of an already-applied sequence — must be dropped at the root.
+      result.current.handleQueueEvent({
+        __typename: 'QueueItemAdded',
+        sequence: 5,
+        stateHash: 'hash-stale',
+        addedItem: staleItem,
+        position: undefined,
+      } as SubscriptionQueueEvent);
+    });
+
+    expect(result.current.queue).toEqual([serverItem]);
+    expect(result.current.lastReceivedStateHash).toBe('hash-1');
+    expect(subscribers.filter((event) => event.__typename === 'QueueItemAdded')).toHaveLength(0);
+  });
+
+  it('triggers resync on a sequence gap without applying the event', () => {
+    const { refs, syncGate } = createHarness([]);
+    const triggerResync = vi.fn();
+    refs.triggerResyncRef.current = triggerResync;
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
+
+    const serverItem = createItem('server-1');
+    const gapItem = createItem('gap-1');
+
+    act(() => {
+      result.current.handleQueueEvent({
+        __typename: 'FullSync',
+        sequence: 5,
+        state: { queue: [serverItem as never], currentClimbQueueItem: null, stateHash: 'hash-1', sequence: 5 },
+      });
+      // Sequence 8 after 5 — events 6 and 7 were lost.
+      result.current.handleQueueEvent({
+        __typename: 'QueueItemAdded',
+        sequence: 8,
+        stateHash: 'hash-8',
+        addedItem: gapItem,
+        position: undefined,
+      } as SubscriptionQueueEvent);
+    });
+
+    expect(triggerResync).toHaveBeenCalledTimes(1);
+    expect(result.current.queue).toEqual([serverItem]);
+    expect(refs.lastReceivedSequenceRef.current).toBe(5);
+  });
+
+  it('QueueReordered with a mismatched item at oldIndex triggers resync instead of applying', () => {
+    // The old hand-rolled switch clamped indices and moved whatever item it
+    // found; order drift is invisible to the sorted-uuid state hash, so it
+    // could diverge forever. The reducer-path pre-validation resyncs instead.
+    const { refs, syncGate } = createHarness([]);
+    const triggerResync = vi.fn();
+    refs.triggerResyncRef.current = triggerResync;
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
+
+    const itemA = createItem('item-a');
+    const itemB = createItem('item-b');
+
+    act(() => {
+      result.current.handleQueueEvent({
+        __typename: 'FullSync',
+        sequence: 5,
+        state: {
+          queue: [itemA as never, itemB as never],
+          currentClimbQueueItem: null,
+          stateHash: 'hash-1',
+          sequence: 5,
+        },
+      });
+      // Server says item-b sits at index 0, but locally item-a is there:
+      // local order has drifted from the server's.
+      result.current.handleQueueEvent({
+        __typename: 'QueueReordered',
+        sequence: 6,
+        stateHash: 'hash-2',
+        uuid: itemB.uuid,
+        oldIndex: 0,
+        newIndex: 1,
+      });
+    });
+
+    expect(triggerResync).toHaveBeenCalledTimes(1);
+    // Order unchanged — the mismatched reorder was not applied.
+    expect(result.current.queue.map((item) => item.uuid)).toEqual([itemA.uuid, itemB.uuid]);
+    // Sequence tracking did not advance past the unapplied event.
+    expect(refs.lastReceivedSequenceRef.current).toBe(5);
+  });
+
+  it('validates a reorder against the freshest state within a synchronous batch', () => {
+    // Delta replay applies a whole batch in one task; React batches the
+    // dispatches, so the reorder validation must read the post-add queue via
+    // the synchronous mirror, not the stale render closure.
+    const { refs, syncGate } = createHarness([]);
+    const triggerResync = vi.fn();
+    refs.triggerResyncRef.current = triggerResync;
+    const { result } = renderHook(() => useEventProcessor({ syncGate, refs }), { wrapper: createWrapper() });
+
+    const itemA = createItem('item-a');
+    const itemB = createItem('item-b');
+
+    act(() => {
+      result.current.handleQueueEvent({
+        __typename: 'FullSync',
+        sequence: 5,
+        state: { queue: [itemA as never], currentClimbQueueItem: null, stateHash: 'hash-1', sequence: 5 },
+      });
+      result.current.handleQueueEvent({
+        __typename: 'QueueItemAdded',
+        sequence: 6,
+        stateHash: 'hash-2',
+        addedItem: itemB,
+        position: undefined,
+      } as SubscriptionQueueEvent);
+      // item-b was appended by the event above in the same tick; the reorder
+      // must see it at index 1.
+      result.current.handleQueueEvent({
+        __typename: 'QueueReordered',
+        sequence: 7,
+        stateHash: 'hash-3',
+        uuid: itemB.uuid,
+        oldIndex: 1,
+        newIndex: 0,
+      });
+    });
+
+    expect(triggerResync).not.toHaveBeenCalled();
+    expect(result.current.queue.map((item) => item.uuid)).toEqual([itemB.uuid, itemA.uuid]);
+    expect(refs.lastReceivedSequenceRef.current).toBe(7);
   });
 });

--- a/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
+++ b/packages/web/app/components/persistent-session/__tests__/event-processor-session-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createQueueSyncGate } from '@boardsesh/queue-runtime';
 import { useEventProcessor } from '../hooks/use-event-processor';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
 import type {
@@ -18,8 +19,6 @@ function createRefs() {
   return {
     lastReceivedSequenceRef: { current: null as number | null },
     triggerResyncRef: { current: null as (() => void) | null },
-    lastCorruptionResyncRef: { current: 0 },
-    isFilteringCorruptedItemsRef: { current: false },
     queueEventSubscribersRef: { current: new Set<(event: SubscriptionQueueEvent) => void>() },
     sessionEventSubscribersRef: { current: new Set<(event: SessionEvent) => void>() },
     offlineBufferRef: { current: [] as LocalClimbQueueItem[] },
@@ -125,7 +124,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
 
   it('does not seed cache when no existing data (waits for HTTP fetch)', () => {
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.handleSessionEvent(createStatsEvent());
@@ -139,7 +140,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.handleSessionEvent(createStatsEvent());
@@ -172,7 +175,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     );
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.handleSessionEvent(
@@ -200,7 +205,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     const ticks = [
       createTick('2026-04-30T10:00:00Z'),
@@ -221,7 +228,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     // Ticks arrive ascending — opposite of the documented newest-first contract.
     const ticks = [
@@ -249,7 +258,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     // 14:30+05:30 == 09:00Z; 12:00Z is later; 11:00Z is earliest in absolute time.
     const ticks = [
@@ -271,7 +282,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     queryClient.setQueryData(SESSION_DETAIL_QUERY_KEY('session-abc'), createExistingSession());
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.handleSessionEvent(createStatsEvent({ ticks: [] }));
@@ -290,7 +303,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     );
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     // The live SessionStatsUpdated event's ticks omit betaLinks (the subscription
     // doesn't select them), so the optimistic merge must preserve the cached ones.
@@ -326,7 +341,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
     );
 
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.handleSessionEvent(
@@ -356,7 +373,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
       subscriberCalls.push(e),
     );
 
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     const event = createStatsEvent();
     act(() => {
@@ -369,7 +388,9 @@ describe('useEventProcessor - SessionStatsUpdated → React Query cache', () => 
 
   it('handles non-SessionStatsUpdated events without touching cache', () => {
     const refs = createRefs();
-    const { result } = renderHook(() => useEventProcessor({ refs }), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useEventProcessor({ syncGate: createQueueSyncGate(), refs }), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.handleSessionEvent({

--- a/packages/web/app/components/persistent-session/__tests__/use-session-subscriptions.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/use-session-subscriptions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { renderHook, act } from '@testing-library/react';
+import { createQueueSyncGate, CORRUPTION_RESYNC_COOLDOWN_MS } from '@boardsesh/queue-runtime';
 
 // Force the watchdog into a permanent mismatch: the local hash never equals the
 // server hash below, so every 60s tick sees drift and would resync forever
@@ -10,6 +11,14 @@ vi.mock('@sentry/nextjs', () => ({ captureMessage: vi.fn() }));
 import { useSessionSubscriptions } from '../hooks/use-session-subscriptions';
 
 type SubscriptionsArgs = Parameters<typeof useSessionSubscriptions>[0];
+
+function createRefs(triggerResync: () => void) {
+  return {
+    triggerResyncRef: { current: triggerResync },
+    queueEventSubscribersRef: { current: new Set() },
+    sessionEventSubscribersRef: { current: new Set() },
+  } as unknown as SubscriptionsArgs['refs'];
+}
 
 describe('useSessionSubscriptions — watchdog convergence (issue #2359)', () => {
   beforeEach(() => {
@@ -23,32 +32,30 @@ describe('useSessionSubscriptions — watchdog convergence (issue #2359)', () =>
 
   it('backs off auto-resync after the loop threshold for an unchanging server hash', () => {
     const triggerResync = vi.fn();
-    const refs = {
-      triggerResyncRef: { current: triggerResync },
-      lastCorruptionResyncRef: { current: 0 },
-      isFilteringCorruptedItemsRef: { current: false },
-      queueEventSubscribersRef: { current: new Set() },
-      sessionEventSubscribersRef: { current: new Set() },
-    } as unknown as SubscriptionsArgs['refs'];
+    const syncGate = createQueueSyncGate();
+    // Seed the gate's server-hash tracking the way the event processor does
+    // after applying a delta.
+    syncGate.noteApplied({ __typename: 'QueueItemAdded', sequence: 1, stateHash: 'server-hash' });
 
     renderHook(() =>
       useSessionSubscriptions({
         session: { id: 'session-1' } as SubscriptionsArgs['session'],
-        // Non-empty, null-free queue: the corruption effect stays quiet and the
-        // watchdog effect actually arms its interval.
+        // Non-empty, null-free queue so the watchdog effect arms its interval.
         queue: [{ uuid: 'climb-a' }] as unknown as SubscriptionsArgs['queue'],
         // Null current climb: the "current not in queue" defensive check returns
         // early, so the only thing that can call triggerResync is the watchdog.
         currentClimbQueueItem: null,
         lastReceivedStateHash: 'server-hash',
-        setQueueState: vi.fn(),
-        refs,
+        needsResync: false,
+        clearResyncFlag: vi.fn(),
+        syncGate,
+        refs: createRefs(triggerResync),
       }),
     );
 
     // Six watchdog ticks. With RESYNC_LOOP_THRESHOLD = 3 the resync fires on the
-    // first three ticks, then the guard suppresses it — it must not keep firing
-    // every minute against a server hash that never changes.
+    // first three ticks, then the gate's backoff verdict suppresses it — it must
+    // not keep firing every minute against a server hash that never changes.
     for (let tick = 0; tick < 6; tick++) {
       act(() => {
         vi.advanceTimersByTime(60_000);
@@ -56,5 +63,54 @@ describe('useSessionSubscriptions — watchdog convergence (issue #2359)', () =>
     }
 
     expect(triggerResync).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('useSessionSubscriptions — reducer-flagged corruption resync', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resyncs on needsResync, acknowledges the flag, and honours the gate cooldown', () => {
+    const triggerResync = vi.fn();
+    const clearResyncFlag = vi.fn();
+    const clock = { now: 1_000_000 };
+    const syncGate = createQueueSyncGate({ now: () => clock.now });
+
+    const buildArgs = (needsResync: boolean): SubscriptionsArgs => ({
+      session: { id: 'session-1' } as SubscriptionsArgs['session'],
+      queue: [{ uuid: 'climb-a' }] as unknown as SubscriptionsArgs['queue'],
+      currentClimbQueueItem: null,
+      // Null hash keeps the 60s watchdog disarmed — this test only exercises
+      // the corruption path.
+      lastReceivedStateHash: null,
+      needsResync,
+      clearResyncFlag,
+      syncGate,
+      refs: createRefs(triggerResync),
+    });
+
+    const { rerender } = renderHook((args: SubscriptionsArgs) => useSessionSubscriptions(args), {
+      initialProps: buildArgs(true),
+    });
+
+    // First corruption: acknowledged and resynced.
+    expect(clearResyncFlag).toHaveBeenCalledTimes(1);
+    expect(triggerResync).toHaveBeenCalledTimes(1);
+
+    // Second corruption inside the cooldown window: acknowledged, but no
+    // resync — the reducer already filtered the nulls out of local state, so
+    // a resync storm gains nothing (KEEP the cooldown).
+    rerender(buildArgs(false));
+    rerender(buildArgs(true));
+    expect(clearResyncFlag).toHaveBeenCalledTimes(2);
+    expect(triggerResync).toHaveBeenCalledTimes(1);
+
+    // After the cooldown elapses, a fresh corruption resyncs again.
+    clock.now += CORRUPTION_RESYNC_COOLDOWN_MS + 1;
+    rerender(buildArgs(false));
+    rerender(buildArgs(true));
+    expect(clearResyncFlag).toHaveBeenCalledTimes(3);
+    expect(triggerResync).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/app/components/persistent-session/__tests__/use-session-subscriptions.test.tsx
+++ b/packages/web/app/components/persistent-session/__tests__/use-session-subscriptions.test.tsx
@@ -113,4 +113,29 @@ describe('useSessionSubscriptions — reducer-flagged corruption resync', () => 
     expect(clearResyncFlag).toHaveBeenCalledTimes(3);
     expect(triggerResync).toHaveBeenCalledTimes(2);
   });
+
+  it('leaves needsResync pending when there is no session (no silent acknowledgement)', () => {
+    const triggerResync = vi.fn();
+    const clearResyncFlag = vi.fn();
+    const syncGate = createQueueSyncGate();
+
+    renderHook(() =>
+      useSessionSubscriptions({
+        session: null,
+        queue: [] as unknown as SubscriptionsArgs['queue'],
+        currentClimbQueueItem: null,
+        lastReceivedStateHash: null,
+        needsResync: true,
+        clearResyncFlag,
+        syncGate,
+        refs: createRefs(triggerResync),
+      }),
+    );
+
+    // Without a session there is nothing to resync against; the flag stays
+    // pending (the next connect()'s FullSync recomputes it) rather than being
+    // acknowledged with no action taken.
+    expect(clearResyncFlag).not.toHaveBeenCalled();
+    expect(triggerResync).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/app/components/persistent-session/event-utils.ts
+++ b/packages/web/app/components/persistent-session/event-utils.ts
@@ -1,11 +1,87 @@
-import type { SessionUser } from '@boardsesh/shared-schema';
+import type { SessionUser, SubscriptionQueueEvent } from '@boardsesh/shared-schema';
 import type { SessionUser as GeneratedSessionUser } from '@boardsesh/shared-schema/generated';
-import { upsertRuntimeSessionUser } from '@boardsesh/queue-runtime';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import { upsertRuntimeSessionUser, type SubscriptionWireEnvelope } from '@boardsesh/queue-runtime';
 
 // Re-export pure queue utilities from the shared package — the web app used to
 // have its own copies; now it delegates to the single implementation.
 export { insertQueueItemIdempotent, evaluateQueueEventSequence } from '@boardsesh/queue';
 export type { QueueSequenceDecision } from '@boardsesh/queue';
+
+/**
+ * Queue-state events only — `PlaybackStateChanged` is ephemeral (consumed by
+ * `use-drawer-playback` for the engine; doesn't mutate queue state) and is
+ * filtered out by callers before reaching `toWireEnvelope`.
+ */
+export type QueueStateEvent = Exclude<SubscriptionQueueEvent, { __typename: 'PlaybackStateChanged' }>;
+
+/**
+ * Adapt the wire-format `SubscriptionQueueEvent` (from `@boardsesh/shared-schema`)
+ * to the runtime's structural `SubscriptionWireEnvelope<ClimbQueueItem>` (from
+ * `@boardsesh/queue-runtime`). Both unions share the same `__typename` set and
+ * the same aliased field names, but their `ClimbQueueItem` declarations come
+ * from different packages so direct assignment isn't possible.
+ *
+ * Explicit per-variant rebuild + `assertNever` default rather than an
+ * `as unknown as` cast: TypeScript — not runtime — surfaces drift between the
+ * two unions (new variant, renamed field, narrowed field type). A silent cast
+ * would let an unrecognized __typename fall through to
+ * `mapSubscriptionEnvelopeToAction`'s switch which has no `default` clause and
+ * would silently drop the event.
+ *
+ * Lives here (not in `graphql-queue/`) because the root persistent-session
+ * event processor is now the primary consumer; the board-route subscription
+ * hook (`use-queue-event-subscription.ts`) re-exports it for its existing
+ * importers until a later workstream deletes that hook.
+ */
+export function toWireEnvelope(event: QueueStateEvent): SubscriptionWireEnvelope<ClimbQueueItem> {
+  switch (event.__typename) {
+    case 'FullSync':
+      return {
+        __typename: 'FullSync',
+        state: {
+          queue: event.state.queue,
+          currentClimbQueueItem: event.state.currentClimbQueueItem,
+        },
+      };
+    case 'QueueItemAdded':
+      return {
+        __typename: 'QueueItemAdded',
+        addedItem: event.addedItem,
+        position: event.position,
+      };
+    case 'QueueItemRemoved':
+      return { __typename: 'QueueItemRemoved', uuid: event.uuid };
+    case 'QueueReordered':
+      return {
+        __typename: 'QueueReordered',
+        uuid: event.uuid,
+        oldIndex: event.oldIndex,
+        newIndex: event.newIndex,
+      };
+    case 'CurrentClimbChanged':
+      return {
+        __typename: 'CurrentClimbChanged',
+        currentItem: event.currentItem,
+        clientId: event.clientId,
+        correlationId: event.correlationId,
+      };
+    case 'ClimbMirrored':
+      return {
+        __typename: 'ClimbMirrored',
+        mirrored: event.mirrored,
+        mirroredUuid: event.mirroredUuid,
+      };
+    default:
+      return assertNever(event);
+  }
+}
+
+function assertNever(unhandledEvent: never): never {
+  throw new Error(`Unhandled SubscriptionQueueEvent variant: ${JSON.stringify(unhandledEvent)}`);
+}
+
+export const toSyncQueueEvent = toWireEnvelope;
 
 /**
  * Normalize a SessionUser coming off the wire (generated GraphQL type, where

--- a/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-event-processor.ts
@@ -1,18 +1,32 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useReducer, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { SubscriptionQueueEvent, SessionEvent, SessionDetail } from '@boardsesh/shared-schema';
+import {
+  queueReducer,
+  initialState as queueInitialState,
+  type QueueAction,
+  type QueueSearchParams,
+  type QueueState,
+} from '@boardsesh/queue';
+import { mapSubscriptionEnvelopeToAction, type QueueSyncGate, type QueueSyncGateEvent } from '@boardsesh/queue-runtime';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import { evaluateQueueEventSequence, insertQueueItemIdempotent } from '../event-utils';
+import { toWireEnvelope, type QueueStateEvent } from '../event-utils';
 import { type SharedRefs, DEBUG } from '../types';
 import { SESSION_DETAIL_QUERY_KEY } from '@/app/hooks/use-session-detail';
 
 type UseEventProcessorArgs = {
+  /**
+   * Shared sync gate owned by `PersistentSessionProvider`. The same instance
+   * is passed to `useSessionLifecycle` (reconnect strategy + reset on session
+   * change/disconnect) and `useSessionSubscriptions` (hash watchdog +
+   * corruption cooldown) so every resync decision reads one sequence/hash
+   * tracker.
+   */
+  syncGate: QueueSyncGate;
   refs: Pick<
     SharedRefs,
     | 'lastReceivedSequenceRef'
     | 'triggerResyncRef'
-    | 'lastCorruptionResyncRef'
-    | 'isFilteringCorruptedItemsRef'
     | 'queueEventSubscribersRef'
     | 'sessionEventSubscribersRef'
     | 'offlineBufferRef'
@@ -23,24 +37,54 @@ export type EventProcessorState = {
   queue: LocalClimbQueueItem[];
   currentClimbQueueItem: LocalClimbQueueItem | null;
   lastReceivedStateHash: string | null;
+  /** Reducer-detected corruption: INITIAL_QUEUE_DATA / UPDATE_QUEUE filtered
+   *  null (or climbless) items out of an incoming payload.
+   *  `useSessionSubscriptions` watches this and consults the gate's
+   *  corruption cooldown before resyncing. */
+  needsResync: boolean;
 };
 
 export type EventProcessorActions = {
   handleQueueEvent: (event: SubscriptionQueueEvent) => void;
   handleSessionEvent: (event: SessionEvent) => void;
-  setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
-  setCurrentClimbQueueItem: Dispatch<SetStateAction<LocalClimbQueueItem | null>>;
-  setLastReceivedStateHash: Dispatch<SetStateAction<string | null>>;
+  /** Acknowledge the reducer's `needsResync` flag after acting on it. */
+  clearResyncFlag: () => void;
   notifyQueueSubscribers: (event: SubscriptionQueueEvent) => void;
   notifySessionSubscribers: (event: SessionEvent) => void;
 };
 
-export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcessorState & EventProcessorActions {
+/**
+ * Flatten a wire event into the shape the sync gate reasons about. FullSync
+ * nests its stateHash under `state`; PlaybackStateChanged carries no hash
+ * (it doesn't mutate the queue).
+ */
+function toGateEvent(event: SubscriptionQueueEvent): QueueSyncGateEvent {
+  if (event.__typename === 'FullSync') {
+    return { __typename: event.__typename, sequence: event.sequence, stateHash: event.state.stateHash };
+  }
+  if (event.__typename === 'PlaybackStateChanged') {
+    return { __typename: event.__typename, sequence: event.sequence };
+  }
+  return { __typename: event.__typename, sequence: event.sequence, stateHash: event.stateHash };
+}
+
+/**
+ * Root-level queue event processor. Runs every incoming queue event through
+ * the shared `queueReducer` — the exact reducer the board-route
+ * `graphql-queue/QueueContext` uses — gated by the shared sync gate, so both
+ * queue copies apply identical semantics (full state unification is a later
+ * workstream). Deliberately does NOT pass a `myClientId` echo-suppression
+ * hint to the action mapper: this copy is the server-authoritative mirror
+ * and must apply every broadcast, including echoes of this client's own
+ * mutations.
+ */
+export function useEventProcessor({
+  syncGate,
+  refs,
+}: UseEventProcessorArgs): EventProcessorState & EventProcessorActions {
   const {
     lastReceivedSequenceRef,
     triggerResyncRef,
-    lastCorruptionResyncRef: _lastCorruptionResyncRef,
-    isFilteringCorruptedItemsRef: _isFilteringCorruptedItemsRef,
     queueEventSubscribersRef,
     sessionEventSubscribersRef,
     offlineBufferRef,
@@ -48,8 +92,28 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
 
   const queryClient = useQueryClient();
 
-  const [queue, setQueueState] = useState<LocalClimbQueueItem[]>([]);
-  const [currentClimbQueueItem, setCurrentClimbQueueItem] = useState<LocalClimbQueueItem | null>(null);
+  const [reducerState, dispatchToReducer] = useReducer(
+    queueReducer<QueueSearchParams>,
+    undefined,
+    (): QueueState<QueueSearchParams> => queueInitialState<QueueSearchParams>({}),
+  );
+
+  // Synchronous mirror of the reducer state. `handleQueueEvent` can run
+  // several times in one task (the reconnect delta-replay loop feeds a whole
+  // batch synchronously); React batches those dispatches, so the render
+  // closure's `reducerState` goes stale mid-batch. The reorder pre-validation
+  // below must read the state the reducer will actually see next, so the
+  // wrapped dispatch replays each action against this mirror — the reducer is
+  // pure, so replaying is deterministic and side-effect-free.
+  const latestStateRef = useRef<QueueState<QueueSearchParams>>(queueInitialState<QueueSearchParams>({}));
+  const dispatch = useCallback((action: QueueAction<QueueSearchParams>) => {
+    latestStateRef.current = queueReducer(latestStateRef.current, action);
+    dispatchToReducer(action);
+  }, []);
+
+  // Server hash mirror for React consumers (the watchdog effect re-arms on
+  // it). The gate tracks the same value internally for its own comparisons;
+  // this state updates at exactly the gate's tracking points.
   const [lastReceivedStateHash, setLastReceivedStateHash] = useState<string | null>(null);
 
   // Notify queue event subscribers
@@ -68,149 +132,112 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
     [sessionEventSubscribersRef],
   );
 
-  // Helper to update sequence ref
-  const updateLastReceivedSequence = useCallback(
-    (sequence: number) => {
-      lastReceivedSequenceRef.current = sequence;
-    },
-    [lastReceivedSequenceRef],
-  );
-
   // Handle queue events internally
   const handleQueueEvent = useCallback(
     (event: SubscriptionQueueEvent) => {
-      // Sequence validation for stale/gap detection (use ref to avoid stale closure).
-      // FullSync always resets local state and sequence tracking.
-      //
-      // PlaybackStateChanged is also exempt: the server stamps it with the
-      // *current* sequence number (it doesn't mutate the queue, so the room
-      // manager doesn't bump). Routing it through the dedup gate would mark
-      // every event after the first as stale and silently drop party-mode
-      // playback sync. The post-switch block below already skips updating
-      // `lastReceivedSequence`/`stateHash` for this event type.
-      if (event.__typename !== 'FullSync' && event.__typename !== 'PlaybackStateChanged') {
-        const lastSeq = lastReceivedSequenceRef.current;
-        const sequenceDecision = evaluateQueueEventSequence(lastSeq, event.sequence);
+      const gateEvent = toGateEvent(event);
+      const decision = syncGate.evaluateIncoming(gateEvent);
 
-        if (sequenceDecision === 'ignore-stale') {
-          if (DEBUG) {
-            console.info(
-              `[PersistentSession] Ignoring stale/duplicate event with sequence ${event.sequence} ` +
-                `(last received: ${lastSeq})`,
-            );
-          }
-          return;
-        }
-
-        if (sequenceDecision === 'gap') {
-          console.warn(
-            `[PersistentSession] Sequence gap detected: expected ${lastSeq! + 1}, got ${event.sequence}. ` +
-              `Triggering resync.`,
+      if (decision === 'ignore-stale') {
+        if (DEBUG) {
+          console.info(
+            `[PersistentSession] Ignoring stale/duplicate event with sequence ${gateEvent.sequence} ` +
+              `(last received: ${syncGate.getLastSequence()})`,
           );
-          if (triggerResyncRef.current) {
-            triggerResyncRef.current();
-          }
-          return;
         }
+        return;
       }
 
-      switch (event.__typename) {
-        case 'FullSync': {
-          const serverQueue = (event.state.queue as LocalClimbQueueItem[]).filter((item) => item != null);
-          // Merge offline-buffered items for visual continuity during reconciliation
-          const pending = offlineBufferRef.current;
-          if (pending.length > 0) {
-            const serverUuids = new Set(serverQueue.map((item) => item.uuid));
-            for (const item of pending) {
-              if (!serverUuids.has(item.uuid)) {
-                serverQueue.push(item);
-              }
+      if (decision === 'resync-gap') {
+        console.warn(
+          `[PersistentSession] Sequence gap detected: expected ${(syncGate.getLastSequence() ?? 0) + 1}, ` +
+            `got ${gateEvent.sequence}. Triggering resync.`,
+        );
+        triggerResyncRef.current?.();
+        return;
+      }
+
+      // decision === 'apply'. PlaybackStateChanged is ephemeral — the queue
+      // reducer has no concept of playback frames, and the gate never
+      // advances tracking for it (the server stamps it with the *current*
+      // sequence, so tracking it would mark the next real delta stale).
+      if (event.__typename !== 'PlaybackStateChanged') {
+        let stateEvent: QueueStateEvent = event;
+
+        if (stateEvent.__typename === 'FullSync') {
+          // Merge offline-buffered items into the FullSync payload BEFORE
+          // dispatch, for visual continuity during reconciliation — climbs
+          // the user added while disconnected must not blink out of the queue
+          // until `useOfflineReconciliation` pushes them to the server.
+          // Server-sent nulls (corrupted items) are deliberately left in
+          // place so the reducer's INITIAL_QUEUE_DATA filter can flag
+          // `needsResync`.
+          const pendingOfflineItems = offlineBufferRef.current;
+          if (pendingOfflineItems.length > 0) {
+            const serverUuids = new Set(stateEvent.state.queue.filter((item) => item != null).map((item) => item.uuid));
+            const missingOfflineItems = pendingOfflineItems.filter((item) => !serverUuids.has(item.uuid));
+            if (missingOfflineItems.length > 0) {
+              stateEvent = {
+                ...stateEvent,
+                state: {
+                  ...stateEvent.state,
+                  queue: [
+                    ...stateEvent.state.queue,
+                    ...(missingOfflineItems as unknown as typeof stateEvent.state.queue),
+                  ],
+                },
+              };
             }
           }
-          setQueueState(serverQueue);
-          setCurrentClimbQueueItem(event.state.currentClimbQueueItem as LocalClimbQueueItem | null);
-          updateLastReceivedSequence(event.sequence);
-          setLastReceivedStateHash(event.state.stateHash);
-          break;
         }
-        case 'QueueItemAdded':
-          if (event.addedItem == null) {
-            console.error('[PersistentSession] Received QueueItemAdded with null/undefined item, skipping');
-            break;
-          }
-          setQueueState((prev) => {
-            return insertQueueItemIdempotent(prev, event.addedItem as LocalClimbQueueItem, event.position ?? undefined);
-          });
-          break;
-        case 'QueueItemRemoved':
-          setQueueState((prev) => prev.filter((item) => item.uuid !== event.uuid));
-          setCurrentClimbQueueItem((prev) => (prev?.uuid === event.uuid ? null : prev));
-          break;
-        case 'QueueReordered':
-          setQueueState((prev) => {
-            const sourceIndex = prev.findIndex((item) => item.uuid === event.uuid);
-            const oldIndex = sourceIndex >= 0 ? sourceIndex : event.oldIndex;
-            if (oldIndex < 0 || oldIndex >= prev.length) {
-              console.warn(
-                `[PersistentSession] Received QueueReordered for missing item ${event.uuid}; waiting for hash watchdog resync`,
-              );
-              return prev;
-            }
-            const newQueue = [...prev];
-            const [item] = newQueue.splice(oldIndex, 1);
-            const newIndex = Math.max(0, Math.min(event.newIndex, newQueue.length));
-            newQueue.splice(newIndex, 0, item);
-            return newQueue;
-          });
-          break;
-        case 'CurrentClimbChanged':
-          setCurrentClimbQueueItem(event.currentItem as LocalClimbQueueItem | null);
-          break;
-        case 'ClimbMirrored':
-          if (event.mirroredUuid) {
-            setQueueState((prev) =>
-              prev.map((item) =>
-                item.uuid === event.mirroredUuid
-                  ? {
-                      ...item,
-                      climb: {
-                        ...item.climb,
-                        mirrored: event.mirrored,
-                      },
-                    }
-                  : item,
-              ),
+
+        if (stateEvent.__typename === 'QueueReordered') {
+          // Reorder pre-validation — a deliberate behavior change from the
+          // old hand-rolled switch, which clamped out-of-range indices and
+          // moved whatever item it found. If the item at oldIndex isn't the
+          // item the server says it moved, local order has drifted from the
+          // server's. Order drift is invisible to the sorted-uuid state hash,
+          // so the 60s watchdog would never catch it and clamping could
+          // diverge silently forever. Resync instead of dispatching.
+          const itemAtOldIndex = latestStateRef.current.queue[stateEvent.oldIndex];
+          if (itemAtOldIndex?.uuid !== stateEvent.uuid) {
+            console.warn(
+              `[PersistentSession] QueueReordered mismatch: expected item ${stateEvent.uuid} at index ` +
+                `${stateEvent.oldIndex}, found ${itemAtOldIndex?.uuid ?? 'nothing'}. Triggering resync.`,
             );
+            triggerResyncRef.current?.();
+            return;
           }
-          setCurrentClimbQueueItem((prev) => {
-            if (!prev) return prev;
-            if (event.mirroredUuid && prev.uuid !== event.mirroredUuid) return prev;
-            return {
-              ...prev,
-              climb: {
-                ...prev.climb,
-                mirrored: event.mirrored,
-              },
-            };
-          });
-          break;
+        }
+
+        const mappingResult = mapSubscriptionEnvelopeToAction(toWireEnvelope(stateEvent));
+        if (mappingResult.kind === 'dispatch') {
+          dispatch(mappingResult.action);
+        } else {
+          // Malformed payload (e.g. QueueItemAdded with no item). Skip the
+          // dispatch but still advance sequence/hash tracking below — the
+          // server did consume this sequence number.
+          console.error(`[PersistentSession] Ignoring ${mappingResult.eventType} event: ${mappingResult.reason}`);
+        }
+
+        syncGate.noteApplied(gateEvent);
+        // `use-offline-reconciliation` reads this ref to detect server-side
+        // changes across a disconnect; the gate owns the value now.
+        lastReceivedSequenceRef.current = syncGate.getLastSequence();
+        setLastReceivedStateHash(gateEvent.stateHash ?? null);
       }
 
-      if (event.__typename !== 'FullSync' && event.__typename !== 'PlaybackStateChanged') {
-        // PlaybackStateChanged is ephemeral — it doesn't carry a stateHash
-        // because it doesn't mutate the queue. The room manager reuses the
-        // current sequence number for ordering, so skip both updates here
-        // to avoid clobbering the watchdog's drift detection with a stale
-        // sequence repeat.
-        updateLastReceivedSequence(event.sequence);
-        setLastReceivedStateHash(event.stateHash);
-      }
-
-      // Notify external subscribers
+      // Notify external subscribers with the ORIGINAL event — the offline
+      // reconciliation hook compares the unmerged server queue against its
+      // buffer, so it must not see the offline items merged in above.
       notifyQueueSubscribers(event);
     },
-    [lastReceivedSequenceRef, triggerResyncRef, notifyQueueSubscribers, updateLastReceivedSequence, offlineBufferRef],
+    [syncGate, dispatch, triggerResyncRef, notifyQueueSubscribers, lastReceivedSequenceRef, offlineBufferRef],
   );
+
+  const clearResyncFlag = useCallback(() => {
+    dispatch({ type: 'CLEAR_RESYNC_FLAG' });
+  }, [dispatch]);
 
   // Handle session events internally
   const handleSessionEvent = useCallback(
@@ -262,14 +289,16 @@ export function useEventProcessor({ refs }: UseEventProcessorArgs): EventProcess
   );
 
   return {
-    queue,
-    currentClimbQueueItem,
+    // TYPE SEAM: the reducer state's items use the shared @boardsesh/queue
+    // ClimbQueueItem; the provider surface exposes the structurally-compatible
+    // web ClimbQueueItem (see the seam note in queue-control/types.ts).
+    queue: reducerState.queue as LocalClimbQueueItem[],
+    currentClimbQueueItem: reducerState.currentClimbQueueItem as LocalClimbQueueItem | null,
     lastReceivedStateHash,
+    needsResync: reducerState.needsResync,
     handleQueueEvent,
     handleSessionEvent,
-    setQueueState,
-    setCurrentClimbQueueItem,
-    setLastReceivedStateHash,
+    clearResyncFlag,
     notifyQueueSubscribers,
     notifySessionSubscribers,
   };

--- a/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-lifecycle.ts
@@ -22,6 +22,7 @@ import {
 import {
   applySessionRuntimeEvent,
   hasContiguousReplayCoverage,
+  type QueueSyncGate,
   type RuntimeSessionEvent,
 } from '@boardsesh/queue-runtime';
 import type {
@@ -157,7 +158,14 @@ type UseSessionLifecycleArgs = {
   isAuthLoading: boolean;
   handleQueueEvent: (event: SubscriptionQueueEvent) => void;
   handleSessionEvent: (event: SessionEvent) => void;
-  setLastReceivedStateHash: Dispatch<SetStateAction<string | null>>;
+  /**
+   * Shared sync gate owned by `PersistentSessionProvider`. This hook asks it
+   * for the reconnect strategy (none / delta-replay / full-sync) and RESETS
+   * it whenever the connection effect tears down (session change, auth
+   * change, unmount) — the next `connect()` re-establishes tracking from a
+   * fresh FullSync.
+   */
+  syncGate: QueueSyncGate;
   refs: Pick<
     SharedRefs,
     | 'wsAuthTokenRef'
@@ -210,7 +218,7 @@ export function useSessionLifecycle({
   isAuthLoading,
   handleQueueEvent,
   handleSessionEvent,
-  setLastReceivedStateHash,
+  syncGate,
   refs,
 }: UseSessionLifecycleArgs): SessionLifecycleState & SessionLifecycleActions {
   const {
@@ -494,7 +502,9 @@ export function useSessionLifecycle({
       try {
         if (DEBUG) console.info('[PersistentSession] Reconnecting...');
 
-        const lastSeq = lastReceivedSequenceRef.current;
+        // The gate owns sequence tracking; the ref is just a mirror for
+        // use-offline-reconciliation.
+        const lastSeq = syncGate.getLastSequence();
         const sessionData = await joinSession(clientForReconnect);
         if (!sessionData || !mountedRef.current) return;
         // joinSession (WS member payload) always returns a full queue
@@ -521,16 +531,30 @@ export function useSessionLifecycle({
         subscriptionRetryCount = 0;
 
         const currentSeq = rejoinedQueueState.sequence;
-        const gap = lastSeq !== null ? currentSeq - lastSeq : 0;
+        // Strategy selection (gap thresholds, first-connection, gap=0 hash
+        // compare) lives in the shared gate — the old inline gap/hash chain
+        // is gone.
+        const strategy = syncGate.decideReconnectStrategy({
+          lastSequence: lastSeq,
+          serverSequence: currentSeq,
+          serverStateHash: rejoinedQueueState.stateHash,
+          localStateHash: computeQueueStateHash(queueRef.current, currentClimbQueueItemRef.current?.uuid || null),
+        });
 
         if (DEBUG)
           console.info(
-            `[PersistentSession] Reconnected. Last seq: ${lastSeq}, Current seq: ${currentSeq}, Gap: ${gap}`,
+            `[PersistentSession] Reconnected. Last seq: ${lastSeq}, Current seq: ${currentSeq}, Strategy: ${strategy}`,
           );
 
-        if (gap > 0 && gap <= 100 && lastSeq !== null && sessionId) {
+        // The gate picks 'delta-replay' purely from the sequence gap; the
+        // legacy branch additionally required a truthy sessionId (falsy → no
+        // resync at all), so that guard stays here at the call site. The
+        // lastSeq null-check is for TypeScript — the gate never returns
+        // 'delta-replay' without a tracked sequence.
+        if (strategy === 'delta-replay' && lastSeq !== null && sessionId) {
           try {
-            if (DEBUG) console.info(`[PersistentSession] Attempting delta sync for ${gap} missed events...`);
+            if (DEBUG)
+              console.info(`[PersistentSession] Attempting delta sync for ${currentSeq - lastSeq} missed events...`);
 
             const response = await execute<{ eventsReplay: EventsReplayResponse }>(clientForReconnect, {
               query: EVENTS_REPLAY,
@@ -567,21 +591,14 @@ export function useSessionLifecycle({
             console.warn('[PersistentSession] Delta sync failed, falling back to full sync:', err);
             applyFullSync(sessionData);
           }
-        } else if (gap > 100) {
-          if (DEBUG) console.info(`[PersistentSession] Gap too large (${gap}), using full sync`);
+        } else if (strategy === 'full-sync') {
+          if (DEBUG) console.info('[PersistentSession] Applying full sync on reconnect');
           applyFullSync(sessionData);
-        } else if (lastSeq === null) {
-          if (DEBUG) console.info('[PersistentSession] First connection, applying initial state');
-          applyFullSync(sessionData);
-        } else if (gap === 0) {
-          const localHash = computeQueueStateHash(queueRef.current, currentClimbQueueItemRef.current?.uuid || null);
-          if (localHash !== rejoinedQueueState.stateHash) {
-            if (DEBUG) console.info('[PersistentSession] Hash mismatch on reconnect despite gap=0, applying full sync');
-            applyFullSync(sessionData);
-          } else {
-            setLastReceivedStateHash(rejoinedQueueState.stateHash);
-            if (DEBUG) console.info('[PersistentSession] No missed events, already in sync');
-          }
+        } else {
+          // 'none': the event processor's hash tracking already matches the
+          // server, so there is no state to update here (the old code's
+          // redundant setLastReceivedStateHash call is gone).
+          if (DEBUG) console.info('[PersistentSession] No missed events, already in sync');
         }
 
         setSession(sessionData);
@@ -844,6 +861,16 @@ export function useSessionLifecycle({
       sessionUnsubscribeRef.current?.();
       sessionUnsubscribeRef.current = null;
 
+      // Gate tracking is connection-scoped: the next connect() (same or
+      // different session) re-establishes sequence/hash tracking from a fresh
+      // FullSync, and a new session deserves a clean corruption cooldown and
+      // resync-loop counter. Transient socket drops do NOT run this cleanup
+      // (graphql-ws reconnects internally via onReconnect), so delta replay
+      // across a network blip still sees the pre-disconnect sequence. Keep
+      // the legacy ref mirror in sync for use-offline-reconciliation.
+      syncGate.reset();
+      lastReceivedSequenceRef.current = null;
+
       if (clientToCleanup) {
         void Promise.resolve()
           .then(async () => {
@@ -874,7 +901,7 @@ export function useSessionLifecycle({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- refs are stable, only .current changes; intentional dep list
-  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, setLastReceivedStateHash, setSession]);
+  }, [activeSession, isAuthLoading, handleQueueEvent, handleSessionEvent, syncGate, setSession]);
 
   return {
     activeSession,

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -1,31 +1,28 @@
-import { useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import type { SubscriptionQueueEvent, SessionEvent } from '@boardsesh/shared-schema';
+import { RESYNC_LOOP_THRESHOLD, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import { computeQueueStateHash } from '@/app/utils/hash';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../../queue-control/types';
-import { type Session, type SharedRefs, CORRUPTION_RESYNC_COOLDOWN_MS, DEBUG } from '../types';
-
-// When the 60s hash watchdog triggers resync for the *same* server hash this
-// many times in a row, the underlying drift isn't getting fixed — the client
-// and server agree on the hash but the client's local computation keeps
-// disagreeing with itself. Surface it to Sentry so we have something to
-// investigate instead of an invisible per-minute resync loop.
-const RESYNC_LOOP_THRESHOLD = 3;
+import { type Session, type SharedRefs, DEBUG } from '../types';
 
 type UseSessionSubscriptionsArgs = {
   session: Session | null;
   queue: LocalClimbQueueItem[];
   currentClimbQueueItem: LocalClimbQueueItem | null;
   lastReceivedStateHash: string | null;
-  setQueueState: Dispatch<SetStateAction<LocalClimbQueueItem[]>>;
-  refs: Pick<
-    SharedRefs,
-    | 'triggerResyncRef'
-    | 'lastCorruptionResyncRef'
-    | 'isFilteringCorruptedItemsRef'
-    | 'queueEventSubscribersRef'
-    | 'sessionEventSubscribersRef'
-  >;
+  /** Reducer-detected corruption flag from the event processor. */
+  needsResync: boolean;
+  /** Acknowledge `needsResync` after acting on it. */
+  clearResyncFlag: () => void;
+  /**
+   * Shared sync gate owned by `PersistentSessionProvider` (see
+   * `use-event-processor.ts`). This hook consumes its hash-drift verdicts
+   * (60s watchdog) and its corruption-resync cooldown; `useSessionLifecycle`
+   * resets it on session change/disconnect.
+   */
+  syncGate: QueueSyncGate;
+  refs: Pick<SharedRefs, 'triggerResyncRef' | 'queueEventSubscribersRef' | 'sessionEventSubscribersRef'>;
 };
 
 export type SessionSubscriptionsActions = {
@@ -39,78 +36,41 @@ export function useSessionSubscriptions({
   queue,
   currentClimbQueueItem,
   lastReceivedStateHash,
-  setQueueState,
+  needsResync,
+  clearResyncFlag,
+  syncGate,
   refs,
 }: UseSessionSubscriptionsArgs): SessionSubscriptionsActions {
-  const {
-    triggerResyncRef,
-    lastCorruptionResyncRef,
-    isFilteringCorruptedItemsRef,
-    queueEventSubscribersRef,
-    sessionEventSubscribersRef,
-  } = refs;
+  const { triggerResyncRef, queueEventSubscribersRef, sessionEventSubscribersRef } = refs;
 
-  // Keep state hash in sync with local state after delta events
-  // Also detects corrupted items and triggers resync if found
+  // Corruption handling. Detection now lives in the shared reducer: when
+  // INITIAL_QUEUE_DATA / UPDATE_QUEUE filters null (or climbless) items out
+  // of an incoming payload it raises `needsResync`. Local state is already
+  // clean post-dispatch (the reducer never stores nulls), so the old
+  // setQueueState-based local re-filtering step is gone — this effect only
+  // decides whether to pull authoritative server state, rate-limited by the
+  // gate's cooldown so resync storms can't loop.
   useEffect(() => {
+    if (!needsResync) return;
+    clearResyncFlag();
     if (!session) return;
 
-    if (isFilteringCorruptedItemsRef.current) {
-      isFilteringCorruptedItemsRef.current = false;
+    if (syncGate.evaluateCorruption() === 'cooldown') {
+      console.error(
+        '[PersistentSession] Reducer filtered corrupted queue items, but corruption resync is on cooldown. ' +
+          'Keeping locally filtered state.',
+      );
       return;
     }
 
-    // Check for corrupted (null/undefined) items in the queue
-    const hasCorruptedItems = queue.some((item) => item == null);
-    if (hasCorruptedItems) {
-      const now = Date.now();
-      const timeSinceLastResync = now - lastCorruptionResyncRef.current;
+    console.error('[PersistentSession] Reducer filtered corrupted queue items, triggering resync');
+    triggerResyncRef.current?.();
+  }, [needsResync, clearResyncFlag, session, syncGate, triggerResyncRef]);
 
-      if (timeSinceLastResync < CORRUPTION_RESYNC_COOLDOWN_MS) {
-        console.error(
-          `[PersistentSession] Detected null/undefined items in queue, but resync on cooldown ` +
-            `(${Math.round((CORRUPTION_RESYNC_COOLDOWN_MS - timeSinceLastResync) / 1000)}s remaining). ` +
-            `Filtering locally.`,
-        );
-        isFilteringCorruptedItemsRef.current = true;
-        setQueueState((prev) => prev.filter((item) => item != null));
-        return;
-      }
-
-      console.error('[PersistentSession] Detected null/undefined items in queue, triggering resync');
-      lastCorruptionResyncRef.current = now;
-      if (triggerResyncRef.current) {
-        triggerResyncRef.current();
-      }
-      return;
-    }
-    // Note: hash is computed in the main provider via the event processor
-  }, [
-    session,
-    queue,
-    currentClimbQueueItem,
-    setQueueState,
-    triggerResyncRef,
-    lastCorruptionResyncRef,
-    isFilteringCorruptedItemsRef,
-  ]);
-
-  // Periodic state hash verification (every 60 seconds)
-  const lastResyncHashRef = useRef<string | null>(null);
-  const consecutiveResyncCountRef = useRef(0);
-  const sentryReportedHashRef = useRef<string | null>(null);
-
-  // Reset the resync-loop trackers whenever the active session changes.
-  // Otherwise a hash that triggered N resyncs in session A would carry
-  // forward into session B and either over-count or suppress the Sentry
-  // breadcrumb that should fire fresh per session.
-  const sessionIdForReset = session?.id ?? null;
-  useEffect(() => {
-    lastResyncHashRef.current = null;
-    consecutiveResyncCountRef.current = 0;
-    sentryReportedHashRef.current = null;
-  }, [sessionIdForReset]);
-
+  // Periodic state hash verification (every 60 seconds). The gate owns the
+  // comparison, the consecutive-resync counting against an unchanging server
+  // hash, and the 3-strike backoff (issue #2359); this effect owns the timer
+  // and the Sentry report.
   useEffect(() => {
     if (!session || !lastReceivedStateHash || queue.length === 0) {
       return;
@@ -118,66 +78,52 @@ export function useSessionSubscriptions({
 
     const verifyInterval = setInterval(() => {
       const localHash = computeQueueStateHash(queue, currentClimbQueueItem?.uuid || null);
+      const { verdict, consecutiveResyncs, serverHash } = syncGate.verifyLocalHash(localHash);
 
-      if (localHash !== lastReceivedStateHash) {
-        console.warn(
-          '[PersistentSession] State hash mismatch detected!',
-          `Local: ${localHash}, Server: ${lastReceivedStateHash}`,
-          'Triggering automatic resync...',
-        );
-
-        if (lastResyncHashRef.current === lastReceivedStateHash) {
-          consecutiveResyncCountRef.current += 1;
-        } else {
-          lastResyncHashRef.current = lastReceivedStateHash;
-          consecutiveResyncCountRef.current = 1;
-          sentryReportedHashRef.current = null;
-        }
-
-        if (
-          consecutiveResyncCountRef.current >= RESYNC_LOOP_THRESHOLD &&
-          sentryReportedHashRef.current !== lastReceivedStateHash
-        ) {
-          sentryReportedHashRef.current = lastReceivedStateHash;
-          console.error(
-            `[PersistentSession] Resync loop detected: ${consecutiveResyncCountRef.current} consecutive resyncs for server hash ${lastReceivedStateHash} (local hash ${localHash}). Capturing Sentry message.`,
-          );
-          Sentry.captureMessage('Resync loop: client keeps disagreeing with server hash', {
-            level: 'warning',
-            tags: { feature: 'party-session', issue: 'hash-resync-loop' },
-            fingerprint: ['party-session', 'hash-resync-loop'],
-            extra: {
-              sessionId: session.id,
-              serverHash: lastReceivedStateHash,
-              localHash,
-              consecutiveResyncs: consecutiveResyncCountRef.current,
-              queueLength: queue.length,
-              currentClimbUuid: currentClimbQueueItem?.uuid ?? null,
-            },
-          });
-        }
-
-        // Stop auto-resyncing once we've hit the loop threshold for this exact
-        // server hash. Repeated resyncs against an unchanging server hash are
-        // no-ops on the server (issue #2359) — the resync isn't fixing the
-        // disagreement, so refiring every minute just spams the session. Keep
-        // the Sentry alert above, but back off here. The counter resets when
-        // the hashes finally agree or the server hash changes, so genuine new
-        // drift still resyncs.
-        if (consecutiveResyncCountRef.current <= RESYNC_LOOP_THRESHOLD && triggerResyncRef.current) {
-          triggerResyncRef.current();
-        }
-      } else {
-        // Hash matches — reset the loop counter so future drift starts fresh.
-        consecutiveResyncCountRef.current = 0;
-        lastResyncHashRef.current = null;
-        sentryReportedHashRef.current = null;
+      if (verdict === 'ok') {
         if (DEBUG) console.info('[PersistentSession] State hash verification passed');
+        return;
+      }
+
+      console.warn(
+        '[PersistentSession] State hash mismatch detected!',
+        `Local: ${localHash}, Server: ${serverHash}`,
+        'Triggering automatic resync...',
+      );
+
+      // Report exactly once per drift streak — the tick where the strike
+      // count reaches the threshold (the same one-shot point the old
+      // ref-based implementation reported at).
+      if (consecutiveResyncs === RESYNC_LOOP_THRESHOLD) {
+        console.error(
+          `[PersistentSession] Resync loop detected: ${consecutiveResyncs} consecutive resyncs for server hash ${serverHash} (local hash ${localHash}). Capturing Sentry message.`,
+        );
+        Sentry.captureMessage('Resync loop: client keeps disagreeing with server hash', {
+          level: 'warning',
+          tags: { feature: 'party-session', issue: 'hash-resync-loop' },
+          fingerprint: ['party-session', 'hash-resync-loop'],
+          extra: {
+            sessionId: session.id,
+            serverHash,
+            localHash,
+            consecutiveResyncs,
+            queueLength: queue.length,
+            currentClimbUuid: currentClimbQueueItem?.uuid ?? null,
+          },
+        });
+      }
+
+      // 'backoff' verdict: repeated resyncs against an unchanging server
+      // hash are no-ops on the server (issue #2359) — stop refiring every
+      // minute. The gate resets its counter when the hashes agree again or
+      // the server hash changes, so genuine new drift still resyncs.
+      if (verdict === 'resync-drift') {
+        triggerResyncRef.current?.();
       }
     }, 60000);
 
     return () => clearInterval(verifyInterval);
-  }, [session, lastReceivedStateHash, queue, currentClimbQueueItem, triggerResyncRef]);
+  }, [session, lastReceivedStateHash, queue, currentClimbQueueItem, syncGate, triggerResyncRef]);
 
   // Defensive state consistency check
   useEffect(() => {

--- a/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
+++ b/packages/web/app/components/persistent-session/hooks/use-session-subscriptions.ts
@@ -52,8 +52,11 @@ export function useSessionSubscriptions({
   // gate's cooldown so resync storms can't loop.
   useEffect(() => {
     if (!needsResync) return;
-    clearResyncFlag();
+    // No session: leave the flag pending rather than acknowledging it with no
+    // action — the next connect()'s FullSync overwrites `needsResync` anyway
+    // (INITIAL_QUEUE_DATA recomputes it from the fresh payload).
     if (!session) return;
+    clearResyncFlag();
 
     if (syncGate.evaluateCorruption() === 'cooldown') {
       console.error(

--- a/packages/web/app/components/persistent-session/persistent-session-context.tsx
+++ b/packages/web/app/components/persistent-session/persistent-session-context.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useCallback, useMemo, useRef, useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import type { SubscriptionQueueEvent, SessionEvent } from '@boardsesh/shared-schema';
+import { createQueueSyncGate, type QueueSyncGate } from '@boardsesh/queue-runtime';
 import type { ClimbQueueItem as LocalClimbQueueItem } from '../queue-control/types';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { usePartyProfile } from '../party-manager/party-profile-context';
@@ -56,8 +57,6 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
   const connectionGenerationRef = useRef(0);
   const triggerResyncRef = useRef<(() => void) | null>(null);
   const lastReceivedSequenceRef = useRef<number | null>(null);
-  const lastCorruptionResyncRef = useRef<number>(0);
-  const isFilteringCorruptedItemsRef = useRef(false);
   const queueUnsubscribeRef = useRef<(() => void) | null>(null);
   const sessionUnsubscribeRef = useRef<(() => void) | null>(null);
   const queueEventSubscribersRef = useRef<Set<(event: SubscriptionQueueEvent) => void>>(new Set());
@@ -93,16 +92,27 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     connectionGenerationRef,
     triggerResyncRef,
     lastReceivedSequenceRef,
-    lastCorruptionResyncRef,
-    isFilteringCorruptedItemsRef,
     queueUnsubscribeRef,
     sessionUnsubscribeRef,
     queueEventSubscribersRef,
     sessionEventSubscribersRef,
   };
 
-  // 1. Event processor: queue state + event handling
-  const eventProcessor = useEventProcessor({ refs });
+  // Shared queue sync gate — ONE instance for all three hooks below, so
+  // sequence/hash tracking, the corruption cooldown, and the resync-loop
+  // backoff read the same state. Ownership: created here (lazily, once per
+  // provider mount); the event processor advances it per applied event; the
+  // lifecycle consults it on reconnect and RESETS it when the connection
+  // effect tears down (session change/disconnect); the subscriptions hook
+  // consumes its watchdog/corruption verdicts.
+  const syncGateRef = useRef<QueueSyncGate | null>(null);
+  if (syncGateRef.current === null) {
+    syncGateRef.current = createQueueSyncGate();
+  }
+  const syncGate = syncGateRef.current;
+
+  // 1. Event processor: queue state (shared queueReducer) + event handling
+  const eventProcessor = useEventProcessor({ syncGate, refs });
 
   // Keep queue refs in sync with event processor state
   useEffect(() => {
@@ -117,7 +127,7 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     isAuthLoading,
     handleQueueEvent: eventProcessor.handleQueueEvent,
     handleSessionEvent: eventProcessor.handleSessionEvent,
-    setLastReceivedStateHash: eventProcessor.setLastReceivedStateHash,
+    syncGate,
     refs,
   });
 
@@ -153,7 +163,9 @@ export const PersistentSessionProvider: React.FC<{ children: React.ReactNode }> 
     queue: eventProcessor.queue,
     currentClimbQueueItem: eventProcessor.currentClimbQueueItem,
     lastReceivedStateHash: eventProcessor.lastReceivedStateHash,
-    setQueueState: eventProcessor.setQueueState,
+    needsResync: eventProcessor.needsResync,
+    clearResyncFlag: eventProcessor.clearResyncFlag,
+    syncGate,
     refs,
   });
 

--- a/packages/web/app/components/persistent-session/types.ts
+++ b/packages/web/app/components/persistent-session/types.ts
@@ -280,9 +280,15 @@ export type SharedRefs = {
   isReconnectingRef: MutableRefObject<boolean>;
   connectionGenerationRef: MutableRefObject<number>;
   triggerResyncRef: MutableRefObject<(() => void) | null>;
+  /**
+   * Mirror of the sync gate's `getLastSequence()` — the gate (created in
+   * `persistent-session-context.tsx`) owns the value; the event processor
+   * writes it here after every applied event and the lifecycle nulls it on
+   * gate reset. Kept as a ref because `use-offline-reconciliation` (board
+   * route) reads it through the context at disconnect time without
+   * subscribing to re-renders.
+   */
   lastReceivedSequenceRef: MutableRefObject<number | null>;
-  lastCorruptionResyncRef: MutableRefObject<number>;
-  isFilteringCorruptedItemsRef: MutableRefObject<boolean>;
   queueUnsubscribeRef: MutableRefObject<(() => void) | null>;
   sessionUnsubscribeRef: MutableRefObject<(() => void) | null>;
   queueEventSubscribersRef: MutableRefObject<Set<(event: SubscriptionQueueEvent) => void>>;
@@ -295,7 +301,8 @@ export const DEFAULT_BACKEND_URL = getBackendWsUrl();
 // Key for persisting ActiveSessionInfo in user-preferences IndexedDB
 export const ACTIVE_SESSION_KEY = 'activeSession';
 
-// Cooldown for corruption-triggered resyncs to prevent infinite loops
-export const CORRUPTION_RESYNC_COOLDOWN_MS = 30000; // 30 seconds
+// The corruption-resync cooldown moved to @boardsesh/queue-runtime
+// (CORRUPTION_RESYNC_COOLDOWN_MS in sync-gate.ts) — the shared sync gate owns
+// that concern now.
 
 export const DEBUG = process.env.NODE_ENV === 'development';


### PR DESCRIPTION
**Stacked on #3339** (`feat/sessions-w2-sync-gate`) — merge that first; this PR targets its branch.

## Summary

Web maintained queue state twice: the board-route `graphql-queue/QueueContext` ran incoming events through the shared `queueReducer`, while the root `persistent-session` event processor hand-rolled its own add/remove/reorder/mirror switch against a `useState` queue, with its own sequence tracking, corruption filtering, and subtly different reorder semantics. This PR makes both copies run **identical logic** by driving the root copy through the same shared reducer, gated by the W2 `createQueueSyncGate`. Full state unification stays a later workstream — this PR only unifies the *logic*.

- **`use-event-processor.ts`**: `useState` + hand-rolled switch → `useReducer(queueReducer)` + `toWireEnvelope` + `mapSubscriptionEnvelopeToAction`, gated by one shared `QueueSyncGate`. The FullSync offline-buffer merge is preserved exactly (buffered items are pre-merged into the payload before dispatch so they don't blink out during reconciliation); external subscribers still receive the original unmerged event, which `useOfflineReconciliation` depends on. A synchronous reducer-state mirror keeps the reorder pre-validation correct inside batched delta-replay loops.
- **`toWireEnvelope`** moved from `graphql-queue/hooks/use-queue-event-subscription.ts` to `persistent-session/event-utils.ts`; the old module re-exports it for its remaining importers (a later workstream deletes that hook).
- **`use-session-lifecycle.ts`**: the inline reconnect gap/hash chain (~60 lines) → `gate.decideReconnectStrategy()`. The legacy truthy-`sessionId` guard on delta-replay stays at the call site, as the gate documents. The gate is **reset in the connection effect's cleanup** (session change / auth change / unmount) — transient socket drops don't run cleanup, so delta replay across a network blip still works.
- **`use-session-subscriptions.ts`**: the 60s hash watchdog now consumes `gate.verifyLocalHash()` verdicts (same interval, same one-shot Sentry capture at the 3-strike threshold, same backoff per #2359). Corruption detection is now the reducer's `INITIAL_QUEUE_DATA`/`UPDATE_QUEUE` null-filtering + `needsResync` flag, rate-limited by `gate.evaluateCorruption()`'s 30s cooldown; the old `setQueueState`-based local re-filtering is gone because reducer state can't contain nulls post-dispatch.
- **`SharedRefs`**: `lastCorruptionResyncRef` and `isFilteringCorruptedItemsRef` removed (the gate owns both concerns). `lastReceivedSequenceRef` is kept as a mirror of `gate.getLastSequence()` because `use-offline-reconciliation` reads it through the context at disconnect time.

**Gate ownership**: created once (lazily) in `PersistentSessionProvider`; the event processor advances it per applied event; the lifecycle consults it on reconnect and resets it on teardown; the subscriptions hook consumes its watchdog/corruption verdicts.

## Behavior changes

- **Reorder pre-validation (replaces index clamping).** The old root copy clamped out-of-range `QueueReordered` indices and moved whatever item it found. Order drift is invisible to the sorted-uuid state hash, so the 60s watchdog could never catch a bad clamp — it could diverge silently forever. Now, if the item at `oldIndex` isn't the item the server says it moved, the event is not applied and a resync is triggered instead.
- **ClimbMirrored alignment.** The shared reducer suppresses `ClimbMirrored` events with a null `mirroredUuid` or a uuid that doesn't match the local current climb (`DELTA_MIRROR_CURRENT_CLIMB`); the old root copy mirrored unconditionally. Reducer semantics win — they're what the board-route UI already uses.
- **CurrentClimbChanged alignment.** Via the shared mapper, a server `CurrentClimbChanged` now also idempotently inserts the item into the queue if missing (the board-route copy has always done this); the old root copy only set the current item.

## Tests

- Migrated `event-processor-offline.test.ts`, `event-processor-session-cache.test.ts`, `use-session-subscriptions.test.tsx` to the new wiring (gate instance instead of the dead imperative setters/refs). `session-events`, `persistent-session-restore`, `join-ended-session`, `session-lifecycle-replay` pass unchanged.
- New cases: stale event ignored at the root; sequence gap triggers resync without applying; reorder-mismatch triggers resync instead of applying; reorder validated against the freshest state inside a synchronous replay batch; FullSync+offline-buffer merge sets `needsResync` on corrupted payloads; corruption resync honours the gate cooldown and acknowledges the flag.

Validation (re-run after re-stacking on the rebased W2 base): `vp check --fix` (0 errors, warning count identical to base), `vp run typecheck`, `vp run test:web` (4857 tests green), targeted persistent-session + graphql-queue suites run twice (green both times), full-repo `vp test run`. Remaining full-repo failures are the known sandbox infra flakes (backend worker-DB init timeouts, board-presence concurrency) that also fail on the clean base.

**CI note:** checks don't trigger while this PR targets the `feat/sessions-w2-sync-gate` feature branch — a manually dispatched CI run on an earlier identical head was green everywhere except the known `mobile-bundle`/`ci-status` Expo-pin-drift failure (#3348). CI will run normally once this retargets `main` after #3339 merges.

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9eAY2yZDGSqossL5UtUQo

