### PR TITLE
refactor(backend): extract generic pubsub channel behind the domain API

### DIFF
--- a/packages/backend/src/__tests__/pubsub-channel.test.ts
+++ b/packages/backend/src/__tests__/pubsub-channel.test.ts
@@ -46,8 +46,8 @@ describe('PubSubChannel', () => {
       const unsubscribe2 = await channel.subscribe('key-a', () => {});
       expect(redisSubscribe).toHaveBeenCalledTimes(1);
 
-      await unsubscribe1();
-      await unsubscribe2();
+      unsubscribe1();
+      unsubscribe2();
     });
 
     it('calls redisSubscribe again for a different key (independent per-key state)', async () => {
@@ -88,6 +88,34 @@ describe('PubSubChannel', () => {
       await Promise.resolve();
       expect(redisUnsubscribe).toHaveBeenCalledTimes(1);
       expect(redisUnsubscribe).toHaveBeenCalledWith('key-a');
+    });
+
+    it('a double unsubscribe is a no-op and cannot strand the remaining subscriber', async () => {
+      // Pins Set-based (idempotent) removal: a future counter-based refactor
+      // that decremented twice on a repeated unsubscribe would tear down the
+      // Redis subscription while subscriber B is still listening.
+      const redisUnsubscribe = vi.fn().mockResolvedValue(undefined);
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe: () => Promise.resolve(),
+        redisUnsubscribe,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      const unsubscribeA = await channel.subscribe('key-a', () => {});
+      const unsubscribeB = await channel.subscribe('key-a', () => {});
+
+      unsubscribeA();
+      unsubscribeA();
+      await Promise.resolve();
+      expect(redisUnsubscribe).not.toHaveBeenCalled();
+      expect(channel.count('key-a')).toBe(1);
+
+      unsubscribeB();
+      await Promise.resolve();
+      expect(redisUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(channel.count('key-a')).toBe(0);
     });
 
     it('re-triggers redisSubscribe if all subscribers left and a new one joins', async () => {
@@ -198,7 +226,7 @@ describe('PubSubChannel', () => {
   });
 
   describe('publish() / dispatchLocal() — per-callback error isolation', () => {
-    it('isolates a throwing subscriber so other subscribers still receive the event', () => {
+    it('isolates a throwing subscriber so other subscribers still receive the event', async () => {
       const logger = makeLogger();
       const channel = new PubSubChannel<TestEvent>({
         label: 'test',
@@ -207,10 +235,10 @@ describe('PubSubChannel', () => {
       });
 
       const received: TestEvent[] = [];
-      channel.subscribe('key-a', () => {
+      await channel.subscribe('key-a', () => {
         throw new Error('boom');
       });
-      channel.subscribe('key-a', (event) => received.push(event));
+      await channel.subscribe('key-a', (event) => received.push(event));
 
       expect(() => channel.publish('key-a', { kind: 'ping', value: 1 })).not.toThrow();
       expect(received).toEqual([{ kind: 'ping', value: 1 }]);

--- a/packages/backend/src/__tests__/pubsub-channel.test.ts
+++ b/packages/backend/src/__tests__/pubsub-channel.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit coverage for `PubSubChannel` (pubsub/channel.ts) — the generic
+ * subscribe/publish/fan-in mechanics factored out of the six copy-pasted
+ * PubSub triplets (queue, session, notification, comment, new-climb,
+ * board-presence). These tests exercise the channel in isolation, with fake
+ * `redisSubscribe`/`redisUnsubscribe`/`redisPublish` deps injected directly —
+ * no real Redis needed. Domain-specific behavior (event buffering, APNs
+ * hooks, board-presence KV helpers) lives outside this class and is covered
+ * by the existing domain-level suites (event-replay-buffer.test.ts,
+ * board-presence.test.ts, redis-pubsub.test.ts).
+ */
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { PubSubChannel, type ChannelLogger } from '../pubsub/channel';
+
+// `winston`'s `Logger.error` is an overloaded `LeveledLogMethod`, which a plain
+// `vi.fn()` doesn't structurally satisfy — build the mock as its own shape and
+// cast to `ChannelLogger` at the injection site instead of fighting the overload.
+type MockLogger = { error: ReturnType<typeof vi.fn> };
+
+function makeLogger(): MockLogger {
+  return { error: vi.fn() };
+}
+
+function asChannelLogger(mockLogger: MockLogger): ChannelLogger {
+  return mockLogger as unknown as ChannelLogger;
+}
+
+type TestEvent = { kind: string; value: number };
+
+describe('PubSubChannel', () => {
+  describe('subscribe() — first-subscribe / last-unsubscribe Redis semantics', () => {
+    it('calls redisSubscribe only for the first subscriber on a key', async () => {
+      const redisSubscribe = vi.fn().mockResolvedValue(undefined);
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      const unsubscribe1 = await channel.subscribe('key-a', () => {});
+      expect(redisSubscribe).toHaveBeenCalledTimes(1);
+      expect(redisSubscribe).toHaveBeenCalledWith('key-a');
+
+      // Second subscriber on the same key must not trigger another Redis subscribe.
+      const unsubscribe2 = await channel.subscribe('key-a', () => {});
+      expect(redisSubscribe).toHaveBeenCalledTimes(1);
+
+      await unsubscribe1();
+      await unsubscribe2();
+    });
+
+    it('calls redisSubscribe again for a different key (independent per-key state)', async () => {
+      const redisSubscribe = vi.fn().mockResolvedValue(undefined);
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      await channel.subscribe('key-a', () => {});
+      await channel.subscribe('key-b', () => {});
+
+      expect(redisSubscribe).toHaveBeenCalledTimes(2);
+      expect(redisSubscribe).toHaveBeenCalledWith('key-a');
+      expect(redisSubscribe).toHaveBeenCalledWith('key-b');
+    });
+
+    it('calls redisUnsubscribe only when the last subscriber for a key leaves', async () => {
+      const redisUnsubscribe = vi.fn().mockResolvedValue(undefined);
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe: () => Promise.resolve(),
+        redisUnsubscribe,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      const unsubscribe1 = await channel.subscribe('key-a', () => {});
+      const unsubscribe2 = await channel.subscribe('key-a', () => {});
+
+      unsubscribe1();
+      expect(redisUnsubscribe).not.toHaveBeenCalled();
+
+      unsubscribe2();
+      // redisUnsubscribe is fire-and-forget; flush microtasks.
+      await Promise.resolve();
+      expect(redisUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(redisUnsubscribe).toHaveBeenCalledWith('key-a');
+    });
+
+    it('re-triggers redisSubscribe if all subscribers left and a new one joins', async () => {
+      const redisSubscribe = vi.fn().mockResolvedValue(undefined);
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe,
+        redisUnsubscribe: () => Promise.resolve(),
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      const unsubscribe = await channel.subscribe('key-a', () => {});
+      unsubscribe();
+      await channel.subscribe('key-a', () => {});
+
+      expect(redisSubscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not blow up when redisSubscribe/redisUnsubscribe are omitted (pure local channel)', async () => {
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      const unsubscribe = await channel.subscribe('key-a', () => {});
+      expect(channel.count('key-a')).toBe(1);
+      unsubscribe();
+      expect(channel.count('key-a')).toBe(0);
+    });
+  });
+
+  describe('subscribe() — redisRequired throw semantics', () => {
+    it('throws and rolls back the subscriber when redisSubscribe fails and Redis is required', async () => {
+      const redisSubscribe = vi.fn().mockRejectedValue(new Error('redis down'));
+      const logger = makeLogger();
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe,
+        isRedisRequired: () => true,
+        logger: asChannelLogger(logger),
+      });
+
+      await expect(channel.subscribe('key-a', () => {})).rejects.toThrow('redis down');
+      // The failed subscriber must be rolled back, not left registered.
+      expect(channel.count('key-a')).toBe(0);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('[PubSub] Failed to subscribe'));
+    });
+
+    it('swallows the error (does not throw) when redisSubscribe fails and Redis is not required', async () => {
+      const redisSubscribe = vi.fn().mockRejectedValue(new Error('redis down'));
+      const logger = makeLogger();
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisSubscribe,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(logger),
+      });
+
+      // The subscriber is still rolled back on a failed Redis subscribe — the
+      // `isRedisRequired` flag only controls whether the error is rethrown,
+      // not whether the local-only fallback keeps the registration.
+      await expect(channel.subscribe('key-a', () => {})).resolves.toBeInstanceOf(Function);
+      expect(channel.count('key-a')).toBe(0);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('publish() — local-first ordering', () => {
+    it('dispatches to local subscribers before calling redisPublish', async () => {
+      const callOrder: string[] = [];
+      const redisPublish = vi.fn().mockImplementation(() => {
+        callOrder.push('redis');
+        return Promise.resolve();
+      });
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisPublish,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      await channel.subscribe('key-a', () => {
+        callOrder.push('local');
+      });
+
+      channel.publish('key-a', { kind: 'ping', value: 1 });
+
+      expect(callOrder[0]).toBe('local');
+      expect(redisPublish).toHaveBeenCalledWith('key-a', { kind: 'ping', value: 1 });
+    });
+
+    it('logs but does not throw when redisPublish rejects', async () => {
+      const logger = makeLogger();
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisPublish: () => Promise.reject(new Error('publish failed')),
+        isRedisRequired: () => true,
+        logger: asChannelLogger(logger),
+      });
+
+      expect(() => channel.publish('key-a', { kind: 'ping', value: 1 })).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(logger.error).toHaveBeenCalledWith('[PubSub] Redis test publish failed:', expect.any(Error));
+    });
+  });
+
+  describe('publish() / dispatchLocal() — per-callback error isolation', () => {
+    it('isolates a throwing subscriber so other subscribers still receive the event', () => {
+      const logger = makeLogger();
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        isRedisRequired: () => false,
+        logger: asChannelLogger(logger),
+      });
+
+      const received: TestEvent[] = [];
+      channel.subscribe('key-a', () => {
+        throw new Error('boom');
+      });
+      channel.subscribe('key-a', (event) => received.push(event));
+
+      expect(() => channel.publish('key-a', { kind: 'ping', value: 1 })).not.toThrow();
+      expect(received).toEqual([{ kind: 'ping', value: 1 }]);
+      expect(logger.error).toHaveBeenCalledWith('Error in test subscriber:', expect.any(Error));
+    });
+  });
+
+  describe('dispatchLocal() — Redis fan-in path does not re-publish', () => {
+    it('dispatches to local subscribers without calling redisPublish', async () => {
+      const redisPublish = vi.fn().mockResolvedValue(undefined);
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        redisPublish,
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      const received: TestEvent[] = [];
+      await channel.subscribe('key-a', (event) => received.push(event));
+
+      channel.dispatchLocal('key-a', { kind: 'fanned-in', value: 2 });
+
+      expect(received).toEqual([{ kind: 'fanned-in', value: 2 }]);
+      expect(redisPublish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('count()', () => {
+    it('returns 0 for an unknown key and the live subscriber count for a known key', async () => {
+      const channel = new PubSubChannel<TestEvent>({
+        label: 'test',
+        isRedisRequired: () => false,
+        logger: asChannelLogger(makeLogger()),
+      });
+
+      expect(channel.count('unknown')).toBe(0);
+
+      const unsubscribe1 = await channel.subscribe('key-a', () => {});
+      await channel.subscribe('key-a', () => {});
+      expect(channel.count('key-a')).toBe(2);
+
+      unsubscribe1();
+      expect(channel.count('key-a')).toBe(1);
+    });
+  });
+});

--- a/packages/backend/src/pubsub/board-presence-store.ts
+++ b/packages/backend/src/pubsub/board-presence-store.ts
@@ -1,0 +1,676 @@
+import type { Logger } from 'winston';
+import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
+import { redisClientManager } from '../redis/client';
+
+/** Result of the Stage-A report gate read (one pipeline, see `getBoardReportGate`). */
+export type BoardReportGate = {
+  /** Whether `emitterId` currently has a live proof-of-presence stamp on the board. */
+  isMember: boolean;
+  /** First-seen epoch-ms for the durable-history dwell gate, or null when unknown/implausible. */
+  firstSeenMs: number | null;
+  /** Value of `board:{id}:lastReport` ("emitterId|climbUuid|angle"), or null when never set / expired. */
+  lastReport: string | null;
+  /**
+   * The board's current connection holder (`board:{id}:writer`), or null when
+   * free / unknown. The dedup short-circuit must only fire while the retrying
+   * emitter still holds the wall — a WS-close backstop clear between the
+   * original send and the retry deletes the writer key but leaves lastReport,
+   * and short-circuiting then would strand the wall looking free while the
+   * emitter holds it (no re-take, no re-broadcast).
+   */
+  currentWriter: string | null;
+};
+
+export type CommitBoardClimbInput = {
+  boardId: string;
+  emitterId: string;
+  climb: BoardPresenceClimb;
+  climbUuid: string;
+  effectiveAngle: number;
+  /** The reporting connection's party-session id, when it's in one. */
+  sessionId: string | null;
+};
+
+export type CommitBoardClimbResult = {
+  /** The writer key's previous value (from the atomic SET..GET), or null when
+   * the board was free / the commit failed. */
+  previousWriter: string | null;
+  /**
+   * True only when the writer SET..GET slot actually executed without error —
+   * i.e. `previousWriter` is a real observation, not a failure collapsed to
+   * null. The caller must gate the hand-off broadcast on this: a failing
+   * pipeline otherwise looks like "board was free" (`null !== emitterId`) and
+   * would spuriously broadcast a hand-off + kick a Live Activity push on
+   * every send while Redis is unhealthy.
+   */
+  writerSlotOk: boolean;
+};
+
+// Board-presence durable history (Redis FIFO) configuration. The live
+// "now on the wall" feed is ephemeral; this buffer backfills late joiners
+// before the `boardNowPlaying` subscription takes over.
+const BOARD_HISTORY_SIZE = 50; // Keep the last 50 climbs per board
+const BOARD_HISTORY_TTL = 604_800; // 1 week
+// The per-board seq counter's TTL matches BOARD_HISTORY_TTL so the common
+// case (an active board) never sees the counter expire while the Redis
+// history buffer is still populated. But `board_climb_events` rows are
+// durable forever, so a board dormant for *longer* than a week still has a
+// live durable floor after this key expires — INCR would otherwise restart
+// at 1 and collide with / precede rows that still exist in Postgres. That
+// residual gap is closed by the dormancy reseed in `nextBoardSeq` (see
+// `boardSeqFloorProvider` / `allocateBoardSeqAtLeast` below), not by this TTL
+// alone.
+const BOARD_SEQ_TTL = 604_800; // 1 week
+// Once INCR returns a value at or below this, nextBoardSeq consults the
+// durable floor provider — a small INCR result is the signature of a
+// freshly-(re)created Redis key, which happens both for a genuinely new board
+// and for a dormant board whose key just expired.
+const BOARD_SEQ_RESEED_THRESHOLD = 50;
+// Proof-of-presence window: how long after connecting (resolveBoardForSerial /
+// resolveBoardForConfig) a user may report climbs to that board's feed. Long
+// enough for a climbing session; a reconnect re-stamps it.
+const BOARD_MEMBERSHIP_TTL = 43_200; // 12 hours
+// Write-side idempotency window for reportBoardClimb: a retry of the exact
+// same (emitter, climb, angle) within this window is treated as a no-op
+// duplicate rather than a new send (see `getBoardReportGate` / A2 dedup).
+const REPORT_DEDUP_WINDOW_MS = 10_000;
+// Epoch-ms floor a first-seen stamp must clear to be trusted. Guards against
+// legacy sentinel values (e.g. an old '1') that would otherwise trivially
+// satisfy the durable-history dwell gate.
+const PLAUSIBLE_EPOCH_MS_FLOOR = 1_600_000_000_000;
+
+function parsePlausibleFirstSeenMs(raw: string | null): number | null {
+  if (raw === null) return null;
+  const firstSeen = Number(raw);
+  if (!Number.isFinite(firstSeen) || firstSeen < PLAUSIBLE_EPOCH_MS_FLOOR) return null;
+  return firstSeen;
+}
+
+/**
+ * Minimal logger surface the store needs (`commitBoardClimb` downgrades
+ * per-command pipeline failures to warnings).
+ */
+export type BoardPresenceStoreLogger = Pick<Logger, 'error' | 'warn'>;
+
+export type BoardPresenceStoreDeps = {
+  /**
+   * Whether Redis is currently connected and available (mirrors
+   * `PubSub.isRedisConnected()`, which already folds in "adapter exists").
+   */
+  isRedisAvailable: () => boolean;
+  /** Whether Redis is required (REDIS_URL configured) — gates fail-closed rethrow. */
+  isRedisRequired: () => boolean;
+  logger: BoardPresenceStoreLogger;
+};
+
+/**
+ * Board-presence Redis KV helpers, extracted out of `PubSub` so the pub/sub
+ * fan-out class (`PubSubChannel`-backed) doesn't also carry these
+ * board-connection bookkeeping concerns. `PubSub` still re-exposes every
+ * method unchanged — this is a pure code-location move, not an API change.
+ *
+ * Every method here degrades gracefully without Redis: local-only mode either
+ * falls back to an in-memory map (seq counter, proof-of-presence) or simply
+ * returns "unknown"/empty (durable history, writer holder, session→board),
+ * matching the single-instance-only guarantees these features already had.
+ */
+export class BoardPresenceStore {
+  // Local-only fallback for the per-board monotonic seq counter. In Redis
+  // mode the authoritative counter is `board:${boardId}:seq` (INCR); this map
+  // only ever serves single-instance deployments that have no Redis.
+  private localBoardSeq = new Map<string, number>();
+  // Per-board watermark for the seq dormancy reseed (see
+  // `ensureBoardSeqClearOfDurableFloor`): the highest seq this instance has
+  // verified clear of the durable floor or allocated through the reseed
+  // check. Lets a brand-new board skip the repeated MAX(seq) Postgres lookup
+  // on each of its first ~BOARD_SEQ_RESEED_THRESHOLD sends. One number per
+  // board that allocates during the process lifetime (bounded like
+  // `localBoardSeq`); never TTL'd — see the safety analysis on the method.
+  private boardSeqVerifiedThrough = new Map<string, number>();
+  // Sticky "the floor consultation FAILED and hasn't succeeded since" marker.
+  // While a board is in here, every nextBoardSeq call retries the floor
+  // consultation — regardless of the INCR value and bypassing the watermark
+  // skip — so a transient Postgres/Lua failure during the reseed window can't
+  // let the counter grow past BOARD_SEQ_RESEED_THRESHOLD while still below
+  // the durable floor (which would permanently freeze clients holding
+  // pre-reset high seqs). Cleared only by a successful verification/reseed.
+  // Same lifecycle/bounds as the watermark map.
+  private boardSeqReseedPending = new Set<string>();
+  // Local-only proof-of-presence: `${boardId}:${userId}` → expiry epoch ms.
+  private localBoardMembership = new Map<string, number>();
+  private localBoardMembershipCleanupTimer: ReturnType<typeof setTimeout> | null = null;
+  private localBoardMembershipCleanupExpiry: number | null = null;
+  // Durable seq floor lookup for the `nextBoardSeq` dormancy reseed (A3).
+  // Injected via `setBoardSeqFloorProvider` at bootstrap so pubsub itself
+  // stays DB-free (and trivially unit-testable without Postgres). Defaults to
+  // "no durable floor" — a board with no floor provider wired never reseeds,
+  // matching pre-A3 behavior.
+  private boardSeqFloorProvider: (boardId: number) => Promise<number> = async () => 0;
+
+  constructor(private readonly deps: BoardPresenceStoreDeps) {}
+
+  /**
+   * Inject the durable seq-floor lookup used by `nextBoardSeq`'s dormancy
+   * reseed (A3). Wired once at backend bootstrap (`server.ts`) to a Drizzle
+   * query over `board_climb_events`; defaults to `async () => 0` so pubsub
+   * unit tests never need a database.
+   */
+  setBoardSeqFloorProvider(provider: (boardId: number) => Promise<number>): void {
+    this.boardSeqFloorProvider = provider;
+  }
+
+  /**
+   * Atomically allocate the next monotonic sequence number for a board.
+   * Redis `INCR` + `EXPIRE` (pipelined — 1 RTT), cluster-safe across
+   * instances; falls back to an in-memory counter in local-only mode.
+   *
+   * The key expires after a week of inactivity. For a genuinely fresh board
+   * that's harmless (INCR restarts at 1 and the empty history buffer expired
+   * along with it). For a board dormant *longer* than the TTL whose durable
+   * `board_climb_events` rows outlive the key, restarting at 1 would collide
+   * with / precede still-existing rows — so whenever INCR comes back small
+   * (<= BOARD_SEQ_RESEED_THRESHOLD, the signature of a fresh key either way),
+   * `ensureBoardSeqClearOfDurableFloor` checks the durable floor and, if the
+   * floor is at or above the INCR result, reseeds atomically past it. The
+   * check memoizes per board so a brand-new board's early sends don't repeat
+   * the Postgres lookup ~50 times (see that method's safety analysis). A
+   * FAILED consultation marks the board reseed-pending, which keeps the
+   * consultation retrying on every subsequent allocation even after the
+   * counter crosses the threshold — otherwise a transient Postgres blip in
+   * the reseed window would leave the counter permanently below the durable
+   * floor.
+   */
+  async nextBoardSeq(boardId: string): Promise<number> {
+    if (this.deps.isRedisAvailable()) {
+      try {
+        const { publisher } = redisClientManager.getClients();
+        const key = `board:${boardId}:seq`;
+        const results = await publisher.pipeline().incr(key).expire(key, BOARD_SEQ_TTL).exec();
+        if (!results) {
+          throw new Error('nextBoardSeq pipeline returned null');
+        }
+        const [incrError, incrResult] = results[0];
+        if (incrError) throw incrError;
+        const next = incrResult as number;
+
+        if (next <= BOARD_SEQ_RESEED_THRESHOLD || this.boardSeqReseedPending.has(boardId)) {
+          return await this.ensureBoardSeqClearOfDurableFloor(boardId, next);
+        }
+
+        return next;
+      } catch (error) {
+        if (this.deps.isRedisRequired()) {
+          this.deps.logger.error('[PubSub] Failed to allocate board seq from required Redis:', error);
+          throw error;
+        }
+        this.deps.logger.error('[PubSub] Failed to allocate board seq from Redis, falling back to local:', error);
+      }
+    }
+
+    const next = (this.localBoardSeq.get(boardId) ?? 0) + 1;
+    this.localBoardSeq.set(boardId, next);
+    return next;
+  }
+
+  /**
+   * Ensures a small (or reseed-pending) INCR result is clear of the durable
+   * `board_climb_events` floor, reseeding atomically via
+   * `allocateBoardSeqAtLeast` when it isn't. Returns the seq to use. Never
+   * throws: a floor-lookup or reseed failure falls back to the INCR result —
+   * but marks the board reseed-pending, so every subsequent allocation
+   * retries the consultation (bypassing the watermark skip) until one
+   * succeeds. Without the sticky flag, a transient Postgres blip covering
+   * the whole <= BOARD_SEQ_RESEED_THRESHOLD window would let the counter
+   * cross the threshold still below the durable floor and never consult
+   * Postgres again — clients holding pre-reset high seqs would then treat
+   * every subsequent event as stale and the live wall would freeze until the
+   * next counter loss.
+   *
+   * Memoization: without it, every send of a brand-new board's first
+   * ~BOARD_SEQ_RESEED_THRESHOLD would run the MAX(seq) Postgres lookup. The
+   * memo is a per-board watermark = the highest seq this instance has either
+   * verified clear of the floor or allocated through this check; the lookup
+   * is skipped only when the fresh INCR result is strictly ahead of it
+   * (normal early-life counter growth, provably not a reset this instance
+   * could collide on). Deliberately NOT the raw floor value: a floor-only
+   * memo (e.g. 0 for a new board) would keep skipping after a mid-process
+   * counter loss (FLUSHALL / failover to an empty replica) once durable rows
+   * exist — INCR restarts at 1, `1 > 0` skips, collision. With the
+   * watermark, any allocation pushes it to >= 1, so the first post-reset
+   * INCR (= 1) can never be ahead of it and always re-consults the floor.
+   *
+   * Accepted residual (documented, not defended): in multi-instance, an
+   * instance holding a small stale watermark can race another instance's
+   * first post-reset reseed and skip the check for a seq the durable floor
+   * already covers. The colliding durable insert lands on the (boardId, seq)
+   * unique index's `onConflictDoNothing` — one dropped duplicate row, no
+   * corruption, and exactly the failure mode every post-dormancy send had
+   * before the reseed existed. That needs a mid-process Redis counter loss
+   * (not mere dormancy — any send or stats publish re-arms the TTL) plus
+   * concurrent sends in the reseed window, so we take the simple memo.
+   */
+  private async ensureBoardSeqClearOfDurableFloor(boardId: string, incrResult: number): Promise<number> {
+    const reseedPending = this.boardSeqReseedPending.has(boardId);
+    const verifiedThrough = this.boardSeqVerifiedThrough.get(boardId);
+    // The watermark skip is only trustworthy when no consultation has failed
+    // since the last success — while reseed-pending, the floor may be far
+    // above anything this instance ever verified, so always re-consult.
+    if (!reseedPending && verifiedThrough !== undefined && incrResult > verifiedThrough) {
+      this.boardSeqVerifiedThrough.set(boardId, incrResult);
+      return incrResult;
+    }
+
+    let floor: number;
+    try {
+      floor = await this.boardSeqFloorProvider(Number(boardId));
+    } catch (error) {
+      this.boardSeqReseedPending.add(boardId);
+      this.deps.logger.error('[PubSub] board seq floor provider failed, using INCR result (reseed pending):', error);
+      return incrResult;
+    }
+
+    if (floor < incrResult) {
+      this.boardSeqReseedPending.delete(boardId);
+      this.boardSeqVerifiedThrough.set(boardId, Math.max(incrResult, verifiedThrough ?? 0));
+      return incrResult;
+    }
+
+    try {
+      const reseeded = await this.allocateBoardSeqAtLeast(boardId, floor);
+      if (reseeded === null) {
+        // Redis went away between the INCR and the reseed — keep retrying.
+        this.boardSeqReseedPending.add(boardId);
+        return incrResult;
+      }
+      this.boardSeqReseedPending.delete(boardId);
+      this.boardSeqVerifiedThrough.set(boardId, Math.max(reseeded, verifiedThrough ?? 0));
+      return reseeded;
+    } catch (error) {
+      this.boardSeqReseedPending.add(boardId);
+      this.deps.logger.error('[PubSub] board seq Lua reseed failed, using INCR result (reseed pending):', error);
+      return incrResult;
+    }
+  }
+
+  /**
+   * Atomically allocate a board seq value guaranteed to exceed both the
+   * current Redis counter and `floor` (`max(currentValue, floor) + 1`),
+   * re-arming the TTL. A single Lua script keeps the read-compare-write
+   * atomic under concurrent callers — two racing reseeds still get distinct,
+   * monotonic results because Redis serializes the script execution.
+   * Redis-only: returns null when Redis is unavailable (callers fall back to
+   * the plain INCR result and mark the reseed pending). May still reject on
+   * a command failure against a connected Redis — the internal reseed path
+   * catches that. Public for direct unit testing.
+   */
+  async allocateBoardSeqAtLeast(boardId: string, floor: number): Promise<number | null> {
+    if (!this.deps.isRedisAvailable()) return null;
+    const { publisher } = redisClientManager.getClients();
+    const key = `board:${boardId}:seq`;
+    const result = await publisher.eval(
+      "local cur = tonumber(redis.call('get', KEYS[1]) or '0'); " +
+        'local nxt = math.max(cur, tonumber(ARGV[1])) + 1; ' +
+        "redis.call('set', KEYS[1], nxt); " +
+        "redis.call('expire', KEYS[1], ARGV[2]); " +
+        'return nxt',
+      1,
+      key,
+      floor,
+      BOARD_SEQ_TTL,
+    );
+    return Number(result);
+  }
+
+  /**
+   * Read a board's recent climbs, newest-first by seq (cap 50). Empty without
+   * Redis.
+   */
+  async getRecentBoardClimbs(boardId: string): Promise<BoardPresenceClimb[]> {
+    if (!this.deps.isRedisAvailable()) {
+      return [];
+    }
+
+    try {
+      const { publisher } = redisClientManager.getClients();
+      const key = `board:${boardId}:history`;
+      const entries = await publisher.lrange(key, 0, -1);
+
+      const climbs: BoardPresenceClimb[] = [];
+      for (const json of entries) {
+        try {
+          climbs.push(JSON.parse(json) as BoardPresenceClimb);
+        } catch (parseError) {
+          this.deps.logger.error('[PubSub] Failed to parse board history entry:', parseError);
+        }
+      }
+
+      // The list is already newest-first (lpush), but sort by seq DESC so a
+      // late, out-of-order write can't surface above a newer climb.
+      climbs.sort((a, b) => b.seq - a.seq);
+      return climbs.slice(0, BOARD_HISTORY_SIZE);
+    } catch (error) {
+      this.deps.logger.error('[PubSub] Failed to read board history:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Record that a user is connected to a board (proof-of-presence), stamped on
+   * resolveBoardForSerial / resolveBoardForConfig. `reportBoardClimb` requires
+   * this so a logged-in user can't inject onto a board they never connected to.
+   * TTL'd; a reconnect re-stamps. Best-effort without Redis (local map).
+   */
+  async stampBoardMembership(boardId: string, userId: string): Promise<void> {
+    const key = `presence:board:${boardId}:user:${userId}`;
+    if (this.deps.isRedisAvailable()) {
+      try {
+        const { publisher } = redisClientManager.getClients();
+        // Store the first-seen epoch-ms (NX preserves it across reconnects) so
+        // the durable-history dwell gate can tell how long this member has been
+        // on the board. A separate EXPIRE keeps the key alive while they're
+        // active without resetting first-seen. EXISTS still answers presence.
+        await publisher.set(key, String(Date.now()), 'EX', BOARD_MEMBERSHIP_TTL, 'NX');
+        await publisher.expire(key, BOARD_MEMBERSHIP_TTL);
+        return;
+      } catch (error) {
+        if (this.deps.isRedisRequired()) {
+          this.deps.logger.error('[PubSub] Failed to stamp board membership in required Redis:', error);
+          throw error;
+        }
+        this.deps.logger.error('[PubSub] Failed to stamp board membership, falling back to local:', error);
+      }
+    }
+    this.setLocalBoardMembership(`${boardId}:${userId}`, Date.now() + BOARD_MEMBERSHIP_TTL * 1000);
+  }
+
+  /** True if the user has a live proof-of-presence stamp for the board. */
+  async hasBoardMembership(boardId: string, userId: string): Promise<boolean> {
+    const key = `presence:board:${boardId}:user:${userId}`;
+    if (this.deps.isRedisAvailable()) {
+      try {
+        const { publisher } = redisClientManager.getClients();
+        return (await publisher.exists(key)) === 1;
+      } catch (error) {
+        if (this.deps.isRedisRequired()) {
+          this.deps.logger.error('[PubSub] Failed to check board membership in required Redis:', error);
+          throw error;
+        }
+        this.deps.logger.error('[PubSub] Failed to check board membership, falling back to local:', error);
+      }
+    }
+    return this.checkLocalBoardMembership(boardId, userId);
+  }
+
+  private checkLocalBoardMembership(boardId: string, userId: string): boolean {
+    const localKey = `${boardId}:${userId}`;
+    const expiry = this.localBoardMembership.get(localKey);
+    if (expiry === undefined) return false;
+    if (expiry <= Date.now()) {
+      this.localBoardMembership.delete(localKey);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * One Redis pipeline (1 RTT) that answers everything `reportBoardClimb`'s
+   * Stage A needs before validating the incoming climb: proof-of-presence
+   * (+ first-seen, for the durable-history dwell gate), the last-report dedup
+   * marker (for write-side idempotency, A2), and the current writer (so the
+   * dedup short-circuit can require the retrying emitter to still hold the
+   * wall — see `BoardReportGate.currentWriter`). Replaces what used to be
+   * separate `hasBoardMembership` + first-seen + `lastReport` reads — 3 RTTs
+   * collapsed into 1, with the writer read riding the same pipeline for free.
+   *
+   * Preserves `hasBoardMembership`'s fail-closed `redisRequired` semantics
+   * (throws when Redis is required but the pipeline fails) and the
+   * plausible-epoch guard on `firstSeenMs` (a legacy/implausible stamp still
+   * counts as a member but never satisfies the dwell gate). Local-only
+   * fallback mirrors today: membership from the in-memory map,
+   * `firstSeenMs`/`lastReport`/`currentWriter` unknown (null) — durable
+   * history and write-side dedup both degrade to off without Redis, same as
+   * before.
+   */
+  async getBoardReportGate(boardId: string, emitterId: string): Promise<BoardReportGate> {
+    const membershipKey = `presence:board:${boardId}:user:${emitterId}`;
+    const lastReportKey = `board:${boardId}:lastReport`;
+    const writerKey = `board:${boardId}:writer`;
+
+    if (this.deps.isRedisAvailable()) {
+      try {
+        const { publisher } = redisClientManager.getClients();
+        const results = await publisher.pipeline().get(membershipKey).get(lastReportKey).get(writerKey).exec();
+        if (!results) {
+          throw new Error('getBoardReportGate pipeline returned null');
+        }
+        const [[membershipError, membershipRaw], [lastReportError, lastReportRaw], [writerError, writerRaw]] = results;
+        if (membershipError) throw membershipError;
+        if (lastReportError) throw lastReportError;
+        if (writerError) throw writerError;
+        const raw = membershipRaw as string | null;
+        return {
+          isMember: raw !== null,
+          firstSeenMs: parsePlausibleFirstSeenMs(raw),
+          lastReport: (lastReportRaw as string | null) ?? null,
+          currentWriter: (writerRaw as string | null) ?? null,
+        };
+      } catch (error) {
+        if (this.deps.isRedisRequired()) {
+          this.deps.logger.error('[PubSub] Failed to read board report gate from required Redis:', error);
+          throw error;
+        }
+        this.deps.logger.error('[PubSub] Failed to read board report gate, falling back to local:', error);
+      }
+    }
+
+    return {
+      isMember: this.checkLocalBoardMembership(boardId, emitterId),
+      firstSeenMs: null,
+      lastReport: null,
+      currentWriter: null,
+    };
+  }
+
+  /**
+   * One Redis pipeline (1 RTT) that commits an accepted `reportBoardClimb`
+   * send: appends to the durable FIFO history (LPUSH/LTRIM/EXPIRE), takes the
+   * connection-holder slot (atomic `SET writer EX GET` — a single command, so
+   * two concurrent reports still can't both observe the same previous
+   * holder), stamps the write-side dedup marker (A2's `lastReport`), and —
+   * when this connection is in a party session — remembers the session→board
+   * mapping (`session:{id}:board`). Replaces what used to be 3 separate
+   * round trips.
+   *
+   * Non-fatal: the whole pipeline (or an individual command within it) can
+   * fail without failing the accepted report — failures are logged and
+   * swallowed. But a swallowed failure means `previousWriter: null` is a
+   * fabrication, not an observation, so the result also carries
+   * `writerSlotOk`: false whenever the writer slot didn't verifiably execute
+   * (Redis off, pipeline threw, or the SET..GET slot itself errored). The
+   * resolver gates the hand-off broadcast on it — without that gate, a
+   * failing pipeline would look like "board was free" on every send and
+   * spuriously re-broadcast the hand-off each time (the pre-pipeline code
+   * never had this failure mode: a writer-update failure was either swallowed
+   * with no broadcast, or thrown in redisRequired mode).
+   */
+  async commitBoardClimb(input: CommitBoardClimbInput): Promise<CommitBoardClimbResult> {
+    if (!this.deps.isRedisAvailable()) {
+      return { previousWriter: null, writerSlotOk: false };
+    }
+
+    try {
+      const { publisher } = redisClientManager.getClients();
+      const historyKey = `board:${input.boardId}:history`;
+      const writerKey = `board:${input.boardId}:writer`;
+      const lastReportKey = `board:${input.boardId}:lastReport`;
+      const lastReportValue = `${input.emitterId}|${input.climbUuid}|${input.effectiveAngle}`;
+
+      const pipeline = publisher.pipeline();
+      const commandLabels: string[] = [];
+      pipeline.lpush(historyKey, JSON.stringify(input.climb));
+      commandLabels.push('history-lpush');
+      pipeline.ltrim(historyKey, 0, BOARD_HISTORY_SIZE - 1);
+      commandLabels.push('history-ltrim');
+      pipeline.expire(historyKey, BOARD_HISTORY_TTL);
+      commandLabels.push('history-expire');
+      const writerCommandIndex = commandLabels.length;
+      pipeline.set(writerKey, input.emitterId, 'EX', BOARD_MEMBERSHIP_TTL, 'GET');
+      commandLabels.push('writer-set');
+      pipeline.set(lastReportKey, lastReportValue, 'PX', REPORT_DEDUP_WINDOW_MS);
+      commandLabels.push('last-report-set');
+      if (input.sessionId) {
+        pipeline.set(`session:${input.sessionId}:board`, input.boardId, 'EX', BOARD_MEMBERSHIP_TTL);
+        commandLabels.push('session-board-set');
+      }
+
+      const results = await pipeline.exec();
+      if (!results) {
+        throw new Error('commitBoardClimb pipeline returned null');
+      }
+
+      results.forEach(([error], index) => {
+        if (error) {
+          this.deps.logger.warn(`[PubSub] commitBoardClimb ${commandLabels[index]} command failed: ${String(error)}`);
+        }
+      });
+
+      const [writerError, writerValue] = results[writerCommandIndex];
+      if (writerError) return { previousWriter: null, writerSlotOk: false };
+      return { previousWriter: (writerValue as string | null) ?? null, writerSlotOk: true };
+    } catch (error) {
+      this.deps.logger.error('[PubSub] commitBoardClimb pipeline failed:', error);
+      return { previousWriter: null, writerSlotOk: false };
+    }
+  }
+
+  /**
+   * Clear the board's holder only if `emitterId` still holds it (atomic
+   * compare-and-delete), so a holder who was already booted can't wipe the new
+   * one. Returns whether it was actually cleared.
+   */
+  async clearBoardWriterIf(boardId: string, emitterId: string): Promise<boolean> {
+    if (!this.deps.isRedisAvailable()) return false;
+    try {
+      const { publisher } = redisClientManager.getClients();
+      const cleared = await publisher.eval(
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+        1,
+        `board:${boardId}:writer`,
+        emitterId,
+      );
+      return cleared === 1;
+    } catch (error) {
+      if (this.deps.isRedisRequired()) throw error;
+      this.deps.logger.error('[PubSub] Failed to clear board writer:', error);
+      return false;
+    }
+  }
+
+  /** The board's current connection holder emitter id, or null when free. */
+  async getBoardWriter(boardId: string): Promise<string | null> {
+    if (!this.deps.isRedisAvailable()) return null;
+    try {
+      const { publisher } = redisClientManager.getClients();
+      return await publisher.get(`board:${boardId}:writer`);
+    } catch (error) {
+      if (this.deps.isRedisRequired()) throw error;
+      this.deps.logger.error('[PubSub] Failed to get board writer:', error);
+      return null;
+    }
+  }
+
+  /**
+   * The shared board_id this party session is on, or null when unknown.
+   *
+   * The mapping (`session:{id}:board`) is written by `commitBoardClimb` as a
+   * side-effect of `reportBoardClimb` — the only moment a session is provably
+   * tied to a board. The APNs Live Activity path reads it to resolve the
+   * board's current holder for a given session (`QueueState` and the
+   * push-token rows carry sessionId but not boardId). Redis-only and TTL'd to
+   * the same window as proof-of-presence so an idle session's mapping doesn't
+   * leak; a fresh send re-stamps it. Without Redis the holder lookup degrades
+   * to "unknown" and the APNs path omits boardConnection (device falls back
+   * to its own App-Group state).
+   */
+  async getSessionBoard(sessionId: string): Promise<string | null> {
+    if (!this.deps.isRedisAvailable()) return null;
+    try {
+      const { publisher } = redisClientManager.getClients();
+      return await publisher.get(`session:${sessionId}:board`);
+    } catch (error) {
+      if (this.deps.isRedisRequired()) throw error;
+      this.deps.logger.error('[PubSub] Failed to get session board:', error);
+      return null;
+    }
+  }
+
+  private setLocalBoardMembership(localKey: string, expiry: number): void {
+    this.localBoardMembership.set(localKey, expiry);
+    if (this.localBoardMembershipCleanupExpiry !== null && expiry >= this.localBoardMembershipCleanupExpiry) {
+      return;
+    }
+    this.scheduleLocalBoardMembershipCleanup();
+  }
+
+  /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
+  resetLocalBoardMembershipForTest(): void {
+    this.clearLocalBoardMembershipCleanupTimer();
+    this.localBoardMembership.clear();
+  }
+
+  /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
+  setLocalBoardMembershipForTest(localKey: string, expiry: number): void {
+    this.setLocalBoardMembership(localKey, expiry);
+  }
+
+  /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
+  hasLocalBoardMembershipForTest(localKey: string): boolean {
+    return this.localBoardMembership.has(localKey);
+  }
+
+  private scheduleLocalBoardMembershipCleanup(): void {
+    this.clearLocalBoardMembershipCleanupTimer();
+
+    if (this.localBoardMembership.size === 0) {
+      return;
+    }
+
+    // Local-only mode is single-process and expected to stay small; keep the
+    // scheduler simple unless proof-of-presence cardinality becomes material.
+    let nextExpiry: number | null = null;
+    for (const expiry of this.localBoardMembership.values()) {
+      nextExpiry = nextExpiry === null ? expiry : Math.min(nextExpiry, expiry);
+    }
+    if (nextExpiry === null) return;
+
+    this.localBoardMembershipCleanupExpiry = nextExpiry;
+    const cleanupDelay = Math.max(0, nextExpiry - Date.now());
+    const cleanupTimer = setTimeout(() => {
+      this.localBoardMembershipCleanupTimer = null;
+      this.localBoardMembershipCleanupExpiry = null;
+      this.evictExpiredLocalBoardMemberships();
+      this.scheduleLocalBoardMembershipCleanup();
+    }, cleanupDelay);
+    this.localBoardMembershipCleanupTimer = cleanupTimer;
+    if (typeof cleanupTimer === 'object') {
+      cleanupTimer.unref?.();
+    }
+  }
+
+  private clearLocalBoardMembershipCleanupTimer(): void {
+    if (this.localBoardMembershipCleanupTimer === null) {
+      return;
+    }
+    clearTimeout(this.localBoardMembershipCleanupTimer);
+    this.localBoardMembershipCleanupTimer = null;
+    this.localBoardMembershipCleanupExpiry = null;
+  }
+
+  private evictExpiredLocalBoardMemberships(now = Date.now()): void {
+    for (const [localKey, expiry] of this.localBoardMembership) {
+      if (expiry <= now) {
+        this.localBoardMembership.delete(localKey);
+      }
+    }
+  }
+}

--- a/packages/backend/src/pubsub/channel.ts
+++ b/packages/backend/src/pubsub/channel.ts
@@ -1,0 +1,146 @@
+import type { Logger } from 'winston';
+
+/** Callback registered against a channel key (session id, user id, board id, ...). */
+export type ChannelSubscriber<TEvent> = (event: TEvent) => void;
+
+/** Minimal logger surface the channel needs — avoids depending on the full winston `Logger`. */
+export type ChannelLogger = Pick<Logger, 'error'>;
+
+export type PubSubChannelDeps<TEvent> = {
+  /**
+   * Human-readable domain name used in log messages, e.g. "queue", "session",
+   * "new climb", "board presence". Must match the historical per-domain
+   * wording exactly (see the six triplets this replaces) so log output/tests
+   * that assert on log text stay unaffected.
+   */
+  label: string;
+  /**
+   * Called when the first local subscriber for a key registers. Omit (or have
+   * it resolve without side effects) for a channel that never needs Redis
+   * fan-out.
+   */
+  redisSubscribe?: (key: string) => Promise<void>;
+  /** Called when the last local subscriber for a key unregisters. */
+  redisUnsubscribe?: (key: string) => Promise<void>;
+  /**
+   * Called on every `publish()`, fire-and-forget. Errors are caught and
+   * logged by the channel — they are never thrown back to the publisher.
+   */
+  redisPublish?: (key: string, event: TEvent) => Promise<void>;
+  /**
+   * Whether Redis is required (REDIS_URL was configured at startup). When
+   * true, a failed first-subscribe Redis call is rethrown (fail-closed)
+   * instead of silently falling back to local-only dispatch.
+   */
+  isRedisRequired: () => boolean;
+  logger: ChannelLogger;
+};
+
+/**
+ * Generic per-key pub/sub channel shared by every PubSub domain (queue,
+ * session, notification, comment, new-climb, board-presence).
+ *
+ * Domain-specific behaviour (event buffering, APNs hooks, board-presence
+ * Redis KV helpers, etc.) is layered outside this class, in `PubSub`'s
+ * domain methods — this class only owns the generic subscribe/publish/fan-in
+ * mechanics that used to be copy-pasted six times.
+ */
+export class PubSubChannel<TEvent> {
+  private readonly subscribers = new Map<string, Set<ChannelSubscriber<TEvent>>>();
+
+  constructor(private readonly deps: PubSubChannelDeps<TEvent>) {}
+
+  /**
+   * Subscribe to events for `key`. The first subscriber for a key triggers
+   * the injected `redisSubscribe`; the returned unsubscribe function removes
+   * the callback and, when it was the last subscriber for that key, calls
+   * `redisUnsubscribe`.
+   *
+   * @throws If `isRedisRequired()` is true and the Redis subscribe call fails
+   *   (fail-closed behavior, preserved from the pre-extraction implementation).
+   */
+  async subscribe(key: string, callback: ChannelSubscriber<TEvent>): Promise<() => void> {
+    const isFirstSubscriber = !this.subscribers.has(key);
+
+    if (!this.subscribers.has(key)) {
+      this.subscribers.set(key, new Set());
+    }
+    this.subscribers.get(key)!.add(callback);
+
+    // Subscribe to Redis if this is the first local subscriber for the key.
+    // IMPORTANT: We must await this to ensure Redis subscription is active
+    // before returning, otherwise events from other instances could be missed.
+    if (isFirstSubscriber && this.deps.redisSubscribe) {
+      try {
+        await this.deps.redisSubscribe(key);
+      } catch (error) {
+        this.deps.logger.error(`[PubSub] Failed to subscribe to Redis ${this.deps.label} channel: ${String(error)}`);
+        // Remove the subscriber since Redis subscription failed
+        this.subscribers.get(key)?.delete(callback);
+        if (this.subscribers.get(key)?.size === 0) {
+          this.subscribers.delete(key);
+        }
+        if (this.deps.isRedisRequired()) {
+          throw error;
+        }
+      }
+    }
+
+    return () => {
+      this.subscribers.get(key)?.delete(callback);
+
+      // Clean up empty sets and unsubscribe from Redis
+      if (this.subscribers.get(key)?.size === 0) {
+        this.subscribers.delete(key);
+
+        if (this.deps.redisUnsubscribe) {
+          this.deps.redisUnsubscribe(key).catch((error) => {
+            this.deps.logger.error(
+              `[PubSub] Failed to unsubscribe from Redis ${this.deps.label} channel: ${String(error)}`,
+            );
+          });
+        }
+      }
+    };
+  }
+
+  /**
+   * Publish an event for `key`. Dispatches to local subscribers first
+   * (synchronous, per-callback error isolation), then fire-and-forget
+   * publishes to Redis for other instances. Redis publish errors are logged,
+   * never thrown — local dispatch already succeeded.
+   */
+  publish(key: string, event: TEvent): void {
+    this.dispatchLocal(key, event);
+
+    if (this.deps.redisPublish) {
+      this.deps.redisPublish(key, event).catch((error) => {
+        this.deps.logger.error(`[PubSub] Redis ${this.deps.label} publish failed:`, error);
+      });
+    }
+  }
+
+  /**
+   * Dispatch an event to local subscribers only, without re-publishing to
+   * Redis. Used by the Redis fan-in path: a message arriving from another
+   * instance must reach this instance's local subscribers but must not be
+   * echoed back out to Redis.
+   */
+  dispatchLocal(key: string, event: TEvent): void {
+    const subscribers = this.subscribers.get(key);
+    if (subscribers) {
+      for (const callback of subscribers) {
+        try {
+          callback(event);
+        } catch (error) {
+          this.deps.logger.error(`Error in ${this.deps.label} subscriber:`, error);
+        }
+      }
+    }
+  }
+
+  /** Count of local subscribers currently registered for `key`. */
+  count(key: string): number {
+    return this.subscribers.get(key)?.size ?? 0;
+  }
+}

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -61,11 +61,13 @@ const EVENT_BUFFER_TTL = 300; // 5 minutes
  * top in this class, documented at their call sites below.
  */
 class PubSub {
+  // No `redisPublish` here: queue publishes don't go through `channel.publish()`.
+  // `publishQueueEvent` issues the Redis publish explicitly so the replay-buffer
+  // LPUSH can be ordered before the fan-out PUBLISH on the wire (see its docstring).
   private readonly queueChannel = new PubSubChannel<QueueEvent>({
     label: 'queue',
     redisSubscribe: (sessionId) => this.redisAdapter?.subscribeQueueChannel(sessionId) ?? Promise.resolve(),
     redisUnsubscribe: (sessionId) => this.redisAdapter?.unsubscribeQueueChannel(sessionId) ?? Promise.resolve(),
-    redisPublish: (sessionId, event) => this.redisAdapter?.publishQueueEvent(sessionId, event) ?? Promise.resolve(),
     isRedisRequired: () => this.redisRequired,
     logger,
   });
@@ -327,10 +329,10 @@ class PubSub {
 
   /**
    * Publish a queue event to all subscribers of a session.
-   * Dispatches locally first, then publishes to Redis for other instances
-   * (both via `queueChannel.publish`). Also stores the event in the delta-sync
-   * buffer and fires the APNs hook — these two are queue-only quirks layered
-   * on top of the generic channel, not part of `PubSubChannel` itself.
+   * Dispatches locally first, then stores the event in the delta-sync buffer,
+   * then publishes to Redis for other instances, then fires the APNs hook —
+   * the buffer and hook are queue-only quirks layered on top of the generic
+   * channel, not part of `PubSubChannel` itself.
    *
    * `PlaybackStateChanged` events are excluded from buffering: they reuse the
    * room's current sequence number (rather than incrementing it) and can fire
@@ -338,17 +340,38 @@ class PubSub {
    * the 100-entry buffer within seconds and hand replaying clients
    * non-monotonic/duplicate sequences. See `publishPlaybackState` in
    * `graphql/resolvers/queue/mutations.ts`.
+   *
+   * Note: Redis publish errors are logged but not thrown to avoid blocking
+   * the local dispatch. In Redis mode, events may not reach other instances
+   * if Redis publish fails.
    */
   publishQueueEvent(sessionId: string, event: QueueEvent): void {
-    // Local dispatch (low latency) + Redis publish for other instances.
-    this.queueChannel.publish(sessionId, event);
+    // Always dispatch to local subscribers first (low latency). Deliberately
+    // NOT `queueChannel.publish()`: the queue domain must interleave the
+    // replay-buffer write between local dispatch and the Redis publish (see
+    // ordering contract below), so the Redis publish is issued explicitly.
+    this.queueChannel.dispatchLocal(sessionId, event);
 
     // Store event in buffer for delta sync (Phase 2), except playback events
     // (see docstring above). Fire and forget - don't block on buffer storage.
+    // Ordering contract: the buffer LPUSH must be written (hit the wire)
+    // before the fan-out PUBLISH below, so a remote instance can never
+    // dispatch an event that a reconnecting client's `getEventsSince` replay
+    // can't yet see. Both commands go through the same Redis connection, so
+    // call order here fixes wire order.
     if (event.__typename !== 'PlaybackStateChanged') {
       this.storeEventInBuffer(sessionId, event).catch((error) => {
         logger.error(`[PubSub] Failed to buffer event for session ${sessionId}:`, error);
         // Non-fatal: clients will fall back to full sync if delta sync fails
+      });
+    }
+
+    // Also publish to Redis if available
+    if (this.redisAdapter) {
+      this.redisAdapter.publishQueueEvent(sessionId, event).catch((error) => {
+        logger.error('[PubSub] Redis queue publish failed:', error);
+        // Log but don't throw - local dispatch already succeeded
+        // Health check will report Redis as unhealthy if connection is lost
       });
     }
 

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -9,14 +9,15 @@ import type {
 } from '@boardsesh/shared-schema';
 import { redisClientManager } from '../redis/client';
 import { createRedisPubSubAdapter, type RedisPubSubAdapter } from './redis-adapter';
+import { PubSubChannel, type ChannelSubscriber } from './channel';
 import { logger } from '../utils/logger';
 
-type QueueSubscriber = (event: QueueEvent) => void;
-type SessionSubscriber = (event: SessionEvent) => void;
-type NotificationSubscriber = (event: NotificationEvent) => void;
-type CommentSubscriber = (event: CommentEvent) => void;
-type NewClimbSubscriber = (event: NewClimbCreatedEvent) => void;
-type BoardPresenceSubscriber = (event: BoardPresenceEvent) => void;
+type QueueSubscriber = ChannelSubscriber<QueueEvent>;
+type SessionSubscriber = ChannelSubscriber<SessionEvent>;
+type NotificationSubscriber = ChannelSubscriber<NotificationEvent>;
+type CommentSubscriber = ChannelSubscriber<CommentEvent>;
+type NewClimbSubscriber = ChannelSubscriber<NewClimbCreatedEvent>;
+type BoardPresenceSubscriber = ChannelSubscriber<BoardPresenceEvent>;
 
 /** Result of the Stage-A report gate read (one pipeline, see `getBoardReportGate`). */
 export type BoardReportGate = {
@@ -120,14 +121,68 @@ const EVENT_BUFFER_TTL = 300; // 5 minutes
  * In local-only mode (single instance, no Redis):
  * - Events are only dispatched to local subscribers
  * - Used when REDIS_URL is not configured
+ *
+ * The six domains below (queue, session, notification, comment, new-climb,
+ * board-presence) all share the exact same subscribe/publish/fan-in mechanics
+ * — that generic behavior lives in `PubSubChannel` (./channel.ts). Each
+ * `redisSubscribe`/`redisUnsubscribe`/`redisPublish` closure below resolves to
+ * a no-op when `redisAdapter` is null (local-only mode or not-yet-initialized),
+ * which is intentional: it reproduces the old `if (this.redisAdapter) { ... }`
+ * guards without the channel needing to know about `redisAdapter` at all.
+ * Domain-specific quirks (queue's replay buffer + APNs hook; board-presence's
+ * Redis KV helpers) are NOT part of the generic channel — they're layered on
+ * top in this class, documented at their call sites below.
  */
 class PubSub {
-  private queueSubscribers = new Map<string, Set<QueueSubscriber>>();
-  private sessionSubscribers = new Map<string, Set<SessionSubscriber>>();
-  private notificationSubscribers = new Map<string, Set<NotificationSubscriber>>();
-  private commentSubscribers = new Map<string, Set<CommentSubscriber>>();
-  private newClimbSubscribers = new Map<string, Set<NewClimbSubscriber>>();
-  private boardPresenceSubscribers = new Map<string, Set<BoardPresenceSubscriber>>();
+  private readonly queueChannel = new PubSubChannel<QueueEvent>({
+    label: 'queue',
+    redisSubscribe: (sessionId) => this.redisAdapter?.subscribeQueueChannel(sessionId) ?? Promise.resolve(),
+    redisUnsubscribe: (sessionId) => this.redisAdapter?.unsubscribeQueueChannel(sessionId) ?? Promise.resolve(),
+    redisPublish: (sessionId, event) => this.redisAdapter?.publishQueueEvent(sessionId, event) ?? Promise.resolve(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
+  private readonly sessionChannel = new PubSubChannel<SessionEvent>({
+    label: 'session',
+    redisSubscribe: (sessionId) => this.redisAdapter?.subscribeSessionChannel(sessionId) ?? Promise.resolve(),
+    redisUnsubscribe: (sessionId) => this.redisAdapter?.unsubscribeSessionChannel(sessionId) ?? Promise.resolve(),
+    redisPublish: (sessionId, event) => this.redisAdapter?.publishSessionEvent(sessionId, event) ?? Promise.resolve(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
+  private readonly notificationChannel = new PubSubChannel<NotificationEvent>({
+    label: 'notification',
+    redisSubscribe: (userId) => this.redisAdapter?.subscribeNotificationChannel(userId) ?? Promise.resolve(),
+    redisUnsubscribe: (userId) => this.redisAdapter?.unsubscribeNotificationChannel(userId) ?? Promise.resolve(),
+    redisPublish: (userId, event) => this.redisAdapter?.publishNotificationEvent(userId, event) ?? Promise.resolve(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
+  private readonly commentChannel = new PubSubChannel<CommentEvent>({
+    label: 'comment',
+    redisSubscribe: (entityKey) => this.redisAdapter?.subscribeCommentChannel(entityKey) ?? Promise.resolve(),
+    redisUnsubscribe: (entityKey) => this.redisAdapter?.unsubscribeCommentChannel(entityKey) ?? Promise.resolve(),
+    redisPublish: (entityKey, event) => this.redisAdapter?.publishCommentEvent(entityKey, event) ?? Promise.resolve(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
+  private readonly newClimbChannel = new PubSubChannel<NewClimbCreatedEvent>({
+    label: 'new climb',
+    redisSubscribe: (channelKey) => this.redisAdapter?.subscribeNewClimbChannel(channelKey) ?? Promise.resolve(),
+    redisUnsubscribe: (channelKey) => this.redisAdapter?.unsubscribeNewClimbChannel(channelKey) ?? Promise.resolve(),
+    redisPublish: (channelKey, event) =>
+      this.redisAdapter?.publishNewClimbEvent(channelKey, event) ?? Promise.resolve(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
+  private readonly boardPresenceChannel = new PubSubChannel<BoardPresenceEvent>({
+    label: 'board presence',
+    redisSubscribe: (boardId) => this.redisAdapter?.subscribeBoardPresenceChannel(boardId) ?? Promise.resolve(),
+    redisUnsubscribe: (boardId) => this.redisAdapter?.unsubscribeBoardPresenceChannel(boardId) ?? Promise.resolve(),
+    redisPublish: (boardId, event) => this.redisAdapter?.publishBoardPresenceEvent(boardId, event) ?? Promise.resolve(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
   // Local-only fallback for the per-board monotonic seq counter. In Redis
   // mode the authoritative counter is `board:${boardId}:seq` (INCR); this map
   // only ever serves single-instance deployments that have no Redis.
@@ -227,10 +282,10 @@ class PubSub {
    *
    * **Publisher-side semantics (important for multi-instance deployments):**
    * The hook fires only on the instance that calls `publishQueueEvent`. It is
-   * NOT invoked by `dispatchToLocalQueueSubscribers` when a Redis fan-out
-   * message arrives from another instance — that path bypasses the hook
-   * intentionally so a single event published in a 3-instance cluster does
-   * not trigger 3 redundant APNs sends.
+   * NOT invoked by the Redis fan-in path (`queueChannel.dispatchLocal`) when a
+   * Redis fan-out message arrives from another instance — that path bypasses
+   * the hook intentionally so a single event published in a 3-instance cluster
+   * does not trigger 3 redundant APNs sends.
    *
    * Implication: every backend instance that receives queue mutations must
    * have APNs env vars configured, otherwise queue events that originate on
@@ -256,27 +311,27 @@ class PubSub {
     if (!this.redisAdapter) return;
 
     this.redisAdapter.onQueueMessage((sessionId, event) => {
-      this.dispatchToLocalQueueSubscribers(sessionId, event);
+      this.queueChannel.dispatchLocal(sessionId, event);
     });
 
     this.redisAdapter.onSessionMessage((sessionId, event) => {
-      this.dispatchToLocalSessionSubscribers(sessionId, event);
+      this.sessionChannel.dispatchLocal(sessionId, event);
     });
 
     this.redisAdapter.onNotificationMessage((userId, event) => {
-      this.dispatchToLocalNotificationSubscribers(userId, event);
+      this.notificationChannel.dispatchLocal(userId, event);
     });
 
     this.redisAdapter.onCommentMessage((entityKey, event) => {
-      this.dispatchToLocalCommentSubscribers(entityKey, event);
+      this.commentChannel.dispatchLocal(entityKey, event);
     });
 
     this.redisAdapter.onNewClimbMessage((channelKey, event) => {
-      this.dispatchToLocalNewClimbSubscribers(channelKey, event);
+      this.newClimbChannel.dispatchLocal(channelKey, event);
     });
 
     this.redisAdapter.onBoardPresenceMessage((boardId, event) => {
-      this.dispatchToLocalBoardPresenceSubscribers(boardId, event);
+      this.boardPresenceChannel.dispatchLocal(boardId, event);
     });
   }
 
@@ -287,47 +342,7 @@ class PubSub {
    */
   async subscribeQueue(sessionId: string, callback: QueueSubscriber): Promise<() => void> {
     this.ensureRedisIfRequired();
-
-    const isFirstSubscriber = !this.queueSubscribers.has(sessionId);
-
-    if (!this.queueSubscribers.has(sessionId)) {
-      this.queueSubscribers.set(sessionId, new Set());
-    }
-    this.queueSubscribers.get(sessionId)!.add(callback);
-
-    // Subscribe to Redis channel if this is first local subscriber for session
-    // IMPORTANT: We must await this to ensure Redis subscription is active
-    // before returning, otherwise events from other instances could be missed
-    if (isFirstSubscriber && this.redisAdapter) {
-      try {
-        await this.redisAdapter.subscribeQueueChannel(sessionId);
-      } catch (error) {
-        logger.error(`[PubSub] Failed to subscribe to Redis queue channel: ${String(error)}`);
-        // Remove the subscriber since Redis subscription failed
-        this.queueSubscribers.get(sessionId)?.delete(callback);
-        if (this.queueSubscribers.get(sessionId)?.size === 0) {
-          this.queueSubscribers.delete(sessionId);
-        }
-        if (this.redisRequired) {
-          throw error;
-        }
-      }
-    }
-
-    return () => {
-      this.queueSubscribers.get(sessionId)?.delete(callback);
-
-      // Clean up empty sets and unsubscribe from Redis
-      if (this.queueSubscribers.get(sessionId)?.size === 0) {
-        this.queueSubscribers.delete(sessionId);
-
-        if (this.redisAdapter) {
-          this.redisAdapter.unsubscribeQueueChannel(sessionId).catch((error) => {
-            logger.error(`[PubSub] Failed to unsubscribe from Redis queue channel: ${String(error)}`);
-          });
-        }
-      }
-    };
+    return this.queueChannel.subscribe(sessionId, callback);
   }
 
   /**
@@ -337,47 +352,7 @@ class PubSub {
    */
   async subscribeSession(sessionId: string, callback: SessionSubscriber): Promise<() => void> {
     this.ensureRedisIfRequired();
-
-    const isFirstSubscriber = !this.sessionSubscribers.has(sessionId);
-
-    if (!this.sessionSubscribers.has(sessionId)) {
-      this.sessionSubscribers.set(sessionId, new Set());
-    }
-    this.sessionSubscribers.get(sessionId)!.add(callback);
-
-    // Subscribe to Redis channel if this is first local subscriber for session
-    // IMPORTANT: We must await this to ensure Redis subscription is active
-    // before returning, otherwise events from other instances could be missed
-    if (isFirstSubscriber && this.redisAdapter) {
-      try {
-        await this.redisAdapter.subscribeSessionChannel(sessionId);
-      } catch (error) {
-        logger.error(`[PubSub] Failed to subscribe to Redis session channel: ${String(error)}`);
-        // Remove the subscriber since Redis subscription failed
-        this.sessionSubscribers.get(sessionId)?.delete(callback);
-        if (this.sessionSubscribers.get(sessionId)?.size === 0) {
-          this.sessionSubscribers.delete(sessionId);
-        }
-        if (this.redisRequired) {
-          throw error;
-        }
-      }
-    }
-
-    return () => {
-      this.sessionSubscribers.get(sessionId)?.delete(callback);
-
-      // Clean up empty sets and unsubscribe from Redis
-      if (this.sessionSubscribers.get(sessionId)?.size === 0) {
-        this.sessionSubscribers.delete(sessionId);
-
-        if (this.redisAdapter) {
-          this.redisAdapter.unsubscribeSessionChannel(sessionId).catch((error) => {
-            logger.error(`[PubSub] Failed to unsubscribe from Redis session channel: ${String(error)}`);
-          });
-        }
-      }
-    };
+    return this.sessionChannel.subscribe(sessionId, callback);
   }
 
   /**
@@ -458,8 +433,10 @@ class PubSub {
 
   /**
    * Publish a queue event to all subscribers of a session.
-   * Dispatches locally first, then publishes to Redis for other instances.
-   * Also stores event in buffer for delta sync (Phase 2).
+   * Dispatches locally first, then publishes to Redis for other instances
+   * (both via `queueChannel.publish`). Also stores the event in the delta-sync
+   * buffer and fires the APNs hook — these two are queue-only quirks layered
+   * on top of the generic channel, not part of `PubSubChannel` itself.
    *
    * `PlaybackStateChanged` events are excluded from buffering: they reuse the
    * room's current sequence number (rather than incrementing it) and can fire
@@ -467,14 +444,10 @@ class PubSub {
    * the 100-entry buffer within seconds and hand replaying clients
    * non-monotonic/duplicate sequences. See `publishPlaybackState` in
    * `graphql/resolvers/queue/mutations.ts`.
-   *
-   * Note: Redis publish errors are logged but not thrown to avoid blocking
-   * the local dispatch. In Redis mode, events may not reach other instances
-   * if Redis publish fails.
    */
   publishQueueEvent(sessionId: string, event: QueueEvent): void {
-    // Always dispatch to local subscribers first (low latency)
-    this.dispatchToLocalQueueSubscribers(sessionId, event);
+    // Local dispatch (low latency) + Redis publish for other instances.
+    this.queueChannel.publish(sessionId, event);
 
     // Store event in buffer for delta sync (Phase 2), except playback events
     // (see docstring above). Fire and forget - don't block on buffer storage.
@@ -482,15 +455,6 @@ class PubSub {
       this.storeEventInBuffer(sessionId, event).catch((error) => {
         logger.error(`[PubSub] Failed to buffer event for session ${sessionId}:`, error);
         // Non-fatal: clients will fall back to full sync if delta sync fails
-      });
-    }
-
-    // Also publish to Redis if available
-    if (this.redisAdapter) {
-      this.redisAdapter.publishQueueEvent(sessionId, event).catch((error) => {
-        logger.error('[PubSub] Redis queue publish failed:', error);
-        // Log but don't throw - local dispatch already succeeded
-        // Health check will report Redis as unhealthy if connection is lost
       });
     }
 
@@ -507,49 +471,9 @@ class PubSub {
   /**
    * Publish a session event to all subscribers.
    * Dispatches locally first, then publishes to Redis for other instances.
-   *
-   * Note: Redis publish errors are logged but not thrown to avoid blocking
-   * the local dispatch. In Redis mode, events may not reach other instances
-   * if Redis publish fails.
    */
   publishSessionEvent(sessionId: string, event: SessionEvent): void {
-    // Always dispatch to local subscribers first (low latency)
-    this.dispatchToLocalSessionSubscribers(sessionId, event);
-
-    // Also publish to Redis if available
-    if (this.redisAdapter) {
-      this.redisAdapter.publishSessionEvent(sessionId, event).catch((error) => {
-        logger.error('[PubSub] Redis session publish failed:', error);
-        // Log but don't throw - local dispatch already succeeded
-        // Health check will report Redis as unhealthy if connection is lost
-      });
-    }
-  }
-
-  private dispatchToLocalQueueSubscribers(sessionId: string, event: QueueEvent): void {
-    const subscribers = this.queueSubscribers.get(sessionId);
-    if (subscribers) {
-      for (const callback of subscribers) {
-        try {
-          callback(event);
-        } catch (error) {
-          logger.error('Error in queue subscriber:', error);
-        }
-      }
-    }
-  }
-
-  private dispatchToLocalSessionSubscribers(sessionId: string, event: SessionEvent): void {
-    const subscribers = this.sessionSubscribers.get(sessionId);
-    if (subscribers) {
-      for (const callback of subscribers) {
-        try {
-          callback(event);
-        } catch (error) {
-          logger.error('Error in session subscriber:', error);
-        }
-      }
-    }
+    this.sessionChannel.publish(sessionId, event);
   }
 
   /**
@@ -558,40 +482,7 @@ class PubSub {
    */
   async subscribeNotifications(userId: string, callback: NotificationSubscriber): Promise<() => void> {
     this.ensureRedisIfRequired();
-
-    const isFirstSubscriber = !this.notificationSubscribers.has(userId);
-
-    if (!this.notificationSubscribers.has(userId)) {
-      this.notificationSubscribers.set(userId, new Set());
-    }
-    this.notificationSubscribers.get(userId)!.add(callback);
-
-    if (isFirstSubscriber && this.redisAdapter) {
-      try {
-        await this.redisAdapter.subscribeNotificationChannel(userId);
-      } catch (error) {
-        logger.error(`[PubSub] Failed to subscribe to Redis notification channel: ${String(error)}`);
-        this.notificationSubscribers.get(userId)?.delete(callback);
-        if (this.notificationSubscribers.get(userId)?.size === 0) {
-          this.notificationSubscribers.delete(userId);
-        }
-        if (this.redisRequired) {
-          throw error;
-        }
-      }
-    }
-
-    return () => {
-      this.notificationSubscribers.get(userId)?.delete(callback);
-      if (this.notificationSubscribers.get(userId)?.size === 0) {
-        this.notificationSubscribers.delete(userId);
-        if (this.redisAdapter) {
-          this.redisAdapter.unsubscribeNotificationChannel(userId).catch((error) => {
-            logger.error(`[PubSub] Failed to unsubscribe from Redis notification channel: ${String(error)}`);
-          });
-        }
-      }
-    };
+    return this.notificationChannel.subscribe(userId, callback);
   }
 
   /**
@@ -599,26 +490,7 @@ class PubSub {
    * Dispatches locally first, then publishes to Redis for other instances.
    */
   publishNotificationEvent(userId: string, event: NotificationEvent): void {
-    this.dispatchToLocalNotificationSubscribers(userId, event);
-
-    if (this.redisAdapter) {
-      this.redisAdapter.publishNotificationEvent(userId, event).catch((error) => {
-        logger.error('[PubSub] Redis notification publish failed:', error);
-      });
-    }
-  }
-
-  private dispatchToLocalNotificationSubscribers(userId: string, event: NotificationEvent): void {
-    const subscribers = this.notificationSubscribers.get(userId);
-    if (subscribers) {
-      for (const callback of subscribers) {
-        try {
-          callback(event);
-        } catch (error) {
-          logger.error('Error in notification subscriber:', error);
-        }
-      }
-    }
+    this.notificationChannel.publish(userId, event);
   }
 
   /**
@@ -628,40 +500,7 @@ class PubSub {
    */
   async subscribeComments(entityKey: string, callback: CommentSubscriber): Promise<() => void> {
     this.ensureRedisIfRequired();
-
-    const isFirstSubscriber = !this.commentSubscribers.has(entityKey);
-
-    if (!this.commentSubscribers.has(entityKey)) {
-      this.commentSubscribers.set(entityKey, new Set());
-    }
-    this.commentSubscribers.get(entityKey)!.add(callback);
-
-    if (isFirstSubscriber && this.redisAdapter) {
-      try {
-        await this.redisAdapter.subscribeCommentChannel(entityKey);
-      } catch (error) {
-        logger.error(`[PubSub] Failed to subscribe to Redis comment channel: ${String(error)}`);
-        this.commentSubscribers.get(entityKey)?.delete(callback);
-        if (this.commentSubscribers.get(entityKey)?.size === 0) {
-          this.commentSubscribers.delete(entityKey);
-        }
-        if (this.redisRequired) {
-          throw error;
-        }
-      }
-    }
-
-    return () => {
-      this.commentSubscribers.get(entityKey)?.delete(callback);
-      if (this.commentSubscribers.get(entityKey)?.size === 0) {
-        this.commentSubscribers.delete(entityKey);
-        if (this.redisAdapter) {
-          this.redisAdapter.unsubscribeCommentChannel(entityKey).catch((error) => {
-            logger.error(`[PubSub] Failed to unsubscribe from Redis comment channel: ${String(error)}`);
-          });
-        }
-      }
-    };
+    return this.commentChannel.subscribe(entityKey, callback);
   }
 
   /**
@@ -669,26 +508,7 @@ class PubSub {
    * Dispatches locally first, then publishes to Redis for other instances.
    */
   publishCommentEvent(entityKey: string, event: CommentEvent): void {
-    this.dispatchToLocalCommentSubscribers(entityKey, event);
-
-    if (this.redisAdapter) {
-      this.redisAdapter.publishCommentEvent(entityKey, event).catch((error) => {
-        logger.error('[PubSub] Redis comment publish failed:', error);
-      });
-    }
-  }
-
-  private dispatchToLocalCommentSubscribers(entityKey: string, event: CommentEvent): void {
-    const subscribers = this.commentSubscribers.get(entityKey);
-    if (subscribers) {
-      for (const callback of subscribers) {
-        try {
-          callback(event);
-        } catch (error) {
-          logger.error('Error in comment subscriber:', error);
-        }
-      }
-    }
+    this.commentChannel.publish(entityKey, event);
   }
 
   /**
@@ -697,66 +517,14 @@ class PubSub {
    */
   async subscribeNewClimbs(channelKey: string, callback: NewClimbSubscriber): Promise<() => void> {
     this.ensureRedisIfRequired();
-
-    const isFirstSubscriber = !this.newClimbSubscribers.has(channelKey);
-
-    if (!this.newClimbSubscribers.has(channelKey)) {
-      this.newClimbSubscribers.set(channelKey, new Set());
-    }
-    this.newClimbSubscribers.get(channelKey)!.add(callback);
-
-    if (isFirstSubscriber && this.redisAdapter) {
-      try {
-        await this.redisAdapter.subscribeNewClimbChannel(channelKey);
-      } catch (error) {
-        logger.error(`[PubSub] Failed to subscribe to Redis new climb channel: ${String(error)}`);
-        this.newClimbSubscribers.get(channelKey)?.delete(callback);
-        if (this.newClimbSubscribers.get(channelKey)?.size === 0) {
-          this.newClimbSubscribers.delete(channelKey);
-        }
-        if (this.redisRequired) {
-          throw error;
-        }
-      }
-    }
-
-    return () => {
-      this.newClimbSubscribers.get(channelKey)?.delete(callback);
-      if (this.newClimbSubscribers.get(channelKey)?.size === 0) {
-        this.newClimbSubscribers.delete(channelKey);
-        if (this.redisAdapter) {
-          this.redisAdapter.unsubscribeNewClimbChannel(channelKey).catch((error) => {
-            logger.error(`[PubSub] Failed to unsubscribe from Redis new climb channel: ${String(error)}`);
-          });
-        }
-      }
-    };
+    return this.newClimbChannel.subscribe(channelKey, callback);
   }
 
   /**
    * Publish a new climb event to subscribers.
    */
   publishNewClimbEvent(channelKey: string, event: NewClimbCreatedEvent): void {
-    this.dispatchToLocalNewClimbSubscribers(channelKey, event);
-
-    if (this.redisAdapter) {
-      this.redisAdapter.publishNewClimbEvent(channelKey, event).catch((error) => {
-        logger.error('[PubSub] Redis new climb publish failed:', error);
-      });
-    }
-  }
-
-  private dispatchToLocalNewClimbSubscribers(channelKey: string, event: NewClimbCreatedEvent): void {
-    const subscribers = this.newClimbSubscribers.get(channelKey);
-    if (subscribers) {
-      for (const callback of subscribers) {
-        try {
-          callback(event);
-        } catch (error) {
-          logger.error('Error in new climb subscriber:', error);
-        }
-      }
-    }
+    this.newClimbChannel.publish(channelKey, event);
   }
 
   // ============================================
@@ -775,40 +543,7 @@ class PubSub {
    */
   async subscribeBoardPresence(boardId: string, callback: BoardPresenceSubscriber): Promise<() => void> {
     this.ensureRedisIfRequired();
-
-    const isFirstSubscriber = !this.boardPresenceSubscribers.has(boardId);
-
-    if (!this.boardPresenceSubscribers.has(boardId)) {
-      this.boardPresenceSubscribers.set(boardId, new Set());
-    }
-    this.boardPresenceSubscribers.get(boardId)!.add(callback);
-
-    if (isFirstSubscriber && this.redisAdapter) {
-      try {
-        await this.redisAdapter.subscribeBoardPresenceChannel(boardId);
-      } catch (error) {
-        logger.error(`[PubSub] Failed to subscribe to Redis board presence channel: ${String(error)}`);
-        this.boardPresenceSubscribers.get(boardId)?.delete(callback);
-        if (this.boardPresenceSubscribers.get(boardId)?.size === 0) {
-          this.boardPresenceSubscribers.delete(boardId);
-        }
-        if (this.redisRequired) {
-          throw error;
-        }
-      }
-    }
-
-    return () => {
-      this.boardPresenceSubscribers.get(boardId)?.delete(callback);
-      if (this.boardPresenceSubscribers.get(boardId)?.size === 0) {
-        this.boardPresenceSubscribers.delete(boardId);
-        if (this.redisAdapter) {
-          this.redisAdapter.unsubscribeBoardPresenceChannel(boardId).catch((error) => {
-            logger.error(`[PubSub] Failed to unsubscribe from Redis board presence channel: ${String(error)}`);
-          });
-        }
-      }
-    };
+    return this.boardPresenceChannel.subscribe(boardId, callback);
   }
 
   /**
@@ -816,26 +551,7 @@ class PubSub {
    * Dispatches locally first, then publishes to Redis for other instances.
    */
   publishBoardPresenceEvent(boardId: string, event: BoardPresenceEvent): void {
-    this.dispatchToLocalBoardPresenceSubscribers(boardId, event);
-
-    if (this.redisAdapter) {
-      this.redisAdapter.publishBoardPresenceEvent(boardId, event).catch((error) => {
-        logger.error('[PubSub] Redis board presence publish failed:', error);
-      });
-    }
-  }
-
-  private dispatchToLocalBoardPresenceSubscribers(boardId: string, event: BoardPresenceEvent): void {
-    const subscribers = this.boardPresenceSubscribers.get(boardId);
-    if (subscribers) {
-      for (const callback of subscribers) {
-        try {
-          callback(event);
-        } catch (error) {
-          logger.error('Error in board presence subscriber:', error);
-        }
-      }
-    }
+    this.boardPresenceChannel.publish(boardId, event);
   }
 
   /**
@@ -1368,8 +1084,8 @@ class PubSub {
    */
   getSubscriberCounts(sessionId: string): { queue: number; session: number } {
     return {
-      queue: this.queueSubscribers.get(sessionId)?.size ?? 0,
-      session: this.sessionSubscribers.get(sessionId)?.size ?? 0,
+      queue: this.queueChannel.count(sessionId),
+      session: this.sessionChannel.count(sessionId),
     };
   }
 }

--- a/packages/backend/src/pubsub/index.ts
+++ b/packages/backend/src/pubsub/index.ts
@@ -10,7 +10,18 @@ import type {
 import { redisClientManager } from '../redis/client';
 import { createRedisPubSubAdapter, type RedisPubSubAdapter } from './redis-adapter';
 import { PubSubChannel, type ChannelSubscriber } from './channel';
+import {
+  BoardPresenceStore,
+  type BoardReportGate,
+  type CommitBoardClimbInput,
+  type CommitBoardClimbResult,
+} from './board-presence-store';
 import { logger } from '../utils/logger';
+
+// Board-presence gate/commit types live with their implementation in
+// board-presence-store.ts; re-exported here so consumers keep importing them
+// from the pubsub entry point.
+export type { BoardReportGate, CommitBoardClimbInput, CommitBoardClimbResult } from './board-presence-store';
 
 type QueueSubscriber = ChannelSubscriber<QueueEvent>;
 type SessionSubscriber = ChannelSubscriber<SessionEvent>;
@@ -18,90 +29,6 @@ type NotificationSubscriber = ChannelSubscriber<NotificationEvent>;
 type CommentSubscriber = ChannelSubscriber<CommentEvent>;
 type NewClimbSubscriber = ChannelSubscriber<NewClimbCreatedEvent>;
 type BoardPresenceSubscriber = ChannelSubscriber<BoardPresenceEvent>;
-
-/** Result of the Stage-A report gate read (one pipeline, see `getBoardReportGate`). */
-export type BoardReportGate = {
-  /** Whether `emitterId` currently has a live proof-of-presence stamp on the board. */
-  isMember: boolean;
-  /** First-seen epoch-ms for the durable-history dwell gate, or null when unknown/implausible. */
-  firstSeenMs: number | null;
-  /** Value of `board:{id}:lastReport` ("emitterId|climbUuid|angle"), or null when never set / expired. */
-  lastReport: string | null;
-  /**
-   * The board's current connection holder (`board:{id}:writer`), or null when
-   * free / unknown. The dedup short-circuit must only fire while the retrying
-   * emitter still holds the wall — a WS-close backstop clear between the
-   * original send and the retry deletes the writer key but leaves lastReport,
-   * and short-circuiting then would strand the wall looking free while the
-   * emitter holds it (no re-take, no re-broadcast).
-   */
-  currentWriter: string | null;
-};
-
-export type CommitBoardClimbInput = {
-  boardId: string;
-  emitterId: string;
-  climb: BoardPresenceClimb;
-  climbUuid: string;
-  effectiveAngle: number;
-  /** The reporting connection's party-session id, when it's in one. */
-  sessionId: string | null;
-};
-
-export type CommitBoardClimbResult = {
-  /** The writer key's previous value (from the atomic SET..GET), or null when
-   * the board was free / the commit failed. */
-  previousWriter: string | null;
-  /**
-   * True only when the writer SET..GET slot actually executed without error —
-   * i.e. `previousWriter` is a real observation, not a failure collapsed to
-   * null. The caller must gate the hand-off broadcast on this: a failing
-   * pipeline otherwise looks like "board was free" (`null !== emitterId`) and
-   * would spuriously broadcast a hand-off + kick a Live Activity push on
-   * every send while Redis is unhealthy.
-   */
-  writerSlotOk: boolean;
-};
-
-// Board-presence durable history (Redis FIFO) configuration. The live
-// "now on the wall" feed is ephemeral; this buffer backfills late joiners
-// before the `boardNowPlaying` subscription takes over.
-const BOARD_HISTORY_SIZE = 50; // Keep the last 50 climbs per board
-const BOARD_HISTORY_TTL = 604_800; // 1 week
-// The per-board seq counter's TTL matches BOARD_HISTORY_TTL so the common
-// case (an active board) never sees the counter expire while the Redis
-// history buffer is still populated. But `board_climb_events` rows are
-// durable forever, so a board dormant for *longer* than a week still has a
-// live durable floor after this key expires — INCR would otherwise restart
-// at 1 and collide with / precede rows that still exist in Postgres. That
-// residual gap is closed by the dormancy reseed in `nextBoardSeq` (see
-// `boardSeqFloorProvider` / `allocateBoardSeqAtLeast` below), not by this TTL
-// alone.
-const BOARD_SEQ_TTL = 604_800; // 1 week
-// Once INCR returns a value at or below this, nextBoardSeq consults the
-// durable floor provider — a small INCR result is the signature of a
-// freshly-(re)created Redis key, which happens both for a genuinely new board
-// and for a dormant board whose key just expired.
-const BOARD_SEQ_RESEED_THRESHOLD = 50;
-// Proof-of-presence window: how long after connecting (resolveBoardForSerial /
-// resolveBoardForConfig) a user may report climbs to that board's feed. Long
-// enough for a climbing session; a reconnect re-stamps it.
-const BOARD_MEMBERSHIP_TTL = 43_200; // 12 hours
-// Write-side idempotency window for reportBoardClimb: a retry of the exact
-// same (emitter, climb, angle) within this window is treated as a no-op
-// duplicate rather than a new send (see `getBoardReportGate` / A2 dedup).
-const REPORT_DEDUP_WINDOW_MS = 10_000;
-// Epoch-ms floor a first-seen stamp must clear to be trusted. Guards against
-// legacy sentinel values (e.g. an old '1') that would otherwise trivially
-// satisfy the durable-history dwell gate.
-const PLAUSIBLE_EPOCH_MS_FLOOR = 1_600_000_000_000;
-
-function parsePlausibleFirstSeenMs(raw: string | null): number | null {
-  if (raw === null) return null;
-  const firstSeen = Number(raw);
-  if (!Number.isFinite(firstSeen) || firstSeen < PLAUSIBLE_EPOCH_MS_FLOOR) return null;
-  return firstSeen;
-}
 
 /** External hook called after every queue event publish. Fire-and-forget. */
 type QueueEventHook = (sessionId: string, event: QueueEvent) => void;
@@ -183,41 +110,18 @@ class PubSub {
     isRedisRequired: () => this.redisRequired,
     logger,
   });
-  // Local-only fallback for the per-board monotonic seq counter. In Redis
-  // mode the authoritative counter is `board:${boardId}:seq` (INCR); this map
-  // only ever serves single-instance deployments that have no Redis.
-  private localBoardSeq = new Map<string, number>();
-  // Per-board watermark for the seq dormancy reseed (see
-  // `ensureBoardSeqClearOfDurableFloor`): the highest seq this instance has
-  // verified clear of the durable floor or allocated through the reseed
-  // check. Lets a brand-new board skip the repeated MAX(seq) Postgres lookup
-  // on each of its first ~BOARD_SEQ_RESEED_THRESHOLD sends. One number per
-  // board that allocates during the process lifetime (bounded like
-  // `localBoardSeq`); never TTL'd — see the safety analysis on the method.
-  private boardSeqVerifiedThrough = new Map<string, number>();
-  // Sticky "the floor consultation FAILED and hasn't succeeded since" marker.
-  // While a board is in here, every nextBoardSeq call retries the floor
-  // consultation — regardless of the INCR value and bypassing the watermark
-  // skip — so a transient Postgres/Lua failure during the reseed window can't
-  // let the counter grow past BOARD_SEQ_RESEED_THRESHOLD while still below
-  // the durable floor (which would permanently freeze clients holding
-  // pre-reset high seqs). Cleared only by a successful verification/reseed.
-  // Same lifecycle/bounds as the watermark map.
-  private boardSeqReseedPending = new Set<string>();
-  // Local-only proof-of-presence: `${boardId}:${userId}` → expiry epoch ms.
-  private localBoardMembership = new Map<string, number>();
-  private localBoardMembershipCleanupTimer: ReturnType<typeof setTimeout> | null = null;
-  private localBoardMembershipCleanupExpiry: number | null = null;
+  // Board-presence Redis KV helpers (seq counter, durable history, proof-of-
+  // presence, writer holder, session→board) live outside the generic channel
+  // — see board-presence-store.ts for why.
+  private readonly boardPresenceStore = new BoardPresenceStore({
+    isRedisAvailable: () => this.isRedisConnected(),
+    isRedisRequired: () => this.redisRequired,
+    logger,
+  });
   private redisAdapter: RedisPubSubAdapter | null = null;
   private initialized = false;
   private redisRequired = false;
   private queueEventHook: QueueEventHook | null = null;
-  // Durable seq floor lookup for the `nextBoardSeq` dormancy reseed (A3).
-  // Injected via `setBoardSeqFloorProvider` at bootstrap so pubsub itself
-  // stays DB-free (and trivially unit-testable without Postgres). Defaults to
-  // "no durable floor" — a board with no floor provider wired never reseeds,
-  // matching pre-A3 behavior.
-  private boardSeqFloorProvider: (boardId: number) => Promise<number> = async () => 0;
 
   /**
    * Initialize the PubSub system.
@@ -295,16 +199,6 @@ class PubSub {
    */
   setQueueEventHook(hook: QueueEventHook): void {
     this.queueEventHook = hook;
-  }
-
-  /**
-   * Inject the durable seq-floor lookup used by `nextBoardSeq`'s dormancy
-   * reseed (A3). Wired once at backend bootstrap (`server.ts`) to a Drizzle
-   * query over `board_climb_events`; defaults to `async () => 0` so pubsub
-   * unit tests never need a database.
-   */
-  setBoardSeqFloorProvider(provider: (boardId: number) => Promise<number>): void {
-    this.boardSeqFloorProvider = provider;
   }
 
   private setupRedisMessageHandlers(): void {
@@ -554,519 +448,84 @@ class PubSub {
     this.boardPresenceChannel.publish(boardId, event);
   }
 
+  // The methods below delegate to `boardPresenceStore` (board-presence-store.ts)
+  // — Redis KV bookkeeping for the board-presence domain (seq counter, durable
+  // history, proof-of-presence, writer holder, session→board) that sits
+  // alongside but outside the generic pub/sub channel above. See that file
+  // for the full rationale on each method; signatures and behavior here are
+  // unchanged from before the extraction.
+
   /**
-   * Atomically allocate the next monotonic sequence number for a board.
-   * Redis `INCR` + `EXPIRE` (pipelined — 1 RTT), cluster-safe across
-   * instances; falls back to an in-memory counter in local-only mode.
-   *
-   * The key expires after a week of inactivity. For a genuinely fresh board
-   * that's harmless (INCR restarts at 1 and the empty history buffer expired
-   * along with it). For a board dormant *longer* than the TTL whose durable
-   * `board_climb_events` rows outlive the key, restarting at 1 would collide
-   * with / precede still-existing rows — so whenever INCR comes back small
-   * (<= BOARD_SEQ_RESEED_THRESHOLD, the signature of a fresh key either way),
-   * `ensureBoardSeqClearOfDurableFloor` checks the durable floor and, if the
-   * floor is at or above the INCR result, reseeds atomically past it. The
-   * check memoizes per board so a brand-new board's early sends don't repeat
-   * the Postgres lookup ~50 times (see that method's safety analysis). A
-   * FAILED consultation marks the board reseed-pending, which keeps the
-   * consultation retrying on every subsequent allocation even after the
-   * counter crosses the threshold — otherwise a transient Postgres blip in
-   * the reseed window would leave the counter permanently below the durable
-   * floor.
+   * Inject the durable seq-floor lookup used by `nextBoardSeq`'s dormancy
+   * reseed (A3). Wired once at backend bootstrap (`server.ts`).
    */
+  setBoardSeqFloorProvider(provider: (boardId: number) => Promise<number>): void {
+    this.boardPresenceStore.setBoardSeqFloorProvider(provider);
+  }
+
+  /** Atomically allocate the next monotonic sequence number for a board (with dormancy reseed). */
   async nextBoardSeq(boardId: string): Promise<number> {
-    if (this.redisAdapter && this.isRedisConnected()) {
-      try {
-        const { publisher } = redisClientManager.getClients();
-        const key = `board:${boardId}:seq`;
-        const results = await publisher.pipeline().incr(key).expire(key, BOARD_SEQ_TTL).exec();
-        if (!results) {
-          throw new Error('nextBoardSeq pipeline returned null');
-        }
-        const [incrError, incrResult] = results[0];
-        if (incrError) throw incrError;
-        const next = incrResult as number;
-
-        if (next <= BOARD_SEQ_RESEED_THRESHOLD || this.boardSeqReseedPending.has(boardId)) {
-          return await this.ensureBoardSeqClearOfDurableFloor(boardId, next);
-        }
-
-        return next;
-      } catch (error) {
-        if (this.redisRequired) {
-          logger.error('[PubSub] Failed to allocate board seq from required Redis:', error);
-          throw error;
-        }
-        logger.error('[PubSub] Failed to allocate board seq from Redis, falling back to local:', error);
-      }
-    }
-
-    const next = (this.localBoardSeq.get(boardId) ?? 0) + 1;
-    this.localBoardSeq.set(boardId, next);
-    return next;
+    return this.boardPresenceStore.nextBoardSeq(boardId);
   }
 
-  /**
-   * Ensures a small (or reseed-pending) INCR result is clear of the durable
-   * `board_climb_events` floor, reseeding atomically via
-   * `allocateBoardSeqAtLeast` when it isn't. Returns the seq to use. Never
-   * throws: a floor-lookup or reseed failure falls back to the INCR result —
-   * but marks the board reseed-pending, so every subsequent allocation
-   * retries the consultation (bypassing the watermark skip) until one
-   * succeeds. Without the sticky flag, a transient Postgres blip covering
-   * the whole <= BOARD_SEQ_RESEED_THRESHOLD window would let the counter
-   * cross the threshold still below the durable floor and never consult
-   * Postgres again — clients holding pre-reset high seqs would then treat
-   * every subsequent event as stale and the live wall would freeze until the
-   * next counter loss.
-   *
-   * Memoization: without it, every send of a brand-new board's first
-   * ~BOARD_SEQ_RESEED_THRESHOLD would run the MAX(seq) Postgres lookup. The
-   * memo is a per-board watermark = the highest seq this instance has either
-   * verified clear of the floor or allocated through this check; the lookup
-   * is skipped only when the fresh INCR result is strictly ahead of it
-   * (normal early-life counter growth, provably not a reset this instance
-   * could collide on). Deliberately NOT the raw floor value: a floor-only
-   * memo (e.g. 0 for a new board) would keep skipping after a mid-process
-   * counter loss (FLUSHALL / failover to an empty replica) once durable rows
-   * exist — INCR restarts at 1, `1 > 0` skips, collision. With the
-   * watermark, any allocation pushes it to >= 1, so the first post-reset
-   * INCR (= 1) can never be ahead of it and always re-consults the floor.
-   *
-   * Accepted residual (documented, not defended): in multi-instance, an
-   * instance holding a small stale watermark can race another instance's
-   * first post-reset reseed and skip the check for a seq the durable floor
-   * already covers. The colliding durable insert lands on the (boardId, seq)
-   * unique index's `onConflictDoNothing` — one dropped duplicate row, no
-   * corruption, and exactly the failure mode every post-dormancy send had
-   * before the reseed existed. That needs a mid-process Redis counter loss
-   * (not mere dormancy — any send or stats publish re-arms the TTL) plus
-   * concurrent sends in the reseed window, so we take the simple memo.
-   */
-  private async ensureBoardSeqClearOfDurableFloor(boardId: string, incrResult: number): Promise<number> {
-    const reseedPending = this.boardSeqReseedPending.has(boardId);
-    const verifiedThrough = this.boardSeqVerifiedThrough.get(boardId);
-    // The watermark skip is only trustworthy when no consultation has failed
-    // since the last success — while reseed-pending, the floor may be far
-    // above anything this instance ever verified, so always re-consult.
-    if (!reseedPending && verifiedThrough !== undefined && incrResult > verifiedThrough) {
-      this.boardSeqVerifiedThrough.set(boardId, incrResult);
-      return incrResult;
-    }
-
-    let floor: number;
-    try {
-      floor = await this.boardSeqFloorProvider(Number(boardId));
-    } catch (error) {
-      this.boardSeqReseedPending.add(boardId);
-      logger.error('[PubSub] board seq floor provider failed, using INCR result (reseed pending):', error);
-      return incrResult;
-    }
-
-    if (floor < incrResult) {
-      this.boardSeqReseedPending.delete(boardId);
-      this.boardSeqVerifiedThrough.set(boardId, Math.max(incrResult, verifiedThrough ?? 0));
-      return incrResult;
-    }
-
-    try {
-      const reseeded = await this.allocateBoardSeqAtLeast(boardId, floor);
-      if (reseeded === null) {
-        // Redis went away between the INCR and the reseed — keep retrying.
-        this.boardSeqReseedPending.add(boardId);
-        return incrResult;
-      }
-      this.boardSeqReseedPending.delete(boardId);
-      this.boardSeqVerifiedThrough.set(boardId, Math.max(reseeded, verifiedThrough ?? 0));
-      return reseeded;
-    } catch (error) {
-      this.boardSeqReseedPending.add(boardId);
-      logger.error('[PubSub] board seq Lua reseed failed, using INCR result (reseed pending):', error);
-      return incrResult;
-    }
-  }
-
-  /**
-   * Atomically allocate a board seq value guaranteed to exceed both the
-   * current Redis counter and `floor` (`max(currentValue, floor) + 1`),
-   * re-arming the TTL. A single Lua script keeps the read-compare-write
-   * atomic under concurrent callers — two racing reseeds still get distinct,
-   * monotonic results because Redis serializes the script execution.
-   * Redis-only: returns null when Redis is unavailable (callers fall back to
-   * the plain INCR result and mark the reseed pending). May still reject on
-   * a command failure against a connected Redis — the internal reseed path
-   * catches that. Public for direct unit testing.
-   */
+  /** Atomically allocate a board seq guaranteed past `floor`; null without Redis. Public for unit tests. */
   async allocateBoardSeqAtLeast(boardId: string, floor: number): Promise<number | null> {
-    if (!this.redisAdapter || !this.isRedisConnected()) return null;
-    const { publisher } = redisClientManager.getClients();
-    const key = `board:${boardId}:seq`;
-    const result = await publisher.eval(
-      "local cur = tonumber(redis.call('get', KEYS[1]) or '0'); " +
-        'local nxt = math.max(cur, tonumber(ARGV[1])) + 1; ' +
-        "redis.call('set', KEYS[1], nxt); " +
-        "redis.call('expire', KEYS[1], ARGV[2]); " +
-        'return nxt',
-      1,
-      key,
-      floor,
-      BOARD_SEQ_TTL,
-    );
-    return Number(result);
+    return this.boardPresenceStore.allocateBoardSeqAtLeast(boardId, floor);
   }
 
-  /**
-   * Read a board's recent climbs, newest-first by seq (cap 50). Empty without
-   * Redis.
-   */
+  /** Read a board's recent climbs, newest-first by seq (cap 50). Empty without Redis. */
   async getRecentBoardClimbs(boardId: string): Promise<BoardPresenceClimb[]> {
-    if (!this.redisAdapter || !this.isRedisConnected()) {
-      return [];
-    }
-
-    try {
-      const { publisher } = redisClientManager.getClients();
-      const key = `board:${boardId}:history`;
-      const entries = await publisher.lrange(key, 0, -1);
-
-      const climbs: BoardPresenceClimb[] = [];
-      for (const json of entries) {
-        try {
-          climbs.push(JSON.parse(json) as BoardPresenceClimb);
-        } catch (parseError) {
-          logger.error('[PubSub] Failed to parse board history entry:', parseError);
-        }
-      }
-
-      // The list is already newest-first (lpush), but sort by seq DESC so a
-      // late, out-of-order write can't surface above a newer climb.
-      climbs.sort((a, b) => b.seq - a.seq);
-      return climbs.slice(0, BOARD_HISTORY_SIZE);
-    } catch (error) {
-      logger.error('[PubSub] Failed to read board history:', error);
-      return [];
-    }
+    return this.boardPresenceStore.getRecentBoardClimbs(boardId);
   }
 
-  /**
-   * Record that a user is connected to a board (proof-of-presence), stamped on
-   * resolveBoardForSerial / resolveBoardForConfig. `reportBoardClimb` requires
-   * this so a logged-in user can't inject onto a board they never connected to.
-   * TTL'd; a reconnect re-stamps. Best-effort without Redis (local map).
-   */
+  /** Record that a user is connected to a board (proof-of-presence). TTL'd; a reconnect re-stamps. */
   async stampBoardMembership(boardId: string, userId: string): Promise<void> {
-    const key = `presence:board:${boardId}:user:${userId}`;
-    if (this.redisAdapter && this.isRedisConnected()) {
-      try {
-        const { publisher } = redisClientManager.getClients();
-        // Store the first-seen epoch-ms (NX preserves it across reconnects) so
-        // the durable-history dwell gate can tell how long this member has been
-        // on the board. A separate EXPIRE keeps the key alive while they're
-        // active without resetting first-seen. EXISTS still answers presence.
-        await publisher.set(key, String(Date.now()), 'EX', BOARD_MEMBERSHIP_TTL, 'NX');
-        await publisher.expire(key, BOARD_MEMBERSHIP_TTL);
-        return;
-      } catch (error) {
-        if (this.redisRequired) {
-          logger.error('[PubSub] Failed to stamp board membership in required Redis:', error);
-          throw error;
-        }
-        logger.error('[PubSub] Failed to stamp board membership, falling back to local:', error);
-      }
-    }
-    this.setLocalBoardMembership(`${boardId}:${userId}`, Date.now() + BOARD_MEMBERSHIP_TTL * 1000);
+    return this.boardPresenceStore.stampBoardMembership(boardId, userId);
   }
 
   /** True if the user has a live proof-of-presence stamp for the board. */
   async hasBoardMembership(boardId: string, userId: string): Promise<boolean> {
-    const key = `presence:board:${boardId}:user:${userId}`;
-    if (this.redisAdapter && this.isRedisConnected()) {
-      try {
-        const { publisher } = redisClientManager.getClients();
-        return (await publisher.exists(key)) === 1;
-      } catch (error) {
-        if (this.redisRequired) {
-          logger.error('[PubSub] Failed to check board membership in required Redis:', error);
-          throw error;
-        }
-        logger.error('[PubSub] Failed to check board membership, falling back to local:', error);
-      }
-    }
-    return this.checkLocalBoardMembership(boardId, userId);
+    return this.boardPresenceStore.hasBoardMembership(boardId, userId);
   }
 
-  private checkLocalBoardMembership(boardId: string, userId: string): boolean {
-    const localKey = `${boardId}:${userId}`;
-    const expiry = this.localBoardMembership.get(localKey);
-    if (expiry === undefined) return false;
-    if (expiry <= Date.now()) {
-      this.localBoardMembership.delete(localKey);
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * One Redis pipeline (1 RTT) that answers everything `reportBoardClimb`'s
-   * Stage A needs before validating the incoming climb: proof-of-presence
-   * (+ first-seen, for the durable-history dwell gate), the last-report dedup
-   * marker (for write-side idempotency, A2), and the current writer (so the
-   * dedup short-circuit can require the retrying emitter to still hold the
-   * wall — see `BoardReportGate.currentWriter`). Replaces what used to be
-   * separate `hasBoardMembership` + first-seen + `lastReport` reads — 3 RTTs
-   * collapsed into 1, with the writer read riding the same pipeline for free.
-   *
-   * Preserves `hasBoardMembership`'s fail-closed `redisRequired` semantics
-   * (throws when Redis is required but the pipeline fails) and the
-   * plausible-epoch guard on `firstSeenMs` (a legacy/implausible stamp still
-   * counts as a member but never satisfies the dwell gate). Local-only
-   * fallback mirrors today: membership from the in-memory map,
-   * `firstSeenMs`/`lastReport`/`currentWriter` unknown (null) — durable
-   * history and write-side dedup both degrade to off without Redis, same as
-   * before.
-   */
+  /** One-pipeline Stage-A read for reportBoardClimb: membership, first-seen, lastReport, writer. */
   async getBoardReportGate(boardId: string, emitterId: string): Promise<BoardReportGate> {
-    const membershipKey = `presence:board:${boardId}:user:${emitterId}`;
-    const lastReportKey = `board:${boardId}:lastReport`;
-    const writerKey = `board:${boardId}:writer`;
-
-    if (this.redisAdapter && this.isRedisConnected()) {
-      try {
-        const { publisher } = redisClientManager.getClients();
-        const results = await publisher.pipeline().get(membershipKey).get(lastReportKey).get(writerKey).exec();
-        if (!results) {
-          throw new Error('getBoardReportGate pipeline returned null');
-        }
-        const [[membershipError, membershipRaw], [lastReportError, lastReportRaw], [writerError, writerRaw]] = results;
-        if (membershipError) throw membershipError;
-        if (lastReportError) throw lastReportError;
-        if (writerError) throw writerError;
-        const raw = membershipRaw as string | null;
-        return {
-          isMember: raw !== null,
-          firstSeenMs: parsePlausibleFirstSeenMs(raw),
-          lastReport: (lastReportRaw as string | null) ?? null,
-          currentWriter: (writerRaw as string | null) ?? null,
-        };
-      } catch (error) {
-        if (this.redisRequired) {
-          logger.error('[PubSub] Failed to read board report gate from required Redis:', error);
-          throw error;
-        }
-        logger.error('[PubSub] Failed to read board report gate, falling back to local:', error);
-      }
-    }
-
-    return {
-      isMember: this.checkLocalBoardMembership(boardId, emitterId),
-      firstSeenMs: null,
-      lastReport: null,
-      currentWriter: null,
-    };
+    return this.boardPresenceStore.getBoardReportGate(boardId, emitterId);
   }
 
-  /**
-   * One Redis pipeline (1 RTT) that commits an accepted `reportBoardClimb`
-   * send: appends to the durable FIFO history (LPUSH/LTRIM/EXPIRE), takes the
-   * connection-holder slot (atomic `SET writer EX GET` — a single command, so
-   * two concurrent reports still can't both observe the same previous
-   * holder), stamps the write-side dedup marker (A2's `lastReport`), and —
-   * when this connection is in a party session — remembers the session→board
-   * mapping (`session:{id}:board`). Replaces what used to be 3 separate
-   * round trips.
-   *
-   * Non-fatal: the whole pipeline (or an individual command within it) can
-   * fail without failing the accepted report — failures are logged and
-   * swallowed. But a swallowed failure means `previousWriter: null` is a
-   * fabrication, not an observation, so the result also carries
-   * `writerSlotOk`: false whenever the writer slot didn't verifiably execute
-   * (Redis off, pipeline threw, or the SET..GET slot itself errored). The
-   * resolver gates the hand-off broadcast on it — without that gate, a
-   * failing pipeline would look like "board was free" on every send and
-   * spuriously re-broadcast the hand-off each time (the pre-pipeline code
-   * never had this failure mode: a writer-update failure was either swallowed
-   * with no broadcast, or thrown in redisRequired mode).
-   */
+  /** One-pipeline commit of an accepted reportBoardClimb send (history, writer take, dedup, session→board). */
   async commitBoardClimb(input: CommitBoardClimbInput): Promise<CommitBoardClimbResult> {
-    if (!this.redisAdapter || !this.isRedisConnected()) {
-      return { previousWriter: null, writerSlotOk: false };
-    }
-
-    try {
-      const { publisher } = redisClientManager.getClients();
-      const historyKey = `board:${input.boardId}:history`;
-      const writerKey = `board:${input.boardId}:writer`;
-      const lastReportKey = `board:${input.boardId}:lastReport`;
-      const lastReportValue = `${input.emitterId}|${input.climbUuid}|${input.effectiveAngle}`;
-
-      const pipeline = publisher.pipeline();
-      const commandLabels: string[] = [];
-      pipeline.lpush(historyKey, JSON.stringify(input.climb));
-      commandLabels.push('history-lpush');
-      pipeline.ltrim(historyKey, 0, BOARD_HISTORY_SIZE - 1);
-      commandLabels.push('history-ltrim');
-      pipeline.expire(historyKey, BOARD_HISTORY_TTL);
-      commandLabels.push('history-expire');
-      const writerCommandIndex = commandLabels.length;
-      pipeline.set(writerKey, input.emitterId, 'EX', BOARD_MEMBERSHIP_TTL, 'GET');
-      commandLabels.push('writer-set');
-      pipeline.set(lastReportKey, lastReportValue, 'PX', REPORT_DEDUP_WINDOW_MS);
-      commandLabels.push('last-report-set');
-      if (input.sessionId) {
-        pipeline.set(`session:${input.sessionId}:board`, input.boardId, 'EX', BOARD_MEMBERSHIP_TTL);
-        commandLabels.push('session-board-set');
-      }
-
-      const results = await pipeline.exec();
-      if (!results) {
-        throw new Error('commitBoardClimb pipeline returned null');
-      }
-
-      results.forEach(([error], index) => {
-        if (error) {
-          logger.warn(`[PubSub] commitBoardClimb ${commandLabels[index]} command failed: ${String(error)}`);
-        }
-      });
-
-      const [writerError, writerValue] = results[writerCommandIndex];
-      if (writerError) return { previousWriter: null, writerSlotOk: false };
-      return { previousWriter: (writerValue as string | null) ?? null, writerSlotOk: true };
-    } catch (error) {
-      logger.error('[PubSub] commitBoardClimb pipeline failed:', error);
-      return { previousWriter: null, writerSlotOk: false };
-    }
+    return this.boardPresenceStore.commitBoardClimb(input);
   }
 
-  /**
-   * Clear the board's holder only if `emitterId` still holds it (atomic
-   * compare-and-delete), so a holder who was already booted can't wipe the new
-   * one. Returns whether it was actually cleared.
-   */
+  /** Clear the board's holder only if `emitterId` still holds it (atomic compare-and-delete). */
   async clearBoardWriterIf(boardId: string, emitterId: string): Promise<boolean> {
-    if (!this.redisAdapter || !this.isRedisConnected()) return false;
-    try {
-      const { publisher } = redisClientManager.getClients();
-      const cleared = await publisher.eval(
-        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
-        1,
-        `board:${boardId}:writer`,
-        emitterId,
-      );
-      return cleared === 1;
-    } catch (error) {
-      if (this.redisRequired) throw error;
-      logger.error('[PubSub] Failed to clear board writer:', error);
-      return false;
-    }
+    return this.boardPresenceStore.clearBoardWriterIf(boardId, emitterId);
   }
 
   /** The board's current connection holder emitter id, or null when free. */
   async getBoardWriter(boardId: string): Promise<string | null> {
-    if (!this.redisAdapter || !this.isRedisConnected()) return null;
-    try {
-      const { publisher } = redisClientManager.getClients();
-      return await publisher.get(`board:${boardId}:writer`);
-    } catch (error) {
-      if (this.redisRequired) throw error;
-      logger.error('[PubSub] Failed to get board writer:', error);
-      return null;
-    }
+    return this.boardPresenceStore.getBoardWriter(boardId);
   }
 
-  /**
-   * The shared board_id this party session is on, or null when unknown.
-   *
-   * The mapping (`session:{id}:board`) is written by `commitBoardClimb` as a
-   * side-effect of `reportBoardClimb` — the only moment a session is provably
-   * tied to a board. The APNs Live Activity path reads it to resolve the
-   * board's current holder for a given session (`QueueState` and the
-   * push-token rows carry sessionId but not boardId). Redis-only and TTL'd to
-   * the same window as proof-of-presence so an idle session's mapping doesn't
-   * leak; a fresh send re-stamps it. Without Redis the holder lookup degrades
-   * to "unknown" and the APNs path omits boardConnection (device falls back
-   * to its own App-Group state).
-   */
+  /** The shared board_id this session is on, or null when unknown (written by commitBoardClimb). */
   async getSessionBoard(sessionId: string): Promise<string | null> {
-    if (!this.redisAdapter || !this.isRedisConnected()) return null;
-    try {
-      const { publisher } = redisClientManager.getClients();
-      return await publisher.get(`session:${sessionId}:board`);
-    } catch (error) {
-      if (this.redisRequired) throw error;
-      logger.error('[PubSub] Failed to get session board:', error);
-      return null;
-    }
-  }
-
-  private setLocalBoardMembership(localKey: string, expiry: number): void {
-    this.localBoardMembership.set(localKey, expiry);
-    if (this.localBoardMembershipCleanupExpiry !== null && expiry >= this.localBoardMembershipCleanupExpiry) {
-      return;
-    }
-    this.scheduleLocalBoardMembershipCleanup();
+    return this.boardPresenceStore.getSessionBoard(sessionId);
   }
 
   /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
   resetLocalBoardMembershipForTest(): void {
-    this.clearLocalBoardMembershipCleanupTimer();
-    this.localBoardMembership.clear();
+    this.boardPresenceStore.resetLocalBoardMembershipForTest();
   }
 
   /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
   setLocalBoardMembershipForTest(localKey: string, expiry: number): void {
-    this.setLocalBoardMembership(localKey, expiry);
+    this.boardPresenceStore.setLocalBoardMembershipForTest(localKey, expiry);
   }
 
   /** @internal Test hook for local-only proof-of-presence cleanup coverage. */
   hasLocalBoardMembershipForTest(localKey: string): boolean {
-    return this.localBoardMembership.has(localKey);
-  }
-
-  private scheduleLocalBoardMembershipCleanup(): void {
-    this.clearLocalBoardMembershipCleanupTimer();
-
-    if (this.localBoardMembership.size === 0) {
-      return;
-    }
-
-    // Local-only mode is single-process and expected to stay small; keep the
-    // scheduler simple unless proof-of-presence cardinality becomes material.
-    let nextExpiry: number | null = null;
-    for (const expiry of this.localBoardMembership.values()) {
-      nextExpiry = nextExpiry === null ? expiry : Math.min(nextExpiry, expiry);
-    }
-    if (nextExpiry === null) return;
-
-    this.localBoardMembershipCleanupExpiry = nextExpiry;
-    const cleanupDelay = Math.max(0, nextExpiry - Date.now());
-    const cleanupTimer = setTimeout(() => {
-      this.localBoardMembershipCleanupTimer = null;
-      this.localBoardMembershipCleanupExpiry = null;
-      this.evictExpiredLocalBoardMemberships();
-      this.scheduleLocalBoardMembershipCleanup();
-    }, cleanupDelay);
-    this.localBoardMembershipCleanupTimer = cleanupTimer;
-    if (typeof cleanupTimer === 'object') {
-      cleanupTimer.unref?.();
-    }
-  }
-
-  private clearLocalBoardMembershipCleanupTimer(): void {
-    if (this.localBoardMembershipCleanupTimer === null) {
-      return;
-    }
-    clearTimeout(this.localBoardMembershipCleanupTimer);
-    this.localBoardMembershipCleanupTimer = null;
-    this.localBoardMembershipCleanupExpiry = null;
-  }
-
-  private evictExpiredLocalBoardMemberships(now = Date.now()): void {
-    for (const [localKey, expiry] of this.localBoardMembership) {
-      if (expiry <= now) {
-        this.localBoardMembership.delete(localKey);
-      }
-    }
+    return this.boardPresenceStore.hasLocalBoardMembershipForTest(localKey);
   }
 
   /**


### PR DESCRIPTION
## Summary

- `packages/backend/src/pubsub/index.ts` had six copy-pasted subscribe/publish/dispatch triplets (queue, session, notification, comment, new-climb, board-presence), differing only in field names and which `RedisPubSubAdapter` method they called. Factors the shared mechanics into a generic `PubSubChannel<TEvent>` (`packages/backend/src/pubsub/channel.ts`): `subscribe()` (first-subscriber-triggers-Redis-subscribe / last-unsubscriber-triggers-Redis-unsubscribe), `publish()` (local-dispatch-first, then fire-and-forget Redis publish), `dispatchLocal()` (Redis fan-in path, no re-publish), and `count()`.
- `PubSub`'s public method surface is unchanged — every method (`subscribeQueue`, `publishSessionEvent`, `subscribeBoardPresence`, ...) now delegates to one of six `PubSubChannel` instances.
- Domain quirks stay outside the generic channel, layered in `PubSub`: queue's delta-replay buffer (incl. the `PlaybackStateChanged` exclusion from #3340) + `queueEventHook`/APNs hook still wrap `publishQueueEvent` on top of `channel.publish()`.
- Second commit moves the board-presence Redis KV bookkeeping (seq counter, durable history, proof-of-presence + its local-map fallback/cleanup timer, writer holder, session→board mapping — ~350 lines with nothing to do with the pub/sub fan-out) into `packages/backend/src/pubsub/board-presence-store.ts`. `PubSub` re-exposes every method (including the `@internal` test hooks `board-presence.test.ts` uses) unchanged via thin delegation. Pure code-location move.
- `packages/backend/src/pubsub/index.ts` shrinks from 1093 → 539 lines.

**Deviation from the original brief:** this was written to stack on the unmerged `fix/sessions-b1-replay-buffer-playback` branch (#3340). By the time work started, #3340 had already merged into `main` — this PR bases on `main` directly (which already contains #3340's `PlaybackStateChanged` exclusion) rather than the now-stale branch ref.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- New `packages/backend/src/__tests__/pubsub-channel.test.ts` (12 tests): first-subscribe/last-unsubscribe Redis semantics, per-key independence, redisRequired throw vs. swallow semantics (subscriber is rolled back either way), publish-local-first ordering, per-callback error isolation, `dispatchLocal` doesn't re-publish, `count()`.
- Full backend suite (`vp test run --project backend`): 1846/1847 passed. The one failure (`board-presence.test.ts > converges concurrent serial-less config creates onto one normalized shared board`, a `user_boards_unique_slug` collision under concurrent inserts) is a documented pre-existing flake — reproduced it on the unmodified B1/main baseline too (slug collision on one run, Postgres deadlock on another), confirming it's unrelated to this refactor.
- `redis-pubsub.test.ts`, `event-replay-buffer.test.ts`, `board-connection.test.ts`, and the rest of `board-presence.test.ts` pass unchanged — the no-behavior-change proof for the extraction.
- `vp check --fix`: 0 errors (185 pre-existing warnings elsewhere in the repo, unrelated to this change).
- `vp run typecheck` (full monorepo): passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9eAY2yZDGSqossL5UtUQo